### PR TITLE
Irc chan

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -21,7 +21,7 @@ https://github.com/scikit-learn/scikit-learn/issues
 
 IRC
 ===
-Some devs like to hang out on channel #learn on irc.freenode.net
+Some devs like to hang out on channel #scikit-learn on irc.freenode.net
 
 If you do not have an irc client or are behind a firewall this web
 client works fine: http://webchat.freenode.net


### PR DESCRIPTION
Corrected the IRC chan on the 0.8 documentation, currently the stable one. I'm not sure I'm asking to pull in the correct branch

If someone could make sure the stable documentation, at http://scikit-learn.sourceforge.net/stable/support.html
is updated.
People are trying to go on the IRC chan, to ask for help, but don't find it as there is a mistake in the stable documentation.

Thanks
