### PR TITLE
rename overwrite_Foo params to copy_Foo (and inversed their meaning)

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -43,7 +43,7 @@ and will store the coefficients :math:`w` of the linear model in its
     >>> from sklearn import linear_model
     >>> clf = linear_model.LinearRegression()
     >>> clf.fit ([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
-    LinearRegression(fit_intercept=True, normalize=False, overwrite_X=False)
+    LinearRegression(copy_X=True, fit_intercept=True, normalize=False)
     >>> clf.coef_
     array([ 0.5,  0.5])
 
@@ -100,7 +100,7 @@ its `coef\_` member::
     >>> from sklearn import linear_model
     >>> clf = linear_model.Ridge (alpha = .5)
     >>> clf.fit ([[0, 0], [0, 0], [1, 1]], [0, .1, 1])
-    Ridge(alpha=0.5, fit_intercept=True, normalize=False, overwrite_X=False,
+    Ridge(alpha=0.5, copy_X=True, fit_intercept=True, normalize=False,
        tol=0.001)
     >>> clf.coef_
     array([ 0.34545455,  0.34545455])
@@ -176,8 +176,8 @@ for another implementation::
 
     >>> clf = linear_model.Lasso(alpha = 0.1)
     >>> clf.fit([[0, 0], [1, 1]], [0, 1])
-    Lasso(alpha=0.1, fit_intercept=True, max_iter=1000, normalize=False,
-       overwrite_X=False, precompute='auto', tol=0.0001)
+    Lasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
+       normalize=False, precompute='auto', tol=0.0001)
     >>> clf.predict([[1, 1]])
     array([ 0.8])
 
@@ -324,9 +324,8 @@ function of the norm of its coefficients.
    >>> from sklearn import linear_model
    >>> clf = linear_model.LassoLars(alpha=.1)
    >>> clf.fit ([[0, 0], [1, 1]], [0, 1])                 # doctest: +ELLIPSIS
-   LassoLars(alpha=0.1, eps=..., fit_intercept=True,
-        max_iter=500, normalize=True, overwrite_X=False, precompute='auto',
-        verbose=False)
+   LassoLars(alpha=0.1, copy_X=True, eps=..., fit_intercept=True,
+        max_iter=500, normalize=True, precompute='auto', verbose=False)
    >>> clf.coef_    # doctest: +ELLIPSIS
    array([ 0.717157...,  0.        ])
 
@@ -468,8 +467,8 @@ By default :math:`\alpha_1 = \alpha_2 =  \lambda_1 = \lambda_2 = 1.e^{-6}`, *i.e
     >>> clf = linear_model.BayesianRidge()
     >>> clf.fit (X, Y)
     BayesianRidge(alpha_1=1e-06, alpha_2=1e-06, compute_score=False,
-           fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06, n_iter=300,
-           normalize=False, overwrite_X=False, tol=0.001, verbose=False)
+           copy_X=True, fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06,
+           n_iter=300, normalize=False, tol=0.001, verbose=False)
 
 After being fitted, the model can then be used to predict new values::
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,5 +1,24 @@
 .. currentmodule:: sklearn
 
+.. _changes_0_10:
+
+0.10
+====
+
+API changes summary
+-------------------
+
+Here are the code migration instructions when updgrading from scikit-learn
+version 0.9:
+
+  - Some estimators that may overwrite their inputs to save memory previously
+    had ``overwrite_`` parameters; these have been replaced with ``copy_``
+    parameters with exactly the opposite meaning.
+
+    This particularly affects some of the estimators in ``linear_models``.
+    The default behavior is still to copy everything passed in.
+
+
 .. _changes_0_9:
 
 0.9

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -23,7 +23,7 @@ from ..linear_model import Lasso, orthogonal_mp_gram, lars_path
 
 def sparse_encode(X, Y, gram=None, cov=None, algorithm='lasso_lars',
                   n_nonzero_coefs=None, alpha=None,
-                  overwrite_gram=False, overwrite_cov=False, init=None):
+                  copy_gram=True, copy_cov=True, init=None):
     """Generic sparse coding
 
     Each column of the result is the solution to a Lasso problem.
@@ -70,11 +70,13 @@ def sparse_encode(X, Y, gram=None, cov=None, algorithm='lasso_lars',
         Initialization value of the sparse codes. Only used if
         `algorithm='lasso_cd'`.
 
-    overwrite_gram: boolean,
-        Whether to overwrite the precomputed Gram matrix.
+    copy_gram: boolean, optional
+        Whether to copy the precomputed Gram matrix; if False, it may be
+        overwritten.
 
-    overwrite_cov: boolean,
-        Whether to overwrite the precomputed covariance matrix.
+    copy_cov: boolean, optional
+        Whether to copy the precomputed covariance matrix; if False, it may be
+        overwritten.
 
     Returns
     -------
@@ -99,8 +101,8 @@ def sparse_encode(X, Y, gram=None, cov=None, algorithm='lasso_lars',
         # The parameter could be removed in this case. Discuss.
         gram = np.dot(X.T, X)
     if cov is None and algorithm != 'lasso_cd':
-        # overwrite_cov is safe
-        overwrite_cov = True
+        # overwriting cov is safe
+        copy_cov = False
         cov = np.dot(X.T, Y)
 
     if algorithm == 'lasso_lars':
@@ -159,7 +161,7 @@ def sparse_encode(X, Y, gram=None, cov=None, algorithm='lasso_lars',
             n_nonzero_coefs = n_features / 10
         norms_squared = np.sum((Y ** 2), axis=0)
         new_code = orthogonal_mp_gram(gram, cov, n_nonzero_coefs, alpha,
-                                      norms_squared, overwrite_Xy=overwrite_cov
+                                      norms_squared, copy_Xy=copy_cov
                                       )
     else:
         raise NotImplemented('Sparse coding method %s not implemented' %
@@ -168,8 +170,8 @@ def sparse_encode(X, Y, gram=None, cov=None, algorithm='lasso_lars',
 
 
 def sparse_encode_parallel(X, Y, gram=None, cov=None, algorithm='lasso_lars',
-                  n_nonzero_coefs=None, alpha=None, overwrite_gram=False,
-                  overwrite_cov=False, init=None, n_jobs=1):
+                  n_nonzero_coefs=None, alpha=None, copy_gram=True,
+                  copy_cov=True, init=None, n_jobs=1):
     """Parallel sparse coding using joblib
 
     Each column of the result is the solution to a Lasso problem.
