### PR TITLE
Fixed a whole load of memory leaks in libsvm/liblinear interface

### DIFF
--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -173,7 +173,7 @@ Python code: it takes around 100% of the cumulated time of the module. In
 order to better understand the profile of this specific function, let
 us install ``line-prof`` and wire it to IPython::
 
-  $ pip install line-prof
+  $ pip install line-profiler
   $ vim ~/.ipython/ipy_user_conf.py
 
 Ensure the following lines are present::

--- a/scikits/learn/datasets/lfw.py
+++ b/scikits/learn/datasets/lfw.py
@@ -91,7 +91,8 @@ def check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
                 url = BASE_URL + target_filename
                 logging.warn("Downloading LFW metadata: %s", url)
                 downloader = urllib.urlopen(BASE_URL + target_filename)
-                open(target_filepath, 'wb').write(downloader.read())
+                data = downloader.read()
+                open(target_filepath, 'wb').write(data)
             else:
                 raise IOError("%s is missing" % target_filepath)
 
@@ -101,7 +102,9 @@ def check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
             if download_if_missing:
                 logging.warn("Downloading LFW data (~200MB): %s", archive_url)
                 downloader = urllib.urlopen(archive_url)
-                open(archive_path, 'wb').write(downloader.read())
+                data = downloader.read()
+                # don't open file until download is complete
+                open(archive_path, 'wb').write(data)
             else:
                 raise IOError("%s is missing" % target_filepath)
 


### PR DESCRIPTION
Hi,

I caught a bunch of potential memory leaks in the C and C++ code that interfaces with liblinear and libsvm, and fixed them. I also took the liberty of cleaning that code while I was at it.

Regards,
Lars Buitinck
Scientific programmer, University of Amsterdam.
