### PR TITLE
min_df text feature_extraction

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -274,7 +274,7 @@ def test_vectorizer_min_df():
                  u'another document appears']
     n_doc = len(test_data)
     max_df = (n_doc - 1.0) / n_doc  # all documents but one
-    min_df = 2.0 / n_doc  # at least two documents
+    min_df = 2  # at least two documents
 
     vect = Vectorizer(WordNGramAnalyzer(stop_words=None),
                       max_df=max_df,

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -266,6 +266,22 @@ def test_vectorizer_max_df():
     assert u'a' not in vect.vocabulary.keys()  # 'a' is ignored
     assert_equals(len(vect.vocabulary.keys()), 4)  # the others remain
 
+def test_vectorizer_min_df():
+    test_data = [u'this is a document',
+                 u'this is another document',
+                 u'another document appears']
+    n_doc = len(test_data)
+    max_df = (n_doc-1.0)/n_doc #all documents but one
+    min_df = 2.0/n_doc #at least two documents
+    
+    vect = Vectorizer(WordNGramAnalyzer(stop_words=None),
+                      max_df=max_df,
+                      min_df=min_df)
+    vect.fit_transform(test_data)
+    assert u'document' not in vect.vocabulary.keys() #term in all documents
+    assert u'appears' not in vect.vocabulary.keys() #term in only one document
+    assert_equals(len(vect.vocabulary.keys()),3) #other terms except 'a' remain
+
 
 def test_vectorizer_inverse_transform():
     # raw documents

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -276,7 +276,7 @@ def test_vectorizer_min_df():
     max_df = (n_doc - 1.0) / n_doc  # all documents but one
     min_df = 2  # at least two documents
 
-    vect = Vectorizer(WordNGramAnalyzer(stop_words=None),
+    vect = Vectorizer(WordNGramAnalyzer(stop_words=None,min_n=0),
                       max_df=max_df,
                       min_df=min_df)
     vect.fit_transform(test_data)
@@ -285,7 +285,7 @@ def test_vectorizer_min_df():
     assert u'document' not in vect.vocabulary.keys()
     # term in only one document
     assert u'appears' not in vect.vocabulary.keys()
-    # other terms except 'a' remain
+    # other terms remain
     assert_equals(len(vect.vocabulary.keys()), 3)
 
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -164,6 +164,7 @@ def test_fit_countvectorizer_twice():
     X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
     assert_not_equal(X1.shape[1], X2.shape[1])
 
+
 def test_vectorizer():
     # raw documents as an iterator
     train_data = iter(ALL_FOOD_DOCS[:-1])
@@ -266,21 +267,26 @@ def test_vectorizer_max_df():
     assert u'a' not in vect.vocabulary.keys()  # 'a' is ignored
     assert_equals(len(vect.vocabulary.keys()), 4)  # the others remain
 
+
 def test_vectorizer_min_df():
     test_data = [u'this is a document',
                  u'this is another document',
                  u'another document appears']
     n_doc = len(test_data)
-    max_df = (n_doc-1.0)/n_doc #all documents but one
-    min_df = 2.0/n_doc #at least two documents
-    
+    max_df = (n_doc - 1.0) / n_doc  # all documents but one
+    min_df = 2.0 / n_doc  # at least two documents
+
     vect = Vectorizer(WordNGramAnalyzer(stop_words=None),
                       max_df=max_df,
                       min_df=min_df)
     vect.fit_transform(test_data)
-    assert u'document' not in vect.vocabulary.keys() #term in all documents
-    assert u'appears' not in vect.vocabulary.keys() #term in only one document
-    assert_equals(len(vect.vocabulary.keys()),3) #other terms except 'a' remain
+
+    # term in all documents
+    assert u'document' not in vect.vocabulary.keys()
+    # term in only one document
+    assert u'appears' not in vect.vocabulary.keys()
+    # other terms except 'a' remain
+    assert_equals(len(vect.vocabulary.keys()), 3)
 
 
 def test_vectorizer_inverse_transform():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -225,16 +225,18 @@ class CountVectorizer(BaseEstimator):
 
         This is useful in order to fix the vocabulary in advance.
 
-    max_df : float in range [0.0, 1.0], optional, 1.0 by default
-        When building the vocabulary ignore terms that have a term frequency
-        strictly higher than the given threshold (corpus specific stop words).
+    max_df : positive int or float in range [0.0, 1.0], optional, 1.0 by
+        default. When building the vocabulary ignore terms that have a term
+        frequency strictly higher than the given threshold (corpus specific
+        stop words).
 
         This parameter is ignored if vocabulary is not None.
 
-    min_df : float in range [0.0, 1.0], optional, 0.0 by default
-        When building the vocabulary ignore terms that have a document
+    min_df : positive int or float in range [0.0, 1.0], optional, 0.0 by
+        default. When building the vocabulary ignore terms that have a document
         frequency strictly lower than the given threshold (e.g. words in only
-        one document).
+        one document). This may also be called document frequency cut-off in IR
+        literature.
 
         This parameter is ignored if vocabulary is not None.
 
@@ -343,11 +345,11 @@ class CountVectorizer(BaseEstimator):
 
         # filter out uninformative words: terms that occur in all/one documents
         if (max_df or min_df) is not None:
-            max_document_count = max_df * n_doc
-            min_document_count = min_df * n_doc
+            max_doc_count = max_df * n_doc if type(max_df) == float else max_df
+            min_doc_count = min_df * n_doc if type(min_df) == float else min_df
             remove_words = set(t for t, dc in document_counts.iteritems()
-                               if dc > max_document_count
-                               or dc < min_document_count)
+                               if dc > max_doc_count
+                               or dc < min_doc_count)
 
         # list the terms that should be part of the vocabulary
         if max_features is None:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -231,6 +231,13 @@ class CountVectorizer(BaseEstimator):
 
         This parameter is ignored if vocabulary is not None.
 
