### PR TITLE
TfidfTransfomer: user-selectable norm

### DIFF
--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -5,16 +5,14 @@ Classification of text documents using sparse features
 
 This is an example showing how the scikit-learn can be used to classify
 documents by topics using a bag-of-words approach. This example uses
-a scipy.sparse matrix to store the features instead of standard numpy arrays.
+a scipy.sparse matrix to store the features instead of standard numpy arrays
+and demos various classifiers that can efficiently handle sparse matrices.
 
 The dataset used in this example is the 20 newsgroups dataset which will be
 automatically downloaded and then cached.
 
 You can adjust the number of categories by giving there name to the dataset
 loader or setting them to None to get the 20 of them.
-
-This example demos various linear classifiers with different training
-strategies.
 
 To run this example use::
 
@@ -75,10 +73,10 @@ categories = [
     'sci.space',
 ]
 # Uncomment the following to do the analysis on all the categories
-#categories = None
+categories = None
 
 print "Loading 20 newsgroups dataset for categories:"
-print categories
+print categories if categories else "all"
 
 data_train = fetch_20newsgroups(subset='train', categories=categories,
                                shuffle=True, random_state=42)

--- a/examples/grid_search_text_feature_extraction.py
+++ b/examples/grid_search_text_feature_extraction.py
@@ -97,6 +97,7 @@ parameters = {
 #    'vect__max_features': (None, 5000, 10000, 50000),
     'vect__analyzer__max_n': (1, 2), # words or bigrams
 #    'tfidf__use_idf': (True, False),
+#    'tfidf__norm': ('l1', 'l2'),
     'clf__alpha': (0.00001, 0.000001),
     'clf__penalty': ('l2', 'elasticnet'),
 #    'clf__n_iter': (10, 50, 80),

--- a/scikits/learn/feature_extraction/tests/test_text.py
+++ b/scikits/learn/feature_extraction/tests/test_text.py
@@ -177,30 +177,30 @@ def _test_vectorizer(cv_class, tf_class, v_class):
         assert_equal(counts_test[0, v.vocabulary[u"pizza"]], 0)
 
     # test tf-idf
-    t1 = tf_class()
+    t1 = tf_class(norm='l1')
     tfidf = toarray(t1.fit(counts_train).transform(counts_train))
-    assert_equal(len(t1.idf), len(v1.vocabulary))
+    assert_equal(len(t1.idf_), len(v1.vocabulary))
     assert_equal(tfidf.shape, (n_train, len(v1.vocabulary)))
 
     res.append(tfidf)
-    res.append(t1.idf)
+    res.append(t1.idf_)
 
     # test tf-idf with new data
     tfidf_test = toarray(t1.transform(counts_test))
     assert_equal(tfidf_test.shape, (len(test_data), len(v1.vocabulary)))
 
     # test tf alone
-    t2 = tf_class(use_idf=False)
+    t2 = tf_class(norm='l1', use_idf=False)
     tf = toarray(t2.fit(counts_train).transform(counts_train))
-    assert_equal(t2.idf, None)
+    assert_equal(t2.idf_, None)
 
-    # term frequencies sum to one
+    # L1-normalized term frequencies sum to one
     assert_array_almost_equal(np.sum(tf, axis=1), [1.0] * n_train)
 
     # test the direct tfidf vectorizer
     # (equivalent to term count vectorizer + tfidf transformer)
     train_data = iter(ALL_FOOD_DOCS[:-1])
-    tv = v_class()
+    tv = v_class(norm='l1')
     tv.tc.max_df = v1.max_df
     tfidf2 = toarray(tv.fit_transform(train_data))
     assert_array_almost_equal(tfidf, tfidf2)

--- a/scikits/learn/feature_extraction/text.py
+++ b/scikits/learn/feature_extraction/text.py
@@ -68,7 +68,7 @@ def strip_accents(s):
 def to_ascii(s):
     """Transform accentuated unicode symbols into ascii or nothing
 
-    Warning: this solution is only suited for roman languages that have a direct
+    Warning: this solution is only suited for languages that have a direct
     transliteration to ASCII symbols.
 
     A better solution would be to use transliteration based on a precomputed
@@ -87,7 +87,7 @@ def strip_tags(s):
 
 
 class RomanPreprocessor(object):
-    """Fast preprocessor suitable for roman languages"""
+    """Fast preprocessor suitable for Latin alphabet text"""
 
     def preprocess(self, unicode_text):
         """Preprocess strings"""
@@ -367,7 +367,6 @@ class CountVectorizer(BaseEstimator):
 
         Parameters
         ----------
-
         raw_documents: iterable
             an iterable which yields either str, unicode or file objects
 
@@ -385,7 +384,6 @@ class CountVectorizer(BaseEstimator):
 
         Parameters
         ----------
-
         raw_documents: iterable
             an iterable which yields either str, unicode or file objects
 
@@ -401,7 +399,6 @@ class CountVectorizer(BaseEstimator):
 
         Parameters
         ----------
-
         raw_documents: iterable
             an iterable which yields either str, unicode or file objects
 
@@ -515,7 +512,6 @@ class Vectorizer(BaseEstimator):
 
         Parameters
         ----------
-
         raw_documents: iterable
             an iterable which yields either str, unicode or file objects
 
@@ -534,7 +530,6 @@ class Vectorizer(BaseEstimator):
 
         Parameters
         ----------
-
         raw_documents: iterable
             an iterable which yields either str, unicode or file objects
 

--- a/scikits/learn/feature_extraction/text.py
+++ b/scikits/learn/feature_extraction/text.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Authors: Olivier Grisel <olivier.grisel@ensta.org>
 #          Mathieu Blondel
 #
@@ -9,7 +10,7 @@ import re
 import unicodedata
 import numpy as np
 from ..base import BaseEstimator, TransformerMixin
-from ..preprocessing import Normalizer
+from ..preprocessing import normalize
 
 ENGLISH_STOP_WORDS = set([
     "a", "about", "above", "across", "after", "afterwards", "again", "against",
@@ -415,38 +416,35 @@ class CountVectorizer(BaseEstimator):
 
 
 class TfidfTransformer(BaseEstimator, TransformerMixin):
-    """Transform a count matrix to a TF or TF-IDF representation
+    """Transform a count matrix to a normalized tf or tf–idf representation
 
-    TF means term-frequency while TF-IDF means term-frequency times inverse
+    Tf means term-frequency while tf–idf means term-frequency times inverse
     document-frequency:
 
-      http://en.wikipedia.org/wiki/TF-IDF
+      http://en.wikipedia.org/wiki/Tf–idf
 
-    The goal of using TF-IDF instead of the raw frequencies of occurrence of a
+    The goal of using Tf–idf instead of the raw frequencies of occurrence of a
     token in a given document is to scale down the impact of tokens that occur
     very frequently in a given corpus and that are hence empirically less
     informative than feature that occur in a small fraction of the training
     corpus.
 
-    TF-IDF can be seen as a smooth alternative to the stop words filtering.
-
     Parameters
     ----------
+    norm : 'l1', 'l2' or None, optional
+        Norm used to normalize term vectors. None for no normalization.
 
-    use_tf: boolean
-        enable term-frequency normalization
-
-    use_idf: boolean
-        enable inverse-document-frequency reweighting
+    use_idf : boolean
+        Enable inverse-document-frequency reweighting.
     """
 
-    def __init__(self, use_tf=True, use_idf=True):
-        self.use_tf = use_tf
+    def __init__(self, norm='l2', use_idf=True):
+        self.norm = norm
         self.use_idf = use_idf
-        self.idf = None
+        self.idf_ = None
 
     def fit(self, X, y=None):
-        """Learn the IDF vector (global term weights)
+        """Learn the idf vector (global term weights)
 
         Parameters
         ----------
@@ -460,12 +458,12 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
             idc = np.zeros(n_features, dtype=np.float64)
             for doc, token in zip(*X.nonzero()):
                 idc[token] += 1
-            self.idf = np.log(float(X.shape[0]) / idc)
+            self.idf_ = np.log(float(X.shape[0]) / idc)
 
         return self
 
     def transform(self, X, copy=True):
-        """Transform a count matrix to a TF or TF-IDF representation
+        """Transform a count matrix to a tf or tf–idf representation
 
         Parameters
         ----------
@@ -480,14 +478,14 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         X = sp.csr_matrix(X, dtype=np.float64, copy=copy)
         n_samples, n_features = X.shape
 
-        if self.use_tf:
-            X = Normalizer(norm='l1').transform(X)
-
         if self.use_idf:
-            d = sp.lil_matrix((len(self.idf), len(self.idf)))
-            d.setdiag(self.idf)
+            d = sp.lil_matrix((len(self.idf_), len(self.idf_)))
+            d.setdiag(self.idf_)
             # *= doesn't work
             X = X * d
+
+        if self.norm:
+            X = normalize(X, norm=self.norm, copy=False)
 
         return X
 
@@ -499,11 +497,11 @@ class Vectorizer(BaseEstimator):
     """
 
     def __init__(self, analyzer=DEFAULT_ANALYZER, max_df=1.0,
-                 max_features=None, use_tf=True, use_idf=True):
+                 max_features=None, norm='l2', use_idf=True):
         self.tc = CountVectorizer(analyzer, max_df=max_df,
                                   max_features=max_features,
                                   dtype=np.float64)
-        self.tfidf = TfidfTransformer(use_tf, use_idf)
+        self.tfidf = TfidfTransformer(norm=norm, use_idf=use_idf)
 
     def fit(self, raw_documents):
         """Learn a conversion law from documents to array data"""


### PR DESCRIPTION
Here's an updated `feature_extraction.text` module as per [Issue 225](https://github.com/scikit-learn/scikit-learn/issues/225). The main changes concern the `TfidfTransformer`, which previously
- had an boolean parameter `use_tf` to enable/disable L1 normalization,
- did normalization before idf reweighing,

and now
- allows the user to select L1, L2 or no normalization with the `norm` parameter,
- performs L2 normalization by default as per the Information Retrieval literature (where tf-idf originated)
- normalizes after applying idf.

The first big result is that the k-NN document classifier example goes from .5 to .8 F1-score, making it competitive. I suspect similar improvements might be got from other similarity-based (as opposed to margin-based) learning methods on tf-idf vectors.