@@ -216,13 +218,15 @@ def sparse_encode_parallel(X, Y, gram=None, cov=None, algorithm='lasso_lars',
         Initialization value of the sparse codes. Only used if
         `algorithm='lasso_cd'`.
 
-    overwrite_gram: boolean,
-        Whether to overwrite the precomputed Gram matrix.
+    copy_gram: boolean, optional
+        Whether to copy the precomputed Gram matrix; if False, it may be
+        overwritten.
 
-    overwrite_cov: boolean,
-        Whether to overwrite the precomputed covariance matrix.
+    copy_cov: boolean, optional
+        Whether to copy the precomputed covariance matrix; if False, it may be
+        overwritten.
 
-    n_jobs: int,
+    n_jobs: int, optional
         Number of parallel jobs to run.
 
     Returns
@@ -239,21 +243,21 @@ def sparse_encode_parallel(X, Y, gram=None, cov=None, algorithm='lasso_lars',
     n_samples, n_features = Y.shape
     n_components = X.shape[1]
     if gram is None:
-        overwrite_gram = True
+        copy_gram = False
         gram = np.dot(X.T, X)
     if cov is None and algorithm != 'lasso_cd':
-        overwrite_cov = True
+        copy_cov = False
         cov = np.dot(X.T, Y)
     if n_jobs == 1 or algorithm == 'threshold':
         return sparse_encode(X, Y, gram, cov, algorithm, n_nonzero_coefs,
-                             alpha, overwrite_gram, overwrite_cov, init)
+                             alpha, copy_gram, copy_cov, init)
     code = np.empty((n_components, n_features))
     slices = list(gen_even_slices(n_features, n_jobs))
     code_views = Parallel(n_jobs=n_jobs)(
                 delayed(sparse_encode)(X, Y[:, this_slice], gram,
                                        cov[:, this_slice], algorithm,
                                        n_nonzero_coefs, alpha,
-                                       overwrite_gram, overwrite_cov,
+                                       copy_gram, copy_cov,
                                        init=init[:, this_slice] if init is not
                                        None else None)
                 for this_slice in slices)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -51,14 +51,14 @@ class LinearModel(BaseEstimator, RegressorMixin):
         return safe_sparse_dot(X, self.coef_.T) + self.intercept_
 
     @staticmethod
-    def _center_data(X, y, fit_intercept, normalize=False, overwrite_X=False):
+    def _center_data(X, y, fit_intercept, normalize=False, copy=True):
         """
         Centers data to have mean zero along axis 0. This is here because
         nearly all linear models will want their data to be centered.
 
-        If overwrite_X is True, modifies X in-place.
+        If copy is False, modifies X in-place.
         """
-        X = as_float_array(X, overwrite_X)
+        X = as_float_array(X, copy)
 
         if fit_intercept:
             if sp.issparse(X):
@@ -110,10 +110,10 @@ class LinearRegression(LinearModel):
 
     """
 
-    def __init__(self, fit_intercept=True, normalize=False, overwrite_X=False):
+    def __init__(self, fit_intercept=True, normalize=False, copy_X=True):
         self.fit_intercept = fit_intercept
         self.normalize = normalize
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
 
     def fit(self, X, y):
         """
@@ -140,7 +140,7 @@ class LinearRegression(LinearModel):
         y = np.asanyarray(y)
 
         X, y, X_mean, y_mean, X_std = self._center_data(X, y,
-                self.fit_intercept, self.normalize, self.overwrite_X)
+                self.fit_intercept, self.normalize, self.copy_X)
 
         self.coef_, self.residues_, self.rank_, self.singular_ = \
                 np.linalg.lstsq(X, y)

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -64,16 +64,14 @@ class BayesianRidge(LinearModel):
         (e.g. data is expected to be already centered).
         Default is True.
 
