### PR TITLE
RBF Svm iris example

### DIFF
--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -15,22 +15,22 @@ from sklearn import svm, datasets
 
 # import some data to play with
 iris = datasets.load_iris()
-X = iris.data[:, :2] # we only take the first two features. We could
-                     # avoid this ugly slicing by using a two-dim dataset
+X = iris.data[:, :2]  # we only take the first two features. We could
+                      # avoid this ugly slicing by using a two-dim dataset
 Y = iris.target
 
-h=.02 # step size in the mesh
+h = .02  # step size in the mesh
 
 # we create an instance of SVM and fit out data. We do not scale our
 # data since we want to plot the support vectors
-svc     = svm.SVC(kernel='linear').fit(X, Y)
-rbf_svc = svm.SVC(kernel='poly').fit(X, Y)
-nu_svc  = svm.NuSVC(kernel='linear').fit(X,Y)
+svc = svm.SVC(kernel='linear').fit(X, Y)
+rbf_svc = svm.SVC(kernel='rbf', gamma=0.7).fit(X, Y)
+poly_svc = svm.SVC(kernel='poly', degree=3).fit(X, Y)
 lin_svc = svm.LinearSVC().fit(X, Y)
 
 # create a mesh to plot in
-x_min, x_max = X[:,0].min()-1, X[:,0].max()+1
-y_min, y_max = X[:,1].min()-1, X[:,1].max()+1
+x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1
+y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
 xx, yy = np.meshgrid(np.arange(x_min, x_max, h),
                      np.arange(y_min, y_max, h))
 
@@ -43,10 +43,10 @@ titles = ['SVC with linear kernel',
 
 pl.set_cmap(pl.cm.Paired)
 
-for i, clf in enumerate((svc, rbf_svc, nu_svc, lin_svc)):
+for i, clf in enumerate((svc, rbf_svc, poly_svc, lin_svc)):
     # Plot the decision boundary. For that, we will asign a color to each
     # point in the mesh [x_min, m_max]x[y_min, y_max].
-    pl.subplot(2, 2, i+1)
+    pl.subplot(2, 2, i + 1)
     Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
 
     # Put the result into a color plot
@@ -56,7 +56,7 @@ for i, clf in enumerate((svc, rbf_svc, nu_svc, lin_svc)):
     pl.axis('off')
 
     # Plot also the training points
-    pl.scatter(X[:,0], X[:,1], c=Y)
+    pl.scatter(X[:, 0], X[:, 1], c=Y)
 
     pl.title(titles[i])
 

--- a/examples/svm/plot_iris.py
+++ b/examples/svm/plot_iris.py
@@ -36,8 +36,8 @@ xx, yy = np.meshgrid(np.arange(x_min, x_max, h),
 
 # title for the plots
 titles = ['SVC with linear kernel',
+          'SVC with RBF kernel',
           'SVC with polynomial (degree 3) kernel',
-          'NuSVC with linear kernel',
           'LinearSVC (linear kernel)']
 
 


### PR DESCRIPTION
This is a somewhat trivial change in the DOCs.
I changed the NuSVC in the SVM examples to a rbf-Kernel SVC.
The result from the NuSVC should be the same as from a SVC with some C so imho there is nothing
really to be seen from the difference of NuSVC and SVC.
On the other hand, I'd really like to have an image of an rbf-Kernel SVM quite at the top.
