### PR TITLE
Cleanup/Speedup of LocallyLinearEmbedding

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -34,7 +34,7 @@ from matplotlib.ticker import NullFormatter
 from scikits.learn import manifold, datasets
 
 X, color = datasets.samples_generator.make_s_curve(1000)
-n_neighbors = 8
+n_neighbors = 10
 out_dim = 2
 
 methods = ['standard', 'ltsa', 'hessian', 'modified']
@@ -58,7 +58,7 @@ ax.set_title('Original Data')
 for i, method in enumerate(methods):
     t0 = time()
     Y = manifold.LocallyLinearEmbedding(n_neighbors, out_dim,
-                                        eigen_solver='arpack',
+                                        eigen_solver='auto',
                                         method=method).fit_transform(X)
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -58,11 +58,11 @@ ax.set_title('Original Data')
 
 for i, method in enumerate(methods):
     t0 = time()
-    Y, err = manifold.locally_linear_embedding(
-        X, n_neighbors, out_dim, eigen_solver='arpack', method=method)
+    Y = manifold.LocallyLinearEmbedding(n_neighbors, out_dim,
+                                        eigen_solver='arpack',
+                                        method=method).fit_transform(X)
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)
-    print ' err = %.2e' % err
 
     ax = fig.add_subplot(322 + i)
     ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=pylab.cm.Spectral)

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -27,8 +27,7 @@ print __doc__
 
 from time import time
 
-import numpy
-import pylab
+import pylab as pl
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.ticker import NullFormatter
 
@@ -41,18 +40,18 @@ out_dim = 2
 methods = ['standard', 'ltsa', 'hessian', 'modified']
 labels = ['LLE', 'LTSA', 'Hessian LLE', 'Modified LLE']
 
-fig = pylab.figure(figsize=(8, 12))
-pylab.suptitle("Manifold Learning with %i points, %i neighbors"
+fig = pl.figure(figsize=(12, 8))
+pl.suptitle("Manifold Learning with %i points, %i neighbors"
                % (1000, n_neighbors), fontsize=14)
 
 try:
     # compatibility matplotlib < 1.0
-    ax = fig.add_subplot(321, projection='3d')
-    ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=pylab.cm.Spectral)
+    ax = fig.add_subplot(231, projection='3d')
+    ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=pl.cm.Spectral)
     ax.view_init(4, -72)
 except:
-    ax = fig.add_subplot(321, projection='3d')
-    ax.scatter(X[:, 0], X[:, 2], c=color, cmap=pylab.cm.Spectral)
+    ax = fig.add_subplot(231, projection='3d')
+    pl.scatter(X[:, 0], X[:, 2], c=color, cmap=pl.cm.Spectral)
 
 ax.set_title('Original Data')
 
@@ -64,20 +63,21 @@ for i, method in enumerate(methods):
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)
 
-    ax = fig.add_subplot(322 + i)
-    ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=pylab.cm.Spectral)
-    ax.set_title("%s (%.2g sec)" % (labels[i], t1 - t0))
+    ax = fig.add_subplot(232 + i)
+    pl.scatter(Y[:, 0], Y[:, 1], c=color, cmap=pl.cm.Spectral)
+    pl.title("%s (%.2g sec)" % (labels[i], t1 - t0))
     ax.xaxis.set_major_formatter(NullFormatter())
     ax.yaxis.set_major_formatter(NullFormatter())
+    pl.axis('tight')
 
 t0 = time()
 Y = manifold.Isomap(n_neighbors, out_dim).fit_transform(X)
 t1 = time()
 print "Isomap: %.2g sec" % (t1 - t0)
-ax = fig.add_subplot(326)
-ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=pylab.cm.Spectral)
-ax.set_title("Isomap (%.2g sec)" % (t1 - t0))
+ax = fig.add_subplot(236)
+pl.scatter(Y[:, 0], Y[:, 1], c=color, cmap=pl.cm.Spectral)
+pl.title("Isomap (%.2g sec)" % (t1 - t0))
 ax.xaxis.set_major_formatter(NullFormatter())
 ax.yaxis.set_major_formatter(NullFormatter())
 
-pylab.show()
+pl.show()

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -51,16 +51,25 @@ X_lda = lda.LDA(n_components=2).fit_transform(X2, y)
 #----------------------------------------------------------------------
 # Locally linear embedding of the digits dataset
 print "Computing LLE embedding"
