### PR TITLE
MRG Sgd fortran layout

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,7 +32,8 @@ Changelog
      solution was retained instead of the best solution.
 
    - Minor refactoring in :ref:`sgd` module; consolidated dense and sparse
-     predict methods.
+     predict methods; Enhanced test time performance by converting model
+     paramters to fortran-style arrays after fitting (only multi-class).
 
    - Adjusted Mutual Information metric added as
      :func:`sklearn.metrics.adjusted_mutual_info_score` by Robert Layton.

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -249,7 +249,12 @@ class BaseSGD(BaseEstimator):
         return sample_weight
 
     def _set_coef(self, coef_):
-        """Make sure that coef_ is fortran-style and 2d. """
+        """Make sure that coef_ is fortran-style and 2d.
+        
+        Fortran-style memory layout is needed to ensure that computing
+        the dot product between input ``X`` and ``coef_`` does not trigger
+        a memory copy.
+        """
         self.coef_ = np.asfortranarray(array2d(coef_))
 
     def _allocate_parameter_mem(self, n_classes, n_features, coef_init=None,

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -249,8 +249,8 @@ class BaseSGD(BaseEstimator):
         return sample_weight
 
     def _set_coef(self, coef_):
-        """Make sure that coef_ is 2d. """
-        self.coef_ = array2d(coef_)
+        """Make sure that coef_ is fortran-style and 2d. """
+        self.coef_ = np.asfortranarray(array2d(coef_))
 
     def _allocate_parameter_mem(self, n_classes, n_features, coef_init=None,
                                 intercept_init=None):

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -183,6 +183,8 @@ class SGDClassifier(BaseSGDClassifier):
             self.coef_[i] = coef
             self.intercept_[i] = intercept
 
+        self._set_coef(self.coef_)
+
 
 def _train_ova_classifier(i, c, X, y, coef_, intercept_, loss_function,
                           penalty_type, alpha, rho, n_iter, fit_intercept,


### PR DESCRIPTION
Enhanced test time performance for SGDClassifier by converting `coef_` to fortran-style array after model fitting. This only affects multi-class classification. Without this fix there is a rather large overhead for making predictions for single data points.

see http://sourceforge.net/mailarchive/message.php?msg_id=28644874
