### PR TITLE
ENH set_params method on BaseEstimator, deprecate estimator params to fit

### DIFF
--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -331,7 +331,7 @@ classifier or a regressor. All estimators implement the fit method::
 All built-in estimators also have a ``set_params`` method, which sets
 data-independent parameters (overriding previous parameter values passed
 to ``__init__``). This method is not required for an object to be an
-estimator, but is used by the :class:`grid_search.GridSearchCV` class.
+estimator.
 
 
 Instantiation

--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -328,6 +328,11 @@ classifier or a regressor. All estimators implement the fit method::
 
     estimator.fit(X, y)
 
+All built-in estimators also have a ``set_params`` method, which sets
+data-independent parameters (overriding previous parameter values passed
+to ``__init__``). This method is not required for an object to be an
+estimator, but is used by the :class:`grid_search.GridSearchCV` class.
+
 
 Instantiation
 ^^^^^^^^^^^^^^

--- a/examples/svm/plot_svm_anova.py
+++ b/examples/svm/plot_svm_anova.py
@@ -40,7 +40,7 @@ score_stds  = list()
 percentiles = (1, 3, 6, 10, 15, 20, 30, 40, 60, 80, 100)
 
 for percentile in percentiles:
-    clf._set_params(anova__percentile=percentile)
+    clf.set_params(anova__percentile=percentile)
     # Compute cross-validation score using all CPUs
     this_scores = cross_val.cross_val_score(clf, X, y, n_jobs=1)
     score_means.append(this_scores.mean())

--- a/scikits/learn/base.py
+++ b/scikits/learn/base.py
@@ -6,8 +6,10 @@ import copy
 import inspect
 import numpy as np
 from scipy import sparse
+import warnings
 
 from .metrics import r2_score
+from .utils import deprecated
 
 
 ###############################################################################
@@ -172,13 +174,17 @@ class BaseEstimator(object):
             out[key] = value
         return out
 
-    def _set_params(self, **params):
+    def set_params(self, **params):
         """ Set the parameters of the estimator.
 
         The method works on simple estimators as well as on nested
         objects (such as pipelines). The former have parameters of the
-        form <component>__<parameter> so that the its possible to
-        update each component of the nested object.
+        form <component>__<parameter> so that it's possible to update
+        each component of a nested object.
+
+        Returns
+        -------
+        self
         """
         if not params:
             # Simple optimisation to gain speed (inspect is slow)
@@ -198,7 +204,7 @@ class BaseEstimator(object):
                     'sub parameter %s' %
                         (sub_name, self.__class__.__name__, sub_name)
                     )
-                sub_object._set_params(**{sub_name: value})
+                sub_object.set_params(**{sub_name: value})
             else:
                 # simple objects case
                 assert key in valid_params, ('Invalid parameter %s '
@@ -206,6 +212,13 @@ class BaseEstimator(object):
                                              (key, self.__class__.__name__))
                 setattr(self, key, value)
         return self
