### PR TITLE
Corrected Easy Install section of documentation

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -55,11 +55,11 @@ This is usually the fastest way to install the latest stable
 release. If you have pip or easy_install, you can install or update
 with the command::
 
-    pip install -U sklearn
+    pip install -U scikit-learn
 
 or::
 
-    easy_install -U sklearn
+    easy_install -U scikit-learn
 
 for easy_install. Note that you might need root privileges to run
 these commands.


### PR DESCRIPTION
When searching or installing scikit-learn with pip or easy_install the right package name is scikit-learn.
