### PR TITLE
Transposing input and output of fastICA

### DIFF
--- a/examples/decomposition/plot_ica_blind_source_separation.py
+++ b/examples/decomposition/plot_ica_blind_source_separation.py
@@ -31,7 +31,7 @@ A = [[1, 1], [0.5, 2]] # Mixing matrix
 X = np.dot(A, S) # Generate observations
 # Compute ICA
 ica = FastICA()
-S_ = ica.fit(X).transform(X) # Get the estimated sources
+S_ = ica.fit(X.T).transform(X.T).T # Get the estimated sources
 A_ = ica.get_mixing_matrix() # Get estimated mixing matrix
 
 assert np.allclose(X, np.dot(A_, S_))

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -79,7 +79,7 @@ def plot_samples(S, axis_list=None):
 
 pl.subplot(2, 2, 1)
 plot_samples(S / S.std())
-pl.title('True Independant Sources')
+pl.title('True Independent Sources')
 
 axis_list = [pca.components_.T, ica.get_mixing_matrix()]
 pl.subplot(2, 2, 2)

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -37,7 +37,7 @@ from scikits.learn.decomposition import PCA, FastICA
 
 ###############################################################################
 # Generate sample data
-S = np.random.standard_t(1.5, size=(10000,2))
+S = np.random.standard_t(1.5, size=(10000, 2))
 S[0] *= 2.
 
 # Mix data

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -37,28 +37,28 @@ from scikits.learn.decomposition import PCA, FastICA
 
 ###############################################################################
 # Generate sample data
-S = np.random.standard_t(1.5, size=(2, 10000))
+S = np.random.standard_t(1.5, size=(10000,2))
 S[0] *= 2.
 
 # Mix data
-A = [[1, 1], [0, 2]]  # Mixing matrix
+A = np.array([[1, 1], [0, 2]])  # Mixing matrix
 
-X = np.dot(A, S)  # Generate observations
+X = np.dot(S, A.T)  # Generate observations
 
 pca = PCA()
-S_pca_ = pca.fit(X.T).transform(X.T).T
+S_pca_ = pca.fit(X).transform(X)
 
 ica = FastICA()
 S_ica_ = ica.fit(X).transform(X)  # Estimate the sources
 
-S_ica_ /= S_ica_.std(axis=1)[:, np.newaxis]
+S_ica_ /= S_ica_.std(axis=0)
 
 
 ###############################################################################
 # Plot results
 
 def plot_samples(S, axis_list=None):
-    pl.scatter(S[0], S[1], s=2, marker='o', linewidths=0, zorder=10)
+    pl.scatter(S[:,0], S[:,1], s=2, marker='o', linewidths=0, zorder=10)
     if axis_list is not None:
         colors = [(0, 0.6, 0), (0.6, 0, 0)]
         for color, axis in zip(colors, axis_list):

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -74,8 +74,8 @@ def plot_samples(S, axis_list=None):
     pl.vlines(0, -3, 3)
     pl.xlim(-3, 3)
     pl.ylim(-3, 3)
-    pl.xlabel('x')
-    pl.ylabel('y')
+    pl.xlabel('$x$')
+    pl.ylabel('$y$')
 
 pl.subplot(2, 2, 1)
 plot_samples(S / S.std())

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -88,7 +88,7 @@ pl.legend(['PCA', 'ICA'], loc='upper left')
 pl.title('Observations')
 
 pl.subplot(2, 2, 3)
-plot_samples(S_pca_ / np.std(S_pca_, axis=-1)[:, np.newaxis])
+plot_samples(S_pca_ / np.std(S_pca_, axis=0))
 pl.title('PCA scores')
 
 pl.subplot(2, 2, 4)

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -74,8 +74,8 @@ def plot_samples(S, axis_list=None):
     pl.vlines(0, -3, 3)
     pl.xlim(-3, 3)
     pl.ylim(-3, 3)
-    pl.xlabel('$x$')
-    pl.ylabel('$y$')
+    pl.xlabel('x')
+    pl.ylabel('y')
 
 pl.subplot(2, 2, 1)
 plot_samples(S / S.std())

--- a/examples/decomposition/plot_pca_vs_lda.py
+++ b/examples/decomposition/plot_pca_vs_lda.py
@@ -1,6 +1,6 @@
 """
 ====================================
-PCA 2D projection of Iris dataset
+Comparison of LDA and PCA 2D projection of Iris dataset
 ====================================
 
 The Iris dataset represents 3 kind of Iris flowers (Setosa, Versicolour
@@ -11,6 +11,10 @@ Principal Component Analysis (PCA) applied to this data identifies the
 combination of attributes (principal components, or directions in the
 feature space) that account for the most variance in the data. Here we
 plot the different samples on the 2 first principal components.
+
+Linear Discriminant Analysis (LDA) tries to identify attributes that
+account for the most variance *between classes*. In particular,
+LDA, in constrast to PCA, is a supervised method, using known class labels.
 """
 print __doc__
 