+
+    def _set_params(self, **params):
+        if params != {}:
+            warnings.warn("Passing estimator parameters to fit is deprecated;"
+                          " use set_params instead",
+                          category=DeprecationWarning)
+        return self.set_params(**params)
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/scikits/learn/cluster/dbscan_.py
+++ b/scikits/learn/cluster/dbscan_.py
@@ -188,7 +188,7 @@ class DBSCAN(BaseEstimator):
             Overwrite keywords from __init__.
         """
 
-        self._set_params(**params)
+        self.set_params(**params)
         self.core_sample_indices_, self.labels_ = dbscan(X,
                                                          **self._get_params())
         self.components_ = X[self.core_sample_indices_].copy()

--- a/scikits/learn/cluster/k_means_.py
+++ b/scikits/learn/cluster/k_means_.py
@@ -489,7 +489,7 @@ class KMeans(BaseEstimator):
             raise ValueError("K-Means does not support sparse input matrices.")
         X = np.asanyarray(X)
         if X.shape[0] < self.k:
-            raise ValueError("n_samples=%d should be larger than k=%d" % (
+            raise ValueError("n_samples=%d should be >= k=%d" % (
                 X.shape[0], self.k))
         return X
 
@@ -498,7 +498,7 @@ class KMeans(BaseEstimator):
 
         self.random_state = check_random_state(self.random_state)
 
-        X = self._check_data(X, **params)
+        X = self._check_data(X)
         if k != None:
             self.k = k
         self._set_params(**params)

--- a/scikits/learn/cluster/k_means_.py
+++ b/scikits/learn/cluster/k_means_.py
@@ -493,14 +493,12 @@ class KMeans(BaseEstimator):
                 X.shape[0], self.k))
         return X
 
-    def fit(self, X, k=None, **params):
+    def fit(self, X, **params):
         """Compute k-means"""
 
         self.random_state = check_random_state(self.random_state)
 
         X = self._check_data(X)
-        if k != None:
-            self.k = k
         self._set_params(**params)
 
         self.cluster_centers_, self.labels_, self.inertia_ = k_means(

--- a/scikits/learn/cluster/k_means_.py
+++ b/scikits/learn/cluster/k_means_.py
@@ -483,25 +483,25 @@ class KMeans(BaseEstimator):
         self.random_state = random_state
         self.copy_x = copy_x
 
-    def _check_data(self, X, **params):
-        """
-        Set parameters and check the sample given is larger than k
-        """
+    def _check_data(self, X):
+        """Verify that the number of samples given is larger than k"""
         if sp.issparse(X):
             raise ValueError("K-Means does not support sparse input matrices.")
         X = np.asanyarray(X)
         if X.shape[0] < self.k:
             raise ValueError("n_samples=%d should be larger than k=%d" % (
                 X.shape[0], self.k))
-        self._set_params(**params)
         return X
 
-    def fit(self, X, **params):
+    def fit(self, X, k=None, **params):
         """Compute k-means"""
 
         self.random_state = check_random_state(self.random_state)
 
         X = self._check_data(X, **params)
+        if k != None:
+            self.k = k
+        self._set_params(**params)
 
         self.cluster_centers_, self.labels_, self.inertia_ = k_means(
             X, k=self.k, init=self.init, n_init=self.n_init,
@@ -648,7 +648,7 @@ class MiniBatchKMeans(KMeans):
         self.cluster_centers_ = None
         self.chunk_size = chunk_size
 
-    def fit(self, X, y=None, **params):
+    def fit(self, X, y=None):
         """
         Calculates the centroids on a batch X
 
@@ -657,7 +657,6 @@ class MiniBatchKMeans(KMeans):
         X: array-like, shape = [n_samples, n_features]
             Coordinates of the data points to cluster
         """
-        self._set_params(**params)
         self.random_state = check_random_state(self.random_state)
         X = check_arrays(X, sparse_format="csr", copy=False)[0]
         n_samples, n_features = X.shape
@@ -711,7 +710,7 @@ class MiniBatchKMeans(KMeans):
 
         return self
 
-    def partial_fit(self, X, y=None, **params):
+    def partial_fit(self, X, y=None):
         """Update k means estimate on a single mini-batch X.
 
         Parameters

--- a/scikits/learn/cluster/tests/test_dbscan.py
+++ b/scikits/learn/cluster/tests/test_dbscan.py
@@ -55,9 +55,8 @@ def test_dbscan_feature():
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_1, n_clusters)
 
-    db = DBSCAN()
-    labels = db.fit(X, metric=metric,
-                    eps=eps, min_samples=min_samples).labels_
+    db = DBSCAN(metric=metric)
+    labels = db.fit(X, eps=eps, min_samples=min_samples).labels_
 
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_2, n_clusters)
@@ -80,9 +79,8 @@ def test_dbscan_callable():
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_1, n_clusters)
 
-    db = DBSCAN()
-    labels = db.fit(X, metric=metric,
-                    eps=eps, min_samples=min_samples).labels_
+    db = DBSCAN(metric=metric)
+    labels = db.fit(X, eps=eps, min_samples=min_samples).labels_
 
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_2, n_clusters)

--- a/scikits/learn/cluster/tests/test_k_means.py
+++ b/scikits/learn/cluster/tests/test_k_means.py
@@ -17,7 +17,7 @@ S = sp.csr_matrix(X)
 
 def test_k_means_pp_init():
     np.random.seed(1)
-    k_means = KMeans(init="k-means++").fit(X, k=n_clusters)
+    k_means = KMeans(init="k-means++", k=n_clusters).fit(X)
 
     centers = k_means.cluster_centers_
     assert_equal(centers.shape, (n_clusters, 2))
@@ -29,7 +29,7 @@ def test_k_means_pp_init():
     assert_equal(np.unique(labels[40:]).size, 1)
 
     # check error on dataset being too small
