### PR TITLE
In spectral clustering example, forced the solver to be arpack

### DIFF
--- a/examples/cluster/plot_segmentation_toy.py
+++ b/examples/cluster/plot_segmentation_toy.py
@@ -68,7 +68,9 @@ graph = image.img_to_graph(img, mask=mask)
 # dependant from the gradient the segmentation is close to a voronoi
 graph.data = np.exp(-graph.data/graph.data.std())
 
-labels = spectral_clustering(graph, k=4)
+# Force the solver to be arpack, since amg is numerically
+# unstable on this example
+labels = spectral_clustering(graph, k=4, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 
@@ -86,7 +88,7 @@ img += 1 + 0.2*np.random.randn(*img.shape)
 graph = image.img_to_graph(img, mask=mask)
 graph.data = np.exp(-graph.data/graph.data.std())
 
-labels = spectral_clustering(graph, k=2)
+labels = spectral_clustering(graph, k=2, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 


### PR DESCRIPTION
(the amg solver is unstable for this example, and results are not
satisfying)

(The example is "broken" on the website, the website will need to be refreshed) 
