### PR TITLE
Allow methods that don't implement transform (but do implement a fit_transoform) in Pipeline

### DIFF
--- a/scikits/learn/pipeline.py
+++ b/scikits/learn/pipeline.py
@@ -102,10 +102,10 @@ class Pipeline(BaseEstimator):
         transforms = estimators[:-1]
         estimator = estimators[-1]
         for t in  transforms:
-            assert (hasattr(t, "fit") or hasattr(t, "fit_transform")) and \
-                    hasattr(t, "transform"), ValueError(
+            assert (hasattr(t, "fit") and hasattr(t, "transform")) or \
+                    hasattr(t, "fit_transform"), ValueError(
                 "All intermediate steps a the chain should be transforms "
-                "and implement fit and transform",
+                "and implement fit and transform or fit_transform",
                 "'%s' (type %s) doesn't)" % (t, type(t))
             )
         assert hasattr(estimator, "fit"), \


### PR DESCRIPTION
I think this is just a bug in the `__init__` logic. Someone with more experience in the Pipeline can hopefully tell.
