### PR TITLE
Svm bench shogun

### DIFF
--- a/benchmarks/bench_svm.py
+++ b/benchmarks/bench_svm.py
@@ -26,7 +26,7 @@ svm_results = []
 mvpa_results = []
 shogun_libsvm_results = []
 
-mu_second = 0.0 + 10**6 # number of microseconds in a second
+mu_second = 0.0 + 10 ** 6  # number of microseconds in a second
 
 
 def bench_scikit(X, Y):
@@ -45,7 +45,7 @@ def bench_scikit(X, Y):
     delta = (datetime.now() - tstart)
     # stop time
 
-    scikit_results.append(delta.seconds + delta.microseconds/mu_second)
+    scikit_results.append(delta.seconds + delta.microseconds / mu_second)
 
 
 def bench_shogun_libsvm(X, Y):
@@ -66,7 +66,8 @@ def bench_shogun_libsvm(X, Y):
     svm.classify(features).get_labels()
 
     delta = (datetime.now() - tstart)
-    shogun_libsvm_results.append(delta.seconds + delta.microseconds / mu_second)
+    shogun_libsvm_results.append(delta.seconds
+            + delta.microseconds / mu_second)
 
 
 def bench_svm(X, Y):
@@ -85,13 +86,13 @@ def bench_svm(X, Y):
     tstart = datetime.now()
     problem = svmutil.svm_problem(Y1, X1)
     param = svmutil.svm_parameter()
-    param.svm_type=0
-    param.kernel_type=2
+    param.svm_type = 0
+    param.kernel_type = 2
     model = svmutil.svm_train(problem, param)
-    svmutil.svm_predict([0]*len(X1), X1, model)
+    svmutil.svm_predict([0] * len(X1), X1, model)
     delta = (datetime.now() - tstart)
     # stop time
-    svm_results.append(delta.seconds + delta.microseconds/mu_second)
+    svm_results.append(delta.seconds + delta.microseconds / mu_second)
 
 
 def bench_pymvpa(X, Y):
@@ -113,7 +114,7 @@ def bench_pymvpa(X, Y):
     delta = (datetime.now() - tstart)
 
     # stop time
-    mvpa_results.append(delta.seconds + delta.microseconds/mu_second)
+    mvpa_results.append(delta.seconds + delta.microseconds / mu_second)
 
 if __name__ == '__main__':
 
@@ -137,7 +138,7 @@ if __name__ == '__main__':
         bench_shogun_libsvm(X, Y)
 
     import pylab as pl
-    xx = range(0, n*step, step)
+    xx = range(0, n * step, step)
     pl.figure(1)
     pl.subplot(211)
     pl.title('SVM with varying number of samples')
@@ -148,7 +149,6 @@ if __name__ == '__main__':
     pl.legend()
     pl.xlabel('number of samples to classify')
     pl.ylabel('time (in microseconds)')
-
 
     # now do a bench where the number of points is fixed
     # and the variable is the number of dimensions
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         print '============================================'
         dim += step
         X, Y = np.random.randn(100, dim), np.random.randn(100)
-        Y = (10*Y).astype(np.int)
+        Y = (10 * Y).astype(np.int)
         # make labels positive and continuing numbers
         Y = np.unique(Y, return_inverse=True)[1]
         bench_scikit(X, Y)
@@ -179,7 +179,7 @@ if __name__ == '__main__':
         bench_pymvpa(X, Y)
         bench_shogun_libsvm(X, Y)
 
-    xx = np.arange(start_dim, start_dim+n*step, step)
+    xx = np.arange(start_dim, start_dim + n * step, step)
     pl.subplot(212)
     pl.title('Classification in high dimensional spaces')
     pl.plot(xx, mvpa_results, 'g-', label='pymvpa')

--- a/benchmarks/bench_svm.py
+++ b/benchmarks/bench_svm.py
@@ -39,7 +39,7 @@ def bench_scikit(X, Y):
 
     # start time
     tstart = datetime.now()
-    clf = SVC(kernel='rbf')
+    clf = SVC(kernel='rbf', gamma=1.)
     clf.fit(X, Y).predict(X)
     delta = (datetime.now() - tstart)
     # stop time

--- a/benchmarks/bench_svm.py
+++ b/benchmarks/bench_svm.py
@@ -106,6 +106,9 @@ if __name__ == '__main__':
         n_samples += step
         X = np.random.randn(n_samples, dim)
         Y = np.random.randn(n_samples)
