### PR TITLE
Fix  a bug of affinity propagation

### DIFF
--- a/scikits/learn/cluster/affinity_propagation_.py
+++ b/scikits/learn/cluster/affinity_propagation_.py
@@ -137,7 +137,7 @@ def affinity_propagation(S, p=None, convit=30, max_iter=200, damping=0.5,
         # Refine the final set of exemplars and clusters and return results
         for k in range(K):
             ii = np.where(c==k)[0]
-            j = np.argmax(np.sum(S[ii, ii], axis=0))
+            j = np.argmax(np.sum(S[ii[:,np.newaxis], ii], axis=0))
             I[k] = ii[j]
 
         c = np.argmax(S[:, I], axis=1)


### PR DESCRIPTION
This bug is caused by incorrect index usage.
BTW, the illustrating examples should also be changed accordingly, since the result would probably be wrong
