### PR TITLE
add converged_ attribute to GMM

### DIFF
--- a/scikits/learn/mixture.py
+++ b/scikits/learn/mixture.py
@@ -166,6 +166,9 @@ class GMM(BaseEstimator):
             (`n_features`, `n_features`)              if 'tied',
             (`n_states`, `n_features`)                if 'diag',
             (`n_states`, `n_features`, `n_features`)  if 'full'
+    converged_ : bool
+        True when convergence was reached in fit(), False
+        otherwise.
 
     Methods
     -------

--- a/scikits/learn/mixture.py
+++ b/scikits/learn/mixture.py
@@ -235,7 +235,8 @@ class GMM(BaseEstimator):
 
         self.weights = np.ones(self._n_states) / self._n_states
 
-        # flag to indicate exit status of fit() method: converged (True) or max-iter reached (False)
+        # flag to indicate exit status of fit() method: converged (True) or
+        # n_iter reached (False)
         self.converged_ = False
 
     # Read-only properties.

--- a/scikits/learn/mixture.py
+++ b/scikits/learn/mixture.py
@@ -235,6 +235,8 @@ class GMM(BaseEstimator):
 
         self.weights = np.ones(self._n_states) / self._n_states
 
+        self.converged_ = False
+
     # Read-only properties.
     @property
     def cvtype(self):
@@ -415,7 +417,7 @@ class GMM(BaseEstimator):
             # occurrences of current component in obs
             comp_in_obs = (comp==comps)
             # number of those occurrences
-            num_comp_in_obs = comp_in_obs.sum() 
+            num_comp_in_obs = comp_in_obs.sum()
             if num_comp_in_obs > 0:
                 if self._cvtype == 'tied':
                     cv = self._covars
@@ -496,6 +498,7 @@ class GMM(BaseEstimator):
 
             # Check for convergence.
             if i > 0 and abs(logprob[-1] - logprob[-2]) < thresh:
+                self.converged_ = True
                 break
 
             # Maximization step

--- a/scikits/learn/mixture.py
+++ b/scikits/learn/mixture.py
@@ -235,6 +235,7 @@ class GMM(BaseEstimator):
 
         self.weights = np.ones(self._n_states) / self._n_states
 
+        # flag to indicate exit status of fit() method: converged (True) or max-iter reached (False)
         self.converged_ = False
 
     # Read-only properties.
@@ -491,6 +492,8 @@ class GMM(BaseEstimator):
 
         # EM algorithm
         logprob = []
+        # reset self.converged_ to False
+        self.converged_ = False
         for i in xrange(n_iter):
             # Expectation step
             curr_logprob, posteriors = self.eval(X)


### PR DESCRIPTION
as discussed in the ML, I have added an attribute 'converged_' to GMM (in mixture.py) to indicate whether the fit() method ended in convergence or not (max_iter reached). The attribute is initialized to False at class initialization, and set to True if convergence is reached in GMM.fit(). It is reset to False when calling fit() again.
