### PR TITLE
Fix for _to_graph

### DIFF
--- a/scikits/learn/feature_extraction/image.py
+++ b/scikits/learn/feature_extraction/image.py
@@ -95,6 +95,7 @@ def _to_graph(n_x, n_y, n_z, mask=None, img=None,
         n_voxels = diag.size
     else:
         if mask is not None:
+            mask = mask.astype(np.bool)
             edges = _mask_edges_weights(mask, edges)
             n_voxels = np.sum(mask)
         else:

--- a/scikits/learn/feature_extraction/tests/test_image.py
+++ b/scikits/learn/feature_extraction/tests/test_image.py
@@ -35,6 +35,11 @@ def test_grid_to_graph():
     mask[-roi_size:, -roi_size:] = True
     mask = mask.reshape(size**2)
     A = grid_to_graph(n_x=size, n_y=size, mask=mask, return_as=np.ndarray)
+    
+    # Checking that the function works whatever the type of mask is
+    mask = np.ones((size, size), dtype=np.int16)
+    A = grid_to_graph(n_x=size, n_y=size, n_z=size, mask=mask)
+    assert(cs_graph_components(A)[0] == 1)
 
 
 def test_connect_regions():


### PR DESCRIPTION
The function failed when used with a mask wich data wasn't of type bool
(a numpy array of type int16 for instance)
