### PR TITLE
Fix to the sparse SVM 'poly' kernel implementation

### DIFF
--- a/scikits/learn/svm/sparse/base.py
+++ b/scikits/learn/svm/sparse/base.py
@@ -102,7 +102,7 @@ class SparseBaseLibSVM(BaseLibSVM):
         self.class_weight, self.class_weight_label = \
                      _get_class_weight(class_weight, y)
 
-        if (kernel_type == 2) and (self.gamma == 0):
+        if (kernel_type in [1, 2]) and (self.gamma == 0):
             # if custom gamma is not provided ...
             self.gamma = 1.0 / X.shape[0]
 

--- a/scikits/learn/svm/tests/test_sparse.py
+++ b/scikits/learn/svm/tests/test_sparse.py
@@ -60,7 +60,7 @@ def test_SVC():
 
 def test_SVC_iris():
     """Test the sparse SVC with the iris dataset"""
-    for k in ('linear', 'rbf'):
+    for k in ('linear', 'poly', 'rbf'):
         sp_clf = svm.sparse.SVC(kernel=k).fit(iris.data, iris.target)
         clf = svm.SVC(kernel=k).fit(iris.data.todense(), iris.target)
 


### PR DESCRIPTION
Fixes the bug that I reported in issue 104.
Includes a fix to the test_parse.py test.

Amit