-    assert_raises(ValueError, k_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, k_means.fit, [[0., 1.]])
 
 
 def test_mini_batch_k_means_pp_init():
@@ -60,7 +60,7 @@ def test_sparse_mini_batch_k_means_pp_init():
 
 def test_k_means_pp_random_init():
     np.random.seed(1)
-    k_means = KMeans(init="random").fit(X, k=n_clusters)
+    k_means = KMeans(init="random", k=n_clusters).fit(X)
 
     centers = k_means.cluster_centers_
     assert_equal(centers.shape, (n_clusters, 2))
@@ -72,13 +72,13 @@ def test_k_means_pp_random_init():
     assert_equal(np.unique(labels[40:]).size, 1)
 
     # check error on dataset being too small
-    assert_raises(ValueError, k_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, k_means.fit, [[0., 1.]])
 
 
 def test_k_means_fixed_array_init():
     np.random.seed(1)
     init_array = np.vstack([X[5], X[25], X[45]])
-    k_means = KMeans(init=init_array, n_init=1).fit(X, k=n_clusters)
+    k_means = KMeans(init=init_array, n_init=1, k=n_clusters).fit(X)
 
     centers = k_means.cluster_centers_
     assert_equal(centers.shape, (n_clusters, 2))
@@ -90,20 +90,20 @@ def test_k_means_fixed_array_init():
     assert_equal(np.unique(labels[40:]).size, 1)
 
     # check error on dataset being too small
-    assert_raises(ValueError, k_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, k_means.fit, [[0., 1.]])
 
 
 def test_k_means_invalid_init():
     np.random.seed(1)
-    k_means = KMeans(init="invalid", n_init=1)
-    assert_raises(ValueError, k_means.fit, X, k=n_clusters)
+    k_means = KMeans(init="invalid", n_init=1, k=n_clusters)
+    assert_raises(ValueError, k_means.fit, X)
 
 
 def test_k_means_copyx():
     """Check if copy_x=False returns nearly equal X after de-centering."""
     np.random.seed(1)
     my_X = X.copy()
-    k_means = KMeans(copy_x=False).fit(my_X, k=n_clusters)
+    k_means = KMeans(copy_x=False, k=n_clusters).fit(my_X)
     centers = k_means.cluster_centers_
     assert_equal(centers.shape, (n_clusters, 2))
 
@@ -122,7 +122,7 @@ def test_k_means_singleton():
     np.random.seed(1)
     my_X = np.array([[1.1, 1.1], [0.9, 1.1], [1.1, 0.9], [0.9, 0.9]])
     array_init = np.array([[1.0, 1.0], [5.0, 5.0]])
-    k_means = KMeans(init=array_init).fit(my_X, k=2)
+    k_means = KMeans(init=array_init, k=2).fit(my_X)
 
     # must be singleton clustering
     assert_equal(np.unique(k_means.labels_).size, 1)
@@ -131,7 +131,7 @@ def test_k_means_singleton():
 def test_mbk_means_fixed_array_init():
     np.random.seed(1)
     init_array = np.vstack([X[5], X[25], X[45]])
-    mbk_means = MiniBatchKMeans(init=init_array).fit(X)
+    mbk_means = MiniBatchKMeans(init=init_array, k=n_clusters).fit(X)
 
     centers = mbk_means.cluster_centers_
     assert_equal(centers.shape, (n_clusters, 2))
@@ -139,7 +139,7 @@ def test_mbk_means_fixed_array_init():
     labels = mbk_means.labels_
     assert_equal(np.unique(labels).size, 3)
 
-    assert_raises(ValueError, mbk_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, mbk_means.fit, [[0., 1.]])
 
 
 def test_sparse_mbk_means_fixed_array_init():
@@ -153,13 +153,13 @@ def test_sparse_mbk_means_fixed_array_init():
     labels = mbk_means.labels_
     assert_equal(np.unique(labels).size, 3)
 
-    assert_raises(ValueError, mbk_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, mbk_means.fit, [[0., 1.]])
 
 
 def test_sparse_mbk_means_pp_init():
     np.random.seed(1)
-    mbk_means = MiniBatchKMeans(init="k-means++")
-    assert_raises(ValueError, mbk_means.fit, S, k=n_clusters)
+    mbk_means = MiniBatchKMeans(init="k-means++", k=n_clusters)
+    assert_raises(ValueError, mbk_means.fit, S)
 
 
 def test_sparse_mbk_means_callable_init():
