### PR TITLE
Libsvm labels

### DIFF
--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -221,7 +221,7 @@ class BaseLibSVM(BaseEstimator):
                       self.support_, self.label_, self.probA_,
                       self.probB_)
 
-        return pprob[:, np.argsort(self.label_)]
+        return pprob
 
     def predict_log_proba(self, T):
         """

--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -276,6 +276,9 @@ class BaseLibSVM(BaseEstimator):
                       self.support_, self.label_, self.probA_,
                       self.probB_)
 
+        # libsvm has the convention of returning negative values for
+        # rightmost labels, so we invert the sign since our label_ is
+        # sorted by increasing order
         return -dec_func
 
     @property

--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -276,7 +276,7 @@ class BaseLibSVM(BaseEstimator):
                       self.support_, self.label_, self.probA_,
                       self.probB_)
 
-        return dec_func
+        return -dec_func
 
     @property
     def coef_(self):

--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -258,11 +258,9 @@ class BaseLibSVM(BaseEstimator):
 
         Returns
         -------
-        T : array-like, shape = [n_samples, n_classes]
+        T : array-like, shape = [n_samples, n_class * (n_class-1) / 2]
             Returns the decision function of the sample for each class
-            in the model, where classes are ordered by arithmetical
-            order.
-
+            in the model.
         """
         T = np.atleast_2d(np.asanyarray(T, dtype=np.float64, order='C'))
         kernel_type, T = self._get_kernel(T)

--- a/scikits/learn/svm/setup.py
+++ b/scikits/learn/svm/setup.py
@@ -28,7 +28,10 @@ def configuration(parent_package='', top_path=None):
                        )
 
     libsvm_sources = [join('src', 'libsvm', '_libsvm.c')]
-    libsvm_depends = [join('src', 'libsvm', 'libsvm_helper.c')]
+    libsvm_depends = [join('src', 'libsvm', 'libsvm_helper.c'),
+                      join('src', 'libsvm', 'libsvm_template.cpp'),
+                      join('src', 'libsvm', 'svm.cpp'),
+                      join('src', 'libsvm', 'svm.h')]
 
     config.add_extension('_libsvm',
                          sources=libsvm_sources,

--- a/scikits/learn/svm/src/libsvm/svm.cpp
+++ b/scikits/learn/svm/src/libsvm/svm.cpp
@@ -46,6 +46,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
      Hsiang-Fu Yu,
      <http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/#weights_for_data_instances>.
 
+   - Make labels sorted in svm_group_classes, Fabian Pedregosa.
+
  */
 
 #include <math.h>
@@ -2199,8 +2201,6 @@ static double svm_svr_probability(
 
 
 
-
-
 // label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
 // perm, length l, must be allocated before calling this subroutine
 static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
@@ -2211,12 +2211,11 @@ static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, in
 	int *label = Malloc(int,max_nr_class);
 	int *count = Malloc(int,max_nr_class);
 	int *data_label = Malloc(int,l);	
-	int i;
+	int i, j, this_label, this_count;
 
 	for(i=0;i<l;i++)
 	{
-		int this_label = (int)prob->y[i];
-		int j;
+		this_label = (int)prob->y[i];
 		for(j=0;j<nr_class;j++)
 		{
 			if(this_label == label[j])
@@ -2225,7 +2224,6 @@ static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, in
 				break;
 			}
 		}
-		data_label[i] = j;
 		if(j == nr_class)
 		{
 			if(nr_class == max_nr_class)
@@ -2240,6 +2238,35 @@ static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, in
 		}
 	}
 
+        /* 
+         * Sort labels by straight insertion and apply the same
+         * transformation to array count.
+         */
+        for(j=1; j<nr_class; j++)
+        {
+                i = j-1;
+                this_label = label[j];
+                this_count = count[j];
+                while(i>=0 && label[i] > this_label)
+                {
+                        label[i+1] = label[i];
+                        count[i+1] = count[i];
+                        i--;
+                }
+                label[i+1] = this_label;
+                count[i+1] = this_count;
+        }
+
+        for (i=0; i<l; i++)
+        {
+                j = 0;
+                this_label = (int)prob->y[i];
+                while(this_label != label[j]){
+                        j ++;
+                }
+                data_label[i] = j;
+        }                
+
 	int *start = Malloc(int,nr_class);
 	start[0] = 0;
 	for(i=1;i<nr_class;i++)
@@ -2249,6 +2276,7 @@ static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, in
 		perm[start[data_label[i]]] = i;
 		++start[data_label[i]];
 	}
+
 	start[0] = 0;
 	for(i=1;i<nr_class;i++)
 		start[i] = start[i-1]+count[i-1];

--- a/scikits/learn/svm/tests/test_svm.py
+++ b/scikits/learn/svm/tests/test_svm.py
@@ -247,7 +247,7 @@ def test_decision_function():
             dec[p] = s
             p += 1
 
-    assert_array_almost_equal(dec, np.ravel(clf.decision_function(data)))
+    assert_array_almost_equal(-dec, np.ravel(clf.decision_function(data)))
 
 
 def test_weight():

--- a/scikits/learn/svm/tests/test_svm.py
+++ b/scikits/learn/svm/tests/test_svm.py
@@ -38,9 +38,17 @@ def test_libsvm_iris():
     """
     Check consistency on dataset iris.
     """
+
+    # shuffle the dataset so that labels are not ordered
+    perm = np.random.permutation(iris.target.size)
+    data = iris.data[perm]
+    target = iris.target[perm]
+
     for k in ('linear', 'rbf'):
-        clf = svm.SVC(kernel=k).fit(iris.data, iris.target)
-        assert np.mean(clf.predict(iris.data) == iris.target) > 0.9
+        clf = svm.SVC(kernel=k).fit(data, target)
+        assert np.mean(clf.predict(data) == target) > 0.9
+
+    assert_array_equal(clf.label_, np.sort(clf.label_))
 
 
 def test_precomputed():
@@ -262,6 +270,7 @@ def test_sample_weights():
     sample_weight=[.1]*3 + [10]*3
     clf.fit(X, Y, sample_weight=sample_weight)
     assert_array_equal(clf.predict(X[2]), [2.])
+
 
 def test_auto_weight():
     """Test class weights for imbalanced data"""


### PR DESCRIPTION
Sort labels by increasing order. This ensures that support vectors, coefs, etc. are also ordered in this fashion.

Also added some test, one of them reconstructs the decision_function from the classifier.

Due to convention in libsvm, original_decision function is the negative of our decision_function. For now i just invert the sign, although it should probably be fixed in libsvm, so that dual_coef_ is not the negative of what users expect.
