### PR TITLE
make Neighbors* faster in high dimensional spaces

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -25,7 +25,7 @@ using the keyword ``strategy``. Possible values are ``'auto'``,
 ``'ball_tree'``, ``'brute'`` and ``'brute_inplace'``. ``'ball_tree'``
 will create an instance of :class:`BallTree` to conduct the search,
 which is usually very efficient in low-dimensional spaces. In higher
-dimension, a brute-force approach is is prefered thus parameters
+dimension, a brute-force approach is prefered thus parameters
 ``'brute'`` and ``'brute_inplace'`` can be used . Both conduct a
 brute-force search, the difference being that ``'brute_inplace'`` does
 not perform any precomputations, and thus is better suited for

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -20,6 +20,19 @@ The :class:`NeighborsClassifier` implements the nearest-neighbors
 classification method using a vote heuristic: the class most present
 in the k nearest neighbors of a point is assigned to this point.
 
+It is possible to use different nearest neighbor search strategies by
+using the keyword ``strategy``. Possible values are ``'auto'``,
+``'ball_tree'``, ``'brute'`` and ``'inplace'``. ``'ball_tree'`` will
+create an instance of :class:`BallTree` to conduct the search, which
+is usually very efficient in low-dimensional spaces. In higher
+dimension, a brute-force approach is is prefered thus parameters
+``'brute'`` and ``'inplace'`` can be used . Both conduct a brute-force
+search, the difference being that ``'inplace'`` does not perform any
+precomputations, and thus is better suited for low-memory settings.
+Finally, ``'auto'`` is a simple heuristic that will guess the best
+approach based on the current dataset.
+
+
 .. figure:: ../auto_examples/images/plot_neighbors.png
    :target: ../auto_examples/plot_neighbors.html
    :align: center

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -22,15 +22,15 @@ in the k nearest neighbors of a point is assigned to this point.
 
 It is possible to use different nearest neighbor search strategies by
 using the keyword ``strategy``. Possible values are ``'auto'``,
-``'ball_tree'``, ``'brute'`` and ``'inplace'``. ``'ball_tree'`` will
-create an instance of :class:`BallTree` to conduct the search, which
-is usually very efficient in low-dimensional spaces. In higher
+``'ball_tree'``, ``'brute'`` and ``'brute_inplace'``. ``'ball_tree'``
+will create an instance of :class:`BallTree` to conduct the search,
+which is usually very efficient in low-dimensional spaces. In higher
 dimension, a brute-force approach is is prefered thus parameters
-``'brute'`` and ``'inplace'`` can be used . Both conduct a brute-force
-search, the difference being that ``'inplace'`` does not perform any
-precomputations, and thus is better suited for low-memory settings.
-Finally, ``'auto'`` is a simple heuristic that will guess the best
-approach based on the current dataset.
+``'brute'`` and ``'brute_inplace'`` can be used . Both conduct a
+brute-force search, the difference being that ``'brute_inplace'`` does
+not perform any precomputations, and thus is better suited for
+low-memory settings.  Finally, ``'auto'`` is a simple heuristic that
+will guess the best approach based on the current dataset.
 
 
 .. figure:: ../auto_examples/images/plot_neighbors.png

--- a/scikits/learn/metrics/__init__.py
+++ b/scikits/learn/metrics/__init__.py
@@ -8,3 +8,5 @@ from .metrics import confusion_matrix, roc_curve, auc, precision_score, \
                 precision_recall_fscore_support, classification_report, \
                 precision_recall_curve, explained_variance_score, r2_score, \
                 zero_one, mean_square_error
+
+from .pairwise import euclidean_distances

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -163,7 +163,7 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
             if self.strategy == 'inplace':
                 neigh_ind = knn_brute(self._fit_X, X, self.n_neighbors)
             else:
-                from .metrics.pairwise import euclidean_distances
+                from .metrics import euclidean_distances
                 dist = euclidean_distances(
                     X, self._fit_X, squared=True)
                 neigh_ind = dist.argsort(axis=1)[:, :self.n_neighbors]

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -16,16 +16,16 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
 
     Parameters
     ----------
-    n_neighbors : int
-        default number of neighbors.
+    n_neighbors : int, optional
+        Default number of neighbors. Defaults to 5.
 
-    window_size : int
+    window_size : int, optional
         Window size passed to BallTree
 
-    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}
-        Strategy used to compute the nearest neighbors. 'btree' will
-        construct a BallTree, 'brute' and 'inplace' will perform
-        brute-force searc.'auto' will guess the most appropriate based
+    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}, optional
+        Strategy used to compute the nearest neighbors. 'ball_tree'
+        will construct a BallTree, 'brute' and 'inplace' will perform
+        brute-force search.'auto' will guess the most appropriate based
         on current dataset.
 
     Examples
@@ -194,19 +194,19 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
 
     Parameters
     ----------
