### PR TITLE
Refactor MCD robust covariance estimator: it is easier to regularize.

### DIFF
--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -37,9 +37,14 @@ Gaussian distribution that one may want to work with. Using MCD-based
 Mahalanobis distances, the two populations become
 distinguishable. Associated applications are outliers detection,
 observations ranking, clustering, ...
+For vizualisation purpose, the cubique root of the Mahalanobis distances
+are represented in the boxplot, as Wilson and Hilferty suggest [2]
 
 [1] P. J. Rousseeuw. Least median of squares regression. J. Am
     Stat Ass, 79:871, 1984.
+[2] Wilson, E. B., & Hilferty, M. M. (1931). The distribution of chi-square.
+    Proceedings of the National Academy of Sciences of the United States
+    of America, 17, 684-688.
 
 """
 print __doc__
@@ -71,15 +76,9 @@ emp_cov = EmpiricalCovariance().fit(X)
 
 # Display results
 fig = pl.figure()
-# variables and parameters for cosmetic
-offset_left = fig.subplotpars.left
-offset_bottom = fig.subplotpars.bottom
-width = fig.subplotpars.right - offset_left
-subfig1 = pl.subplot(3, 1, 1)
-subfig2 = pl.subplot(3, 1, 2)
-subfig3 = pl.subplot(3, 1, 3)
 
 # Show data set
+subfig1 = pl.subplot(3, 1, 1)
 subfig1.scatter(X[:, 0], X[:, 1], color='black', label='inliers')
 subfig1.scatter(X[:, 0][-n_outliers:], X[:, 1][-n_outliers:],
                 color='red', label='outliers')
@@ -87,24 +86,27 @@ subfig1.set_xlim(subfig1.get_xlim()[0], 11.)
 subfig1.set_title("Mahalanobis distances of a contaminated data set:")
 subfig1.legend(loc="upper right")
 
-# Empirical covariance -based Mahalanobis distances
-subfig2.scatter(np.arange(n_samples), emp_cov.mahalanobis(X),
-                color='black', label='inliers')
-subfig2.scatter(np.arange(n_samples)[-n_outliers:],
-                emp_cov.mahalanobis(X)[-n_outliers:],
-                color='red', label='outliers')
-subfig2.set_ylabel("Mahal. dist.")
-subfig2.set_title("1. from empirical estimates")
-subfig2.axes.set_position(pos=[offset_left, 0.39, width, .2])
+emp_mahal = emp_cov.mahalanobis(X) ** (0.33)
+subfig2 = pl.subplot(2, 2, 3)
+subfig2.boxplot([emp_mahal[:-n_outliers], emp_mahal[-n_outliers:]], widths=.25)
+subfig2.plot(1.26 * np.ones(n_samples - n_outliers),
+             emp_mahal[:-n_outliers], '+k', markeredgewidth=1)
+subfig2.plot(2.26 * np.ones(n_outliers),
+             emp_mahal[-n_outliers:], '+k', markeredgewidth=1)
+subfig2.axes.set_xticklabels(('inliers', 'outliers'), size=11)
+subfig2.set_ylabel(r"$\sqrt[3]{\rm{(Mahal. dist.)}}$")
+subfig2.set_title("1. from non-robust estimates\n(Maximum Likelihood)")
 
-# MCD-based Mahalanobis distances
-subfig3.scatter(np.arange(n_samples), robust_cov.mahalanobis(X),
-                color='black', label='inliers')
-subfig3.scatter(np.arange(n_samples)[-n_outliers:],
-                robust_cov.mahalanobis(X)[-n_outliers:],
-                color='red', label='outliers')
-subfig3.set_ylabel("Mahal. dist.")
-subfig3.set_title("2. from robust estimates (Minimum Covariance Determinant)")
-subfig3.axes.set_position(pos=[offset_left, offset_bottom, width, .2])
+robust_mahal = robust_cov.mahalanobis(X) ** (0.33)
+subfig3 = pl.subplot(2, 2, 4)
+subfig3.boxplot([robust_mahal[:-n_outliers], robust_mahal[-n_outliers:]],
+                widths=.25)
+subfig3.plot(1.26 * np.ones(n_samples - n_outliers),
+             robust_mahal[:-n_outliers], '+k', markeredgewidth=1)
+subfig3.plot(2.26 * np.ones(n_outliers),
+             robust_mahal[-n_outliers:], '+k', markeredgewidth=1)
+subfig3.axes.set_xticklabels(('inliers', 'outliers'), size=11)
+subfig3.set_ylabel(r"$\sqrt[3]{\rm{(Mahal. dist.)}}$")
+subfig3.set_title("2. from robust estimates\n(Minimum Covariance Determinant)")
 
 pl.show()

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -3,26 +3,27 @@
 Robust covariance estimation and Mahalanobis distances relevance
 ================================================================
 
-For Gaussian ditributed data, the distance of an observation $x_i$ to
-the mode of the distribution can be computed using its Mahalanobis
-distance: $d_{(\mu,\Sigma)}(x_i)^2 = (x_i - \mu)'\Sigma^{-1}(x_i -
-\mu)$ where $\mu$ and $\Sigma$ are the location and the covariance of
-the underlying gaussian distribution.
+For Gaussian ditributed data, the distance of an observation
+:math:`x_i` to the mode of the distribution can be computed using its
+Mahalanobis distance: :math:`d_{(\mu,\Sigma)}(x_i)^2 = (x_i -
+\mu)'\Sigma^{-1}(x_i - \mu)` where :math:`\mu` and :math:`\Sigma` are
+the location and the covariance of the underlying gaussian
+distribution.
 
-In practice, $\mu$ and $\Sigma$ are replaced by some estimates.  The
-usual covariance maximum likelihood estimate is very sensitive to the
-presence of outliers in the data set and therefor, the corresponding
-Mahalanobis distances are. One would better have to use a robust
-estimator of covariance to garanty that the estimation is resistant to
-"errorneous" observations in the data set and that the associated
-Mahalanobis distances accurately reflect the true organisation of the
-observations.
+In practice, :math:`\mu` and :math:`\Sigma` are replaced by some
+estimates.  The usual covariance maximum likelihood estimate is very
+sensitive to the presence of outliers in the data set and therefor,
+the corresponding Mahalanobis distances are. One would better have to
+use a robust estimator of covariance to garanty that the estimation is
+resistant to "errorneous" observations in the data set and that the
+associated Mahalanobis distances accurately reflect the true
+organisation of the observations.
 
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
 matrix of highly contaminated datasets, up to
-$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
-covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+:math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
+covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
 observations whose empirical covariance has the smallest determinant,
 yielding a "pure" subset of observations from which to compute
 standards estimates of location and covariance.

--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -47,7 +47,7 @@ print __doc__
 import numpy as np
 import pylab as pl
 
-from sklearn.covariance import EmpiricalCovariance, MCD
+from sklearn.covariance import EmpiricalCovariance, MinCovDet
 
 n_samples = 125
 n_outliers = 25
@@ -63,7 +63,7 @@ outliers_cov[np.arange(1, n_features), np.arange(1, n_features)] = 7.
 X[-n_outliers:] = np.dot(np.random.randn(n_outliers, n_features), outliers_cov)
 
 # fit a Minimum Covariance Determinant (MCD) robust estimator to data
-robust_cov = MCD().fit(X, reweight=None)
+robust_cov = MinCovDet().fit(X)
 
 # compare estimators learnt from the full data set with true parameters
 emp_cov = EmpiricalCovariance().fit(X)

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -52,7 +52,7 @@ import numpy as np
 import pylab as pl
 import matplotlib.font_manager
 
-from sklearn.covariance import EmpiricalCovariance, MCD
+from sklearn.covariance import EmpiricalCovariance, MinCovDet
 
 # example settings
 n_samples = 80
@@ -84,12 +84,12 @@ for i, n_outliers in enumerate(range_n_outliers):
         inliers_mask[outliers_index] = False
 
         # fit a Minimum Covariance Determinant (MCD) robust estimator to data
-        S = MCD().fit(X, reweight=None)
+        S = MinCovDet(reweighting=None).fit(X)
         # compare robust estimates with the true location and covariance
         err_loc_mcd[i, j] = np.sum(S.location_ ** 2)
         err_cov_mcd[i, j] = S.error_norm(np.eye(n_features))
-        # fit a reweighted MCD robust estimator to data
-        S = MCD().fit(X)
+        # reweight MCD robust estimator
+        S.reweight(data=X, permanent=True)
         # compare robust estimates with the true location and covariance
         err_loc_mcd_reweighted[i, j] = np.sum(S.location_ ** 2)
         err_cov_mcd_reweighted[i, j] = S.error_norm(np.eye(n_features))

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -12,8 +12,8 @@ set.
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
 matrix of highly contaminated datasets, up to
-$\frac{n_samples-n_features-1}{2}$ outliers) estimator of
-covariance. The idea is to find $\frac{n_samples+n_features+1}{2}$
+:math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
+covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
 observations whose empirical covariance has the smallest determinant,
 yielding a "pure" subset of observations from which to compute
 standards estimates of location and covariance. After a correction
@@ -25,17 +25,11 @@ The Minimum Covariance Determinant estimator (MCD) has been introduced
 by P.J.Rousseuw in [1].
 
 In this example, we compare the estimation errors that are made when
-using four types of location and covariance estimates on contaminated
+using three types of location and covariance estimates on contaminated
 gaussian distributed data sets:
  - The mean and the empirical covariance of the full dataset, which break
    down as soon as there are outliers in the data set
  - The robust MCD, that has a low error provided n_samples > 5 * n_features
- - The robust MCD reweighted according to Rousseeuw's recommandations:
-   observations are given a 0 weight if they are found to be outlying
-   according to their MCD-based Mahalanobis distance. Doing so improve the
-   efficiency of the estimators at gaussian models but it assumes that
-   we perfectly know the distribution of the mahalanobis distances computed
-   from the MCD estimate (see [2] for further details).
  - The mean and the empirical covariance of the observations that are known
    to be good ones. This can be considered as a "perfect" MCD estimation,
    so one can trust our implementation by comparing to this case.
@@ -66,8 +60,6 @@ range_n_outliers = np.concatenate(
 # definition of arrays to store results
 err_loc_mcd = np.zeros((range_n_outliers.size, repeat))
 err_cov_mcd = np.zeros((range_n_outliers.size, repeat))
-err_loc_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
-err_cov_mcd_reweighted = np.zeros((range_n_outliers.size, repeat))
 err_loc_emp_full = np.zeros((range_n_outliers.size, repeat))
 err_cov_emp_full = np.zeros((range_n_outliers.size, repeat))
 err_loc_emp_pure = np.zeros((range_n_outliers.size, repeat))
@@ -87,15 +79,10 @@ for i, n_outliers in enumerate(range_n_outliers):
         inliers_mask[outliers_index] = False
 
         # fit a Minimum Covariance Determinant (MCD) robust estimator to data
-        S = MinCovDet(reweighting=None).fit(X)
-        # compare robust estimates with the true location and covariance
+        S = MinCovDet().fit(X)
+        # compare raw robust estimates with the true location and covariance
         err_loc_mcd[i, j] = np.sum(S.location_ ** 2)
         err_cov_mcd[i, j] = S.error_norm(np.eye(n_features))
-        # reweight MCD robust estimator
-        S.reweight(data=X, permanent=True)
-        # compare robust estimates with the true location and covariance
-        err_loc_mcd_reweighted[i, j] = np.sum(S.location_ ** 2)
-        err_cov_mcd_reweighted[i, j] = S.error_norm(np.eye(n_features))
         # compare estimators learnt from the full data set with true parameters
         err_loc_emp_full[i, j] = np.sum(X.mean(0) ** 2)
         err_cov_emp_full[i, j] = EmpiricalCovariance().fit(X).error_norm(
@@ -113,10 +100,7 @@ font_prop = matplotlib.font_manager.FontProperties(size=11)
 pl.subplot(2, 1, 1)
 pl.errorbar(range_n_outliers, err_loc_mcd.mean(1),
             yerr=err_loc_mcd.std(1) / np.sqrt(repeat),
-            label="Robust location", color='cyan')
-pl.errorbar(range_n_outliers, err_loc_mcd_reweighted.mean(1),
-            yerr=err_loc_mcd_reweighted.std(1) / np.sqrt(repeat),
-            label="Robust location (reweighted)", color='blue')
+            label="Robust location", color='m')
 pl.errorbar(range_n_outliers, err_loc_emp_full.mean(1),
             yerr=err_loc_emp_full.std(1) / np.sqrt(repeat),
             label="Full data set mean", color='green')
@@ -131,10 +115,7 @@ pl.subplot(2, 1, 2)
 x_size = range_n_outliers.size
 pl.errorbar(range_n_outliers, err_cov_mcd.mean(1),
             yerr=err_cov_mcd.std(1),
-            label="Robust covariance (MCD)", color='cyan')
-pl.errorbar(range_n_outliers, err_cov_mcd_reweighted.mean(1),
-            yerr=err_cov_mcd_reweighted.std(1),
-            label="Robust covariance (reweighted MCD)", color='blue')
+            label="Robust covariance (MCD)", color='m')
 pl.errorbar(range_n_outliers[:(x_size / 5 + 1)],
             err_cov_emp_full.mean(1)[:(x_size / 5 + 1)],
             yerr=err_cov_emp_full.std(1)[:(x_size / 5 + 1)],

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -58,7 +58,10 @@ from sklearn.covariance import EmpiricalCovariance, MinCovDet
 n_samples = 80
 n_features = 5
 repeat = 10
-range_n_outliers = np.arange(0, n_samples / 2, 5)
+
+range_n_outliers = np.concatenate(
+    (np.linspace(0, n_samples / 8, 5),
+     np.linspace(n_samples / 8, n_samples / 2, 5)[1:-1]))
 
 # definition of arrays to store results
 err_loc_mcd = np.zeros((range_n_outliers.size, repeat))
@@ -145,6 +148,6 @@ pl.errorbar(range_n_outliers, err_cov_emp_pure.mean(1),
 pl.title("Influence of outliers on the covariance estimation")
 pl.xlabel("Amount of contamination (%)")
 pl.ylabel("RMSE")
-pl.legend(loc="upper right", prop=font_prop)
+pl.legend(loc="upper center", prop=font_prop)
 
 pl.show()

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -14,5 +14,5 @@ from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
     log_likelihood
 from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
     ledoit_wolf, LedoitWolf, oas, OAS
-from .robust_covariance import fast_mcd, MCD
+from .robust_covariance import fast_mcd, MinCovDet
 from graph_lasso_ import graph_lasso, GraphLasso, GraphLassoCV

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -11,6 +11,7 @@ Maximum likelihood covariance estimator.
 
 # avoid division truncation
 from __future__ import division
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -55,7 +56,9 @@ def empirical_covariance(X, assume_centered=False):
     """
     X = np.asarray(X)
     if X.ndim == 1:
