### PR TITLE
Neighbors refactoring

### DIFF
--- a/doc/developers/neighbors.rst
+++ b/doc/developers/neighbors.rst
@@ -1,0 +1,69 @@
+
+.. _notes_neighbors:
+
+
+.. currentmodule:: scikits.learn.neighbors
+
+=====================================
+scikits.learn.neighbors working notes
+=====================================
+
+barycenter
+==========
+
+Function :func:`barycenter` tries to find appropriate weights to
+reconstruct the point x from a subset (y1, y2, ..., yn), where weights
+sum to one.
+
+This is just a simple case of Equality Constrained Least Squares
+[#f1]_ with constrain dot(np.ones(n), x) = 1. In particular, the Q
+matrix from the QR decomposition of B is the Householder reflection of
+np.ones(n).
+
+
+Purpose
+-------
+
+This method was added to ease some computations in the future manifold
+module, namely in LLE. However, it is still to be shown that it is
+useful and efficient in that context.
+
+
+Performance
+-----------
+
+The algorithm has to iterate over n_samples, which is the main
+bottleneck. It would be great to vectorize this loop.
+
+Also, least squares solution could be computed more efficiently by a
+QR factorization, since probably we don't care about a minimum norm
+solution for the undertermined case.
+
+The paper 'An introduction to Locally Linear Embeddings', Saul &
+Roweis solves the problem by the normal equation method over the
+covariance matrix. This has the disadvantage that it does not degrade
+grathefully when the covariance is singular, requiring to explicitly
+add regularization.
+
+
+Stability
+---------
+
+Should be good as it uses SVD to solve the LS problem. TODO: explicit
+bounds.
+
+
+API
+---
+
+The API is convenient to use from NeighborsBarycenter and
+kneighbors_graph, but might not be very easy to use directly due to
+the fact that Y must be a 3-D array.
+
+It should be checked that it is usable in other contexts.
+
+
+.. rubric:: Footnotes
+
+.. [#f1] Section 12.1.4 ('Equality Constrained Least Squares'),
+         'Matrix Computations' by Golub & Van Loan 

--- a/doc/developers/neighbors.rst
+++ b/doc/developers/neighbors.rst
@@ -33,7 +33,8 @@ Performance
 -----------
 
 The algorithm has to iterate over n_samples, which is the main
-bottleneck. It would be great to vectorize this loop.
+bottleneck. It would be great to vectorize this loop. Also, the rank
+updates could probably be moved outside the loop.
 
 Also, least squares solution could be computed more efficiently by a
 QR factorization, since probably we don't care about a minimum norm

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -93,5 +93,6 @@ Development
    :maxdepth: 2
 
    developers/index
+   developers/neighbors
    performance
    about

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -105,8 +105,8 @@ Nearest Neighbors
    :toctree: generated/
    :template: class.rst
 
-   neighbors.Neighbors
-   neighbors.NeighborsBarycenter
+   neighbors.NeighborsClassifier
+   neighbors.NeighborsRegressor
    ball_tree.BallTree
 
 .. autosummary::

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -16,9 +16,9 @@ the decision boundary is very irregular.
 Classification
 ==============
 
-The :class:`Neighbors` estimators implements the nearest-neighbors
-classification method using a vote heuristic: the class most present in
-the k nearest neighbors of a point is assigned to this point.
+The :class:`NeighborsClassifier` implements the nearest-neighbors
+classification method using a vote heuristic: the class most present
+in the k nearest neighbors of a point is assigned to this point.
 
 .. figure:: ../auto_examples/images/plot_neighbors.png
    :target: ../auto_examples/plot_neighbors.html
@@ -31,12 +31,17 @@ the k nearest neighbors of a point is assigned to this point.
   * :ref:`example_plot_neighbors.py`: an example of classification
     using nearest neighbor.
 
+
 Regression
 ==========
 
-The :class:`NeighborsBarycenter` estimator implements a nearest-neighbors
-regression method using barycenter weighting of the targets of the
-k-neighbors.
+The :class:`NeighborsRegressor` estimator implements a
+nearest-neighbors regression method by weighting the targets of the
+k-neighbors. Two different weighting strategies are implemented:
+``barycenter`` and ``mean``. ``barycenter`` will apply the weights
+that best reconstruct the point from its neighbors while ``mean`` will
+apply constant weights to each point. This plot shows the behavior of
+both classifier for a simple regression task.
 
 .. figure:: ../auto_examples/images/plot_neighbors_regression.png
    :target: ../auto_examples/plot_neighbors_regression.html

--- a/examples/plot_neighbors.py
+++ b/examples/plot_neighbors.py
@@ -22,7 +22,7 @@ h = .02 # step size in the mesh
 
 # we create an instance of SVM and fit out data. We do not scale our
 # data since we want to plot the support vectors
-clf = neighbors.Neighbors()
+clf = neighbors.NeighborsClassifier()
 clf.fit(X, Y)
 
 # Plot the decision boundary. For that, we will asign a color to each

--- a/examples/plot_neighbors_regression.py
+++ b/examples/plot_neighbors_regression.py
@@ -16,7 +16,7 @@ import numpy as np
 
 np.random.seed(0)
 X = np.sort(5*np.random.rand(40, 1), axis=0)
-T = np.linspace(0, 5, 500)
+T = np.linspace(0, 5, 500)[:, np.newaxis]
 y = np.sin(X).ravel()
 
 # Add noise to targets

--- a/examples/plot_neighbors_regression.py
+++ b/examples/plot_neighbors_regression.py
@@ -5,14 +5,22 @@ k-Nearest Neighbors regression
 
 Demonstrate the resolution of a regression problem
 using a k-Nearest Neighbor and the interpolation of the
-target using barycenter computation.
+target using both barycenter and constant weights.
 
 """
 print __doc__
 
+# Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#         Fabian Pedregosa <fabian.pedregosa@inria.fr>
+#
+# License: BSD, (C) INRIA
+
+
 ###############################################################################
 # Generate sample data
 import numpy as np
+import pylab as pl
+from scikits.learn import neighbors
 
 np.random.seed(0)
 X = np.sort(5*np.random.rand(40, 1), axis=0)
@@ -25,20 +33,17 @@ y[::5] += 1*(0.5 - np.random.rand(8))
 ###############################################################################
 # Fit regression model
 
-from scikits.learn import neighbors
+for i, mode in enumerate(('mean', 'barycenter')):
+    knn = neighbors.NeighborsRegressor(n_neighbors=4, mode=mode)
+    y_ = knn.fit(X, y).predict(T)
 
-knn_barycenter = neighbors.NeighborsBarycenter(n_neighbors=5)
-y_ = knn_barycenter.fit(X, y).predict(T)
+    pl.subplot(2, 1, 1 + i)
+    pl.scatter(X, y, c='k', label='data')
+    pl.plot(T, y_, c='g', label='prediction')
+    pl.axis('tight')
+    pl.legend()
+    pl.title('NeighborsRegressor with %s weights' % mode)
 
-###############################################################################
-# look at the results
-import pylab as pl
-pl.scatter(X, y, c='k', label='data')
-pl.hold('on')
-pl.plot(T, y_, c='g', label='k-NN prediction')
-pl.xlabel('data')
-pl.ylabel('target')
-pl.legend()
-pl.title('k-NN Regression')
+
 pl.show()
 

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -30,14 +30,14 @@ class Neighbors(BaseEstimator, ClassifierMixin):
 
     Examples
     --------
-    >>> samples = [[0.,0.,1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
-    >>> labels = [0, 0, 1, 1]
+    >>> samples = [[0, 0, 1], [1, 0, 0]]
+    >>> labels = [0, 1]
     >>> from scikits.learn.neighbors import Neighbors
-    >>> neigh = Neighbors(n_neighbors=3)
+    >>> neigh = Neighbors(n_neighbors=1)
     >>> neigh.fit(samples, labels)
-    Neighbors(n_neighbors=3, window_size=1)
+    Neighbors(n_neighbors=1, window_size=1)
     >>> print neigh.predict([[0,0,0]])
-    [0]
+    [1]
 
     Notes
     -----

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -250,7 +250,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         neigh = self.ball_tree.data[neigh_ind]
 
         # compute barycenters at each point
-        B = barycenter(X, neigh)
+        B = barycenter_weights(X, neigh)
         labels = self._y[neigh_ind]
 
         return (B * labels).sum(axis=1)
@@ -259,7 +259,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
 ###############################################################################
 # Utils k-NN based Functions
 
-def barycenter(X, Z, cond=None):
+def barycenter_weights(X, Z, cond=None):
     """ 
     Compute barycenter weights of X from Y along the first axis.
 
@@ -368,7 +368,7 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity'):
         ind = ball_tree.query(
             X, k=n_neighbors + 1, return_distance=False)
         A_ind = ind[:, 1:]
-        A_data = barycenter(X, X[A_ind])
+        A_data = barycenter_weights(X, X[A_ind])
 
     else:
         raise ValueError("Unsupported mode type")

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -306,7 +306,7 @@ def barycenter(X, Z, cond=None):
         C = rank_update(alpha, np.dot(A, v), v, a=A)
         B[i, 1:] = linalg.lstsq(
             C[:, 1:], X[i] - C[:, 0] / np.sqrt(n_neighbors), cond=cond,
-            overwrite_a=True, overwrite_b=True)[0]
+            overwrite_a=True, overwrite_b=True)[0].ravel()
         B[i] = rank_update(alpha, v, np.dot(v.T, B[i]), a=B[i])
     return B
 

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -188,7 +188,7 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
     window_size : int
         Window size passed to BallTree
 
-    mode : 'barycenter' | 'distance' | 'mean'
+    mode : {'mean', 'barycenter'}
         Weights to apply to labels.
 
     Examples
@@ -198,7 +198,7 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
     >>> from scikits.learn.neighbors import NeighborsRegressor
     >>> neigh = NeighborsRegressor(n_neighbors=2)
     >>> neigh.fit(X, y)
-    NeighborsRegressor(n_neighbors=2, window_size=1, mode='barycenter')
+    NeighborsRegressor(n_neighbors=2, window_size=1, mode='mean')
     >>> print neigh.predict([[1.5]])
     [ 0.5]
 
@@ -208,7 +208,7 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
     """
 
 
-    def __init__(self, n_neighbors=5, mode='barycenter', window_size=1):
+    def __init__(self, n_neighbors=5, mode='mean', window_size=1):
         self.n_neighbors = n_neighbors
         self.window_size = window_size
         self.mode = mode

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -1,17 +1,12 @@
 """
-k-Nearest Neighbor Algorithm.
-
-Uses BallTree algorithm, which is an efficient way to perform fast
-neighbor searches in high dimensionality.
+Nearest Neighbor related algorithms.
 """
 # Author: Fabian Pedregosa <fabian.pedregosa@inria.fr>
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
-
-# License: BSD
+#
+# License: BSD, (C) INRIA
 
 import numpy as np
-from scipy import stats
-from scipy import linalg
 
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from .ball_tree import BallTree
@@ -36,50 +31,74 @@ class Neighbors(BaseEstimator, ClassifierMixin):
     Examples
     --------
     >>> samples = [[0.,0.,1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
-    >>> labels = [0,0,1,1]
+    >>> labels = [0, 0, 1, 1]
     >>> from scikits.learn.neighbors import Neighbors
     >>> neigh = Neighbors(n_neighbors=3)
     >>> neigh.fit(samples, labels)
     Neighbors(n_neighbors=3, window_size=1)
     >>> print neigh.predict([[0,0,0]])
-    [ 0.]
+    [0]
 
     Notes
     -----
+    Internally uses the ball tree datastructure and algorithm for fast
+    neighbors lookups on high dimensional datasets.
+
+    References
+    ----------
     http://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """
 
     def __init__(self, n_neighbors=5, window_size=1):
-        """Internally uses the ball tree datastructure and algorithm for fast
-        neighbors lookups on high dimensional datasets.
-        """
         self.n_neighbors = n_neighbors
         self.window_size = window_size
 
-    def fit(self, X, Y=()):
-        # we need Y to be an integer, because after we'll use it an index
-        self.Y = np.asanyarray(Y, dtype=np.int)
+    def fit(self, X, Y, **params):
+        """
+        Fit the model using X, y as training data.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Training data.
+
+        y : array-like, shape = [n_samples]
+            Target values, array of integer values.
+
+        params : list of keyword, optional
+            Overwrite keywords from __init__
+        """
+        self._y = np.asanyarray(Y)
+        self._set_params(**params)
+
         self.ball_tree = BallTree(X, self.window_size)
         return self
 
-    def kneighbors(self, data, n_neighbors=None):
+    def kneighbors(self, data, return_distance=True, **params):
         """Finds the K-neighbors of a point.
+
+        Returns distance
 
         Parameters
         ----------
         point : array-like
             The new point.
+
         n_neighbors : int
             Number of neighbors to get (default is the value
             passed to the constructor).
 
+        return_distance : boolean, optional. Defaults to True.
+           If False, distances will not be returned
+
         Returns
         -------
         dist : array
-            Array representing the lengths to point.
+            Array representing the lengths to point, only present if
+            return_distance=True
+
         ind : array
-            Array representing the indices of the nearest points in the
-            population matrix.
+            Indices of the nearest points in the population matrix.
 
         Examples
         --------
@@ -94,27 +113,30 @@ class Neighbors(BaseEstimator, ClassifierMixin):
         >>> neigh.fit(samples, labels)
         Neighbors(n_neighbors=1, window_size=1)
         >>> print neigh.kneighbors([1., 1., 1.])
-        (array(0.5), array(2))
+        (array([ 0.5]), array([2]))
 
         As you can see, it returns [0.5], and [2], which means that the
         element is at distance 0.5 and is the third element of samples
         (indexes start at 0). You can also query for multiple points:
 
-        >>> print neigh.kneighbors([[0., 1., 0.], [1., 0., 1.]])
-        (array([ 0.5       ,  1.11803399]), array([1, 2]))
+        >>> X = [[0., 1., 0.], [1., 0., 1.]]
+        >>> neigh.kneighbors(X, return_distance=False)
+        array([[1],
+               [2]])
 
         """
-        if n_neighbors is None:
-            n_neighbors = self.n_neighbors
-        return self.ball_tree.query(data, k=n_neighbors)
+        self._set_params(**params)
+        return self.ball_tree.query(
+            data, k=self.n_neighbors, return_distance=return_distance)
 
-    def predict(self, T, n_neighbors=None):
+    def predict(self, X, **params):
         """Predict the class labels for the provided data.
 
         Parameters
         ----------
-        test: array
+        X: array
             A 2-D array representing the test point.
+
         n_neighbors : int
             Number of neighbors to get (default is the value
             passed to the constructor).
@@ -132,32 +154,27 @@ class Neighbors(BaseEstimator, ClassifierMixin):
         >>> neigh = Neighbors(n_neighbors=1)
         >>> neigh.fit(samples, labels)
         Neighbors(n_neighbors=1, window_size=1)
-        >>> print neigh.predict([.2, .1, .2])
-        0
-        >>> print neigh.predict([[0., -1., 0.], [3., 2., 0.]])
-        [0 1]
+        >>> neigh.predict([.2, .1, .2])
+        array([0])
+        >>> neigh.predict([[0., -1., 0.], [3., 2., 0.]])
+        array([0, 1])
         """
-        T = np.asanyarray(T)
-        if n_neighbors is None:
-            n_neighbors = self.n_neighbors
-        return _predict_from_BallTree(self.ball_tree, self.Y, T, n_neighbors)
+        X = np.atleast_2d(X)
+        self._set_params(**params)
 
+        ind = self.ball_tree.query(
+            X, self.n_neighbors, return_distance=False)
+        pred_labels = self._y[ind]
 
-def _predict_from_BallTree(ball_tree, Y, test, n_neighbors):
-    """Predict target from BallTree object containing the data points.
+        from scipy import stats
+        mode, _ = stats.mode(pred_labels, axis=1)
+        return mode.flatten().astype(np.int)
 
-    This is a helper method, not meant to be used directly. It will
-    not check that input is of the correct type.
-    """
-    Y_ = Y[ball_tree.query(test, k=n_neighbors, return_distance=False)]
-    if n_neighbors == 1:
-        return Y_
-    return (stats.mode(Y_, axis=1)[0]).ravel()
 
 ###############################################################################
 # Neighbors Barycenter class for regression problems
 
-class NeighborsBarycenter(BaseEstimator, RegressorMixin):
+class NeighborsBarycenter(Neighbors, RegressorMixin):
     """Regression based on k-Nearest Neighbor Algorithm.
 
     The target is predicted by local interpolation of the targets
@@ -169,11 +186,14 @@ class NeighborsBarycenter(BaseEstimator, RegressorMixin):
     X : array-like, shape (n_samples, n_features)
         The data points to be indexed. This array is not copied, and so
         modifying this data will result in bogus results.
-    y : array
+
+    y : array-like, shape (n_samples)
         An array representing labels for the data (only arrays of
         integers are supported).
+
     n_neighbors : int
         default number of neighbors.
+
     window_size : int
         Window size passed to BallTree
 
@@ -193,25 +213,14 @@ class NeighborsBarycenter(BaseEstimator, RegressorMixin):
     http://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """
 
-    def __init__(self, n_neighbors=5, window_size=1):
-        """Internally uses the ball tree datastructure and algorithm for fast
-        neighbors lookups on high dimensional datasets.
-        """
-        self.n_neighbors = n_neighbors
-        self.window_size = window_size
-
-    def fit(self, X, y, copy=True):
-        self._y = np.array(y, copy=copy)
-        self.ball_tree = BallTree(X, self.window_size)
-        return self
-
-    def predict(self, T, n_neighbors=None):
+    def predict(self, X, **params):
         """Predict the target for the provided data.
 
         Parameters
         ----------
-        T : array
+        X : array
             A 2-D array representing the test data.
+
         n_neighbors : int
             Number of neighbors to get (default is the value
             passed to the constructor).
@@ -229,70 +238,89 @@ class NeighborsBarycenter(BaseEstimator, RegressorMixin):
         >>> neigh = NeighborsBarycenter(n_neighbors=2)
         >>> neigh.fit(X, y)
         NeighborsBarycenter(n_neighbors=2, window_size=1)
-        >>> print neigh.predict([[.5], [1.5]])
-        [ 0.   0.5]
+        >>> neigh.predict([[.5], [1.5]])
+        array([ 0. ,  0.5])
         """
-        T = np.asanyarray(T)
-        if T.ndim == 1:
-            T = T[:, None]
-        if n_neighbors is None:
-            n_neighbors = self.n_neighbors
-        A = kneighbors_graph(T, n_neighbors=n_neighbors, weight="barycenter",
-                                  ball_tree=self.ball_tree)
-        return A * self._y
+        X = np.atleast_2d(np.asanyarray(X))
+        self._set_params(**params)
+
+        # get neighbors of X
+        neigh_ind = self.ball_tree.query(
+            X, k=self.n_neighbors, return_distance=False)
+        neigh = self.ball_tree.data[neigh_ind]
+
+        # compute barycenters at each point
+        B = barycenter(X, neigh)
+        labels = self._y[neigh_ind]
+
+        return (B * labels).sum(axis=1)
+
 
 ###############################################################################
 # Utils k-NN based Functions
 
-def barycenter_weights(x, X_neighbors, tol=1e-3):
-    """Computes barycenter weights
+def barycenter(X, Y, eps=1e-6):
+    """
+    Compute barycenter weights of X from Y along the first axis.
 
-    We estimate the weights to assign to each point in X_neighbors
-    to recover the point x. The barycenter weights sum to 1.
-    If x do not belong to the span of X_neighbors, it's the
-    projection of x onto the span that is recovered.
+    We estimate the weights to assign to each point in Y[i] to recover
+    the point X[i]. The barycenter weights sum to 1.
 
     Parameters
     ----------
-    x : array
-        a 1D array
+    X : array-like, shape (n_samples, n_dim)
 
-    X_neighbors : array
-        a 2D array containing samples
+    Y : array-like, shape (n_samples, n_neighbors, n_dim)
 
-    tol : float
-        tolerance
+    eps: float, optional
+        Amount of regularization to add to the diagonal of the Gram
+        matrix.
 
     Returns
     -------
-    array of barycenter weights that sum to 1
+    B : array-like, shape (n_samples, n_neighbors)
 
-    Examples
-    --------
-    >>> from scikits.learn.neighbors import barycenter_weights
-    >>> X_neighbors, x = [[0], [2]], [0.5]
-    >>> barycenter_weights(x, X_neighbors)
-    array([ 0.74968789,  0.25031211])
+    Reference
+    ---------
+    'An introduction to Locally Linear Embeddings', Saul & Roweis
     """
-    x = np.asanyarray(x)
-    X_neighbors = np.asanyarray(X_neighbors)
-    if x.ndim == 1:
-        x = x[None, :]
-    if X_neighbors.ndim == 1:
-        X_neighbors = X_neighbors[:, None]
-    z = x - X_neighbors
-    gram = np.dot(z, z.T)
-    # Add constant on diagonal to avoid singular matrices
-    diag_stride = gram.shape[0] + 1
-    gram.flat[::diag_stride] += tol * np.trace(gram)
-    w = linalg.solve(gram, np.ones(len(X_neighbors)))
-    w /= np.sum(w)
-    return w
+    from scipy import linalg
+
+    X = np.atleast_2d(X)
+    if X.dtype.kind == 'i':
+        # integer arrays truncate regularization
+        X = X.astype(np.float)
+
+    Y = np.asanyarray(Y)
+    n_samples, n_neighbors = X.shape[0], Y.shape[1]
+
+    B = np.empty((n_samples, n_neighbors), dtype=X.dtype)
+
+    Z = X[:, np.newaxis] - Y
+
+    # Compute the weights that best reconstruct each data point
+    # from its neighbors, minimizing the cost function:
+    #
+    #     phi(X) = Sum_i|X_i - Sum_j{W_ij X_j}|
+    #
+
+    for i, D in enumerate(Z):
+
+        # Compute Gram matrix
+        Gram = np.dot(D, D.T)
+
+        # Add regularization
+        Gram.flat[::n_neighbors + 1] += eps * np.trace(Gram)
+
+        # Solve the system
+        B[i] = linalg.solve(Gram, np.ones(Gram.shape[0]), sym_pos=True)
+        B[i] /= np.sum(B[i])
+
+    return B
 
 
-def kneighbors_graph(X, n_neighbors, weight=None, ball_tree=None,
-                     window_size=1, drop_first=False):
-    """Computes the (weighted) graph of k-Neighbors
+def kneighbors_graph(X, n_neighbors, mode='adjacency', eps=1e-6):
+    """Computes the (weighted) graph of k-Neighbors for points in X
 
     Parameters
     ----------
@@ -302,96 +330,64 @@ def kneighbors_graph(X, n_neighbors, weight=None, ball_tree=None,
     n_neighbors : int
         Number of neighbors for each sample.
 
-    weight : None (default)
-        Weights to apply on graph edges. If weight is None
-        then no weighting is applied (1 for each edge).
-        If weight equals 'distance' the edge weight is the
-        euclidian distance. If weight equals 'barycenter'
-        the weights are barycenter weights estimated by
-        solving a linear system for each point.
+    mode : 'adjacency' | 'distance' | 'barycenter'
+        Type of returned matrix: 'adjacency' will return the adjacency
+        matrix with ones and zeros, in 'distance' the edges are
+        euclidian distance between points. In 'barycenter' they are
+        barycenter weights estimated by solving a linear system for
+        each point.
 
-    ball_tree : None or instance of precomputed BallTree
-
-    window_size : int
-        Window size pass to the BallTree
-
-    drop_first : bool
-        Drops the first neighbor (Default: False)
+    eps : float
+        Amount of regularization to add to the Gram matrix. Only
+        significant in the case of weight='barycenter'.
 
     Returns
     -------
-    A : sparse matrix, shape = [n_samples, n_samples]
-        A is returned as CSR sparse matrix
-        A[i,j] = weight of edge that connects i to j
+
+    A : CSR sparse matrix, shape = [n_samples, n_samples]
+        A[i,j] is assigned the weight of edge that connects i to j.
 
     Examples
     --------
-    >>> X = [[0], [2], [1]]
+    >>> X = [[0], [3], [1]]
     >>> from scikits.learn.neighbors import kneighbors_graph
     >>> A = kneighbors_graph(X, 2)
     >>> A.todense()
-    matrix([[1, 0, 1],
-            [0, 1, 1],
-            [0, 1, 1]])
+    matrix([[ 1.,  0.,  1.],
+            [ 0.,  1.,  1.],
+            [ 1.,  0.,  1.]])
     """
     from scipy import sparse
     X = np.asanyarray(X)
+
     n_samples = X.shape[0]
 
-    if ball_tree is None:
-        ball_tree = BallTree(X, window_size)
+    ball_tree = BallTree(X)
 
-    dist, ind = ball_tree.query(X, k=n_neighbors)
-    if drop_first:
-        ind = ind[:, 1:]
-        dist = dist[:, 1:]
-        n_neighbors -= 1
+    # CSR matrix A is represented as A_data, A_ind and A_indptr.
+    n_nonzero = n_neighbors * n_samples
+    A_indptr = np.arange(0, n_nonzero + 1, n_neighbors)
 
-    # allocate space for sparse csr matrix
-    if weight is None:
-        data = np.empty(ind.shape, dtype=np.int)
-    else:
-        data = np.empty(ind.shape, dtype=np.float)
-    data_indices = np.empty(ind.shape, dtype=np.int)
-    data_indptr = np.empty(1 + n_samples, dtype=np.int)
-    data_indptr[0] = 0
+    if mode is 'adjacency':
+        A_data = np.ones((n_samples, n_neighbors))
+        A_ind = ball_tree.query(
+            X, k=n_neighbors, return_distance=False)
 
-    if weight is None:
-        for i, li in enumerate(ind):
-            if n_neighbors > 1:
-                data[i] = np.ones(n_neighbors)
-            else:
-                data[i] = 1.0
+    elif mode is 'distance':
+        data, ind = ball_tree.query(X, k=n_neighbors + 1)
+        A_data, A_ind = data[:, 1:], ind[:, 1:]
 
-            data_indices[i] = li
-            data_indptr[i + 1] = data_indptr[i] + data.shape[1]
-
-    elif weight is 'distance':
-        for i, li in enumerate(ind):
-            if n_neighbors > 1:
-                data[i] = dist[i, :]
-            else:
-                data[i] = dist[i, 0]
-
-            data_indices[i] = li
-            data_indptr[i + 1] = data_indptr[i] + data.shape[1]
-
-    elif weight is 'barycenter':
-        for i, li in enumerate(ind):
-            if n_neighbors > 1:
-                X_i = ball_tree.data[li]
-                data[i] = barycenter_weights(X[i], X_i)
-            else:
-                data[i] = 1.0
-
-            data_indices[i] = li
-            data_indptr[i + 1] = data_indptr[i] + data.shape[1]
+    elif mode is 'barycenter':
+        ind = ball_tree.query(
+            X, k=n_neighbors + 1, return_distance=False)
+        A_ind = ind[:, 1:]
+        A_data = barycenter(X, X[A_ind], eps=eps)
 
     else:
-        raise ValueError("Unknown weight type")
+        raise ValueError("Unsupported mode type")
 
     A = sparse.csr_matrix(
-        (data.reshape(-1), data_indices.reshape(-1), data_indptr),
-        shape=(n_samples, ball_tree.data.shape[0]))
+        (A_data.reshape(-1), A_ind.reshape(-1), A_indptr),
+        shape=(n_samples, n_samples))
 
     return A

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -213,7 +213,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
     http://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """
 
