### PR TITLE
WIP: Complement Naive Bayes

### DIFF
--- a/scikits/learn/naive_bayes.py
+++ b/scikits/learn/naive_bayes.py
@@ -280,7 +280,8 @@ class BaseDiscreteNB(BaseEstimator, ClassifierMixin):
         C : array, shape = [n_samples]
         """
         joint_log_likelihood = self._joint_log_likelihood(X)
-        y_pred = self.unique_y[np.argmax(joint_log_likelihood, axis=0)]
+        argopt = np.argmin if getattr(self, 'complement', False) else np.argmax
+        y_pred = self.unique_y[argopt(joint_log_likelihood, axis=0)]
 
         return y_pred
 
@@ -336,6 +337,10 @@ class MultinomialNB(BaseDiscreteNB):
     alpha: float, optional (default=1.0)
         Additive (Laplace/Lidstone) smoothing parameter
         (0 for no smoothing).
+    complement: boolean
+        If True, fit a complement naive Bayes model (see References).
+        Currently, predict_proba and predict_log_proba should not be used
+        with complement models.
     fit_prior: boolean
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
@@ -373,7 +378,7 @@ class MultinomialNB(BaseDiscreteNB):
     >>> from scikits.learn.naive_bayes import MultinomialNB
     >>> clf = MultinomialNB()
     >>> clf.fit(X, Y)
-    MultinomialNB(alpha=1.0, fit_prior=True)
+    MultinomialNB(alpha=1.0, complement=False, fit_prior=True)
     >>> print clf.predict(X[2])
     [3]
 
@@ -384,12 +389,28 @@ class MultinomialNB(BaseDiscreteNB):
     Tackling the poor assumptions of naive Bayes text classifiers, ICML.
     """
 
-    def __init__(self, alpha=1.0, fit_prior=True):
+    def __init__(self, alpha=1.0, complement=False, fit_prior=True):
         self.alpha = alpha
+        self.complement = complement
         self.fit_prior = fit_prior
 
     intercept_ = property(lambda self: self.class_log_prior_)
     coef_ = property(lambda self: self.feature_log_prob_)
+
+    def _count(self, X, Y):
+        """Count feature occurrences.
+
+        Returns (N_c, N_c_i), where
+            N_c is the count of all features in all samples of class c;
+            N_c_i is the count of feature i in all samples of class c.
+        """
+        N_c_i = safe_sparse_dot(Y.T, X)
+        if self.complement:
+            N_c_i_sum = np.atleast_2d(N_c_i.sum(axis=0))
+            N_c_i = np.concatenate([N_c_i_sum] * N_c_i.shape[0]) - N_c_i
+        N_c = np.sum(N_c_i, axis=1)
+
+        return N_c, N_c_i
 
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""

--- a/scikits/learn/naive_bayes.py
+++ b/scikits/learn/naive_bayes.py
@@ -254,15 +254,17 @@ class BaseDiscreteNB(BaseEstimator, ClassifierMixin):
 
         return self
 
-    @staticmethod
-    def _count(X, Y):
-        """Count feature occurrences.
+    def _count(self, X, Y):
+        """Count raw feature occurrences.
 
         Returns (N_c, N_c_i), where
             N_c is the count of all features in all samples of class c;
             N_c_i is the count of feature i in all samples of class c.
         """
         N_c_i = safe_sparse_dot(Y.T, X)
+        if self.complement:
+            N_c_i_sum = np.atleast_2d(N_c_i.sum(axis=0))
+            N_c_i = np.concatenate([N_c_i_sum] * N_c_i.shape[0]) - N_c_i
         N_c = np.sum(N_c_i, axis=1)
 
         return N_c, N_c_i
@@ -280,7 +282,7 @@ class BaseDiscreteNB(BaseEstimator, ClassifierMixin):
         C : array, shape = [n_samples]
         """
         joint_log_likelihood = self._joint_log_likelihood(X)
-        argopt = np.argmin if getattr(self, 'complement', False) else np.argmax
+        argopt = np.argmin if self.complement else np.argmax
         y_pred = self.unique_y[argopt(joint_log_likelihood, axis=0)]
 
         return y_pred
@@ -438,6 +440,10 @@ class BernoulliNB(BaseDiscreteNB):
     binarize: float or None, optional
         Threshold for binarizing (mapping to booleans) of sample features.
         If None, input is presumed to already consist of binary vectors.
+    complement: boolean
+        If True, fit a complement naive Bayes model (see References).
+        Currently, predict_proba and predict_log_proba should not be used
+        with complement models.
     fit_prior: boolean
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
@@ -472,7 +478,7 @@ class BernoulliNB(BaseDiscreteNB):
     >>> from scikits.learn.naive_bayes import BernoulliNB
     >>> clf = BernoulliNB()
     >>> clf.fit(X, Y)
-    BernoulliNB(binarize=0.0, alpha=1.0, fit_prior=True)
+    BernoulliNB(binarize=0.0, alpha=1.0, complement=False, fit_prior=True)
     >>> print clf.predict(X[2])
     [3]
 
@@ -489,9 +495,11 @@ class BernoulliNB(BaseDiscreteNB):
     naive Bayes -- Which naive Bayes? 3rd Conf. on Email and Anti-Spam (CEAS).
     """
 
-    def __init__(self, alpha=1.0, binarize=.0, fit_prior=True):
+    def __init__(self, alpha=1.0, binarize=.0, complement=False,
+                 fit_prior=True):
         self.alpha = alpha
         self.binarize = binarize
+        self.complement = complement
         self.fit_prior = fit_prior
 
     def _count(self, X, Y):

--- a/scikits/learn/tests/test_naive_bayes.py
+++ b/scikits/learn/tests/test_naive_bayes.py
@@ -128,3 +128,11 @@ def test_discretenb_uniform_prior():
         prior = np.exp(clf.class_log_prior_)
         assert prior[0] == prior[1]
         assert prior[0] == .5
+
+
+def test_complement_nb():
+    """Test MultinomialNB in complement naive Bayes mode"""
+
+    # Synthetic dataset from Rennie et al.
+    X1 = np.array([[0, 1]] * 3, [[1, 0]] * 3)
+    X2 = np.array([[0, 2]] * 2, [[1, 1]] * 2, [[2, 0]] * 2)

--- a/scikits/learn/tests/test_naive_bayes.py
+++ b/scikits/learn/tests/test_naive_bayes.py
@@ -109,7 +109,7 @@ def test_discretenb_predict_proba():
     y = [0, 0, 2]   # 2 is regression test for binary case, 02e673
 
     for cls, X in ([BernoulliNB, MultinomialNB], [X_bernoulli, X_multinomial]):
-        clf = MultinomialNB().fit([[0, 1], [1, 3], [4, 0]], [0, 0, 2])
+        clf = MultinomialNB().fit([[0, 1], [1, 3], [4, 0]], y)
         assert clf.predict([4, 1]) == 2
         assert clf.predict_proba([0, 1]).shape == (1, 2)
         assert np.sum(clf.predict_proba([1, 5])) == 1


### PR DESCRIPTION
I implemented [J. Rennie et al.](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8572)'s complement naive Bayes multiclass strategy and refactored the categorical naive Bayes classes a bit further. The new strategy is not demo'd in the document classification example since it performs less well than ordinary multiclass naive Bayes. I send this pull request anyway because it may be useful for some datasets.

(The fact that CNB doesn't perform very well is not unexpected, given [Kibriya et.al's](http://www.cs.waikato.ac.nz/~eibe/pubs/kibriya_et_al_cr.pdf) criticism of it.)
