### PR TITLE
MRG: Explicitly mark the array returned by the linear svm readonly property coef_ as immutable

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -58,6 +58,9 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin,
     `coef_` : array, shape = [n_classes-1, n_features]
         Coefficient of the features in the decision function.
 
+        `coef_` is readonly property derived from `raw_coef_` that
+        follows the internal memory layout of liblinear.
+
     `intercept_` : array, shape = [n_classes-1]
         intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -537,12 +537,18 @@ class BaseLibLinear(BaseEstimator):
     @property
     def coef_(self):
         if self.fit_intercept:
-            ret = self.raw_coef_[:, : -1]
+            ret = self.raw_coef_[:, : -1].copy()
         else:
-            ret = self.raw_coef_
+            ret = self.raw_coef_.copy()
+
+        # as coef_ is readonly property, mark the returned value as immutable
+        # to avoid silencing potential bugs
         if len(self.label_) <= 2:
-            return -ret
+            ret = -ret
+            ret.flags.writeable = False
+            return ret
         else:
+            ret.flags.writeable = False
             return ret
 
     def _get_bias(self):

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -118,7 +118,11 @@ class BaseLibSVM(BaseEstimator):
         if self.kernel != 'linear':
             raise NotImplementedError('coef_ is only available when using a '
                                       'linear kernel')
-        return dot(self.dual_coef_, self.support_vectors_)
+        coef = dot(self.dual_coef_, self.support_vectors_)
+        # coef_ being a read-only property it's better to mark the value as
+        # immutable to avoid hiding potential bugs for the unsuspecting user
+        coef.flags.writeable = False
+        return coef
 
 
 class DenseBaseLibSVM(BaseLibSVM):

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -544,7 +544,7 @@ class BaseLibLinear(BaseEstimator):
         # as coef_ is readonly property, mark the returned value as immutable
         # to avoid silencing potential bugs
         if len(self.label_) <= 2:
-            ret = -ret
+            ret *= -1
             ret.flags.writeable = False
             return ret
         else:

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -146,6 +146,9 @@ class SVC(DenseBaseLibSVM, ClassifierMixin):
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
+        `coef_` is readonly property derived from `dual_coef_` and
+        `support_vectors_`
+
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
@@ -233,6 +236,9 @@ class NuSVC(DenseBaseLibSVM, ClassifierMixin):
     `coef_` : array, shape = [n_classes-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
+
+        `coef_` is readonly property derived from `dual_coef_` and
+        `support_vectors_`
 
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
@@ -328,6 +334,9 @@ class SVR(DenseBaseLibSVM, RegressorMixin):
     `coef_` : array, shape = [n_classes-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
+
+        `coef_` is readonly property derived from `dual_coef_` and
+        `support_vectors_`
 
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
@@ -449,6 +458,9 @@ class NuSVR(DenseBaseLibSVM, RegressorMixin):
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
+        `coef_` is readonly property derived from `dual_coef_` and
+        `support_vectors_`
+
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
@@ -558,6 +570,9 @@ class OneClassSVM(DenseBaseLibSVM):
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
+        `coef_` is readonly property derived from `dual_coef_` and
+        `support_vectors_`
+
     `intercept_` : array, shape = [n_classes-1]
         Constants in decision function.
 
@@ -592,3 +607,4 @@ class OneClassSVM(DenseBaseLibSVM):
         super(OneClassSVM, self).fit(
             X, [], class_weight=class_weight, sample_weight=sample_weight,
             **params)
+        return self

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -63,6 +63,9 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, CoefSelectTransformerMixin):
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
+        `coef_` is readonly property derived from `raw_coef_` that
+        follows the internal memory layout of liblinear.
+
     `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -543,6 +543,8 @@ def test_immutable_coef_property():
         svm.sparse.NuSVC(kernel='linear').fit(iris.data, iris.target),
         svm.sparse.SVR(kernel='linear').fit(iris.data, iris.target),
         svm.sparse.NuSVR(kernel='linear').fit(iris.data, iris.target),
+        svm.LinearSVC().fit(iris.data, iris.target),
+        linear_model.LogisticRegression().fit(iris.data, iris.target),
     ]
     for clf in svms:
         assert_raises(AttributeError, clf.__setattr__, 'coef_', np.arange(3))

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -531,6 +531,20 @@ def test_nu_svc_samples_scaling():
         assert_true(error_with_scale < 1e-5)
 
 
+def test_immutable_coef_property():
+    """Check that primal coef modification are not silently ignored"""
+    svms = [
+        svm.SVC(kernel='linear').fit(iris.data, iris.target),
+        svm.NuSVC(kernel='linear').fit(iris.data, iris.target),
+        svm.SVR(kernel='linear').fit(iris.data, iris.target),
+        svm.NuSVR(kernel='linear').fit(iris.data, iris.target),
+        svm.OneClassSVM(kernel='linear').fit(iris.data),
+    ]
+    for clf in svms:
+        assert_raises(AttributeError, clf.__setattr__, 'coef_', np.arange(3))
+        assert_raises(RuntimeError, clf.coef_.__setitem__, (0, 0), 0)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -539,6 +539,10 @@ def test_immutable_coef_property():
         svm.SVR(kernel='linear').fit(iris.data, iris.target),
         svm.NuSVR(kernel='linear').fit(iris.data, iris.target),
         svm.OneClassSVM(kernel='linear').fit(iris.data),
+        svm.sparse.SVC(kernel='linear').fit(iris.data, iris.target),
+        svm.sparse.NuSVC(kernel='linear').fit(iris.data, iris.target),
+        svm.sparse.SVR(kernel='linear').fit(iris.data, iris.target),
+        svm.sparse.NuSVR(kernel='linear').fit(iris.data, iris.target),
     ]
     for clf in svms:
         assert_raises(AttributeError, clf.__setattr__, 'coef_', np.arange(3))


### PR DESCRIPTION
This pull-request #539 should be taken into account to  understand the context about the debate of readonly properties in the scikit-learn API.

This pull request is also related to issue #470 LogisticRegression and LinearSVC should have read-write coef_ and intercept_ attributes (it does not fix it but makes it a less dangerous behavior).

The following is an example session were the unsuspecting user might overlook a bug: 

```
>>> from sklearn.svm import SVC
>>> from sklearn.datasets import load_iris
>>> iris = load_iris()
>>> clf = SVC(kernel='linear').fit(iris.data, iris.target)
>>> clf.coef_

array([[-1.0443518 ,  0.01195155, -1.91966087, -0.81040704],
       [ 1.5863679 ,  1.66207276, -1.65274791, -1.95241805]])
>>> clf.coef_[0, 3] = 0
>>> clf.coef_

array([[-1.0443518 ,  0.01195155, -1.91966087, -0.81040704],
       [ 1.5863679 ,  1.66207276, -1.65274791, -1.95241805]])
```
