### PR TITLE
Implements a robust covariance estimator: Rousseeuw's MCD.

### DIFF
--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -42,8 +42,8 @@ X_test = np.dot(base_X_test, coloring_matrix)
 ###############################################################################
 # Compute Ledoit-Wolf and Covariances on a grid of shrinkages
 
-from scikits.learn.covariance import LedoitWolf, OAS, ShrunkCovariance, \
-    log_likelihood, empirical_covariance
+from scikits.learn.covariance import LedoitWolf, OracleApproxShrinkage, \
+    ShrunkCovariance, log_likelihood, empirical_covariance
 
 # Ledoit-Wolf optimal shrinkage coefficient estimate
 lw = LedoitWolf()
@@ -51,7 +51,7 @@ loglik_lw = lw.fit(X_train, assume_centered=True).score(
     X_test, assume_centered=True)
 
 # OAS coefficient estimate
-oa = OAS()
+oa = OracleApproxShrinkage()
 loglik_oa = oa.fit(X_train, assume_centered=True).score(
     X_test, assume_centered=True)
 

--- a/examples/covariance/plot_lw_vs_oas.py
+++ b/examples/covariance/plot_lw_vs_oas.py
@@ -26,7 +26,7 @@ import numpy as np
 import pylab as pl
 from scipy.linalg import toeplitz, cholesky
 
-from scikits.learn.covariance import LedoitWolf, OAS
+from scikits.learn.covariance import LedoitWolf, OracleApproxShrinkage
 
 ###############################################################################
 n_features = 100
@@ -51,7 +51,7 @@ for i, n_samples in enumerate(n_samples_range):
         lw_mse[i,j] = lw.error_norm(real_cov, scaling=False)
         lw_shrinkage[i,j] = lw.shrinkage_
 
-        oa = OAS(store_precision=False)
+        oa = OracleApproxShrinkage(store_precision=False)
         oa.fit(X, assume_centered=True)
         oa_mse[i,j] = oa.error_norm(real_cov, scaling=False)
         oa_shrinkage[i,j] = oa.shrinkage_

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -1,0 +1,111 @@
+"""
+================================================================
+Robust covariance estimation and Mahalanobis distances relevance
+================================================================
+
+For Gaussian ditributed data, the distance of an observation $x_i$ to
+the mode of the distribution can be computed using its Mahalanobis
+distance: $d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i -
+\mu)$ where $\mu$ and $\Sigma$ are the location and the covariance of
+the underlying gaussian distribution.
+
+In practice, $\mu$ and $\Sigma$ are replaced by some estimates.  The
+usual covariance maximum likelihood estimate is very sensitive to the
+presence of outliers in the data set and therefor, the corresponding
+Mahalanobis distances are. One would better have to use a robust
+estimator of covariance to garanty that the estimation is resistant to
+"errorneous" observations in the data set and that the associated
+Mahalanobis distances accurately reflect the true organisation of the
+observations.
+
+The Minimum Covariance Determinant estimator is a robust,
+high-breakdown point (i.e. it can be used to estimate the covariance
+matrix of highly contaminated datasets, up to
+$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
+covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+observations whose empirical covariance has the smallest determinant,
+yielding a "pure" subset of observations from which to compute
+standards estimates of location and covariance.
+
+The Minimum Covariance Determinant estimator (MCD) has been introduced
+by P.J.Rousseuw in [1].
+
+This example illustrates how the Mahalanobis distances are affected by
+outlying data: observations drawn from a contaminating distribution
+are not distinguishable from the observations comming from the real,
+Gaussian distribution that one may want to work with. Using MCD-based
+Mahalanobis distances, the two populations become
+distinguishable. Associated applications are outliers detection,
+observations ranking, clustering, ...
+
+[1] P. J. Rousseeuw. Least median of squares regression. J. Am
+    Stat Ass, 79:871, 1984.
+
+"""
+print __doc__
+
+import numpy as np
+import pylab as pl
+import matplotlib.font_manager
+
+from scikits.learn.covariance import EmpiricalCovariance, MCD
+
+n_samples = 125
+n_outliers = 25
+n_features = 2
+
+# generate data
+gen_cov = np.eye(n_features)
+gen_cov[0,0] = 2.
+X = np.dot(np.random.randn(n_samples, n_features), gen_cov)
+# add some outliers
+outliers_cov = np.eye(n_features)
+outliers_cov[np.arange(1,n_features),np.arange(1,n_features)] = 7.
+X[-n_outliers:] = np.dot(np.random.randn(n_outliers, n_features), outliers_cov)
+
+# fit a Minimum Covariance Determinant (MCD) robust estimator to data
+robust_cov = MCD().fit(X, reweight=None)
+
+# compare estimators learnt from the full data set with true parameters
+emp_cov = EmpiricalCovariance().fit(X)
+
+
+# Display results
+fig = pl.figure()
+# variables and parameters for cosmetic
+offset_left = fig.subplotpars.left
+offset_bottom = fig.subplotpars.bottom
+width = fig.subplotpars.right - offset_left
+subfig1 = pl.subplot(3,1,1)
+subfig2 = pl.subplot(3,1,2)
+subfig3 = pl.subplot(3,1,3)
+
+# Show data set
+subfig1.scatter(X[:,0], X[:,1], color='black', label='inliers')
+subfig1.scatter(X[:,0][-n_outliers:], X[:,1][-n_outliers:],
+           color='red', label='outliers')
+subfig1.set_xlim(subfig1.get_xlim()[0], 11.)
+subfig1.set_title("Mahalanobis distances of a contaminated data set:")
+subfig1.legend(loc="upper right")
+
+# Empirical covariance -based Mahalanobis distances
+subfig2.scatter(np.arange(n_samples), emp_cov.mahalanobis(X),
+           color='black', label='inliers')
+subfig2.scatter(np.arange(n_samples)[-n_outliers:],
+           emp_cov.mahalanobis(X)[-n_outliers:],
+           color='red', label='outliers')
+subfig2.set_ylabel("Mahal. dist.")
+subfig2.set_title("1. from empirical estimates")
+subfig2.axes.set_position(pos=[offset_left,0.39,width,.2])
+
+# MCD-based Mahalanobis distances
+subfig3.scatter(np.arange(n_samples), robust_cov.mahalanobis(X),
+           color='black', label='inliers')
+subfig3.scatter(np.arange(n_samples)[-n_outliers:],
+           robust_cov.mahalanobis(X)[-n_outliers:],
+           color='red', label='outliers')
+subfig3.set_ylabel("Mahal. dist.")
+subfig3.set_title("2. from robust estimates (Minimum Covariance Determinant)")
+subfig3.axes.set_position(pos=[offset_left,offset_bottom,width,.2])
+
+pl.show()

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -56,11 +56,11 @@ n_features = 2
 
 # generate data
 gen_cov = np.eye(n_features)
-gen_cov[0,0] = 2.
+gen_cov[0, 0] = 2.
 X = np.dot(np.random.randn(n_samples, n_features), gen_cov)
 # add some outliers
 outliers_cov = np.eye(n_features)
-outliers_cov[np.arange(1,n_features),np.arange(1,n_features)] = 7.
+outliers_cov[np.arange(1, n_features), np.arange(1, n_features)] = 7.
 X[-n_outliers:] = np.dot(np.random.randn(n_outliers, n_features), outliers_cov)
 
 # fit a Minimum Covariance Determinant (MCD) robust estimator to data
@@ -76,13 +76,13 @@ fig = pl.figure()
 offset_left = fig.subplotpars.left
 offset_bottom = fig.subplotpars.bottom
 width = fig.subplotpars.right - offset_left
-subfig1 = pl.subplot(3,1,1)
-subfig2 = pl.subplot(3,1,2)
-subfig3 = pl.subplot(3,1,3)
+subfig1 = pl.subplot(3, 1, 1)
+subfig2 = pl.subplot(3, 1, 2)
+subfig3 = pl.subplot(3, 1, 3)
 
 # Show data set