-        X = np.atleast_2d(X).T
+        X = np.reshape(X, (1, -1))
+        warnings.warn("Only one sample available. " \
+                          "You may want to reshape your data array")
 
     if assume_centered:
         covariance = np.dot(X.T, X) / X.shape[0]

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -20,7 +20,7 @@ from ..utils.extmath import fast_logdet
 
 
 def log_likelihood(emp_cov, precision):
-    """Computes the negative log_likelihood of the data
+    """Computes the log_likelihood of the data
 
     Params
     ------

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -98,8 +98,8 @@ class EmpiricalCovariance(BaseEstimator):
         Params
         ------
         covariance: 2D ndarray, shape (n_features, n_features)
-            Estimated covariance matrix to be stored, and from which precision
-            is computed.
+          Estimated covariance matrix to be stored, and from which precision
+          is computed.
 
         """
         covariance = array2d(covariance)
@@ -151,8 +151,8 @@ class EmpiricalCovariance(BaseEstimator):
         Returns
         -------
         res: float
-            The likelihood of the data set with self.covariance_ as an
-            estimator of its covariance matrix.
+          The likelihood of the data set with self.covariance_ as an
+          estimator of its covariance matrix.
 
         """
         # compute empirical covariance of the test set

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy import linalg
 from scipy.stats import chi2
 from . import empirical_covariance, EmpiricalCovariance
