### PR TITLE
Refactor Neighbors module

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -206,6 +206,13 @@ keyword ``algorithm = 'kd_tree'``, and are computed using the class
 :class:`scipy.spatial.cKDTree`.
 
 
+.. topic:: References:
+
+   * `"Multidimensional binary search trees used for associative searching"
+     <http://dl.acm.org/citation.cfm?doid=361002.361007>`_,
+     Bentley, J.L., Communications of the ACM (1975)
+
+
 .. _ball_tree:
 
 Ball Tree
@@ -235,6 +242,13 @@ does not degrade at high dimensions.  In scikit-learn, ball-tree-based
 neighbors searches are specified using the keyword ``algorithm = 'ball_tree'``,
 and are computed using the class :class:`sklearn.neighbors.BallTree`.
 Alternatively, the user can work with the :class:`BallTree` class directly.
+
+.. topic:: References:
+
+   * `"Five balltree construction algorithms"
+     <http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.91.8209>`_,
+     Omohundro, S.M., International Computer Science Institute
+     Technical Report (1989)
 
 Choice of Nearest Neighbors Algorithm
 -------------------------------------
@@ -304,9 +318,9 @@ depends on a number of factors:
 
 Currently, ``algorithm = 'auto'`` selects ``'ball_tree'`` if
 :math:`k < N/2`, and ``'brute'`` otherwise.  This choice is based on
-the assumption that the number of query points on the same order as the
-number of training points, and that ``leaf_size`` is close to its default
-value of ``30``.
+the assumption that the number of query points is at least the same order
+as the number of training points, and that ``leaf_size`` is close to its
+default value of ``30``.
 
 Effect of ``leaf_size``
 -----------------------
@@ -336,17 +350,6 @@ leaf nodes.  The level of this switch can be specified with the parameter
   the size of the training set.
 
 ``leaf_size`` is not referenced for brute force queries.
-
-.. topic:: References:
-
-   * `"Multidimensional binary search trees used for associative searching"
-     <http://dl.acm.org/citation.cfm?doid=361002.361007>`_,
-     Bentley, J.L., Communications of the ACM (1975)
-
-   * `"Five balltree construction algorithms"
-     <http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.91.8209>`_,
-     Omohundro, S.M., International Computer Science Institute
-     Technical Report (1989)
 
 
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -78,19 +78,28 @@ class NeighborsBase(BaseEstimator):
         self._fit_method = None
 
     def _fit(self, X):
-        if isinstance(X, BallTree):
+        if isinstance(X, NeighborsBase):
+            self._fit_X = X._fit_X
+            self._tree = X._tree
+            self._fit_method = X._fit_method
+            return self
+
+        elif isinstance(X, BallTree):
             self._fit_X = X.data
             self._tree = X
             self._fit_method = 'ball_tree'
             return self
 
-        if isinstance(X, cKDTree):
+        elif isinstance(X, cKDTree):
             self._fit_X = X.data
             self._tree = X
             self._fit_method = 'kd_tree'
             return self
 
         X = safe_asanyarray(X)
+
+        if X.ndim != 2:
+            raise ValueError("data type not understood")
 
         if issparse(X):
             if self.algorithm not in ('auto', 'brute'):
@@ -320,7 +329,7 @@ class RadiusNeighborsMixin(object):
         >>> neigh.fit(samples) # doctest: +ELLIPSIS
         NearestNeighbors(algorithm='auto', leaf_size=30, ...)
         >>> print neigh.radius_neighbors([1., 1., 1.]) # doctest: +ELLIPSIS
