### PR TITLE
Implements a robust covariance estimator: Rousseeuw's MCD.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,7 @@ version 0.9:
     longer supports loading two files at once; use ``load_svmlight_files``
     instead. Also, the (unused) ``buffer_mb`` parameter is gone.
 
-  - The ``sklearn.covariance`` module now has a robust estimator of
+  - The :ref:`covariance` module now has a robust estimator of
     covariance, the Minimum Covariance Determinant estimator.
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,9 @@ version 0.9:
     longer supports loading two files at once; use ``load_svmlight_files``
     instead. Also, the (unused) ``buffer_mb`` parameter is gone.
 
+  - The ``sklearn.covariance`` module now has a robust estimator of
+    covariance, the Minimum Covariance Determinant estimator.
+
 
 .. _changes_0_9:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,7 +29,7 @@ version 0.9:
     ``coef_`` instead of ``sparse_coef_``. This significantly improves
     test time performance.
   
-  - The ``sklearn.covariance`` module now has a robust estimator of
+  - The :ref:`covariance` module now has a robust estimator of
     covariance, the Minimum Covariance Determinant estimator.
 
 Changelog

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,9 @@ version 0.9:
   - Sparse estimators in the :ref:`sgd` module use dense parameter vector 
     ``coef_`` instead of ``sparse_coef_``. This significantly improves
     test time performance.
+  
+  - The ``sklearn.covariance`` module now has a robust estimator of
+    covariance, the Minimum Covariance Determinant estimator.
 
 Changelog
 ---------

--- a/examples/covariance/README.txt
+++ b/examples/covariance/README.txt
@@ -1,4 +1,4 @@
 Covariance estimation
 ---------------------
 
-Examples concerning the `scikits.learn.covariance` package.
+Examples concerning the :ref:`covariance` package.

--- a/examples/covariance/README.txt
+++ b/examples/covariance/README.txt
@@ -1,4 +1,4 @@
 Covariance estimation
 ---------------------
 
-Examples concerning the `sklearn.covariance` package.
+Examples concerning the `scikits.learn.covariance` package.

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -68,6 +68,7 @@ loglik_real = -log_likelihood(emp_cov, linalg.inv(real_cov))
 
 ###############################################################################
 # Plot results
+pl.figure(-1)
 pl.title("Regularized covariance: likelihood and shrinkage coefficient")
 pl.xlabel('Shrinkage')
 pl.ylabel('Negative log-likelihood')
