### PR TITLE
MRG: Convert BallTree to Nearest Neighbors

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..utils import extmath, check_random_state
 from ..base import BaseEstimator
-from ..neighbors import BallTree
+from ..neighbors import NearestNeighbors
 
 
 def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
@@ -40,8 +40,10 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
     if n_samples is not None:
         idx = random_state.permutation(X.shape[0])[:n_samples]
         X = X[idx]
-    d, _ = BallTree(X).query(X, int(X.shape[0] * quantile),
-                             return_distance=True)
+    nbrs = NearestNeighbors(n_neighbors=int(X.shape[0] * quantile))
+    nbrs.fit(X)
+    d, _ = nbrs.kneighbors(X, return_distance=True)
+
     bandwidth = np.mean(np.max(d, axis=1))
     return bandwidth
 
@@ -103,14 +105,16 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     n_points, n_features = X.shape
     stop_thresh = 1e-3 * bandwidth  # when mean has converged
     center_intensity_dict = {}
-    ball_tree = BallTree(X)  # to efficiently look up nearby points
+    nbrs = NearestNeighbors(radius=bandwidth).fit(X)
 
     # For each seed, climb gradient until convergence or max_iterations
     for my_mean in seeds:
         completed_iterations = 0
         while True:
             # Find mean of points within bandwidth
-            points_within = X[ball_tree.query_radius([my_mean], bandwidth)[0]]
+            i_nbrs = nbrs.radius_neighbors([my_mean], bandwidth,
+                                           return_distance=False)[0]
+            points_within = X[i_nbrs]
             if len(points_within) == 0:
                 break  # Depending on seeding strategy this condition may occur
             my_old_mean = my_mean  # save the old mean
@@ -130,18 +134,19 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                                  key=lambda tup: tup[1], reverse=True)
     sorted_centers = np.array([tup[0] for tup in sorted_by_intensity])
     unique = np.ones(len(sorted_centers), dtype=np.bool)
-    cc_tree = BallTree(sorted_centers)
+    nbrs = NearestNeighbors(radius=bandwidth).fit(sorted_centers)
     for i, center in enumerate(sorted_centers):
         if unique[i]:
-            neighbor_idxs = cc_tree.query_radius([center], bandwidth)[0]
+            neighbor_idxs = nbrs.radius_neighbors([center],
+                                                  return_distance=False)[0]
             unique[neighbor_idxs] = 0
             unique[i] = 1  # leave the current point as unique
     cluster_centers = sorted_centers[unique]
 
     # ASSIGN LABELS: a point belongs to the cluster that it is closest to
-    centers_tree = BallTree(cluster_centers)
+    nbrs = NearestNeighbors(n_neighbors=1).fit(cluster_centers)
     labels = np.zeros(n_points, dtype=np.int)
-    distances, idxs = centers_tree.query(X, 1)
+    distances, idxs = nbrs.kneighbors(X)
     if cluster_all:
         labels = idxs.flatten()
     else:

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -136,9 +136,10 @@ class Isomap(BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix, BallTree, cKDTree}
-            Training vector, where n_samples in the number of samples
-            and n_features is the number of features.
+        X : {array-like, sparse matrix, BallTree, cKDTree, NearestNeighbors}
+            Sample data, shape = (n_samples, n_features), in the form of a
+            numpy array, sparse array, precomputed tree, or NearestNeighbors
+            object.
 
         Returns
         -------

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from ..base import BaseEstimator
-from ..neighbors import BallTree, kneighbors_graph
+from ..neighbors import NearestNeighbors, kneighbors_graph
 from ..utils.graph import graph_shortest_path
 from ..decomposition import KernelPCA
 from ..preprocessing import KernelCenterer
@@ -47,6 +47,10 @@ class Isomap(BaseEstimator):
         'FW' : Floyd-Warshall algorithm
         'D' : Dijkstra algorithm with Fibonacci Heaps
 
+    neighbors_algorithm : string ['auto'|'brute'|'kd_tree'|'ball_tree']
+        algorithm to use for nearest neighbors search,
+        passed to neighbors.NearestNeighbors instance
+
     Attributes
     ----------
     `embedding_` : array-like, shape (n_samples, out_dim)
