### PR TITLE
Data compression in 20 news groups features

### DIFF
--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -90,29 +90,29 @@ data_train = fetch_20newsgroups(subset='train', categories=categories,
 
 data_test = fetch_20newsgroups(subset='test', categories=categories,
                               shuffle=True, random_state=42)
+print 'data loaded'
 
 categories = data_train.target_names    # for case categories == None
 
-print "%d documents (training set)" % len(data_train.filenames)
-print "%d documents (testing set)" % len(data_test.filenames)
+print "%d documents (training set)" % len(data_train.data)
+print "%d documents (testing set)" % len(data_test.data)
 print "%d categories" % len(categories)
 print
 
 # split a training set and a test set
-filenames_train, filenames_test = data_train.filenames, data_test.filenames
 y_train, y_test = data_train.target, data_test.target
 
 print "Extracting features from the training dataset using a sparse vectorizer"
 t0 = time()
 vectorizer = Vectorizer()
-X_train = vectorizer.fit_transform((open(f).read() for f in filenames_train))
+X_train = vectorizer.fit_transform(data_train.data)
 print "done in %fs" % (time() - t0)
 print "n_samples: %d, n_features: %d" % X_train.shape
 print
 
 print "Extracting features from the test dataset using the same vectorizer"
 t0 = time()
-X_test = vectorizer.transform((open(f).read() for f in filenames_test))
+X_test = vectorizer.transform(data_test.data)
 print "done in %fs" % (time() - t0)
 print "n_samples: %d, n_features: %d" % X_test.shape
 print

--- a/scikits/learn/datasets/__init__.py
+++ b/scikits/learn/datasets/__init__.py
@@ -1,6 +1,6 @@
 from .base import load_diabetes
 from .base import load_digits
-from .base import load_filenames
+from .base import load_files
 from .base import load_iris
 from .base import load_linnerud
 from .base import get_data_home
@@ -18,7 +18,9 @@ from .svmlight_format import load_svmlight_file
 from .olivetti_faces import fetch_olivetti_faces
 from ..utils import deprecated
 
+# backward compatibility
 @deprecated("to be removed in 0.9;"
-            " use scikits.learn.datasets.load_filenames instead")
-def load_files(*args, **kwargs):
-    return load_filenames(*args, **kwargs)
+            " use scikits.learn.datasets.load_files instead")
+def load_filenames(*args, **kwargs):
+    """Deprecated, use ``scikits.learn.datasets.load_files`` instead"""
+    return load_files(*args, **kwargs)

--- a/scikits/learn/datasets/base.py
+++ b/scikits/learn/datasets/base.py
@@ -21,6 +21,7 @@ from os import makedirs
 
 import numpy as np
 
+from ..utils import check_random_state
 
 ###############################################################################
 
