### PR TITLE
Allow sparse input to NMF

### DIFF
--- a/examples/applications/topics_extraction_with_nmf.py
+++ b/examples/applications/topics_extraction_with_nmf.py
@@ -60,9 +60,6 @@ counts = vectorizer.fit_transform(dataset.data[:n_samples])
 tfidf = text.TfidfTransformer().fit_transform(counts)
 print "done in %0.3fs." % (time() - t0)
 
-# Convert scipy.sparse.csr_matrix representation to dense numpy array
-tfidf = tfidf.toarray()
-
 # Fit the NMF model
 print "Fitting the NMF model on with n_samples=%d and n_features=%d..." % (
     n_samples, n_features)

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1,6 +1,7 @@
 """ Non-negative matrix factorization
 """
 # Author: Vlad Niculae
+#         Lars Buitinck <L.J.Buitinck@uva.nl>
 # Author: Chih-Jen Lin, National Taiwan University (original projected gradient
 #     NMF implementation)
 # Author: Anthony Di Franco (original Python and NumPy port)
@@ -224,14 +225,13 @@ def _nls_subproblem(V, W, H_init, tol, max_iter):
                     H = Hn
                     break
                 else:
-                    alpha = alpha * beta
+                    alpha *= beta
+            elif not suff_decr or (Hp == Hn).all():
+                H = Hp
+                break
             else:
-                if not suff_decr or (Hp == Hn).all():
-                    H = Hp
-                    break
-                else:
-                    alpha = alpha / beta
-                    Hp = Hn
+                alpha /= beta
+                Hp = Hn
 
     if n_iter == max_iter:
         warnings.warn("Iteration limit reached in nls subproblem.")
@@ -385,8 +385,10 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         else:
             try:
                 rng = check_random_state(self.init)