@@ -57,8 +61,9 @@ class Isomap(BaseEstimator):
     `training_data_` : array-like, shape (n_samples, n_features)
         Stores the training data
 
-    `ball_tree_` : sklearn.neighbors.BallTree instance
-        Stores ball tree of training data for faster transform
+    `nbrs_` : sklearn.neighbors.NearestNeighbors instance
+        Stores nearest neighbors instance, including BallTree or KDtree
+        if applicable.
 
     `dist_matrix_` : array-like, shape (n_samples, n_samples)
         Stores the geodesic distance matrix of training data
@@ -71,23 +76,27 @@ class Isomap(BaseEstimator):
 
     def __init__(self, n_neighbors=5, out_dim=2,
                  eigen_solver='auto', tol=0,
-                 max_iter=None, path_method='auto'):
+                 max_iter=None, path_method='auto',
+                 neighbors_algorithm='auto'):
         self.n_neighbors = n_neighbors
         self.out_dim = out_dim
         self.eigen_solver = eigen_solver
         self.tol = tol
         self.max_iter = max_iter
         self.path_method = path_method
+        self.neighbors_algorithm = neighbors_algorithm
+        self.nbrs_ = NearestNeighbors(n_neighbors=n_neighbors,
+                                      algorithm=neighbors_algorithm)
 
     def _fit_transform(self, X):
-        self.training_data_ = X
+        self.nbrs_.fit(X)
+        self.training_data_ = self.nbrs_._fit_X
         self.kernel_pca_ = KernelPCA(n_components=self.out_dim,
                                      kernel="precomputed",
                                      eigen_solver=self.eigen_solver,
                                      tol=self.tol, max_iter=self.max_iter)
 