-from ..utils.extmath import fast_logdet as exact_logdet
+from ..utils.extmath import fast_logdet
 
 
 ###############################################################################
@@ -23,12 +23,8 @@ from ..utils.extmath import fast_logdet as exact_logdet
 #   for Quality, TECHNOMETRICS)
 ###############################################################################
 def c_step(X, h, remaining_iterations=30, initial_estimates=None,
-           verbose=False, covariance_computation_method=empirical_covariance):
+           verbose=False, cov_computation_method=empirical_covariance):
     """C_step procedure described in [1] aiming at computing the MCD
-
-    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
-        1999, American Statistical Association and the American Society
-        for Quality, TECHNOMETRICS
 
     Parameters
     ----------
@@ -52,13 +48,20 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
 
     Returns
     -------
-    T: array-like, shape (n_features,)
+    location: array-like, shape (n_features,)
       Robust location estimates
-    S: array-like, shape (n_features, n_features)
+    covariance: array-like, shape (n_features, n_features)
       Robust covariance estimates
-    H: array-like, shape (n_samples,)
+    support: array-like, shape (n_samples,)
       A mask for the `h` observations whose scatter matrix has minimum
       determinant
+
+    Notes
+    -----
+    References:
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
 
     """
     n_samples, n_features = X.shape
