### PR TITLE
ROC fixes for trivial classifiers (always predict one class) and input ch

### DIFF
--- a/scikits/learn/metrics/metrics.py
+++ b/scikits/learn/metrics/metrics.py
@@ -69,13 +69,15 @@ def confusion_matrix(y_true, y_pred, labels=None):
 def roc_curve(y_true, y_score):
     """compute Receiver operating characteristic (ROC)
 
+    Note: this implementation is restricted to the binary classification task.
+
     Parameters
     ----------
 
     y_true : array, shape = [n_samples]
         true binary labels
 
-    y_scores : array, shape = [n_samples]
+    y_score : array, shape = [n_samples]
         target scores, can either be probability estimates of
         the positive class, confidence values, or binary decisions.
 
@@ -98,7 +100,7 @@ def roc_curve(y_true, y_score):
     >>> fpr, tpr, thresholds = roc_curve(y, scores)
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
-    
+
 
     References
     ----------

--- a/scikits/learn/metrics/metrics.py
+++ b/scikits/learn/metrics/metrics.py
@@ -137,15 +137,15 @@ def roc_curve(y_true, y_score):
     return fpr, tpr, thresholds
 
 
-def auc(fpr, tpr):
+def auc(x, y):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
 
     Parameters
     ----------
-    fpr : array, shape = [n]
+    x : array, shape = [n]
         x coordinates
 
-    tpr : array, shape = [n]
+    y : array, shape = [n]
         y coordinates
 
     Returns
@@ -162,18 +162,18 @@ def auc(fpr, tpr):
     0.75
 
     """
-    fpr = np.asanyarray(fpr)
-    tpr = np.asanyarray(tpr)
-    assert fpr.shape[0] == tpr.shape[0]
-    assert fpr.shape[0] >= 3
+    x = np.asanyarray(x)
+    y = np.asanyarray(y)
+    assert x.shape[0] == y.shape[0]
+    assert x.shape[0] >= 3
 
     # reorder the data points according to the x axis
-    order = np.argsort(fpr)
-    fpr = fpr[order]
-    tpr = tpr[order]
+    order = np.argsort(x)
+    x = x[order]
+    y = y[order]
 
-    h = np.diff(fpr)
-    area = np.sum(h * (tpr[1:] + tpr[:-1])) / 2.0
+    h = np.diff(x)
+    area = np.sum(h * (y[1:] + y[:-1])) / 2.0
     return area
 
 

--- a/scikits/learn/metrics/tests/test_metrics.py
+++ b/scikits/learn/metrics/tests/test_metrics.py
@@ -1,7 +1,7 @@
 import random
 import numpy as np
-import nose
 
+from nose.tools import raises
 from nose.tools import assert_true
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
@@ -75,6 +75,45 @@ def test_roc_curve():
     fpr, tpr, thresholds = roc_curve(y_true, probas_pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.80, decimal=2)
+
+
+@raises(ValueError)
+def test_roc_curve_multi():
+    """roc_curve not applicable for multi-class problems"""
+    y_true, _, probas_pred = make_prediction(binary=False)
+
+    fpr, tpr, thresholds = roc_curve(y_true, probas_pred)
+
+
+def test_roc_curve_confidence():
+    """roc_curve for confidence scores"""
+    y_true, _, probas_pred = make_prediction(binary=True)
+
+    fpr, tpr, thresholds = roc_curve(y_true, probas_pred - 0.5)
+    roc_auc = auc(fpr, tpr)
+    assert_array_almost_equal(roc_auc, 0.80, decimal=2)
+
+
+def test_roc_curve_hard():
+    """roc_curve for hard decisions"""
+    y_true, pred, probas_pred = make_prediction(binary=True)
+
+    # always predict one
+    trivial_pred = np.ones(y_true.shape)
+    fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
+    roc_auc = auc(fpr, tpr)
+    assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+
+    # always predict zero
+    trivial_pred = np.zeros(y_true.shape)
+    fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
+    roc_auc = auc(fpr, tpr)
+    assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+
+    # hard decisions
+    fpr, tpr, thresholds = roc_curve(y_true, pred)
+    roc_auc = auc(fpr, tpr)
+    assert_array_almost_equal(roc_auc, 0.74, decimal=2)
 
 
 def test_precision_recall_f1_score_binary():
@@ -242,6 +281,3 @@ def test_symmetry():
     assert_true(r2_score(y_true, y_pred) != \
             r2_score(y_pred, y_true))
     # FIXME: precision and recall aren't symmetric either
-
-
-


### PR DESCRIPTION
ROC fixes for trivial classifiers (always predict one class) and input checks (raise ValueError in case of multi-class).

metrics.roc_curve now always returns arrays of size at least 3. That is, in the case of decision classifiers (classifiers which do not return confidence scores or probability estimates) (0,0) and (1,1) are included to ensure that metrics.auc gives right results. 

Additional tests for AUC.

Tested AUC values agains SIGKDD evaluation tool perf [1] -> give same results on test data supplied by perf + other boundary cases.

[1] http://www.sigkdd.org/kddcup/index.php?section=2004&method=soft
