### PR TITLE
SGD refactoring + enhancements

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,15 @@ version 0.9:
     longer supports loading two files at once; use ``load_svmlight_files``
     instead. Also, the (unused) ``buffer_mb`` parameter is gone.
 
+  - Sparse estimators in the :ref:`sgd` module use dense parameter vector 
+    ``coef_`` instead of ``sparse_coef_``. This significantly improves
+    test time performance.
+
+Changelog
+---------
+
+   - Minor refactoring in :ref:`sgd` module; consolidated 
+     dense and sparse predict methods.
 
 .. _changes_0_9:
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -536,7 +536,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         ----------
         X : array or scipy.sparse matrix of shape [n_samples, n_features]
            Whether the numpy.array or scipy.sparse matrix is accepted dependes
-           on the actual implementation
+           on the actual implementation. 
 
         Returns
         -------

--- a/sklearn/linear_model/sparse/coordinate_descent.py
+++ b/sklearn/linear_model/sparse/coordinate_descent.py
@@ -70,6 +70,11 @@ class ElasticNet(LinearModel):
         X = sp.csc_matrix(X)
         y = np.asanyarray(y, dtype=np.float64)
 
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y have incompatible shapes.\n" +
+                             "Note: Sparse matrices cannot be indexed w/" +
+                             "boolean masks (use `indices=True` in CV).")
+
         # NOTE: we are explicitly not centering the data the naive way to
         # avoid breaking the sparsity of X
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -143,7 +143,7 @@ class SGDClassifier(BaseSGDClassifier):
                                       self.learning_rate_code, self.eta0,
                                       self.power_t)
 
-        self.coef_ = np.atleast_2d(coef_)
+        self._set_coef(coef_)
         self.intercept_ = np.asarray(intercept_)
 
     def _fit_multiclass(self, X, y):
@@ -173,25 +173,6 @@ class SGDClassifier(BaseSGDClassifier):
         for i, coef, intercept in res:
             self.coef_[i] = coef
             self.intercept_[i] = intercept
-
-    def decision_function(self, X):
-        """Predict signed 'distance' to the hyperplane (aka confidence score)
-
-        Parameters
-        ----------
-        X : array, shape [n_samples, n_features]
-
-        Returns
-        -------
-        array, shape = [n_samples] if n_classes == 2 else [n_samples,n_classes]
-          The signed 'distances' to the hyperplane(s).
-        """
-        X = np.atleast_2d(np.asanyarray(X))
-        scores = np.dot(X, self.coef_.T) + self.intercept_
-        if self.classes.shape[0] == 2:
-            return np.ravel(scores)
-        else:
-            return scores
 
 
 def _train_ova_classifier(i, c, X, y, coef_, intercept_, loss_function,

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -20,12 +20,15 @@ complete documentation.
 #
 # License: BSD Style.
 
+import numpy as np
+from scipy.sparse import issparse
+
 from .base import BaseEstimator, ClassifierMixin
 from .preprocessing import binarize, LabelBinarizer
 from .utils import safe_asanyarray, atleast2d_or_csr
 from .utils.extmath import safe_sparse_dot, logsum
 from .utils.fixes import unique
-import numpy as np
+
 
 
 class BaseNB(BaseEstimator, ClassifierMixin):
@@ -228,6 +231,13 @@ class BaseDiscreteNB(BaseNB):
         """
         X = atleast2d_or_csr(X)
         y = safe_asanyarray(y)
+
+        if X.shape[0] != y.shape[0]:
+            msg = "X and y have incompatible shapes."
+            if issparse(X):
+                msg += "\nNote: Sparse matrices cannot be indexed w/ boolean \
+                masks (use `indices=True` in CV)."
+            raise ValueError(msg)
 
         self.unique_y, inv_y_ind = unique(y, return_inverse=True)
         n_classes = self.unique_y.size

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -123,7 +123,7 @@ class BaseLibSVM(BaseEstimator):
         solver_type = LIBSVM_IMPL.index(self.impl)
         if solver_type != 2 and X.shape[0] != y.shape[0]:
             raise ValueError("X and y have incompatible shapes.\n" +
-                             "X has %s features, but y has %s." % \
+                             "X has %s samples, but y has %s." % \
                              (X.shape[0], y.shape[0]))
 
         if self.kernel == "precomputed" and X.shape[0] != X.shape[1]:

--- a/sklearn/svm/sparse/base.py
+++ b/sklearn/svm/sparse/base.py
@@ -47,7 +47,7 @@ class SparseBaseLibSVM(BaseLibSVM):
         # only used in classification
         self.n_support_ = np.empty(0, dtype=np.int32, order='C')
 
-    def fit(self, X, y, class_weight=None, sample_weight=[], cache_size=100.):
+    def fit(self, X, y, class_weight=None, sample_weight=None, cache_size=100.):
         """
         Fit the SVM model according to the given training data and
         parameters.
@@ -88,8 +88,8 @@ class SparseBaseLibSVM(BaseLibSVM):
         X = scipy.sparse.csr_matrix(X)
         X.data = np.asanyarray(X.data, dtype=np.float64, order='C')
         y = np.asanyarray(y, dtype=np.float64, order='C')
-        sample_weight = np.asanyarray(sample_weight, dtype=np.float64,
-                                      order='C')
+        sample_weight = np.asanyarray([] if sample_weight is None
+                                         else sample_weight, dtype=np.float64)
 
         if X.shape[0] != y.shape[0]:
             raise ValueError("X and y have incompatible shapes.\n" +

--- a/sklearn/svm/sparse/base.py
+++ b/sklearn/svm/sparse/base.py
@@ -91,6 +91,16 @@ class SparseBaseLibSVM(BaseLibSVM):
         sample_weight = np.asanyarray(sample_weight, dtype=np.float64,
                                       order='C')
 
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y have incompatible shapes.\n" +
+                             "Note: Sparse matrices cannot be indexed w/" +
+                             "boolean masks (use `indices=True` in CV).")
+
+        if sample_weight.shape[0] > 0 and sample_weight.shape[0] != X.shape[0]:
+            raise ValueError("sample_weight and X have incompatible shapes.\n" +
+                             "Note: Sparse matrices cannot be indexed w/" +
+                             "boolean masks (use `indices=True` in CV).")
+
         solver_type = self._svm_types.index(self.impl)
         kernel_type = self._kernel_types.index(self.kernel)
 
@@ -168,7 +178,6 @@ class SparseBaseLibSVM(BaseLibSVM):
                       self.probability, self.n_support_, self.label_,
                       self.probA_, self.probB_)
 