@@ -68,70 +71,71 @@ def c_step(X, h, remaining_iterations=30, initial_estimates=None,
         # compute initial robust estimates from a random subset
         support = np.zeros(n_samples).astype(bool)
         support[np.random.permutation(n_samples)[:h]] = True
-        T = X[support].mean(0)
-        S = covariance_computation_method(X[support])
+        location = X[support].mean(0)
+        covariance = cov_computation_method(X[support])
     else:
         # get initial robust estimates from the function parameters
-        T = initial_estimates[0]
-        S = initial_estimates[1]
+        location = initial_estimates[0]
+        covariance = initial_estimates[1]
         # run a special iteration for that case (to get an initial support)
-        inv_S = linalg.pinv(S)
-        X_centered = X - T
-        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        precision = linalg.pinv(covariance)
+        X_centered = X - location
+        dist = (np.dot(X_centered, precision) * X_centered).sum(1)
         # compute new estimates
         support = np.zeros(n_samples).astype(bool)
         support[np.argsort(dist)[:h]] = True
-        T = X[support].mean(0)
-        S = covariance_computation_method(X[support])
-        detS = exact_logdet(S)
-    previous_detS = np.inf
+        location = X[support].mean(0)
+        covariance = cov_computation_method(X[support])
+        det = fast_logdet(covariance)
+    previous_det = np.inf
 
     # Iterative procedure for Minimum Covariance Determinant computation
-    detS = exact_logdet(S)
-    while (detS < previous_detS) and (remaining_iterations > 0):
+    det = fast_logdet(covariance)
+    while (det < previous_det) and (remaining_iterations > 0):
         # compute a new support from the full data set mahalanobis distances
-        inv_S = linalg.pinv(S)
-        X_centered = X - T
-        dist = (np.dot(X_centered, inv_S) * X_centered).sum(1)
+        precision = linalg.pinv(covariance)
+        X_centered = X - location
+        dist = (np.dot(X_centered, precision) * X_centered).sum(1)
         # save old estimates values
-        previous_T = T
-        previous_S = S
-        previous_detS = detS
+        previous_location = location
+        previous_covariance = covariance
+        previous_det = det
         previous_support = support
         # compute new estimates
         support = np.zeros(n_samples).astype(bool)
         support[np.argsort(dist)[:h]] = True
-        T = X[support].mean(0)
-        S = covariance_computation_method(X[support])
-        detS = np.log(linalg.det(S))
+        location = X[support].mean(0)
+        covariance = cov_computation_method(X[support])
+        det = np.log(linalg.det(covariance))
         # update remaining iterations for early stopping
         remaining_iterations = remaining_iterations - 1
 
     # Check convergence
-    if np.allclose(detS, previous_detS):
+    if np.allclose(det, previous_det):
         # c_step procedure converged
         if verbose:
-            print 'Optimal couple (T,S) found before ending iterations' \
-                '(%d left)' % (remaining_iterations)
-        results = T, S, detS, support
-    elif detS > previous_detS:
+            print "Optimal couple (location, covariance) found before" \
+                "ending iterations (%d left)" % (remaining_iterations)
+        results = location, covariance, det, support
+    elif det > previous_det:
         # determinant has increased (should not happen)
-        warnings.warn("Warning! detS > previous_detS (%.15f > %.15f)" \
-                          % (detS, previous_detS), RuntimeWarning)
-        results = previous_T, previous_S, previous_detS, previous_support
+        warnings.warn("Warning! det > previous_det (%.15f > %.15f)" \
+                          % (det, previous_det), RuntimeWarning)
+        results = previous_location, previous_covariance, \
+            previous_det, previous_support
 
     # Check early stopping
     if remaining_iterations == 0:
         if verbose:
             print 'Maximum number of iterations reached'
-        detS = exact_logdet(S)
-        results = T, S, detS, support
+        det = fast_logdet(covariance)
+        results = location, covariance, det, support
 
     return results
 
 
 def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False,
-                      covariance_computation_method=empirical_covariance):
+                      cov_computation_method=empirical_covariance):
     """Finds the best pure subset of observations to compute MCD from it.
 
     The purpose of this function is to find the best sets of h
@@ -143,10 +147,6 @@ def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False,
 
     Starting from a random support, the pure data set is found by the
     c_step procedure introduced by Rousseeuw and Van Driessen in [1].
-
-    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
-        1999, American Statistical Association and the American Society
-        for Quality, TECHNOMETRICS
 
     Parameters
     ----------
@@ -176,14 +176,21 @@ def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False,
 
     Returns
     -------
-    best_T: array-like, shape (select, n_features)
+    best_locations: array-like, shape (select, n_features)
       The `select` location estimates computed from the `select` best
       supports found in the data set (`X`)
-    best_S: array-like, shape (select, n_features, n_features)
+    best_covariances: array-like, shape (select, n_features, n_features)
       The `select` covariance estimates computed from the `select`
       best supports found in the data set (`X`)
-    best_H: array-like, shape (select, n_samples)
+    best_supports: array-like, shape (select, n_samples)
       The `select` best supports found in the data set (`X`)
+
+    Notes
+    -----
+    References:
+    [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+        1999, American Statistical Association and the American Society
+        for Quality, TECHNOMETRICS
 
     """
     n_samples, n_features = X.shape
@@ -198,36 +205,35 @@ def select_candidates(X, h, n_trials, select=1, n_iter=30, verbose=False,
         raise Exception('Bad \'n_trials\' parameter (wrong type)')
 
     # compute `n_trials` location and shape estimates candidates in the subset
-    all_T_sub = np.zeros((n_trials, n_features))
-    all_S_sub = np.zeros((n_trials, n_features, n_features))
-    all_detS_sub = np.zeros(n_trials)
-    all_H_sub = np.zeros((n_trials, n_samples)).astype(bool)
+    all_estimates = []
     if not run_from_estimates:
         # perform `n_trials` computations from random initial supports
         for j in range(n_trials):
-            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
-                X, h, remaining_iterations=n_iter, verbose=verbose,
-                covariance_computation_method=covariance_computation_method)
+            all_estimates.append(
+                c_step(
+                    X, h, remaining_iterations=n_iter, verbose=verbose,
+                    cov_computation_method=cov_computation_method))
     else:
         # perform computations from every given initial estimates
         for j in range(n_trials):
-            all_T_sub[j], all_S_sub[j], all_detS_sub[j], all_H_sub[j] = c_step(
-                X, h, remaining_iterations=n_iter,
-                initial_estimates=(estimates_list[0][j], estimates_list[1][j]),
-                verbose=verbose,
-                covariance_computation_method=covariance_computation_method)
-
+            initial_estimates = (estimates_list[0][j], estimates_list[1][j])
+            all_estimates.append(c_step(
+                    X, h, remaining_iterations=n_iter,
+                    initial_estimates=initial_estimates, verbose=verbose,
+                    cov_computation_method=cov_computation_method))
+    all_locations_sub, all_covariances_sub, all_dets_sub, all_supports_sub = \
+                                     zip(*all_estimates)
     # find the `n_best` best results among the `n_trials` ones
-    index_best = np.argsort(all_detS_sub)[:select]
-    best_T = all_T_sub[index_best]
-    best_S = all_S_sub[index_best]
-    best_H = all_H_sub[index_best]
+    index_best = np.argsort(all_dets_sub)[:select]
+    best_locations = np.asarray(all_locations_sub)[index_best]
+    best_covariances = np.asarray(all_covariances_sub)[index_best]
+    best_supports = np.asarray(all_supports_sub)[index_best]
 
-    return best_T, best_S, best_H
+    return best_locations, best_covariances, best_supports
 
 
 def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
-             covariance_computation_method=empirical_covariance):
+             cov_computation_method=empirical_covariance):
     """Estimates the Minimum Covariance Determinant matrix.
 
     The FastMCD algorithm has been introduced by Rousseuw and Van Driessen
@@ -262,7 +268,9 @@ def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
           data set before computing location and covariance estimates)
         - else: no reweighting
 
-
+    Notes
+    -----
+    References:
     [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
         1999, American Statistical Association and the American Society
         for Quality, TECHNOMETRICS
@@ -272,19 +280,24 @@ def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
 
     Returns
     -------
-    T: array-like, shape (n_features,)
+    location: array-like, shape (n_features,)
       Robust location of the data
-    S: array-like, shape (n_features, n_features)
+    covariance: array-like, shape (n_features, n_features)
       Robust covariance of the features
     support: array-like, type boolean, shape (n_samples,)
       a mask of the observations that have been used to compute
       the robust location and covariance estimates of the data set
 
     """
