### PR TITLE
MRG: Inplace Import Fix

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -15,6 +15,7 @@ See http://scikit-learn.sourceforge.net for complete documentation.
 
 from . import check_build
 from .base import clone
+import warnings
 
 
 try:
@@ -48,7 +49,7 @@ __version__ = '0.10-git'
 try:
     from sklearn.__config__ import show as show_config
 except ImportError:
-    msg = """Error importing scikit-learn: you cannot import sklearn while
-    being in scikit-learn source directory; please exit the source
-    tree first, and relaunch your python intepreter."""
-    raise ImportError(msg)
+    warnings.warn("Warning: importing sklearn from within the scikit-learn "
+                  "source directory.  This can cause problems: please exit "
+                  "the source tree first, and relaunch your python "
+                  "intepreter.")

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -44,3 +44,11 @@ __all__ = ['check_build', 'cross_validation', 'cluster', 'covariance',
            'preprocessing', 'qda', 'svm', 'test', 'clone', 'pls']
 
 __version__ = '0.10-git'
+
+try:
+    from sklearn.__config__ import show as show_config
+except ImportError:
+    msg = """Error importing scikit-learn: you cannot import sklearn while
+    being in scikit-learn source directory; please exit the source
+    tree first, and relaunch your python intepreter."""
+    raise ImportError(msg)

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -58,6 +58,9 @@ def configuration(parent_package='', top_path=None):
     # add the test directory
     config.add_subpackage('tests')
 
+    # Generate __config__.py file: this helps handle inplace issues
+    config.make_config_py()
+
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses the problem that @amueller was having running tests.  It raises an ImportError if sklearn is imported within the scikit-learn source directory.  The fix is based on a similar check within the scipy setup file.

I'm a bit of a distutils novice: this worked on my system, but I'd love some feedback before it's merged.
