### PR TITLE
Check for consistent input in Logistic Regression

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -55,11 +55,19 @@ def test_predict_iris():
 
 
 def test_inconsistent_input():
-    """Test that an exception is raised on inconsistent input to predict"""
+    """Test that an exception is raised on inconsistent input"""
     X_ = np.random.random((5, 10))
     y_ = np.ones(X_.shape[0])
+
+    clf = logistic.LogisticRegression()
+
+    # Wrong dimensions for training data
+    y_wrong = y_[:-1]
+    assert_raises(ValueError, clf.fit, X, y_wrong)
+
+    # Wrong dimensions for test data
     assert_raises(ValueError,
-                  logistic.LogisticRegression().fit(X_, y_).predict,
+                  clf.fit(X_, y_).predict,
                   np.random.random((3, 12)))
 
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -386,6 +386,11 @@ class BaseLibLinear(BaseEstimator):
                              % type(X))
         y = np.asarray(y, dtype=np.int32, order='C')
 
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y have incompatible shapes.\n" +
+                             "X has %s samples, but y has %s." % \
+                             (X.shape[0], y.shape[0]))
+
         self.raw_coef_, self.label_ = liblinear.train_wrap(X, y,
                        self._get_solver_type(), self.tol,
                        self._get_bias(), self.C,


### PR DESCRIPTION
Currently BaseLibLinear, the base class of Logistic Regression, does not check whether the target and training vectors have the same number of samples.

This pull request adds that validation and the corresponding test case.