-subfig1.scatter(X[:,0], X[:,1], color='black', label='inliers')
-subfig1.scatter(X[:,0][-n_outliers:], X[:,1][-n_outliers:],
+subfig1.scatter(X[:, 0], X[:, 1], color='black', label='inliers')
+subfig1.scatter(X[:, 0][-n_outliers:], X[:, 1][-n_outliers:],
            color='red', label='outliers')
 subfig1.set_xlim(subfig1.get_xlim()[0], 11.)
 subfig1.set_title("Mahalanobis distances of a contaminated data set:")
@@ -96,7 +96,7 @@ subfig2.scatter(np.arange(n_samples)[-n_outliers:],
            color='red', label='outliers')
 subfig2.set_ylabel("Mahal. dist.")
 subfig2.set_title("1. from empirical estimates")
-subfig2.axes.set_position(pos=[offset_left,0.39,width,.2])
+subfig2.axes.set_position(pos=[offset_left, 0.39, width, .2])
 
 # MCD-based Mahalanobis distances
 subfig3.scatter(np.arange(n_samples), robust_cov.mahalanobis(X),
@@ -106,6 +106,6 @@ subfig3.scatter(np.arange(n_samples)[-n_outliers:],
            color='red', label='outliers')
 subfig3.set_ylabel("Mahal. dist.")
 subfig3.set_title("2. from robust estimates (Minimum Covariance Determinant)")
-subfig3.axes.set_position(pos=[offset_left,offset_bottom,width,.2])
+subfig3.axes.set_position(pos=[offset_left, offset_bottom, width, .2])
 
 pl.show()

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -48,7 +48,7 @@ import numpy as np
 import pylab as pl
 import matplotlib.font_manager
 
-from scikits.learn.covariance import EmpiricalCovariance, MCD
+from scikits.learn.covariance import EmpiricalCovariance, MinCovDet
 
 n_samples = 125
 n_outliers = 25
@@ -64,7 +64,7 @@ outliers_cov[np.arange(1, n_features), np.arange(1, n_features)] = 7.
 X[-n_outliers:] = np.dot(np.random.randn(n_outliers, n_features), outliers_cov)
 
 # fit a Minimum Covariance Determinant (MCD) robust estimator to data
-robust_cov = MCD().fit(X, reweight=None)
+robust_cov = MinCovDet().fit(X, reweight=None)
 
 # compare estimators learnt from the full data set with true parameters
 emp_cov = EmpiricalCovariance().fit(X)

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -5,24 +5,24 @@ Robust covariance estimation and Mahalanobis distances relevance
 
 For Gaussian ditributed data, the distance of an observation $x_i$ to
 the mode of the distribution can be computed using its Mahalanobis
-distance: $d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i -
-\mu)$ where $\mu$ and $\Sigma$ are the location and the covariance of
-the underlying gaussian distribution.
+distance: :math:`d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i
+- \mu)` where :math:`\mu` and :math:`\Sigma` are the location and the
+covariance of the underlying gaussian distribution.
 
-In practice, $\mu$ and $\Sigma$ are replaced by some estimates.  The
-usual covariance maximum likelihood estimate is very sensitive to the
-presence of outliers in the data set and therefor, the corresponding
-Mahalanobis distances are. One would better have to use a robust
-estimator of covariance to garanty that the estimation is resistant to
-"errorneous" observations in the data set and that the associated
-Mahalanobis distances accurately reflect the true organisation of the
-observations.
+In practice, :math:`\mu` and :math:`\Sigma` are replaced by some
+estimates.  The usual covariance maximum likelihood estimate is very
+sensitive to the presence of outliers in the data set and therefore,
+the corresponding Mahalanobis distances are. One would better have to
+use a robust estimator of covariance to garanty that the estimation is
+resistant to "errorneous" observations in the data set and that the
+associated Mahalanobis distances accurately reflect the true
+organisation of the observations.
 
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
 matrix of highly contaminated datasets, up to
-$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
-covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+:math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
+covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
 observations whose empirical covariance has the smallest determinant,
 yielding a "pure" subset of observations from which to compute
 standards estimates of location and covariance.

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -3,24 +3,24 @@
 Robust covariance estimation and Mahalanobis distances relevance
 ================================================================
 
-For Gaussian ditributed data, the distance of an observation $x_i$ to
+For Gaussian distributed data, the distance of an observation $x_i$ to
 the mode of the distribution can be computed using its Mahalanobis
 distance: :math:`d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i
 - \mu)` where :math:`\mu` and :math:`\Sigma` are the location and the
-covariance of the underlying gaussian distribution.
+covariance of the underlying Gaussian distribution.
 
 In practice, :math:`\mu` and :math:`\Sigma` are replaced by some
 estimates.  The usual covariance maximum likelihood estimate is very
 sensitive to the presence of outliers in the data set and therefore,
-the corresponding Mahalanobis distances are. One would better have to
-use a robust estimator of covariance to garanty that the estimation is
-resistant to "errorneous" observations in the data set and that the
+the corresponding Mahalanobis distances are. It's recommended to
+use a robust estimator of covariance to guaranty that the estimation is
+resistant to "erroneous" observations in the data set and that the
 associated Mahalanobis distances accurately reflect the true
 organisation of the observations.
 
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
-matrix of highly contaminated datasets, up to
+matrix of highly contaminated data sets, up to
 :math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
 covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
 observations whose empirical covariance has the smallest determinant,
@@ -32,7 +32,7 @@ by P.J.Rousseuw in [1].
 
 This example illustrates how the Mahalanobis distances are affected by
 outlying data: observations drawn from a contaminating distribution
-are not distinguishable from the observations comming from the real,
+are not distinguishable from the observations coming from the real,
 Gaussian distribution that one may want to work with. Using MCD-based
 Mahalanobis distances, the two populations become
 distinguishable. Associated applications are outliers detection,

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -52,7 +52,7 @@ import numpy as np
 import pylab as pl
 import matplotlib.font_manager
 
-from scikits.learn.covariance import EmpiricalCovariance, MCD
+from scikits.learn.covariance import EmpiricalCovariance, MinCovDet
 
 # example settings
 n_samples = 80
@@ -84,12 +84,12 @@ for i, n_outliers in enumerate(range_n_outliers):
         inliers_mask[outliers_index] = False
         
         # fit a Minimum Covariance Determinant (MCD) robust estimator to data
-        S = MCD().fit(X, reweight=None)
+        S = MinCovDet().fit(X, reweight=None)
         # compare robust estimates with the true location and covariance
         err_loc_mcd[i, j] = np.sum(S.location_ ** 2)
         err_cov_mcd[i, j] = S.error_norm(np.eye(n_features))
         # fit a reweighted MCD robust estimator to data
-        S = MCD().fit(X)
+        S = MinCovDet().fit(X)
         # compare robust estimates with the true location and covariance
         err_loc_mcd_reweighted[i, j] = np.sum(S.location_ ** 2)
         err_cov_mcd_reweighted[i, j] = S.error_norm(np.eye(n_features))

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -12,8 +12,8 @@ set.
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
 matrix of highly contaminated datasets, up to
-$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
-covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+:math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
+covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
 observations whose empirical covariance has the smallest determinant,
 yielding a "pure" subset of observations from which to compute
 standards estimates of location and covariance. After a correction

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -4,36 +4,37 @@ Robust vs Empirical covariance estimate
 =======================================
 
 The usual covariance maximum likelihood estimate is very sensitive to
-the presence of outliers in the data set. In such a case, one would
-have better to use a robust estimator of covariance to garanty that
-the estimation is resistant to "errorneous" observations in the data
+the presence of outliers in the data set. In such a case, it's
+recommended to use a robust estimator of covariance to guaranty that
+the estimation is resistant to "erroneous" observations in the data
 set.
 
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
-matrix of highly contaminated datasets, up to
+matrix of highly contaminated data sets, up to
 :math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
-covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
-observations whose empirical covariance has the smallest determinant,
-yielding a "pure" subset of observations from which to compute
-standards estimates of location and covariance. After a correction
-step aiming at compensating the fact the the estimates were learnt
-from only a portion of the initial data, we end up with robust
-estimates of the data set location and covariance.
+covariance. The idea is to find
+:math:`\frac{n_samples+n_features+1}{2}` observations whose empirical
+covariance has the smallest determinant, yielding a "pure" subset of
+observations from which to compute standards estimates of location and
+covariance. After a correction step aiming at compensating the fact
+the the estimates were learnt from only a portion of the initial data,
+we end up with robust estimates of the data set location and
+covariance.
 
 The Minimum Covariance Determinant estimator (MCD) has been introduced
 by P.J.Rousseuw in [1].
 
 In this example, we compare the estimation errors that are made when
 using four types of location and covariance estimates on contaminated
-gaussian distributed data sets:
- - The mean and the empirical covariance of the full dataset, which break
+Gaussian distributed data sets:
+ - The mean and the empirical covariance of the full data set, which break
    down as soon as there are outliers in the data set
  - The robust MCD, that has a low error provided n_samples > 5 * n_features
- - The robust MCD reweighted according to Rousseeuw's recommandations:
+ - The robust MCD re-weighted according to Rousseeuw's recommendations:
    observations are given a 0 weight if they are found to be outlying
    according to their MCD-based Mahalanobis distance. Doing so improve the
-   efficiency of the estimators at gaussian models but it assumes that
+   efficiency of the estimators at Gaussian models but it assumes that
    we perfectly know the distribution of the mahalanobis distances computed
    from the MCD estimate (see [2] for further details).
  - The mean and the empirical covariance of the observations that are known

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -1,0 +1,150 @@
+"""
+=======================================
+Robust vs Empirical covariance estimate
+=======================================
+
+The usual covariance maximum likelihood estimate is very sensitive to
+the presence of outliers in the data set. In such a case, one would
+have better to use a robust estimator of covariance to garanty that
+the estimation is resistant to "errorneous" observations in the data
+set.
+
+The Minimum Covariance Determinant estimator is a robust,
+high-breakdown point (i.e. it can be used to estimate the covariance
+matrix of highly contaminated datasets, up to
+$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
+covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+observations whose empirical covariance has the smallest determinant,
+yielding a "pure" subset of observations from which to compute
+standards estimates of location and covariance. After a correction
+step aiming at compensating the fact the the estimates were learnt
+from only a portion of the initial data, we end up with robust
+estimates of the data set location and covariance.
+
+The Minimum Covariance Determinant estimator (MCD) has been introduced
+by P.J.Rousseuw in [1].
+
+In this example, we compare the estimation errors that are made when
+using four types of location and covariance estimates on contaminated
+gaussian distributed data sets:
+ - The mean and the empirical covariance of the full dataset, which break
+   down as soon as there are outliers in the data set
+ - The robust MCD, that has a low error provided n_samples > 5 * n_features
+ - The robust MCD reweighted according to Rousseeuw's recommandations:
+   observations are given a 0 weight if they are found to be outlying
+   according to their MCD-based Mahalanobis distance. Doing so improve the
+   efficiency of the estimators at gaussian models but it assumes that
+   we perfectly know the distribution of the mahalanobis distances computed
+   from the MCD estimate (see [2] for further details).
+ - The mean and the empirical covariance of the observations that are known
+   to be good ones. This can be considered as a "perfect" MCD estimation,
+   so one can trust our implementation by comparing to this case.
+
+[1] P. J. Rousseeuw. Least median of squares regression. J. Am
+    Stat Ass, 79:871, 1984.
+[2] Johanna Hardin, David M Rocke. Journal of Computational and
+    Graphical Statistics. December 1, 2005, 14(4): 928-946.
+
+"""
+print __doc__
+
+import numpy as np
+import pylab as pl
+import matplotlib.font_manager
+
+from scikits.learn.covariance import EmpiricalCovariance, MCD
+
+# example settings
+n_samples = 80
+n_features = 5
+repeat = 10
+range_n_outliers = np.arange(0, n_samples / 2, 5)
+
+# definition of arrays to store results
+err_loc_mcd = np.zeros((range_n_outliers.size, repeat))
+err_cov_mcd = np.zeros((range_n_outliers.size, repeat))
+err_loc_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
+err_cov_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
+err_loc_emp_full = np.zeros((range_n_outliers.size, repeat))
+err_cov_emp_full = np.zeros((range_n_outliers.size, repeat))
+err_loc_emp_pure = np.zeros((range_n_outliers.size, repeat))
+err_cov_emp_pure = np.zeros((range_n_outliers.size, repeat))
+
+# computation
+for i, n_outliers in enumerate(range_n_outliers):
+    for j in range(repeat):
+        # generate data
+        X = np.random.randn(n_samples, n_features)
+        # add some outliers
+        outliers_index = np.random.permutation(n_samples)[:n_outliers]
+        outliers_offset = 10. * \
+            (np.random.randint(2, size=(n_outliers,n_features)) - 0.5)
+        X[outliers_index] += outliers_offset
+        inliers_mask = np.ones(n_samples).astype(bool)
+        inliers_mask[outliers_index] = False
+        
+        # fit a Minimum Covariance Determinant (MCD) robust estimator to data
+        S = MCD().fit(X, reweight=None)
+        # compare robust estimates with the true location and covariance
+        err_loc_mcd[i,j] = np.sum(S.location_ ** 2)
+        err_cov_mcd[i,j] = S.error_norm(np.eye(n_features))
+        # fit a reweighted MCD robust estimator to data
+        S = MCD().fit(X)
+        # compare robust estimates with the true location and covariance
+        err_loc_mcd_reweighted[i,j] = np.sum(S.location_ ** 2)
+        err_cov_mcd_reweighted[i,j] = S.error_norm(np.eye(n_features))
+        # compare estimators learnt from the full data set with true parameters
+        err_loc_emp_full[i,j] = np.sum(X.mean(0) ** 2)
+        err_cov_emp_full[i,j] = EmpiricalCovariance().fit(X).error_norm(
+            np.eye(n_features))
+        # compare with an empirical covariance learnt from a pure data set
+        # (i.e. "perfect" MCD)
+        pure_X = X[inliers_mask]
+        pure_location = pure_X.mean(0)
+        pure_emp_cov = EmpiricalCovariance().fit(pure_X)
+        err_loc_emp_pure[i,j] = np.sum(pure_location ** 2)
+        err_cov_emp_pure[i,j] = pure_emp_cov.error_norm(np.eye(n_features))    
+
+# Display results
+font_prop = matplotlib.font_manager.FontProperties(size=11)
+pl.subplot(2,1,1)
+pl.errorbar(range_n_outliers, err_loc_mcd.mean(1),
+            yerr=err_loc_mcd.std(1)/np.sqrt(repeat),
+            label="Robust location", color='cyan')
+pl.errorbar(range_n_outliers, err_loc_mcd_reweighted.mean(1),
+            yerr=err_loc_mcd_reweighted.std(1)/np.sqrt(repeat),
+            label="Robust location (reweighted)", color='blue')
+pl.errorbar(range_n_outliers, err_loc_emp_full.mean(1),
+            yerr=err_loc_emp_full.std(1)/np.sqrt(repeat),
+            label="Full data set mean", color='green')
+pl.errorbar(range_n_outliers, err_loc_emp_pure.mean(1),
+            yerr=err_loc_emp_pure.std(1)/np.sqrt(repeat),
+            label="Pure data set mean", color='black')
+pl.title("Influence of outliers on the location estimation")
+pl.ylabel(r"Error ($||\mu - \hat{\mu}||_2^2$)")
+pl.legend(loc="upper left", prop=font_prop)
+
+pl.subplot(2,1,2)
+x_size = range_n_outliers.size
+pl.errorbar(range_n_outliers, err_cov_mcd.mean(1),
+            yerr=err_cov_mcd.std(1),
+            label="Robust covariance (MCD)", color='cyan')
+pl.errorbar(range_n_outliers, err_cov_mcd_reweighted.mean(1),
+            yerr=err_cov_mcd_reweighted.std(1),
+            label="Robust covariance (reweighted MCD)", color='blue')
+pl.errorbar(range_n_outliers[:(x_size/5 + 1)],
+            err_cov_emp_full.mean(1)[:(x_size/5 + 1)],
+            yerr=err_cov_emp_full.std(1)[:(x_size/5 + 1)],
+            label="Full data set empirical covariance", color='green')
+pl.plot(range_n_outliers[(x_size/5):(x_size/2 - 1)],
+         err_cov_emp_full.mean(1)[(x_size/5):(x_size/2 - 1)],
+         color='green', ls='--')
+pl.errorbar(range_n_outliers, err_cov_emp_pure.mean(1),
+            yerr=err_cov_emp_pure.std(1),
+            label="Pure data set empirical covariance", color='black')
+pl.title("Influence of outliers on the covariance estimation")
+pl.xlabel("Amount of contamination (%)")
+pl.ylabel("RMSE") 
+pl.legend(loc="upper right", prop=font_prop)
+
+pl.show()

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -78,7 +78,7 @@ for i, n_outliers in enumerate(range_n_outliers):
         # add some outliers
         outliers_index = np.random.permutation(n_samples)[:n_outliers]
         outliers_offset = 10. * \
-            (np.random.randint(2, size=(n_outliers,n_features)) - 0.5)
+            (np.random.randint(2, size=(n_outliers, n_features)) - 0.5)
         X[outliers_index] += outliers_offset
         inliers_mask = np.ones(n_samples).astype(bool)
         inliers_mask[outliers_index] = False
@@ -86,45 +86,45 @@ for i, n_outliers in enumerate(range_n_outliers):
         # fit a Minimum Covariance Determinant (MCD) robust estimator to data
         S = MCD().fit(X, reweight=None)
         # compare robust estimates with the true location and covariance
-        err_loc_mcd[i,j] = np.sum(S.location_ ** 2)
-        err_cov_mcd[i,j] = S.error_norm(np.eye(n_features))
+        err_loc_mcd[i, j] = np.sum(S.location_ ** 2)
+        err_cov_mcd[i, j] = S.error_norm(np.eye(n_features))
         # fit a reweighted MCD robust estimator to data
         S = MCD().fit(X)
         # compare robust estimates with the true location and covariance
-        err_loc_mcd_reweighted[i,j] = np.sum(S.location_ ** 2)
-        err_cov_mcd_reweighted[i,j] = S.error_norm(np.eye(n_features))
+        err_loc_mcd_reweighted[i, j] = np.sum(S.location_ ** 2)
+        err_cov_mcd_reweighted[i, j] = S.error_norm(np.eye(n_features))
         # compare estimators learnt from the full data set with true parameters
-        err_loc_emp_full[i,j] = np.sum(X.mean(0) ** 2)
-        err_cov_emp_full[i,j] = EmpiricalCovariance().fit(X).error_norm(
+        err_loc_emp_full[i, j] = np.sum(X.mean(0) ** 2)
+        err_cov_emp_full[i, j] = EmpiricalCovariance().fit(X).error_norm(
             np.eye(n_features))
         # compare with an empirical covariance learnt from a pure data set
         # (i.e. "perfect" MCD)
         pure_X = X[inliers_mask]
         pure_location = pure_X.mean(0)
         pure_emp_cov = EmpiricalCovariance().fit(pure_X)
-        err_loc_emp_pure[i,j] = np.sum(pure_location ** 2)
-        err_cov_emp_pure[i,j] = pure_emp_cov.error_norm(np.eye(n_features))    
+        err_loc_emp_pure[i, j] = np.sum(pure_location ** 2)
+        err_cov_emp_pure[i, j] = pure_emp_cov.error_norm(np.eye(n_features))    
 
 # Display results
 font_prop = matplotlib.font_manager.FontProperties(size=11)
-pl.subplot(2,1,1)
+pl.subplot(2, 1, 1)
 pl.errorbar(range_n_outliers, err_loc_mcd.mean(1),
-            yerr=err_loc_mcd.std(1)/np.sqrt(repeat),
+            yerr=err_loc_mcd.std(1) / np.sqrt(repeat),
             label="Robust location", color='cyan')
 pl.errorbar(range_n_outliers, err_loc_mcd_reweighted.mean(1),
-            yerr=err_loc_mcd_reweighted.std(1)/np.sqrt(repeat),
+            yerr=err_loc_mcd_reweighted.std(1) / np.sqrt(repeat),
             label="Robust location (reweighted)", color='blue')
 pl.errorbar(range_n_outliers, err_loc_emp_full.mean(1),
-            yerr=err_loc_emp_full.std(1)/np.sqrt(repeat),
+            yerr=err_loc_emp_full.std(1) / np.sqrt(repeat),
             label="Full data set mean", color='green')
 pl.errorbar(range_n_outliers, err_loc_emp_pure.mean(1),
-            yerr=err_loc_emp_pure.std(1)/np.sqrt(repeat),
+            yerr=err_loc_emp_pure.std(1) / np.sqrt(repeat),
             label="Pure data set mean", color='black')
 pl.title("Influence of outliers on the location estimation")
 pl.ylabel(r"Error ($||\mu - \hat{\mu}||_2^2$)")
 pl.legend(loc="upper left", prop=font_prop)
 
-pl.subplot(2,1,2)
+pl.subplot(2, 1, 2)
 x_size = range_n_outliers.size
 pl.errorbar(range_n_outliers, err_cov_mcd.mean(1),
             yerr=err_cov_mcd.std(1),
@@ -132,12 +132,12 @@ pl.errorbar(range_n_outliers, err_cov_mcd.mean(1),
 pl.errorbar(range_n_outliers, err_cov_mcd_reweighted.mean(1),
             yerr=err_cov_mcd_reweighted.std(1),
             label="Robust covariance (reweighted MCD)", color='blue')
-pl.errorbar(range_n_outliers[:(x_size/5 + 1)],
-            err_cov_emp_full.mean(1)[:(x_size/5 + 1)],
-            yerr=err_cov_emp_full.std(1)[:(x_size/5 + 1)],
+pl.errorbar(range_n_outliers[:(x_size / 5 + 1)],
+            err_cov_emp_full.mean(1)[:(x_size / 5 + 1)],
+            yerr=err_cov_emp_full.std(1)[:(x_size / 5 + 1)],
             label="Full data set empirical covariance", color='green')
-pl.plot(range_n_outliers[(x_size/5):(x_size/2 - 1)],
-         err_cov_emp_full.mean(1)[(x_size/5):(x_size/2 - 1)],
+pl.plot(range_n_outliers[(x_size / 5):(x_size / 2 - 1)],
+         err_cov_emp_full.mean(1)[(x_size / 5):(x_size / 2 - 1)],
          color='green', ls='--')
 pl.errorbar(range_n_outliers, err_cov_emp_pure.mean(1),
             yerr=err_cov_emp_pure.std(1),

--- a/scikits/learn/covariance/__init__.py
+++ b/scikits/learn/covariance/__init__.py
@@ -14,3 +14,4 @@ from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
     log_likelihood
 from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
     ledoit_wolf, LedoitWolf, oas, OAS
+from .robust_covariance import fast_mcd, MCD

--- a/scikits/learn/covariance/__init__.py
+++ b/scikits/learn/covariance/__init__.py
@@ -13,5 +13,5 @@ to the theory of Gaussian Graphical Models.
 from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
     log_likelihood
 from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
-    ledoit_wolf, LedoitWolf, oas, OAS
-from .robust_covariance import fast_mcd, MCD
+    ledoit_wolf, LedoitWolf, oracle_approx_shrinkage, OracleApproxShrinkage
+from .robust_covariance import fast_mcd, MinCovDet

--- a/scikits/learn/covariance/empirical_covariance_.py
+++ b/scikits/learn/covariance/empirical_covariance_.py
@@ -213,3 +213,34 @@ class EmpiricalCovariance(BaseEstimator):
             result = np.sqrt(squared_norm)
         
         return result
+    
+    
+    def mahalanobis(self, observations):
+        """Computes the mahalanobis distances of given observations.
+        
+        The provided observations are assumed to be centered. One may
+        want to center it using a location estimate of its choice
+        first.
+        
+        Parameters
+        ----------
+        observations: array-like, shape = [n_observations, n_features]
+          The observations, the Mahalanobis distances of the which we compute.
+        
+        Returns
+        -------
+        mahalanobis_distance: 1D ndarray, shape = [n_observations,]
+          Mahalanobis distances of the observations.
+
+        """
+        # get precision
+        if self.store_precision:
+            precision = self.precision_
+        else:
+            precision = linalg.pinv(self.covariance_)
+            
+        # compute mahalanobis distances
+        mahalanobis_dist = np.sum(
+            np.dot(observations, precision) * observations, 1)
+        
+        return mahalanobis_dist 

--- a/scikits/learn/covariance/empirical_covariance_.py
+++ b/scikits/learn/covariance/empirical_covariance_.py
@@ -213,8 +213,7 @@ class EmpiricalCovariance(BaseEstimator):
             result = np.sqrt(squared_norm)
         
         return result
-    
-    
+        
     def mahalanobis(self, observations):
         """Computes the mahalanobis distances of given observations.
         

--- a/scikits/learn/covariance/robust_covariance.py
+++ b/scikits/learn/covariance/robust_covariance.py
@@ -392,7 +392,7 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
     return T_reweighted, S_reweighted, support
 
 
-class MCD(EmpiricalCovariance):
+class MinCovDet(EmpiricalCovariance):
     """Minimum Covariance Determinant (MCD) robust estimator of covariance
     
     The Minimum Covariance Determinant estimator is a robust estimator

--- a/scikits/learn/covariance/robust_covariance.py
+++ b/scikits/learn/covariance/robust_covariance.py
@@ -22,6 +22,7 @@ from ..utils.extmath import fast_logdet as exact_logdet
 #   for Quality, TECHNOMETRICS)
 ###############################################################################
 
+
 def c_step(X, h, remaining_iterations=30, initial_estimates=None,
            verbose=False):
     """C_step procedure described in [1] aiming at computing the MCD
@@ -59,10 +60,10 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
     H: array-like, shape (n_samples,)
       A mask for the `h` observations whose scatter matrix has minimum
       determinant
-    
+
     """
     n_samples, n_features = X.shape
-    
+
     # Initialisation
     if initial_estimates is None:
         # compute initial robust estimates from a random subset
@@ -85,7 +86,7 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
         S = empirical_covariance(X[support])
         detS = exact_logdet(S)
     previous_detS = np.inf
-    
+
     # Iterative procedure for Minimum Covariance Determinant computation
     detS = exact_logdet(S)
     while (detS < previous_detS) and (remaining_iterations > 0):
@@ -273,7 +274,7 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
     """
     X = np.asanyarray(X)
     if X.ndim <= 1:
-        X = X.reshape((-1,1))
+        X = X.reshape((-1, 1))
     n_samples, n_features = X.shape
 
     # minimum breakdown value
@@ -315,7 +316,8 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
             high_bound = low_bound + n_samples_subsets
             current_subset = X[samples_shuffle[low_bound:high_bound]]
             best_T_sub, best_S_sub, _ = select_candidates(
-                current_subset, h_subset, n_trials, select=n_best_sub, n_iter=2)
+                current_subset, h_subset, n_trials,
+                select=n_best_sub, n_iter=2)
             subset_slice = np.arange(i * n_best_sub, (i+1) * n_best_sub)
             all_best_T[subset_slice] = best_T_sub
             all_best_S[subset_slice] = best_S_sub
@@ -375,7 +377,8 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
     ## 5. Reweight estimate
     if reweight == "rousseeuw":
         X_centered = X - T
-        dist = (np.dot(X_centered, linalg.inv(S_corrected)) * X_centered).sum(1)
+        dist = (np.dot(X_centered, linalg.inv(S_corrected)) * \
+                    X_centered).sum(1)
         mask = dist < chi2(n_features).isf(0.025)
         T_reweighted = X[mask].mean(0)
         S_reweighted = empirical_covariance(X[mask])

--- a/scikits/learn/covariance/robust_covariance.py
+++ b/scikits/learn/covariance/robust_covariance.py
@@ -1,0 +1,494 @@
+"""
+Robust location and covariance estimators.
+
+Here are implemented estimators that are resistant to outliers.
+
+"""
+# Author: Virgile Fritsch <virgile.fritsch@inria.fr>
+#
+# License: BSD Style.
+import warnings
+import numpy as np
+from scipy import linalg
+from scipy.stats import chi2
+from scikits.learn.covariance import empirical_covariance, EmpiricalCovariance
+from ..utils.extmath import fast_logdet as exact_logdet
+
+###############################################################################
+### Minimum Covariance Determinant
+#   Implementing of an algorithm by Rousseeuw & Van Driessen described in
+#   (A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+#   1999, American Statistical Association and the American Society
+#   for Quality, TECHNOMETRICS)
+###############################################################################
+
+def c_step(X, h, remaining_iterations=30, initial_estimates=None,
+           verbose=False):
+    """C_step procedure described in [1] aiming at computing the MCD
+
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      Data set in which we look for the h observations whose scatter matrix
+      has minimum determinant
+    h: int, > n_samples / 2
+      Number of observations to compute the ribust estimates of location
+      and covariance from.
+    remaining_iterations: int
+      Number of iterations to perform.
+      According to Rousseeuw [1], two iterations are sufficient to get close
+      to the minimum, and we never need more than 30 to reach convergence.
+    initial_estimates: 2-tuple
+      Initial estimates of location and shape from which to run the c_step
+      procedure:
+      - initial_estimates[0]: an initial location estimate
+      - initial_estimates[1]: an initial covariance estimate
+    verbose: boolean
+      Verbose mode
+
+    Returns
+    -------
+    T: array-like, shape (n_features,)
+      Robust location estimates
+    S: array-like, shape (n_features, n_features)
+      Robust covariance estimates
+    H: array-like, shape (n_samples,)
+      A mask for the `h` observations whose scatter matrix has minimum
+      determinant
+    
+    """
+    n_samples, n_features = X.shape
+    
+    # Initialisation
+    if initial_estimates is None:
+        # compute initial robust estimates from a random subset
+        support = np.zeros(n_samples).astype(bool)
+        support[np.random.permutation(n_samples)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+    else:
+        # get initial robust estimates from the function parameters
+        T = initial_estimates[0]
+        S = initial_estimates[1]
+        # run a special iteration for that case (to get an initial support)
+        inv_S = linalg.pinv(S)
+        X_centered = X - T
+        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        # compute new estimates
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(dist)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+        detS = exact_logdet(S)
+    previous_detS = np.inf
+    
+    # Iterative procedure for Minimum Covariance Determinant computation
+    detS = exact_logdet(S)
+    while (detS < previous_detS) and (remaining_iterations > 0):
+        # compute a new support from the full data set mahalanobis distances
+        inv_S = linalg.pinv(S)
+        X_centered = X - T
+        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        # save old estimates values
+        previous_T = T
+        previous_S = S
+        previous_detS = detS
+        previous_support = support
+        # compute new estimates
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(dist)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+        detS = np.log(linalg.det(S))
+        # update remaining iterations for early stopping
+        remaining_iterations = remaining_iterations - 1
+    
+    # Check convergence
+    if np.allclose(detS, previous_detS):
+        # c_step procedure converged
+        if verbose:
+            print 'Optimal couple (T,S) found before ending iterations' \
+                '(%d left)' %(remaining_iterations)
+        results = T, S, detS, support
+    elif detS > previous_detS:
+        # determinant has increased (should not happen)
+        warnings.warn("Warning! detS > previous_detS (%.15f > %.15f)" \
+                          %(detS, previous_detS), RuntimeWarning)
+        results = previous_T, previous_S, previous_detS, previous_support
+    
+    # Check early stopping
+    if remaining_iterations == 0:
+        if verbose:
+            print 'Maximum number of iterations reached'
+        detS = exact_logdet(S)
+        results = T, S, detS, support
+
+    return results
+
+
+def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False):
+    """Finds the best pure subset of observations to compute MCD from it.
+    
+    The purpose of this function is to find the best sets of h
+    observations with respect to a minimization of their covariance
+    matrix determinant. Equivalently, it removes n_samples-h
+    observations to construct what we call a pure data set (i.e. not
+    containing outliers). The list of the observations of the pure
+    data set is referred to as the `support`.
+    
+    Starting from a random support, the pure data set is found by the
+    c_step procedure introduced by Rousseeuw and Van Driessen in [1].
+    
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      Data (sub)set in which we look for the h purest observations
+    h: int, [(n + p + 1)/2] < h < n
+      The number of samples the pure data set must contain.
+    select: int, int > 0
+      Number of best candidates results to return.
+    n_trials: int, nb_trials > 0 or 2-tuple
+      Number of different initial sets of observations from which to
+      run the algorithm.
+      Instead of giving a number of trials to perform, one can provide a
+      list of initial estimates that will be used to iteratively run
+      c_step procedures. In this case:
+      - n_trials[0]: array-like, shape (n_trials, n_features)
+        is the list of `n_trials` initial location estimates
+      - n_trials[1]: array-like, shape (n_trials, n_features, n_features)
+        is the list of `n_trials` initial covariances estimates
+    n_iter: int, nb_iter > 0
+      Maximum number of iterations for the c_step procedure.
+      (2 is enough to be close to the final solution. "Never" exceeds 20)
+      
+    See
+    ---
+    `c_step` function
+
+    Returns
+    -------
+    best_T: array-like, shape (select, n_features)
+      The `select` location estimates computed from the `select` best
+      supports found in the data set (`X`)
+    best_S: array-like, shape (select, n_features, n_features)
+      The `select` covariance estimates computed from the `select`
+      best supports found in the data set (`X`)
+    best_H: array-like, shape (select, n_samples)
+      The `select` best supports found in the data set (`X`)
+
+    """
+    n_samples, n_features = X.shape
+    
+    if isinstance(n_trials, int):
+        run_from_estimates = False
+    elif isinstance(n_trials, tuple):
+        run_from_estimates = True
+        estimates_list = n_trials
+        n_trials = estimates_list[0].shape[0]
+    else:
+        raise Exception('Bad \'n_trials\' parameter (wrong type)')
+    
+    # compute `n_trials` location and shape estimates candidates in the subset
+    all_T_sub = np.zeros((n_trials, n_features))
+    all_S_sub = np.zeros((n_trials, n_features, n_features))
+    all_detS_sub = np.zeros(n_trials)
+    all_H_sub = np.zeros((n_trials, n_samples)).astype(bool)
+    if not run_from_estimates:
+        # perform `n_trials` computations from random initial supports
+        for j in range(n_trials):
+            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
+                X, h, remaining_iterations=n_iter, verbose=verbose)
+    else:
+        # perform computations from every given initial estimates
+        for j in range(n_trials):
+            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
+                X, h, remaining_iterations=n_iter,
+                initial_estimates=(estimates_list[0][j], estimates_list[1][j]),
+                verbose=verbose)
+    
+    # find the `n_best` best results among the `n_trials` ones
+    index_best = np.argsort(all_detS_sub)[:select]
+    best_T = all_T_sub[index_best]
+    best_S = all_S_sub[index_best]
+    best_H = all_H_sub[index_best]
+    
+    return best_T, best_S, best_H
+
+
+def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
+    """Estimates the Minimum Covariance Determinant matrix.
+    
+    The FastMCD algorithm has been introduced by Rousseuw and Van Driessen
+    in "A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+    1999, American Statistical Association and the American Society
+    for Quality, TECHNOMETRICS".
+    The principle is to compute robust estimates and random subsets before
+    pooling them into a larger subsets, and finally into the full data set.
+    Depending on the size of the initial sample, we have one, two or three
+    such computation levels.
+    
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      The data matrix, with p features and n samples.
+    reweight: int (0 < reweight < 2)
+      Computation of a reweighted estimator:
+        - "rousseeuw" (default): Reweight observations using Rousseeuw's
+          method (equivalent to deleting outlying observations from the
+          data set before computing location and covariance estimates)
+        - else: no reweighting
+    correction: str
+      Improve the covariance estimator consistency at gaussian models
+        - "empirical" (default): correction using the empirical correction
+          factor suggested by Rousseeuw and Van Driessen in [1]
+        - "theoretical": correction using the theoretical correction factor
+          derived in [2]
+        - else: no correction
+    
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+    [2] R. W. Butler, P. L. Davies and M. Jhun,
+        Asymptotics For The Minimum Covariance Determinant Estimator,
+        The Annals of Statistics, 1993, Vol. 21, No. 3, 1385-1400
+
+    Returns
+    -------
+    T: array-like, shape (n_features,)
+      Robust location of the data
+    S: array-like, shape (n_features, n_features)
+      Robust covariance of the features
+    support: array-like, type boolean, shape (n_samples,)
+      a mask of the observations that have been used to compute
+      the robust location and covariance estimates of the data set
+    
+    """
+    X = np.asanyarray(X)
+    if X.ndim <= 1:
+        X = X.reshape((-1,1))
+    n_samples, n_features = X.shape
+
+    # minimum breakdown value
+    h = int(np.ceil(0.5 * (n_samples + n_features + 1)))
+    
+    # 1-dimensional case quick computation
+    # (Rousseeuw, P. J. and Leroy, A. M. (2005) References, in Robust
+    #  Regression and Outlier Detection, John Wiley & Sons, chapter 4)
+    if n_features == 1:
+        # find the sample shortest halves
+        X_sorted = np.sort(np.ravel(X))
+        diff = X_sorted[h:] - X_sorted[:n_samples-h]
+        halves_start = np.where(diff == np.min(diff))[0]
+        # take the middle points' mean to get the robust location estimate
+        T = 0.5 * (X_sorted[h+halves_start] + X_sorted[halves_start]).mean()
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(np.abs(X - T), axis=0)[:h]] = True
+        S = np.asarray([[np.var(X[support])]])
+        T = np.array([T])
+
+    ### Starting FastMCD algorithm for p-dimensional case
+    if (n_samples > 500) and (n_features > 1):
+        ## 1. Find candidate supports on subsets
+        # a. split the set in subsets of size ~ 300
+        n_subsets = n_samples / 300
+        n_samples_subsets = n_samples / n_subsets
+        samples_shuffle = np.random.permutation(n_samples)
+        h_subset = np.ceil(n_samples_subsets * (h / float(n_samples)))
+        # b. perform a total of 500 trials
+        n_trials_tot = 500
+        n_trials = n_trials_tot / n_subsets
+        # c. select 10 best (T,S) for each subset
+        n_best_sub = 10
+        n_best_tot = n_subsets * n_best_sub
+        all_best_T = np.zeros((n_best_tot, n_features))
+        all_best_S = np.zeros((n_best_tot, n_features, n_features))
+        for i in range(n_subsets):
+            low_bound = i * n_samples_subsets
+            high_bound = low_bound + n_samples_subsets
+            current_subset = X[samples_shuffle[low_bound:high_bound]]
+            best_T_sub, best_S_sub, _ = select_candidates(
+                current_subset, h_subset, n_trials, select=n_best_sub, n_iter=2)
+            subset_slice = np.arange(i * n_best_sub, (i+1) * n_best_sub)
+            all_best_T[subset_slice] = best_T_sub
+            all_best_S[subset_slice] = best_S_sub
+        ## 2. Pool the candidate supports into a merged set
+        ##    (possibly the full dataset)
+        n_samples_merged = min(1500, n_samples)
+        h_merged = np.ceil(n_samples_merged * (h / float(n_samples)))
+        if n_samples > 1500:
+            n_best_merged = 10
+        else:
+            n_best_merged = 1
+        # find the best couples (T,S) on the merged set
+        T_merged, S_merged, H_merged = select_candidates(
+            X[np.random.permutation(n_samples)[:n_samples_merged]],
+            h_merged, n_trials=(all_best_T, all_best_S), select=n_best_merged)
+        ## 3. Finally get the overall best (T,S) couple
+        if n_samples < 1500:
+            # directly get the best couple (T,S)
+            T = T_merged[0]
+            S = S_merged[0]
+            H = H_merged[0]
+        else:
+            # select the best couple on the full dataset
+            T_full, S_full, H_full = select_candidates(
+                X, h, n_trials=(T_merged, S_merged), select=1)
+            T = T_full[0]
+            S = S_full[0]
+            H = H_full[0]
+    elif n_features > 1:
+        ## 1. Find the 10 best couples (T,S) considering two iterations
+        n_trials = 30
+        n_best = 10
+        T_best, S_best, _ = select_candidates(
+            X, h, n_trials=n_trials, select=n_best, n_iter=2)
+        ## 2. Select the best couple on the full dataset amongst the 10
+        T_full, S_full, H_full = select_candidates(
+            X, h, n_trials=(T_best, S_best), select=1)
+        T = T_full[0]
+        S = S_full[0]
+        H = H_full[0]
+
+    ## 4. Obtain consistency at Gaussian models
+    if correction == "empirical":
+        # theoretical correction
+        inliers_ratio = h / float(n_samples)
+        S_corrected = S * (inliers_ratio) \
+            / chi2(n_features + 2).cdf(chi2(n_features).ppf(inliers_ratio))
+    elif correction == "theoretical":
+        # empirical correction
+        X_centered = X - T
+        dist = (np.dot(X_centered, linalg.inv(S)) * X_centered).sum(1)
+        S_corrected = S * (np.median(dist)/chi2(n_features).isf(0.5))
+    else:
+        # no correction
+        S_corrected = S
+    
+    ## 5. Reweight estimate
+    if reweight == "rousseeuw":
+        X_centered = X - T
+        dist = (np.dot(X_centered, linalg.inv(S_corrected)) * X_centered).sum(1)
+        mask = dist < chi2(n_features).isf(0.025)
+        T_reweighted = X[mask].mean(0)
+        S_reweighted = empirical_covariance(X[mask])
+        support = np.zeros(n_samples).astype(bool)
+        support[mask] = True
+    else:
+        T_reweighted = T
+        S_reweighted = S_corrected
+        support = H
+    
+    return T_reweighted, S_reweighted, support
+
+
+class MCD(EmpiricalCovariance):
+    """Minimum Covariance Determinant (MCD) robust estimator of covariance
+    
+    The Minimum Covariance Determinant estimator is a robust estimator
+    of a data set's covariance introduced by P.J.Rousseuw in [1].
+    The idea is to find a given proportion of "good" observations which
+    are not outliers and compute their empirical covariance matrix.
+    This empirical covariance matrix is then rescaled to compensate the
+    performed selection of observations ("consistency step").
+    Having computed the Minimum Covariance Determinant estimator, one
+    can give weights to observations according to their Mahalanobis
+    distance, leading the a reweighted estimate of the covariance
+    matrix of the data set.
+    
+    Rousseuw and Van Driessen [2] developed the FastMCD algorithm in order
+    to compute the Minimum Covariance Determinant. This algorithm is used
+    when fitting an MCD object to data.
+    The FastMCD algorithm also computes a robust estimate of the data set
+    location at the same time.
+    
+    Parameters
+    ----------
+    store_precision: bool
+        Specify if the estimated precision is stored
+
+    Attributes
+    ----------
+    `location_`: array-like, shape (n_features,)
+        Estimated robust location
+        
+    `covariance_`: array-like, shape (n_features, n_features)
+        Estimated robust covariance matrix
+
+    `precision_`: array-like, shape (n_features, n_features)
+        Estimated pseudo inverse matrix.
+        (stored only if store_precision is True)
+    
+    `support_`: array-like, shape (n_samples,)
+        A mask of the observations that have been used to compute
+        the robust estimates of location and shape.
+        
+    `correction`: str
+        Improve the covariance estimator consistency at gaussian models
+          - "empirical" (default): correction using the empirical correction
+            factor suggested by Rousseeuw and Van Driessen in [2]
+          - "theoretical": correction using the theoretical correction factor
+            derived in [3]
+          - else: no correction
+    
+    `reweight`: str
+        Computation of a reweighted MCD estimator:
+          - "rousseeuw" (default): Reweight observations using Rousseeuw's
+            method (equivalent to deleting outlying observations from the
+            data set before computing location and covariance estimates)
+          - else: no reweighting
+    
+    [1] P. J. Rousseeuw. Least median of squares regression. J. Am
+        Stat Ass, 79:871, 1984.
+    [2] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+    [3] R. W. Butler, P. L. Davies and M. Jhun,
+        Asymptotics For The Minimum Covariance Determinant Estimator,
+        The Annals of Statistics, 1993, Vol. 21, No. 3, 1385-1400
+        
+    """
+    def fit(self, X, assume_centered=False, correction="empirical",
+            reweight="rousseeuw"):
+        """Fits a Minimum Covariance Determinant with the FastMCD algorithm.
+
+        Parameters
+        ----------
+        X: array-like, shape = [n_samples, n_features]
+          Training data, where n_samples is the number of samples
+          and n_features is the number of features.
+
+        assume_centered: Boolean
+          If True, the support of robust location and covariance estimates
+          is computed, and a covariance estimate is recomputed from it,
+          without centering the data.
+          Usefull to work with data whose mean is significantly equal to
+          zero but is not exactly zero.
+          If False, the robust location and covariance are directly computed
+          with the FastMCD algorithm without additional treatment.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        location, covariance, support = fast_mcd(
+            X, correction=correction, reweight=reweight)
+        if assume_centered:
+            location = np.zeros(location.shape[0])
+            covariance = empirical_covariance(X[support], assume_centered=True)
+        self._set_estimates(covariance)
+        self.location_ = location
+        self.support_ = support
+        self.reweight = reweight
+        self.correction = correction
+
+        return self

--- a/scikits/learn/covariance/robust_covariance.py
+++ b/scikits/learn/covariance/robust_covariance.py
@@ -295,7 +295,7 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
         S = np.asarray([[np.var(X[support])]])
         T = np.array([T])
 
-    ### Starting FastMCD algorithm for p-dimensional case
+    # Starting FastMCD algorithm for p-dimensional case
     if (n_samples > 500) and (n_features > 1):
         ## 1. Find candidate supports on subsets
         # a. split the set in subsets of size ~ 300

--- a/scikits/learn/covariance/robust_covariance.py
+++ b/scikits/learn/covariance/robust_covariance.py
@@ -37,7 +37,7 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
       Data set in which we look for the h observations whose scatter matrix
       has minimum determinant
     h: int, > n_samples / 2
-      Number of observations to compute the ribust estimates of location
+      Number of observations to compute the robust estimates of location
       and covariance from.
     remaining_iterations: int
       Number of iterations to perform.
@@ -48,7 +48,7 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
       procedure:
       - initial_estimates[0]: an initial location estimate
       - initial_estimates[1]: an initial covariance estimate
-    verbose: boolean
+    verbose: Boolean
       Verbose mode
 
     Returns
@@ -245,9 +245,9 @@ def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
         - "rousseeuw" (default): Reweight observations using Rousseeuw's
           method (equivalent to deleting outlying observations from the
           data set before computing location and covariance estimates)
-        - else: no reweighting
+        - else: no re-weighting
     correction: str
-      Improve the covariance estimator consistency at gaussian models
+      Improve the covariance estimator consistency at Gaussian models
         - "empirical" (default): correction using the empirical correction
           factor suggested by Rousseeuw and Van Driessen in [1]
         - "theoretical": correction using the theoretical correction factor
@@ -434,7 +434,7 @@ class MinCovDet(EmpiricalCovariance):
         the robust estimates of location and shape.
         
     `correction`: str
-        Improve the covariance estimator consistency at gaussian models
+        Improve the covariance estimator consistency at Gaussian models
           - "empirical" (default): correction using the empirical correction
             factor suggested by Rousseeuw and Van Driessen in [2]
           - "theoretical": correction using the theoretical correction factor
@@ -442,11 +442,11 @@ class MinCovDet(EmpiricalCovariance):
           - else: no correction
     
     `reweight`: str
-        Computation of a reweighted MCD estimator:
+        Computation of a re-weighted MCD estimator:
           - "rousseeuw" (default): Reweight observations using Rousseeuw's
             method (equivalent to deleting outlying observations from the
             data set before computing location and covariance estimates)
-          - else: no reweighting
+          - else: no re-weighting
     
     [1] P. J. Rousseeuw. Least median of squares regression. J. Am
         Stat Ass, 79:871, 1984.
@@ -472,7 +472,7 @@ class MinCovDet(EmpiricalCovariance):
           If True, the support of robust location and covariance estimates
           is computed, and a covariance estimate is recomputed from it,
           without centering the data.
-          Usefull to work with data whose mean is significantly equal to
+          Useful to work with data whose mean is significantly equal to
           zero but is not exactly zero.
           If False, the robust location and covariance are directly computed
           with the FastMCD algorithm without additional treatment.

--- a/scikits/learn/covariance/shrunk_covariance_.py
+++ b/scikits/learn/covariance/shrunk_covariance_.py
@@ -271,7 +271,7 @@ class LedoitWolf(EmpiricalCovariance):
 ###############################################################################
 # OAS estimator
 
-def oas(X, assume_centered=False):
+def oracle_approx_shrinkage(X, assume_centered=False):
     """Estimate covariance with the Oracle Approximating Shrinkage algorithm.
 
     Parameters
@@ -298,7 +298,7 @@ def oas(X, assume_centered=False):
     -----
     The regularised (shrunk) covariance is:
 
-    (1 - shrinkage)*cov
+    (1 - shrinkage) * cov
       + shrinkage * mu * np.identity(n_features)
 
     where mu = trace(cov) / n_features
@@ -327,7 +327,7 @@ def oas(X, assume_centered=False):
     return shrunk_cov, shrinkage
 
 
-class OAS(EmpiricalCovariance):
+class OracleApproxShrinkage(EmpiricalCovariance):
     """
     Oracle Approximating Shrinkage Estimator
 
@@ -395,7 +395,8 @@ class OAS(EmpiricalCovariance):
             Returns self.
 
         """
-        covariance, shrinkage = oas(X, assume_centered=assume_centered)
+        covariance, shrinkage = oracle_approx_shrinkage(
+            X, assume_centered=assume_centered)
         self.shrinkage_ = shrinkage
         self._set_estimates(covariance)
 

--- a/scikits/learn/covariance/tests/test_covariance.py
+++ b/scikits/learn/covariance/tests/test_covariance.py
@@ -16,6 +16,7 @@ from scikits.learn import datasets
 X = datasets.load_iris().data
 n_samples, n_features = X.shape
 
+
 def test_covariance():
     """Tests Covariance module on a simple dataset.
 
@@ -39,7 +40,7 @@ def test_covariance():
     assert(np.amin(mahal_dist) > 50)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     cov = EmpiricalCovariance()
     cov.fit(X_1d)
     assert_array_almost_equal(empirical_covariance(X_1d), cov.covariance_, 4)
@@ -48,8 +49,8 @@ def test_covariance():
         cov.error_norm(empirical_covariance(X_1d), norm='spectral'), 0)
 
     # test integer type
-    X_integer = np.asarray([[0,1],[1,0]])
-    result = np.asarray([[0.25,-0.25],[-0.25,0.25]])
+    X_integer = np.asarray([[0, 1], [1, 0]])
+    result = np.asarray([[0.25, -0.25], [-0.25, 0.25]])
     assert_array_almost_equal(empirical_covariance(X_integer), result)
 
 
@@ -62,8 +63,7 @@ def test_shrunk_covariance():
     cov.fit(X)
     assert_array_almost_equal(
         shrunk_covariance(empirical_covariance(X), shrinkage=0.5),
-        cov.covariance_, 4
-        )
+        cov.covariance_, 4)
 
     # same test with shrinkage not provided
     cov = ShrunkCovariance()
@@ -77,7 +77,7 @@ def test_shrunk_covariance():
     assert_array_almost_equal(empirical_covariance(X), cov.covariance_, 4)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     cov = ShrunkCovariance(shrinkage=0.3)
     cov.fit(X_1d)
     assert_array_almost_equal(empirical_covariance(X_1d), cov.covariance_, 4)
@@ -98,7 +98,8 @@ def test_ledoit_wolf():
     assert_almost_equal(lw.shrinkage_, 0.00192, 4)
     assert_almost_equal(lw.score(X, assume_centered=True), -2.89795, 4)
     # compare shrunk covariance obtained from data and from MLE estimate
-    lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X,assume_centered=True)
+    lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(
+        X, assume_centered=True)
     assert_array_almost_equal(lw_cov_from_mle, lw.covariance_, 4)
     assert_almost_equal(lw_shinkrage_from_mle, lw.shrinkage_)
     # compare estimates given by LW and ShrunkCovariance
@@ -107,14 +108,14 @@ def test_ledoit_wolf():
     assert_array_almost_equal(scov.covariance_, lw.covariance_, 4)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     lw = LedoitWolf()
     lw.fit(X_1d, assume_centered=True)
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X_1d,
                                                          assume_centered=True)
     assert_array_almost_equal(lw_cov_from_mle, lw.covariance_, 4)
     assert_almost_equal(lw_shinkrage_from_mle, lw.shrinkage_)
-    assert_array_almost_equal((X_1d**2).sum()/n_samples, lw.covariance_, 4)
+    assert_array_almost_equal((X_1d ** 2).sum() / n_samples, lw.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
     lw = LedoitWolf(store_precision=False)
@@ -138,7 +139,7 @@ def test_ledoit_wolf():
     assert_array_almost_equal(scov.covariance_, lw.covariance_, 4)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     lw = LedoitWolf()
     lw.fit(X_1d)
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X_1d)
@@ -172,13 +173,13 @@ def test_oas():
     assert_array_almost_equal(scov.covariance_, oa.covariance_, 4)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     oa = OAS()
     oa.fit(X_1d, assume_centered=True)
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X_1d, assume_centered=True)
     assert_array_almost_equal(oa_cov_from_mle, oa.covariance_, 4)
     assert_almost_equal(oa_shinkrage_from_mle, oa.shrinkage_)
-    assert_array_almost_equal((X_1d**2).sum()/n_samples, oa.covariance_, 4)
+    assert_array_almost_equal((X_1d ** 2).sum() / n_samples, oa.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
     oa = OAS(store_precision=False)
@@ -202,7 +203,7 @@ def test_oas():
     assert_array_almost_equal(scov.covariance_, oa.covariance_, 4)
 
     # test with n_features = 1
-    X_1d = X[:,0]
+    X_1d = X[:, 0]
     oa = OAS()
     oa.fit(X_1d)
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X_1d)
@@ -223,7 +224,8 @@ def test_mcd():
     """
     yield generator_mcd, "empirical"
     yield generator_mcd, "theoretical"
-    
+
+
 def generator_mcd(correction):
     """Tests the fastMCD algorithm implementation with a given correction type
 
@@ -255,7 +257,7 @@ def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
     # add some outliers
     outliers_index = np.random.permutation(n_samples)[:n_outliers]
     outliers_offset = 10. * \
-        (np.random.randint(2, size=(n_outliers,n_features)) - 0.5)
+        (np.random.randint(2, size=(n_outliers, n_features)) - 0.5)
     data[outliers_index] += outliers_offset
     inliers_mask = np.ones(n_samples).astype(bool)
     inliers_mask[outliers_index] = False
@@ -264,15 +266,15 @@ def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
     T, S, H = fast_mcd(data, correction=correction)
     # compare with the estimates learnt from the inliers
     pure_data = data[inliers_mask]
-    error_location = np.sum((pure_data.mean(0) - T)**2)
+    error_location = np.sum((pure_data.mean(0) - T) ** 2)
     assert(error_location < tol_loc)
     emp_cov = EmpiricalCovariance().fit(pure_data)
     #print emp_cov.error_norm(S)
     assert(emp_cov.error_norm(S) < tol_cov)
     assert(np.sum(H) > tol_support)
     # check improvement
-    if (n_outliers/float(n_samples) > 0.1) and (n_features > 1):
-        error_bad_location = np.sum((data.mean(0) - T)**2)
+    if (n_outliers / float(n_samples) > 0.1) and (n_features > 1):
+        error_bad_location = np.sum((data.mean(0) - T) ** 2)
         assert(error_bad_location > error_location)
         bad_emp_cov = EmpiricalCovariance().fit(data)
         assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))
