### PR TITLE
FIX: Corrected NuSVR impl type and set epsilon to None

### DIFF
--- a/scikits/learn/svm/classes.py
+++ b/scikits/learn/svm/classes.py
@@ -275,7 +275,7 @@ class SVR(BaseLibSVM, RegressorMixin):
         penalty parameter C of the error term.
 
     epsilon : float, optional (default=0.1)
-         epsilon in the epsilon-SVR model. It specifies the espilon-tube
+         epsilon in the epsilon-SVR model. It specifies the epsilon-tube
          within which no penalty is associated in the training loss function 
          with points predicted within a distance epsilon from the actual 
          value.
@@ -455,9 +455,9 @@ class NuSVR(BaseLibSVM, RegressorMixin):
                  gamma=0.0, coef0=0.0, shrinking=True,
                  probability=False, tol=1e-3):
 
-        BaseLibSVM.__init__(self, 'epsilon_svr', kernel, degree,
+        BaseLibSVM.__init__(self, 'nu_svr', kernel, degree,
                          gamma, coef0, tol, C, nu,
-                         0.0, shrinking, probability)
+                         None, shrinking, probability)
 
     def fit(self, X, y, sample_weight=None, **params):
         """


### PR DESCRIPTION
The implementation type for NuSVR was passing through epsilon_svr to the base class instead of nu_svr.  Also, for NuSVR, epsilon is not used (although I realise that it is passed into libsvm's params but not used).
