### PR TITLE
ENH: use integer indexing instead of boolean masks by default for CV

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -102,6 +102,19 @@ that can be used to generate dataset splits according to different cross
 validation strategies.
 
 
+.. topic:: Boolean mask vs integer indices
+
+   Most cross validators support generating both boolean masks or integer
+   indices to select the samples from a given fold.
+
+   When the data matrix is sparse, only the integer indices will work as
+   expected. Integer indexing is hence the default behavior (since version
+   0.10).
+
+   You can explicitly pass ``indices=False`` to the constructor of the
+   CV object (when supported) to use the boolean mask method instead.
+
+
 K-fold
 ------
 
@@ -117,7 +130,7 @@ Example of 2-fold::
   >>> X = np.array([[0., 0.], [1., 1.], [-1., -1.], [2., 2.]])
   >>> Y = np.array([0, 1, 0, 1])
 
-  >>> kf = KFold(len(Y), 2)
+  >>> kf = KFold(len(Y), 2, indices=False)
   >>> print kf
   sklearn.cross_validation.KFold(n=4, k=2)
 
@@ -156,7 +169,13 @@ percentage for each target class as in the complete set.
 Example of stratified 2-fold::
 
   >>> from sklearn.cross_validation import StratifiedKFold
-  >>> X = [[0., 0.], [1., 1.], [-1., -1.], [2., 2.], [3., 3.], [4., 4.], [0., 1.]]
+  >>> X = [[0., 0.],
+  ...      [1., 1.],
+  ...      [-1., -1.],
+  ...      [2., 2.],
+  ...      [3., 3.],
+  ...      [4., 4.],
+  ...      [0., 1.]]
   >>> Y = [0, 0, 0, 1, 1, 1, 0]
 
   >>> skf = StratifiedKFold(Y, 2)
@@ -165,8 +184,8 @@ Example of stratified 2-fold::
 
   >>> for train, test in skf:
   ...     print train, test
-  [False  True False False  True False  True] [ True False  True  True False  True False]
-  [ True False  True  True False  True False] [False  True False False  True False  True]
+  [1 4 6] [0 2 3 5]
+  [0 2 3 5] [1 4 6]
 
 
 Leave-One-Out - LOO
@@ -188,10 +207,10 @@ not waste much data as only one sample is removed from the learning set::
 
   >>> for train, test in loo:
   ...    print train, test
-  [False  True  True  True] [ True False False False]
-  [ True False  True  True] [False  True False False]
-  [ True  True False  True] [False False  True False]
-  [ True  True  True False] [False False False  True]
+  [1 2 3] [0]
+  [0 2 3] [1]
+  [0 1 3] [2]
+  [0 1 2] [3]
 
 
 Leave-P-Out - LPO
@@ -212,12 +231,12 @@ Example of Leave-2-Out::
 
   >>> for train, test in lpo:
   ...     print train, test
-  [False False  True  True] [ True  True False False]
-  [False  True False  True] [ True False  True False]
-  [False  True  True False] [ True False False  True]
-  [ True False False  True] [False  True  True False]
-  [ True False  True False] [False  True False  True]
-  [ True  True False False] [False False  True  True]
+  [2 3] [0 1]
+  [1 3] [0 2]
+  [1 2] [0 3]
+  [0 3] [1 2]
+  [0 2] [1 3]
+  [0 1] [2 3]
 
 
 Leave-One-Label-Out - LOLO
@@ -246,8 +265,8 @@ a training set using the samples of all the experiments except one::
 
   >>> for train, test in lolo:
   ...     print train, test
-  [False False  True  True] [ True  True False False]
-  [ True  True False False] [False False  True  True]
+  [2 3] [0 1]
+  [0 1] [2 3]
 
 Another common application is to use time information: for instance the
 labels could be the year of collection of the samples and thus allow
@@ -273,9 +292,9 @@ Example of Leave-2-Label Out::
 
   >>> for train, test in lplo:
   ...     print train, test
-  [False False False False  True  True] [ True  True  True  True False False]
-  [False False  True  True False False] [ True  True False False  True  True]
-  [ True  True False False False False] [False False  True  True  True  True]
+  [4 5] [0 1 2 3]
+  [2 3] [0 1 4 5]
+  [0 1] [2 3 4 5]
 
 .. _ShuffleSplit:
 
@@ -299,14 +318,14 @@ Here is a usage example::
   >>> len(ss)
   3
   >>> print ss                                            # doctest: +ELLIPSIS
