### PR TITLE
Safer assert_all_finite.

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -2,18 +2,15 @@ import numpy as np
 import scipy.sparse as sp
 import warnings
 
-_FLOAT_CODES = np.typecodes['AllFloat']
-
-
 def assert_all_finite(X):
     """Throw a ValueError if X contains NaN or infinity.
     Input MUST be an np.ndarray instance or a scipy.sparse matrix."""
 
-    # O(n) time, O(1) solution. XXX: will fail if the sum over X is
-    # *extremely* large. A proper solution would be a C-level loop to check
-    # each element.
-    if X.dtype.char in _FLOAT_CODES and not np.isfinite(X.sum()):
-        raise ValueError("array contains NaN or infinity")
+    # O(n) time, O(1) solution. Much faster than np.asarray_chkfinite
+    if X.dtype.char in np.typecodes['AllFloat'] and not np.isfinite(X.sum()):
+        # probably contains Inf/NaNs, but sum could overflow
+        if not np.isfinite(a).all():
+            raise ValueError("array contains NaN or infinity")
 
 
 def safe_asanyarray(X, dtype=None, order=None):


### PR DESCRIPTION
Check for Inf/NaN when X.sum() is not finite. This avoids the risk of
false positivs because of sum overflow while remaining performant for
the usual case where all values are finite.

This idea is taken from:

   https://github.com/tecki/numpy/commit/57167f7c02b02bfb49204233eaee0f289ad37c92

@larsmans: what do you think ?
