### PR TITLE
Fix/svm

### DIFF
--- a/scikits/learn/svm/src/libsvm/svm.cpp
+++ b/scikits/learn/svm/src/libsvm/svm.cpp
@@ -908,6 +908,7 @@ void Solver::Solve(int l, const QMatrix& Q, const double *p_, const schar *y_,
 	delete[] active_set;
 	delete[] G;
 	delete[] G_bar;
+	delete[] C;
 }
 
 // return 1 if already optimal, return 0 otherwise


### PR DESCRIPTION
Fixed https://github.com/scikit-learn/scikit-learn/issues/217.

Valgrind on linux does a much better job than anything (including DUMA) on windows:

$ valgrind python mem_bug.py

At present there are still memory leaks, but they are in python itself and not in the svm module.