-  ShuffleSplit(5, n_iterations=3, test_fraction=0.25, indices=False, ...)
+  ShuffleSplit(5, n_iterations=3, test_fraction=0.25, indices=True, ...)
 
   >>> for train_index, test_index in ss:
   ...    print train_index, test_index
   ...
-  [ True  True  True False False] [False False False  True  True]
-  [ True  True  True False False] [False False False  True  True]
-  [False  True False  True  True] [ True False  True False False]
+  [2 0 1] [3 4]
+  [0 2 1] [4 3]
+  [1 3 4] [0 2]
 
 :class:`ShuffleSplit` is thus a good alternative to :class:`KFold` cross
 validation that allows a finer control on the number of iterations and

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,10 @@ version 0.9:
   - The permutation_test_score function now behaves the same way as
     cross_val_score (i.e. uses the mean score across the folds.)
 
+  - Cross Validation generators now use integer indices (``indices=True``)
+    by default instead of boolean masks. This make it more intuitive to
+    use with sparse matrix data.
+
 
 .. _changes_0_9:
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -9,6 +9,7 @@ from math import ceil
 import operator
 
 import numpy as np
+import scipy.sparse as sp
 
 from .base import is_classifier, clone
 from .utils import check_arrays, check_random_state
@@ -54,9 +55,9 @@ class LeaveOneOut(object):
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
     ...    print X_train, X_test, y_train, y_test
-    TRAIN: [False  True] TEST: [ True False]
+    TRAIN: [1] TEST: [0]
     [[3 4]] [[1 2]] [2] [1]
-    TRAIN: [ True False] TEST: [False  True]
+    TRAIN: [0] TEST: [1]
     [[1 2]] [[3 4]] [1] [2]
 
     See also
@@ -65,7 +66,7 @@ class LeaveOneOut(object):
     domain-specific stratification of the dataset.
     """
 
-    def __init__(self, n, indices=False):
+    def __init__(self, n, indices=True):
         self.n = n
         self.indices = indices
 
@@ -130,15 +131,15 @@ class LeavePOut(object):
     ...    print "TRAIN:", train_index, "TEST:", test_index
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [False False  True  True] TEST: [ True  True False False]
-    TRAIN: [False  True False  True] TEST: [ True False  True False]
-    TRAIN: [False  True  True False] TEST: [ True False False  True]
-    TRAIN: [ True False False  True] TEST: [False  True  True False]
-    TRAIN: [ True False  True False] TEST: [False  True False  True]
-    TRAIN: [ True  True False False] TEST: [False False  True  True]
+    TRAIN: [2 3] TEST: [0 1]
+    TRAIN: [1 3] TEST: [0 2]
+    TRAIN: [1 2] TEST: [0 3]
+    TRAIN: [0 3] TEST: [1 2]
+    TRAIN: [0 2] TEST: [1 3]
+    TRAIN: [0 1] TEST: [2 3]
     """
 
-    def __init__(self, n, p, indices=False):
+    def __init__(self, n, p, indices=True):
         self.n = n
         self.p = p
         self.indices = indices
@@ -206,8 +207,8 @@ class KFold(object):
     ...    print "TRAIN:", train_index, "TEST:", test_index
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [False False  True  True] TEST: [ True  True False False]
-    TRAIN: [ True  True False False] TEST: [False False  True  True]
+    TRAIN: [2 3] TEST: [0 1]
+    TRAIN: [0 1] TEST: [2 3]
 
     Notes
     -----
@@ -221,7 +222,7 @@ class KFold(object):
     classification tasks).
     """
 
-    def __init__(self, n, k, indices=False):
+    def __init__(self, n, k, indices=True):
         assert k > 0, ValueError('Cannot have number of folds k below 1.')
         assert k <= n, ValueError('Cannot have number of folds k=%d, '
                                   'greater than the number '
@@ -296,8 +297,8 @@ class StratifiedKFold(object):
     ...    print "TRAIN:", train_index, "TEST:", test_index
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [False  True False  True] TEST: [ True False  True False]
-    TRAIN: [ True False  True False] TEST: [False  True False  True]
+    TRAIN: [1 3] TEST: [0 2]
+    TRAIN: [0 2] TEST: [1 3]
 
     Notes
     -----
@@ -305,7 +306,7 @@ class StratifiedKFold(object):
     complementary.
     """
 
-    def __init__(self, y, k, indices=False):
+    def __init__(self, y, k, indices=True):
         y = np.asarray(y)
         n = y.shape[0]
         assert k > 0, ValueError('Cannot have number of folds k below 1.')