-    def predict(self, X, **params):
+    def predict(self, X, eps=1e-6, **params):
         """Predict the target for the provided data.
 
         Parameters
@@ -221,9 +221,12 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         X : array
             A 2-D array representing the test data.
 
-        n_neighbors : int
+        n_neighbors : int, optional
             Number of neighbors to get (default is the value
             passed to the constructor).
+
+        eps : float, optional
+           Amount of regularization to add to the Gram matrix.
 
         Returns
         -------
@@ -250,7 +253,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         neigh = self.ball_tree.data[neigh_ind]
 
         # compute barycenters at each point
-        B = barycenter(X, neigh)
+        B = barycenter(X, neigh, eps=eps)
         labels = self._y[neigh_ind]
 
         return (B * labels).sum(axis=1)
@@ -361,7 +364,6 @@ def kneighbors_graph(X, n_neighbors, mode='adjacency', eps=1e-6):
     X = np.asanyarray(X)
 
     n_samples = X.shape[0]
-
     ball_tree = BallTree(X)
 
     # CSR matrix A is represented as A_data, A_ind and A_indptr.

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -12,19 +12,14 @@ from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from .ball_tree import BallTree
 
 
-class Neighbors(BaseEstimator, ClassifierMixin):
+class NeighborsClassifier(BaseEstimator, ClassifierMixin):
     """Classifier implementing k-Nearest Neighbor Algorithm.
 
     Parameters
     ----------
