### PR TITLE
Fix typo in SGDClassifier's docstring (via GitHub).

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -73,7 +73,7 @@ class SGDClassifier(BaseSGDClassifier):
         multi-class problems) computation. -1 means 'all CPUs'. Defaults
         to 1.
 
-    learning_rate : int
+    learning_rate : str
         The learning rate:
         constant: eta = eta0
         optimal: eta = 1.0/(t+t0) [default]


### PR DESCRIPTION
-learning_rate: int
+learning_rate: str

HTH
