### PR TITLE
RF: use joblib.logger submodule itself while accessing its function in grid_search

### DIFF
--- a/scikits/learn/grid_search.py
+++ b/scikits/learn/grid_search.py
@@ -10,8 +10,7 @@ import time
 import numpy as np
 import scipy.sparse as sp
 
-from .externals.joblib import Parallel, delayed
-from .externals.joblib.logger import short_format_time
+from .externals.joblib import Parallel, delayed, logger
 from .cross_val import KFold, StratifiedKFold
 from .base import BaseEstimator, is_classifier, clone
 
@@ -122,7 +121,7 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
 
     if verbose > 1:
         end_msg = "%s -%s" % (msg,
-                                short_format_time(time.time() - start_time))
+                                logger.short_format_time(time.time() - start_time))
         print "[GridSearchCV] %s %s" % ((64 - len(end_msg)) * '.', end_msg)
     return this_score, clf, this_n_test_samples
 


### PR DESCRIPTION
That would make it easier to allow using system-wide installed joblib on Debian
installations which provide only rudimentary externals/joblib/**init**.py

Please cherry-pick into 0.8.X
