### PR TITLE
LinearModelCV fix

### DIFF
--- a/scikits/learn/linear_model/coordinate_descent.py
+++ b/scikits/learn/linear_model/coordinate_descent.py
@@ -363,7 +363,7 @@ class LinearModelCV(LinearModel):
             keyword arguments passed to the Lasso fit method
 
         """
-
+        self._set_params(**fit_params)
         X = np.asfortranarray(X, dtype=np.float64)
         y = np.asanyarray(y, dtype=np.float64)
 

--- a/scikits/learn/linear_model/coordinate_descent.py
+++ b/scikits/learn/linear_model/coordinate_descent.py
@@ -379,7 +379,7 @@ class LinearModelCV(LinearModel):
         # Update the alphas list
         alphas = [model.alpha for model in models]
         n_alphas = len(alphas)
-        path_params.update({'alphas':alphas, 'n_alphas':n_alphas})
+        path_params.update({'alphas': alphas, 'n_alphas': n_alphas})
 
         # init cross-validation generator
         cv = self.cv if self.cv else KFold(n_samples, 5)
@@ -520,5 +520,3 @@ class ElasticNetCV(LinearModelCV):
         self.max_iter = max_iter
         self.tol = tol
         self.cv = cv
-
-

--- a/scikits/learn/linear_model/coordinate_descent.py
+++ b/scikits/learn/linear_model/coordinate_descent.py
@@ -297,6 +297,7 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     -----
     See examples/plot_lasso_coordinate_descent_path.py for an example.
     """
+   
     X, y, Xmean, ymean = LinearModel._center_data(X, y, fit_intercept)
     X = np.asfortranarray(X)  # make data contiguous in memory
 
@@ -370,32 +371,26 @@ class LinearModelCV(LinearModel):
         n_samples = X.shape[0]
 
         # Start to compute path on full data
-        path_params = fit_params.copy()
+        path_params = dict()
         acceptable_params = self.estimator._get_param_names()
         for param, value in self._get_params().iteritems():
             if param in acceptable_params:
                 path_params[param] = value
         models = self.path(X, y, **path_params)
 
+        # Path params update
         alphas = [model.alpha for model in models]
         n_alphas = len(alphas)
+        path_params.update({'alphas':alphas, 'n_alphas':n_alphas})
 
         # init cross-validation generator
         cv = self.cv if self.cv else KFold(n_samples, 5)
 
-        params = dict()
-        for param, value in self._get_params().iteritems():
-            if param in acceptable_params:
-                params[param] = value
-        params['alphas'] = alphas
-        params['n_alphas'] = n_alphas
-
         # Compute path for all folds and compute MSE to get the best alpha
         folds = list(cv)
         mse_alphas = np.zeros((len(folds), n_alphas))
-        fit_params.update(params)
         for i, (train, test) in enumerate(folds):
-            models_train = self.path(X[train], y[train], **fit_params)
+            models_train = self.path(X[train], y[train], **path_params)
             for i_alpha, model in enumerate(models_train):
                 y_ = model.predict(X[test])
                 mse_alphas[i, i_alpha] += ((y_ - y[test]) ** 2).mean()

