### PR TITLE
Add ARPACK support to KernelPCA

### DIFF
--- a/scikits/learn/decomposition/kernel_pca.py
+++ b/scikits/learn/decomposition/kernel_pca.py
@@ -6,6 +6,7 @@
 import numpy as np
 from scipy import linalg
 
+from ..utils.arpack import eigsh
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import KernelCenterer
 from ..metrics.pairwise import linear_kernel
@@ -49,6 +50,19 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         (i.e. learn to find the pre-image of a point)
         Default: False
 
+    eigen_solver: string ['auto'|'dense'|'arpack']
+        Select eigensolver to use.  If n_components is much less than
+        the number of training samples, arpack may be more efficient
+        than the dense eigensolver.
+
+    tol: float
+        convergence tolerance for arpack.
+        Default: 0 (optimal value will be chosen by arpack)
+
+    max_iter : int
+        maximum number of iterations for arpack
+        Default: None (optimal value will be chosen by arpack)
+
     Attributes
     ----------
 
@@ -71,7 +85,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_components=None, kernel="linear", gamma=0, degree=3,
-                 coef0=1, alpha=1.0, fit_inverse_transform=False):
+                 coef0=1, alpha=1.0, fit_inverse_transform=False,
+                 eigen_solver='auto', tol=0, max_iter=None):
         self.n_components = n_components
         self.kernel = kernel.lower()
         self.gamma = gamma
@@ -79,6 +94,9 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self.coef0 = coef0
         self.alpha = alpha
         self.fit_inverse_transform = fit_inverse_transform
+        self.eigen_solver = eigen_solver
+        self.tol = tol
+        self.max_iter = max_iter
         self.centerer = KernelCenterer()
 
     def _get_kernel(self, X, Y=None):
@@ -106,14 +124,34 @@ class KernelPCA(BaseEstimator, TransformerMixin):
                              % self.kernel)
 
     def _fit_transform(self, X):
-        # compute kernel and eigenvectors
+        # compute kernel
         K = self.centerer.fit_transform(self._get_kernel(X))
-        self.lambdas_, self.alphas_ = linalg.eigh(K)
+
+        if self.n_components is None:
+            n_components = K.shape[0]
+        else:
+            n_components = min(K.shape[0], self.n_components)
+
+        # compute eigenvectors
+        if self.eigen_solver == 'auto':
+            if K.shape[0] > 200 and n_components < 10:
+                eigen_solver = 'arpack'
+            else:
+                eigen_solver = 'dense'
+        else:
+            eigen_solver = self.eigen_solver
+
+        if eigen_solver == 'dense':
+            self.lambdas_, self.alphas_ = linalg.eigh(
+                K, eigvals=(K.shape[0] - n_components, K.shape[0] - 1))
+        elif eigen_solver == 'arpack':
+            self.lambdas_, self.alphas_ = eigsh(K, n_components,
+                                                which="LM",
+                                                tol=self.tol,
+                                                maxiter=self.max_iter)
 
         # sort eignenvectors in descending order
         indices = self.lambdas_.argsort()[::-1]
-        if self.n_components is not None:
-            indices = indices[:self.n_components]
         self.lambdas_ = self.lambdas_[indices]
         self.alphas_ = self.alphas_[:, indices]
 

--- a/scikits/learn/decomposition/tests/test_kernel_pca.py
+++ b/scikits/learn/decomposition/tests/test_kernel_pca.py
@@ -9,59 +9,84 @@ from .. import PCA, KernelPCA
 
 
 def test_kernel_pca():
+    np.random.seed(0)
+
     X_fit = np.random.random((5, 4))
     X_pred = np.random.random((2, 4))
 
