### PR TITLE
Dataset API for loading the labeled faces datasets

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -269,22 +269,3 @@ Pipeline
 
    pipeline.Pipeline
 
-
-Dataset generation and loading
-==============================
-
-.. currentmodule:: scikits.learn.datasets
-
-.. autosummary::
-   :toctree: generated/
-   :template: class.rst
-
-   get_data_home
-   load_diabetes
-   load_digits
-   load_files
-   load_iris
-   load_lfw_pairs
-   load_lfw_people
-   load_mlcomp
-

--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -165,7 +165,7 @@ for penalty in ["l2", "l1"]:
     print "%s penalty" % penalty.upper()
     # Train Liblinear model
     liblinear_results = benchmark(LinearSVC(loss='l2', penalty=penalty, C=1000,
-                                        dual=False, eps=1e-3))
+                                            dual=False, eps=1e-3))
 
     # Train SGD model
     sgd_results = benchmark(SGDClassifier(alpha=.0001, n_iter=50,

--- a/scikits/learn/datasets/lfw.py
+++ b/scikits/learn/datasets/lfw.py
@@ -235,11 +235,6 @@ def load_lfw_people(data_home=None, funneled=True, resize=0.5,
         'interesting' part of the jpeg files and avoid use statistical
         correlation from the background
     """
-
-    parameters = locals().copy()
-    del parameters['data_home']
-    del parameters['funneled']
-
     lfw_home, data_folder_path = check_fetch_lfw(data_home=data_home,
                                                  funneled=funneled)
     logging.info('Loading LFW people faces from %s', lfw_home)
@@ -250,7 +245,9 @@ def load_lfw_people(data_home=None, funneled=True, resize=0.5,
     load_func = m.cache(_load_lfw_people)
 
     # load and memoize the pairs as np arrays
-    faces, target, class_names = load_func(data_folder_path, **parameters)
+    faces, target, class_names = load_func(
+        data_folder_path, resize=resize,
+        min_faces_per_person=min_faces_per_person, color=color, slice_=slice_)
 
     # pack the results as a Bunch instance
     return Bunch(data=faces, target=target, class_names=class_names,
@@ -362,12 +359,6 @@ def load_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
         'interesting' part of the jpeg files and avoid use statistical
         correlation from the background
     """
-
-    parameters = locals().copy()
-    del parameters['subset']
-    del parameters['data_home']
-    del parameters['funneled']
-
     lfw_home, data_folder_path = check_fetch_lfw(data_home=data_home,
                                                  funneled=funneled)
     logging.info('Loading %s LFW pairs from %s', subset, lfw_home)
@@ -389,8 +380,9 @@ def load_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
     index_file_path = join(lfw_home, label_filenames[subset])
 
     # load and memoize the pairs as np arrays
-    pairs, target, class_names = load_func(index_file_path, data_folder_path,
-                                           **parameters)
+    pairs, target, class_names = load_func(
+        index_file_path, data_folder_path, resize=resize, color=color,
+        slice_=slice_)
 
     # pack the results as a Bunch instance
     return Bunch(data=pairs, target=target, class_names=class_names,


### PR DESCRIPTION
Hi all,

Here is a preliminary request for comments for a new dataset loader for the Labeled Faces in the Wild dataset that download the original data (the jpeg files tarball and the labels text files and official CV splits).

I use joblib to memoize the result of the jpeg extraction (using scipy.misc.imread) in a folder that is a subfolder of "~/scikit_learn_data/lfw_home/" that also keep a cached copy of the original data.

I am willing to write some doc and tests for this but running the doc and tests will imply downloading ~230MB the first time. Is this acceptable? Is there a way to implement a global switch to skip tests that would require such a heavy network access? Especially how to implement such a switch so as not to pollute the doctests in the documentation.

Edit: there is no example for the useage of the `load_lfw_pairs` function that is used for the official face verification task. I plan to use it with another feature extractor that will arrive later with it's own pull request.
