### PR TITLE
make BaseEstimator an abstract base class

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -2,6 +2,7 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD Style
 
+from abc import ABCMeta, abstractmethod
 import copy
 import inspect
 import numpy as np
@@ -135,6 +136,12 @@ class BaseEstimator(object):
     at the class level in their __init__ as explicit keyword
     arguments (no *args, **kwargs).
     """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def fit(self, X, y=None, *args):
+        """Fit estimator on samples X, with optional labels/output y."""
 
     @classmethod
     def _get_param_names(cls):


### PR DESCRIPTION
Now that we have Python 2.6 as a requirement, we can use abstract base classes to prevent users from instantiating what they shouldn't instantiate. I've already used this in the Naive Bayes module.

Here's a patch that does the same trick for `BaseEstimator`. I'm putting this up as a PR because I wasn't sure if this is the direction that we want to take.
