### PR TITLE
WIP: PU learning: the 1-DNF method

### DIFF
--- a/sklearn/semi_supervised/__init__.py
+++ b/sklearn/semi_supervised/__init__.py
@@ -6,3 +6,4 @@ Propagation.
 """
 
 from .label_propagation import LabelPropagation, LabelSpreading
+from .pu import OneDNFTransformer

--- a/sklearn/semi_supervised/pu.py
+++ b/sklearn/semi_supervised/pu.py
@@ -1,0 +1,99 @@
+"""
+Algorithms for learning from positive and unlabeled samples
+"""
+
+# Author: Lars Buitinck <L.J.Buitinck@uva.nl>
+# Copyright 2011-2012, University of Amsterdam
+# License: three-clause BSD
+
+from ..base import BaseEstimator, TransformerMixin
+from ..utils import atleast2d_or_csr
+
+import numpy as np
+
+
+def _densify(X):
+    return X.toarray() if hasattr(X, 'toarray') else X
+
+
+class OneDNFTransformer(BaseEstimator, TransformerMixin):
+    """1-DNF algorithm for PU learning
+
+    The 1-DNF algorithm is a simple bootstrap method for PU learning on
+    multinomially distributed data (e.g., text classification). When fit, it
+    estimates a subset of the features to be regarded indicative of positive
+    examples (here called the "positive support" in analogy to feature
+    selection); when applied, all samples that cannot meet a pre-set threshold
+    for each of the positive support features are considered negatives.
+
+    Parameters
+    ----------
+    thresh : numeric, optional
+        Threshold value for transform: samples with all support feature values
+        below this number are considered negatives.
+
+    References
+    ----------
+    B. Liu (2007). Web Data Mining. Springer, pp. 172-173.
+    H. Yu, J. Han and K. Chang (2002). PEBL: Positive Example Based Learning
+        for web page classification using SVM. Proc. KDD'02, pp. 239-248.
+    """
+    def __init__(self, thresh=0):
+        self.thresh = thresh
+
+    def fit(self, X, y):
+        """Estimate which of the unlabeled samples can be considered negatives
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            Array of samples.
+
+        y : array-like, shape = n_samples
+            Label vector; 1 indicates a positive sample, -1 an unlabeled one.
+        """
+        X = atleast2d_or_csr(X)
+        y = np.asanyarray(y)
+
+        # np.ravel to get rid of np.matrix objects
+        feature_freq_p = np.ravel(X[np.where(y != -1)[0]].sum(axis=0))
+        feature_freq_u = np.ravel(X[np.where(y == -1)[0]].sum(axis=0))
+
+        n_unlabeled = (y == -1).sum()
+        feature_freq_u /= n_unlabeled.astype(np.float)
+        self.pos_support_ = np.where(feature_freq_p > feature_freq_u)[0]
+
+        return self
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X, y)
+
+    def transform(self, X, y):
+        """Transform {positive, unlabeled} samples to include negatives
+
+        Note that this method, even when handed a sparse matrix, will build a
+        temporary dense array of size len(self.pos_support_) * n_unlabeled.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            Array of samples.
+
+        y : array-like, shape = n_samples
+            Label vector; 1 indicates a positive sample, -1 an unlabeled one.
+        """
+        X = atleast2d_or_csr(X)
+        y = np.array(y)
+
+        # The following computes:
+        # for i in the unlabeled X do:
+        #   if for any j in pos_support_ s.t. X[i, j] > thresh:
+        #       y[i] = 0
+        # ... but without loops.
+
+        X_sup = X[np.where(y == -1)[0]][:, self.pos_support_]
+        negative = np.all(_densify(X_sup) <= self.thresh, axis=1)
+
+        y[np.where(y == -1)[0][np.where(negative)]] = 0
+
+        return y

--- a/sklearn/semi_supervised/tests/test_pu.py
+++ b/sklearn/semi_supervised/tests/test_pu.py
@@ -1,0 +1,30 @@
+from sklearn.naive_bayes import MultinomialNB
+from sklearn.semi_supervised import OneDNFTransformer
+
+import numpy as np
+import scipy.sparse as sp
+
+from numpy.testing import assert_equal
+
+
+X = [[4, 5, 1, 0, 0],
+     [6, 7, 1, 0, 0],
+     [0, 0, 9, 0, 0],
+     [0, 0, 0, 1, 6],
+     [1, 0, 0, 4, 5]]
+
+y = [1, 1, -1, -1, -1]
+
+
+def test_1dnf():
+    onednf = OneDNFTransformer()
+    y_l = onednf.fit_transform(X, y)
+    assert_equal(onednf.pos_support_, [0, 1])
+    assert_equal(y_l, [1, 1, 0, 0, -1])
+
+
+def test_sparse_1dnf():
+    onednf = OneDNFTransformer()
+    y_l = onednf.fit_transform(sp.lil_matrix(X), y)
+    assert_equal(onednf.pos_support_, [0, 1])
+    assert_equal(y_l, [1, 1, 0, 0, -1])


### PR DESCRIPTION
Early pull request: the 1-DNF method for binary classifier learning from positive and unlabeled data only (PU learning). Issues:
- this works more or less on the dataset I'm currently working on, but that's not public yet, huge and XML-encoded
- I tried to come up with an example based on 20news (my `pu-learning-example` branch), but that performs very poorly
- the implementation is a transformer that takes `X` and `y` and returns `y_transformed` rather than `X_transformed`; this is different from other transformers
- I've adopted the convention that `-1` means unlabeled

If someone can devise an example that makes this work on a benchmark dataset, I'd be very glad...