-    normalize : boolean, optional
+    normalize : boolean, optional, default False
         If True, the regressors X are normalized
-        Default is False
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
-    verbose : boolean, optional
-        Verbose mode when fitting the model. Default is False.
+    verbose : boolean, optional, default False
+        Verbose mode when fitting the model.
 
 
     Attributes
@@ -102,10 +100,10 @@ class BayesianRidge(LinearModel):
     --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.BayesianRidge()
-    >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
+    >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2]) # doctest: +NORMALIZE_WHITESPACE
     BayesianRidge(alpha_1=1e-06, alpha_2=1e-06, compute_score=False,
-           fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06, n_iter=300,
-           normalize=False, overwrite_X=False, tol=0.001, verbose=False)
+           copy_X=True, fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06,
+           n_iter=300, normalize=False, tol=0.001, verbose=False)
     >>> clf.predict([[1, 1]])
     array([ 1.])
 
@@ -117,7 +115,7 @@ class BayesianRidge(LinearModel):
     def __init__(self, n_iter=300, tol=1.e-3, alpha_1=1.e-6, alpha_2=1.e-6,
                 lambda_1=1.e-6, lambda_2=1.e-6, compute_score=False,
                 fit_intercept=True, normalize=False,
-                overwrite_X=False, verbose=False):
+                copy_X=True, verbose=False):
         self.n_iter = n_iter
         self.tol = tol
         self.alpha_1 = alpha_1
@@ -127,7 +125,7 @@ class BayesianRidge(LinearModel):
         self.compute_score = compute_score
         self.fit_intercept = fit_intercept
         self.normalize = normalize
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.verbose = verbose
 
     def fit(self, X, y):
@@ -147,7 +145,7 @@ class BayesianRidge(LinearModel):
         X = np.asanyarray(X, dtype=np.float)
         y = np.asanyarray(y, dtype=np.float)
         X, y, X_mean, y_mean, X_std = self._center_data(X, y,
-                self.fit_intercept, self.normalize, self.overwrite_X)
+                self.fit_intercept, self.normalize, self.copy_X)
         n_samples, n_features = X.shape
 
         ### Initialization of the values of the parameters
@@ -285,12 +283,11 @@ class ARDRegression(LinearModel):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True.
+        If True, X will be copied; else, it may be overwritten.
 
-    verbose : boolean, optional
-        Verbose mode when fitting the model. Default is False.
+    verbose : boolean, optional, default False
+        Verbose mode when fitting the model.
 
     Attributes
     ----------
@@ -321,11 +318,11 @@ class ARDRegression(LinearModel):
     --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.ARDRegression()
-    >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
+    >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])  # doctest: +NORMALIZE_WHITESPACE
     ARDRegression(alpha_1=1e-06, alpha_2=1e-06, compute_score=False,
-           fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06, n_iter=300,
-           normalize=False, overwrite_X=False, threshold_lambda=10000.0,
-           tol=0.001, verbose=False)
+           copy_X=True, fit_intercept=True, lambda_1=1e-06, lambda_2=1e-06,
+           n_iter=300, normalize=False, threshold_lambda=10000.0, tol=0.001,
+           verbose=False)
     >>> clf.predict([[1, 1]])
     array([ 1.])
 
@@ -337,7 +334,7 @@ class ARDRegression(LinearModel):
     def __init__(self, n_iter=300, tol=1.e-3, alpha_1=1.e-6, alpha_2=1.e-6,
                   lambda_1=1.e-6, lambda_2=1.e-6, compute_score=False,
                   threshold_lambda=1.e+4, fit_intercept=True,
-                  normalize=False, overwrite_X=False, verbose=False):
+                  normalize=False, copy_X=True, verbose=False):
         self.n_iter = n_iter
         self.tol = tol
         self.fit_intercept = fit_intercept