-    data : array-like, shape (n, k)
-        The data points to be indexed. This array is not copied, and so
-        modifying this data will result in bogus results.
-    labels : array
-        An array representing labels for the data (only arrays of
-        integers are supported).
     n_neighbors : int
         default number of neighbors.
+
     window_size : int
         Window size passed to BallTree
 
@@ -32,10 +27,10 @@ class Neighbors(BaseEstimator, ClassifierMixin):
     --------
     >>> samples = [[0, 0, 1], [1, 0, 0]]
     >>> labels = [0, 1]
-    >>> from scikits.learn.neighbors import Neighbors
-    >>> neigh = Neighbors(n_neighbors=1)
+    >>> from scikits.learn.neighbors import NeighborsClassifier
+    >>> neigh = NeighborsClassifier(n_neighbors=1)
     >>> neigh.fit(samples, labels)
-    Neighbors(n_neighbors=1, window_size=1)
+    NeighborsClassifier(n_neighbors=1, window_size=1)
     >>> print neigh.predict([[0,0,0]])
     [1]
 
@@ -102,16 +97,16 @@ class Neighbors(BaseEstimator, ClassifierMixin):
 
         Examples
         --------
-        In the following example, we construnct a Neighbors class from an
+        In the following example, we construnct a NeighborsClassifier class from an
         array representing our data set and ask who's the closest point to
         [1,1,1]
 
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
         >>> labels = [0, 0, 1]
