### PR TITLE
Refactoring in ridge.py

### DIFF
--- a/scikits/learn/linear_model/tests/test_ridge.py
+++ b/scikits/learn/linear_model/tests/test_ridge.py
@@ -166,7 +166,7 @@ def _test_ridge_loo(filter_):
     y_pred = ridge_gcv.predict(filter_(X_diabetes))
 
     assert_array_almost_equal(np.vstack((y_pred,y_pred)).T,
-                              Y_pred)
+                              Y_pred, decimal=5)
 
     return ret
 
@@ -202,7 +202,7 @@ def _test_multi_ridge_diabetes(filter_):
     ridge.fit(filter_(X_diabetes), y_diabetes)
     y_pred = ridge.predict(filter_(X_diabetes))
     assert_array_almost_equal(np.vstack((y_pred,y_pred)).T,
-                              Y_pred)
+                              Y_pred, decimal=3)
 
 def _test_ridge_classifiers(filter_):
     for clf in (RidgeClassifier(), RidgeClassifierCV()):


### PR DESCRIPTION
I'd like to expose the computational routines behind Ridge\*  as they might be useful in some manifold routines (among others). Also minor changes, like lazy import of scipy.sparse and docstring changes.

As a future note, it might be useful to add the 'auto' to {'cg', 'default'} as keywords for solve, and rename 'default' to something more explicit like 'cholesky' or 'dense'. 