-    n_neighbors : int
-        default number of neighbors.
+    n_neighbors : int, optional
+        Default number of neighbors. Defaults to 5.
 
-    window_size : int
+    window_size : int, optional
         Window size passed to BallTree
 
-    mode : {'mean', 'barycenter'}
+    mode : {'mean', 'barycenter'}, optional
         Weights to apply to labels.
 
-    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}
-        Strategy used to compute the nearest neighbors. 'btree' will
-        construct a BallTree, 'brute' and 'inplace' will perform
-        brute-force searc.'auto' will guess the most appropriate based
+    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}, optional
+        Strategy used to compute the nearest neighbors. 'ball_tree'
+        will construct a BallTree, 'brute' and 'inplace' will perform
+        brute-force search.'auto' will guess the most appropriate based
         on current dataset.
 
     Examples

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -22,11 +22,11 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
     window_size : int, optional
         Window size passed to BallTree
 
-    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}, optional
+    strategy : {'auto', 'ball_tree', 'brute', 'brute_inplace'}, optional
         Strategy used to compute the nearest neighbors. 'ball_tree'
-        will construct a BallTree, 'brute' and 'inplace' will perform
-        brute-force search.'auto' will guess the most appropriate based
-        on current dataset.
+        will construct a BallTree, 'brute' and 'brute_inplace' will
+        perform brute-force search.'auto' will guess the most
+        appropriate based on current dataset.
 
     Examples
     --------
@@ -160,7 +160,7 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
 
         # .. get neighbors ..
         if self.ball_tree is None:
-            if self.strategy == 'inplace':
+            if self.strategy == 'brute_inplace':
                 neigh_ind = knn_brute(self._fit_X, X, self.n_neighbors)
             else:
                 from .metrics import euclidean_distances
@@ -203,11 +203,11 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
     mode : {'mean', 'barycenter'}, optional
         Weights to apply to labels.
 
-    strategy : {'auto', 'ball_tree', 'brute', 'inplace'}, optional
+    strategy : {'auto', 'ball_tree', 'brute', 'brute_inplace'}, optional
         Strategy used to compute the nearest neighbors. 'ball_tree'
-        will construct a BallTree, 'brute' and 'inplace' will perform
-        brute-force search.'auto' will guess the most appropriate based
-        on current dataset.
+        will construct a BallTree, 'brute' and 'brute_inplace' will
+        perform brute-force search.'auto' will guess the most
+        appropriate based on current dataset.
 
     Examples
     --------
@@ -256,7 +256,7 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
 
         # .. get neighbors ..
         if self.ball_tree is None:
