### PR TITLE
Systematic check for NaN and infinity

### DIFF
--- a/scikits/learn/linear_model/tests/test_logistic.py
+++ b/scikits/learn/linear_model/tests/test_logistic.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numpy.testing import assert_array_equal
 import nose
-from nose.tools import assert_raises
+from nose.tools import assert_raises, raises
 
 from scikits.learn.linear_model import logistic
 from scikits.learn import datasets
@@ -11,6 +11,7 @@ X = [[-1, 0], [0, 1], [1, 1]]
 Y1 = [0, 1, 1]
 Y2 = [2, 1, 0]
 iris = datasets.load_iris()
+
 
 def test_predict_2_classes():
     """Simple sanity check on a 2 classes dataset
@@ -32,13 +33,14 @@ def test_predict_2_classes():
 
 def test_error():
     """Test for appropriate exception on errors"""
-    assert_raises (ValueError, logistic.LogisticRegression(C=-1).fit, X, Y1)
+    assert_raises(ValueError, logistic.LogisticRegression(C=-1).fit, X, Y1)
 
 
 def test_predict_3_classes():
     clf = logistic.LogisticRegression(C=10).fit(X, Y2)
     assert_array_equal(clf.predict(X), Y2)
     assert_array_equal(clf.predict_proba(X).argmax(axis=1), Y2)
+
 
 def test_predict_iris():
     """Test logisic regression with the iris dataset"""
@@ -51,13 +53,26 @@ def test_predict_iris():
     pred = clf.predict_proba(iris.data).argmax(axis=1)
     assert np.mean(pred == iris.target) > .95
 
+
 def test_inconsistent_input():
-    """Test that an exception is raised when input to predict is inconsistent"""
+    """Test that an exception is raised on inconsistent input to predict"""
     X_ = np.random.random((5, 10))
     y_ = np.ones(X_.shape[0])
     assert_raises(ValueError,
                   logistic.LogisticRegression().fit(X_, y_).predict,
-                  np.random.random((3,12)))
+                  np.random.random((3, 12)))
+
+
+@raises(ValueError)
+def test_nan():
+    """Test proper NaN handling.
+
+    Regression test for Issue #252: fit used to go into an infinite loop.
+    """
+    Xnan = np.array(X)
+    Xnan[0, 1] = np.nan
+    logistic.LogisticRegression().fit(X, Y1)
+
 
 def test_transform():
     clf = logistic.LogisticRegression(penalty="l1")

--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from . import libsvm, liblinear
 from ..base import BaseEstimator
+from ..utils import safe_asanyarray
 
 
 LIBSVM_IMPL = ['c_svc', 'nu_svc', 'one_class', 'epsilon_svr', 'nu_svr']
@@ -372,7 +373,7 @@ class BaseLibLinear(BaseEstimator):
         self.class_weight, self.class_weight_label = \
                      _get_class_weight(class_weight, y)
 
-        X = np.asanyarray(X, dtype=np.float64, order='C')
+        X = safe_asanyarray(X, dtype=np.float64, order='C')
         y = np.asanyarray(y, dtype=np.int32, order='C')
 
         self.raw_coef_, self.label_ = liblinear.train_wrap(X, y,

--- a/scikits/learn/svm/base.py
+++ b/scikits/learn/svm/base.py
@@ -374,6 +374,9 @@ class BaseLibLinear(BaseEstimator):
                      _get_class_weight(class_weight, y)
 
         X = safe_asanyarray(X, dtype=np.float64, order='C')
+        if not isinstance(X, np.ndarray):   # sparse X passed in by user
+            raise ValueError("Training vectors should be array-like, not %s"
+                             % type(X))
         y = np.asanyarray(y, dtype=np.int32, order='C')
 
         self.raw_coef_, self.label_ = liblinear.train_wrap(X, y,

--- a/scikits/learn/utils/__init__.py
+++ b/scikits/learn/utils/__init__.py
@@ -1,7 +1,20 @@
 import numpy as np
 import scipy.sparse as sp
 
+
+def assert_all_finite(X):
+    """Throw a ValueError if X contains NaN or infinity."""
+    if sp.issparse(X):
+        X = X.data()
+    # O(n) time, O(1) solution. XXX: will fail if the sum over X is
+    # *extremely* large. A proper solution would be a C-level loop to check
+    # each element.
+    if not np.isfinite(np.sum(X)):
+        raise ValueError("array contains NaN or infinity")
+
+
 def safe_asanyarray(X, dtype=None, order=None):
+    assert_all_finite(X)
     if sp.issparse(X):
         return X
         #return type(X)(X, dtype)
@@ -10,6 +23,7 @@ def safe_asanyarray(X, dtype=None, order=None):
 
 
 def atleast2d_or_csr(X):
+    assert_all_finite(X)
     """Like numpy.atleast_2d, but converts sparse matrices to CSR format"""
     if sp.issparse(X):
         return X.tocsr()

--- a/scikits/learn/utils/__init__.py
+++ b/scikits/learn/utils/__init__.py
@@ -4,8 +4,11 @@ import scipy.sparse as sp
 
 def assert_all_finite(X):
     """Throw a ValueError if X contains NaN or infinity."""
+
     if sp.issparse(X):
         X = X.data()
+    if isinstance(X, np.ndarray) and X.dtype.name[:5] != 'float':
+        return
     # O(n) time, O(1) solution. XXX: will fail if the sum over X is
     # *extremely* large. A proper solution would be a C-level loop to check
     # each element.


### PR DESCRIPTION
Here's a patch that enables checking for NaN and infinity in any estimator that uses the `safe_asanyarray` or `atleast2d_or_csr` functions in its input. Specifically, it fixes <a href="../issues/252">issue 252</a>: logistic regression would go into an infinite loop when fed NaN. That's fixed at the `BaseLibLinear` level.

The check is done by calling `isfinite` on the result of `np.sum(X)` for the input array `X`. This is not the most elegant solution, but it'll work for any non-floating point array and at least all FP arrays whose sum isn't greater than 3.4028235e+38 (the `float32` maximum). I reckon that's pretty safe.

The alternative `not (np.isfinite(np.min(X)) and np.isfinite(np.max(X)))` takes more than twice as long to compute, and `np.isfinite(X)` takes O(n) space because it constructs a boolean array of shape `X.shape`, so I didn't even bother to measure that.

Running the full test suite is not significantly slower, nor is running the document classification example with four classes. Datasets too large to fit in RAM might suffer, so we might want to do something about that, e.g. assume finiteness for memory-mapped arrays.