+        Y = (10 * Y).astype(np.int)
+        # make labels positive and continuing numbers
+        Y = np.unique(Y, return_inverse=True)[1]
         bench_scikit(X, Y)
         bench_pymvpa(X, Y)
         bench_svm(X, Y)
@@ -144,6 +147,8 @@ if __name__ == '__main__':
         dim += step
         X, Y = np.random.randn(100, dim), np.random.randn(100)
         Y = (10*Y).astype(np.int)
+        # make labels positive and continuing numbers
+        Y = np.unique(Y, return_inverse=True)[1]
         bench_scikit(X, Y)
         bench_svm(X, Y)
         bench_pymvpa(X, Y)

--- a/benchmarks/bench_svm.py
+++ b/benchmarks/bench_svm.py
@@ -24,6 +24,7 @@ from datetime import datetime
 scikit_results = []
 svm_results = []
 mvpa_results = []
+shogun_libsvm_results = []
 
 mu_second = 0.0 + 10**6 # number of microseconds in a second
 
@@ -45,6 +46,27 @@ def bench_scikit(X, Y):
     # stop time
 
     scikit_results.append(delta.seconds + delta.microseconds/mu_second)
+
+
+def bench_shogun_libsvm(X, Y):
+    from shogun.Features import RealFeatures, Labels
+    from shogun.Kernel import GaussianKernel
+    from shogun.Classifier import LibSVMMultiClass
+    features = RealFeatures(X.T.copy())
+    labels = Labels(Y.astype(np.float))
+
+    gc.collect()
+
+    tstart = datetime.now()
+    kernel = GaussianKernel(features, features, 1.)
+    C = 1
+    svm = LibSVMMultiClass(C, kernel, labels)
+    svm.train()
+
+    svm.classify(features).get_labels()
+
+    delta = (datetime.now() - tstart)
+    shogun_libsvm_results.append(delta.seconds + delta.microseconds / mu_second)
 
 
 def bench_svm(X, Y):
@@ -112,6 +134,7 @@ if __name__ == '__main__':
         bench_scikit(X, Y)
         bench_pymvpa(X, Y)
         bench_svm(X, Y)
+        bench_shogun_libsvm(X, Y)
 
     import pylab as pl
     xx = range(0, n*step, step)
@@ -121,6 +144,7 @@ if __name__ == '__main__':
     pl.plot(xx, mvpa_results, 'g-', label='pymvpa')
     pl.plot(xx, svm_results, 'r-', label='libsvm (ctypes binding)')
     pl.plot(xx, scikit_results, 'b-', label='scikit-learn')
+    pl.plot(xx, shogun_libsvm_results, 'y-', label='shogun-libsvm')
     pl.legend()
     pl.xlabel('number of samples to classify')
     pl.ylabel('time (in microseconds)')
@@ -131,6 +155,7 @@ if __name__ == '__main__':
     scikit_results = []
     svm_results = []
     mvpa_results = []
+    shogun_libsvm_results = []
     n = 10
     step = 500
     start_dim = 100
@@ -152,6 +177,7 @@ if __name__ == '__main__':
         bench_scikit(X, Y)
         bench_svm(X, Y)
         bench_pymvpa(X, Y)
+        bench_shogun_libsvm(X, Y)
 
     xx = np.arange(start_dim, start_dim+n*step, step)
     pl.subplot(212)
@@ -159,6 +185,7 @@ if __name__ == '__main__':
     pl.plot(xx, mvpa_results, 'g-', label='pymvpa')
     pl.plot(xx, svm_results, 'r-', label='libsvm (ctypes binding)')
     pl.plot(xx, scikit_results, 'b-', label='scikit-learn')
+    pl.plot(xx, shogun_libsvm_results, 'y-', label='shogun-libsvm')
     pl.legend()
     pl.xlabel('number of dimensions')
     pl.ylabel('time (in seconds)')

--- a/benchmarks/bench_svm.py
+++ b/benchmarks/bench_svm.py
@@ -3,6 +3,7 @@ To run this, you'll need to have installed.
 
   * pymvpa
   * libsvm and it's python bindings
+  * shogun-python-modular
   * scikit-learn (of course)
 
 Does two benchmarks


### PR DESCRIPTION
This adds the shogun libsvm bindings to the svm benchmark.
It also corrects a bug in the benchmark: as far as I can see, sklearn has gamma=1/n_features as default, while the other libs have gamma=1 as default.