-        (array([[ 1.5  0.5]]...), array([[1 2]]...)
+        (array([[ 1.5,  0.5]]...), array([[1, 2]]...)
 
         The first array returned contains the distances to all points which
         are closer than 1.6, while the second array returned contains their
@@ -328,8 +337,8 @@ class RadiusNeighborsMixin(object):
         Because the number of neighbors of each point is not necessarily
         equal, `radius_neighbors` returns an array of objects, where each
         object is a 1D array of indices.
-
         """
+
         if self._fit_method == None:
             raise ValueError("must fit neighbors before querying")
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -110,7 +110,10 @@ class NeighborsBase(BaseEstimator):
 
         if self._fit_method == 'auto':
             # BallTree outperforms the others in nearly any circumstance.
-            self._fit_method = 'ball_tree'
+            if self.n_neighbors < self._fit_X.shape[0] / 2:
+                self._fit_method = 'ball_tree'
+            else:
+                self._fit_method = 'brute'
 
         if self._fit_method == 'kd_tree':
             self._tree = cKDTree(X, self.leaf_size)

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -1,4 +1,4 @@
-"""Nearest Neighbor Classification"""
+"""Nearest Neighbor Regression"""
 
 # Authors: Jake Vanderplas <vanderplas@astro.washington.edu>
 #          Fabian Pedregosa <fabian.pedregosa@inria.fr>

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -23,9 +23,7 @@ ALGORITHMS = ('ball_tree', 'brute', 'kd_tree', 'auto')
 def test_unsupervised_kneighbors(n_samples=20, n_features=5,
                                  n_query_pts=2, n_neighbors=5,
                                  random_state=0):
-    """
-    Samples are are set of n two-category equally spaced points.
-    """
+    """Test unsupervised neighbors methods"""
     rng = np.random.RandomState(random_state)
 
     X = rng.rand(n_samples, n_features)
@@ -50,19 +48,20 @@ def test_unsupervised_kneighbors(n_samples=20, n_features=5,
 
 
 def test_unsupervised_inputs():
-    X = np.random.random((10,3))
+    """test the types of valid input into NearestNeighbors"""
+    X = np.random.random((10, 3))
 
     nbrs_fid = neighbors.NearestNeighbors(n_neighbors=1)
     nbrs_fid.fit(X)
-    
+
     dist1, ind1 = nbrs_fid.kneighbors(X)
 
-    nbrs = neighbors.NearestNeighbors(n_neighbors=1)    
+    nbrs = neighbors.NearestNeighbors(n_neighbors=1)
 
     for input in (nbrs_fid, neighbors.BallTree(X), cKDTree(X)):
         nbrs.fit(input)
         dist2, ind2 = nbrs.kneighbors(X)
-        
+
         assert_array_almost_equal(dist1, dist2)
         assert_array_almost_equal(ind1, ind2)
 
@@ -70,9 +69,7 @@ def test_unsupervised_inputs():
 def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,
                                        n_query_pts=2, radius=0.5,
                                        random_state=0):
-    """
-    Samples are are set of n two-category equally spaced points.
-    """
+    """Test unsupervised radius-based query"""
     rng = np.random.RandomState(random_state)
 
     X = rng.rand(n_samples, n_features)
@@ -112,6 +109,7 @@ def test_kneighbors_classifier(n_samples=40,
                                n_test_pts=10,
                                n_neighbors=5,
                                random_state=0):
+    """Test k-neighbors classification"""
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = ((X ** 2).sum(axis=1) < .25).astype(np.int)
@@ -134,6 +132,7 @@ def test_radius_neighbors_classifier(n_samples=40,
                                      n_test_pts=10,
                                      radius=0.5,
                                      random_state=0):
+    """Test radius-based classification"""
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = ((X ** 2).sum(axis=1) < .25).astype(np.int)
@@ -180,6 +179,7 @@ def test_kneighbors_regressor(n_samples=40,
                               n_test_pts=10,
                               n_neighbors=3,
                               random_state=0):
+    """Test k-neighbors regression"""
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = np.sqrt((X ** 2).sum(1))
@@ -205,6 +205,7 @@ def test_radius_neighbors_regressor(n_samples=40,
                                     n_test_pts=10,
                                     radius=0.5,
                                     random_state=0):
+    """Test radius-based neighbors regression"""
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = np.sqrt((X ** 2).sum(1))
@@ -230,7 +231,7 @@ def test_kneighbors_regressor_sparse(n_samples=40,
                                      n_test_pts=10,
                                      n_neighbors=5,
                                      random_state=0):
-    """Test radius-neighbors classifier on sparse matrices"""
+    """Test radius-based regression on sparse matrices"""
     # Like the above, but with various types of sparse matrices
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
@@ -250,8 +251,7 @@ def test_kneighbors_regressor_sparse(n_samples=40,
 
 
 def test_neighbors_iris():
-    """
-    Sanity checks on the iris dataset
+    """Sanity checks on the iris dataset
 
     Puts three points of each label in the plane and performs a
     nearest neighbor query on points near the decision boundary.
@@ -275,9 +275,7 @@ def test_neighbors_iris():
 
 
 def test_kneighbors_graph():
-    """
-    Test kneighbors_graph to build the k-Nearest Neighbor graph.
-    """
+    """Test kneighbors_graph to build the k-Nearest Neighbor graph."""
     X = np.array([[0, 1], [1.01, 1.], [2, 0]])
 
     # n_neighbors = 1
@@ -314,9 +312,7 @@ def test_kneighbors_graph():
 
 
 def test_radius_neighbors_graph():
-    """
-    Test radius_neighbors_graph to build the Nearest Neighbor graph.
-    """
+    """Test radius_neighbors_graph to build the Nearest Neighbor graph."""
     X = np.array([[0, 1], [1.01, 1.], [2, 0]])
 
     A = neighbors.radius_neighbors_graph(X, 1.5, mode='connectivity')
@@ -333,32 +329,27 @@ def test_radius_neighbors_graph():
          [ 1.01      ,  0.        ,  1.40716026],
          [ 0.        ,  1.40716026,  0.        ]])
 
-def test_neighbors_badargs():
-    neigh_types = [neighbors.KNeighborsClassifier,
-                   neighbors.RadiusNeighborsClassifier,
-                   neighbors.KNeighborsRegressor,
-                   neighbors.RadiusNeighborsRegressor]
 
-    
+def test_neighbors_badargs():
+    """Test bad argument values: these should all raise ValueErrors"""
     assert_raises(ValueError,
                   neighbors.NearestNeighbors,
                   algorithm='blah')
 
-    X = np.random.random((10,2))
+    X = np.random.random((10, 2))
 
-    for cls in neigh_types:
+    for cls in (neighbors.KNeighborsClassifier,
+                neighbors.RadiusNeighborsClassifier,
+                neighbors.KNeighborsRegressor,
+                neighbors.RadiusNeighborsRegressor):
         assert_raises(ValueError,
                       cls,
                       weights='blah')
-
-    for cls in neigh_types:
         nbrs = cls()
         assert_raises(ValueError,
                       nbrs.predict,
                       X)
-        
 
-        
     nbrs = neighbors.NearestNeighbors().fit(X)
 
     assert_raises(ValueError,
@@ -368,8 +359,6 @@ def test_neighbors_badargs():
                   nbrs.radius_neighbors_graph,
                   X, mode='blah')
 
-
-    
 
 if __name__ == '__main__':
     import nose

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -47,10 +47,10 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
       NearestNeighbors(algorithm='auto', leaf_size=30, n_neighbors=2, radius=0.4)
 
       >>> neigh.kneighbors([[0, 0, 1.3]], 2, return_distance=False)
-      array([[2, 0]], dtype=int32)
+      array([[2, 0]])
 
       >>> neigh.radius_neighbors([0, 0, 1.3], 0.4, return_distance=False)
-      array([[2]], dtype=object)
+      array([[2]])
 
     See also
     --------


### PR DESCRIPTION
This attempts to address the changes to the neighbors module which were recently discussed on the mailing list. (see discussion thread <a href="http://sourceforge.net/mailarchive/forum.php?thread_name=CAC8MkjzwrHdZb5J1b8fiw5kE%2BBFPqVmzmjfr%3D%3DLB8VFTCBpy1Q%40mail.gmail.com&forum_name=scikit-learn-general">here</a>)

The basic idea is this: I've written a `NearestNeighbors` class which implements all unsupervised neighbors-based learning methods.  It provides a uniform interface for brute force, `BallTree`, and `cKDTree`.  I've made `NeighborsClassifier` and `NeighborsRegressor` inherit from `NearestNeighbors`.  I think this is the correct thing to do here. it meets the LSP because both of these classes should be valid inputs into functions like `kneighbors_graph`, where only the unsupervised functionality is used.

I've made `kneighbors_graph` and `radius_neighbors_graph` into methods of `NearestNeighbors`, and kept the old stand-alone versions as convenience functions.

The new version retains nearly complete backward compatibility with the old version (aside from the order of keyword arguments in some cases).  The test-suite passed with no modification.

A few issues to think about:
- I've included `cKDTree` as an option in `NearestNeighbors`.  This adds flexibility for free, but breaks picklability.  I did this mainly to ease the task of comparing execution times for the three neighbors search methods.  If picklability is a concern, we could still keep `cKDTree` and write `__getstate__` and `__setstate__` such that the KD-tree is rebuilt on deserialization.
- For completeness, I'd need to implement a new version of `barycenter_weights` which works in cases where `k` is different for each neighborhood (i.e. in `radius_neighbors_graph`).  @fabianp has mentioned in the past that `barycenter_weights` may be removed at some point.  This would be a great time to make that decision.
- I'm not completely happy with the `classification_type` keyword.  It could be misleading: for example, if someone creates a classifier using `NeighborsClassifier(r_neighbors=0.5)`, any prediction will still be performed using `kneighbors()` with the default `n_neighbors=5`, not `radius_neighbors()` as the user may naively expect.  We could try to anticipate this by checking which keywords are passed to the constructor, but this could lead to other sources of confusion.
- The `method='auto'` decision process should be more sophisticated, as mentioned in issue #195.  I'm writing a profiler suite which will help address this.  With the new cython version of `BallTree` in place, initial tests make it look like `method='auto'` will simply end up choosing `BallTree` in all cases.

I'm waiting on people's input before I fully update tests and documentation, and comb the code-base to make sure the appropriate neighbors object is being used in all cases.