@@ -348,7 +345,7 @@ class ARDRegression(LinearModel):
         self.lambda_2 = lambda_2
         self.compute_score = compute_score
         self.threshold_lambda = threshold_lambda
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.verbose = verbose
 
     def fit(self, X, y):
@@ -377,7 +374,7 @@ class ARDRegression(LinearModel):
         coef_ = np.zeros(n_features)
 
         X, y, X_mean, y_mean, X_std = self._center_data(X, y, self.fit_intercept,
-                self.normalize, self.overwrite_X)
+                self.normalize, self.copy_X)
 
         ### Launch the convergence loop
         keep_lambda = np.ones(n_features, dtype=bool)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -50,9 +50,8 @@ class ElasticNet(LinearModel):
     max_iter: int, optional
         The maximum number of iterations
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default False
+        If True, X will be copied; else, it may be overwritten.
 
     tol: float, optional
         The tolerance for the optimization: if the updates are
@@ -83,7 +82,7 @@ class ElasticNet(LinearModel):
     """
     def __init__(self, alpha=1.0, rho=0.5, fit_intercept=True,
                  normalize=False, precompute='auto', max_iter=1000,
-                 overwrite_X=False, tol=1e-4):
+                 copy_X=True, tol=1e-4):
         self.alpha = alpha
         self.rho = rho
         self.coef_ = None
@@ -91,7 +90,7 @@ class ElasticNet(LinearModel):
         self.normalize = normalize
         self.precompute = precompute
         self.max_iter = max_iter
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.tol = tol
 
     def fit(self, X, y, Xy=None, coef_init=None):
@@ -121,7 +120,7 @@ class ElasticNet(LinearModel):
         """
         X = np.asanyarray(X, dtype=np.float64)
         y = np.asanyarray(y, dtype=np.float64)
-        X = as_float_array(X, self.overwrite_X)
+        X = as_float_array(X, self.copy_X)
 
         n_samples, n_features = X.shape
 
@@ -129,7 +128,7 @@ class ElasticNet(LinearModel):
         X, y, X_mean, y_mean, X_std = self._center_data(X, y,
                                                         self.fit_intercept,
                                                         self.normalize,
-                                                        overwrite_X=True)
+                                                        copy=False)
         precompute = self.precompute
         if X_init is not X and hasattr(precompute, '__array__'):
             precompute = 'auto'  # recompute Gram
@@ -199,9 +198,8 @@ class Lasso(ElasticNet):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     precompute : True | False | 'auto' | array-like
         Whether to use a precomputed Gram matrix to speed up
@@ -231,8 +229,8 @@ class Lasso(ElasticNet):
     >>> from sklearn import linear_model
     >>> clf = linear_model.Lasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
-    Lasso(alpha=0.1, fit_intercept=True, max_iter=1000, normalize=False,
-       overwrite_X=False, precompute='auto', tol=0.0001)
+    Lasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
+       normalize=False, precompute='auto', tol=0.0001)
     >>> print clf.coef_
     [ 0.85  0.  ]
     >>> print clf.intercept_
@@ -253,11 +251,11 @@ class Lasso(ElasticNet):
     """
 
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
-                 precompute='auto', overwrite_X=False, max_iter=1000,
+                 precompute='auto', copy_X=True, max_iter=1000,
                  tol=1e-4):
         super(Lasso, self).__init__(alpha=alpha, rho=1.0,
                             fit_intercept=fit_intercept, normalize=normalize,
-                            precompute=precompute, overwrite_X=overwrite_X,
+                            precompute=precompute, copy_X=copy_X,
                             max_iter=max_iter, tol=tol)
 
 
@@ -266,7 +264,7 @@ class Lasso(ElasticNet):
 
 def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
                precompute='auto', Xy=None, fit_intercept=True,
-               normalize=False, overwrite_X=False, verbose=False,
+               normalize=False, copy_X=True, verbose=False,
                **params):
     """Compute Lasso path with coordinate descent
 
@@ -305,9 +303,8 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     verbose : bool or integer
         Amount of verbosity
@@ -329,12 +326,12 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     return enet_path(X, y, rho=1., eps=eps, n_alphas=n_alphas, alphas=alphas,
                      precompute='auto', Xy=None,
                      fit_intercept=fit_intercept, normalize=normalize,
-                     overwrite_X=overwrite_X, verbose=verbose, **params)
+                     copy_X=copy_X, verbose=verbose, **params)
 
 
 def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
               precompute='auto', Xy=None, fit_intercept=True,
