### PR TITLE
Fastica wowhiten

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -295,7 +295,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         return K, W, S.T
     else:
         S = np.dot(W, X)
-        return W, S.T
+        return W, S.T, None
 
 
 class FastICA(BaseEstimator):

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -160,9 +160,11 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     Returns
     -------
-    K: (n_components, p) array
-        pre-whitening matrix that projects data onto th first n.comp
-        principal components. Returned only if whiten is True
+    K: (n_components, p) array or None.
+        If whiten is 'True', K is the pre-whitening matrix that projects data
+        onto the first n.comp principal components. If whiten is 'False', K is
+        'None'.
+
     W: (n_components, n_components) array
         estimated un-mixing matrix
         The mixing matrix can be obtained by::

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -295,7 +295,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         return K, W, S.T
     else:
         S = np.dot(W, X)
-        return W, S.T, None
+        return None, W, S.T
 
 
 class FastICA(BaseEstimator):
@@ -362,7 +362,10 @@ class FastICA(BaseEstimator):
                         self.algorithm, self.whiten,
                         self.fun, self.fun_prime, self.fun_args, self.max_iter,
                         self.tol, self.w_init)
-        self.unmixing_matrix_ = np.dot(unmixing_, whitening_)
+        if self.whiten == True:
+            self.unmixing_matrix_ = np.dot(unmixing_, whitening_)
+        else:
+            self.unmixing_matrix_ = unmixing_
         self.components_ = sources_
         return self
 

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -106,7 +106,6 @@ def test_fastica_nowhiten():
     ica.get_mixing_matrix()
 
 
-
 def test_non_square_fastica(add_noise=False):
     """ Test the FastICA algorithm on very simple data.
     """

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -99,6 +99,14 @@ def test_fastica(add_noise=False):
     ica.get_mixing_matrix()
 
 
+def test_fastica_nowhiten():
+    m = [[0, 1], [1, 0]]
+    ica = FastICA(whiten=False)
+    ica.fit(m)
+    ica.get_mixing_matrix()
+
+
+
 def test_non_square_fastica(add_noise=False):
     """ Test the FastICA algorithm on very simple data.
     """

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -4,7 +4,6 @@ import scipy.sparse as sp
 from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_equal
 from nose.tools import assert_raises
-from nose import SkipTest
 
 from .. import PCA, KernelPCA
 
@@ -32,6 +31,7 @@ def test_kernel_pca():
             # inverse transform
             X_pred2 = kpca.inverse_transform(X_pred_transformed)
             assert_equal(X_pred2.shape, X_pred.shape)
+
 
 def test_kernel_pca_sparse():
     rng = np.random.RandomState(0)


### PR DESCRIPTION
As nothing happened here:
https://github.com/scikit-learn/scikit-learn/pull/243

I fixed issue 238 since it seemed pretty trivial.
fastica now returns "none" as whitening matrix when whitening is false.
This seems to be the agreed solution as discussed in the pull request above.

I also added a non-regression test.