-    X = np.asarray(X)
-    if X.ndim <= 1:
-        X = X.reshape((-1, 1))
-    n_samples, n_features = X.shape
+    X = np.asanyarray(X)
+    if X.ndim == 1:
+        X = np.reshape(X, (1, -1))
+        warnings.warn("Only one sample available. " \
+                          "You may want to reshape your data array")
+        n_samples = 1
+        n_features = X.size
+    else:
+        n_samples, n_features = X.shape
 
     # minimum breakdown value
     if h is None:
@@ -301,12 +314,12 @@ def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
         diff = X_sorted[h:] - X_sorted[:(n_samples - h)]
         halves_start = np.where(diff == np.min(diff))[0]
         # take the middle points' mean to get the robust location estimate
-        T = 0.5 * (X_sorted[h + halves_start] + X_sorted[halves_start]).mean()
+        location = 0.5 * \
+            (X_sorted[h + halves_start] + X_sorted[halves_start]).mean()
         support = np.zeros(n_samples).astype(bool)
-        support[np.argsort(np.abs(X - T), axis=0)[:h]] = True
-        S = np.asarray([[np.var(X[support])]])
-        T = np.array([T])
-        H = support
+        support[np.argsort(np.abs(X - location), axis=0)[:h]] = True
+        covariance = np.asarray([[np.var(X[support])]])
+        location = np.array([location])
 
     ### Starting FastMCD algorithm for p-dimensional case
     if (n_samples > 500) and (n_features > 1):
@@ -319,22 +332,22 @@ def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
         # b. perform a total of 500 trials
         n_trials_tot = 500
         n_trials = n_trials_tot / n_subsets
-        # c. select 10 best (T,S) for each subset
+        # c. select 10 best (location, covariance) for each subset
         n_best_sub = 10
         n_best_tot = n_subsets * n_best_sub
-        all_best_T = np.zeros((n_best_tot, n_features))
-        all_best_S = np.zeros((n_best_tot, n_features, n_features))
+        all_best_locations = np.zeros((n_best_tot, n_features))
+        all_best_covariances = np.zeros((n_best_tot, n_features, n_features))
         for i in range(n_subsets):
             low_bound = i * n_samples_subsets
             high_bound = low_bound + n_samples_subsets
             current_subset = X[samples_shuffle[low_bound:high_bound]]
-            best_T_sub, best_S_sub, _ = select_candidates(
+            best_locations_sub, best_covariances_sub, _ = select_candidates(
                 current_subset, h_subset, n_trials,
                 select=n_best_sub, n_iter=2,
-                covariance_computation_method=covariance_computation_method)
+                cov_computation_method=cov_computation_method)
             subset_slice = np.arange(i * n_best_sub, (i + 1) * n_best_sub)
-            all_best_T[subset_slice] = best_T_sub
-            all_best_S[subset_slice] = best_S_sub
+            all_best_locations[subset_slice] = best_locations_sub
+            all_best_covariances[subset_slice] = best_covariances_sub
         ## 2. Pool the candidate supports into a merged set
         ##    (possibly the full dataset)
         n_samples_merged = min(1500, n_samples)