-              normalize=False, overwrite_X=False, verbose=False,
+              normalize=False, copy_X=True, verbose=False,
               **params):
     """Compute Elastic-Net path with coordinate descent
 
@@ -377,9 +374,8 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     verbose : bool or integer
         Amount of verbosity
@@ -395,13 +391,13 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     -----
     See examples/plot_lasso_coordinate_descent_path.py for an example.
     """
-    X = as_float_array(X, overwrite_X)
+    X = as_float_array(X, copy_X)
 
     X_init = X
     X, y, X_mean, y_mean, X_std = LinearModel._center_data(X, y,
                                                            fit_intercept,
                                                            normalize,
-                                                           overwrite_X=True)
+                                                           copy=False)
     X = np.asfortranarray(X)  # make data contiguous in memory
     n_samples, n_features = X.shape
 
@@ -453,7 +449,7 @@ class LinearModelCV(LinearModel):
 
     def __init__(self, eps=1e-3, n_alphas=100, alphas=None, fit_intercept=True,
             normalize=False, precompute='auto', max_iter=1000, tol=1e-4,
-            overwrite_X=False, cv=None, verbose=False):
+            copy_X=True, cv=None, verbose=False):
         self.eps = eps
         self.n_alphas = n_alphas
         self.alphas = alphas
@@ -462,7 +458,7 @@ class LinearModelCV(LinearModel):
         self.precompute = precompute
         self.max_iter = max_iter
         self.tol = tol
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.cv = cv
         self.verbose = verbose
 
@@ -657,7 +653,7 @@ class ElasticNetCV(LinearModelCV):
 
     def __init__(self, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
                  fit_intercept=True, normalize=False, precompute='auto',
-                 max_iter=1000, tol=1e-4, cv=None, overwrite_X=False,
+                 max_iter=1000, tol=1e-4, cv=None, copy_X=True,
                  verbose=0):
         self.rho = rho
         self.eps = eps
@@ -669,5 +665,5 @@ class ElasticNetCV(LinearModelCV):
         self.max_iter = max_iter
         self.tol = tol
         self.cv = cv
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.verbose = verbose

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -22,9 +22,9 @@ from ..externals.joblib import Parallel, delayed
 
 
 def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
-              alpha_min=0, method='lar', overwrite_X=False,
+              alpha_min=0, method='lar', copy_X=True,
               eps=np.finfo(np.float).eps,
-              overwrite_Gram=False, verbose=False):
+              copy_Gram=True, verbose=False):
     """Compute Least Angle Regression and LASSO path
 
     Parameters
@@ -100,7 +100,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     potrs, = get_lapack_funcs(('potrs',), (X,))
 
     if Gram is None:
-        if not overwrite_X:
+        if copy_X:
             # force copy. setting the array to be fortran-ordered
             # speeds up the calculation of the (partial) Gram matrix
             # and allows to easily swap columns
@@ -109,8 +109,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         Gram = None
         if X.shape[0] > X.shape[1]:
             Gram = np.dot(X.T, X)
-    else:
-        if not overwrite_Gram:
+    elif copy_Gram:
             Gram = Gram.copy()
 
     if Xy is None:
@@ -324,9 +323,8 @@ class Lars(LinearModel):
         calculations. If set to 'auto' let us decide. The Gram
         matrix can also be passed as argument.
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     eps: float, optional
         The machine-precision regularization in the computation of the
@@ -348,9 +346,9 @@ class Lars(LinearModel):
     --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.Lars(n_nonzero_coefs=1)
-    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111]) # doctest: +ELLIPSIS
-    Lars(eps=..., fit_intercept=True, n_nonzero_coefs=1,
-       normalize=True, overwrite_X=False, precompute='auto', verbose=False)
+    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111]) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    Lars(copy_X=True, eps=..., fit_intercept=True, n_nonzero_coefs=1,
+       normalize=True, precompute='auto', verbose=False)
     >>> print clf.coef_ # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0. -1.11...]
 
@@ -365,7 +363,7 @@ class Lars(LinearModel):
     """
     def __init__(self, fit_intercept=True, verbose=False, normalize=True,
                  precompute='auto', n_nonzero_coefs=500,
-                 eps=np.finfo(np.float).eps, overwrite_X=False):
+                 eps=np.finfo(np.float).eps, copy_X=True):
         self.fit_intercept = fit_intercept
         self.verbose = verbose
         self.normalize = normalize