--- a/scikits/learn/decomposition/fastica_.py
+++ b/scikits/learn/decomposition/fastica_.py
@@ -189,6 +189,9 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
       pp. 411-430
 
     """
+    # make interface compatible with other decompositions
+    X = X.T
+
     algorithm_funcs = {'parallel': _ica_par,
                        'deflation': _ica_def}
 
@@ -281,10 +284,10 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     if whiten:
         S = np.dot(np.dot(W, K), X)
-        return K, W, S
+        return K, W, S.T
     else:
         S = np.dot(W, X)
-        return W, S
+        return W, S.T
 
 
 class FastICA(BaseEstimator):
@@ -359,9 +362,9 @@ class FastICA(BaseEstimator):
     def transform(self, X):
         """Apply un-mixing matrix "W" to X to recover the sources
 
-        S = W * X
+        S = X * W.T
         """
-        return np.dot(self.unmixing_matrix_, X)
+        return np.dot(X,self.unmixing_matrix_.T)
 
     def get_mixing_matrix(self):
         """Compute the mixing matrix

--- a/scikits/learn/decomposition/fastica_.py
+++ b/scikits/learn/decomposition/fastica_.py
@@ -10,6 +10,7 @@ Independent Component Analysis, by  Hyvarinen et al.
 # License: BSD 3 clause
 
 import types
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -190,6 +191,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     """
     # make interface compatible with other decompositions
+    warnings.warn("The interface of fastica changed: X is now assumed to be of shape [n_samples, n_features]")
     X = X.T
 
     algorithm_funcs = {'parallel': _ica_par,

--- a/scikits/learn/decomposition/fastica_.py
+++ b/scikits/learn/decomposition/fastica_.py
@@ -191,7 +191,8 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     """
     # make interface compatible with other decompositions
-    warnings.warn("The interface of fastica changed: X is now assumed to be of shape [n_samples, n_features]")
+    warnings.warn("The interface of fastica changed: X is now 
+        assumed to be of shape [n_samples, n_features]")
     X = X.T
 
     algorithm_funcs = {'parallel': _ica_par,
@@ -366,7 +367,7 @@ class FastICA(BaseEstimator):
 
         S = X * W.T
         """
-        return np.dot(X,self.unmixing_matrix_.T)
+        return np.dot(X, self.unmixing_matrix_.T)
 
     def get_mixing_matrix(self):
         """Compute the mixing matrix

--- a/scikits/learn/decomposition/fastica_.py
+++ b/scikits/learn/decomposition/fastica_.py
@@ -191,7 +191,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     """
     # make interface compatible with other decompositions
-    warnings.warn("The interface of fastica changed: X is now 
+    warnings.warn("The interface of fastica changed: X is now\
         assumed to be of shape [n_samples, n_features]")
     X = X.T
 

--- a/scikits/learn/decomposition/tests/test_fastica.py
+++ b/scikits/learn/decomposition/tests/test_fastica.py
@@ -71,8 +71,8 @@ def test_fastica(add_noise=False):
     non_linearity = ['logcosh', 'exp', 'cube']
     for nl in non_linearity:
         for algo in algorithm:
-            k_, mixing_, s_ = fastica(m, fun=nl, algorithm=algo)
-
+            k_, mixing_, s_ = fastica(m.T, fun=nl, algorithm=algo)
+            s_ = s_.T
             # Check that the mixing model described in the docstring holds:
             assert_almost_equal(s_, np.dot(np.dot(mixing_, k_), m))
 
@@ -122,7 +122,8 @@ def test_non_square_fastica(add_noise=False):
 
     center_and_norm(m)
 
-    k_, mixing_, s_ = fastica(m, n_components=2)
+    k_, mixing_, s_ = fastica(m.T, n_components=2)
+    s_ = s_.T
 
     # Check that the mixing model described in the docstring holds:
     assert_almost_equal(s_, np.dot(np.dot(mixing_, k_), m))


### PR DESCRIPTION
This transposes input and output of fastICA as discussed on the mailing list.
I tried to transpose everything in the algorithm but gave up. Now everything is  just transposed in the beginning and the end - which is a free operation in numpy afaik.
Hope this is ok.
