### PR TITLE
Mldata

### DIFF
--- a/scikits/learn/datasets/tests/test_mldata.py
+++ b/scikits/learn/datasets/tests/test_mldata.py
@@ -2,8 +2,7 @@
 
 from scikits.learn import datasets
 from scikits.learn.datasets import mldata_filename, fetch_mldata
-from scikits.learn.utils.testing import (assert_in, mock_urllib2,
-                                         fake_mldata_cache)
+from scikits.learn.utils.testing import (assert_in, mock_urllib2)
 from nose.tools import assert_equal, assert_raises
 from nose import with_setup
 from numpy.testing import assert_array_equal
@@ -42,8 +41,7 @@ def test_download():
     _urllib2_ref = datasets.mldata.urllib2
     datasets.mldata.urllib2 = mock_urllib2({'mock':
                                             {'label': sp.ones((150,)),
-                                             'data': sp.ones((150, 4))}},
-                                           tmpdir)
+                                             'data': sp.ones((150, 4))}})
     try:
         mock = fetch_mldata('mock', data_home=tmpdir)
         assert_in(mock, in_=['COL_NAMES', 'DESCR', 'target', 'data'])
@@ -51,75 +49,95 @@ def test_download():
         assert_equal(mock.target.shape, (150,))
         assert_equal(mock.data.shape, (150, 4))
 
-        assert_raises(IOError, fetch_mldata, 'not_existing_name')
+        assert_raises(datasets.mldata.urllib2.HTTPError,
+                      fetch_mldata, 'not_existing_name')
     finally:
         datasets.mldata.urllib2 = _urllib2_ref
 
 
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_one_column():
-    dataname = 'onecol'
-    # create fake data set in cache
-    x = sp.arange(6).reshape(2, 3)
-    fake_mldata_cache({'x': x}, dataname, tmpdir)
+    _urllib2_ref = datasets.mldata.urllib2
+    try:
+        dataname = 'onecol'
+        # create fake data set in cache
+        x = sp.arange(6).reshape(2, 3)
+        datasets.mldata.urllib2 = mock_urllib2({dataname: {'x': x}})
 
-    dset = fetch_mldata(dataname, data_home=tmpdir)
-    assert_in(dset, in_=['COL_NAMES', 'DESCR', 'data'], out_=['target'])
+        dset = fetch_mldata(dataname, data_home=tmpdir)
+        assert_in(dset, in_=['COL_NAMES', 'DESCR', 'data'], out_=['target'])
 
-    assert_equal(dset.data.shape, (2, 3))
-    assert_array_equal(dset.data, x)
+        assert_equal(dset.data.shape, (2, 3))
+        assert_array_equal(dset.data, x)
 
-    # transposing the data array
-    dset = fetch_mldata(dataname, transpose_data=False, data_home=tmpdir)
-    assert_equal(dset.data.shape, (3, 2))
+        # transposing the data array
+        dset = fetch_mldata(dataname, transpose_data=False, data_home=tmpdir)
+        assert_equal(dset.data.shape, (3, 2))
+    finally:
+        datasets.mldata.urllib2 = _urllib2_ref
 
 
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_multiple_column():
-    dataname = 'threecol'
-    # create fake data set in cache
-    x = sp.arange(6).reshape(2, 3)
-    y = sp.array([1, -1])
-    z = sp.arange(12).reshape(4, 3)
+    _urllib2_ref = datasets.mldata.urllib2
+    try:
+        # create fake data set in cache
+        x = sp.arange(6).reshape(2, 3)
+        y = sp.array([1, -1])
+        z = sp.arange(12).reshape(4, 3)
 
-    # by default
-    fake_mldata_cache({'label': y, 'data': x, 'z': z}, dataname, tmpdir,
-                      ordering=['z', 'data', 'label'])
+        # by default
+        dataname = 'threecol-default'
+        datasets.mldata.urllib2 = mock_urllib2({dataname:
+                                                ({'label': y,
+                                                  'data': x,
+                                                  'z': z},
+                                                 ['z', 'data', 'label'])})
 
-    dset = fetch_mldata(dataname, data_home=tmpdir)
-    assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'z'],
-              out_=['x', 'y'])
+        dset = fetch_mldata(dataname, data_home=tmpdir)
+        assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'z'],
+                  out_=['x', 'y'])
 
-    assert_array_equal(dset.data, x)
-    assert_array_equal(dset.target, y)
-    assert_array_equal(dset.z, z.T)
+        assert_array_equal(dset.data, x)
+        assert_array_equal(dset.target, y)
+        assert_array_equal(dset.z, z.T)
 
-    # by order
-    fake_mldata_cache({'y': y, 'x': x, 'z': z}, dataname, tmpdir,
-                      ordering=['y', 'x', 'z'])
+        # by order
+        dataname = 'threecol-order'
+        datasets.mldata.urllib2 = mock_urllib2({dataname:
+                                                ({'y': y,
+                                                  'x': x,
+                                                  'z': z},
+                                                 ['y', 'x', 'z'])})
 