-
     def predict_proba(self, X):
         """
         This function does classification or regression on a test vector X
@@ -198,7 +207,8 @@ class SparseBaseLibSVM(BaseLibSVM):
                     "probability estimates must be enabled to use this method")
 
         if self.impl not in ('c_svc', 'nu_svc'):
-            raise NotImplementedError("predict_proba only implemented for SVC and NuSVC")
+            raise NotImplementedError("predict_proba only implemented for " +
+                                      "SVC and NuSVC")
 
         import scipy.sparse
         X = scipy.sparse.csr_matrix(X)
@@ -217,6 +227,7 @@ class SparseBaseLibSVM(BaseLibSVM):
             self.nu, self.epsilon, self.shrinking,
             self.probability, self.n_support_, self.label_,
             self.probA_, self.probB_)
+
 
 class SparseBaseLibLinear(BaseLibLinear):
 
@@ -240,8 +251,13 @@ class SparseBaseLibLinear(BaseLibLinear):
 
         import scipy.sparse
         X = scipy.sparse.csr_matrix(X)
-        X.data = np.asanyarray(X.data, dtype=np.float64, order='C')
         y = np.asanyarray(y, dtype=np.int32, order='C')
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y have incompatible shapes.\n" +
+                             "Note: Sparse matrices cannot be indexed w/" +
+                             "boolean masks (use `indices=True` in CV).")
+
+        X.data = np.asanyarray(X.data, dtype=np.float64, order='C')
 
         self.class_weight, self.class_weight_label = \
                      _get_class_weight(class_weight, y)

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -38,8 +38,7 @@ class SVC(SparseBaseLibSVM, ClassifierMixin):
                          shrinking, probability)
 
 
-
-class NuSVC (SparseBaseLibSVM, ClassifierMixin):
+class NuSVC(SparseBaseLibSVM, ClassifierMixin):
     """NuSVC for sparse matrices (csr).
 
     See :class:`sklearn.svm.NuSVC` for a complete list of parameters
@@ -64,7 +63,6 @@ class NuSVC (SparseBaseLibSVM, ClassifierMixin):
     [ 1.]
     """
 
-
     def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
                  tol=1e-3):
@@ -74,9 +72,7 @@ class NuSVC (SparseBaseLibSVM, ClassifierMixin):
                          shrinking, probability)
 
 
-
-
-class SVR (SparseBaseLibSVM, RegressorMixin):
+class SVR(SparseBaseLibSVM, RegressorMixin):
     """SVR for sparse matrices (csr)
 
     See :class:`sklearn.svm.SVR` for a complete list of parameters
@@ -110,10 +106,7 @@ class SVR (SparseBaseLibSVM, RegressorMixin):
                          epsilon, shrinking, probability)
 
 
-
-
-
-class NuSVR (SparseBaseLibSVM, RegressorMixin):
+class NuSVR(SparseBaseLibSVM, RegressorMixin):
     """NuSVR for sparse matrices (csr)
 
     See :class:`sklearn.svm.NuSVC` for a complete list of parameters
@@ -147,8 +140,7 @@ class NuSVR (SparseBaseLibSVM, RegressorMixin):
                          epsilon, shrinking, probability)
 
 
-
-class OneClassSVM (SparseBaseLibSVM):
+class OneClassSVM(SparseBaseLibSVM):
     """NuSVR for sparse matrices (csr)
 
     See :class:`sklearn.svm.NuSVC` for a complete list of parameters

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -168,9 +168,9 @@ class OneClassSVM (SparseBaseLibSVM):
                          gamma, coef0, tol, 0.0, nu, 0.0,
                          shrinking, probability)
 
-    def fit(self, X, class_weight={}, sample_weight=[]):
+    def fit(self, X, class_weight=None, sample_weight=None):
         super(OneClassSVM, self).fit(
-            X, [], class_weight=class_weight, ample_weight=sample_weight)
+            X, [], class_weight=class_weight, sample_weight=sample_weight)
 
 
 class LinearSVC(SparseBaseLibLinear, ClassifierMixin,


### PR DESCRIPTION
This pull request includes::
- refactoring of sgd; unifying of sparse and dense prediction; now uses only dense coef - which is much faster at test time.
- added input size check to sparse.svm, naive_bayes, linear_model.sparse; I just got bitten by the CV - sparse matrix problem (sparse matrices cannot be indexed by boolean masks! I'd propose to swap to index arrays completely)
- some love to svm.sparse.classes (pep8, mutable default values)
