### PR TITLE
Reverse coef_ in Ridge.

### DIFF
--- a/scikits/learn/linear_model/base.py
+++ b/scikits/learn/linear_model/base.py
@@ -44,7 +44,7 @@ class LinearModel(BaseEstimator, RegressorMixin):
             Returns predicted values.
         """
         X = safe_asanyarray(X)
-        return safe_sparse_dot(X, self.coef_) + self.intercept_
+        return safe_sparse_dot(X, self.coef_.T) + self.intercept_
 
     @staticmethod
     def _center_data(X, y, fit_intercept):
@@ -70,7 +70,7 @@ class LinearModel(BaseEstimator, RegressorMixin):
         """Set the intercept_
         """
         if self.fit_intercept:
-            self.intercept_ = ymean - np.dot(Xmean, self.coef_)
+            self.intercept_ = ymean - np.dot(Xmean, self.coef_.T)
         else:
             self.intercept_ = 0
 

--- a/scikits/learn/linear_model/tests/test_ridge.py
+++ b/scikits/learn/linear_model/tests/test_ridge.py
@@ -51,6 +51,7 @@ def test_ridge():
 
     ridge = Ridge(alpha=alpha)
     ridge.fit(X, y)
+    assert_equal(ridge.coef_.shape, (X.shape[1], ))
     assert ridge.score(X, y) > 0.5
 
     ridge.fit(X, y, sample_weight=np.ones(n_samples))
@@ -195,9 +196,11 @@ def _test_ridge_diabetes(filter_):
 def _test_multi_ridge_diabetes(filter_):
     # simulate several responses
     Y = np.vstack((y_diabetes,y_diabetes)).T
+    n_features = X_diabetes.shape[1]
 
     ridge = Ridge(fit_intercept=False)
     ridge.fit(filter_(X_diabetes), Y)
+    assert_equal(ridge.coef_.shape, (2, n_features))
     Y_pred = ridge.predict(filter_(X_diabetes))
     ridge.fit(filter_(X_diabetes), y_diabetes)
     y_pred = ridge.predict(filter_(X_diabetes))
@@ -205,8 +208,11 @@ def _test_multi_ridge_diabetes(filter_):
                               Y_pred, decimal=3)
 
 def _test_ridge_classifiers(filter_):
+    n_classes = np.unique(y_iris).shape[0]
+    n_features = X_iris.shape[1]
     for clf in (RidgeClassifier(), RidgeClassifierCV()):
         clf.fit(filter_(X_iris), y_iris)
+        assert_equal(clf.coef_.shape, (n_classes, n_features))
         y_pred = clf.predict(filter_(X_iris))
         assert np.mean(y_iris == y_pred) >= 0.8
 


### PR DESCRIPTION
This is probably not so well-known but Ridge support Y of shape `[n_samples, n_responses]` for multivariate regression. There was as an inconsistency in that `coef_` was `[n_features, n_responses]` where as all other linear classifiers use `[n_classes, n_features]`. This is fixed in this pull request. @vene and @fabianp, can you check that it doesn't break your code? The case when Y is `[n_samples]` shouldn't be affected at all.