-        >>> from scikits.learn.neighbors import Neighbors
-        >>> neigh = Neighbors(n_neighbors=1)
+        >>> from scikits.learn.neighbors import NeighborsClassifier
+        >>> neigh = NeighborsClassifier(n_neighbors=1)
         >>> neigh.fit(samples, labels)
-        Neighbors(n_neighbors=1, window_size=1)
+        NeighborsClassifier(n_neighbors=1, window_size=1)
         >>> print neigh.kneighbors([1., 1., 1.])
         (array([ 0.5]), array([2]))
 
@@ -150,10 +145,10 @@ class Neighbors(BaseEstimator, ClassifierMixin):
         --------
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
         >>> labels = [0, 0, 1]
-        >>> from scikits.learn.neighbors import Neighbors
-        >>> neigh = Neighbors(n_neighbors=1)
+        >>> from scikits.learn.neighbors import NeighborsClassifier
+        >>> neigh = NeighborsClassifier(n_neighbors=1)
         >>> neigh.fit(samples, labels)
-        Neighbors(n_neighbors=1, window_size=1)
+        NeighborsClassifier(n_neighbors=1, window_size=1)
         >>> neigh.predict([.2, .1, .2])
         array([0])
         >>> neigh.predict([[0., -1., 0.], [3., 2., 0.]])
