### PR TITLE
One-hot/1-of-K transformer in preprocessing module

### DIFF
--- a/scikits/learn/metrics/pairwise.py
+++ b/scikits/learn/metrics/pairwise.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
-from ..utils import safe_asanyarray, atleast2d_or_csr
+from ..utils import safe_asanyarray, safe_atleast2d
 from ..utils.extmath import safe_sparse_dot
 
 
@@ -73,7 +73,7 @@ def euclidean_distances(X, Y, Y_norm_squared=None, squared=False):
         else:
             YY = np.sum(Y ** 2, axis=1)[np.newaxis, :]
     else:
-        YY = atleast2d_or_csr(Y_norm_squared)
+        YY = safe_atleast2d(Y_norm_squared, 'csr')
         if YY.shape != (1, Y.shape[0]):
             raise ValueError(
                         "Incompatible dimensions for Y and Y_norm_squared")

--- a/scikits/learn/naive_bayes.py
+++ b/scikits/learn/naive_bayes.py
@@ -22,7 +22,7 @@ complete documentation.
 
 from .base import BaseEstimator, ClassifierMixin
 from .preprocessing import binarize, LabelBinarizer
-from .utils import safe_asanyarray, atleast2d_or_csr
+from .utils import safe_asanyarray, safe_atleast2d
 from .utils.extmath import safe_sparse_dot
 from .utils.fixes import unique
 import numpy as np
@@ -233,7 +233,7 @@ class BaseDiscreteNB(BaseEstimator, ClassifierMixin):
         self : object
             Returns self.
         """
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X)
         y = safe_asanyarray(y)
 
         self.unique_y, inv_y_ind = unique(y, return_inverse=True)
@@ -401,7 +401,7 @@ class MultinomialNB(BaseDiscreteNB):
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""
 
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X)
 
         jll = safe_sparse_dot(self.coef_, X.T)
         return jll + np.atleast_2d(self.intercept_).T
@@ -500,7 +500,7 @@ class BernoulliNB(BaseDiscreteNB):
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""
 
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X)
 
         if self.binarize is not None:
             X = binarize(X, threshold=self.binarize)

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -13,7 +13,7 @@ from scipy.sparse import csr_matrix, issparse
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from .ball_tree import BallTree
 from .metrics import euclidean_distances
-from .utils import safe_asanyarray, atleast2d_or_csr
+from .utils import safe_asanyarray, safe_atleast2d
 
 
 class NeighborsClassifier(BaseEstimator, ClassifierMixin):
@@ -194,7 +194,7 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
 
         """
         self._set_params(**params)
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X, 'csr')
         if self.ball_tree is None:
             dist = euclidean_distances(X, self._fit_X, squared=True)
             # XXX: should be implemented with a partial sort
@@ -224,7 +224,7 @@ class NeighborsClassifier(BaseEstimator, ClassifierMixin):
         labels: array
             List of class labels (one for each data sample).
         """
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X, 'csr')
         self._set_params(**params)
 
         # get neighbors
@@ -312,7 +312,7 @@ class NeighborsRegressor(NeighborsClassifier, RegressorMixin):
         y: array
             List of target values (one for each data sample).
         """
-        X = atleast2d_or_csr(X)
+        X = safe_atleast2d(X, 'csr')
         self._set_params(**params)
 
         # compute nearest neighbors

--- a/scikits/learn/preprocessing/tests/test_preprocessing.py
+++ b/scikits/learn/preprocessing/tests/test_preprocessing.py
@@ -14,6 +14,8 @@ from scikits.learn.preprocessing import KernelCenterer
 from scikits.learn.preprocessing import LabelBinarizer
 from scikits.learn.preprocessing import Normalizer
 from scikits.learn.preprocessing import normalize
+from scikits.learn.preprocessing import OneHotTransformer
+from scikits.learn.preprocessing import one_hot
 from scikits.learn.preprocessing import Scaler
 from scikits.learn.preprocessing import scale
 
@@ -290,6 +292,29 @@ def test_label_binarizer_iris():
     y_pred2 = SGDClassifier().fit(iris.data, iris.target).predict(iris.data)
     accuracy2 = np.mean(iris.target == y_pred2)
     assert_almost_equal(accuracy, accuracy2)
+
+
+def test_onehot():
+    n_samples = 3
+    n_features = 4
+    X = np.arange(12).reshape((n_samples, n_features))
+
+    Xt = one_hot(X).toarray()
+    assert_equal(Xt, np.array([[1, 0, 0] * n_features,
+                               [0, 1, 0] * n_features,
+                               [0, 0, 1] * n_features]))
+
+    # Binary features should not be "blown up" to several features
+    oh = OneHotTransformer()
+    X[:, 1] = [1, 0, 0]
+    oh.fit(X)
+    X_test = oh.transform(np.array([[0, 1, 6, 11]]))
+    assert_equal(X_test.shape, (1, 10))
+
+    oh_dense = OneHotTransformer(sparse_output=False)
+    oh_dense.fit(X)
+    X_test_dense = oh_dense.transform(np.array([[0, 1, 6, 11]]))
+    assert_equal(X_test.toarray(), X_test_dense)
 
 
 def test_center_kernel():

--- a/scikits/learn/utils/__init__.py
+++ b/scikits/learn/utils/__init__.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 
+
 def safe_asanyarray(X, dtype=None, order=None):
     if sp.issparse(X):
         return X
@@ -9,10 +10,11 @@ def safe_asanyarray(X, dtype=None, order=None):
         return np.asanyarray(X, dtype, order)
 
 
-def atleast2d_or_csr(X):
-    """Like numpy.atleast_2d, but converts sparse matrices to CSR format"""
+def safe_atleast2d(X, format=None):
+    """Like numpy.asleast_2d, but works on sparse matrices as well
+       and converts those to a specific format if needed."""
     if sp.issparse(X):
-        return X.tocsr()
+        return X.asformat(format) if format else X
     else:
         return np.atleast_2d(X)
 


### PR DESCRIPTION
This is an early pull request for a transformer that builds the sparse one-hot/1-of-K representation of a feature space. There's no example yet, the implementation can't handle sparse input and I haven't optimized it.

What might further have to be done:
- allow the user to "mask out" some features that must be left as-is;
- <del>refactor `LabelBinarizer` and `OneHotTransformer` to factor out the basic operation;</del>
- handle sparse matrices in a smarter way, without requiring a dense intermediate representation.

I want to have this functionality because I'm working on a program that has several features that depend on the presence of items from a vocabulary. Using one-hot representation for such features is recommended by [Hsu, Chang and Lin](http://www.csie.ntu.edu.tw/~cjlin/papers/guide/guide.pdf), a.o.
