### PR TITLE
MRG: AdaBoost for regression and multi-class classification

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -253,7 +253,7 @@ AdaBoost
 
 The module :mod:`sklearn.ensemble` implements the popular boosting algorithm
 known as AdaBoost. This algorithm was first introduced by Freud and Schapire
-[FS1995]_ back in 1995.
+[FS1995]_ in 1995.
 
 The core principle of AdaBoost is to fit a sequence of weak learners (i.e.,
 models that are only slightly better than random guessing, such as small
@@ -324,7 +324,7 @@ of decision trees).
  .. [ZZRH2009] J. Zhu, H. Zou, S. Rosset, T. Hastie. "Multi-class AdaBoost",
                2009.
 
- .. [D1997] H. Drucker. "Improving Regressor using Boosting Techniques", 1997.
+ .. [D1997] H. Drucker. "Improving Regressors using Boosting Techniques", 1997.
 
  .. [HTF2009] T. Hastie, R. Tibshirani and J. Friedman, "Elements of
               Statistical Learning Ed. 2", Springer, 2009.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -251,9 +251,9 @@ the transformation performs an implicit, non-parametric density estimation.
 AdaBoost
 ========
 
-The module :mod:`sklearn.ensemble` implements the popular boosting algorithm
-known as AdaBoost. This algorithm was first introduced by Freud and Schapire
-[FS1995]_ in 1995.
+The module :mod:`sklearn.ensemble.weight_boosting` implements the popular
+boosting algorithm known as AdaBoost introduced in 1995 by Freud and
+Schapire [FS1995]_.
 
 The core principle of AdaBoost is to fit a sequence of weak learners (i.e.,
 models that are only slightly better than random guessing, such as small
@@ -266,7 +266,7 @@ to each of the training samples. Initially, those weights are all set to
 original data. For each successive iteration, the sample weights are
 individually modified and the learning algorithm is reapplied to the reweighted
 data. At a given step, those training examples that were incorrectly predicted
-by the boosting model induced at the previous step have their weights increased,
+by the boosted model induced at the previous step have their weights increased,
 whereas the weights are decreased for those that were predicted correctly. As
 iterations proceed, examples that are difficult to predict receive
 ever-increasing influence. Each subsequent weak learner is thereby forced to
@@ -306,15 +306,25 @@ The number of weak learners is controlled by the parameter ``n_estimators``. The
 the final combination. By default, weak learners are decision stumps. Different
 weak learners can be specified through the ``base_estimator`` parameter.
 The main parameters to tune to obtain good results are ``n_estimators`` and
-the complexity of the base estimators (e.g., its depth ``max_depth`` in case
-of decision trees).
+the complexity of the base estimators (e.g., its depth ``max_depth`` or
+minimum required number of samples at a leaf ``min_samples_leaf`` in case of
+decision trees).
 
 .. topic:: Examples:
 
- * :ref:`example_ensemble_plot_adaboost_hastie_10_2.py`
- * :ref:`example_ensemble_plot_adaboost_multiclass.py`
- * :ref:`example_ensemble_plot_adaboost_regression.py`
- * :ref:`example_ensemble_plot_adaboost_twoclass.py`
+ * :ref:`example_ensemble_plot_adaboost_hastie_10_2.py` compares the
+   classification error of a decision stump, decision tree, and a boosted
+   decision stump using AdaBoost-SAMME and AdaBoost-SAMME.R.
+
+ * :ref:`example_ensemble_plot_adaboost_multiclass.py` shows the performance
+   of AdaBoost-SAMME and AdaBoost-SAMME.R on a multi-class problem.
+
+ * :ref:`example_ensemble_plot_adaboost_twoclass.py` shows the decision boundary
+   and decision function values for a non-linearly separable two-class problem
+   using AdaBoost-SAMME.
+
+ * :ref:`example_ensemble_plot_adaboost_regression.py` demonstrates regression
+   with the AdaBoost.R2 algorithm.
 
 .. topic:: References
 

--- a/examples/ensemble/plot_adaboost_regression.py
+++ b/examples/ensemble/plot_adaboost_regression.py
@@ -27,10 +27,8 @@ from sklearn.ensemble import AdaBoostRegressor
 
 clf_1 = DecisionTreeRegressor(max_depth=4)
 
-clf_2 = AdaBoostRegressor(
-    DecisionTreeRegressor(max_depth=4),
-    n_estimators=300,
-    random_state=rng)
+clf_2 = AdaBoostRegressor(DecisionTreeRegressor(max_depth=4),
+                          n_estimators=300, random_state=rng)
 
 clf_1.fit(X, y)
 clf_2.fit(X, y)

--- a/examples/ensemble/plot_adaboost_twoclass.py
+++ b/examples/ensemble/plot_adaboost_twoclass.py
@@ -37,10 +37,9 @@ X = np.concatenate((X1, X2))
 y = np.concatenate((y1, - y2 + 1))
 
 # Create and fit an AdaBoosted decision tree
-bdt = AdaBoostClassifier(
-    DecisionTreeClassifier(max_depth=1),
-    algorithm="SAMME",
-    n_estimators=200)
+bdt = AdaBoostClassifier(DecisionTreeClassifier(max_depth=1),
+                         algorithm="SAMME",
+                         n_estimators=200)
 
 bdt.fit(X, y)
 
@@ -68,7 +67,8 @@ for i, n, c in zip(xrange(2), class_names, plot_colors):
     pl.scatter(X[idx, 0], X[idx, 1],
                c=c, cmap=pl.cm.Paired,
                label="Class %s" % n)
-pl.axis("tight")
+pl.xlim(x_min, x_max)
+pl.ylim(y_min, y_max)
 pl.legend(loc='upper right')
 pl.xlabel("Decision Boundary")
 


### PR DESCRIPTION
This PR adds:
- a new ensemble.weight_boosting module with AdaBoostRegressor (using AdaBoost.R2 [1]) and AdaBoostClassifier (using the multi-class SAMME algorithm [2])
- a new "Gaussian quantiles" dataset in datasets.samples_generator as used in [2]

Examples are provided:

![hastie](https://f.cloud.github.com/assets/202816/74736/07057cd0-60a3-11e2-87e3-dd8572078d11.png)

![twoclass](https://f.cloud.github.com/assets/202816/121925/d7a0c70c-6e11-11e2-8927-e0471292262f.png)

![multiclass](https://f.cloud.github.com/assets/202816/121927/dceefd78-6e11-11e2-8959-60c051ef6118.png)

![regression](https://f.cloud.github.com/assets/202816/121928/e1155136-6e11-11e2-9cf2-1d51cae3969a.png)

[1] http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.31.314
[2] http://www.stanford.edu/~hastie/Papers/samme.pdf