@@ -283,13 +285,13 @@ def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
     S = mcd_fit.covariance_
     H = mcd_fit.support_
     # compare with the estimates learnt from the inliers
-    error_location = np.sum((pure_data.mean(0) - T)**2)
+    error_location = np.sum((pure_data.mean(0) - T) ** 2)
     assert(error_location < tol_loc)
     assert(emp_cov.error_norm(S) < tol_cov)
     assert(np.sum(H) > tol_support)
     # check improvement
-    if (n_outliers/float(n_samples) > 0.1) and (n_features > 1):
-        error_bad_location = np.sum((data.mean(0) - T)**2)
+    if (n_outliers / float(n_samples) > 0.1) and (n_features > 1):
+        error_bad_location = np.sum((data.mean(0) - T) ** 2)
         assert(error_bad_location > error_location)
         bad_emp_cov = EmpiricalCovariance().fit(data)
         assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))

--- a/scikits/learn/covariance/tests/test_covariance.py
+++ b/scikits/learn/covariance/tests/test_covariance.py
@@ -19,7 +19,7 @@ n_samples, n_features = X.shape
 
 
 def test_covariance():
-    """Tests Covariance module on a simple dataset.
+    """Tests Covariance module on a simple data set.
 
     """
     # test covariance fit from data
@@ -56,7 +56,7 @@ def test_covariance():
 
 
 def test_shrunk_covariance():
-    """Tests ShrunkCovariance module on a simple dataset.
+    """Tests ShrunkCovariance module on a simple data set.
 
     """
     # compare shrunk covariance obtained from data and from MLE estimate
