### PR TITLE
FIX - error in the bibtex entry - extra comma that makes bibtex fail

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -19,7 +19,7 @@ citations to the following paper:
 
    @article{,
     title={{Scikit-learn: Machine Learning in Python }},
-    author={Pedregosa, F. and Varoquaux, G. and Gramfort, A., and Michel, V.
+    author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
             and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
             and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
             Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay E.},


### PR DESCRIPTION
There is an error in the bibtex entry for the article: an extra comma that made bibtex fail.

Thanks,