-X_lle, err = manifold.locally_linear_embedding(X, n_neighbors, 2)
-print "Done. Reconstruction error: %g" % err
+clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='standard')
+X_lle = clf.fit_transform(X)
+print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 
 
 #----------------------------------------------------------------------
 # Modified Locally linear embedding of the digits dataset
 print "Computing modified LLE embedding"
-X_mlle, err = manifold.locally_linear_embedding(X, n_neighbors, 2,
-                                                method='modified')
-print "Done. Reconstruction error: %g" % err
+clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='modified')
+X_mlle = clf.fit_transform(X)
+print "Done. Reconstruction error: %g" % clf.reconstruction_error_
+
+
+#----------------------------------------------------------------------
+# LTSA embedding of the digits dataset
+print "Computing LTSA embedding"
+clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='ltsa')
+X_ltsa = clf.fit_transform(X)
+print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 
 
 #----------------------------------------------------------------------
@@ -105,6 +114,7 @@ plot_embedding(X_pca, "Principal Components projection of the digits")
 plot_embedding(X_lda, "Linear Discriminant projection of the digits")
 plot_embedding(X_lle, "Locally Linear Embedding of the digits")
 plot_embedding(X_mlle, "Modified Locally Linear Embedding of the digits")
+plot_embedding(X_ltsa, "Local Tangent Space Alignment of the digits")
 plot_embedding(X_iso, "Isomap projection of the digits")
 
 pl.show()

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -51,7 +51,8 @@ X_lda = lda.LDA(n_components=2).fit_transform(X2, y)
 #----------------------------------------------------------------------
 # Locally linear embedding of the digits dataset
 print "Computing LLE embedding"
-clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='standard')
+clf = manifold.LocallyLinearEmbedding(n_neighbors, out_dim=2,
+                                      method='standard')
 X_lle = clf.fit_transform(X)
 print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 
@@ -59,7 +60,8 @@ print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 #----------------------------------------------------------------------
 # Modified Locally linear embedding of the digits dataset
 print "Computing modified LLE embedding"
-clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='modified')
+clf = manifold.LocallyLinearEmbedding(n_neighbors, out_dim=2,
+                                      method='modified')
 X_mlle = clf.fit_transform(X)
 print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 
@@ -67,15 +69,25 @@ print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 #----------------------------------------------------------------------
 # LTSA embedding of the digits dataset
 print "Computing LTSA embedding"
-clf = manifold.LocallyLinearEmbedding(n_neighbors, 2, method='ltsa')
+clf = manifold.LocallyLinearEmbedding(n_neighbors, out_dim=2,
+                                      method='ltsa')
 X_ltsa = clf.fit_transform(X)
+print "Done. Reconstruction error: %g" % clf.reconstruction_error_
+
+
+#----------------------------------------------------------------------
+# HLLE embedding of the digits dataset
+print "Computing Hessian LLE embedding"
+clf = manifold.LocallyLinearEmbedding(n_neighbors, out_dim=2,
+                                      method='hessian')
+X_hlle = clf.fit_transform(X)
 print "Done. Reconstruction error: %g" % clf.reconstruction_error_
 
 
 #----------------------------------------------------------------------
 # Isomap projection of the digits dataset
 print "Computing Isomap embedding"
-X_iso = manifold.Isomap(n_neighbors, 2).fit_transform(X)
+X_iso = manifold.Isomap(n_neighbors, out_dim=2).fit_transform(X)
 print "Done."
 
 
@@ -115,6 +127,7 @@ plot_embedding(X_lda, "Linear Discriminant projection of the digits")
 plot_embedding(X_lle, "Locally Linear Embedding of the digits")
 plot_embedding(X_mlle, "Modified Locally Linear Embedding of the digits")
 plot_embedding(X_ltsa, "Local Tangent Space Alignment of the digits")
+plot_embedding(X_hlle, "Hessian Locally Linear Embedding of the digits")
 plot_embedding(X_iso, "Isomap projection of the digits")
 
 pl.show()

--- a/scikits/learn/manifold/locally_linear.py
+++ b/scikits/learn/manifold/locally_linear.py
@@ -7,7 +7,6 @@
 import numpy as np
 from scipy.linalg import eigh, svd, qr
 from scipy.sparse import linalg, eye, csr_matrix