-    for kernel in ("linear", "rbf", "poly"):
-        # transform fit data
-        kpca = KernelPCA(kernel=kernel, fit_inverse_transform=True)
-        X_fit_transformed = kpca.fit_transform(X_fit)
-        X_fit_transformed2 = kpca.fit(X_fit).transform(X_fit)
-        assert_array_almost_equal(X_fit_transformed, X_fit_transformed2)
+    for eigen_solver in ("auto", "dense", "arpack"):
+        for kernel in ("linear", "rbf", "poly"):
+            # transform fit data
+            kpca = KernelPCA(4, kernel=kernel, eigen_solver=eigen_solver,
+                             fit_inverse_transform=True)
+            X_fit_transformed = kpca.fit_transform(X_fit)
+            X_fit_transformed2 = kpca.fit(X_fit).transform(X_fit)
+            assert_array_almost_equal(np.abs(X_fit_transformed),
+                                      np.abs(X_fit_transformed2))
 
-        # transform new data
-        X_pred_transformed = kpca.transform(X_pred)
-        assert_equal(X_pred_transformed.shape[1], X_fit_transformed.shape[1])
+            # transform new data
+            X_pred_transformed = kpca.transform(X_pred)
+            assert_equal(X_pred_transformed.shape[1],
+                         X_fit_transformed.shape[1])
 
-        # inverse transform
-        X_pred2 = kpca.inverse_transform(X_pred_transformed)
-        assert_equal(X_pred2.shape, X_pred.shape)
+            # inverse transform
+            X_pred2 = kpca.inverse_transform(X_pred_transformed)
+            assert_equal(X_pred2.shape, X_pred.shape)
 
 
 def test_kernel_pca_linear_kernel():
-    raise SkipTest
+    np.random.seed(0)
+
     X_fit = np.random.random((5, 4))
     X_pred = np.random.random((2, 4))
 
     # for a linear kernel, kernel PCA should find the same projection as PCA
     # modulo the sign (direction)
-    assert_array_almost_equal(np.abs(KernelPCA().fit(X_fit).transform(X_pred)),
-                              np.abs(PCA().fit(X_fit).transform(X_pred)))
+    # fit only the first four components: fifth is near zero eigenvalue, so
+    # can be trimmed due to roundoff error
+    assert_array_almost_equal(
+        np.abs(KernelPCA(4).fit(X_fit).transform(X_pred)),
+        np.abs(PCA(4).fit(X_fit).transform(X_pred)))
 
 
 def test_kernel_pca_n_components():
+    np.random.seed(0)
+
     X_fit = np.random.random((5, 4))
     X_pred = np.random.random((2, 4))
 
-    for c in [1, 2, 4]:
-        kpca = KernelPCA(n_components = c)
-        shape = kpca.fit(X_fit).transform(X_pred).shape
+    for eigen_solver in ("dense", "arpack"):
+        for c in [1, 2, 4]:
+            kpca = KernelPCA(n_components=c, eigen_solver=eigen_solver)
+            shape = kpca.fit(X_fit).transform(X_pred).shape
 
-        assert_equal(shape, (2, c))
+            assert_equal(shape, (2, c))
 
 
 def test_kernel_pca_precomputed():
+    np.random.seed(0)
+
     X_fit = np.random.random((5, 4))
     X_pred = np.random.random((2, 4))
 
-    X_kpca = KernelPCA().fit(X_fit).transform(X_pred)
-    X_kpca2 = KernelPCA(kernel="precomputed").fit(np.dot(X_fit, X_fit.T)). \
-              transform(np.dot(X_pred, X_fit.T))
+    for eigen_solver in ("dense", "arpack"):
+        X_kpca = KernelPCA(4, eigen_solver=eigen_solver).\
+            fit(X_fit).transform(X_pred)
+        X_kpca2 = KernelPCA(4, kernel="precomputed",
+                            eigen_solver=eigen_solver).\
+                            fit(np.dot(X_fit, X_fit.T)).\
+                            transform(np.dot(X_pred, X_fit.T))
 
-    assert_array_almost_equal(X_kpca, X_kpca2)
+        assert_array_almost_equal(np.abs(X_kpca),
+                                  np.abs(X_kpca2))
 
 
 def test_kernel_pca_invalid_kernel():
     X_fit = np.random.random((2, 4))
     kpca = KernelPCA(kernel="tototiti")
     assert_raises(ValueError, kpca.fit, X_fit)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.run(argv=['', __file__])