@@ -386,18 +387,18 @@ class LeaveOneLabelOut(object):
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
     ...    print X_train, X_test, y_train, y_test
-    TRAIN: [False False  True  True] TEST: [ True  True False False]
+    TRAIN: [2 3] TEST: [0 1]
     [[5 6]
      [7 8]] [[1 2]
      [3 4]] [1 2] [1 2]
-    TRAIN: [ True  True False False] TEST: [False False  True  True]
+    TRAIN: [0 1] TEST: [2 3]
     [[1 2]
      [3 4]] [[5 6]
      [7 8]] [1 2] [1 2]
 
     """
 
-    def __init__(self, labels, indices=False):
+    def __init__(self, labels, indices=True):
         self.labels = labels
         self.n_unique_labels = unique(labels).size
         self.indices = indices
@@ -471,18 +472,18 @@ class LeavePLabelOut(object):
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
     ...    print X_train, X_test, y_train, y_test
-    TRAIN: [False False  True] TEST: [ True  True False]
+    TRAIN: [2] TEST: [0 1]
     [[5 6]] [[1 2]
      [3 4]] [1] [1 2]
-    TRAIN: [False  True False] TEST: [ True False  True]
+    TRAIN: [1] TEST: [0 2]
     [[3 4]] [[1 2]
      [5 6]] [2] [1 1]
-    TRAIN: [ True False False] TEST: [False  True  True]
+    TRAIN: [0] TEST: [1 2]
     [[1 2]] [[3 4]
      [5 6]] [1] [2 1]
     """
 
-    def __init__(self, labels, p, indices=False):
+    def __init__(self, labels, p, indices=True):
         self.labels = labels
         self.unique_labels = unique(self.labels)
         self.n_unique_labels = self.unique_labels.size
@@ -587,6 +588,9 @@ class Bootstrap(object):
     ShuffleSplit: cross validation using random permutations.
     """
 
+    # Static marker to be able to introspect the CV type
+    indices = True
+
     def __init__(self, n, n_bootstraps=3, n_train=0.5, n_test=None,
                  random_state=None):
         self.n = n
@@ -682,13 +686,13 @@ class ShuffleSplit(object):
     3
     >>> print rs
     ... # doctest: +ELLIPSIS
-    ShuffleSplit(4, n_iterations=3, test_fraction=0.25, indices=False, ...)
+    ShuffleSplit(4, n_iterations=3, test_fraction=0.25, indices=True, ...)
     >>> for train_index, test_index in rs:
     ...    print "TRAIN:", train_index, "TEST:", test_index
     ...
-    TRAIN: [False  True  True  True] TEST: [ True False False False]
-    TRAIN: [ True  True  True False] TEST: [False False False  True]
-    TRAIN: [ True False  True  True] TEST: [False  True False False]
+    TRAIN: [2 3 1] TEST: [0]
+    TRAIN: [0 2 1] TEST: [3]
+    TRAIN: [3 0 2] TEST: [1]
 
     See also
     --------
@@ -696,7 +700,7 @@ class ShuffleSplit(object):
     """
 
     def __init__(self, n, n_iterations=10, test_fraction=0.1,
-                 indices=False, random_state=None):
+                 indices=True, random_state=None):
         self.n = n
         self.n_iterations = n_iterations
         self.test_fraction = test_fraction