-from scipy.sparse.linalg import LinearOperator
 from ..base import BaseEstimator
 from ..utils import check_random_state
 from ..utils.arpack import eigsh

--- a/scikits/learn/manifold/locally_linear.py
+++ b/scikits/learn/manifold/locally_linear.py
@@ -237,7 +237,7 @@ def locally_linear_embedding(
                 U = svd(Gi, full_matrices=0)[0]
             else:
                 Ci = np.dot(Gi, Gi.T)
-                U = eigh(Ci)[1]
+                U = eigh(Ci)[1][:, ::-1]
 
             Yi[:, 1:1 + out_dim] = U[:, :out_dim]
 

--- a/scikits/learn/manifold/locally_linear.py
+++ b/scikits/learn/manifold/locally_linear.py
@@ -6,7 +6,8 @@
 
 import numpy as np
 from scipy.linalg import eigh, svd, qr
-from scipy.sparse import linalg, eye, csr_matrix
+from scipy.sparse import linalg, eye, csr_matrix, isspmatrix_csr, \
+                isspmatrix_bsr
 from ..base import BaseEstimator
 from ..utils import check_random_state
 from ..utils.arpack import eigsh
@@ -65,7 +66,8 @@ def null_space(M, k, k_skip=1, eigen_solver='arpack', tol=1E-6, max_iter=100,
         except ImportError:
             raise ImportError("PyAMG is not installed,"
                               " cannot use lobcpg solver")
-
+        if not isspmatrix_csr(M) or isspmatrix_bsr(M):
+            M = csr_matrix(M)
         # initial vectors for iteration
         X = random_state.rand(M.shape[0], k + k_skip)
         try:

--- a/scikits/learn/manifold/tests/test_locally_linear.py
+++ b/scikits/learn/manifold/tests/test_locally_linear.py
@@ -6,12 +6,6 @@ from scikits.learn.utils.fixes import product
 
 eigen_solvers = ['dense', 'arpack']
 
-try:
-    import pyamg
-    eigen_solvers.append('lobpcg')
-except ImportError:
-    pass
-
 
 def assert_lower(a, b, details=None):
     message = "%r is not lower than %r" % (a, b)
@@ -24,13 +18,11 @@ def assert_lower(a, b, details=None):
 # Test LLE by computing the reconstruction error on some manifolds.
 
 def test_lle_simple_grid():
-    rng = np.random.RandomState(42)
-
+    rng = np.random.RandomState(0)
     # grid of equidistant points in 2D, out_dim = n_dim
     X = np.array(list(product(range(5), repeat=2)))
     out_dim = 2
-    clf = manifold.LocallyLinearEmbedding(n_neighbors=5, out_dim=out_dim,
-                                          random_state=rng)
+    clf = manifold.LocallyLinearEmbedding(n_neighbors=5, out_dim=out_dim)
     tol = .1
 
     N = neighbors.kneighbors_graph(
@@ -60,8 +52,7 @@ def test_lle_manifold():
     X = np.array(list(product(range(20), repeat=2)))
     X = np.c_[X, X[:, 0] ** 2 / 20]
     out_dim = 2
-    clf = manifold.LocallyLinearEmbedding(n_neighbors=5, out_dim=out_dim,
-                                          random_state=42)
+    clf = manifold.LocallyLinearEmbedding(n_neighbors=5, out_dim=out_dim)
     tol = .5
 
     N = neighbors.kneighbors_graph(X, clf.n_neighbors,
@@ -85,7 +76,7 @@ def test_pipeline():
     from scikits.learn import pipeline, datasets
     iris = datasets.load_iris()
     clf = pipeline.Pipeline(
-        [('filter', manifold.LocallyLinearEmbedding(random_state=42)),
+        [('filter', manifold.LocallyLinearEmbedding()),
          ('clf', neighbors.NeighborsClassifier())])
     clf.fit(iris.data, iris.target)
     assert_lower(.7, clf.score(iris.data, iris.target))


### PR DESCRIPTION
I cleaned up the `LocallyLinearEmbedding` class: it now conforms to the standard of defining all parameters in `__init__` rather than `fit`.  I also implemented `fit_transform`, and made some small improvements to the Hessian, LTSA, and MLLE algorithms that should speed up execution on high-dimensional data.