--- a/scikits/learn/decomposition/tests/test_kernel_pca.py
+++ b/scikits/learn/decomposition/tests/test_kernel_pca.py
@@ -9,10 +9,9 @@ from .. import PCA, KernelPCA
 
 
 def test_kernel_pca():
-    np.random.seed(0)
-
-    X_fit = np.random.random((5, 4))
-    X_pred = np.random.random((2, 4))
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((5, 4))
+    X_pred = rng.random_sample((2, 4))
 
     for eigen_solver in ("auto", "dense", "arpack"):
         for kernel in ("linear", "rbf", "poly"):
@@ -35,10 +34,9 @@ def test_kernel_pca():
 
 
 def test_kernel_pca_linear_kernel():
-    np.random.seed(0)
-
-    X_fit = np.random.random((5, 4))
-    X_pred = np.random.random((2, 4))
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((5, 4))
+    X_pred = rng.random_sample((2, 4))
 
     # for a linear kernel, kernel PCA should find the same projection as PCA
     # modulo the sign (direction)
@@ -50,10 +48,9 @@ def test_kernel_pca_linear_kernel():
 
 
 def test_kernel_pca_n_components():
-    np.random.seed(0)
-
-    X_fit = np.random.random((5, 4))
-    X_pred = np.random.random((2, 4))
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((5, 4))
+    X_pred = rng.random_sample((2, 4))
 
     for eigen_solver in ("dense", "arpack"):
         for c in [1, 2, 4]:
@@ -64,10 +61,9 @@ def test_kernel_pca_n_components():
 
 
 def test_kernel_pca_precomputed():
-    np.random.seed(0)
-
-    X_fit = np.random.random((5, 4))
-    X_pred = np.random.random((2, 4))
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((5, 4))
+    X_pred = rng.random_sample((2, 4))
 
     for eigen_solver in ("dense", "arpack"):
         X_kpca = KernelPCA(4, eigen_solver=eigen_solver).\
@@ -82,7 +78,8 @@ def test_kernel_pca_precomputed():
 
 
 def test_kernel_pca_invalid_kernel():
-    X_fit = np.random.random((2, 4))
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((2, 4))
     kpca = KernelPCA(kernel="tototiti")
     assert_raises(ValueError, kpca.fit, X_fit)
 

--- a/scikits/learn/preprocessing/__init__.py
+++ b/scikits/learn/preprocessing/__init__.py
@@ -583,7 +583,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         """
         n_samples = K.shape[0]
         self.K_fit_rows = np.sum(K, axis=0) / n_samples
-        self.K_fit_all = K.sum() / (n_samples ** 2)
+        self.K_fit_all = self.K_fit_rows.sum() / n_samples
         return self
 
     def transform(self, K, copy=True):

--- a/scikits/learn/preprocessing/__init__.py
+++ b/scikits/learn/preprocessing/__init__.py
@@ -582,8 +582,8 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         n_samples = K.shape[0]
-        self.K_fit_rows = np.sum(K, axis=0) / n_samples
-        self.K_fit_all = self.K_fit_rows.sum() / n_samples
+        self.K_fit_rows_ = np.sum(K, axis=0) / n_samples
+        self.K_fit_all_ = self.K_fit_rows_.sum() / n_samples
         return self
 
     def transform(self, K, copy=True):
@@ -603,10 +603,10 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
             K = K.copy()
 
         K_pred_cols = (np.sum(K, axis=1) /
-                       self.K_fit_rows.shape[0])[:, np.newaxis]
+                       self.K_fit_rows_.shape[0])[:, np.newaxis]
 
-        K -= self.K_fit_rows
+        K -= self.K_fit_rows_
         K -= K_pred_cols
-        K += self.K_fit_all
+        K += self.K_fit_all_
 
         return K


### PR DESCRIPTION
As discussed in the <a href="https://github.com/scikit-learn/scikit-learn/pull/282">Isomap pull request</a>, I've added `arpack` support to `KernelPCA` to facilitate the `Isomap` implementation.  It leads to a factor of a few speedup for large matrices when only a few eigenvectors are sought.

A few of the tests needed to be modified, because they asked for more eigenvectors than the rank of the matrix.  ARPACK rightly raises an error in this case.