@@ -172,39 +167,38 @@ class Neighbors(BaseEstimator, ClassifierMixin):
 
 
 ###############################################################################
-# Neighbors Barycenter class for regression problems
+# NeighborsRegressor class for regression problems
 
-class NeighborsBarycenter(Neighbors, RegressorMixin):
+class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
     """Regression based on k-Nearest Neighbor Algorithm.
 
     The target is predicted by local interpolation of the targets
     associated of the k-Nearest Neighbors in the training set.
-    The interpolation weights correspond to barycenter weights.
+
+    Different modes for estimating the result can be set via parameter
+    mode. 'barycenter' will apply the weights that best reconstruct
+    the point from its neighbors while 'mean' will apply constant
+    weights to each point.
 
     Parameters
     ----------
-    X : array-like, shape (n_samples, n_features)
-        The data points to be indexed. This array is not copied, and so
-        modifying this data will result in bogus results.
-
-    y : array-like, shape (n_samples)
-        An array representing labels for the data (only arrays of
-        integers are supported).
-
     n_neighbors : int
         default number of neighbors.
 
     window_size : int
         Window size passed to BallTree
 
+    mode : 'barycenter' | 'distance' | 'mean'
+        Weights to apply to labels.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]
     >>> y = [0, 0, 1, 1]
-    >>> from scikits.learn.neighbors import NeighborsBarycenter
-    >>> neigh = NeighborsBarycenter(n_neighbors=2)
+    >>> from scikits.learn.neighbors import NeighborsRegressor
+    >>> neigh = NeighborsRegressor(n_neighbors=2)
     >>> neigh.fit(X, y)
-    NeighborsBarycenter(n_neighbors=2, window_size=1)
+    NeighborsRegressor(n_neighbors=2, window_size=1, mode='barycenter')
     >>> print neigh.predict([[1.5]])
     [ 0.5]
 
@@ -212,6 +206,13 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
     -----
     http://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """
