### PR TITLE
HLP: Use shift-invert mode in spectral_embedding.

### DIFF
--- a/examples/cluster/plot_lena_segmentation.py
+++ b/examples/cluster/plot_lena_segmentation.py
@@ -38,10 +38,10 @@ beta = 5
 eps  = 1e-6
 graph.data = np.exp(-beta*graph.data/lena.std()) + eps
 
-# Apply spectral clustering (this step goes much faster if you have pyamg
-# installed)
+# Apply spectral clustering. To speed things up we use small tolerance
+# and the pyamg solver if available.
 N_REGIONS = 11
-labels = spectral_clustering(graph, k=N_REGIONS)
+labels = spectral_clustering(graph, k=N_REGIONS, tol=1e-3)
 labels = labels.reshape(lena.shape)
 
 ################################################################################

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -12,7 +12,6 @@ from ..utils import check_random_state
 from ..utils.graph import graph_laplacian
 from .k_means_ import k_means
 
-
 def spectral_embedding(adjacency, n_components=8, mode=None,
                        random_state=None):
     """Project the sample on the first eigen vectors of the graph Laplacian
@@ -102,8 +101,9 @@ def spectral_embedding(adjacency, n_components=8, mode=None,
                 # csr has the fastest matvec and is thus best suited to
                 # arpack
                 laplacian = laplacian.tocsr()
-        lambdas, diffusion_map = eigsh(-laplacian, k=n_components,
-                                        which='LA')
+
+        lambdas, diffusion_map = eigsh(-laplacian, k=n_components, sigma=1.)
+
         embedding = diffusion_map.T[::-1] * dd
     elif mode == 'amg':
         # Use AMG to get a preconditioner and speed up the eigenvalue


### PR DESCRIPTION
I need some help on this. I checked empirically that the largest eigenvalue of  `-laplacian` in spectral_embedding is always 1. and swiching to shift-invert mode makes me win a 2.5x factor in the lena example.

The question is: is this true or I'm just lucky (no test failures)?
