### PR TITLE
Lars n_features

### DIFF
--- a/scikits/learn/linear_model/least_angle.py
+++ b/scikits/learn/linear_model/least_angle.py
@@ -341,8 +341,8 @@ class LARS(LinearModel):
     >>> from scikits.learn import linear_model
     >>> clf = linear_model.LARS()
     >>> clf.fit([[-1,1], [0, 0], [1, 1]], [-1, 0, -1], max_features=1)
-    LARS(normalize=True, precompute='auto', max_iter=500, verbose=False,
-       fit_intercept=True)
+    LARS(normalize=True, verbose=False, fit_intercept=True, max_iter=500,
+       precompute='auto', n_features=None)
     >>> print clf.coef_
     [ 0. -1.]
 
@@ -472,7 +472,7 @@ class LassoLARS (LARS):
     >>> clf = linear_model.LassoLARS(alpha=0.01)
     >>> clf.fit([[-1,1], [0, 0], [1, 1]], [-1, 0, -1])
     LassoLARS(normalize=True, verbose=False, fit_intercept=True, max_iter=500,
-         precompute='auto', alpha=0.01)
+         precompute='auto', alpha=0.01, n_features=None)
     >>> print clf.coef_
     [ 0.         -0.96325765]
 

--- a/scikits/learn/linear_model/least_angle.py
+++ b/scikits/learn/linear_model/least_angle.py
@@ -37,7 +37,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_features=None, max_iter=500,
 
     Gram: None, 'auto', array, shape: (n_features, n_features), optional
         Precomputed Gram matrix (X' * X), if 'auto', the Gram
-        matrix is precomputed from the given X, if there are more samples 
+        matrix is precomputed from the given X, if there are more samples
         than features
 
     alpha_min: float, optional
@@ -132,10 +132,10 @@ def lars_path(X, y, Xy=None, Gram=None, max_features=None, max_iter=500,
             if n_iter > 0:
                 # In the first iteration, all alphas are zero, the formula
                 # below would make ss a NaN
-                ss = (alphas[n_iter-1] - alpha_min) / (alphas[n_iter-1] -
+                ss = (alphas[n_iter - 1] - alpha_min) / (alphas[n_iter - 1] -
                                                     alphas[n_iter])
-                coefs[n_iter] = coefs[n_iter-1] + ss*(coefs[n_iter] -
-                                coefs[n_iter-1])
+                coefs[n_iter] = coefs[n_iter - 1] + ss * (coefs[n_iter] -
+                                coefs[n_iter - 1])
             alphas[n_iter] = alpha_min
             break
 
@@ -298,7 +298,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_features=None, max_iter=500,
     return alphas, active, coefs.T
 
 
-################################################################################
+###############################################################################
 # Estimator classes
 
 class LARS(LinearModel):
@@ -354,14 +354,14 @@ class LARS(LinearModel):
     --------
     lars_path, LassoLARS
     """
-    def __init__(self, fit_intercept=True, verbose=False, normalize=True, 
+    def __init__(self, fit_intercept=True, verbose=False, normalize=True,
                  precompute='auto', max_iter=500, n_features=None):
         self.fit_intercept = fit_intercept
         self.max_iter = max_iter
         self.verbose = verbose
         self.normalize = normalize
         self.method = 'lar'
-        self.precompute = precompute 
+        self.precompute = precompute
         self.n_features = n_features
 
     def fit(self, X, y, max_features=None, overwrite_X=False, **params):
@@ -485,7 +485,7 @@ class LassoLARS (LARS):
     lars_path, Lasso
     """
 
-    def __init__(self, alpha=1.0, fit_intercept=True, verbose=False, 
+    def __init__(self, alpha=1.0, fit_intercept=True, verbose=False,
                  normalize=True, precompute='auto', max_iter=500,
                  n_features=None):
         self.alpha = alpha

--- a/scikits/learn/linear_model/least_angle.py
+++ b/scikits/learn/linear_model/least_angle.py
@@ -355,13 +355,14 @@ class LARS(LinearModel):
     lars_path, LassoLARS
     """
     def __init__(self, fit_intercept=True, verbose=False, normalize=True, 
-                 precompute='auto', max_iter=500):
+                 precompute='auto', max_iter=500, n_features=None):
         self.fit_intercept = fit_intercept
         self.max_iter = max_iter
         self.verbose = verbose
         self.normalize = normalize
         self.method = 'lar'
         self.precompute = precompute 
+        self.n_features = n_features
 
     def fit(self, X, y, max_features=None, overwrite_X=False, **params):
         """Fit the model using X, y as training data.
@@ -386,6 +387,12 @@ class LARS(LinearModel):
 
         X, y, Xmean, ymean = LinearModel._center_data(X, y, self.fit_intercept)
         alpha = getattr(self, 'alpha', 0.)
+
+        if self.n_features:  # n_features parametrization takes priority
+            alpha = 0.
+
+        if not max_features:
+            max_features = self.n_features
 
         if self.normalize:
             norms = np.sqrt(np.sum(X ** 2, axis=0))
@@ -479,13 +486,13 @@ class LassoLARS (LARS):
     """
 
     def __init__(self, alpha=1.0, fit_intercept=True, verbose=False, 
-                 normalize=True, precompute='auto', max_iter=500):
+                 normalize=True, precompute='auto', max_iter=500,
+                 n_features=None):
         self.alpha = alpha
         self.fit_intercept = fit_intercept
         self.max_iter = max_iter
         self.verbose = verbose
         self.normalize = normalize
         self.method = 'lasso'
-        self.precompute = precompute 
-
-
+        self.precompute = precompute
+        self.n_features = n_features

--- a/scikits/learn/linear_model/tests/test_least_angle.py
+++ b/scikits/learn/linear_model/tests/test_least_angle.py
@@ -158,6 +158,13 @@ def test_lars_add_features(verbose=False):
         np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]))
 
 
+def test_lars_n_features(verbose=False):
+    lars = linear_model.Lars(n_features=6, alpha=0.1).fit(X, y)
+    assert len(lars.coef_.nonzero()) == 6
+    lars = linear_model.Lars(n_features=6, alpha=1.0).fit(X, y)
+    assert len(lars.coef_.nonzero()) < 6
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/scikits/learn/linear_model/tests/test_least_angle.py
+++ b/scikits/learn/linear_model/tests/test_least_angle.py
@@ -159,10 +159,15 @@ def test_lars_add_features(verbose=False):
 
 
 def test_lars_n_features(verbose=False):
-    lars = linear_model.Lars(n_features=6, alpha=0.1).fit(X, y)
-    assert len(lars.coef_.nonzero()) == 6
-    lars = linear_model.Lars(n_features=6, alpha=1.0).fit(X, y)
-    assert len(lars.coef_.nonzero()) < 6
+    lars = linear_model.LARS(n_features=6, verbose=verbose)
+    lars.fit(X, y)
+    assert len(lars.coef_.nonzero()[0]) == 6
+    lars = linear_model.LassoLARS(n_features=6, alpha=0.1, verbose=verbose)
+    lars.fit(X, y)
+    assert len(lars.coef_.nonzero()[0]) == 6
+    lars = linear_model.LassoLARS(n_features=6, alpha=1.0, verbose=verbose)
+    lars.fit(X, y)
+    assert len(lars.coef_.nonzero()[0]) == 6
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
LARS and LassoLARS classes docstrings say that they take a n_features parameter. This used to be a lie. They did indeed take a max_features fit parameter, but max_features has different semantics (ie. can be overridden by alpha in the lasso case; as per lars_path function.)

This pull request adds the n_features class parameter, makes it play nicely with the max_features fit parameter, and adds a test to enforce this behavior.
