### PR TITLE
ENH: make ShuffleSplit able to subsample the data

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -81,7 +81,7 @@ validation iterator instead, for instance::
 
   >>> cross_validation.cross_val_score(clf, iris.data, iris.target, cv=cv)
   ...                                                     # doctest: +ELLIPSIS
-  array([ 0.97...,  0.95...,  0.95...])
+  array([ 0.97...,  0.97...,  1.        ])
 
 The available cross validation iterators are introduced in the following.
 
@@ -323,9 +323,9 @@ Here is a usage example::
   >>> for train_index, test_index in ss:
   ...    print train_index, test_index
   ...
-  [2 0 1] [3 4]
-  [0 2 1] [4 3]
-  [1 3 4] [0 2]
+  [1 3 4] [2 0]
+  [1 4 3] [0 2]
+  [4 0 2] [1 3]
 
 :class:`ShuffleSplit` is thus a good alternative to :class:`KFold` cross
 validation that allows a finer control on the number of iterations and

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,9 @@ Changelog
    - Feature importances using decision trees and/or forest of trees,
      by `Gilles Louppe`_.
 
+   - :class:`sklearn.cross_validation.ShuffleSplit` can subsample the train
+     sets as well as the test sets by `Olivier Grisel`_.
+
 
 API changes summary
 -------------------

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -199,6 +199,15 @@ def test_bootstrap_errors():
     assert_raises(ValueError, cross_validation.Bootstrap, 10, n_test=1.1)
 
 
+def test_shufflesplit_errors():
+    assert_raises(ValueError, cross_validation.ShuffleSplit, 10,
+                  test_fraction=2.0)
+    assert_raises(ValueError, cross_validation.ShuffleSplit, 10,
+                  test_fraction=1.0)
+    assert_raises(ValueError, cross_validation.ShuffleSplit, 10,
+                  test_fraction=0.1, train_fraction=0.95)
+
+
 def test_cross_indices_exception():
     X = coo_matrix(np.array([[1, 2], [3, 4], [5, 6], [7, 8]]))
     y = np.array([1, 1, 2, 2])


### PR DESCRIPTION
Add the `train_fraction` option to `ShuffleSplit`. This will be useful to easily implement the cv / training errors curves to qualitatively evaluate the under / overfitting of a model.