@@ -90,7 +90,7 @@ def test_shrunk_covariance():
 
 
 def test_ledoit_wolf():
-    """Tests LedoitWolf module on a simple dataset.
+    """Tests LedoitWolf module on a simple data set.
 
     """
     # test shrinkage coeff on a simple data set
@@ -251,7 +251,7 @@ def generator_mcd(correction):
 
 def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
                           tol_loc, tol_cov, tol_support, correction):
-    """Runs a serie of tests on the MCD with given parameters
+    """Run a serie of tests of MCD performed on random data
     
     The tests consist in estimating the covariance of a data set using
     the Minimum Covariance Determinant estimator. The correctness of
@@ -284,9 +284,10 @@ def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
         - "theoretical", theoretical correction factor
     
     """
-    data = np.random.randn(n_samples, n_features)
+    prng = np.random.RandomState(0)
+    data = prng.randn(n_samples, n_features)
     # add some outliers
-    outliers_index = np.random.permutation(n_samples)[:n_outliers]
+    outliers_index = prng.permutation(n_samples)[:n_outliers]
     outliers_offset = 10. * \
         (np.random.randint(2, size=(n_outliers, n_features)) - 0.5)
     data[outliers_index] += outliers_offset

--- a/scikits/learn/covariance/tests/test_covariance.py
+++ b/scikits/learn/covariance/tests/test_covariance.py
@@ -187,7 +187,7 @@ def test_oas():
     assert_almost_equal(oa.score(X, assume_centered=True), -5.03605, 4)
     assert(oa.precision_ is None)
 
