### PR TITLE
Changed the default return type of ward_tree from bool to int

### DIFF
--- a/scikits/learn/feature_extraction/image.py
+++ b/scikits/learn/feature_extraction/image.py
@@ -10,8 +10,9 @@ import numpy as np
 from scipy import sparse
 from ..utils.fixes import in1d
 
-################################################################################
+###############################################################################
 # From an image to a graph
+
 
 def _make_edges_3d(n_x, n_y, n_z=1):
     """Returns a list of edges for a 3D image.
@@ -59,7 +60,7 @@ def _mask_edges_weights(mask, edges, weights=None):
     if len(edges.ravel()):
         maxval = edges.max()
     else:
-        maxval=0
+        maxval = 0
     order = np.searchsorted(np.unique(edges.ravel()), np.arange(maxval+1))
     edges = order[edges]
     if weights is None:
@@ -73,7 +74,7 @@ def _to_graph(n_x, n_y, n_z, mask=None, img=None,
     """Auxiliary function for img_to_graph and grid_to_graph
     """
     edges = _make_edges_3d(n_x, n_y, n_z)
-    
+
     if dtype is None:
         if img is None:
             dtype = np.int
@@ -160,5 +161,3 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
         The data of the returned sparse matrix. By default it is int
     """
     return _to_graph(n_x, n_y, n_z, mask=mask, return_as=return_as, dtype=dtype)
-
-

--- a/scikits/learn/feature_extraction/image.py
+++ b/scikits/learn/feature_extraction/image.py
@@ -56,7 +56,10 @@ def _mask_edges_weights(mask, edges, weights=None):
     edges = edges[:, ind_mask]
     if weights is not None:
         weights = weights[ind_mask]
-    maxval = edges.max()
+    if len(edges.ravel()):
+        maxval = edges.max()
+    else:
+        maxval=0
     order = np.searchsorted(np.unique(edges.ravel()), np.arange(maxval+1))
     edges = order[edges]
     if weights is None:
@@ -70,12 +73,15 @@ def _to_graph(n_x, n_y, n_z, mask=None, img=None,
     """Auxiliary function for img_to_graph and grid_to_graph
     """
     edges = _make_edges_3d(n_x, n_y, n_z)
-
+    
     if dtype is None:
         if img is None:
-            dtype = np.bool
+            dtype = np.int
         else:
             dtype = img.dtype
+
+    if dtype == np.bool:
+        dtype = np.int
 
     if img is not None:
         img = np.atleast_3d(img)
@@ -132,7 +138,7 @@ def img_to_graph(img, mask=None, return_as=sparse.coo_matrix, dtype=None):
 
 
 def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
-                  dtype=np.bool):
+                  dtype=np.int):
     """Graph of the pixel-to-pixel connections
 
     Edges exist if 2 voxels are connected.
@@ -150,8 +156,8 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
         pixels.
     return_as: np.ndarray or a sparse matrix class, optional
         The class to use to build the returned adjacency matrix.
-    dtype: dtype, optional, default bool
-        The data of the returned sparse matrix. By default it is bool
+    dtype: dtype, optional, default int
+        The data of the returned sparse matrix. By default it is int
     """
     return _to_graph(n_x, n_y, n_z, mask=mask, return_as=return_as, dtype=dtype)
 

--- a/scikits/learn/feature_extraction/tests/test_image.py
+++ b/scikits/learn/feature_extraction/tests/test_image.py
@@ -11,6 +11,7 @@ import nose
 from ..image import img_to_graph, grid_to_graph
 from ...utils.graph import cs_graph_components
 
+
 def test_img_to_graph():
     x, y = np.mgrid[:4, :4] - 10
     grad_x = img_to_graph(x)
@@ -22,13 +23,14 @@ def test_img_to_graph():
     np.testing.assert_array_equal(grad_x.data[grad_x.data > 0],
                                   grad_y.data[grad_y.data > 0])
 
+
 def test_grid_to_graph():
     #Checking that the function works with graphs containing no edges
     size = 2
     roi_size = 1
     # Generating two convex parts with one vertex
     # Thus, edges will be empty in _to_graph
-    mask = np.zeros((size, size), dtype=bool)
+    mask = np.zeros((size, size), dtype=np.bool)
     mask[0:roi_size, 0:roi_size] = True
     mask[-roi_size:, -roi_size:] = True
     mask = mask.reshape(size**2)
@@ -55,4 +57,3 @@ def test_connect_regions_with_grid():
     graph = grid_to_graph(*lena.shape, **{'mask' : mask, 'dtype' : None})
     nose.tools.assert_equal(ndimage.label(mask)[1],
                             cs_graph_components(graph)[0])
-

--- a/scikits/learn/feature_extraction/tests/test_image.py
+++ b/scikits/learn/feature_extraction/tests/test_image.py
@@ -22,6 +22,17 @@ def test_img_to_graph():
     np.testing.assert_array_equal(grad_x.data[grad_x.data > 0],
                                   grad_y.data[grad_y.data > 0])
 
+def test_grid_to_graph():
+    #Checking that the function works with graphs containing no edges
+    size = 2
+    roi_size = 1
+    # Generating two convex parts with one vertex
+    mask = np.zeros((size, size), dtype=bool)
+    mask[0:roi_size, 0:roi_size] = True
+    mask[-roi_size:, -roi_size:] = True
+    mask = mask.reshape(size**2)
+    A = grid_to_graph(n_x=size, n_y=size, mask=mask, return_as=np.ndarray)
+
 
 def test_connect_regions():
     lena = sp.lena()

--- a/scikits/learn/feature_extraction/tests/test_image.py
+++ b/scikits/learn/feature_extraction/tests/test_image.py
@@ -27,6 +27,7 @@ def test_grid_to_graph():
     size = 2
     roi_size = 1
     # Generating two convex parts with one vertex
+    # Thus, edges will be empty in _to_graph
     mask = np.zeros((size, size), dtype=bool)
     mask[0:roi_size, 0:roi_size] = True
     mask[-roi_size:, -roi_size:] = True


### PR DESCRIPTION
Changed the return type for ward_tree function from bool to int to avoid
an error when the parameter 'return_as' is set to 'numpy.ndarray', or when applying todense method to the sparse matrix returned.

fix : when edges is empty

added tests for grid_to_graph