+
+
+    def __init__(self, n_neighbors=5, mode='barycenter', window_size=1):
+        self.n_neighbors = n_neighbors
+        self.window_size = window_size
+        self.mode = mode
+
 
     def predict(self, X, **params):
         """Predict the target for the provided data.
@@ -229,32 +230,31 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         -------
         y: array
             List of target values (one for each data sample).
-
-        Examples
-        --------
-        >>> X = [[0], [1], [2]]
-        >>> y = [0, 0, 1]
-        >>> from scikits.learn.neighbors import NeighborsBarycenter
-        >>> neigh = NeighborsBarycenter(n_neighbors=2)
-        >>> neigh.fit(X, y)
-        NeighborsBarycenter(n_neighbors=2, window_size=1)
-        >>> neigh.predict([[.5], [1.5]])
-        array([ 0. ,  0.5])
         """
         X = np.atleast_2d(np.asanyarray(X))
         self._set_params(**params)
 
-        # get neighbors of X
+#
+#       .. compute neighbors ..
+#
         neigh_ind = self.ball_tree.query(
             X, k=self.n_neighbors, return_distance=False)
         neigh = self.ball_tree.data[neigh_ind]
 
-        # compute barycenters at each point
-        B = barycenter_weights(X, neigh)
-        labels = self._y[neigh_ind]
+#
+#       .. return labels ..
+#
+        if self.mode == 'barycenter':
+            W = barycenter_weights(X, neigh)
+            return (W * self._y[neigh_ind]).sum(axis=1)
 
-        return (B * labels).sum(axis=1)
+        elif self.mode == 'mean':
+            return np.mean(self._y[neigh_ind], axis=1)
 
+        else:
+            raise ValueError(
+                'Unsupported mode, must be one of "barycenter" or '
+                '"mean" but got %s instead' % self.mode)
 
 ###############################################################################
 # Utils k-NN based Functions
@@ -281,6 +281,9 @@ def barycenter_weights(X, Z, cond=None):
     -------
     B : array-like, shape (n_samples, n_neighbors)
 
+    Notes
+    -----
+    See developers note for more information.
     """
 #
 #       .. local variables ..
@@ -308,6 +311,7 @@ def barycenter_weights(X, Z, cond=None):
             C[:, 1:], X[i] - C[:, 0] / np.sqrt(n_neighbors), cond=cond,
             overwrite_a=True, overwrite_b=True)[0].ravel()
         B[i] = rank_update(alpha, v, np.dot(v.T, B[i]), a=B[i])
+
     return B
 
 
@@ -345,16 +349,20 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity'):
             [ 0.,  1.,  1.],
             [ 1.,  0.,  1.]])
     """
+
+#
+#       .. local variables ..
+#
     from scipy import sparse
     X = np.asanyarray(X)
-
     n_samples = X.shape[0]
     ball_tree = BallTree(X)
-
-    # CSR matrix A is represented as A_data, A_ind and A_indptr.
     n_nonzero = n_neighbors * n_samples
     A_indptr = np.arange(0, n_nonzero + 1, n_neighbors)
 
