### PR TITLE
Bug: euclidean distances 

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -73,6 +73,16 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
     Considering the rows of X (and Y=X) as vectors, compute the
     distance matrix between each pair of vectors.
 
+    For efficiency reasons, the euclidean distance between a pair of row
+    vector x and y is computed as::
+
+        dist(x, y) = sqrt(dot(x, x) - 2 * dot(x, y) + dot(y, y))
+
+    This formulation has two main advantages. First, it is computationally
+    efficient when dealing with sparse data. Second, if x varies but y
+    remains unchanged, then the right-most dot-product `dot(y, y)` can be
+    pre-computed.
+
     Parameters
     ----------
     X: {array-like, sparse matrix}, shape = [n_samples_1, n_features]
@@ -80,7 +90,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
     Y: {array-like, sparse matrix}, shape = [n_samples_2, n_features]
 
     Y_norm_squared: array-like, shape = [n_samples_2], optional
-        Pre-computed (Y**2).sum(axis=1)
+        Pre-computed dot-products of vectors in Y (e.g., `(Y**2).sum(axis=1)`)
 
     squared: boolean, optional
         Return squared Euclidean distances.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -143,6 +143,10 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
     distances += XX
     distances += YY
     distances = np.maximum(distances, 0)
+
+    if X is Y:
+        np.fill_diagonal(distances, 0.0)
+
     return distances if squared else np.sqrt(distances)
 
 


### PR DESCRIPTION
On my machine (32-bits) `sklearn.cluster.tests.test_k_means.test_transform` fails.

``` ======================================================================
FAIL: sklearn.cluster.tests.test_k_means.test_transform
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose-1.0.0-py2.7.egg/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/home/gilles/Sources/scikit-learn/sklearn/cluster/tests/test_k_means.py", line 280, in test_transform
    assert_equal(X_new[c, c], 0)
  File "/usr/lib/pymodules/python2.7/numpy/testing/utils.py", line 313, in assert_equal
    raise AssertionError(msg)
AssertionError: 
Items are not equal:
 ACTUAL: 2.384185791015625e-07
 DESIRED: 0
```

I tracked down the bug and it actually comes from the `euclidean_distances` metric. Computing `(x-y)^2` as `x*x - 2*x*y + y*y` seems to introduce rounding errors due to floating point arithmetic. In my opinion, it would be better if `(x-y)^2` was actually computed as `(x-y)` and then squared. In all cases if `x == y`, then `x-y` would cancel itself and no rounding error would occur. 

For now, I have simply added `if X is Y: np.fill_diagonal(distances, 0.0)`, which resolves the test issue, but imo the euclidean metric should be rewritten properly from scratch. What is your opinion?