@@ -373,7 +371,7 @@ class Lars(LinearModel):
         self.precompute = precompute
         self.n_nonzero_coefs = n_nonzero_coefs
         self.eps = eps
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
 
     def _get_gram(self):
         # precompute if n_samples > n_features
@@ -387,12 +385,12 @@ class Lars(LinearModel):
             Gram = None
         return Gram
 
-    def fit(self, X, y, overwrite_X=False):
+    def fit(self, X, y, copy_X=True):
         """Fit the model using X, y as training data.
 
         parameters
         ----------
-        x : array-like, shape = [n_samples, n_features]
+        X : array-like, shape = [n_samples, n_features]
             training data.
 
         y : array-like, shape = [n_samples]
@@ -410,7 +408,7 @@ class Lars(LinearModel):
         X, y, X_mean, y_mean, X_std = self._center_data(X, y,
                                                         self.fit_intercept,
                                                         self.normalize,
-                                                        self.overwrite_X)
+                                                        self.copy_X)
         alpha = getattr(self, 'alpha', 0.)
         if hasattr(self, 'n_nonzero_coefs'):
             alpha = 0.  # n_nonzero_coefs parametrization takes priority
@@ -421,8 +419,8 @@ class Lars(LinearModel):
         Gram = self._get_gram()
 
         self.alphas_, self.active_, self.coef_path_ = lars_path(X, y,
-                  Gram=Gram, overwrite_X=self.overwrite_X,
-                  overwrite_Gram=True, alpha_min=alpha,
+                  Gram=Gram, copy_X=self.copy_X,
+                  copy_Gram=False, alpha_min=alpha,
                   method=self.method, verbose=self.verbose,
                   max_iter=max_iter, eps=self.eps)
 
@@ -452,9 +450,8 @@ class LassoLars(Lars):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     precompute : True | False | 'auto' | array-like
         Whether to use a precomputed Gram matrix to speed up
@@ -484,10 +481,9 @@ class LassoLars(Lars):
     --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.LassoLars(alpha=0.01)
-    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1, 0, -1]) # doctest: +ELLIPSIS
-    LassoLars(alpha=0.01, eps=..., fit_intercept=True,
-         max_iter=500, normalize=True, overwrite_X=False, precompute='auto',
-         verbose=False)
+    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1, 0, -1]) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    LassoLars(alpha=0.01, copy_X=True, eps=..., fit_intercept=True,
+         max_iter=500, normalize=True, precompute='auto', verbose=False)
     >>> print clf.coef_ # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0.         -0.963257...]
 
@@ -502,7 +498,7 @@ class LassoLars(Lars):
 
     def __init__(self, alpha=1.0, fit_intercept=True, verbose=False,
                  normalize=True, precompute='auto', max_iter=500,
-                 eps=np.finfo(np.float).eps, overwrite_X=False):
+                 eps=np.finfo(np.float).eps, copy_X=True):
         self.alpha = alpha
         self.fit_intercept = fit_intercept
         self.max_iter = max_iter
@@ -510,7 +506,7 @@ class LassoLars(Lars):
         self.normalize = normalize
         self.method = 'lasso'
         self.precompute = precompute
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.eps = eps
 
 
@@ -529,9 +525,9 @@ LassoLARS = deprecated("Use LassoLars instead")(LassoLARS)
 # Cross-validated estimator classes
 
 def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
-                     overwrite_data=False, method='lars', verbose=False,
-                     fit_intercept=True, normalize=True, max_iter=500,
-                     eps=np.finfo(np.float).eps):
+                        copy=True, method='lars', verbose=False,
+                        fit_intercept=True, normalize=True, max_iter=500,
+                        eps=np.finfo(np.float).eps):
     """Compute the residues on left-out data for a full LARS path
 
     Parameters
