### PR TITLE
MRG The consistency brigade strikes again

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -312,7 +312,7 @@ class TransformerMixin(object):
         X_new : numpy array of shape [n_samples, n_features_new]
             Transformed array.
 
-        Note
+        Notes
         -----
         This method just calls fit and transform consecutively, i.e., it is not
         an optimized implementation of fit_transform, unlike other transformers

--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -50,8 +50,8 @@ class AgglomerationTransform(TransformerMixin):
         Xred : array of size k
             The values to be assigned to each cluster of samples
 
-        Return
-        ------
+        Returns
+        -------
         X : array of size nb_samples
             A vector of size nb_samples with the values of Xred assigned to
             each of the cluster of samples.

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -166,8 +166,8 @@ def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
          The vector in which we keep track of the numbers of elements in a
          cluster
 
-    Return
-    ------
+    Returns
+    -------
     inertia: float
         The inertia of the batch prior to centers update, i.e. the sum
         distances to the closest center for each sample. This is the objective

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -45,7 +45,7 @@ def affinity_propagation(S, p=None, convit=30, max_iter=200, damping=0.5,
     -----
     See examples/plot_affinity_propagation.py for an example.
 
-    Reference:
+    **References**:
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
 
@@ -187,7 +187,7 @@ class AffinityPropagation(BaseEstimator):
     -----
     See examples/plot_affinity_propagation.py for an example.
 
-    Reference:
+    **References**:
 
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -173,11 +173,6 @@ class AffinityPropagation(BaseEstimator):
     copy: boolean, optional
         Make a copy of input data. True by default.
 
-    Methods
-    -------
-
-    fit:
-        Compute the clustering
 
     Attributes
     ----------
@@ -208,7 +203,7 @@ class AffinityPropagation(BaseEstimator):
         self.copy = copy
 
     def fit(self, S, p=None):
-        """compute MeanShift
+        """Compute MeanShift clustering.
 
         Parameters
         ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -54,7 +54,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
     -----
     See examples/plot_dbscan.py for an example.
 
-    Reference:
+    **References**:
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, “A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise”.
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
@@ -154,7 +154,7 @@ class DBSCAN(BaseEstimator):
     -----
     See examples/plot_dbscan.py for an example.
 
-    Reference:
+    **References**:
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, “A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise”.
     In: Proceedings of the 2nd International Conference on Knowledge Discovery

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -138,11 +138,6 @@ class DBSCAN(BaseEstimator):
     verbose: boolean, optional
         The verbosity level
 
-    Methods
-    -------
-    fit:
-        Compute the clustering
-
     Attributes
     ----------
     core_sample_indices_: array, shape = [n_core_samples]

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -269,11 +269,6 @@ class Ward(BaseEstimator):
         The number of connected components in the graph defined by the
         connectivity matrix. If not set, it is estimated.
 
-    Methods
-    -------
-    fit:
-        Compute the clustering
-
     Attributes
     ----------
     children_ : array-like, shape = [n_nodes, 2]
@@ -350,11 +345,6 @@ class WardAgglomeration(AgglomerationTransform, Ward):
     n_components : int (optional)
         The number of connected components in the graph defined by the
         connectivity matrix. If not set, it is estimated.
-
-    Methods
-    -------
-    fit:
-        Compute the clustering of features
 
     Attributes
     ----------

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -194,8 +194,8 @@ def _hc_get_descendent(ind, children, n_leaves):
     n_leaves : int
         Number of leaves.
 
-    Return
-    ------
+    Returns
+    -------
     descendent : list of int
     """
     descendent = []
@@ -224,8 +224,8 @@ def _hc_cut(n_clusters, children, n_leaves):
     n_leaves : int
         Number of leaves of the tree.
 
-    Return
-    ------
+    Returns
+    -------
     labels : array [n_points]
         cluster labels for each point
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -23,7 +23,6 @@ from ..utils import check_random_state
 from ..utils import atleast2d_or_csr
 from ..utils import as_float_array
 from ..utils import safe_asarray
-from ..utils.sparsefuncs import mean_variance_axis0
 
 from . import _k_means
 
@@ -856,16 +855,6 @@ class MiniBatchKMeans(KMeans):
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
-
-    Methods
-    -------
-
-    fit(X):
-        Compute K-Means clustering
-
-    partial_fit(X):
-        Compute a partial K-Means clustering for streaming large scale data
-        into the estimator with incremental fitting.
 
     Attributes
     ----------

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -231,12 +231,6 @@ class MeanShift(BaseEstimator):
     Notes
     -----
 
-    Reference:
-
-    Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward
-    feature space analysis". IEEE Transactions on Pattern Analysis and
-    Machine Intelligence. 2002. pp. 603-619.
-
     Scalability:
 
     Because this implementation uses a flat kernel and
@@ -250,6 +244,13 @@ class MeanShift(BaseEstimator):
 
     Note that the estimate_bandwidth function is much less scalable than
     the mean shift algorithm and will be the bottleneck if it is used.
+
+    **References**:
+
+    Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward
+    feature space analysis". IEEE Transactions on Pattern Analysis and
+    Machine Intelligence. 2002. pp. 603-619.
+
     """
     def __init__(self, bandwidth=None, seeds=None, bin_seeding=False,
                  cluster_all=True):

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -220,11 +220,6 @@ class MeanShift(BaseEstimator):
         not within any kernel. Orphans are assigned to the nearest kernel.
         If false, then orphans are given cluster label -1.
 
-    Methods
-    -------
-    fit(X):
-        Compute MeanShift clustering
-
     Attributes
     ----------
     cluster_centers_: array, [n_clusters, n_features]

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -239,12 +239,6 @@ class SpectralClustering(BaseEstimator):
         centroid seeds. The final results will be the best output of
         n_init consecutive runs in terms of inertia.
 
-    Methods
-    -------
-
-    fit(X):
-        Compute spectral clustering
-
     Attributes
     ----------
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -179,7 +179,7 @@ def spectral_clustering(affinity, k=8, n_components=None, mode=None,
 
     Notes
     -----
-    References:
+    **References**:
 
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik
@@ -253,7 +253,7 @@ class SpectralClustering(BaseEstimator):
 
     Notes
     -----
-    References:
+    **References**:
 
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -63,7 +63,7 @@ class OutlierDetectionMixin(ClassifierMixin):
 
         Notes
         -----
-        References:
+        **References**:
 
         [1] Wilson, E. B., & Hilferty, M. M. (1931).
             The distribution of chi-square.

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -64,7 +64,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
 
     Notes
     -----
-    References:
+    **References**:
     [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
         1999, American Statistical Association and the American Society
         for Quality, TECHNOMETRICS
@@ -198,7 +198,7 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
 
     Notes
     -----
-    References:
+    **References**:
     [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
         1999, American Statistical Association and the American Society
         for Quality, TECHNOMETRICS
@@ -279,7 +279,7 @@ def fast_mcd(X, support_fraction=None,
     Note that only raw estimates are returned. If one is intersted in the
     correction and reweighting steps described in [1], see the MinCovDet
     object.
-    References:
+    **References**:
     [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
         1999, American Statistical Association and the American Society
         for Quality, TECHNOMETRICS
@@ -445,7 +445,7 @@ class MinCovDet(EmpiricalCovariance):
     Notes
     -----
 
-    References:
+    **References**:
     [1] P. J. Rousseeuw. Least median of squares regression. J. Am
         Stat Ass, 79:871, 1984.
     [2] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
@@ -547,7 +547,7 @@ class MinCovDet(EmpiricalCovariance):
 
         Notes
         -----
-        References:
+        **References**:
         [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
             1999, American Statistical Association and the American Society
             for Quality, TECHNOMETRICS
@@ -591,7 +591,7 @@ class MinCovDet(EmpiricalCovariance):
 
         Notes
         -----
-        References:
+        **References**:
         [1] A Fast Algorithm for the Minimum Covariance Determinant Estimator,
             1999, American Statistical Association and the American Society
             for Quality, TECHNOMETRICS

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -237,10 +237,9 @@ class LedoitWolf(EmpiricalCovariance):
                 + shrinkage*mu*np.identity(n_features)
 
     where mu = trace(cov) / n_features
-    and shinkage is given by the Ledoit and Wolf formula (see Reference)
+    and shinkage is given by the Ledoit and Wolf formula (see References)
 
-    Reference
-    ---------
+    **References**:
     "A Well-Conditioned Estimator for Large-Dimensional Covariance Matrices",
     Ledoit and Wolf, Journal of Multivariate Analysis, Volume 88, Issue 2,
     February 2004, pages 365-411.
@@ -379,10 +378,9 @@ class OAS(EmpiricalCovariance):
                 + shrinkage*mu*np.identity(n_features)
 
     where mu = trace(cov) / n_features
-    and shinkage is given by the OAS formula (see Reference)
+    and shinkage is given by the OAS formula (see References)
 
-    Reference
-    ---------
+    **References**:
     "Shrinkage Algorithms for MMSE Covariance Estimation"
     Chen et al., IEEE Trans. on Sign. Proc., Volume 58, Issue 10, October 2010.
 

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -45,8 +45,7 @@ pages 244-261 of the latter.
 The Boston house-price data has been used in many machine learning papers that address regression
 problems.   
      
-References
-----------
+**References**
 
    - Belsley, Kuh & Welsch, 'Regression diagnostics: Identifying Influential Data and Sources of Collinearity', Wiley, 1980. 244-261.
    - Quinlan,R. (1993). Combining Instance-Based and Model-Based Learning. In Proceedings on the Tenth International Conference of Machine Learning, 236-243, University of Massachusetts, Amherst. Morgan Kaufmann.

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -261,8 +261,8 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    Return
-    ------
+    Returns
+    -------
     X : array of shape [n_samples, n_features]
         The generated samples.
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -99,7 +99,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     The algorithm is adapted from Guyon [1] and was designed to generate
     the "Madelon" dataset.
 
-    References:
+    **References**:
 
     .. [1] I. Guyon, "Design of experiments for the NIPS 2003 variable
            selection benchmark", 2003.
@@ -552,7 +552,7 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -615,7 +615,7 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -683,7 +683,7 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -868,7 +868,7 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] G. Celeux, M. El Anbari, J.-M. Marin, C. P. Robert,
            "Regularization in regression: comparing Bayesian and frequentist
@@ -998,7 +998,7 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
     -----
     The algorithm is from Marsland [1].
 
-    References:
+    **References**:
 
     .. [1] S. Marsland, "Machine Learning: An Algorithmic Perpsective",
            Chapter 10, 2009.

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -448,7 +448,6 @@ def dict_learning(X, n_atoms, alpha, max_iter=100, tol=1e-8,
     method = 'lasso_' + method
 
     t0 = time.time()
-    n_features = X.shape[1]
     # Avoid integer division problems
     alpha = float(alpha)
     random_state = check_random_state(random_state)
@@ -922,7 +921,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
 
     Notes
     -----
-    References:
+    **References:**
 
     J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009: Online dictionary learning
     for sparse coding (http://www.di.ens.fr/sierra/pdfs/icml09.pdf)
@@ -1065,7 +1064,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
 
     Notes
     -----
-    References:
+    **References:**
 
     J. Mairal, F. Bach, J. Ponce, G. Sapiro, 2009: Online dictionary learning
     for sparse coding (http://www.di.ens.fr/sierra/pdfs/icml09.pdf)
@@ -1083,7 +1082,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
                  shuffle=True, dict_init=None, transform_algorithm='omp',
                  transform_n_nonzero_coefs=None, transform_alpha=None,
                  verbose=False, split_sign=False, random_state=None):
-        
+
         self._set_sparse_coding_params(n_atoms, transform_algorithm,
                                        transform_n_nonzero_coefs,
                                        transform_alpha, split_sign, n_jobs)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -75,8 +75,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     X_transformed_fit_:
         Projection of the fitted data on the kernel principal components
 
-    Reference
-    ---------
+    **References**:
     Kernel PCA was intoduced in:
         Bernhard Schoelkopf, Alexander J. Smola,
         and Klaus-Robert Mueller. 1999. Kernel principal
@@ -244,8 +243,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         -------
         X_new: array-like, shape (n_samples, n_features)
 
-        Reference
-        ---------
+        **References**:
         "Learning to Find Pre-Images", G BakIr et al, 2004.
         """
         if not self.fit_inverse_transform:

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -66,13 +66,13 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     Attributes
     ----------
 
-    lambdas_, alphas_:
+    `lambdas_`, `alphas_`:
         Eigenvalues and eigenvectors of the centered kernel matrix
 
-    dual_coef_:
+    `dual_coef_`:
         Inverse transform matrix
 
-    X_transformed_fit_:
+    `X_transformed_fit_`:
         Projection of the fitted data on the kernel principal components
 
     **References**:

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -407,7 +407,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
 
     Notes
     -------
-    References:
+    **References**:
 
     * Finding structure with randomness: Stochastic algorithms for
       constructing approximate matrix decompositions Halko, et al., 2009

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -79,8 +79,8 @@ class Forest(BaseEnsemble):
             The target values (integers that correspond to classes in
             classification, real numbers in regression).
 
-        Return
-        ------
+        Returns
+        -------
         self : object
             Returns self.
         """

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -458,7 +458,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
 
     Notes
     -----
-    References:
+    **References**:
 
     R. Baeza-Yates and B. Ribeiro-Neto (2011). Modern Information Retrieval.
         Addison Wesley, pp. 68–74.

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -78,7 +78,7 @@ class RFE(BaseEstimator):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] Guyon, I., Weston, J., Barnhill, S., & Vapnik, V., "Gene selection
            for cancer classification using support vector machines",
@@ -255,7 +255,7 @@ class RFECV(RFE):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] Guyon, I., Weston, J., Barnhill, S., & Vapnik, V., "Gene selection
            for cancer classification using support vector machines",

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -64,7 +64,7 @@ def f_oneway(*args):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
            Statistics". Chapter 14.

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -172,7 +172,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
     The presentation implementation is based on a translation of the DACE
     Matlab toolbox, see reference [1].
 
-    References:
+    **References**:
 
     [1] H.B. Nielsen, S.N. Lophaven, H. B. Nielsen and J. Sondergaard (2002).
         DACE - A MATLAB Kriging Toolbox.

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -28,11 +28,11 @@ class IterGrid(object):
         The parameter grid to explore, as a dictionary mapping estimator
         parameters to sequences of allowed values.
 
-    Yields
-    ------
+    Returns
+    -------
     params: dict of string to any
-        Dictionaries mapping each estimator parameter to one of its allowed
-        values.
+        **Yields** dictionaries mapping each estimator parameter to one of its
+        allowed values.
 
     Examples
     ---------

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -49,22 +49,6 @@ class _BaseHMM(BaseEstimator):
     startprob : array, shape ('n_components`,)
         Initial state occupation distribution.
 
-    Methods
-    -------
-    eval(X)
-        Compute the log likelihood of `X` under the HMM.
-    decode(X)
-        Find most likely state sequence for each point in `X` using the
-        Viterbi algorithm.
-    rvs(n=1)
-        Generate `n` samples from the HMM.
-    fit(X)
-        Estimate HMM parameters from `X`.
-    predict(X)
-        Like decode, find most likely state sequence corresponding to `X`.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
     See Also
     --------
     GMM : Gaussian mixture model
@@ -578,24 +562,6 @@ class GaussianHMM(_BaseHMM):
             (`n_components`, `n_features`)           if 'diag',
             (`n_components`, `n_features`, `n_features`)  if 'full'
 
-    Methods
-    -------
-    eval(X)
-        Compute the log likelihood of `X` under the HMM.
-    decode(X)
-        Find most likely state sequence for each point in `X` using the
-        Viterbi algorithm.
-    rvs(n=1)
-        Generate `n` samples from the HMM.
-    init(X)
-        Initialize HMM parameters from `X`.
-    fit(X)
-        Estimate HMM parameters from `X` using the Baum-Welch algorithm.
-    predict(X)
-        Like decode, find most likely state sequence corresponding to `X`.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
     Examples
     --------
     >>> from sklearn.hmm import GaussianHMM
@@ -825,24 +791,6 @@ class MultinomialHMM(_BaseHMM):
     emissionprob: array, shape ('n_components`, 'n_symbols`)
         Probability of emitting a given symbol when in each state.
 
-    Methods
-    -------
-    eval(X)
-        Compute the log likelihood of `X` under the HMM.
-    decode(X)
-        Find most likely state sequence for each point in `X` using the
-        Viterbi algorithm.
-    rvs(n=1)
-        Generate `n` samples from the HMM.
-    init(X)
-        Initialize HMM parameters from `X`.
-    fit(X)
-        Estimate HMM parameters from `X` using the Baum-Welch algorithm.
-    predict(X)
-        Like decode, find most likely state sequence corresponding to `X`.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
     Examples
     --------
     >>> from sklearn.hmm import MultinomialHMM
@@ -943,24 +891,6 @@ class GMMHMM(_BaseHMM):
         Initial state occupation distribution.
     gmms: array of GMM objects, length 'n_components`
         GMM emission distributions for each state
-
-    Methods
-    -------
-    eval(X)
-        Compute the log likelihood of `X` under the HMM.
-    decode(X)
-        Find most likely state sequence for each point in `X` using the
-        Viterbi algorithm.
-    rvs(n=1)
-        Generate `n` samples from the HMM.
-    init(X)
-        Initialize HMM parameters from `X`.
-    fit(X)
-        Estimate HMM parameters from `X` using the Baum-Welch algorithm.
-    predict(X)
-        Like decode, find most likely state sequence corresponding to `X`.
-    score(X)
-        Compute the log likelihood of `X` under the model.
 
     Examples
     --------

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -88,14 +88,6 @@ class BayesianRidge(LinearModel):
     `scores_` : float
         if computed, value of the objective function (to be maximized)
 
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
-
     Examples
     --------
     >>> from sklearn import linear_model
@@ -306,14 +298,6 @@ class ARDRegression(LinearModel):
 
     `scores_` : float
         if computed, value of the objective function (to be maximized)
-
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
 
     Examples
     --------

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -73,7 +73,7 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin,
     to have slightly different results for the same input data. If
     that happens, try with a smaller tol parameter.
 
-    References:
+    **References**:
 
     LIBLINEAR -- A Library for Large Linear Classification
     http://www.csie.ntu.edu.tw/~cjlin/liblinear/

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -399,48 +399,48 @@ class OrthogonalMatchingPursuit(LinearModel):
 
     Parameters
     ----------
-    n_nonzero_coefs: int, optional
+    n_nonzero_coefs : int, optional
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol: float, optional
+    tol : float, optional
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    fit_intercept: boolean, optional
+    fit_intercept : boolean, optional
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (e.g. data is expected to be already centered).
 
-    normalize: boolean, optional
+    normalize : boolean, optional
         If False, the regressors X are assumed to be already normalized.
 
-    precompute_gram: {True, False, 'auto'},
+    precompute_gram : {True, False, 'auto'},
         Whether to use a precomputed Gram and Xy matrix to speed up
         calculations. Improves performance when `n_targets` or `n_samples` is
         very large. Note that if you already have such matrices, you can pass
         them directly to the fit method.
 
-    copy_X: bool, optional
+    copy_X : bool, optional
         Whether the design matrix X must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    copy_Gram: bool, optional
+    copy_Gram : bool, optional
         Whether the gram matrix must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    copy_Xy: bool, optional
+    copy_Xy : bool, optional
         Whether the covariance vector Xy must be copied by the algorithm.
         If False, it may be overwritten.
 
 
     Attributes
     ----------
-    coef_: array, shape = (n_features,) or (n_features, n_targets)
+    `coef_` : array, shape = (n_features,) or (n_features, n_targets)
         parameter vector (w in the fomulation formula)
 
-    intercept_: float or array, shape =(n_targets,)
+    `intercept_` : float or array, shape =(n_targets,)
         independent term in decision function.
 
     Notes

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -249,8 +249,8 @@ class RidgeClassifier(Ridge):
     --------
     Ridge, RidgeClassifierCV
 
-    Note
-    ----
+    Notes
+    -----
     For multi-class classification, n_class classifiers are trained in
     a one-versus-all approach.
     """
@@ -334,9 +334,7 @@ class _RidgeGCV(LinearModel):
 
     looe = y - loov = c / diag(G)
 
-    Reference
-    ---------
-
+    **References**:
     http://cbcl.mit.edu/projects/cbcl/publications/ps/MIT-CSAIL-TR-2007-025.pdf
     http://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf
     """

--- a/sklearn/linear_model/sparse/coordinate_descent.py
+++ b/sklearn/linear_model/sparse/coordinate_descent.py
@@ -17,7 +17,7 @@ from . import cd_fast_sparse
 class ElasticNet(LinearModel):
     """Linear Model trained with L1 and L2 prior as regularizer
 
-    This implementation works on scipy.sparse X and dense coef_.
+    This implementation works on scipy.sparse X and dense `coef_`.
 
     rho=1 is the lasso penalty. Currently, rho <= 0.01 is not
     reliable, unless you supply your own sequence of alpha.
@@ -28,7 +28,7 @@ class ElasticNet(LinearModel):
         Constant that multiplies the L1 term. Defaults to 1.0
     rho : float
         The ElasticNet mixing parameter, with 0 < rho <= 1.
-    coef_ : ndarray of shape n_features
+    `coef_` : ndarray of shape n_features
         The initial coeffients to warm-start the optimization
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -130,7 +130,7 @@ class Lasso(ElasticNet):
     ----------
     alpha : float
         Constant that multiplies the L1 term. Defaults to 1.0
-    coef_ : ndarray of shape n_features
+    `coef_` : ndarray of shape n_features
         The initial coeffients to warm-start the optimization
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the

--- a/sklearn/linear_model/sparse/logistic.py
+++ b/sklearn/linear_model/sparse/logistic.py
@@ -78,8 +78,7 @@ class LogisticRegression(SparseBaseLibLinear, ClassifierMixin,
     to have slightly different results for the same input data. If
     that happens, try with a smaller tol parameter.
 
-    References
-    ----------
+    **References**:
     LIBLINEAR -- A Library for Large Linear Classification
     http://www.csie.ntu.edu.tw/~cjlin/liblinear/
     """

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -70,7 +70,7 @@ class Isomap(BaseEstimator):
 
     Notes
     -----
-    References:
+    **References**:
 
     [1] Tenenbaum, J.B.; De Silva, V.; & Langford, J.C. A global geometric
         framework for nonlinear dimensionality reduction. Science 290 (5500)

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -239,7 +239,7 @@ def locally_linear_embedding(
 
     Notes
     -----
-    References:
+    **References**:
 
       [1] Roweis, S. & Saul, L. Nonlinear dimensionality reduction by
           locally linear embedding.  Science 290:2323 (2000).

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -149,7 +149,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     Notes
     -----
-    References:
+    **References**:
 
     - L. Hubert and P. Arabie, Comparing Partitions,
       Journal of Classification 1985
@@ -303,7 +303,7 @@ def homogeneity_score(labels_true, labels_pred):
 
     Notes
     -----
-    References:
+    **References**:
 
     V-Measure: A conditional entropy-based external cluster evaluation measure
     Andrew Rosenberg and Julia Hirschberg, 2007
@@ -371,7 +371,7 @@ def completeness_score(labels_true, labels_pred):
 
     Notes
     -----
-    References:
+    **References**:
 
     V-Measure: A conditional entropy-based external cluster evaluation measure
     Andrew Rosenberg and Julia Hirschberg, 2007
@@ -442,7 +442,7 @@ def v_measure_score(labels_true, labels_pred):
 
     Notes
     -----
-    References:
+    **References**:
 
     V-Measure: A conditional entropy-based external cluster evaluation measure
     Andrew Rosenberg and Julia Hirschberg, 2007

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -118,8 +118,8 @@ def adjusted_rand_score(labels_true, labels_pred):
        Similarity score between -1.0 and 1.0. Random labelings have an ARI
        close to 0.0. 1.0 stands for perfect match.
 
-    Example
-    -------
+    Examples
+    --------
 
     Perfectly maching labelings have a score of 1 even
 

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -63,7 +63,7 @@ def silhouette_score(X, labels, metric='euclidean',
 
     Notes
     -----
-    References:
+    **References**:
 
     Peter J. Rousseeuw (1987). "Silhouettes: a Graphical Aid to the
         Interpretation and Validation of Cluster Analysis". Computational
@@ -127,7 +127,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     Notes
     -----
-    References:
+    **References**:
 
     Peter J. Rousseeuw (1987). "Silhouettes: a Graphical Aid to the
         Interpretation and Validation of Cluster Analysis". Computational

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -47,8 +47,9 @@ def confusion_matrix(y_true, y_pred, labels=None):
     CM : array, shape = [n_classes, n_classes]
         confusion matrix
 
-    References
-    ----------
+    Notes
+    -----
+    **References**:
     http://en.wikipedia.org/wiki/Confusion_matrix
 
     """
@@ -104,9 +105,9 @@ def roc_curve(y_true, y_score):
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
 
-
-    References
-    ----------
+    Notes
+    -----
+    **References**:
     http://en.wikipedia.org/wiki/Receiver_operating_characteristic
 
     """
@@ -363,8 +364,9 @@ def f1_score(y_true, y_pred, pos_label=1):
         f1_score of the positive class in binary classification or weighted
         avergage of the f1_scores of each class for the multiclass task
 
-    References
-    ----------
+    Notes
+    -----
+    **References**:
     http://en.wikipedia.org/wiki/F1_score
 
     """
@@ -410,8 +412,9 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None):
     f1_score: array, shape = [n_unique_labels], dtype = np.double
     support: array, shape = [n_unique_labels], dtype = np.long
 
-    References
-    ----------
+    Notes
+    -----
+    **References**:
     http://en.wikipedia.org/wiki/Precision_and_recall
 
     """

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -194,24 +194,6 @@ class DPGMM(GMM):
         True when convergence was reached in fit(), False
         otherwise.
 
-    Methods
-    -------
-    decode(X)
-        Find most likely mixture components for each point in `X`.
-    eval(X)
-        Compute a lower-bound of the log likelihood of `X` under the model
-        and an approximate posterior distribution over mixture components.
-    fit(X)
-        Estimate the posterior of themodel parameters from `X` using the
-        variational mean-field algorithm.
-    predict(X)
-        Like decode, find most likely mixtures components for each
-        observation in `X`.
-    rvs(n=1)
-        Generate `n` samples from the posterior for the model.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
     See Also
     --------
     GMM : Finite gaussian mixture model fit with EM
@@ -684,25 +666,6 @@ class VBGMM(DPGMM):
     converged_ : bool
         True when convergence was reached in fit(), False
         otherwise.
-
-    Methods
-    -------
-    decode(X)
-        Find most likely mixture components for each point in `X`.
-    eval(X)
-        Compute a lower-bound of the log likelihood of `X` under the model
-        and an approximate posterior distribution over mixture components.
-    fit(X)
-        Estimate the posterior of themodel parameters from `X` using the
-        variational mean-field algorithm.
-    predict(X)
-        Like decode, find most likely mixtures components for each
-        observation in `X`.
-    rvs(n=1)
-        Generate `n` samples from the posterior for the model.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
 
     See Also
     --------

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -168,23 +168,6 @@ class GMM(BaseEstimator):
         True when convergence was reached in fit(), False
         otherwise.
 
-    Methods
-    -------
-    decode(X)
-        Find most likely mixture components for each point in `X`.
-    eval(X)
-        Compute the log likelihood of `X` under the model and the
-        posterior distribution over mixture components.
-    fit(X)
-        Estimate model parameters from `X` using the EM algorithm.
-    predict(X)
-        Like decode, find most likely mixtures components for each
-        observation in `X`.
-    rvs(n=1, random_state=None)
-        Generate `n` samples from the model.
-    score(X)
-        Compute the log likelihood of `X` under the model.
-
     See Also
     --------
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -367,7 +367,7 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin):
 
     Notes
     -----
-    References:
+    **References**:
 
      * [1] "Solving multiclass learning problems via error-correcting ouput
         codes",

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -367,7 +367,7 @@ class BernoulliNB(BaseDiscreteNB):
 
     Notes
     -----
-    References:
+    **References**:
 
     C.D. Manning, P. Raghavan and H. Schütze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234–265.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -118,21 +118,6 @@ class GaussianNB(BaseNB):
     sigma : array, shape = [n_classes, n_features]
         variance of each feature per class
 
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
-
-    predict_proba(X) : array
-        Predict the probability of each class using the model.
-
-    predict_log_proba(X) : array
-        Predict the log-probability of each class using the model.
-
-
     Examples
     --------
     >>> import numpy as np
@@ -299,20 +284,6 @@ class MultinomialNB(BaseDiscreteNB):
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
 
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
-
-    predict_proba(X) : array
-        Predict the probability of each class using the model.
-
-    predict_log_proba(X) : array
-        Predict the log probability of each class using the model.
-
     Attributes
     ----------
     `intercept_`, `class_log_prior_` : array, shape = [n_classes]
@@ -373,20 +344,6 @@ class BernoulliNB(BaseDiscreteNB):
     fit_prior: boolean
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
-
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
-
-    predict_proba(X) : array
-        Predict the probability of each class using the model.
-
-    predict_log_proba(X) : array
-        Predict the log probability of each class using the model.
 
     Attributes
     ----------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -42,28 +42,6 @@ class Pipeline(BaseEstimator):
         List of the named object that compose the pipeline, in the \
         order that they are applied on the data.
 
-    Methods
-    -------
-    fit:
-        Fit all the transforms one after the other and transform the
-        data, then fit the transformed data using the final estimator
-    fit_transform:
-        Fit all the transforms one after the other and transform the
-        data, then use fit_transform on transformed data using the final
-        estimator. Valid only if the final estimator implements
-        fit_transform.
-    predict:
-        Applies transforms to the data, and the predict method of the
-        final estimator. Valid only if the final estimator implements
-        predict.
-    transform:
-        Applies transforms to the data, and the transform method of the
-        final estimator. Valid only if the final estimator implements
-        transform.
-    score:
-        Applies transforms to the data, and the score method of the
-        final estimator. Valid only if the final estimator implements
-        score.
 
     Examples
     --------
@@ -144,15 +122,25 @@ class Pipeline(BaseEstimator):
         return Xt, fit_params_steps[self.steps[-1][0]]
 
     def fit(self, X, y=None, **fit_params):
+        """Fit all the transforms one after the other and transform the
+        data, then fit the transformed data using the final estimator.
+        """
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
         self.steps[-1][-1].fit(Xt, y, **fit_params)
         return self
 
     def fit_transform(self, X, y=None, **fit_params):
+        """Fit all the transforms one after the other and transform the
+        data, then use fit_transform on transformed data using the final
+        estimator. Valid only if the final estimator implements
+        fit_transform."""
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
         return self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
 
     def predict(self, X):
+        """Applies transforms to the data, and the predict method of the
+        final estimator. Valid only if the final estimator implements
+        predict."""
         Xt = X
         for name, transform in self.steps[:-1]:
             Xt = transform.transform(Xt)
@@ -171,6 +159,9 @@ class Pipeline(BaseEstimator):
         return self.steps[-1][-1].predict_log_proba(Xt)
 
     def transform(self, X):
+        """Applies transforms to the data, and the transform method of the
+        final estimator. Valid only if the final estimator implements
+        transform."""
         Xt = X
         for name, transform in self.steps[:-1]:
             Xt = transform.transform(Xt)
@@ -185,6 +176,9 @@ class Pipeline(BaseEstimator):
         return Xt
 
     def score(self, X, y=None):
+        """Applies transforms to the data, and the score method of the
+        final estimator. Valid only if the final estimator implements
+        score."""
         Xt = X
         for name, transform in self.steps[:-1]:
             Xt = transform.transform(Xt)

--- a/sklearn/pls.py
+++ b/sklearn/pls.py
@@ -174,7 +174,7 @@ class _PLS(BaseEstimator):
 
     Notes
     -----
-    References:
+    **References**:
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -480,7 +480,7 @@ class PLSRegression(_PLS):
 
     Notes
     -----
-    References:
+    **References**:
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -587,7 +587,7 @@ class PLSCanonical(_PLS):
 
     Notes
     -----
-    References:
+    **References**:
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -698,7 +698,7 @@ class CCA(_PLS):
 
     Notes
     -----
-    References:
+    **References**:
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of

--- a/sklearn/pls.py
+++ b/sklearn/pls.py
@@ -73,8 +73,8 @@ def _svd_cross_product(X, Y):
 
 def _center_scale_xy(X, Y, scale=True):
     """ Center X, Y and scale if the scale parameter==True
-    Return
-    ------
+    Returns
+    -------
         X, Y, x_mean, y_mean, x_std, y_std
     """
     # center

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -312,8 +312,8 @@ class Normalizer(BaseEstimator, TransformerMixin):
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix).
 
-    Note
-    ----
+    Notes
+    -----
     This estimator is stateless (besides constructor parameters), the
     fit method does nothing but is useful when used in a pipeline.
 
@@ -603,7 +603,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             Target values. In the multilabel case the nested sequences can
             have variable lengths.
 
-        Note
+        Notes
         -----
         In the case when the binary labels are fractional
         (probabilistic), inverse_transform chooses the class with the

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -237,23 +237,6 @@ class NuSVC(DenseBaseLibSVM, ClassifierMixin):
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
-    Methods
-    -------
-    fit(X, y) : self
-        Fit the model
-
-    predict(X) : array
-        Predict using the model.
-
-    predict_proba(X) : array
-        Return probability estimates.
-
-    predict_log_proba(X) : array
-        Return log-probability estimates.
-
-    decision_function(X) : array
-        Return distance to predicted margin.
-
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/svm/liblinear.pyx
+++ b/sklearn/svm/liblinear.pyx
@@ -327,15 +327,13 @@ def predict_prob_wrap(np.ndarray[np.float64_t, ndim=2, mode='c'] T,
     We have to reconstruct model and parameters to make sure we stay
     in sync with the python object. predict_wrap skips this step.
 
+    See scikits.learn.svm.predict for a complete list of parameters.
+
     Parameters
     ----------
     X: array-like, dtype=float
     Y: array
         target vector
-
-    Optional Parameters
-    -------------------
-    See scikits.learn.svm.predict for a complete list of parameters.
 
     Returns
     -------

--- a/sklearn/svm/liblinear.pyx
+++ b/sklearn/svm/liblinear.pyx
@@ -28,7 +28,7 @@ cdef extern from "src/liblinear/liblinear_helper.c":
         char *indices, np.npy_intp *n_indptr, char *indptr, char *Y,
         np.npy_intp n_features, double bias)
     parameter *set_parameter(int, double, double, int, char *, char *)
-                          
+
     model *set_model(parameter *, char *, np.npy_intp *, char *, double)
     int copy_predict(char *, model *, np.npy_intp *, char *)
 
@@ -337,8 +337,8 @@ def predict_prob_wrap(np.ndarray[np.float64_t, ndim=2, mode='c'] T,
     -------------------
     See scikits.learn.svm.predict for a complete list of parameters.
 
-    Return
-    ------
+    Returns
+    -------
     dec_values : array
         predicted values.
     """

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -97,8 +97,8 @@ def fit(
 
     cache_size : float64
 
-    Return
-    ------
+    Returns
+    -------
     support : array, shape=[n_support]
         index of support vectors
 
@@ -274,8 +274,8 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
         C parameter in C-Support Vector Classification
 
 
-    Return
-    ------
+    Returns
+    -------
     dec_values : array
         predicted values.
 
@@ -352,8 +352,8 @@ def predict_proba(
     -------------------
     See scikits.learn.svm.predict for a complete list of parameters.
 
-    Return
-    ------
+    Returns
+    -------
     dec_values : array
         predicted values.
     """

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -339,6 +339,8 @@ def predict_proba(
     We have to reconstruct model and parameters to make sure we stay
     in sync with the python object.
 
+    See scikits.learn.svm.predict for a complete list of parameters.
+
     Parameters
     ----------
     X: array-like, dtype=float
@@ -347,10 +349,6 @@ def predict_proba(
 
     kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
 
-
-    Optional Parameters
-    -------------------
-    See scikits.learn.svm.predict for a complete list of parameters.
 
     Returns
     -------

--- a/sklearn/svm/sparse/libsvm.pyx
+++ b/sklearn/svm/sparse/libsvm.pyx
@@ -230,8 +230,8 @@ def libsvm_sparse_predict (np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
     -------------------
     See scikits.learn.svm.predict for a complete list of parameters.
 
-    Return
-    ------
+    Returns
+    -------
     dec_values : array
         predicted values.
     """

--- a/sklearn/svm/sparse/libsvm.pyx
+++ b/sklearn/svm/sparse/libsvm.pyx
@@ -220,15 +220,13 @@ def libsvm_sparse_predict (np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
     We have to reconstruct model and parameters to make sure we stay
     in sync with the python object.
 
+    See scikits.learn.svm.predict for a complete list of parameters.
+
     Parameters
     ----------
-    X: array-like, dtype=float
-    Y: array
+    X : array-like, dtype=float
+    Y : array
         target vector
-
-    Optional Parameters
-    -------------------
-    See scikits.learn.svm.predict for a complete list of parameters.
 
     Returns
     -------

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -529,7 +529,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] http://en.wikipedia.org/wiki/Decision_tree_learning
 
@@ -656,7 +656,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] http://en.wikipedia.org/wiki/Decision_tree_learning
 
@@ -715,7 +715,7 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.
@@ -754,7 +754,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     Notes
     -----
-    References:
+    **References**:
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -109,8 +109,8 @@ def resample(*arrays, **options):
     Sequence of resampled views of the collections. The original arrays are
     not impacted.
 
-    Example
-    -------
+    Examples
+    --------
     It is possible to mix sparse and dense arrays in the same run::
 
       >>> X = [[1., 0.], [2., 1.], [0., 0.]]
@@ -210,8 +210,8 @@ def shuffle(*arrays, **options):
     Sequence of shuffled views of the collections. The original arrays are
     not impacted.
 
-    Example
-    -------
+    Examples
+    --------
     It is possible to mix sparse and dense arrays in the same run::
 
       >>> X = [[1., 0.], [2., 1.], [0., 0.]]

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -104,8 +104,8 @@ def resample(*arrays, **options):
     random_state : int or RandomState instance
         Control the shuffling for reproducible behavior.
 
-    Return
-    ------
+    Returns
+    -------
     Sequence of resampled views of the collections. The original arrays are
     not impacted.
 
@@ -205,8 +205,8 @@ def shuffle(*arrays, **options):
         Number of samples to generate. If left to None this is
         automatically set to the first dimension of the arrays.
 
-    Return
-    ------
+    Returns
+    -------
     Sequence of shuffled views of the collections. The original arrays are
     not impacted.
 

--- a/sklearn/utils/_csgraph.py
+++ b/sklearn/utils/_csgraph.py
@@ -26,13 +26,13 @@ def cs_graph_components(x):
     checked.
 
     Parameters
-    -----------
+    ----------
     x: ndarray-like, 2 dimensions, or sparse matrix
         The adjacency matrix of the graph. Only the upper triangular part
         is used.
 
     Returns
-    --------
+    -------
     n_components: int
         The number of connected components.
     label: ndarray (ints, 1 dimension):
@@ -40,14 +40,14 @@ def cs_graph_components(x):
         indicate empty rows: 0 everywhere, including diagonal).
 
     Notes
-    ------
+    -----
 
     The matrix is assumed to be symmetric and the upper triangular part
     of the matrix is used. The matrix is converted to a CSR matrix unless
     it is already a CSR.
 
-    Example
-    -------
+    Examples
+    --------
 
     >>> from scipy.sparse import cs_graph_components
     >>> import numpy as np

--- a/sklearn/utils/arpack.py
+++ b/sklearn/utils/arpack.py
@@ -1154,12 +1154,6 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     eigsh : eigenvalues and eigenvectors for symmetric matrix A
     svds : singular value decomposition for a matrix A
 
-    Notes
-    -----
-    This function is a wrapper to the ARPACK [1]_ SNEUPD, DNEUPD, CNEUPD,
-    ZNEUPD, functions which use the Implicitly Restarted Arnoldi Method to
-    find the eigenvalues and eigenvectors [2]_.
-
     Examples
     --------
     Find 6 eigenvectors of the identity matrix:
@@ -1174,7 +1168,11 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Notes
     -----
-    References:
+    This function is a wrapper to the ARPACK [1]_ SNEUPD, DNEUPD, CNEUPD,
+    ZNEUPD, functions which use the Implicitly Restarted Arnoldi Method to
+    find the eigenvalues and eigenvectors [2]_.
+
+    **References**:
 
     .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
@@ -1412,8 +1410,9 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     >>> vecs.shape
     (13, 6)
 
-    References
-    ----------
+    Notes
+    -----
+    **References**:
     .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
@@ -1555,8 +1554,8 @@ def svds(A, k=6, ncv=None, tol=0):
     tol : float, optional
         Tolerance for singular values. Zero (default) means machine precision.
 
-    Note
-    ----
+    Notes
+    -----
     This is a naive implementation using an eigensolver on A.H * A or
     A * A.H, depending on which one is more efficient.
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -83,7 +83,7 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
     """Computes an orthonormal matrix whose range approximates the range of A.
 
     Parameters
-    ==========
+    ----------
     A: 2D array
         The input data matrix
     size: integer
@@ -94,13 +94,13 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
         A random number generator instance
 
     Returns
-    =======
+    -------
     Q: 2D array
         A (size x size) projection matrix, the range of which
         approximates well the range of the input matrix A.
 
     Notes
-    =====
+    -----
 
     Follows Algorithm 4.3 of
     Finding structure with randomness: Stochastic algorithms for constructing
@@ -130,7 +130,7 @@ def fast_svd(M, k, p=None, n_iterations=0, transpose='auto', random_state=0):
     """Computes the k-truncated randomized SVD
 
     Parameters
-    ===========
+    ----------
     M: ndarray or sparse matrix
         Matrix to decompose
 
@@ -156,7 +156,7 @@ def fast_svd(M, k, p=None, n_iterations=0, transpose='auto', random_state=0):
         A random number generator instance to make behavior
 
     Notes
-    =====
+    -----
     This algorithm finds the exact truncated singular values decomposition
     using randomization to speed up the computations. It is particularly
     fast on large matrices on which you whish to extract only a small
@@ -166,7 +166,7 @@ def fast_svd(M, k, p=None, n_iterations=0, transpose='auto', random_state=0):
     checked by ensuring that the lowest extracted singular value is on
     the order of the machine precision of floating points.
 
-    References:
+    **References**:
 
     * Finding structure with randomness: Stochastic algorithms for constructing
       approximate matrix decompositions
@@ -212,7 +212,7 @@ def logsumexp(arr, axis=0):
     over/underflow.
 
     Examples
-    ========
+    --------
 
     >>> import numpy as np
     >>> from sklearn.utils.extmath import logsumexp


### PR DESCRIPTION
These are some typo fixes 'Example'->'Examples', making 'Reference' **bold**, removing 'Methods' sections and pyflakes whenever I found some.