@@ -343,49 +356,55 @@ def fast_mcd(X, h=None, correction="empirical", reweighting="rousseeuw",
             n_best_merged = 10
         else:
             n_best_merged = 1
-        # find the best couples (T,S) on the merged set
-        T_merged, S_merged, H_merged = select_candidates(
+        # find the best couples (location, covariance) on the merged set
+        locations_merged, covariances_merged, supports_merged = \
+            select_candidates(
             X[np.random.permutation(n_samples)[:n_samples_merged]],
-            h_merged, n_trials=(all_best_T, all_best_S), select=n_best_merged,
-            covariance_computation_method=covariance_computation_method)
-        ## 3. Finally get the overall best (T,S) couple
+            h_merged, n_trials=(all_best_locations, all_best_covariances),
+            select=n_best_merged,
+            cov_computation_method=cov_computation_method)
+        ## 3. Finally get the overall best (locations, covariance) couple
         if n_samples < 1500:
-            # directly get the best couple (T,S)
-            T = T_merged[0]
-            S = S_merged[0]
-            H = H_merged[0]
+            # directly get the best couple (location, covariance)
+            location = locations_merged[0]
+            covariance = covariances_merged[0]
+            support = supports_merged[0]
         else:
             # select the best couple on the full dataset
-            T_full, S_full, H_full = select_candidates(
-                X, h, n_trials=(T_merged, S_merged), select=1,
-                covariance_computation_method=covariance_computation_method)
-            T = T_full[0]
-            S = S_full[0]
-            H = H_full[0]
+            locations_full, covariances_full, supports_full = \
+                select_candidates(
+                X, h, n_trials=(locations_merged, covariances_merged),
+                select=1,
+                cov_computation_method=cov_computation_method)
+            location = locations_full[0]
+            covariance = covariances_full[0]
+            support = supports_full[0]
     elif n_features > 1:
-        ## 1. Find the 10 best couples (T,S) considering two iterations
+        ## 1. Find the 10 best couples (location, covariance)
+        ## considering two iterations
         n_trials = 30
         n_best = 10
-        T_best, S_best, _ = select_candidates(
+        locations_best, covariances_best, _ = select_candidates(
             X, h, n_trials=n_trials, select=n_best, n_iter=2,
-            covariance_computation_method=covariance_computation_method)
+            cov_computation_method=cov_computation_method)
         ## 2. Select the best couple on the full dataset amongst the 10
-        T_full, S_full, H_full = select_candidates(
-            X, h, n_trials=(T_best, S_best), select=1,
-            covariance_computation_method=covariance_computation_method)
-        T = T_full[0]
-        S = S_full[0]
-        H = H_full[0]
+        locations_full, covariances_full, supports_full = select_candidates(
+            X, h, n_trials=(locations_best, covariances_best), select=1,
+            cov_computation_method=cov_computation_method)
+        location = locations_full[0]
+        covariance = covariances_full[0]
+        support = supports_full[0]
 
     ## 4. Obtain consistency at Gaussian models
-    S_corrected = _correct(T, S, H, correction, data=X)
+    covariance_corrected = _correct(
+        location, covariance, support, correction, data=X)
 
     ## 5. Reweight estimate
-    T_reweighted, S_reweighted, support = _reweight(
-            T, S_corrected, H, reweighting, data=X,
-            covariance_computation_method=covariance_computation_method)
+    location_reweighted, covariance_reweighted, support = _reweight(
+        location, covariance_corrected, support, reweighting, data=X,
+        cov_computation_method=cov_computation_method)
 
-    return T_reweighted, S_reweighted, support
+    return location_reweighted, covariance_reweighted, support
 
 
 def _correct(location, covariance, support, correction="empirical", data=None):
@@ -395,7 +414,7 @@ def _correct(location, covariance, support, correction="empirical", data=None):
     ----------
     location: array-like, shape (n_features,)
       Raw robust location estimate.
-    S: array-like, shape (n_features, n_features)
+    covariance: array-like, shape (n_features, n_features)
       Raw robust covariance estimate.
     support: array-like, type boolean, shape (n_samples,)
       A mask of the observations that have been used to compute
@@ -413,7 +432,7 @@ def _correct(location, covariance, support, correction="empirical", data=None):
 
     Returns
     -------
-    S_corrected: array-like, shape (n_features, n_features)
+    covariance_corrected: array-like, shape (n_features, n_features)
       Corrected robust covariance estimate.
 
     """
@@ -423,36 +442,36 @@ def _correct(location, covariance, support, correction="empirical", data=None):
     if correction == "theoretical":
         # theoretical correction
         inliers_ratio = h / float(n_samples)
-        S_corrected = covariance * (inliers_ratio) \
+        covariance_corrected = covariance * (inliers_ratio) \
             / chi2(n_features + 2).cdf(chi2(n_features).ppf(inliers_ratio))
     elif correction == "empirical":
+        # empirical correction
         if data is None:
             raise ValueError("Need `data` for empirical correction")
         else:
-            # empirical correction
             X_centered = data - location
             dist = np.sum(
                     np.dot(X_centered, linalg.pinv(covariance)) * X_centered,
                     1)
-            S_corrected = covariance * \
+            covariance_corrected = covariance * \
                               (np.median(dist) / chi2(n_features).isf(0.5))
     else:
         # no correction
-        S_corrected = covariance
+        covariance_corrected = covariance
 
-    return S_corrected
+    return covariance_corrected
 
 
 def _reweight(location, covariance, support,
               reweighting="rousseeuw", data=None,
-              covariance_computation_method=empirical_covariance):
+              cov_computation_method=empirical_covariance):
     """Reweight a raw Minimum Covariance Determinant estimate
 
     Parameters
     ----------
     location: array-like, shape (n_features,)
       Raw robust location estimate.
-    S: array-like, shape (n_features, n_features)
+    covariance: array-like, shape (n_features, n_features)
       Raw robust covariance estimate.
     support: array-like, type boolean, shape (n_samples,)
       A mask of the observations that have been used to compute
@@ -469,9 +488,9 @@ def _reweight(location, covariance, support,
 
     Returns
     -------
-    T_reweighted: array-like, shape (n_features, )
+    location_reweighted: array-like, shape (n_features, )
       Reweighted robust location estimate.
-    S_reweighted: array-like, shape (n_features, n_features)
+    covariance_reweighted: array-like, shape (n_features, n_features)
       Reweighted robust covariance estimate.
     support: array-like, type boolean, shape (n_samples,)
       A mask of the observations that have been used to compute
@@ -489,16 +508,16 @@ def _reweight(location, covariance, support,
                 np.dot(X_centered, linalg.pinv(covariance)) * X_centered,
                 1)
             mask = dist < chi2(n_features).isf(0.025)
-            T_reweighted = data[mask].mean(0)
-            S_reweighted = covariance_computation_method(data[mask])
+            location_reweighted = data[mask].mean(0)
+            covariance_reweighted = cov_computation_method(data[mask])
             support = np.zeros(n_samples).astype(bool)
             support[mask] = True
     else:
-        T_reweighted = location
-        S_reweighted = covariance
+        location_reweighted = location
+        covariance_reweighted = covariance
         support = support
 
-    return T_reweighted, S_reweighted, support
+    return location_reweighted, covariance_reweighted, support
 
 
 class MinCovDet(EmpiricalCovariance):
@@ -521,11 +540,6 @@ class MinCovDet(EmpiricalCovariance):
     The FastMCD algorithm also computes a robust estimate of the data set
     location at the same time.
 
-    Parameters
-    ----------
-    store_precision: bool
-        Specify if the estimated precision is stored
-
     Attributes
     ----------
     `location_`: array-like, shape (n_features,)
@@ -542,25 +556,9 @@ class MinCovDet(EmpiricalCovariance):
         A mask of the observations that have been used to compute
         the robust estimates of location and shape.
 
-    `h`: float, 0 < h < 1
-        The proportion of points to be included in the support of the raw
-        MCD estimate.
-
-    `correction`: str
-        Improve the covariance estimator consistency at gaussian models
-          - "empirical" (default): correction using the empirical correction
-            factor suggested by Rousseeuw and Van Driessen in [2]
-          - "theoretical": correction using the theoretical correction factor
-            derived in [3]
-          - else: no correction
-
-    `reweighting`: str
-        Computation of a reweighted MCD estimator:
-          - "rousseeuw" (default): Reweight observations using Rousseeuw's
-            method (equivalent to deleting outlying observations from the
-            data set before computing location and covariance estimates)
-          - else: no reweighting
-
+    Notes
+    -----
+    References:
     [1] P. J. Rousseeuw. Least median of squares regression. J. Am
         Stat Ass, 79:871, 1984.
     [2] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
@@ -574,6 +572,11 @@ class MinCovDet(EmpiricalCovariance):
     def __init__(self, store_precision=True, assume_centered=False,
                  h=None, correction="empirical", reweighting="rousseeuw"):
         """
+
+        Parameters
+        ----------
+        store_precision: bool
+          Specify if the estimated precision is stored
         assume_centered: Boolean
           If True, the support of robust location and covariance estimates
           is computed, and a covariance estimate is recomputed from it,
@@ -600,9 +603,6 @@ class MinCovDet(EmpiricalCovariance):
               method (equivalent to deleting outlying observations from the
               data set before computing location and covariance estimates)
             - else: no re-weighting
-        shrinkage: float
-          The amount of shrinkage (ridge regularization) for ill-conditionned
-          matrices.
         """
         self.store_precision = store_precision
         self.assume_centered = assume_centered
@@ -621,18 +621,21 @@ class MinCovDet(EmpiricalCovariance):
 
         Returns
         -------
-        self : object
-            Returns self.
+        self: object
+          Returns self.
 
         """
+        n_samples, n_features = X.shape
         # compute and store raw estimates
         raw_location, raw_covariance, raw_support = fast_mcd(
                 X, h=self.h, correction=None, reweighting=None,
-                covariance_computation_method=self._nonrobust_covariance)
+                cov_computation_method=self._nonrobust_covariance)
         if self.assume_centered:
-            raw_location = np.zeros(raw_location.shape[0])
+            raw_location = np.zeros(n_features)
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
+        if self.h is None:
+            self.h = int(np.ceil(0.5 * (n_samples + n_features + 1)))
         self.raw_location_ = raw_location
         self.raw_covariance_ = raw_covariance
         self.raw_support_ = raw_support
@@ -686,16 +689,26 @@ class MinCovDet(EmpiricalCovariance):
 
         Returns
         -------
-        S: array-like, shape (n_features, n_features)
+        covariance: array-like, shape (n_features, n_features)
           Corrected robust covariance estimate.
 
+        Notes
+        -----
+        References:
+        [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
+            1999, American Statistical Association and the American Society
+            for Quality, TECHNOMETRICS
+        [2] R. W. Butler, P. L. Davies and M. Jhun,
+            Asymptotics For The Minimum Covariance Determinant Estimator,
+            The Annals of Statistics, 1993, Vol. 21, No. 3, 1385-1400
+
         """
-        S = _correct(self.raw_location_, self.raw_covariance_,
+        covariance = _correct(self.raw_location_, self.raw_covariance_,
                      self.raw_support_, correction, data=data)
         if permanent:
-            self._set_estimates(S)
+            self._set_estimates(covariance)
             self.correction = correction
-        return S
+        return covariance
 
     def reweight(self, reweighting="rousseeuw", data=None, permanent=False):
         """Reweight raw Minimum Covariance Determinant estimates.
@@ -718,22 +731,22 @@ class MinCovDet(EmpiricalCovariance):
 
         Returns
         -------
-        T: array-like, shape (n_features, )
+        location: array-like, shape (n_features, )
           Reweighted robust location estimate.
-        S: array-like, shape (n_features, n_features)
+        covariance: array-like, shape (n_features, n_features)
           Reweighted robust covariance estimate.
-        H: array-like, type boolean, shape (n_samples,)
+        support: array-like, type boolean, shape (n_samples,)
           A mask of the observations that have been used to compute
           the reweighted robust location and covariance estimates.
 
         """
-        T, S, H = _reweight(
+        location, covariance, support = _reweight(
                 self.location_, self.covariance_, self.support_,
                 reweighting, data=data,
-                covariance_computation_method=self._nonrobust_covariance)
+                cov_computation_method=self._nonrobust_covariance)
         if permanent:
-            self._set_estimates(S)
-            self.location_ = T
-            self.support_ = H
+            self._set_estimates(covariance)
+            self.location_ = location
+            self.support_ = support
             self.reweighting = reweighting
-        return T, S, H
+        return location, covariance, support

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -14,7 +14,7 @@ shrunk_cov = (1-shrinkage)*cov + shrinkage*structured_estimate.
 
 # avoid division truncation
 from __future__ import division
-
+import warnings
 import numpy as np
 
 from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance
@@ -122,8 +122,8 @@ class ShrunkCovariance(EmpiricalCovariance):
             Returns self.
 
         """
-        empirical_cov = empirical_covariance(X,
-                                             assume_centered=assume_centered)
+        empirical_cov = empirical_covariance(
+            X, assume_centered=assume_centered)
         covariance = shrunk_covariance(empirical_cov, self.shrinkage)
         self._set_estimates(covariance)
 
@@ -168,11 +168,18 @@ def ledoit_wolf(X, assume_centered=False):
     """
     X = np.asarray(X)
     # for only one feature, the result is the same whatever the shrinkage
-    if X.ndim == 1:
+    if len(X.shape) == 2 and X.shape[1] == 1:
         if not assume_centered:
             X = X - X.mean()
         return np.atleast_2d((X ** 2).mean()), 0.
-    n_samples, n_features = X.shape
+    if X.ndim == 1:
+        X = np.reshape(X, (1, -1))
+        warnings.warn("Only one sample available. " \
+                          "You may want to reshape your data array")
+        n_samples = 1
+        n_features = X.size
+    else:
+        n_samples, n_features = X.shape
 
     # optionaly center data
     if not assume_centered:
@@ -306,11 +313,18 @@ def oas(X, assume_centered=False):
     """
     X = np.asarray(X)
     # for only one feature, the result is the same whatever the shrinkage
-    if X.ndim == 1:
+    if len(X.shape) == 2 and X.shape[1] == 1:
         if not assume_centered:
             X = X - X.mean()
         return np.atleast_2d((X ** 2).mean()), 0.
-    n_samples, n_features = X.shape
+    if X.ndim == 1:
+        X = np.reshape(X, (1, -1))
+        warnings.warn("Only one sample available. " \
+                          "You may want to reshape your data array")
+        n_samples = 1
+        n_features = X.size
+    else:
+        n_samples, n_features = X.shape
 
     emp_cov = empirical_covariance(X, assume_centered=assume_centered)
     mu = np.trace(emp_cov) / n_features

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -41,6 +41,7 @@ def test_covariance():
     assert(np.amin(mahal_dist) > 50)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     cov = EmpiricalCovariance()
     cov.fit(X_1d)
     assert_array_almost_equal(empirical_covariance(X_1d), cov.covariance_, 4)
@@ -63,8 +64,7 @@ def test_shrunk_covariance():
     cov.fit(X)
     assert_array_almost_equal(
         shrunk_covariance(empirical_covariance(X), shrinkage=0.5),
-        cov.covariance_, 4
-        )
+        cov.covariance_, 4)
 
     # same test with shrinkage not provided
     cov = ShrunkCovariance()
@@ -78,6 +78,7 @@ def test_shrunk_covariance():
     assert_array_almost_equal(empirical_covariance(X), cov.covariance_, 4)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     cov = ShrunkCovariance(shrinkage=0.3)
     cov.fit(X_1d)
     assert_array_almost_equal(empirical_covariance(X_1d), cov.covariance_, 4)
@@ -108,6 +109,7 @@ def test_ledoit_wolf():
     assert_array_almost_equal(scov.covariance_, lw.covariance_, 4)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     lw = LedoitWolf()
     lw.fit(X_1d, assume_centered=True)
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X_1d,
@@ -138,6 +140,7 @@ def test_ledoit_wolf():
     assert_array_almost_equal(scov.covariance_, lw.covariance_, 4)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     lw = LedoitWolf()
     lw.fit(X_1d)
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X_1d)
@@ -171,6 +174,7 @@ def test_oas():
     assert_array_almost_equal(scov.covariance_, oa.covariance_, 4)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     oa = OAS()
     oa.fit(X_1d, assume_centered=True)
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X_1d, assume_centered=True)
@@ -200,6 +204,7 @@ def test_oas():
     assert_array_almost_equal(scov.covariance_, oa.covariance_, 4)
 
     # test with n_features = 1
+    X_1d = X[:, 0].reshape((-1, 1))
     oa = OAS()
     oa.fit(X_1d)
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X_1d)

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -223,76 +223,48 @@ def test_mcd():
     """Tests the FastMCD algorithm implementation
 
     """
-    yield generator_mcd, "empirical"
-    yield generator_mcd, "theoretical"
-
-
-def generator_mcd(correction):
-    """Tests the fastMCD algorithm implementation with a given correction type
-
-    """
     ### Small data set
     # test without outliers (random independant normal data)
-    launch_mcd_on_dataset(100, 5, 0, 0.3, 0.3, 70, correction)
+    launch_mcd_on_dataset(100, 5, 0, 0.01, 0.1, 80)
     # test with a contaminated data set (medium contamination)
-    launch_mcd_on_dataset(100, 5, 20, 0.1, 0.2, 65, correction)
+    launch_mcd_on_dataset(100, 5, 20, 0.01, 0.01, 70)
     # test with a contaminated data set (strong contamination)
-    launch_mcd_on_dataset(100, 5, 40, 0.1, 0.1, 50, correction)
+    launch_mcd_on_dataset(100, 5, 40, 0.1, 0.1, 50)
 
     ### Medium data set
-    launch_mcd_on_dataset(1000, 5, 450, 1e-3, 0.01, 540, correction)
+    launch_mcd_on_dataset(1000, 5, 450, 1e-3, 1e-3, 540)
 
     ### Large data set
-    launch_mcd_on_dataset(1700, 5, 800, 1e-3, 1e-3, 870, correction)
+    launch_mcd_on_dataset(1700, 5, 800, 1e-3, 1e-3, 870)
 
     ### 1D data set
-    launch_mcd_on_dataset(500, 1, 100, 0.1, 0.1, 350, correction)
+    launch_mcd_on_dataset(500, 1, 100, 0.001, 0.001, 350)
 
 
-def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
-                          tol_loc, tol_cov, tol_support, correction):
+def launch_mcd_on_dataset(
+    n_samples, n_features, n_outliers, tol_loc, tol_cov, tol_support):
     """
 
     """
-    data = np.random.randn(n_samples, n_features)
+    rand_gen = np.random.RandomState(0)
+    data = rand_gen.randn(n_samples, n_features)
     # add some outliers
-    outliers_index = np.random.permutation(n_samples)[:n_outliers]
+    outliers_index = rand_gen.permutation(n_samples)[:n_outliers]
     outliers_offset = 10. * \
-        (np.random.randint(2, size=(n_outliers, n_features)) - 0.5)
+        (rand_gen.randint(2, size=(n_outliers, n_features)) - 0.5)
     data[outliers_index] += outliers_offset
     inliers_mask = np.ones(n_samples).astype(bool)
     inliers_mask[outliers_index] = False
 
-    # compute MCD directly
-    T, S, H = fast_mcd(data, correction=correction)
-    # compare with the estimates learnt from the inliers
     pure_data = data[inliers_mask]
-    error_location = np.sum((pure_data.mean(0) - T) ** 2)
-    assert(error_location < tol_loc)
-    emp_cov = EmpiricalCovariance().fit(pure_data)
-    #print emp_cov.error_norm(S)
-    assert(emp_cov.error_norm(S) < tol_cov)
-    assert(np.sum(H) > tol_support)
-    # check improvement
-    if (n_outliers / float(n_samples) > 0.1) and (n_features > 1):
-        error_bad_location = np.sum((data.mean(0) - T) ** 2)
-        assert(error_bad_location > error_location)
-        bad_emp_cov = EmpiricalCovariance().fit(data)
-        assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))
-
     # compute MCD by fitting an object
     mcd_fit = MinCovDet().fit(data)
     T = mcd_fit.location_
     S = mcd_fit.covariance_
     H = mcd_fit.support_
     # compare with the estimates learnt from the inliers
-    error_location = np.sum((pure_data.mean(0) - T) ** 2)
+    error_location = np.mean((pure_data.mean(0) - T) ** 2)
     assert(error_location < tol_loc)
-    assert(emp_cov.error_norm(S) < tol_cov)
-    assert(np.sum(H) > tol_support)
-    # check improvement
-    if (n_outliers / float(n_samples) > 0.1) and (n_features > 1):
-        error_bad_location = np.sum((data.mean(0) - T) ** 2)
-        assert(error_bad_location > error_location)
-        bad_emp_cov = EmpiricalCovariance().fit(data)
-        assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))
+    error_cov = np.mean((empirical_covariance(pure_data) - S) ** 2)
+    assert(error_cov < tol_cov)
+    assert(np.sum(H) >= tol_support)

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -11,7 +11,7 @@ import numpy as np
 from sklearn import datasets
 from sklearn.covariance import empirical_covariance, EmpiricalCovariance, \
     ShrunkCovariance, shrunk_covariance, LedoitWolf, ledoit_wolf, OAS, oas, \
-    fast_mcd, MCD
+    fast_mcd, MinCovDet
 
 X = datasets.load_iris().data
 X_1d = X[:, 0]
@@ -228,7 +228,7 @@ def generator_mcd(correction):
     """
     ### Small data set
     # test without outliers (random independant normal data)
-    launch_mcd_on_dataset(100, 5, 0, 0.3, 0.2, 70, correction)
+    launch_mcd_on_dataset(100, 5, 0, 0.3, 0.3, 70, correction)
     # test with a contaminated data set (medium contamination)
     launch_mcd_on_dataset(100, 5, 20, 0.1, 0.2, 65, correction)
     # test with a contaminated data set (strong contamination)
@@ -276,7 +276,7 @@ def launch_mcd_on_dataset(n_samples, n_features, n_outliers,
         assert(emp_cov.error_norm(S) < bad_emp_cov.error_norm(S))
 
     # compute MCD by fitting an object
-    mcd_fit = MCD().fit(data)
+    mcd_fit = MinCovDet().fit(data)
     T = mcd_fit.location_
     S = mcd_fit.covariance_
     H = mcd_fit.support_


### PR DESCRIPTION
I need to reuse my MInimum Covariance Determinant code outside from sklearn. I propose a change in the code structure so that it will be easier to me to base my new code on the existing one.
What I want to do is to be able to plug any covariance estimator within the MCD computation. that's why I introduced a method `nonrobust_covariance` which only aims at computing a non-robust covariance in a consistent way accross the MCD computation. Just by changing what is inside this method, one can do what I want to do.