-    dset = fetch_mldata(dataname, data_home=tmpdir)
-    assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'z'],
-              out_=['x', 'y'])
-    assert_array_equal(dset.data, x)
-    assert_array_equal(dset.target, y)
-    assert_array_equal(dset.z, z.T)
+        dset = fetch_mldata(dataname, data_home=tmpdir)
+        assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'z'],
+                  out_=['x', 'y'])
+        assert_array_equal(dset.data, x)
+        assert_array_equal(dset.target, y)
+        assert_array_equal(dset.z, z.T)
 
-    # by number
-    fake_mldata_cache({'y': y, 'x': x, 'z': z}, dataname, tmpdir,
-                      ordering=['z', 'x', 'y'])
+        # by number
+        dataname = 'threecol-number'
+        datasets.mldata.urllib2 = mock_urllib2({dataname:
+                                                ({'y': y,
+                                                  'x': x,
+                                                  'z': z},
+                                                 ['z', 'x', 'y'])})
 
-    dset = fetch_mldata(dataname, data_home=tmpdir,
-                        target_name=2, data_name=0)
-    assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'x'],
-              out_=['z', 'y'])
-    assert_array_equal(dset.data, z)
-    assert_array_equal(dset.target, y)
+        dset = fetch_mldata(dataname, target_name=2, data_name=0,
+                            data_home=tmpdir)
+        assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'x'],
+                  out_=['z', 'y'])
+        assert_array_equal(dset.data, z)
+        assert_array_equal(dset.target, y)
 
-    # by name
-    dset = fetch_mldata(dataname, data_home=tmpdir,
-                        target_name='y', data_name='z')
-    assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'x'],
-              out_=['z', 'y'])
-    assert_array_equal(dset.data, z)
-    assert_array_equal(dset.target, y)
+        # by name
+        dset = fetch_mldata(dataname, target_name='y', data_name='z',
+                            data_home=tmpdir)
+        assert_in(dset, in_=['COL_NAMES', 'DESCR', 'target', 'data', 'x'],
+                  out_=['z', 'y'])
+        assert_array_equal(dset.data, z)
+        assert_array_equal(dset.target, y)
+    finally:
+        datasets.mldata.urllib2 = _urllib2_ref

--- a/scikits/learn/utils/testing.py
+++ b/scikits/learn/utils/testing.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2011 Pietro Berkes
 # License: Simplified BSD
 
-import os
+import urllib2
 from StringIO import StringIO
 import scipy as sp
 from scipy.io import savemat
@@ -57,8 +57,11 @@ class mock_urllib2(object):
     def __init__(self, mock_datasets):
         """Object that mocks the urllib2 module to fake requests to mldata.
 
-        `mock_datasets` is a dictionary of {dataset_name: data_dict}, and
-        `data_dict` itself is a dictionary of {column_name: data_array}
+        `mock_datasets` is a dictionary of {dataset_name: data_dict}, or
+        {dataset_name: (data_dict, ordering).
+        `data_dict` itself is a dictionary of {column_name: data_array},
+        and `ordering` is a list of column_names to determine the ordering
+        in the data set (see `fake_mldata_cache` for details).
 
         When requesting a dataset with a name that is in mock_datasets,
         this object creates a fake dataset in a StringIO object and
@@ -66,17 +69,25 @@ class mock_urllib2(object):
         """
         self.mock_datasets = mock_datasets
 
-    class URLError(Exception):
-        pass
+    class HTTPError(urllib2.URLError):
+        code = 404
 
     def urlopen(self, urlname):
         dataset_name = urlname.split('/')[-1]
         if dataset_name in self.mock_datasets:
             resource_name = '_' + dataset_name
             matfile = StringIO()
-            fake_mldata_cache(self.mock_datasets[dataset_name],
-                              resource_name, matfile)
+
+            dataset = self.mock_datasets[dataset_name]
+            ordering = None
+            if isinstance(dataset, tuple):
+                dataset, ordering = dataset
+            fake_mldata_cache(dataset, resource_name, matfile, ordering)
+
             matfile.seek(0)
             return matfile
         else:
-            raise mock_urllib2.URLError('%s not found.', urlname)
+            raise mock_urllib2.HTTPError('%s not found.' % urlname)
+
+    def quote(self, string, safe='/'):
+        return urllib2.quote(string, safe)


### PR DESCRIPTION
The branch mldata contains a new function 'fetch_mldata' to download  data sets from the mldata.org repository. The data set is stored in cache as usual in scikits.learn.

Mikio Braun confirmed that there is no fixed convention in mldata.org for distinguishing between target values and data, nor is there a convention for the column names. fetch_mldata uses default values that work with the most common data sets, and accepts keyword arguments to adapt to the other cases.

For example, it is possible to write:
from scikits.learn import datasets as dt

mnist = dt.fetch_mldata('MNIST original')
iris = dt.fetch_mldata('iris')
news20 = dt.fetch_mldata('news20.binary')

but also:

iris2 = dt.fetch_mldata('datasets-UCI iris', target_name=1, data_name=0) 
iris3 = dt.fetch_mldata('datasets-UCI iris', target_name='class', data_name='double0') 
