### PR TITLE
Replace mixture.logsum with numpy.logaddexp

### DIFF
--- a/scikits/learn/hmm.py
+++ b/scikits/learn/hmm.py
@@ -7,10 +7,13 @@ import string
 import numpy as np
 
 from .base import BaseEstimator
-from .mixture import (GMM, lmvnpdf, logsum, normalize, sample_gaussian,
+from .mixture import (GMM, lmvnpdf, normalize, sample_gaussian,
                  _distribute_covar_matrix_to_match_cvtype, _validate_covars)
 from . import cluster
 ZEROLOGPROB = -1e200
+
+
+logsum = np.logaddexp.reduce
 
 
 class _BaseHMM(BaseEstimator):

--- a/scikits/learn/mixture.py
+++ b/scikits/learn/mixture.py
@@ -12,25 +12,6 @@ from .base import BaseEstimator
 from . import cluster
 
 
-def logsum(A, axis=None):
-    """Computes the sum of A assuming A is in the log domain.
-
-    Returns log(sum(exp(A), axis)) while minimizing the possibility of
-    over/underflow.
-    """
-    Amax = A.max(axis)
-    if axis and A.ndim > 1:
-        shape = list(A.shape)
-        shape[axis] = 1
-        Amax.shape = shape
-    Asum = np.log(np.sum(np.exp(A - Amax), axis))
-    Asum += Amax.reshape(Asum.shape)
-    if axis:
-        # Look out for underflow.
-        Asum[np.isnan(Asum)] = - np.Inf
-    return Asum
-
-
 # TODO: this lacks a docstring
 def normalize(A, axis=None):
     A += np.finfo(float).eps
@@ -326,7 +307,7 @@ class GMM(BaseEstimator):
         obs = np.asanyarray(obs)
         lpr = (lmvnpdf(obs, self._means, self._covars, self._cvtype)
                + self._log_weights)
-        logprob = logsum(lpr, axis=1)
+        logprob = np.logaddexp.reduce(lpr, axis=1)
         posteriors = np.exp(lpr - logprob[:, np.newaxis])
         return logprob, posteriors
 

--- a/scikits/learn/tests/test_mixture.py
+++ b/scikits/learn/tests/test_mixture.py
@@ -20,23 +20,6 @@ def _generate_random_spd_matrix(ndim):
     return randspd
 
 
-def test_logsum_1D():
-    A = np.random.rand(2) + 1.0
-    for axis in range(1):
-        Asum = mixture.logsum(A, axis)
-        assert_array_almost_equal(np.exp(Asum), np.sum(np.exp(A), axis))
-
-
-def test_logsum_3D():
-    """
-    Test also on a 3D matrix
-    """
-    A = np.random.rand(2, 2, 2) + 1.0
-    for axis in range(3):
-        Asum = mixture.logsum(A, axis)
-        assert_array_almost_equal(np.exp(Asum), np.sum(np.exp(A), axis))
-
-
 def test_normalize_1D():
     A = np.random.rand(2) + 1.0
     for axis in range(1):


### PR DESCRIPTION
Since I'm venturing into other people's area of expertise, I decided to make this commit a pull request. I suggest we drop `mixture.logsum` in favor of `numpy.logaddexp`, which has the same function but is maintained upstream.