@@ -175,17 +175,17 @@ def test_sparse_mbk_means_callable_init():
     labels = mbk_means.labels_
     assert_equal(np.unique(labels).size, 3)
 
-    assert_raises(ValueError, mbk_means.fit, [[0., 1.]], k=n_clusters)
+    assert_raises(ValueError, mbk_means.fit, [[0., 1.]])
 
 
 def test_k_means_fixed_array_init_fit():
     np.random.seed(1)
     init_array = np.vstack([X[5], X[25], X[45]])
-    k_means = KMeans(init=init_array, n_init=1).fit(X, k=n_clusters)
+    k_means = KMeans(init=init_array, n_init=1, k=n_clusters).fit(X)
 
     another_init_array = np.vstack([X[1], X[30], X[50]])
-    other_k_means = KMeans(init=init_array, n_init=1)
-    other_k_means.fit(X, init=another_init_array, k=n_clusters)
+    other_k_means = KMeans(init=init_array, n_init=1, k=n_clusters)
+    other_k_means.fit(X, init=another_init_array)
     assert_true(not np.allclose(k_means.init, other_k_means.init),
                 "init attributes must be different")
 
@@ -193,10 +193,10 @@ def test_k_means_fixed_array_init_fit():
 def test_mbkm_fixed_array_init_fit():
     np.random.seed(1)
     init_array = np.vstack([X[5], X[25], X[45]])
-    k_means = MiniBatchKMeans(init=init_array).fit(X, k=n_clusters)
+    k_means = MiniBatchKMeans(init=init_array, k=n_clusters).fit(X)
 
     another_init_array = np.vstack([X[1], X[30], X[50]])
-    other_k_means = MiniBatchKMeans(init=init_array)
-    other_k_means.fit(X, init=another_init_array, k=n_clusters)
+    other_k_means = MiniBatchKMeans(init=another_init_array, k=n_clusters)
+    other_k_means.fit(X)
     assert_true(not np.allclose(k_means.init, other_k_means.init),
                 "init attributes must be different")

--- a/scikits/learn/feature_selection/univariate_selection.py
+++ b/scikits/learn/feature_selection/univariate_selection.py
@@ -446,9 +446,9 @@ class GenericUnivariateSelect(_AbstractUnivariateFilter):
         selector = self._selection_modes[self.mode](lambda x: x)
         selector._pvalues = self._pvalues
         selector._scores = self._scores
-        # Now make some acrobaties to set the right named parameter in
+        # Now perform some acrobatics to set the right named parameter in
         # the selector
         possible_params = selector._get_param_names()
         possible_params.remove('score_func')
-        selector._set_params(**{possible_params[0]: self.param})
+        selector.set_params(**{possible_params[0]: self.param})
         return selector._get_support_mask()

--- a/scikits/learn/grid_search.py
+++ b/scikits/learn/grid_search.py
@@ -67,7 +67,9 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
         msg = '%s' % (', '.join('%s=%s' % (k, v)
                                      for k, v in clf_params.iteritems()))
         print "[GridSearchCV] %s %s" % (msg, (64 - len(msg)) * '.')
+
     # update parameters of the classifier after a copy of its base structure
+    # FIXME we should be doing a clone here
     clf = copy.deepcopy(base_clf)
     clf.set_params(**clf_params)
 

--- a/scikits/learn/grid_search.py
+++ b/scikits/learn/grid_search.py
@@ -69,7 +69,7 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
         print "[GridSearchCV] %s %s" % (msg, (64 - len(msg)) * '.')
     # update parameters of the classifier after a copy of its base structure
     clf = copy.deepcopy(base_clf)
-    clf._set_params(**clf_params)
+    clf.set_params(**clf_params)
 
     if isinstance(X, list) or isinstance(X, tuple):
         X_train = [X[i] for i, cond in enumerate(train) if cond]

--- a/scikits/learn/tests/test_base.py
+++ b/scikits/learn/tests/test_base.py
@@ -93,9 +93,9 @@ def test_get_params():
     assert_true('a__d' in test._get_params(deep=True))
     assert_true('a__d' not in test._get_params(deep=False))
 
-    test._set_params(a__d=2)
+    test.set_params(a__d=2)
     assert test.a.d == 2
