### PR TITLE
add support for n_components in KernelPCA

### DIFF
--- a/scikits/learn/decomposition/pca.py
+++ b/scikits/learn/decomposition/pca.py
@@ -522,7 +522,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     def __init__(self, n_components=None, kernel="linear", sigma=1.0, degree=3,
                 alpha=1.0, fit_inverse_transform=False):
-        self.n_components = None
+        self.n_components = n_components
         self.kernel = kernel.lower()
         self.sigma = sigma
         self.degree = degree
@@ -548,8 +548,6 @@ class KernelPCA(BaseEstimator, TransformerMixin):
                              % self.kernel)
 
     def _fit_transform(self, X):
-        n_samples, n_components = X.shape
-
         # compute kernel and eigenvectors
         K = self.centerer.fit_transform(self._get_kernel(X))
         self.lambdas_, self.alphas_ = linalg.eigh(K)
@@ -557,7 +555,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         # sort eignenvectors in descending order
         indices = self.lambdas_.argsort()[::-1]
         if self.n_components is not None:
-            indices = indices[:n_components]
+            indices = indices[:self.n_components]
         self.lambdas_ = self.lambdas_[indices]
         self.alphas_ = self.alphas_[:, indices]
 

--- a/scikits/learn/decomposition/tests/test_pca.py
+++ b/scikits/learn/decomposition/tests/test_pca.py
@@ -356,6 +356,15 @@ def test_kernel_pca_linear_kernel():
     assert_array_almost_equal(np.abs(KernelPCA().fit(X_fit).transform(X_pred)),
                               np.abs(PCA().fit(X_fit).transform(X_pred)))
 
+def test_kernel_pca_n_components():
+    X_fit = np.random.random((5, 4))
+    X_pred = np.random.random((2, 4))
+
+    for c in [1, 2, 4]:
+        kpca = KernelPCA(n_components = c)
+        shape = kpca.fit(X_fit).transform(X_pred).shape
+
+        assert_equal(shape, (2, c))
 
 def test_kernel_pca_precomputed():
     X_fit = np.random.random((5, 4))

--- a/scikits/learn/decomposition/tests/test_pca.py
+++ b/scikits/learn/decomposition/tests/test_pca.py
@@ -356,6 +356,7 @@ def test_kernel_pca_linear_kernel():
     assert_array_almost_equal(np.abs(KernelPCA().fit(X_fit).transform(X_pred)),
                               np.abs(PCA().fit(X_fit).transform(X_pred)))
 
+
 def test_kernel_pca_n_components():
     X_fit = np.random.random((5, 4))
     X_pred = np.random.random((2, 4))
@@ -365,6 +366,7 @@ def test_kernel_pca_n_components():
         shape = kpca.fit(X_fit).transform(X_pred).shape
 
         assert_equal(shape, (2, c))
+
 
 def test_kernel_pca_precomputed():
     X_fit = np.random.random((5, 4))


### PR DESCRIPTION
Support for n_components in KernelPCA, along with an associated test case. Fixes #166.
