### PR TITLE
API change in SVMlight reader: handle multiple files with svmlight_load_files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,10 @@ version 0.9:
     This particularly affects some of the estimators in ``linear_models``.
     The default behavior is still to copy everything passed in.
 
+  - The SVMlight dataset loader ``sklearn.datasets.load_svmlight_file`` no
+    longer supports loading two files at once; use ``load_svmlight_files``
+    instead. Also, the (unused) ``buffer_mb`` parameter is gone.
+
 
 .. _changes_0_9:
 

--- a/sklearn/datasets/__init__.py
+++ b/sklearn/datasets/__init__.py
@@ -29,6 +29,7 @@ from .samples_generator import make_spd_matrix
 from .samples_generator import make_swiss_roll
 from .samples_generator import make_s_curve
 from .svmlight_format import load_svmlight_file
+from .svmlight_format import load_svmlight_files
 from .svmlight_format import dump_svmlight_file
 from .olivetti_faces import fetch_olivetti_faces
 from ..utils import deprecated


### PR DESCRIPTION
API change in SVMlight reader: handle multiple files with `svmlight_load_files`. Documented this in `whats_new.rst`.

This might not seem as convenient as having svmlight_load_file handle multiple files itself, but it's much easier to keep consistent and document (!): I found it very hard to write a proper and concise docstring for an `svmlight_load_file` that could handle multiple files.

Also, I removed the `buffer_mb` parameter, which was unused anyway, and introduced a `dtype` parameter to determine the underlying type of the returned sample vectors. I admit right away that this is kind of a package deal.

@ogrisel, @mblondel, what do you think?
