### PR TITLE
Doc fix in cross_validation.py

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -806,9 +806,8 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
         supervised learning.
 
     score_func: callable, optional
-        callable taking as arguments the fitted estimator, the
-        test data (X_test) and the test target (y_test) if y is
-        not None.
+        callable taking as arguments the test target (y_test) if y is
+        not None and values predicted by the estimator (y_pred).
 
     cv: cross-validation generator, optional
         A cross-validation generator. If None, a 3-fold cross

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -806,8 +806,10 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
         supervised learning.
 
     score_func: callable, optional
-        callable taking as arguments the test target (y_test) if y is
-        not None and values predicted by the estimator (y_pred).
+        callable, has priority over the score function in the estimator.
+        In a non-supervised setting, where y is None, it takes the test
+        data (X_test) as its only argument. In a supervised setting it takes
+        the test target (y_true) and the test prediction (y_pred) as arguments.
 
     cv: cross-validation generator, optional
         A cross-validation generator. If None, a 3-fold cross


### PR DESCRIPTION
If you pass your own score_func to cross_val_score, then this function takes one argument (X_test) in the non supervised setting and two arguments (y_true and y_pred, which is estimator.predict(X_test)) in the supervised setting.
As opposed to the three arguments (estimator, X_test, y_test) that were mentioned before.

Hope I got this right :)