-                W = np.abs(rng.randn(n_samples, self.n_components))
-                H = np.abs(rng.randn(self.n_components, n_features))
+                W = rng.randn(n_samples, self.n_components)
+                np.abs(W, out=W)
+                H = rng.randn(self.n_components, n_features)
+                np.abs(H, out=H)
             except ValueError:
                 raise ValueError(
                     'Invalid init parameter: got %r instead of one of %r' %

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -8,12 +8,15 @@
 
 
 from __future__ import division
-import warnings
+
+from ..base import BaseEstimator, TransformerMixin
+from ..utils import atleast2d_or_csr, check_random_state
+from ..utils.extmath import fast_svd, safe_sparse_dot
 
 import numpy as np
-from ..base import BaseEstimator, TransformerMixin
-from ..utils import check_random_state
-from ..utils.extmath import fast_svd
+from scipy.optimize import nnls
+import scipy.sparse as sp
+import warnings
 
 
 def _pos(x):
@@ -41,6 +44,12 @@ def _sparseness(x):
     """Hoyer's measure of sparsity for a vector"""
     sqrt_n = np.sqrt(len(x))
     return (sqrt_n - np.linalg.norm(x, 1) / norm(x)) / (sqrt_n - 1)
+
+
+def check_non_negative(X, whom):
+    X = X.data if sp.issparse(X) else X
+    if (X < 0).any():
+        raise ValueError("Negative values in data passed to %s" % whom)
 
 
 def _initialize_nmf(X, n_components, variant=None, eps=1e-6,
@@ -92,8 +101,7 @@ def _initialize_nmf(X, n_components, variant=None, eps=1e-6,
 
     http://www.cs.rpi.edu/~boutsc/files/nndsvd.pdf
     """
-    if (X < 0).any():
-        raise ValueError("Negative values in data passed to initialization")
+    check_non_negative(X, "NMF initialization")
     if variant not in (None, 'a', 'ar'):
         raise ValueError("Invalid variant name")
 
@@ -186,8 +194,8 @@ def _nls_subproblem(V, W, H_init, tol, max_iter):
         raise ValueError("Negative values in H_init passed to NLS solver.")
 
     H = H_init
-    WtV = np.dot(W.T, V)
-    WtW = np.dot(W.T, W)
+    WtV = safe_sparse_dot(W.T, V, dense_output=True)
+    WtW = safe_sparse_dot(W.T, W, dense_output=True)
 
     # values justified in the paper
     alpha = 1
@@ -236,7 +244,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    X: array, [n_samples, n_features]
+    X: {array-like, sparse matrix}, shape = [n_samples, n_features]
         Data the model will be fit to.
 
     n_components: int or None
@@ -285,6 +293,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Frobenius norm of the matrix difference between the
         training data and the reconstructed data from the
         fit produced by the model. || X - WH ||_2
+        Not computed for sparse input matrices because it is
+        too expensive in terms of memory.
 
     Examples
     --------
@@ -350,7 +360,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Parameters
         ----------
 
-        X: array, [n_samples, n_features]
+        X: {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data matrix to be decomposed
 
         Returns
@@ -358,9 +368,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         data: array, [n_samples, n_components]
             Transformed data
         """
-        X = np.atleast_2d(X)
-        if (X < 0).any():
-            raise ValueError("Negative data passed to NMF.fit.")
+        X = atleast2d_or_csr(X)
+        check_non_negative(X, "NMF.fit")
 
         n_samples, n_features = X.shape
 
@@ -384,8 +393,10 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
                     (self.init, (None, 'nndsvd', 'nndsvda', 'nndsvdar',
                                  int, np.random.RandomState)))
 
-        gradW = np.dot(W, np.dot(H, H.T)) - np.dot(X, H.T)
-        gradH = np.dot(np.dot(W.T, W), H) - np.dot(W.T, X)
+        gradW = (np.dot(W, np.dot(H, H.T))
+                 - safe_sparse_dot(X, H.T, dense_output=True))
+        gradH = (np.dot(np.dot(W.T, W), H)
+                 - safe_sparse_dot(W.T, X, dense_output=True))
         init_grad = norm(np.r_[gradW, gradH.T])
         tolW = max(0.001, self.tol) * init_grad  # why max?
         tolH = tolW
@@ -440,7 +451,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
                 tolH = 0.1 * tolH
             self.comp_sparseness_ = _sparseness(H.ravel())
             self.data_sparseness_ = _sparseness(W.ravel())
-            self.reconstruction_err_ = norm(X - np.dot(W, H))
+            if not sp.issparse(X):
+                self.reconstruction_err_ = norm(X - np.dot(W, H))
             self.components_ = H
 
         if n_iter == self.max_iter:
@@ -453,7 +465,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Parameters
         ----------
 
-        X: array, [n_samples, n_features]
+        X: {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data matrix to be decomposed
 
         Returns
@@ -469,7 +481,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Parameters
         ----------
 
-        X: array, [n_samples, n_features]
+        X: {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data matrix to be transformed by the model
 
         Returns
@@ -477,8 +489,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         data: array, [n_samples, n_components]
             Transformed data
         """
-        from scipy.optimize import nnls
-        X = np.atleast_2d(X)
+        X = atleast2d_or_csr(X)
         H = np.zeros((X.shape[0], self.n_components))
         for j in xrange(0, X.shape[0]):
             H[j, :], _ = nnls(self.components_.T, X[j, :])

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -386,9 +386,12 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
             try:
                 rng = check_random_state(self.init)
                 W = rng.randn(n_samples, self.n_components)
-                np.abs(W, out=W)
+                # we do not write np.abs(W, out=W) to stay compatible with numpy
+                # 1.5 and earlier where the 'out' keyword is not supported as a
+                # kwarg on ufuncs
+                np.abs(W, W)
                 H = rng.randn(self.n_components, n_features)
-                np.abs(H, out=H)
+                np.abs(H, H)
             except ValueError:
                 raise ValueError(
                     'Invalid init parameter: got %r instead of one of %r' %

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -1,6 +1,7 @@
 import numpy as np
 from .. import nmf
 from nose.tools import assert_true, assert_false, raises
+from numpy.testing import assert_array_almost_equal
 
 random_state = np.random.mtrand.RandomState(0)
 
@@ -119,6 +120,20 @@ def test_projgrad_nmf_sparseness():
     comp_sp = nmf.ProjectedGradientNMF(n_components=5,
                   sparseness='components').fit(A).comp_sparseness_
     assert_true(data_sp > m.data_sparseness_ and comp_sp > m.comp_sparseness_)
+
+
+def test_sparse_input():
+    """Test that sparse matrices are accepted as input"""
+    from scipy.sparse import csr_matrix
+
+    A = np.arange(100).reshape(10, 10)
+    A[np.where(A % 2 == 0)] = 0
+    T1 = nmf.ProjectedGradientNMF(n_components=5, init=999).fit_transform(A)
+
+    A = csr_matrix(A)
+    T2 = nmf.ProjectedGradientNMF(n_components=5, init=999).fit_transform(A)
+
+    assert_array_almost_equal(T1, T2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I patched up the NMF code to accept `scipy.sparse` matrices. Allows the topic detection example to scale up a bit: I can run it with 10000 examples and 10000 features in just over half a minute, using on the scale of 200MB of memory. That used to be 1.5GB of memory and no end in sight after several minutes.