+#
+#       .. construct CSR matrix ..
+#
     if mode is 'connectivity':
         A_data = np.ones((n_samples, n_neighbors))
         A_ind = ball_tree.query(
@@ -371,7 +379,9 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity'):
         A_data = barycenter_weights(X, X[A_ind])
 
     else:
-        raise ValueError("Unsupported mode type")
+        raise ValueError(
+            'Unsupported mode, must be one of "connectivity", '
+            '"distance" or "barycenter" but got %s instead' % mode)
 
     A = sparse.csr_matrix(
         (A_data.reshape(-1), A_ind.reshape(-1), A_indptr),

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -322,7 +322,7 @@ def barycenter(X, Y, eps=1e-6):
     return B
 
 
-def kneighbors_graph(X, n_neighbors, mode='adjacency', eps=1e-6):
+def kneighbors_graph(X, n_neighbors, mode='connectivity', eps=1e-6):
     """Computes the (weighted) graph of k-Neighbors for points in X
 
     Parameters
@@ -333,12 +333,12 @@ def kneighbors_graph(X, n_neighbors, mode='adjacency', eps=1e-6):
     n_neighbors : int
         Number of neighbors for each sample.
 
-    mode : 'adjacency' | 'distance' | 'barycenter'
-        Type of returned matrix: 'adjacency' will return the adjacency
-        matrix with ones and zeros, in 'distance' the edges are
-        euclidian distance between points. In 'barycenter' they are
-        barycenter weights estimated by solving a linear system for
-        each point.
+    mode : 'connectivity' | 'distance' | 'barycenter'
+        Type of returned matrix: 'connectivity' will return the
+        connectivity matrix with ones and zeros, in 'distance' the
+        edges are euclidian distance between points. In 'barycenter'
+        they are barycenter weights estimated by solving a linear
+        system for each point.
 
     eps : float
         Amount of regularization to add to the Gram matrix. Only
@@ -370,7 +370,7 @@ def kneighbors_graph(X, n_neighbors, mode='adjacency', eps=1e-6):
     n_nonzero = n_neighbors * n_samples
     A_indptr = np.arange(0, n_nonzero + 1, n_neighbors)
 
-    if mode is 'adjacency':
+    if mode is 'connectivity':
         A_data = np.ones((n_samples, n_neighbors))
         A_ind = ball_tree.query(
             X, k=n_neighbors, return_distance=False)

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -213,7 +213,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
     http://en.wikipedia.org/wiki/K-nearest_neighbor_algorithm
     """
 
-    def predict(self, X, eps=1e-6, **params):
+    def predict(self, X, **params):
         """Predict the target for the provided data.
 
         Parameters
@@ -224,9 +224,6 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         n_neighbors : int, optional
             Number of neighbors to get (default is the value
             passed to the constructor).
-
-        eps : float, optional
-           Amount of regularization to add to the Gram matrix.
 
         Returns
         -------
@@ -253,7 +250,7 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
         neigh = self.ball_tree.data[neigh_ind]
 
         # compute barycenters at each point
-        B = barycenter(X, neigh, eps=eps)
+        B = barycenter(X, neigh)
         labels = self._y[neigh_ind]
 
         return (B * labels).sum(axis=1)
@@ -262,8 +259,8 @@ class NeighborsBarycenter(Neighbors, RegressorMixin):
 ###############################################################################
 # Utils k-NN based Functions
 
-def barycenter(X, Y, eps=1e-6):
-    """
+def barycenter(X, Z, cond=None):
+    """ 
     Compute barycenter weights of X from Y along the first axis.
 
     We estimate the weights to assign to each point in Y[i] to recover
@@ -273,56 +270,48 @@ def barycenter(X, Y, eps=1e-6):
     ----------
     X : array-like, shape (n_samples, n_dim)
 
-    Y : array-like, shape (n_samples, n_neighbors, n_dim)
+    Z : array-like, shape (n_samples, n_neighbors, n_dim)
 
-    eps: float, optional
-        Amount of regularization to add to the diagonal of the Gram
-        matrix.
+    cond: float, optional
+        Cutoff for small singular values; used to determine effective
+        rank of Z[i]. Singular values smaller than ``rcond *
+        largest_singular_value`` are considered zero.
 
     Returns
     -------
     B : array-like, shape (n_samples, n_neighbors)
 
-    Reference
-    ---------
-    'An introduction to Locally Linear Embeddings', Saul & Roweis
     """
+#
+#       .. local variables ..
+#
     from scipy import linalg
-
-    X = np.atleast_2d(X)
+    X, Z = map(np.asanyarray, (X, Z))
+    n_samples, n_neighbors = X.shape[0], Z.shape[1]
     if X.dtype.kind == 'i':
-        # integer arrays truncate regularization
         X = X.astype(np.float)
-
-    Y = np.asanyarray(Y)
-    n_samples, n_neighbors = X.shape[0], Y.shape[1]
-
     B = np.empty((n_samples, n_neighbors), dtype=X.dtype)
+    v = np.ones(n_neighbors, dtype=X.dtype)
+    rank_update, = linalg.get_blas_funcs(('ger',), (X,))
 
-    Z = X[:, np.newaxis] - Y
-
-    # Compute the weights that best reconstruct each data point
-    # from its neighbors, minimizing the cost function:
-    #
-    #     phi(X) = Sum_i|X_i - Sum_j{W_ij X_j}|
-    #
-
-    for i, D in enumerate(Z):
-
-        # Compute Gram matrix
-        Gram = np.dot(D, D.T)
-
-        # Add regularization
-        Gram.flat[::n_neighbors + 1] += eps * np.trace(Gram)
-
-        # Solve the system
-        B[i] = linalg.solve(Gram, np.ones(Gram.shape[0]), sym_pos=True)
-        B[i] /= np.sum(B[i])
-
+#
+#       .. constrained least squares ..
+#
+    v[0] -= np.sqrt(n_neighbors)
+    B[:, 0] = 1. / np.sqrt(n_neighbors)
+    if n_neighbors <= 1:
+        return B
+    alpha = - 1. / (n_neighbors - np.sqrt(n_neighbors))
+    for i, A in enumerate(Z.transpose(0, 2, 1)):
+        C = rank_update(alpha, np.dot(A, v), v, a=A)
+        B[i, 1:] = linalg.lstsq(
+            C[:, 1:], X[i] - C[:, 0] / np.sqrt(n_neighbors), cond=cond,
+            overwrite_a=True, overwrite_b=True)[0]
+        B[i] = rank_update(alpha, v, np.dot(v.T, B[i]), a=B[i])
     return B
 
 
-def kneighbors_graph(X, n_neighbors, mode='connectivity', eps=1e-6):
+def kneighbors_graph(X, n_neighbors, mode='connectivity'):
     """Computes the (weighted) graph of k-Neighbors for points in X
 
     Parameters
@@ -339,10 +328,6 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', eps=1e-6):
         edges are euclidian distance between points. In 'barycenter'
         they are barycenter weights estimated by solving a linear
         system for each point.
-
-    eps : float
-        Amount of regularization to add to the Gram matrix. Only
-        significant in the case of weight='barycenter'.
 
     Returns
     -------
@@ -383,7 +368,7 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', eps=1e-6):
         ind = ball_tree.query(
             X, k=n_neighbors + 1, return_distance=False)
         A_ind = ind[:, 1:]
-        A_data = barycenter(X, X[A_ind], eps=eps)
+        A_data = barycenter(X, X[A_ind])
 
     else:
         raise ValueError("Unsupported mode type")

--- a/scikits/learn/src/BallTree.cpp
+++ b/scikits/learn/src/BallTree.cpp
@@ -243,31 +243,6 @@ BallTree_query(BallTreeObject *self, PyObject *args, PyObject *kwds){
         }
     }
 
-  //if only one neighbor is requested, then resize the neighbors array
-    if(k==1){
-        PyArray_Dims dims;
-        dims.ptr = PyArray_DIMS(arr);
-        dims.len = PyArray_NDIM(arr)-1;
-
-    //PyArray_Resize returns None - this needs to be picked
-    // up and dereferenced.
-        PyObject *NoneObj = PyArray_Resize( (PyArrayObject*)nbrs, &dims,
-            0, NPY_ANYORDER );
-        if (NoneObj == NULL){
-            goto fail;
-        }
-        Py_DECREF(NoneObj);
-
-        if(return_distance){
-            NoneObj = PyArray_Resize( (PyArrayObject*)dist, &dims,
-                0, NPY_ANYORDER );
-            if (NoneObj == NULL){
-                goto fail;
-            }
-            Py_DECREF(NoneObj);
-        }
-    }
-
     if(return_distance){
         Py_DECREF(arr_iter);
         Py_DECREF(nbrs_iter);

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -65,59 +65,56 @@ def test_neighbors_barycenter():
     y = [0, 0, 1, 1]
     neigh = neighbors.NeighborsBarycenter(n_neighbors=2)
     neigh.fit(X, y)
-    assert_equal(neigh.predict([[1.5]]), 0.5)
+    assert_array_almost_equal(neigh.predict([[1.5]]), [0.5])
 
 
 def test_kneighbors_graph():
     """
     Test kneighbors_graph to build the k-Nearest Neighbor graph.
     """
-    X = [[0, 0], [1.01, 0], [2, 0]]
+    X = [[0, 1], [1.01, 1.], [2, 0]]
 
     # n_neighbors = 1
     A = neighbors.kneighbors_graph(X, 1, mode='connectivity')
     assert_array_equal(A.todense(), np.eye(A.shape[0]))
 
     A = neighbors.kneighbors_graph(X, 1, mode='distance')
-    assert_array_equal(
+    assert_array_almost_equal(
         A.todense(),
-        [[ 0.  ,  1.01,  0.  ],
-         [ 0.  ,  0.  ,  0.99],
-         [ 0.  ,  0.99,  0.  ]])
+        [[ 0.        ,  1.01      ,  0.        ],
+         [ 1.01      ,  0.        ,  0.        ],
+         [ 0.        ,  1.40716026,  0.        ]])
 
     A = neighbors.kneighbors_graph(X, 1, mode='barycenter')
-    assert_array_equal(
+    assert_array_almost_equal(
         A.todense(),
         [[ 0.,  1.,  0.],
-        [ 0.,  0.,  1.],
-        [ 0.,  1.,  0.]])
+         [ 1.,  0.,  0.],
+         [ 0.,  1.,  0.]])
 
     # n_neigbors = 2
     A = neighbors.kneighbors_graph(X, 2, mode='connectivity')
     assert_array_equal(
         A.todense(),
         [[ 1.,  1.,  0.],
-         [ 0.,  1.,  1.],
+         [ 1.,  1.,  0.],
          [ 0.,  1.,  1.]])
 
     A = neighbors.kneighbors_graph(X, 2, mode='distance')
     assert_array_almost_equal(
         A.todense(),
-        [[ 0.  ,  1.01,  2.  ],
-        [ 1.01,  0.  ,  0.99],
-        [ 2.  ,  0.99,  0.  ]])
+        [[ 0.        ,  1.01      ,  2.23606798],
+         [ 1.01      ,  0.        ,  1.40716026],
+         [ 2.23606798,  1.40716026,  0.        ]])
 
     A = neighbors.kneighbors_graph(X, 2, mode='barycenter')
     # check that columns sum to one
     assert_array_almost_equal(np.sum(A.todense(), 1), np.ones((3, 1)))
     assert_array_almost_equal(
         A.todense(),
-        [[ 0.        ,  2.02018645, -1.02018645],
-        [ 0.49500001,  0.        ,  0.50499999],
-        [-0.98018357,  1.98018357,  0.        ]])
-    # check that we can reconstruct X from A
-    assert_array_almost_equal(
-        X, A.dot(X), decimal=3)
+        [[ 0.        ,  1.5049745 , -0.5049745 ],
+        [ 0.596     ,  0.        ,  0.404     ],
+        [-0.98019802,  1.98019802,  0.        ]])
 
     # n_neighbors = 3
     A = neighbors.kneighbors_graph(X, 3, mode='connectivity')

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -75,7 +75,7 @@ def test_kneighbors_graph():
     X = [[0, 0], [1.01, 0], [2, 0]]
 
     # n_neighbors = 1
-    A = neighbors.kneighbors_graph(X, 1, mode='adjacency')
+    A = neighbors.kneighbors_graph(X, 1, mode='connectivity')
     assert_array_equal(A.todense(), np.eye(A.shape[0]))
 
     A = neighbors.kneighbors_graph(X, 1, mode='distance')
@@ -93,7 +93,7 @@ def test_kneighbors_graph():
         [ 0.,  1.,  0.]])
 
     # n_neigbors = 2
-    A = neighbors.kneighbors_graph(X, 2, mode='adjacency')
+    A = neighbors.kneighbors_graph(X, 2, mode='connectivity')
     assert_array_equal(
         A.todense(),
         [[ 1.,  1.,  0.],
@@ -120,7 +120,7 @@ def test_kneighbors_graph():
         X, A.dot(X), decimal=3)
 
     # n_neighbors = 3
-    A = neighbors.kneighbors_graph(X, 3, mode='adjacency')
+    A = neighbors.kneighbors_graph(X, 3, mode='connectivity')
     assert_array_almost_equal(
         A.todense(),
         [[1, 1, 1], [1, 1, 1], [1, 1, 1]])

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal, \
-                          assert_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from scikits.learn import neighbors
 

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -16,20 +16,20 @@ def test_neighbors_1D():
     Y = [0]*(n/2) + [1]*(n/2)
 
     # n_neighbors = 1
-    knn = neighbors.Neighbors(n_neighbors=1)
+    knn = neighbors.NeighborsClassifier(n_neighbors=1)
     knn.fit(X, Y)
     test = [[i + 0.01] for i in range(0, n/2)] + \
            [[i - 0.01] for i in range(n/2, n)]
     assert_array_equal(knn.predict(test), [0]*3 + [1]*3)
 
     # n_neighbors = 2
-    knn = neighbors.Neighbors(n_neighbors=2)
+    knn = neighbors.NeighborsClassifier(n_neighbors=2)
     knn.fit(X, Y)
     assert_array_equal(knn.predict(test), [0]*4 + [1]*2)
 
 
     # n_neighbors = 3
-    knn = neighbors.Neighbors(n_neighbors=3)
+    knn = neighbors.NeighborsClassifier(n_neighbors=3)
     knn.fit(X, Y)
     assert_array_equal(knn.predict([[i +0.01] for i in range(0, n/2)]),
                         [0 for i in range(n/2)])
@@ -49,22 +49,27 @@ def test_neighbors_2D():
         (-1, 0), (-1, -1), (0, -1)) # label 1
     n_2 = len(X)/2
     Y = [0]*n_2 + [1]*n_2
-    knn = neighbors.Neighbors()
+    knn = neighbors.NeighborsClassifier()
     knn.fit(X, Y)
 
     prediction = knn.predict([[0, .1], [0, -.1], [.1, 0], [-.1, 0]])
     assert_array_equal(prediction, [0, 1, 0, 1])
 
 
-def test_neighbors_barycenter():
+def test_neighbors_regressor():
     """
-    NeighborsBarycenter for regression using k-NN
+    NeighborsRegressor for regression using k-NN
     """
     X = [[0], [1], [2], [3]]
     y = [0, 0, 1, 1]
-    neigh = neighbors.NeighborsBarycenter(n_neighbors=2)
+    neigh = neighbors.NeighborsRegressor(n_neighbors=3)
     neigh.fit(X, y)
-    assert_array_almost_equal(neigh.predict([[1.5]]), [0.5])
+    assert_array_almost_equal(
+        neigh.predict([[1.], [1.5]]), [0.333, 0.583], decimal=3)
+    neigh.fit(X, y, mode='mean')
+    assert_array_almost_equal(
+        neigh.predict([[1.], [1.5]]), [0.333, 0.333], decimal=3)
+    
 
 
 def test_kneighbors_graph():

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -63,7 +63,7 @@ def test_neighbors_regressor():
     X = [[0], [1], [2], [3]]
     y = [0, 0, 1, 1]
     neigh = neighbors.NeighborsRegressor(n_neighbors=3)
-    neigh.fit(X, y)
+    neigh.fit(X, y, mode='barycenter')
     assert_array_almost_equal(
         neigh.predict([[1.], [1.5]]), [0.333, 0.583], decimal=3)
     neigh.fit(X, y, mode='mean')


### PR DESCRIPTION
Heavy refactoring in scikits.learn.neighbors: most of loops could be eliminated in kneighbors_graph, cleaner implementation.

The patch is difficult to follow as it touches a lot of paths, most illuminating maybe to take a look into the resulting kneighbors_graph.

The biggest change is that the output of kneighbors_graph is modified: now it always returns a sparse matrix with exactly n_neighbors \* n_samples nonzero coefficients. As a side-effect, drop_fist keyword is dropped and places where drop_first where used (NeighborBarycenter) now use the (improved) barycenter function.

Detailed API changes:
- barycenter_weights has been renamed to barycenters and accepts
   now X as 2D array and 3D array Y. This way iteration happens
   inside barycenters, rendering kneighbor_graph considerably
   cleaner. Also, NeighborRegressor directly uses barycenters
   instead of kneighbor_graph. Apart from being conceptually
   clearer, this lets us drop keyword drop_first in kneighbor_graph,
   making the output of kneighbor_graph more consistent.
- weight keyword was renamed to mode. This is in the spirit of some
   scipy function (qr) that perform slightly different algorithms
   based on that keyword.
- added keyword eps to control how much regularization is
   needed. Better names, anyone ?
- dropped keyword drop_first. By default, the first is not used on
   'distance' and 'barycenter', so that exactly n_neighbors are
   nonzero on each row. This is what is expected in my opinion and
   makes API simpler.
