### PR TITLE
WIP Adding class weight parameter to svm constructors

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -47,7 +47,7 @@ class BaseLibSVM(BaseEstimator):
 
     def __init__(self, impl, kernel, degree, gamma, coef0,
                  tol, C, nu, epsilon, shrinking, probability, cache_size,
-                 scale_C):
+                 scale_C, class_weight=None):
 
         if not impl in LIBSVM_IMPL:
             raise ValueError("impl should be one of %s, %s was given" % (
@@ -74,6 +74,7 @@ class BaseLibSVM(BaseEstimator):
         self.probability = probability
         self.cache_size = cache_size
         self.scale_C = scale_C
+        self.class_weight = class_weight
 
     @abstractmethod
     def fit(self, X, y, class_weight=None, sample_weight=None):
@@ -176,6 +177,9 @@ class DenseBaseLibSVM(BaseLibSVM):
             # TODO: add keyword copy to copy on demand
             self.__Xfit = X
             X = self._compute_kernel(X)
+
+        if class_weight == None:
+            class_weight == self.class_weight
 
         class_weight, class_weight_label = \
                      _get_class_weight(class_weight, y)
@@ -360,7 +364,7 @@ class BaseLibLinear(BaseEstimator):
 
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
                  multi_class=False, fit_intercept=True, intercept_scaling=1,
-                 scale_C=False):
+                 scale_C=False, class_weight=None):
         self.penalty = penalty
         self.loss = loss
         self.dual = dual
@@ -370,6 +374,7 @@ class BaseLibLinear(BaseEstimator):
         self.intercept_scaling = intercept_scaling
         self.multi_class = multi_class
         self.scale_C = scale_C
+        self.class_weight = class_weight
 
         # Check that the arguments given are valid:
         self._get_solver_type()

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -56,6 +56,14 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, CoefSelectTransformerMixin):
         Scale C with number of samples. It makes the setting of C independent
         of the number of samples.
 
+    class_weight : {dict, 'auto'}, optional
+        Set the parameter C of class i to class_weight[i]*C for
+        SVC. If not given, all classes are supposed to have
+        weight one. The 'auto' mode uses the values of y to
+        automatically adjust weights inversely proportional to
+        class frequencies.
+
+
     Attributes
     ----------
     `coef_` : array, shape = [n_features] if n_classes == 2 \
@@ -127,6 +135,13 @@ class SVC(DenseBaseLibSVM, ClassifierMixin):
     scale_C : bool
         Scale C with number of samples. It makes the setting of C independant
         of the number of samples.
+
+    class_weight : {dict, 'auto'}, optional
+        Set the parameter C of class i to class_weight[i]*C for
+        SVC. If not given, all classes are supposed to have
+        weight one. The 'auto' mode uses the values of y to
+        automatically adjust weights inversely proportional to
+        class frequencies.
 
     Attributes
     ----------
@@ -215,6 +230,13 @@ class NuSVC(DenseBaseLibSVM, ClassifierMixin):
 
     cache_size: float, optional
         Specify the size of the kernel cache (in MB)
+
+    class_weight : {dict, 'auto'}, optional
+        Set the parameter C of class i to class_weight[i]*C for
+        SVC. If not given, all classes are supposed to have
+        weight one. The 'auto' mode uses the values of y to
+        automatically adjust weights inversely proportional to
+        class frequencies.
 
     Attributes
     ----------


### PR DESCRIPTION
Trying to address issue #64 (Make class_weights a constructor parameter for all classifier models).

After this modification, the grid search test fails. The svm can not be cloned any more. I don't get that.