@@ -846,10 +850,10 @@ def check_cv(cv, X=None, y=None, classifier=False):
         whether the task is a classification task, in which case
         stratified KFold will be used.
     """
+    is_sparse = sp.issparse(X)
     if cv is None:
         cv = 3
     if operator.isNumberType(cv):
-        is_sparse = hasattr(X, 'tocsr')
         if classifier:
             cv = StratifiedKFold(y, cv, indices=is_sparse)
         else:
@@ -858,6 +862,9 @@ def check_cv(cv, X=None, y=None, classifier=False):
             else:
                 n_samples = X.shape[0]
             cv = KFold(n_samples, cv, indices=is_sparse)
+    if is_sparse and not getattr(cv, "indices", True):
+        raise ValueError("Sparse data require indices-based cross validation"
+                         " generator, got: %r", cv)
     return cv
 
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -48,6 +48,7 @@ y = np.arange(10) / 2
 ##############################################################################
 # Tests
 
+
 def test_kfold():
     # Check that errors are raise if there is not enough samples
     assert_raises(AssertionError, cross_validation.KFold, 3, 4)
@@ -72,7 +73,8 @@ def test_cross_val_score_with_score_func_classification():
     clf = SVC(kernel='linear')
 
     # Default score (should be the accuracy score)
-    scores = cross_validation.cross_val_score(clf, iris.data, iris.target, cv=5)
+    scores = cross_validation.cross_val_score(clf, iris.data, iris.target,
+                                              cv=5)
     assert_array_almost_equal(scores, [1., 0.97, 0.90, 0.97, 1.], 2)
 
     # Correct classification score (aka. zero / one score) - should be the
@@ -99,8 +101,8 @@ def test_cross_val_score_with_score_func_regression():
 
     # R2 score (aka. determination coefficient) - should be the
     # same as the default estimator score
-    r2_scores = cross_validation.cross_val_score(reg, X, y, score_func=r2_score,
-                                          cv=5)
+    r2_scores = cross_validation.cross_val_score(reg, X, y,
+                                                 score_func=r2_score, cv=5)
     assert_array_almost_equal(r2_scores, [0.94, 0.97, 0.97, 0.99, 0.92], 2)
 
     # Mean squared error
@@ -155,6 +157,23 @@ def test_permutation_score():
     assert_true(pvalue > 0.4)
 
 
+def test_cross_val_generator_with_mask():
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    y = np.array([1, 1, 2, 2])
+    labels = np.array([1, 2, 3, 4])
+    loo = cross_validation.LeaveOneOut(4, indices=False)
+    lpo = cross_validation.LeavePOut(4, 2, indices=False)
+    kf = cross_validation.KFold(4, 2, indices=False)
+    skf = cross_validation.StratifiedKFold(y, 2, indices=False)
+    lolo = cross_validation.LeaveOneLabelOut(labels, indices=False)
+    lopo = cross_validation.LeavePLabelOut(labels, 2, indices=False)
+    ss = cross_validation.ShuffleSplit(2, indices=False)
+    for cv in [loo, lpo, kf, skf, lolo, lopo, ss]:
+        for train, test in cv:
+            X_train, X_test = X[train], X[test]
+            y_train, y_test = y[train], y[test]
+
+
 def test_cross_val_generator_with_indices():
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
     y = np.array([1, 1, 2, 2])
@@ -165,7 +184,9 @@ def test_cross_val_generator_with_indices():
     skf = cross_validation.StratifiedKFold(y, 2, indices=True)
     lolo = cross_validation.LeaveOneLabelOut(labels, indices=True)
     lopo = cross_validation.LeavePLabelOut(labels, 2, indices=True)
-    for cv in [loo, lpo, kf, skf, lolo, lopo]:
+    b = cross_validation.Bootstrap(2)  # only in index mode
+    ss = cross_validation.ShuffleSplit(2, indices=True)
+    for cv in [loo, lpo, kf, skf, lolo, lopo, b, ss]:
         for train, test in cv:
             X_train, X_test = X[train], X[test]
             y_train, y_test = y[train], y[test]
@@ -176,3 +197,22 @@ def test_bootstrap_errors():
     assert_raises(ValueError, cross_validation.Bootstrap, 10, n_test=100)
     assert_raises(ValueError, cross_validation.Bootstrap, 10, n_train=1.1)
     assert_raises(ValueError, cross_validation.Bootstrap, 10, n_test=1.1)
+
+
+def test_cross_indices_exception():
+    X = coo_matrix(np.array([[1, 2], [3, 4], [5, 6], [7, 8]]))
+    y = np.array([1, 1, 2, 2])
+    labels = np.array([1, 2, 3, 4])
+    loo = cross_validation.LeaveOneOut(4, indices=False)
+    lpo = cross_validation.LeavePOut(4, 2, indices=False)
+    kf = cross_validation.KFold(4, 2, indices=False)
+    skf = cross_validation.StratifiedKFold(y, 2, indices=False)
+    lolo = cross_validation.LeaveOneLabelOut(labels, indices=False)
+    lopo = cross_validation.LeavePLabelOut(labels, 2, indices=False)
+
+    assert_raises(ValueError, cross_validation.check_cv, loo, X, y)
+    assert_raises(ValueError, cross_validation.check_cv, lpo, X, y)
+    assert_raises(ValueError, cross_validation.check_cv, kf, X, y)
+    assert_raises(ValueError, cross_validation.check_cv, skf, X, y)
+    assert_raises(ValueError, cross_validation.check_cv, lolo, X, y)
+    assert_raises(ValueError, cross_validation.check_cv, lopo, X, y)


### PR DESCRIPTION
As discussed on the mailing list:
- use integer indices by default
- update check_cv to raise ValueError when `cv.indices == False` and input data is sparse.