@@ -79,8 +80,8 @@ pl.hlines(loglik_real, pl.xlim()[0], pl.xlim()[1], color='red',
 # adjust view
 lik_max = np.amax(negative_logliks)
 lik_min = np.amin(negative_logliks)
-ylim0 = lik_min - 5.*np.log((pl.ylim()[1]-pl.ylim()[0]))
-ylim1 = lik_max + 10.*np.log(lik_max-lik_min)
+ylim0 = lik_min - 5. * np.log((pl.ylim()[1] - pl.ylim()[0]))
+ylim1 = lik_max + 10. * np.log(lik_max - lik_min)
 # LW likelihood
 pl.vlines(lw.shrinkage_, ylim0, -loglik_lw, color='g',
           linewidth=3, label='Ledoit-Wolf estimate')

--- a/examples/covariance/plot_lw_vs_oas.py
+++ b/examples/covariance/plot_lw_vs_oas.py
@@ -32,7 +32,7 @@ from sklearn.covariance import LedoitWolf, OAS
 n_features = 100
 # simulation covariance matrix (AR(1) process)
 r = 0.1
-real_cov = toeplitz(r**np.arange(n_features))
+real_cov = toeplitz(r ** np.arange(n_features))
 coloring_matrix = cholesky(real_cov)
 
 n_samples_range = np.arange(6, 31, 1)
@@ -48,16 +48,16 @@ for i, n_samples in enumerate(n_samples_range):
 
         lw = LedoitWolf(store_precision=False)
         lw.fit(X, assume_centered=True)
-        lw_mse[i,j] = lw.error_norm(real_cov, scaling=False)
-        lw_shrinkage[i,j] = lw.shrinkage_
+        lw_mse[i, j] = lw.error_norm(real_cov, scaling=False)
+        lw_shrinkage[i, j] = lw.shrinkage_
 
         oa = OAS(store_precision=False)
         oa.fit(X, assume_centered=True)
-        oa_mse[i,j] = oa.error_norm(real_cov, scaling=False)
-        oa_shrinkage[i,j] = oa.shrinkage_
+        oa_mse[i, j] = oa.error_norm(real_cov, scaling=False)
+        oa_shrinkage[i, j] = oa.shrinkage_
 
 # plot MSE
-pl.subplot(2,1,1)
+pl.subplot(2, 1, 1)
 pl.errorbar(n_samples_range, lw_mse.mean(1), yerr=lw_mse.std(1),
             label='Ledoit-Wolf', color='g')
 pl.errorbar(n_samples_range, oa_mse.mean(1), yerr=oa_mse.std(1),
@@ -68,7 +68,7 @@ pl.title("Comparison of covariance estimators")
 pl.xlim(5, 31)
 
 # plot shrinkage coefficient
-pl.subplot(2,1,2)
+pl.subplot(2, 1, 2)
 pl.errorbar(n_samples_range, lw_shrinkage.mean(1), yerr=lw_shrinkage.std(1),
             label='Ledoit-Wolf', color='g')
 pl.errorbar(n_samples_range, oa_shrinkage.mean(1), yerr=oa_shrinkage.std(1),
@@ -76,7 +76,7 @@ pl.errorbar(n_samples_range, oa_shrinkage.mean(1), yerr=oa_shrinkage.std(1),
 pl.xlabel("n_samples")
 pl.ylabel("Shrinkage")
 pl.legend(loc="lower right")
-pl.ylim(pl.ylim()[0], 1. + (pl.ylim()[1] - pl.ylim()[0])/10.)
+pl.ylim(pl.ylim()[0], 1. + (pl.ylim()[1] - pl.ylim()[0]) / 10.)
 pl.xlim(5, 31)
 
 pl.show()

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -1,0 +1,110 @@
+"""
+================================================================
+Robust covariance estimation and Mahalanobis distances relevance
+================================================================
+
+For Gaussian ditributed data, the distance of an observation $x_i$ to
+the mode of the distribution can be computed using its Mahalanobis
+distance: $d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i -
+\mu)$ where $\mu$ and $\Sigma$ are the location and the covariance of
+the underlying gaussian distribution.
+
+In practice, $\mu$ and $\Sigma$ are replaced by some estimates.  The
+usual covariance maximum likelihood estimate is very sensitive to the
+presence of outliers in the data set and therefor, the corresponding
+Mahalanobis distances are. One would better have to use a robust
+estimator of covariance to garanty that the estimation is resistant to
+"errorneous" observations in the data set and that the associated
+Mahalanobis distances accurately reflect the true organisation of the
+observations.
+
+The Minimum Covariance Determinant estimator is a robust,
+high-breakdown point (i.e. it can be used to estimate the covariance
+matrix of highly contaminated datasets, up to
+$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
+covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+observations whose empirical covariance has the smallest determinant,
+yielding a "pure" subset of observations from which to compute
+standards estimates of location and covariance.
+
+The Minimum Covariance Determinant estimator (MCD) has been introduced
+by P.J.Rousseuw in [1].
+
+This example illustrates how the Mahalanobis distances are affected by
+outlying data: observations drawn from a contaminating distribution
+are not distinguishable from the observations comming from the real,
+Gaussian distribution that one may want to work with. Using MCD-based
+Mahalanobis distances, the two populations become
+distinguishable. Associated applications are outliers detection,
+observations ranking, clustering, ...
+
+[1] P. J. Rousseeuw. Least median of squares regression. J. Am
+    Stat Ass, 79:871, 1984.
+
+"""
+print __doc__
+
+import numpy as np
+import pylab as pl
+
+from sklearn.covariance import EmpiricalCovariance, MCD
+
+n_samples = 125
+n_outliers = 25
+n_features = 2
+
+# generate data
+gen_cov = np.eye(n_features)
+gen_cov[0, 0] = 2.
+X = np.dot(np.random.randn(n_samples, n_features), gen_cov)
+# add some outliers
+outliers_cov = np.eye(n_features)
+outliers_cov[np.arange(1, n_features), np.arange(1, n_features)] = 7.
+X[-n_outliers:] = np.dot(np.random.randn(n_outliers, n_features), outliers_cov)
+
+# fit a Minimum Covariance Determinant (MCD) robust estimator to data
+robust_cov = MCD().fit(X, reweight=None)
+
+# compare estimators learnt from the full data set with true parameters
+emp_cov = EmpiricalCovariance().fit(X)
+
+
+# Display results
+fig = pl.figure()
+# variables and parameters for cosmetic
+offset_left = fig.subplotpars.left
+offset_bottom = fig.subplotpars.bottom
+width = fig.subplotpars.right - offset_left
+subfig1 = pl.subplot(3, 1, 1)
+subfig2 = pl.subplot(3, 1, 2)
+subfig3 = pl.subplot(3, 1, 3)
+
+# Show data set
+subfig1.scatter(X[:, 0], X[:, 1], color='black', label='inliers')
+subfig1.scatter(X[:, 0][-n_outliers:], X[:, 1][-n_outliers:],
+                color='red', label='outliers')
+subfig1.set_xlim(subfig1.get_xlim()[0], 11.)
+subfig1.set_title("Mahalanobis distances of a contaminated data set:")
+subfig1.legend(loc="upper right")
+
+# Empirical covariance -based Mahalanobis distances
+subfig2.scatter(np.arange(n_samples), emp_cov.mahalanobis(X),
+                color='black', label='inliers')
+subfig2.scatter(np.arange(n_samples)[-n_outliers:],
+                emp_cov.mahalanobis(X)[-n_outliers:],
+                color='red', label='outliers')
+subfig2.set_ylabel("Mahal. dist.")
+subfig2.set_title("1. from empirical estimates")
+subfig2.axes.set_position(pos=[offset_left, 0.39, width, .2])
+
+# MCD-based Mahalanobis distances
+subfig3.scatter(np.arange(n_samples), robust_cov.mahalanobis(X),
+                color='black', label='inliers')
+subfig3.scatter(np.arange(n_samples)[-n_outliers:],
+                robust_cov.mahalanobis(X)[-n_outliers:],
+                color='red', label='outliers')
+subfig3.set_ylabel("Mahal. dist.")
+subfig3.set_title("2. from robust estimates (Minimum Covariance Determinant)")
+subfig3.axes.set_position(pos=[offset_left, offset_bottom, width, .2])
+
+pl.show()

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -1,0 +1,150 @@
+"""
+=======================================
+Robust vs Empirical covariance estimate
+=======================================
+
+The usual covariance maximum likelihood estimate is very sensitive to
+the presence of outliers in the data set. In such a case, one would
+have better to use a robust estimator of covariance to garanty that
+the estimation is resistant to "errorneous" observations in the data
+set.
+
+The Minimum Covariance Determinant estimator is a robust,
+high-breakdown point (i.e. it can be used to estimate the covariance
+matrix of highly contaminated datasets, up to
+$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
+covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+observations whose empirical covariance has the smallest determinant,
+yielding a "pure" subset of observations from which to compute
+standards estimates of location and covariance. After a correction
+step aiming at compensating the fact the the estimates were learnt
+from only a portion of the initial data, we end up with robust
+estimates of the data set location and covariance.
+
+The Minimum Covariance Determinant estimator (MCD) has been introduced
+by P.J.Rousseuw in [1].
+
+In this example, we compare the estimation errors that are made when
+using four types of location and covariance estimates on contaminated
+gaussian distributed data sets:
+ - The mean and the empirical covariance of the full dataset, which break
+   down as soon as there are outliers in the data set
+ - The robust MCD, that has a low error provided n_samples > 5 * n_features
+ - The robust MCD reweighted according to Rousseeuw's recommandations:
+   observations are given a 0 weight if they are found to be outlying
+   according to their MCD-based Mahalanobis distance. Doing so improve the
+   efficiency of the estimators at gaussian models but it assumes that
+   we perfectly know the distribution of the mahalanobis distances computed
+   from the MCD estimate (see [2] for further details).
+ - The mean and the empirical covariance of the observations that are known
+   to be good ones. This can be considered as a "perfect" MCD estimation,
+   so one can trust our implementation by comparing to this case.
+
+[1] P. J. Rousseeuw. Least median of squares regression. J. Am
+    Stat Ass, 79:871, 1984.
+[2] Johanna Hardin, David M Rocke. Journal of Computational and
+    Graphical Statistics. December 1, 2005, 14(4): 928-946.
+
+"""
+print __doc__
+
+import numpy as np
+import pylab as pl
+import matplotlib.font_manager
+
+from sklearn.covariance import EmpiricalCovariance, MCD
+
+# example settings
+n_samples = 80
+n_features = 5
+repeat = 10
+range_n_outliers = np.arange(0, n_samples / 2, 5)
+
+# definition of arrays to store results
+err_loc_mcd = np.zeros((range_n_outliers.size, repeat))
+err_cov_mcd = np.zeros((range_n_outliers.size, repeat))
+err_loc_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
+err_cov_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
+err_loc_emp_full = np.zeros((range_n_outliers.size, repeat))
+err_cov_emp_full = np.zeros((range_n_outliers.size, repeat))
+err_loc_emp_pure = np.zeros((range_n_outliers.size, repeat))
+err_cov_emp_pure = np.zeros((range_n_outliers.size, repeat))
+
+# computation
+for i, n_outliers in enumerate(range_n_outliers):
+    for j in range(repeat):
+        # generate data
+        X = np.random.randn(n_samples, n_features)
+        # add some outliers
+        outliers_index = np.random.permutation(n_samples)[:n_outliers]
+        outliers_offset = 10. * \
+            (np.random.randint(2, size=(n_outliers, n_features)) - 0.5)
+        X[outliers_index] += outliers_offset
+        inliers_mask = np.ones(n_samples).astype(bool)
+        inliers_mask[outliers_index] = False
+
+        # fit a Minimum Covariance Determinant (MCD) robust estimator to data
+        S = MCD().fit(X, reweight=None)
+        # compare robust estimates with the true location and covariance
+        err_loc_mcd[i, j] = np.sum(S.location_ ** 2)
+        err_cov_mcd[i, j] = S.error_norm(np.eye(n_features))
+        # fit a reweighted MCD robust estimator to data
+        S = MCD().fit(X)
+        # compare robust estimates with the true location and covariance
+        err_loc_mcd_reweighted[i, j] = np.sum(S.location_ ** 2)
+        err_cov_mcd_reweighted[i, j] = S.error_norm(np.eye(n_features))
+        # compare estimators learnt from the full data set with true parameters
+        err_loc_emp_full[i, j] = np.sum(X.mean(0) ** 2)
+        err_cov_emp_full[i, j] = EmpiricalCovariance().fit(X).error_norm(
+            np.eye(n_features))
+        # compare with an empirical covariance learnt from a pure data set
+        # (i.e. "perfect" MCD)
+        pure_X = X[inliers_mask]
+        pure_location = pure_X.mean(0)
+        pure_emp_cov = EmpiricalCovariance().fit(pure_X)
+        err_loc_emp_pure[i, j] = np.sum(pure_location ** 2)
+        err_cov_emp_pure[i, j] = pure_emp_cov.error_norm(np.eye(n_features))
+
+# Display results
+font_prop = matplotlib.font_manager.FontProperties(size=11)
+pl.subplot(2, 1, 1)
+pl.errorbar(range_n_outliers, err_loc_mcd.mean(1),
+            yerr=err_loc_mcd.std(1) / np.sqrt(repeat),
+            label="Robust location", color='cyan')
+pl.errorbar(range_n_outliers, err_loc_mcd_reweighted.mean(1),
+            yerr=err_loc_mcd_reweighted.std(1) / np.sqrt(repeat),
+            label="Robust location (reweighted)", color='blue')
+pl.errorbar(range_n_outliers, err_loc_emp_full.mean(1),
+            yerr=err_loc_emp_full.std(1) / np.sqrt(repeat),
+            label="Full data set mean", color='green')
+pl.errorbar(range_n_outliers, err_loc_emp_pure.mean(1),
+            yerr=err_loc_emp_pure.std(1) / np.sqrt(repeat),
+            label="Pure data set mean", color='black')
+pl.title("Influence of outliers on the location estimation")
+pl.ylabel(r"Error ($||\mu - \hat{\mu}||_2^2$)")
+pl.legend(loc="upper left", prop=font_prop)
+
+pl.subplot(2, 1, 2)
+x_size = range_n_outliers.size
+pl.errorbar(range_n_outliers, err_cov_mcd.mean(1),
+            yerr=err_cov_mcd.std(1),
+            label="Robust covariance (MCD)", color='cyan')
+pl.errorbar(range_n_outliers, err_cov_mcd_reweighted.mean(1),
+            yerr=err_cov_mcd_reweighted.std(1),
+            label="Robust covariance (reweighted MCD)", color='blue')
+pl.errorbar(range_n_outliers[:(x_size / 5 + 1)],
+            err_cov_emp_full.mean(1)[:(x_size / 5 + 1)],
+            yerr=err_cov_emp_full.std(1)[:(x_size / 5 + 1)],
+            label="Full data set empirical covariance", color='green')
+pl.plot(range_n_outliers[(x_size / 5):(x_size / 2 - 1)],
+         err_cov_emp_full.mean(1)[(x_size / 5):(x_size / 2 - 1)],
+         color='green', ls='--')
+pl.errorbar(range_n_outliers, err_cov_emp_pure.mean(1),
+            yerr=err_cov_emp_pure.std(1),
+            label="Pure data set empirical covariance", color='black')
+pl.title("Influence of outliers on the covariance estimation")
+pl.xlabel("Amount of contamination (%)")
+pl.ylabel("RMSE")
+pl.legend(loc="upper right", prop=font_prop)
+
+pl.show()

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -14,3 +14,4 @@ from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
     log_likelihood
 from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
     ledoit_wolf, LedoitWolf, oas, OAS
+from .robust_covariance import fast_mcd, MCD

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -108,7 +108,7 @@ class EmpiricalCovariance(BaseEstimator):
         else:
             self.precision_ = None
 
-    def fit(self, X, assume_centered=False):
+    def fit(self, X, assume_centered=False, **params):
         """ Fits the Maximum Likelihood Estimator covariance model
         according to the given training data and parameters.
 
@@ -130,6 +130,7 @@ class EmpiricalCovariance(BaseEstimator):
             Returns self.
 
         """
+        self._set_params(**params)
         covariance = empirical_covariance(X, assume_centered=assume_centered)
         self._set_estimates(covariance)
 
@@ -210,5 +211,36 @@ class EmpiricalCovariance(BaseEstimator):
             result = squared_norm
         else:
             result = np.sqrt(squared_norm)
-
+        
         return result
+    
+    
+    def mahalanobis(self, observations):
+        """Computes the mahalanobis distances of given observations.
+        
+        The provided observations are assumed to be centered. One may
+        want to center it using a location estimate of its choice
+        first.
+        
+        Parameters
+        ----------
+        observations: array-like, shape = [n_observations, n_features]
+          The observations, the Mahalanobis distances of the which we compute.
+        
+        Returns
+        -------
+        mahalanobis_distance: 1D ndarray, shape = [n_observations,]
+          Mahalanobis distances of the observations.
+
+        """
+        # get precision
+        if self.store_precision:
+            precision = self.precision_
+        else:
+            precision = linalg.pinv(self.covariance_)
+            
+        # compute mahalanobis distances
+        mahalanobis_dist = np.sum(
+            np.dot(observations, precision) * observations, 1)
+        
+        return mahalanobis_dist 

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -108,7 +108,7 @@ class EmpiricalCovariance(BaseEstimator):
         else:
             self.precision_ = None
 
-    def fit(self, X, assume_centered=False, **params):
+    def fit(self, X, assume_centered=False):
         """ Fits the Maximum Likelihood Estimator covariance model
         according to the given training data and parameters.
 
@@ -130,7 +130,6 @@ class EmpiricalCovariance(BaseEstimator):
             Returns self.
 
         """
-        self._set_params(**params)
         covariance = empirical_covariance(X, assume_centered=assume_centered)
         self._set_estimates(covariance)
 

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -1,0 +1,497 @@
+"""
+Robust location and covariance estimators.
+
+Here are implemented estimators that are resistant to outliers.
+
+"""
+# Author: Virgile Fritsch <virgile.fritsch@inria.fr>
+#
+# License: BSD Style.
+import warnings
+import numpy as np
+from scipy import linalg
+from scipy.stats import chi2
+from sklearn.covariance import empirical_covariance, EmpiricalCovariance
+from ..utils.extmath import fast_logdet as exact_logdet
+
+
+###############################################################################
+### Minimum Covariance Determinant
+#   Implementing of an algorithm by Rousseeuw & Van Driessen described in
+#   (A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+#   1999, American Statistical Association and the American Society
+#   for Quality, TECHNOMETRICS)
+###############################################################################
+def c_step(X, h, remaining_iterations=30, initial_estimates=None,
+           verbose=False):
+    """C_step procedure described in [1] aiming at computing the MCD
+
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      Data set in which we look for the h observations whose scatter matrix
+      has minimum determinant
+    h: int, > n_samples / 2
+      Number of observations to compute the ribust estimates of location
+      and covariance from.
+    remaining_iterations: int
+      Number of iterations to perform.
+      According to Rousseeuw [1], two iterations are sufficient to get close
+      to the minimum, and we never need more than 30 to reach convergence.
+    initial_estimates: 2-tuple
+      Initial estimates of location and shape from which to run the c_step
+      procedure:
+      - initial_estimates[0]: an initial location estimate
+      - initial_estimates[1]: an initial covariance estimate
+    verbose: boolean
+      Verbose mode
+
+    Returns
+    -------
+    T: array-like, shape (n_features,)
+      Robust location estimates
+    S: array-like, shape (n_features, n_features)
+      Robust covariance estimates
+    H: array-like, shape (n_samples,)
+      A mask for the `h` observations whose scatter matrix has minimum
+      determinant
+
+    """
+    n_samples, n_features = X.shape
+
+    # Initialisation
+    if initial_estimates is None:
+        # compute initial robust estimates from a random subset
+        support = np.zeros(n_samples).astype(bool)
+        support[np.random.permutation(n_samples)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+    else:
+        # get initial robust estimates from the function parameters
+        T = initial_estimates[0]
+        S = initial_estimates[1]
+        # run a special iteration for that case (to get an initial support)
+        inv_S = linalg.pinv(S)
+        X_centered = X - T
+        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        # compute new estimates
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(dist)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+        detS = exact_logdet(S)
+    previous_detS = np.inf
+
+    # Iterative procedure for Minimum Covariance Determinant computation
+    detS = exact_logdet(S)
+    while (detS < previous_detS) and (remaining_iterations > 0):
+        # compute a new support from the full data set mahalanobis distances
+        inv_S = linalg.pinv(S)
+        X_centered = X - T
+        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        # save old estimates values
+        previous_T = T
+        previous_S = S
+        previous_detS = detS
+        previous_support = support
+        # compute new estimates
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(dist)[:h]] = True
+        T = X[support].mean(0)
+        S = empirical_covariance(X[support])
+        detS = np.log(linalg.det(S))
+        # update remaining iterations for early stopping
+        remaining_iterations = remaining_iterations - 1
+
+    # Check convergence
+    if np.allclose(detS, previous_detS):
+        # c_step procedure converged
+        if verbose:
+            print 'Optimal couple (T,S) found before ending iterations' \
+                '(%d left)' % (remaining_iterations)
+        results = T, S, detS, support
+    elif detS > previous_detS:
+        # determinant has increased (should not happen)
+        warnings.warn("Warning! detS > previous_detS (%.15f > %.15f)" \
+                          % (detS, previous_detS), RuntimeWarning)
+        results = previous_T, previous_S, previous_detS, previous_support
+
+    # Check early stopping
+    if remaining_iterations == 0:
+        if verbose:
+            print 'Maximum number of iterations reached'
+        detS = exact_logdet(S)
+        results = T, S, detS, support
+
+    return results
+
+
+def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False):
+    """Finds the best pure subset of observations to compute MCD from it.
+
+    The purpose of this function is to find the best sets of h
+    observations with respect to a minimization of their covariance
+    matrix determinant. Equivalently, it removes n_samples-h
+    observations to construct what we call a pure data set (i.e. not
+    containing outliers). The list of the observations of the pure
+    data set is referred to as the `support`.
+
+    Starting from a random support, the pure data set is found by the
+    c_step procedure introduced by Rousseeuw and Van Driessen in [1].
+
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      Data (sub)set in which we look for the h purest observations
+    h: int, [(n + p + 1)/2] < h < n
+      The number of samples the pure data set must contain.
+    select: int, int > 0
+      Number of best candidates results to return.
+    n_trials: int, nb_trials > 0 or 2-tuple
+      Number of different initial sets of observations from which to
+      run the algorithm.
+      Instead of giving a number of trials to perform, one can provide a
+      list of initial estimates that will be used to iteratively run
+      c_step procedures. In this case:
+      - n_trials[0]: array-like, shape (n_trials, n_features)
+        is the list of `n_trials` initial location estimates
+      - n_trials[1]: array-like, shape (n_trials, n_features, n_features)
+        is the list of `n_trials` initial covariances estimates
+    n_iter: int, nb_iter > 0
+      Maximum number of iterations for the c_step procedure.
+      (2 is enough to be close to the final solution. "Never" exceeds 20)
+
+    See
+    ---
+    `c_step` function
+
+    Returns
+    -------
+    best_T: array-like, shape (select, n_features)
+      The `select` location estimates computed from the `select` best
+      supports found in the data set (`X`)
+    best_S: array-like, shape (select, n_features, n_features)
+      The `select` covariance estimates computed from the `select`
+      best supports found in the data set (`X`)
+    best_H: array-like, shape (select, n_samples)
+      The `select` best supports found in the data set (`X`)
+
+    """
+    n_samples, n_features = X.shape
+
+    if isinstance(n_trials, int):
+        run_from_estimates = False
+    elif isinstance(n_trials, tuple):
+        run_from_estimates = True
+        estimates_list = n_trials
+        n_trials = estimates_list[0].shape[0]
+    else:
+        raise Exception('Bad \'n_trials\' parameter (wrong type)')
+
+    # compute `n_trials` location and shape estimates candidates in the subset
+    all_T_sub = np.zeros((n_trials, n_features))
+    all_S_sub = np.zeros((n_trials, n_features, n_features))
+    all_detS_sub = np.zeros(n_trials)
+    all_H_sub = np.zeros((n_trials, n_samples)).astype(bool)
+    if not run_from_estimates:
+        # perform `n_trials` computations from random initial supports
+        for j in range(n_trials):
+            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
+                X, h, remaining_iterations=n_iter, verbose=verbose)
+    else:
+        # perform computations from every given initial estimates
+        for j in range(n_trials):
+            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
+                X, h, remaining_iterations=n_iter,
+                initial_estimates=(estimates_list[0][j], estimates_list[1][j]),
+                verbose=verbose)
+
+    # find the `n_best` best results among the `n_trials` ones
+    index_best = np.argsort(all_detS_sub)[:select]
+    best_T = all_T_sub[index_best]
+    best_S = all_S_sub[index_best]
+    best_H = all_H_sub[index_best]
+
+    return best_T, best_S, best_H
+
+
+def fast_mcd(X, correction="empirical", reweight="rousseeuw"):
+    """Estimates the Minimum Covariance Determinant matrix.
+
+    The FastMCD algorithm has been introduced by Rousseuw and Van Driessen
+    in "A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+    1999, American Statistical Association and the American Society
+    for Quality, TECHNOMETRICS".
+    The principle is to compute robust estimates and random subsets before
+    pooling them into a larger subsets, and finally into the full data set.
+    Depending on the size of the initial sample, we have one, two or three
+    such computation levels.
+
+    Parameters
+    ----------
+    X: array-like, shape (n_samples, n_features)
+      The data matrix, with p features and n samples.
+    reweight: int (0 < reweight < 2)
+      Computation of a reweighted estimator:
+        - "rousseeuw" (default): Reweight observations using Rousseeuw's
+          method (equivalent to deleting outlying observations from the
+          data set before computing location and covariance estimates)
+        - else: no reweighting
+    correction: str
+      Improve the covariance estimator consistency at gaussian models
+        - "empirical" (default): correction using the empirical correction
+          factor suggested by Rousseeuw and Van Driessen in [1]
+        - "theoretical": correction using the theoretical correction factor
+          derived in [2]
+        - else: no correction
+
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+    [2] R. W. Butler, P. L. Davies and M. Jhun,
+        Asymptotics For The Minimum Covariance Determinant Estimator,
+        The Annals of Statistics, 1993, Vol. 21, No. 3, 1385-1400
+
+    Returns
+    -------
+    T: array-like, shape (n_features,)
+      Robust location of the data
+    S: array-like, shape (n_features, n_features)
+      Robust covariance of the features
+    support: array-like, type boolean, shape (n_samples,)
+      a mask of the observations that have been used to compute
+      the robust location and covariance estimates of the data set
+
+    """
+    X = np.asanyarray(X)
+    if X.ndim <= 1:
+        X = X.reshape((-1, 1))
+    n_samples, n_features = X.shape
+
+    # minimum breakdown value
+    h = int(np.ceil(0.5 * (n_samples + n_features + 1)))
+
+    # 1-dimensional case quick computation
+    # (Rousseeuw, P. J. and Leroy, A. M. (2005) References, in Robust
+    #  Regression and Outlier Detection, John Wiley & Sons, chapter 4)
+    if n_features == 1:
+        # find the sample shortest halves
+        X_sorted = np.sort(np.ravel(X))
+        diff = X_sorted[h:] - X_sorted[:(n_samples - h)]
+        halves_start = np.where(diff == np.min(diff))[0]
+        # take the middle points' mean to get the robust location estimate
+        T = 0.5 * (X_sorted[h + halves_start] + X_sorted[halves_start]).mean()
+        support = np.zeros(n_samples).astype(bool)
+        support[np.argsort(np.abs(X - T), axis=0)[:h]] = True
+        S = np.asarray([[np.var(X[support])]])
+        T = np.array([T])
+
+    ### Starting FastMCD algorithm for p-dimensional case
+    if (n_samples > 500) and (n_features > 1):
+        ## 1. Find candidate supports on subsets
+        # a. split the set in subsets of size ~ 300
+        n_subsets = n_samples / 300
+        n_samples_subsets = n_samples / n_subsets
+        samples_shuffle = np.random.permutation(n_samples)
+        h_subset = np.ceil(n_samples_subsets * (h / float(n_samples)))
+        # b. perform a total of 500 trials
+        n_trials_tot = 500
+        n_trials = n_trials_tot / n_subsets
+        # c. select 10 best (T,S) for each subset
+        n_best_sub = 10
+        n_best_tot = n_subsets * n_best_sub
+        all_best_T = np.zeros((n_best_tot, n_features))
+        all_best_S = np.zeros((n_best_tot, n_features, n_features))
+        for i in range(n_subsets):
+            low_bound = i * n_samples_subsets
+            high_bound = low_bound + n_samples_subsets
+            current_subset = X[samples_shuffle[low_bound:high_bound]]
+            best_T_sub, best_S_sub, _ = select_candidates(
+                current_subset, h_subset, n_trials,
+                select=n_best_sub, n_iter=2)
+            subset_slice = np.arange(i * n_best_sub, (i + 1) * n_best_sub)
+            all_best_T[subset_slice] = best_T_sub
+            all_best_S[subset_slice] = best_S_sub
+        ## 2. Pool the candidate supports into a merged set
+        ##    (possibly the full dataset)
+        n_samples_merged = min(1500, n_samples)
+        h_merged = np.ceil(n_samples_merged * (h / float(n_samples)))
+        if n_samples > 1500:
+            n_best_merged = 10
+        else:
+            n_best_merged = 1
+        # find the best couples (T,S) on the merged set
+        T_merged, S_merged, H_merged = select_candidates(
+            X[np.random.permutation(n_samples)[:n_samples_merged]],
+            h_merged, n_trials=(all_best_T, all_best_S), select=n_best_merged)
+        ## 3. Finally get the overall best (T,S) couple
+        if n_samples < 1500:
+            # directly get the best couple (T,S)
+            T = T_merged[0]
+            S = S_merged[0]
+            H = H_merged[0]
+        else:
+            # select the best couple on the full dataset
+            T_full, S_full, H_full = select_candidates(
+                X, h, n_trials=(T_merged, S_merged), select=1)
+            T = T_full[0]
+            S = S_full[0]
+            H = H_full[0]
+    elif n_features > 1:
+        ## 1. Find the 10 best couples (T,S) considering two iterations
+        n_trials = 30
+        n_best = 10
+        T_best, S_best, _ = select_candidates(
+            X, h, n_trials=n_trials, select=n_best, n_iter=2)
+        ## 2. Select the best couple on the full dataset amongst the 10
+        T_full, S_full, H_full = select_candidates(
+            X, h, n_trials=(T_best, S_best), select=1)
+        T = T_full[0]
+        S = S_full[0]
+        H = H_full[0]
+
+    ## 4. Obtain consistency at Gaussian models
+    if correction == "empirical":
+        # theoretical correction
+        inliers_ratio = h / float(n_samples)
+        S_corrected = S * (inliers_ratio) \
+            / chi2(n_features + 2).cdf(chi2(n_features).ppf(inliers_ratio))
+    elif correction == "theoretical":
+        # empirical correction
+        X_centered = X - T
+        dist = (np.dot(X_centered, linalg.inv(S)) * X_centered).sum(1)
+        S_corrected = S * (np.median(dist) / chi2(n_features).isf(0.5))
+    else:
+        # no correction
+        S_corrected = S
+
+    ## 5. Reweight estimate
+    if reweight == "rousseeuw":
+        X_centered = X - T
+        dist = np.sum(
+            np.dot(X_centered, linalg.inv(S_corrected)) * X_centered,
+            1)
+        mask = dist < chi2(n_features).isf(0.025)
+        T_reweighted = X[mask].mean(0)
+        S_reweighted = empirical_covariance(X[mask])
+        support = np.zeros(n_samples).astype(bool)
+        support[mask] = True
+    else:
+        T_reweighted = T
+        S_reweighted = S_corrected
+        support = H
+
+    return T_reweighted, S_reweighted, support
+
+
+class MCD(EmpiricalCovariance):
+    """Minimum Covariance Determinant (MCD) robust estimator of covariance
+
+    The Minimum Covariance Determinant estimator is a robust estimator
+    of a data set's covariance introduced by P.J.Rousseuw in [1].
+    The idea is to find a given proportion of "good" observations which
+    are not outliers and compute their empirical covariance matrix.
+    This empirical covariance matrix is then rescaled to compensate the
+    performed selection of observations ("consistency step").
+    Having computed the Minimum Covariance Determinant estimator, one
+    can give weights to observations according to their Mahalanobis
+    distance, leading the a reweighted estimate of the covariance
+    matrix of the data set.
+
+    Rousseuw and Van Driessen [2] developed the FastMCD algorithm in order
+    to compute the Minimum Covariance Determinant. This algorithm is used
+    when fitting an MCD object to data.
+    The FastMCD algorithm also computes a robust estimate of the data set
+    location at the same time.
+
+    Parameters
+    ----------
+    store_precision: bool
+        Specify if the estimated precision is stored
+
+    Attributes
+    ----------
+    `location_`: array-like, shape (n_features,)
+        Estimated robust location
+
+    `covariance_`: array-like, shape (n_features, n_features)
+        Estimated robust covariance matrix
+
+    `precision_`: array-like, shape (n_features, n_features)
+        Estimated pseudo inverse matrix.
+        (stored only if store_precision is True)
+
+    `support_`: array-like, shape (n_samples,)
+        A mask of the observations that have been used to compute
+        the robust estimates of location and shape.
+
+    `correction`: str
+        Improve the covariance estimator consistency at gaussian models
+          - "empirical" (default): correction using the empirical correction
+            factor suggested by Rousseeuw and Van Driessen in [2]
+          - "theoretical": correction using the theoretical correction factor
+            derived in [3]
+          - else: no correction
+
+    `reweight`: str
+        Computation of a reweighted MCD estimator:
+          - "rousseeuw" (default): Reweight observations using Rousseeuw's
+            method (equivalent to deleting outlying observations from the
+            data set before computing location and covariance estimates)
+          - else: no reweighting
+
+    [1] P. J. Rousseeuw. Least median of squares regression. J. Am
+        Stat Ass, 79:871, 1984.
+    [2] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
+    [3] R. W. Butler, P. L. Davies and M. Jhun,
+        Asymptotics For The Minimum Covariance Determinant Estimator,
+        The Annals of Statistics, 1993, Vol. 21, No. 3, 1385-1400
+
+    """
+    def fit(self, X, assume_centered=False, correction="empirical",
+            reweight="rousseeuw"):
+        """Fits a Minimum Covariance Determinant with the FastMCD algorithm.
+
+        Parameters
+        ----------
+        X: array-like, shape = [n_samples, n_features]
+          Training data, where n_samples is the number of samples
+          and n_features is the number of features.
+
+        assume_centered: Boolean
+          If True, the support of robust location and covariance estimates
+          is computed, and a covariance estimate is recomputed from it,
+          without centering the data.
+          Usefull to work with data whose mean is significantly equal to
+          zero but is not exactly zero.
+          If False, the robust location and covariance are directly computed
+          with the FastMCD algorithm without additional treatment.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        location, covariance, support = fast_mcd(
+            X, correction=correction, reweight=reweight)
+        if assume_centered:
+            location = np.zeros(location.shape[0])
+            covariance = empirical_covariance(X[support], assume_centered=True)
+        self._set_estimates(covariance)
+        self.location_ = location
+        self.support_ = support
+        self.reweight = reweight
+        self.correction = correction
+
+        return self

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -26,8 +26,8 @@ from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance
 def shrunk_covariance(emp_cov, shrinkage=0.1):
     """Calculates a covariance matrix shrunk on the diagonal
 
-    Params
-    ------
+    Parameters
+    ----------
     emp_cov: array-like, shape (n_features, n_features)
       Covariance matrix to be shrunk
 
@@ -99,7 +99,7 @@ class ShrunkCovariance(EmpiricalCovariance):
         self.store_precision = store_precision
         self.shrinkage = shrinkage
 
-    def fit(self, X, assume_centered=False, **params):
+    def fit(self, X, assume_centered=False):
         """ Fits the shrunk covariance model
         according to the given training data and parameters.
 
@@ -121,7 +121,6 @@ class ShrunkCovariance(EmpiricalCovariance):
             Returns self.
 
         """
-        self._set_params(**params)
         empirical_cov = empirical_covariance(X,
                                              assume_centered=assume_centered)
         covariance = shrunk_covariance(empirical_cov, self.shrinkage)

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -99,7 +99,7 @@ class ShrunkCovariance(EmpiricalCovariance):
         self.store_precision = store_precision
         self.shrinkage = shrinkage
 
-    def fit(self, X, assume_centered=False):
+    def fit(self, X, assume_centered=False, **params):
         """ Fits the shrunk covariance model
         according to the given training data and parameters.
 
@@ -121,6 +121,7 @@ class ShrunkCovariance(EmpiricalCovariance):
             Returns self.
 
         """
+        self._set_params(**params)
         empirical_cov = empirical_covariance(X,
                                              assume_centered=assume_centered)
         covariance = shrunk_covariance(empirical_cov, self.shrinkage)
@@ -195,13 +196,13 @@ def ledoit_wolf(X, assume_centered=False):
 
 
 class LedoitWolf(EmpiricalCovariance):
-    """Ledoit-Wolf shrinkage estimator
+    """LedoitWolf Estimator
 
     Ledoit-Wolf is a particular form of shrinkage, where the shrinkage
-    coefficient is computed using O. Ledoit and M. Wolf's formula as
+    coefficient is computed using O.Ledoit and M.Wolf's formula as
     described in "A Well-Conditioned Estimator for Large-Dimensional
-    Covariance Matrices", Journal of Multivariate Analysis, Volume 88,
-    Issue 2, February 2004, pages 365-411.
+    Covariance Matrices", Ledoit and Wolf, Journal of Multivariate
+    Analysis, Volume 88, Issue 2, February 2004, pages 365-411.
 
     Parameters
     ----------


### PR DESCRIPTION
Minimum Covariance Determinant (MCD) is a robust estimator of
covariance introduced by Rousseeuw [1]. The main idea behind the MCD
is to find a fixed proportion of observations whose scatter matrix has
the minimum determinant.
The MCD estimator is computed with the FastMCD algorithm [2].

[1] P. J. Rousseeuw. Least median of squares regression. J. Am Stat
Ass, 79:871, 1984.
[2] P. J. Rousseeuw and K. Van Driessen. A fast algorithm for the
minimum covariance determinant estimator. Technometrics, 41(3):212,
1999.