+    min_df : float in range [0.0, 1.0], optional, 0.0 by default
+        When building the vocabulary ignore terms that have a document
+        frequency strictly lower than the given threshold (e.g. words in only
+        one document).
+
+        This parameter is ignored if vocabulary is not None.
+
     max_features : optional, None by default
         If not None, build a vocabulary that only consider the top
         max_features ordered by term frequency across the corpus.
@@ -242,7 +249,7 @@ class CountVectorizer(BaseEstimator):
     """
 
     def __init__(self, analyzer=DEFAULT_ANALYZER, vocabulary=None, max_df=1.0,
-                 max_features=None, dtype=long):
+                 min_df=0.0, max_features=None, dtype=long):
         self.analyzer = analyzer
         self.fit_vocabulary = vocabulary is None
         if vocabulary is not None and not isinstance(vocabulary, dict):
@@ -250,6 +257,7 @@ class CountVectorizer(BaseEstimator):
         self.vocabulary = vocabulary
         self.dtype = dtype
         self.max_df = max_df
+        self.min_df = min_df
         self.max_features = max_features
 
     def _term_count_dicts_to_matrix(self, term_count_dicts):
@@ -313,6 +321,7 @@ class CountVectorizer(BaseEstimator):
         document_counts = Counter()
 
         max_df = self.max_df
+        min_df = self.min_df
         max_features = self.max_features
 
         # TODO: parallelize the following loop with joblib?
@@ -324,7 +333,7 @@ class CountVectorizer(BaseEstimator):
                 term_count_current[term] += 1
                 term_counts[term] += 1
 
-            if max_df is not None:
+            if (max_df or min_df) is not None:
                 for term in term_count_current:
                     document_counts[term] += 1
 
@@ -332,20 +341,22 @@ class CountVectorizer(BaseEstimator):
 
         n_doc = len(term_counts_per_doc)
 
-        # filter out stop words: terms that occur in almost all documents
-        if max_df is not None:
+        # filter out uninformative words: terms that occur in all/one documents
+        if (max_df or min_df) is not None:
             max_document_count = max_df * n_doc
-            stop_words = set(t for t, dc in document_counts.iteritems()
-                               if dc > max_document_count)
+            min_document_count = min_df * n_doc
+            remove_words = set(t for t, dc in document_counts.iteritems()
+                               if dc > max_document_count
+                               or dc < min_document_count)
 
         # list the terms that should be part of the vocabulary
         if max_features is None:
-            terms = [t for t in term_counts if t not in stop_words]
+            terms = [t for t in term_counts if t not in remove_words]
         else:
             # extract the most frequent terms for the vocabulary
             terms = set()
             for t, tc in term_counts.most_common():
-                if t not in stop_words:
+                if t not in remove_words:
                     terms.add(t)
                 if len(terms) >= max_features:
                     break
@@ -514,9 +525,9 @@ class Vectorizer(BaseEstimator):
     Equivalent to CountVectorizer followed by TfidfTransformer.
     """
 