-    ### Same tests without assuming centered data
+    # Same tests without assuming centered data
     # test shrinkage coeff on a simple data set
     oa = OAS()
     oa.fit(X)
@@ -230,7 +230,7 @@ def generator_mcd(correction):
     """Tests the fastMCD algorithm implementation with a given correction type
 
     """
-    ### Small data set
+    # Small data set
     # test without outliers (random independant normal data)
     launch_mcd_on_dataset(100, 5, 0, 0.3, 0.2, 70, correction)
     # test with a contaminated data set (medium contamination)
@@ -238,20 +238,48 @@ def generator_mcd(correction):
     # test with a contaminated data set (strong contamination)
     launch_mcd_on_dataset(100, 5, 40, 0.1, 0.1, 50, correction)
     
-    ### Medium data set
+    # Medium data set
     launch_mcd_on_dataset(1000, 5, 450, 1e-3, 0.01, 540, correction)
     
-    ### Large data set
+    # Large data set
     launch_mcd_on_dataset(1700, 5, 800, 1e-3, 1e-3, 870, correction)
     
-    ### 1D data set
+    # 1D data set
     launch_mcd_on_dataset(500, 1, 100, 0.1, 0.1, 350, correction)
     
 
 def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
                           tol_loc, tol_cov, tol_support, correction):