--- a/scikits/learn/linear_model/coordinate_descent.py
+++ b/scikits/learn/linear_model/coordinate_descent.py
@@ -297,7 +297,6 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     -----
     See examples/plot_lasso_coordinate_descent_path.py for an example.
     """
-   
     X, y, Xmean, ymean = LinearModel._center_data(X, y, fit_intercept)
     X = np.asfortranarray(X)  # make data contiguous in memory
 
@@ -370,15 +369,14 @@ class LinearModelCV(LinearModel):
 
         n_samples = X.shape[0]
 
+        # All LinearModelCV parameters except 'cv' are acceptable
+        path_params = self._get_params()
+        del path_params['cv']
+
         # Start to compute path on full data
-        path_params = dict()
-        acceptable_params = self.estimator._get_param_names()
-        for param, value in self._get_params().iteritems():
-            if param in acceptable_params:
-                path_params[param] = value
         models = self.path(X, y, **path_params)
 
-        # Path params update
+        # Update the alphas list
         alphas = [model.alpha for model in models]
         n_alphas = len(alphas)
         path_params.update({'alphas':alphas, 'n_alphas':n_alphas})

--- a/scikits/learn/linear_model/tests/test_coordinate_descent.py
+++ b/scikits/learn/linear_model/tests/test_coordinate_descent.py
@@ -3,7 +3,8 @@
 # License: BSD Style.
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal, \
+                          assert_equal
 
 from ..coordinate_descent import Lasso, LassoCV, ElasticNet, ElasticNetCV
 
@@ -156,3 +157,22 @@ def test_enet_path():
     X_test = np.random.randn(n_samples, n_features)
     y_test = np.dot(X_test, w)
     assert clf.score(X_test, y_test) > 0.99
+    
+def test_path_parameters():
+    # build an ill-posed linear regression problem with many noisy features and
+    # comparatively few samples
+    n_samples, n_features, max_iter = 50, 200, 50
+    np.random.seed(0)
+    w = np.random.randn(n_features)
+    w[10:] = 0.0 # only the top 10 features are impacting the model
+    X = np.random.randn(n_samples, n_features)
+    y = np.dot(X, w)
+    
+    clf = ElasticNetCV(n_alphas=100, eps=1e-3, rho=0.95)
+    clf.fit(X, y, max_iter=max_iter, rho=0.5, n_alphas=50) # new params
+    assert_almost_equal(0.5, clf.rho)
+    assert_equal(50, clf.n_alphas)
+    assert_equal(50, len(clf.alphas))
+
+    
+    

--- a/scikits/learn/linear_model/tests/test_coordinate_descent.py
+++ b/scikits/learn/linear_model/tests/test_coordinate_descent.py
@@ -90,13 +90,13 @@ def test_enet_toy():
     assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf.fit(X, Y, max_iter=1000, precompute=True) # with Gram
+    clf.fit(X, Y, max_iter=1000, precompute=True)  # with Gram
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
     assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf.fit(X, Y, max_iter=1000, precompute=np.dot(X.T, X)) # with Gram
+    clf.fit(X, Y, max_iter=1000, precompute=np.dot(X.T, X))  # with Gram
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
     assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
@@ -117,7 +117,7 @@ def test_lasso_path():
     n_samples, n_features, max_iter = 50, 200, 30
     random_state = np.random.RandomState(0)
     w = random_state.randn(n_features)
-    w[10:] = 0.0 # only the top 10 features are impacting the model
+    w[10:] = 0.0  # only the top 10 features are impacting the model
     X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
 
@@ -141,7 +141,7 @@ def test_enet_path():
     n_samples, n_features, max_iter = 50, 200, 50
     random_state = np.random.RandomState(0)
     w = random_state.randn(n_features)
-    w[10:] = 0.0 # only the top 10 features are impacting the model
+    w[10:] = 0.0  # only the top 10 features are impacting the model
     X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
 
@@ -157,22 +157,21 @@ def test_enet_path():
     X_test = random_state.randn(n_samples, n_features)
     y_test = np.dot(X_test, w)
     assert clf.score(X_test, y_test) > 0.99
-    
+
+
 def test_path_parameters():
+
     # build an ill-posed linear regression problem with many noisy features and
     # comparatively few samples
     n_samples, n_features, max_iter = 50, 200, 50
     random_state = np.random.RandomState(0)
     w = random_state.randn(n_features)
-    w[10:] = 0.0 # only the top 10 features are impacting the model
+    w[10:] = 0.0  # only the top 10 features are impacting the model
     X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
-    
+
     clf = ElasticNetCV(n_alphas=100, eps=1e-3, rho=0.95)
-    clf.fit(X, y, max_iter=max_iter, rho=0.5, n_alphas=50) # new params
+    clf.fit(X, y, max_iter=max_iter, rho=0.5, n_alphas=50)  # new params
     assert_almost_equal(0.5, clf.rho)
     assert_equal(50, clf.n_alphas)
     assert_equal(50, len(clf.alphas))
-
-    
-    

--- a/scikits/learn/linear_model/tests/test_coordinate_descent.py
+++ b/scikits/learn/linear_model/tests/test_coordinate_descent.py
@@ -115,10 +115,10 @@ def test_lasso_path():
     # build an ill-posed linear regression problem with many noisy features and
     # comparatively few samples
     n_samples, n_features, max_iter = 50, 200, 30
-    np.random.seed(0)
-    w = np.random.randn(n_features)
+    random_state = np.random.RandomState(0)
+    w = random_state.randn(n_features)
     w[10:] = 0.0 # only the top 10 features are impacting the model
-    X = np.random.randn(n_samples, n_features)
+    X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
 
     clf = LassoCV(n_alphas=100, eps=1e-3).fit(X, y, max_iter=max_iter)
@@ -129,7 +129,7 @@ def test_lasso_path():
     assert_almost_equal(clf.alpha, 0.011, 2)
 
     # test set
-    X_test = np.random.randn(n_samples, n_features)
+    X_test = random_state.randn(n_samples, n_features)
     y_test = np.dot(X_test, w)
     assert clf.score(X_test, y_test) > 0.85
 
@@ -139,10 +139,10 @@ def test_enet_path():
     # build an ill-posed linear regression problem with many noisy features and
     # comparatively few samples
     n_samples, n_features, max_iter = 50, 200, 50
-    np.random.seed(0)
-    w = np.random.randn(n_features)
+    random_state = np.random.RandomState(0)
+    w = random_state.randn(n_features)
     w[10:] = 0.0 # only the top 10 features are impacting the model
-    X = np.random.randn(n_samples, n_features)
+    X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
 
     clf = ElasticNetCV(n_alphas=100, eps=1e-3, rho=0.95)
@@ -154,7 +154,7 @@ def test_enet_path():
     assert_almost_equal(clf.alpha, 0.00779, 2)
 
     # test set
-    X_test = np.random.randn(n_samples, n_features)
+    X_test = random_state.randn(n_samples, n_features)
     y_test = np.dot(X_test, w)
     assert clf.score(X_test, y_test) > 0.99
     
@@ -162,10 +162,10 @@ def test_path_parameters():
     # build an ill-posed linear regression problem with many noisy features and
     # comparatively few samples
     n_samples, n_features, max_iter = 50, 200, 50
-    np.random.seed(0)
-    w = np.random.randn(n_features)
+    random_state = np.random.RandomState(0)
+    w = random_state.randn(n_features)
     w[10:] = 0.0 # only the top 10 features are impacting the model
-    X = np.random.randn(n_samples, n_features)
+    X = random_state.randn(n_samples, n_features)
     y = np.dot(X, w)
     
     clf = ElasticNetCV(n_alphas=100, eps=1e-3, rho=0.95)


### PR DESCRIPTION
Here is a small fix into the LinearModelCV class. The previous version does not pass correctly the fit parameters to the internal "path" function. (eg. in `test_enet_path` the `max_iter` parameter has no effect in the `fit` call).
