### PR TITLE
Make locally_linear_embedding robust to zero eigenvalues.

### DIFF
--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -140,8 +140,17 @@ def null_space(M, k, k_skip=1, eigen_solver='arpack', tol=1E-6, max_iter=100):
             eigen_solver = 'dense'
 
     if eigen_solver == 'arpack':
-        eigen_values, eigen_vectors = eigsh(M, k + k_skip, sigma=0.0,
-                                            tol=tol, maxiter=max_iter)
+        try:
+            # arpack in shift-invert mode is usually more robust
+            # but might fail if M contains zero singular values
+            # Relative to scipy v0.10
+            eigen_values, eigen_vectors = eigsh(
+                M, k + k_skip, sigma=0.0, tol=tol, maxiter=max_iter)
+        except:
+            # in non-invert mode (sigma=None) zero eigenvalues are
+            # correctly retrieved
+            eigen_values, eigen_vectors = eigsh(
+                M, k + k_skip, sigma=None, tol=tol, maxiter=max_iter)
 
         return eigen_vectors[:, k_skip:], np.sum(eigen_values[k_skip:])
     elif eigen_solver == 'dense':

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -90,6 +90,11 @@ def test_lle_manifold():
         assert_lower(np.abs(clf.reconstruction_error_ - reconstruction_error),
                      tol * reconstruction_error, details=details)
 
+def test_singular():
+    """Case when the zero is one of the eigenvalues in the LLE algorithm"""
+    M = [[1, 1, 1], [1, 1, 1], [1, 1, 1]]
+    _, error = manifold.locally_linear_embedding(M, 2, 1, eigen_solver='arpack')
+    assert error < 2.
 
 def test_pipeline():
     # check that LocallyLinearEmbedding works fine as a Pipeline


### PR DESCRIPTION
arpack in shift-invert mode raises an Exception with zero eigenvalues,
so degrade gratefully to the non shirt-invert mode for those cases.

Issue reported by Timmy Wilson in the mailing list:

```
http://permalink.gmane.org/gmane.comp.python.scikit-learn/1123
```