-    def __init__(self, analyzer=DEFAULT_ANALYZER, max_df=1.0,
+    def __init__(self, analyzer=DEFAULT_ANALYZER, max_df=1.0, min_df=0.0,
                  max_features=None, norm='l2', use_idf=True, smooth_idf=True):
-        self.tc = CountVectorizer(analyzer, max_df=max_df,
+        self.tc = CountVectorizer(analyzer, max_df=max_df, min_df=min_df,
                                   max_features=max_features,
                                   dtype=np.float64)
         self.tfidf = TfidfTransformer(norm=norm, use_idf=use_idf,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -329,11 +329,8 @@ class CountVectorizer(BaseEstimator):
         # term counts across entire corpus (count each term maximum once per
         # document)
         document_counts = Counter()
-
-        #document frequencies into ratios
-        n_doc = len(raw_documents)
-        max_df = self.max_df if np.issubdtype(type(self.max_df),float) else float(self.max_df)/n_doc
-        min_df = self.min_df if np.issubdtype(type(self.min_df),float) else float(self.min_df)/n_doc
+        max_df = self.max_df
+        min_df = self.min_df
         max_features = self.max_features
 
         # TODO: parallelize the following loop with joblib?
@@ -345,13 +342,17 @@ class CountVectorizer(BaseEstimator):
                 term_count_current[term] += 1
                 term_counts[term] += 1
 
-            if min_df>0 or max_df<1:
+            if min_df>0:
                 for term in term_count_current:
                     document_counts[term] += 1
 
             term_counts_per_doc.append(term_count_current)
 
+        n_doc = len(term_counts_per_doc)
+
         # filter out uninformative words: terms that occur in all/few documents
+        max_df = max_df if np.issubdtype(type(max_df),float) else float(max_df)/n_doc
+        min_df = min_df if np.issubdtype(type(min_df),float) else float(min_df)/n_doc
         if min_df>0 or max_df<1:
             remove_words = set(t for t, dc in document_counts.iteritems()
                                if dc > max_df * n_doc or dc < min_df * n_doc)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -342,9 +342,8 @@ class CountVectorizer(BaseEstimator):
                 term_count_current[term] += 1
                 term_counts[term] += 1
 
-            if min_df>0:
-                for term in term_count_current:
-                    document_counts[term] += 1
+            for term in term_count_current:
+                document_counts[term] += 1
 
             term_counts_per_doc.append(term_count_current)
 
@@ -353,6 +352,7 @@ class CountVectorizer(BaseEstimator):
         # filter out uninformative words: terms that occur in all/few documents
         max_df = max_df if np.issubdtype(type(max_df),float) else float(max_df)/n_doc
         min_df = min_df if np.issubdtype(type(min_df),float) else float(min_df)/n_doc
+        remove_words = set()
         if min_df>0 or max_df<1:
             remove_words = set(t for t, dc in document_counts.iteritems()
                                if dc > max_df * n_doc or dc < min_df * n_doc)


### PR DESCRIPTION
comit: "added min_df to control the minimum document frequency a term must have to be a part of the vocabulary in the text feature extraction"

This is a complement to the max_df param in the text feature extraction. Parameter min_df may be used to restrict terms that only appear in one or two documents. By default min_df is zero and does not restrict terms.

Also provided the unit test 'test_vectorizer_min_df()'