@@ -145,13 +146,12 @@ def load_filenames(container_path, description=None, categories=None,
         target.extend(len(documents) * [label])
         filenames.extend(documents)
 
-    # convert as array for fancy indexing
+    # convert to array for fancy indexing
     filenames = np.array(filenames)
     target = np.array(target)
 
     if shuffle:
-        if isinstance(random_state, int):
-            random_state = np.random.RandomState(random_state)
+        random_state = check_random_state(random_state)
         indices = np.arange(filenames.shape[0])
         random_state.shuffle(indices)
         filenames = filenames[indices]

--- a/scikits/learn/datasets/base.py
+++ b/scikits/learn/datasets/base.py
@@ -65,9 +65,9 @@ def clear_data_home(data_home=None):
     shutil.rmtree(data_home)
 
 
-def load_filenames(container_path, description=None, categories=None,
-                   shuffle=True, random_state=42):
-    """Load filenames with categories as subfolder names
+def load_files(container_path, description=None, categories=None,
+               load_content=True, shuffle=True, random_state=42):
+    """Load text files with categories as subfolder names
 
     Individual samples are assumed to be files stored a two levels folder
     structure such as the following:
@@ -87,7 +87,8 @@ def load_filenames(container_path, description=None, categories=None,
     file names are not important.
 
     This function does not try to extract features into a numpy array or
-    scipy sparse matrix, nor does it try to load the files in memory.
+    scipy sparse matrix. In addition, if load_content is false it
+    does not try to load the files in memory.
 
     To use utf-8 text files in a scikit-learn classification or clustering
     algorithm you will first need to use the `scikits.learn.features.text`
@@ -100,7 +101,7 @@ def load_filenames(container_path, description=None, categories=None,
     Parameters
     ----------
 
-    container_path : string or unicode
+    container_path : string or unicode, or TarFile object
         Path to the main folder holding one subfolder per category
 
     description: string or unicode
@@ -110,6 +111,12 @@ def load_filenames(container_path, description=None, categories=None,
     categories : None or collection of string or unicode
         If None (default), load all the categories.
         If not None, list of category names to load (other categories ignored).
+
+    load_content : boolean
+        Whether to load or not the content of the different files. If
+        true a 'data' attribute containing the text information is present 
+        in the data structure returned. If not, a filenames attribute
+        gives the path to the files.
 
     shuffle : bool, optional
         Whether or not to shuffle the data: might be important for models that
@@ -122,11 +129,11 @@ def load_filenames(container_path, description=None, categories=None,
     Returns
     -------
     data : Bunch
-        Dictionary-like object, the interesting attributes are:
-        'filenames', the files holding the raw to learn, 'target', the
-        classification labels (integer index), 'target_names',
-        the meaning of the labels, and 'DESCR', the full description of the
-        dataset.
+        Dictionary-like object, the interesting attributes are: either
+        data, the raw text data to learn, or 'filenames', the files
+        holding it, 'target', the classification labels (integer index),
+        'target_names', the meaning of the labels, and 'DESCR', the full
+        description of the dataset.
     """
     target = []
     target_names = []
@@ -156,6 +163,13 @@ def load_filenames(container_path, description=None, categories=None,
         random_state.shuffle(indices)
         filenames = filenames[indices]
         target = target[indices]
+
+    if load_content:
+        data = [open(filename).read() for filename in filenames]
+        return Bunch(data=data,
+                     target_names=target_names,
+                     target=target,
+                     DESCR=description)
 
     return Bunch(filenames=filenames,
                  target_names=target_names,

--- a/scikits/learn/datasets/base.py
+++ b/scikits/learn/datasets/base.py
@@ -101,7 +101,7 @@ def load_files(container_path, description=None, categories=None,
     Parameters
     ----------
 
-    container_path : string or unicode, or TarFile object
+    container_path : string or unicode
         Path to the main folder holding one subfolder per category
 
     description: string or unicode

--- a/scikits/learn/datasets/mlcomp.py
+++ b/scikits/learn/datasets/mlcomp.py
@@ -3,13 +3,13 @@
 """Glue code to load http://mlcomp.org data as a scikit.learn dataset"""
 
 import os
-from scikits.learn.datasets.base import load_filenames
+from scikits.learn.datasets.base import load_files
 
 
 def _load_document_classification(dataset_path, metadata, set_=None, **kwargs):
     if set_ is not None:
         dataset_path = os.path.join(dataset_path, set_)
-    return load_filenames(dataset_path, metadata.get('description'), **kwargs)
+    return load_files(dataset_path, metadata.get('description'), **kwargs)
 
 
 LOADERS = {

--- a/scikits/learn/datasets/tests/test_20news.py
+++ b/scikits/learn/datasets/tests/test_20news.py
@@ -1,0 +1,37 @@
+""" Test the 20news downloader, if the data is available.
+"""
+import numpy as np
+import nose
+
+from scikits.learn import datasets
+
+def test_20news():
+    try:
+        data = datasets.fetch_20newsgroups(subset='all',
+                        download_if_missing=False, 
+                        shuffle=False)
+    except IOError:
+        # Data not there
+        return
+
+    # Extract a reduced dataset
+    data2cats = datasets.fetch_20newsgroups(subset='all', 
+                            categories=data.target_names[-1:-3:-1],
+                            shuffle=False)
+    # Check that the ordering of the target_names is the same
+    # as the ordering in the full dataset
+    nose.tools.assert_equal(data2cats.target_names, 
+                            data.target_names[-2:])
+    # Assert that we have only 0 and 1 as labels
+    nose.tools.assert_equal(np.unique(data2cats.target).tolist(), [0, 1])
+
+    # Check that the first entry of the reduced dataset corresponds to 
+    # the first entry of the corresponding category in the full dataset
+    entry1 = data2cats.data[0]
+    category = data2cats.target_names[data2cats.target[0]]
+    label = data.target_names.index(category)
+    entry2 = data.data[np.where(data.target == label)[0][0]]
+    nose.tools.assert_true(entry1 == entry2)
+
+    
+

--- a/scikits/learn/datasets/twenty_newsgroups.py
+++ b/scikits/learn/datasets/twenty_newsgroups.py
@@ -39,12 +39,16 @@ import os
 import urllib
 import logging
 import tarfile
+import pickle
 import warnings
+import shutil
 
 import numpy as np
 
 from .base import get_data_home
 from .base import load_files
+from ..utils import check_random_state
+from ..utils.fixes import in1d
 
 
 logger = logging.getLogger(__name__)
@@ -53,8 +57,38 @@ logger = logging.getLogger(__name__)
 URL = ("http://people.csail.mit.edu/jrennie/"
             "20Newsgroups/20news-bydate.tar.gz")
 ARCHIVE_NAME = "20news-bydate.tar.gz"
+CACHE_NAME = "20news-bydate.pkz"
 TRAIN_FOLDER = "20news-bydate-train"
 TEST_FOLDER = "20news-bydate-test"
+
+def download_20newsgroups(target_dir, cache_path):
+    """ Download the 20Newsgroups data and convert is in a zipped pickle
+        storage.
+    """
+    archive_path = os.path.join(target_dir, ARCHIVE_NAME)
+    train_path = os.path.join(target_dir, TRAIN_FOLDER)
+    test_path = os.path.join(target_dir, TEST_FOLDER)
+
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    if not os.path.exists(archive_path):
+        logger.warn("Downloading dataset from %s (14 MB)", URL)
+        opener = urllib.urlopen(URL)
+        open(archive_path, 'wb').write(opener.read())
+
+    logger.info("Decompressing %s", archive_path)
+    tarfile.open(archive_path, "r:gz").extractall(path=target_dir)
+    os.remove(archive_path)
+
+    # Store a zipped pickle
+    cache = dict(
+            train=load_files(train_path),
+            test=load_files(test_path)
+        )
+    open(cache_path, 'wb').write(pickle.dumps(cache).encode('zip'))
+    shutil.rmtree(target_dir)
+    return cache
 
 
 def fetch_20newsgroups(data_home=None, subset='train', categories=None,
@@ -90,52 +124,67 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     """
 
     data_home = get_data_home(data_home=data_home)
+    cache_path = os.path.join(data_home, CACHE_NAME)
     twenty_home = os.path.join(data_home, "20news_home")
-    archive_path = os.path.join(twenty_home, ARCHIVE_NAME)
-    train_path = os.path.join(twenty_home, TRAIN_FOLDER)
-    test_path = os.path.join(twenty_home, TEST_FOLDER)
+    cache = None
+    if os.path.exists(cache_path):
+        try:
+            cache = pickle.loads(open(cache_path, 'rb').read().decode('zip'))
+        except Exception, e:
+            print 80*'_'
+            print 'Cache loading failed'
+            print 80*'_'
+            print e
 
-    if not os.path.exists(twenty_home):
-        os.makedirs(twenty_home)
-
-    if not os.path.exists(train_path) or not os.path.exists(test_path):
-        if not os.path.exists(archive_path):
-            if download_if_missing:
-                logger.warn("Downloading dataset from %s (14 MB)", URL)
-                opener = urllib.urlopen(URL)
-                open(archive_path, 'wb').write(opener.read())
-            else:
-                raise IOError("%s is missing" % archive_path)
-
-        logger.info("Decompressing %s", archive_path)
-        tarfile.open(archive_path, "r:gz").extractall(path=twenty_home)
-        os.remove(archive_path)
-
+    if cache is None:
+        if download_if_missing:
+            cache = download_20newsgroups(target_dir=twenty_home,
+                                          cache_path=cache_path)
+        else:
+            raise IOError('20Newsgroups dataset not found')
+        
     if subset in ('train', 'test'):
-        if subset == 'train':
-            folder_path = train_path
-        elif subset == 'test':
-            folder_path = test_path
-        description = subset + ' subset of the 20 newsgroups by date dataset'
-        return load_files(folder_path, description=description,
-                            categories=categories, shuffle=shuffle, 
-                            random_state=random_state)
-    elif not subset == 'all':
+        data = cache[subset]
+    elif subset == 'all':
+        data_lst = list()
+        target = list()
+        for subset in ('train', 'test'):
+            data = cache[subset]
+            data_lst.extend(data.data)
+            target.extend(data.target)
+
+        data.data = data_lst
+        data.target = np.array(target)
+        data.description = 'the 20 newsgroups by date dataset'
+    else:
         raise ValueError(
             "subset can only be 'train', 'test' or 'all', got '%s'" % subset)
 
-    data_lst = list()
-    target = list()
-    for folder_path in (train_path, test_path):
-        data = load_files(folder_path, categories=categories,
-                              shuffle=shuffle,
-                              random_state=random_state)
-        data_lst.extend(data.filenames)
-        target.extend(data.target)
+    if categories is not None:
+        labels = [(data.target_names.index(cat), cat) for cat in categories]
+        # Sort the categories to have the ordering of the labels
+        labels.sort()
+        labels, categories = zip(*labels)
+        mask = in1d(data.target, labels)
+        data.target = data.target[mask]
+        # searchsorted to have continuous labels
+        data.target = np.searchsorted(labels, data.target)
+        data.target_names = list(categories)
+        # Use an object array to shuffle: avoids memory copy
+        data_lst = np.array(data.data, dtype=object)
+        data_lst = data_lst[mask]
+        data.data = data_lst.tolist()
 
-    data.data = data_lst
-    data.target = np.array(target)
-    data.description = 'the 20 newsgroups by date dataset'
+    if shuffle:
+        random_state = check_random_state(random_state)
+        indices = np.arange(data.target.shape[0])
+        random_state.shuffle(indices)
+        data.target = data.target[indices]
+        # Use an object array to shuffle: avoids memory copy
+        data_lst = np.array(data.data, dtype=object)
+        data_lst = data_lst[indices]
+        data.data = data_lst.tolist()
+
     return data
 
 

--- a/scikits/learn/datasets/twenty_newsgroups.py
+++ b/scikits/learn/datasets/twenty_newsgroups.py
@@ -39,6 +39,7 @@ import os
 import urllib
 import logging
 import tarfile
+import warnings
 
 import numpy as np
 
@@ -144,4 +145,6 @@ def load_20newsgroups(download_if_missing=False, **kwargs):
     Check out fetch_20newsgroups.__doc__ for the documentation and parameters
     list.
     """
+    warnings.warn('load_20newsgroups is depreciated. Use fetch_20newsgroups',
+                  DeprecationWarning)
     return fetch_20newsgroups(download_if_missing=download_if_missing, **kwargs)

--- a/scikits/learn/datasets/twenty_newsgroups.py
+++ b/scikits/learn/datasets/twenty_newsgroups.py
@@ -44,7 +44,7 @@ import warnings
 import numpy as np
 
 from .base import get_data_home
-from .base import load_filenames
+from .base import load_files
 
 
 logger = logging.getLogger(__name__)
@@ -117,23 +117,23 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         elif subset == 'test':
             folder_path = test_path
         description = subset + ' subset of the 20 newsgroups by date dataset'
-        return load_filenames(folder_path, description=description,
+        return load_files(folder_path, description=description,
                             categories=categories, shuffle=shuffle, 
                             random_state=random_state)
     elif not subset == 'all':
         raise ValueError(
             "subset can only be 'train', 'test' or 'all', got '%s'" % subset)
 
-    filenames = list()
+    data_lst = list()
     target = list()
     for folder_path in (train_path, test_path):
-        data = load_filenames(folder_path, categories=categories,
+        data = load_files(folder_path, categories=categories,
                               shuffle=shuffle,
                               random_state=random_state)
-        filenames.extend(data.filenames)
+        data_lst.extend(data.filenames)
         target.extend(data.target)
 
-    data.filenames = np.array(filenames)
+    data.data = data_lst
     data.target = np.array(target)
     data.description = 'the 20 newsgroups by date dataset'
     return data


### PR DESCRIPTION
This pull request implements several features:
- Loading of file contents by default in `load_files`
- Renaming `load_filenames` back to `load_files` as the new version of `load_files` now loads more than filenames (`load_files` had recently been depreciated in favor of `load_filenames`. I am changing this back: there has been no release since the depreciation).
- `fetch_20newsgroups` now supports a `subset='all'` to load both the training and testing set.
- Compression of the 20 newsgroup dataset storage on the disk. The storage requirement go from 80Mo to 15Mo, which makes it usable in examples ran to generate the docs.