-            if self.strategy == 'inplace':
+            if self.strategy == 'brute_inplace':
                 neigh_ind = knn_brute(self._fit_X, X, self.n_neighbors)
             else:
                 from .metrics.pairwise import euclidean_distances

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -165,7 +165,7 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
             else:
                 from .metrics.pairwise import euclidean_distances
                 dist = euclidean_distances(
-                    X, self._fit_X, squared=False)
+                    X, self._fit_X, squared=True)
                 neigh_ind = dist.argsort(axis=1)[:, :self.n_neighbors]
         else:
             neigh_ind = self.ball_tree.query(

--- a/scikits/learn/src/BallTree.cpp
+++ b/scikits/learn/src/BallTree.cpp
@@ -712,22 +712,6 @@ BallTree_knn_brute(PyObject *self, PyObject *args, PyObject *kwds){
     for(int i=0;i<N;i++)
         delete Points[i];
 
-  //if only one neighbor is requested, then resize the neighbors array
-    if(k==1){
-        PyArray_Dims dims;
-        dims.ptr = PyArray_DIMS(arr2);
-        dims.len = PyArray_NDIM(arr2)-1;
-
-    //PyArray_Resize returns None - this needs to be picked
-    // up and dereferenced.
-        PyObject *NoneObj = PyArray_Resize( (PyArrayObject*)nbrs, &dims,
-            0, NPY_ANYORDER );
-        if (NoneObj == NULL){
-            goto fail;
-        }
-        Py_DECREF(NoneObj);
-    }
-
     return nbrs;
 
     fail:

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -15,26 +15,26 @@ def test_neighbors_1D():
     X = [[x] for x in range(0, n)]
     Y = [0]*(n/2) + [1]*(n/2)
 
-    # n_neighbors = 1
-    knn = neighbors.NeighborsClassifier(n_neighbors=1)
-    knn.fit(X, Y)
-    test = [[i + 0.01] for i in range(0, n/2)] + \
-           [[i - 0.01] for i in range(n/2, n)]
-    assert_array_equal(knn.predict(test), [0]*3 + [1]*3)
+    for s in ('auto', 'ball_tree', 'brute', 'inplace'):
+        # n_neighbors = 1
+        knn = neighbors.NeighborsClassifier(n_neighbors=1, strategy=s)
+        knn.fit(X, Y)
+        test = [[i + 0.01] for i in range(0, n/2)] + \
+               [[i - 0.01] for i in range(n/2, n)]
+        assert_array_equal(knn.predict(test), [0]*3 + [1]*3)
 
-    # n_neighbors = 2
-    knn = neighbors.NeighborsClassifier(n_neighbors=2)
-    knn.fit(X, Y)
-    assert_array_equal(knn.predict(test), [0]*4 + [1]*2)
+        # n_neighbors = 2
+        knn = neighbors.NeighborsClassifier(n_neighbors=2, strategy=s)
+        knn.fit(X, Y)
+        assert_array_equal(knn.predict(test), [0]*4 + [1]*2)
 
-
-    # n_neighbors = 3
-    knn = neighbors.NeighborsClassifier(n_neighbors=3)
-    knn.fit(X, Y)
-    assert_array_equal(knn.predict([[i +0.01] for i in range(0, n/2)]),
-                        [0 for i in range(n/2)])
-    assert_array_equal(knn.predict([[i-0.01] for i in range(n/2, n)]),
-                        [1 for i in range(n/2)])
+        # n_neighbors = 3
+        knn = neighbors.NeighborsClassifier(n_neighbors=3, strategy=s)
+        knn.fit(X, Y)
+        assert_array_equal(knn.predict([[i +0.01] for i in range(0, n/2)]),
+                            [0 for i in range(n/2)])
+        assert_array_equal(knn.predict([[i-0.01] for i in range(n/2, n)]),
+                            [1 for i in range(n/2)])
 
 
 def test_neighbors_2D():

--- a/scikits/learn/tests/test_neighbors.py
+++ b/scikits/learn/tests/test_neighbors.py
@@ -1,7 +1,14 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, \
+     assert_allclose, assert_
 
-from scikits.learn import neighbors
+from scikits.learn import neighbors, datasets
+
+# load and shuffle iris dataset
+iris = datasets.load_iris()
+perm = np.random.permutation(iris.target.size)
+iris.data = iris.data[perm]
+iris.target = iris.target[perm]
 
 
 def test_neighbors_1D():
@@ -37,39 +44,27 @@ def test_neighbors_1D():
                             [1 for i in range(n/2)])
 
 
-def test_neighbors_2D():
+def test_neighbors_iris():
     """
-    Nearest Neighbor in the plane.
+    Sanity checks on the iris dataset
 
     Puts three points of each label in the plane and performs a
     nearest neighbor query on points near the decision boundary.
     """
-    X = (
-        (0, 1), (1, 1), (1, 0), # label 0
-        (-1, 0), (-1, -1), (0, -1)) # label 1
-    n_2 = len(X)/2
-    Y = [0]*n_2 + [1]*n_2
-    knn = neighbors.NeighborsClassifier()
-    knn.fit(X, Y)
 
-    prediction = knn.predict([[0, .1], [0, -.1], [.1, 0], [-.1, 0]])
-    assert_array_equal(prediction, [0, 1, 0, 1])
+    for s in ('auto', 'ball_tree', 'brute', 'inplace'):
+        clf = neighbors.NeighborsClassifier()
+        clf.fit(iris.data, iris.target, n_neighbors=1, strategy=s)
+        assert_array_equal(clf.predict(iris.data), iris.target)
 
+        clf.fit(iris.data, iris.target, n_neighbors=9, strategy=s)
+        assert_(np.mean(clf.predict(iris.data)== iris.target) > 0.95)
 
-def test_neighbors_regressor():
-    """
-    NeighborsRegressor for regression using k-NN
-    """
-    X = [[0], [1], [2], [3]]
-    y = [0, 0, 1, 1]
-    neigh = neighbors.NeighborsRegressor(n_neighbors=3)
-    neigh.fit(X, y, mode='barycenter')
-    assert_array_almost_equal(
-        neigh.predict([[1.], [1.5]]), [0.333, 0.583], decimal=3)
-    neigh.fit(X, y, mode='mean')
-    assert_array_almost_equal(
-        neigh.predict([[1.], [1.5]]), [0.333, 0.333], decimal=3)
-    
+        for m in ('barycenter', 'mean'):
+            rgs = neighbors.NeighborsRegressor()
+            rgs.fit(iris.data, iris.target, mode=m, strategy=s)
+            assert_(np.mean(
+                rgs.predict(iris.data).round() == iris.target) > 0.95)
 
 
 def test_kneighbors_graph():


### PR DESCRIPTION
I get some 10x speedup in high dimensional (500 features) spaces. For this, added keyword strategy={'auto', 'btree', 'brute', 'inplace'} to Neighbors*.

This implements the possibility of using a brute-force algorithm when
the ambient space becomes too big. It also implements a strategy='auto'
that uses a simple heuristic to use the best method.