-    assert_raises(AssertionError, test._set_params, a__a=2)
+    assert_raises(AssertionError, test.set_params, a__a=2)
 
 
 def test_is_classifier():

--- a/scikits/learn/tests/test_cross_val.py
+++ b/scikits/learn/tests/test_cross_val.py
@@ -23,8 +23,7 @@ class MockClassifier(BaseEstimator):
     def __init__(self, a=0):
         self.a = a
 
-    def fit(self, X, Y, **params):
-        self._set_params(**params)
+    def fit(self, X, Y):
         return self
 
     def predict(self, T):

--- a/scikits/learn/tests/test_grid_search.py
+++ b/scikits/learn/tests/test_grid_search.py
@@ -21,8 +21,7 @@ class MockClassifier(BaseEstimator):
     def __init__(self, foo_param=0):
         self.foo_param = foo_param
 
-    def fit(self, X, Y, **params):
-        self._set_params(**params)
+    def fit(self, X, Y):
         return self
 
     def predict(self, T):
@@ -88,7 +87,7 @@ def test_grid_search_sparse_score_func():
     clf = LinearSVC()
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
     # XXX: set refit to False due to a random bug when True (default)
-    cv.fit(X_[:180], y_[:180], refit=False)
+    cv.set_params(refit=False).fit(X_[:180], y_[:180])
     y_pred = cv.predict(X_[180:])
     C = cv.best_estimator.C
 
@@ -96,7 +95,7 @@ def test_grid_search_sparse_score_func():
     clf = SparseLinearSVC()
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
     # XXX: set refit to False due to a random bug when True (default)
-    cv.fit(X_[:180], y_[:180], refit=False)
+    cv.set_params(refit=False).fit(X_[:180], y_[:180])
     y_pred2 = cv.predict(X_[180:])
     C2 = cv.best_estimator.C
 

--- a/scikits/learn/tests/test_naive_bayes.py
+++ b/scikits/learn/tests/test_naive_bayes.py
@@ -123,7 +123,8 @@ def test_discretenb_uniform_prior():
        when fit_prior=False and class_prior=None"""
 
     for cls in [BernoulliNB, MultinomialNB]:
-        clf = cls(fit_prior=False)
+        clf = cls()
+        clf.set_params(fit_prior=False)
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
         assert prior[0] == prior[1]

--- a/scikits/learn/tests/test_pipeline.py
+++ b/scikits/learn/tests/test_pipeline.py
@@ -44,7 +44,7 @@ def test_pipeline_init():
                  dict(svc__a=None, svc__b=None, svc=clf))
 
     # Check that params are set
-    pipe._set_params(svc__a=0.1)
+    pipe.set_params(svc__a=0.1)
     assert_equal(clf.a, 0.1)
     # Smoke test the repr:
     repr(pipe)
@@ -55,13 +55,13 @@ def test_pipeline_init():
     pipe = Pipeline([('anova', filter1), ('svc', clf)])
 
     # Check that params are set
-    pipe._set_params(svc__C=0.1)
+    pipe.set_params(svc__C=0.1)
     assert_equal(clf.C, 0.1)
     # Smoke test the repr:
     repr(pipe)
 
     # Check that params are not set when naming them wrong
-    assert_raises(AssertionError, pipe._set_params, anova__C=0.1)
+    assert_raises(AssertionError, pipe.set_params, anova__C=0.1)
 
     # Test clone
     pipe2 = clone(pipe)


### PR DESCRIPTION
As proposed on the mailing list, here's a patch that introduces a public `set_params` method on all built-in estimators. The rationale is summarized in the c94ac99f08505073f7c46b004c202c1a54e897a0's commit message. Passing data-independent parameters to `fit`, `partial_fit` or `fit_transform` is now deprecated. `set_params` returns `self`, so it can be chained.

Some more remarks: estimators behave inconsistently in that some do `_set_params` first, then input validation, while other do both steps in reverse order. I've removed the params keyword from `MiniBatchKMeans`' `fit` and `partial_fit`, since that hasn't featured in any release yet. (`partial_fit` accepted a `params` keyword arg, but then ignored it, btw.)

`KMeans` got a `k` parameter to `fit`. The remaining problem is `DBSCAN`, where could I not decide whether the `metric`, `eps` and `min_samples` parameters should be given to `__init__` or `fit`. Maybe @robertlayton has an opinion on that?