-        self.ball_tree_ = BallTree(X)
-        kng = kneighbors_graph(self.ball_tree_, self.n_neighbors,
+        kng = kneighbors_graph(self.nbrs_, self.n_neighbors,
                                mode='distance')
 
         self.dist_matrix_ = graph_shortest_path(kng,
@@ -127,9 +136,9 @@ class Isomap(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            training set. If kernel='precomputed', X can be an
-            (n_features, n_features) affinity matrix.
+        X : {array-like, sparse matrix, BallTree, cKDTree}
+            Training vector, where n_samples in the number of samples
+            and n_features is the number of features.
 
         Returns
         -------
@@ -143,7 +152,7 @@ class Isomap(BaseEstimator):
 
         Parameters
         ----------
-        X: array-like, shape (n_samples, n_features)
+        X: {array-like, sparse matrix, BallTree, cKDTree}
             Training vector, where n_samples in the number of samples
             and n_features is the number of features.
 
@@ -173,7 +182,7 @@ class Isomap(BaseEstimator):
         -------
         X_new: array-like, shape (n_samples, out_dim)
         """
-        distances, indices = self.ball_tree_.query(X, return_distance=True)
+        distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
 
         #Create the graph of shortest distances from X to self.training_data_
         # via the nearest neighbors of X.

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -10,7 +10,7 @@ from scipy.sparse import eye, csr_matrix
 from ..base import BaseEstimator
 from ..utils import array2d
 from ..utils.arpack import eigsh
-from ..neighbors import NearestNeighbors, BallTree
+from ..neighbors import NearestNeighbors
 
 
 def barycenter_weights(X, Z, reg=1e-3):
@@ -69,9 +69,10 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3):
 
     Parameters
     ----------
-    X : array-like or BallTree, shape = [n_samples, n_features]
-        Sample data, in the form of a numpy array or a precomputed
-        :class:`BallTree`.
+    X : {array-like, sparse matrix, BallTree, cKDTree, NearestNeighbors}
+        Sample data, shape = (n_samples, n_features), in the form of a
+        numpy array, sparse array, precomputed tree, or NearestNeighbors
+        object.
 
     n_neighbors : int
         Number of neighbors for each sample.
@@ -175,9 +176,10 @@ def locally_linear_embedding(
 
     Parameters
     ----------
-    X : array-like or BallTree, shape [n_samples, n_features]
-        Input data, in the form of a numpy array or a precomputed
-        :class:`BallTree`.
+    X : {array-like, sparse matrix, BallTree, cKDTree, NearestNeighbors}
+        Sample data, shape = (n_samples, n_features), in the form of a
+        numpy array, sparse array, precomputed tree, or NearestNeighbors
+        object.
 
     n_neighbors : integer
         number of neighbors to consider for each point.
@@ -255,13 +257,9 @@ def locally_linear_embedding(
     if method not in ('standard', 'hessian', 'modified', 'ltsa'):
         raise ValueError("unrecognized method '%s'" % method)
 
-    if hasattr(X, 'query'):
-        # X is a ball tree
-        balltree = X
-        X = balltree.data
-    else:
-        X = np.asarray(X)
-        balltree = BallTree(np.asarray(X))
+    nbrs = NearestNeighbors(n_neighbors=n_neighbors + 1)
+    nbrs.fit(X)
+    X = nbrs._fit_X
 
     N, d_in = X.shape
 
@@ -271,11 +269,14 @@ def locally_linear_embedding(
     if n_neighbors >= N:
         raise ValueError("n_neighbors must be less than number of points")
 
+    if n_neighbors <= 0:
+        raise ValueError("n_neighbors must be positive") 
+
     M_sparse = (eigen_solver != 'dense')
 
     if method == 'standard':
         W = barycenter_kneighbors_graph(
-            balltree, n_neighbors=n_neighbors, reg=reg)
+            nbrs, n_neighbors=n_neighbors, reg=reg)
 
         # we'll compute M = (I-W)'(I-W)
         # depending on the solver, we'll do this differently
@@ -293,7 +294,8 @@ def locally_linear_embedding(
             raise ValueError("for method='hessian', n_neighbors must be "
                              "greater than [out_dim * (out_dim + 3) / 2]")
 
-        neighbors = balltree.query(X, k=n_neighbors + 1, return_distance=False)
+        neighbors = nbrs.kneighbors(X, n_neighbors=n_neighbors + 1,
+                                    return_distance=False)
         neighbors = neighbors[:, 1:]
 
         Yi = np.empty((n_neighbors, 1 + out_dim + dp), dtype=np.float)
@@ -339,7 +341,8 @@ def locally_linear_embedding(
         if n_neighbors < out_dim:
             raise ValueError("modified LLE requires n_neighbors >= out_dim")
 
-        neighbors = balltree.query(X, k=n_neighbors + 1, return_distance=False)
+        neighbors = nbrs.kneighbors(X, n_neighbors=n_neighbors + 1,
+                                    return_distance=False)
         neighbors = neighbors[:, 1:]
 
         #find the eigenvectors and eigenvalues of each local covariance
@@ -441,7 +444,8 @@ def locally_linear_embedding(
             M = csr_matrix(M)
 
     elif method == 'ltsa':
-        neighbors = balltree.query(X, k=n_neighbors + 1, return_distance=False)
+        neighbors = nbrs.kneighbors(X, n_neighbors=n_neighbors + 1,
+                                    return_distance=False)
         neighbors = neighbors[:, 1:]
 
         M = np.zeros((N, N))
@@ -488,7 +492,6 @@ class LocallyLinearEmbedding(BaseEstimator):
         regularization constant, multiplies the trace of the local covariance
         matrix of the distances.
 
-
     eigen_solver : string, {'auto', 'arpack', 'dense'}
         auto : algorithm will attempt to choose the best method for input data
         arpack : use arnoldi iteration in shift-invert mode.
@@ -505,6 +508,7 @@ class LocallyLinearEmbedding(BaseEstimator):
 
     max_iter : integer
         maximum number of iterations for the arpack solver.
+        Not used if eigen_solver=='dense'.
 
     method : string ['standard' | 'hessian' | 'modified']
         standard : use the standard locally linear embedding algorithm.
@@ -525,6 +529,10 @@ class LocallyLinearEmbedding(BaseEstimator):
         Tolerance for modified LLE method.
         Only used if method == 'modified'
 
+    neighbors_algorithm : string ['auto'|'brute'|'kd_tree'|'ball_tree']
+        algorithm to use for nearest neighbors search,
+        passed to neighbors.NearestNeighbors instance
+
     Attributes
     ----------
     `embedding_vectors_` : array-like, shape [out_dim, n_samples]
@@ -533,13 +541,15 @@ class LocallyLinearEmbedding(BaseEstimator):
     `reconstruction_error_` : float
         Reconstruction error associated with `embedding_vectors_`
 
-    `ball_tree_` : BallTree object
-        Ball Tree used for nearest neighbors
+    `nbrs_` : NearestNeighbors object
+        Stores nearest neighbors instance, including BallTree or KDtree
+        if applicable.
     """
 
     def __init__(self, n_neighbors=5, out_dim=2, reg=1E-3,
-                 eigen_solver='arpack', tol=1E-6, max_iter=100,
-                 method='standard', hessian_tol=1E-4, modified_tol=1E-12):
+                 eigen_solver='auto', tol=1E-6, max_iter=100,
+                 method='standard', hessian_tol=1E-4, modified_tol=1E-12,
+                 neighbors_algorithm='auto'):
         self.n_neighbors = n_neighbors
         self.out_dim = out_dim
         self.reg = reg
@@ -549,12 +559,14 @@ class LocallyLinearEmbedding(BaseEstimator):
         self.method = method
         self.hessian_tol = hessian_tol
         self.modified_tol = modified_tol
+        self.nbrs_ = NearestNeighbors(n_neighbors,
+                                      algorithm=neighbors_algorithm)
 
     def _fit_transform(self, X):
-        self.ball_tree_ = BallTree(X)
+        self.nbrs_.fit(X)
         self.embedding_, self.reconstruction_error_ = \
             locally_linear_embedding(
-                self.ball_tree_, self.n_neighbors, self.out_dim,
+                self.nbrs_, self.n_neighbors, self.out_dim,
                 eigen_solver=self.eigen_solver, tol=self.tol,
                 max_iter=self.max_iter, method=self.method,
                 hessian_tol=self.hessian_tol, modified_tol=self.modified_tol)
@@ -607,11 +619,9 @@ class LocallyLinearEmbedding(BaseEstimator):
         it together with methods that are not scale-invariant (like SVMs)
         """
         X = array2d(X)
-        if not hasattr(self, 'ball_tree_'):
-            raise ValueError('The model is not fitted')
-        ind = self.ball_tree_.query(X, k=self.n_neighbors,
-                                   return_distance=False)
-        weights = barycenter_weights(X, self.ball_tree_.data[ind],
+        ind = self.nbrs_.kneighbors(X, n_neighbors=self.n_neighbors,
+                                    return_distance=False)
+        weights = barycenter_weights(X, self.nbrs_._fit_X[ind],
                                      reg=self.reg)
         X_new = np.empty((X.shape[0], self.out_dim))
         for i in range(X.shape[0]):

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -270,7 +270,7 @@ def locally_linear_embedding(
         raise ValueError("n_neighbors must be less than number of points")
 
     if n_neighbors <= 0:
-        raise ValueError("n_neighbors must be positive") 
+        raise ValueError("n_neighbors must be positive")
 
     M_sparse = (eigen_solver != 'dense')
 

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -105,7 +105,7 @@ def test_pipeline():
 # Test the error raised when the weight matrix is singular
 def test_singular_matrix():
     from nose.tools import assert_raises
-    M = np.ones((4,3))
+    M = np.ones((10,3))
 
     assert_raises(ValueError, manifold.locally_linear_embedding,
                   M, 2, 1, method='standard', eigen_solver='arpack')

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -105,7 +105,7 @@ def test_pipeline():
 # Test the error raised when the weight matrix is singular
 def test_singular_matrix():
     from nose.tools import assert_raises
-    M = np.ones((10,3))
+    M = np.ones((10, 3))
 
     assert_raises(ValueError, manifold.locally_linear_embedding,
                   M, 2, 1, method='standard', eigen_solver='arpack')


### PR DESCRIPTION
This pull request contains changes to three modules:
- `sklearn.clustering.mean_shift`
- `sklearn.clustering.isomap`
- `sklearn.clustering.locally_linear_embedding`

Previously, all three used a `BallTree` object directly.  With this pull request, they use a `NearestNeighbors` object for more flexibility.  All previous tests pass, and example plots appear unchanged.

This pull request also addresses issue #191