-    """
-
+    """Runs a serie of tests on the MCD with given parameters
+    
+    The tests consist in estimating the covariance of a data set using
+    the Minimum Covariance Determinant estimator. The correctness of
+    the estimation is determined form a comparison with the real
+    covariance of the data set, using an user-defined threshold.  The
+    same serie of tests is run for the location estimate.  The number
+    of subjects found as normal (i.e. in the MCD's support) is also
+    tested.
+    
+    Parameters
+    ----------
+    n_samples: int, n_samples > 0
+      Number of samples in the data set
+    n_features: int, n_features > 0
+      Number of features of the data set
+    n_outliers: int, n_outliers >= 0
+      Number of outliers in the data set
+    tol_loc: float
+      A tolerance for comparing the estimated and real locations
+    tol_cov: float
+      A tolerance factor for comparing the estimated and real covariances
+    tol_support: int
+      A tolerance factor for comparing the number of observations that
+      are and should be in the MCD support
+    correction: str, correction = "empirical" or "theoretical"
+      Correction type for the MCD estimator:
+        - "empirical" (default), empirical correction factor
+        - "theoretical", theoretical correction factor
+    
     """
     data = np.random.randn(n_samples, n_features)
     # add some outliers

--- a/scikits/learn/covariance/tests/test_covariance.py
+++ b/scikits/learn/covariance/tests/test_covariance.py
@@ -7,7 +7,8 @@
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from .. import empirical_covariance, EmpiricalCovariance, \
-    ShrunkCovariance, shrunk_covariance, LedoitWolf, ledoit_wolf, OAS, oas
+    ShrunkCovariance, shrunk_covariance, LedoitWolf, ledoit_wolf, OAS, oas, \
+    fast_mcd, MCD
 
 import numpy as np
 from scikits.learn import datasets
@@ -26,6 +27,16 @@ def test_covariance():
     assert_almost_equal(cov.error_norm(empirical_covariance(X)), 0)
     assert_almost_equal(
         cov.error_norm(empirical_covariance(X), norm='spectral'), 0)
+    assert_almost_equal(
+        cov.error_norm(empirical_covariance(X), norm='frobenius'), 0)
+    assert_almost_equal(
+        cov.error_norm(empirical_covariance(X), scaling=False), 0)
+    assert_almost_equal(
+        cov.error_norm(empirical_covariance(X), squared=False), 0)
+    # Mahalanobis distances computation test
+    mahal_dist = cov.mahalanobis(X)
+    assert(np.amax(mahal_dist) < 250)
+    assert(np.amin(mahal_dist) > 50)
 
     # test with n_features = 1
     X_1d = X[:,0]
@@ -204,3 +215,81 @@ def test_oas():
     oa.fit(X)
     assert_almost_equal(oa.score(X), 2.079025, 4)
     assert(oa.precision_ is None)
+
+
+def test_mcd():
+    """Tests the FastMCD algorithm implementation
+
+    """
+    yield generator_mcd, "empirical"
+    yield generator_mcd, "theoretical"
+    
+def generator_mcd(correction):
+    """Tests the fastMCD algorithm implementation with a given correction type
+
+    """
+    ### Small data set
+    # test without outliers (random independant normal data)
+    launch_mcd_on_dataset(100, 5, 0, 0.3, 0.2, 70, correction)
+    # test with a contaminated data set (medium contamination)
+    launch_mcd_on_dataset(100, 5, 20, 0.1, 0.2, 65, correction)    
+    # test with a contaminated data set (strong contamination)
+    launch_mcd_on_dataset(100, 5, 40, 0.1, 0.1, 50, correction)
+    
+    ### Medium data set
+    launch_mcd_on_dataset(1000, 5, 450, 1e-3, 0.01, 540, correction)
+    
+    ### Large data set
+    launch_mcd_on_dataset(1700, 5, 800, 1e-3, 1e-3, 870, correction)
+    
+    ### 1D data set
+    launch_mcd_on_dataset(500, 1, 100, 0.1, 0.1, 350, correction)
+    
+
+def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
+                          tol_loc, tol_cov, tol_support, correction):
+    """
+
+    """
+    data = np.random.randn(n_samples, n_features)
+    # add some outliers
+    outliers_index = np.random.permutation(n_samples)[:n_outliers]
+    outliers_offset = 10. * \
+        (np.random.randint(2, size=(n_outliers,n_features)) - 0.5)
+    data[outliers_index] += outliers_offset
+    inliers_mask = np.ones(n_samples).astype(bool)
+    inliers_mask[outliers_index] = False
+    
+    # compute MCD directly
+    T, S, H = fast_mcd(data, correction=correction)
+    # compare with the estimates learnt from the inliers
+    pure_data = data[inliers_mask]
+    error_location = np.sum((pure_data.mean(0) - T)**2)
+    assert(error_location < tol_loc)
+    emp_cov = EmpiricalCovariance().fit(pure_data)
+    #print emp_cov.error_norm(S)
+    assert(emp_cov.error_norm(S) < tol_cov)
+    assert(np.sum(H) > tol_support)
+    # check improvement
+    if (n_outliers/float(n_samples) > 0.1) and (n_features > 1):
+        error_bad_location = np.sum((data.mean(0) - T)**2)
+        assert(error_bad_location > error_location)
+        bad_emp_cov = EmpiricalCovariance().fit(data)
+        assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))
+    
+    # compute MCD by fitting an object
+    mcd_fit = MCD().fit(data)
+    T = mcd_fit.location_
+    S = mcd_fit.covariance_
+    H = mcd_fit.support_
+    # compare with the estimates learnt from the inliers
+    error_location = np.sum((pure_data.mean(0) - T)**2)
+    assert(error_location < tol_loc)
+    assert(emp_cov.error_norm(S) < tol_cov)
+    assert(np.sum(H) > tol_support)
+    # check improvement
+    if (n_outliers/float(n_samples) > 0.1) and (n_features > 1):
+        error_bad_location = np.sum((data.mean(0) - T)**2)
+        assert(error_bad_location > error_location)
+        bad_emp_cov = EmpiricalCovariance().fit(data)
+        assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))


### PR DESCRIPTION
(in replacement of previous, bad pull-request)

Minimum Covariance Determinant (MCD) is a robust estimator of
covariance introduced by Rousseeuw [1]. The main idea behind the MCD
is to find a fixed proportion of observations whose scatter matrix has
the minimum determinant.
The MCD estimator is computed with the FastMCD algorithm [2].

[1] P. J. Rousseeuw. Least median of squares regression. J. Am Stat
Ass, 79:871, 1984.
[2] P. J. Rousseeuw and K. Van Driessen. A fast algorithm for the
minimum covariance determinant estimator. Technometrics, 41(3):212,
1999.
