### PR TITLE
ENH: Make LinearRegression work with sparse

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -4,11 +4,14 @@
 # License: BSD Style.
 
 from numpy.testing import assert_array_almost_equal
+import numpy as np
+from scipy import sparse
 
 from ..base import LinearRegression
+from ...utils import check_random_state
 
 
-def test_LinearRegression():
+def test_linear_regression():
     """
     Test LinearRegression on a simple dataset.
     """
@@ -32,3 +35,18 @@ def test_LinearRegression():
     assert_array_almost_equal(clf.coef_, [0])
     assert_array_almost_equal(clf.intercept_, [0])
     assert_array_almost_equal(clf.predict(X), [0])
+
+
+def test_linear_regression_sparse(random_state=0):
+    "Test that linear regression also works with sparse data"
+    random_state = check_random_state(random_state)
+    n = 100
+    X = sparse.eye(n, n)
+    beta = random_state.rand(n)
+    y = X * beta[:, np.newaxis]
+
+    ols = LinearRegression()
+    ols.fit(X, y.ravel())
+    assert_array_almost_equal(beta, ols.coef_ + ols.intercept_)
+    assert_array_almost_equal(ols.residues_, 0)
+


### PR DESCRIPTION
Fixes #533

Trivial PR to make LinearRegression work with sparse data.