@@ -548,8 +544,9 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
         Precomputed Gram matrix (X' * X), if 'auto', the Gram
         matrix is precomputed from the given X, if there are more samples
         than features
-    overwrite_data: boolean, optional
-        Whether X_train, X_test, y_train and y_test get overriden
+    copy: boolean, optional
+        Whether X_train, X_test, y_train and y_test should be copied;
+        if False, they may be overwritten.
     method: 'lar' | 'lasso'
         Specifies the returned model. Select 'lar' for Least Angle
         Regression, 'lasso' for the Lasso.
@@ -586,7 +583,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     residues: array, shape (n_features, max_features + 1)
         Residues of the prediction on the test data
     """
-    if not overwrite_data:
+    if copy:
         X_train = X_train.copy()
         y_train = y_train.copy()
         X_test = X_test.copy()
@@ -606,7 +603,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
         X_train[:, nonzeros] /= norms[nonzeros]
 
     alphas, active, coefs = lars_path(X_train, y_train, Gram=Gram,
-                            overwrite_X=True, overwrite_Gram=True,
+                            copy_X=False, copy_Gram=False,
                             method=method, verbose=verbose,
                             max_iter=max_iter, eps=eps)
     if normalize:
@@ -632,9 +629,8 @@ class LarsCV(LARS):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     precompute : True | False | 'auto' | array-like
         Whether to use a precomputed Gram matrix to speed up
@@ -678,13 +674,13 @@ class LarsCV(LARS):
 
     def __init__(self, fit_intercept=True, verbose=False, max_iter=500,
                  normalize=True, precompute='auto', cv=None, n_jobs=1,
-                 eps=np.finfo(np.float).eps, overwrite_X=False):
+                 eps=np.finfo(np.float).eps, copy_X=True):
         self.fit_intercept = fit_intercept
         self.max_iter = max_iter
         self.verbose = verbose
         self.normalize = normalize
         self.precompute = precompute
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.cv = cv
         self.n_jobs = n_jobs
         self.eps = eps
@@ -716,7 +712,7 @@ class LarsCV(LARS):
         cv_paths = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                     delayed(_lars_path_residues)(X[train], y[train],
                             X[test], y[test], Gram=Gram,
-                            overwrite_data=True, method=self.method,
+                            copy=False, method=self.method,
                             verbose=max(0, self.verbose - 1),
                             normalize=self.normalize,
                             fit_intercept=self.fit_intercept,
@@ -790,10 +786,8 @@ class LassoLarsCV(LarsCV):
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems.
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
-
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     Attributes
     ----------
@@ -862,9 +856,8 @@ class LassoLarsIC(LassoLars):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        Default is False.
-        If True, X will be overwritten
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     precompute : True | False | 'auto' | array-like
         Whether to use a precomputed Gram matrix to speed up
@@ -895,9 +888,9 @@ class LassoLarsIC(LassoLars):
     --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.LassoLarsIC(criterion='bic')
-    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111]) # doctest: +ELLIPSIS
-    LassoLarsIC(criterion='bic', eps=..., fit_intercept=True,
-          max_iter=500, normalize=True, overwrite_X=False, precompute='auto',
+    >>> clf.fit([[-1, 1], [0, 0], [1, 1]], [-1.1111, 0, -1.1111]) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    LassoLarsIC(copy_X=True, criterion='bic', eps=..., fit_intercept=True,
+          max_iter=500, normalize=True, precompute='auto',
           verbose=False)
     >>> print clf.coef_ # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     [ 0.  -1.11...]
@@ -919,7 +912,7 @@ class LassoLarsIC(LassoLars):
     """
     def __init__(self, criterion='aic', fit_intercept=True, verbose=False,
                  normalize=True, precompute='auto', max_iter=500,
-                 eps=np.finfo(np.float).eps, overwrite_X=False):
+                 eps=np.finfo(np.float).eps, copy_X=True):
         if criterion not in ['aic', 'bic']:
             raise ValueError('criterion should be either bic or aic')
         self.criterion = criterion
@@ -927,11 +920,11 @@ class LassoLarsIC(LassoLars):
         self.max_iter = max_iter
         self.verbose = verbose
         self.normalize = normalize
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.precompute = precompute
         self.eps = eps
 
-    def fit(self, X, y, overwrite_X=False):
+    def fit(self, X, y, copy_X=True):
         """Fit the model using X, y as training data.
 
         parameters
@@ -953,14 +946,14 @@ class LassoLarsIC(LassoLars):
         X, y, Xmean, ymean, Xstd = LinearModel._center_data(X, y,
                                                     self.fit_intercept,
                                                     self.normalize,
-                                                    self.overwrite_X)
+                                                    self.copy_X)
         max_iter = self.max_iter
 
         Gram = self._get_gram()
 
         alphas_, active_, coef_path_ = lars_path(X, y,
-                  Gram=Gram, overwrite_X=overwrite_X,
-                  overwrite_Gram=True, alpha_min=0.0,
+                  Gram=Gram, copy_X=copy_X,
+                  copy_Gram=False, alpha_min=0.0,
                   method='lasso', verbose=self.verbose,
                   max_iter=max_iter, eps=self.eps)
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -140,9 +140,8 @@ class Ridge(LinearModel):
     normalize : boolean, optional
         If True, the regressors X are normalized
 
-    overwrite_X : boolean, optional
-        If True, X will not be copied
-        Default is False
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
 
     tol: float
         Precision of the solution.
@@ -162,17 +161,17 @@ class Ridge(LinearModel):
     >>> y = np.random.randn(n_samples)
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)
-    >>> clf.fit(X, y)
-    Ridge(alpha=1.0, fit_intercept=True, normalize=False, overwrite_X=False,
+    >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
+    Ridge(alpha=1.0, copy_X=True, fit_intercept=True, normalize=False,
        tol=0.001)
     """
 
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
-            overwrite_X=False, tol=1e-3):
+            copy_X=True, tol=1e-3):
         self.alpha = alpha
         self.fit_intercept = fit_intercept
         self.normalize = normalize
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
         self.tol = tol
 
     def fit(self, X, y, sample_weight=1.0, solver='auto'):
@@ -207,7 +206,7 @@ class Ridge(LinearModel):
 
         X, y, X_mean, y_mean, X_std = \
            self._center_data(X, y, self.fit_intercept,
-                   self.normalize, self.overwrite_X)
+                   self.normalize, self.copy_X)
 
         self.coef_ = ridge_regression(X, y, self.alpha, sample_weight,
                                       solver, self.tol)
@@ -335,13 +334,13 @@ class _RidgeGCV(LinearModel):
     """
 
     def __init__(self, alphas=[0.1, 1.0, 10.0], fit_intercept=True, normalize=False,
-            score_func=None, loss_func=None, overwrite_X=False):
+            score_func=None, loss_func=None, copy_X=True):
         self.alphas = np.asanyarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.score_func = score_func
         self.loss_func = loss_func
-        self.overwrite_X = overwrite_X
+        self.copy_X = copy_X
 
     def _pre_compute(self, X, y):
         # even if X is very sparse, K is usually very dense
@@ -401,7 +400,7 @@ class _RidgeGCV(LinearModel):
         n_samples = X.shape[0]
 
         X, y, X_mean, y_mean, X_std = LinearModel._center_data(X, y,
-                self.fit_intercept, self.normalize, self.overwrite_X)
+                self.fit_intercept, self.normalize, self.copy_X)
 
         K, v, Q = self._pre_compute(X, y)
         n_y = 1 if len(y.shape) == 1 else y.shape[1]

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -22,22 +22,20 @@ def safe_asanyarray(X, dtype=None, order=None):
     return X
 
 
-def as_float_array(X, overwrite_X=False):
+def as_float_array(X, copy=True):
     """Converts a numpy array to an array of floats
 
     The new dtype will be np.float32 or np.float64, depending on the original
     type. The function can create a copy or modify the argument depending
-    on the argument overwrite_X.
-
-    WARNING : If X is not of type float, then a copy of X with the right type
-              will be returned
+    on the argument copy.
 
     Parameters
     ----------
     X : array
 
-    overwrite_X : bool, optional
-        if False, a copy of X will be created
+    copy : bool, optional
+        If True, a copy of X will be created. If False, a copy may still be
+        returned if X's dtype is not a floating point type.
 
     Returns
     -------
@@ -45,10 +43,7 @@ def as_float_array(X, overwrite_X=False):
         An array of type np.float
     """
     if X.dtype in [np.float32, np.float64]:
-        if overwrite_X:
-            return X
-        else:
-            return X.copy()
+        return X.copy() if copy else X
     if X.dtype == np.int32:
         X = X.astype(np.float32)
     else:

--- a/sklearn/utils/tests/test___init__.py
+++ b/sklearn/utils/tests/test___init__.py
@@ -9,15 +9,15 @@ def test_as_float_array():
     X = np.ones((3, 10), dtype=np.int32)
     X = X + np.arange(10, dtype=np.int32)
     # Checks that the return type is ok
-    X2 = as_float_array(X, overwrite_X=True)
+    X2 = as_float_array(X, copy=False)
     np.testing.assert_equal(X2.dtype, np.float32)
     # Another test
     X = X.astype(np.int64)
-    X2 = as_float_array(X, overwrite_X=False)
+    X2 = as_float_array(X, copy=True)
     # Checking that the array wasn't overwritten
     assert as_float_array(X, False) is not X
     # Checking that the new type is ok
     np.testing.assert_equal(X2.dtype, np.float64)
     # Here, X is of the right type, it shouldn't be modified
     X = np.ones((3, 2), dtype=np.float32)
-    assert as_float_array(X, overwrite_X=True) is X
+    assert as_float_array(X, copy=False) is X


### PR DESCRIPTION
As promised, here's a patch to change all `overwrite_` params to `copy_` for consistency with older sklearn code that favored `copy`. It also resolves the `overwrite_Gram` (`least_angle`) vs. `overwrite_gram` (@vene's code) issue in favor of `copy_Gram`; I found that most consistent with `copy_Xy` etc. All tests, including doctests, seem to pass.
