### PR TITLE
More convenient warm start

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -54,7 +54,8 @@ def affinity_propagation(S, p=None, convit=30, max_iter=200, damping=0.5,
 
     n_points = S.shape[0]
 
-    assert S.shape[0] == S.shape[1]
+    if S.shape[0] != S.shape[1]:
+        raise ValueError("S must be a square array (shape=%r)" % S.shape)
 
     if p is None:
         p = np.median(S)

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -66,9 +66,6 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
     random_state = check_random_state(random_state)
     index_order = np.arange(n)
     random_state.shuffle(index_order)
-    assert len(index_order) == n, ("Index order must be of length n"
-                                   " (%d expected, %d given)"
-                                   % (n, len(index_order)))
     D = pairwise_distances(X, metric=metric)
     # Calculate neighborhood for all samples. This leaves the original point
     # in, which needs to be considered later (i.e. point i is the

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -225,7 +225,8 @@ class _AbstractUnivariateFilter(BaseEstimator, TransformerMixin):
             function taking two arrays X and y, and returning 2 arrays:
             both scores and pvalues
         """
-        assert callable(score_func), ValueError(
+        if not callable(score_func):
+            raise TypeError(
                 "The score function should be a callable, '%s' (type %s) "
                 "was passed." % (score_func, type(score_func)))
         self.score_func = score_func
@@ -288,8 +289,9 @@ class SelectPercentile(_AbstractUnivariateFilter):
 
     def _get_support_mask(self):
         percentile = self.percentile
-        assert percentile <= 100, ValueError('percentile should be \
-                            between 0 and 100 (%f given)' % (percentile))
+        if percentile > 100:
+            raise ValueError("percentile should be between 0 and 100"
+                             " (%f given)" % (percentile))
         # Cater for Nans
         if percentile == 100:
             return np.ones(len(self._pvalues), dtype=np.bool)
@@ -319,8 +321,9 @@ class SelectKBest(_AbstractUnivariateFilter):
 
     def _get_support_mask(self):
         k = self.k
-        assert k <= len(self._pvalues), ValueError('cannot select %d features'
-                                    ' among %d ' % (k, len(self._pvalues)))
+        if k > len(self._pvalues):
+            raise ValueError("cannot select %d features among %d"
+                             % (k, len(self._pvalues)))
         alpha = np.sort(self._pvalues)[k - 1]
         return (self._pvalues <= alpha)
 
@@ -429,10 +432,12 @@ class GenericUnivariateSelect(_AbstractUnivariateFilter):
                         }
 
     def __init__(self, score_func, mode='percentile', param=1e-5):
-        assert callable(score_func), ValueError(
+        if not callable(score_func):
+            raise TypeError(
                 "The score function should be a callable, '%s' (type %s) "
                 "was passed." % (score_func, type(score_func)))
-        assert mode in self._selection_modes, ValueError(
+        if mode not in self._selection_modes:
+            raise ValueError(
                 "The mode passed should be one of %s, '%s', (type %s) "
                 "was passed." % (
                         self._selection_modes.keys(),

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -370,8 +370,6 @@ class GridSearchCV(BaseEstimator):
             self.predict = best_estimator.predict
         if hasattr(best_estimator, 'predict_proba'):
             self.predict_proba = best_estimator.predict_proba
-        if hasattr(best_estimator, 'score'):
-            self.score_ = best_estimator.score
 
         # Store the computed scores
         # XXX: the name is too specific, it shouldn't have
@@ -383,8 +381,12 @@ class GridSearchCV(BaseEstimator):
         return self
 
     def score(self, X, y=None):
-        # This method is overridden during the fit if the best estimator
-        # found has a score function.
+        if hasattr(self.best_estimator, 'score'):
+             return self.best_estimator.score(X, y)
+        if self.score_func is None:
+            raise ValueError("No score function explicitly defined, "
+                             "and the estimator doesn't provide one %s"
+                             % self.best_estimator)
         y_predicted = self.predict(X)
         return self.score_func(y, y_predicted)
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -253,13 +253,15 @@ class GridSearchCV(BaseEstimator):
                  fit_params=None, n_jobs=1, iid=True, refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs',
                 ):
-        assert hasattr(estimator, 'fit') and (hasattr(estimator, 'predict')
-                        or hasattr(estimator, 'score')), (
-            "estimator should a be an estimator implementing 'fit' and "
-            "'predict' or 'score' methods, %s (type %s) was passed" %
-                    (estimator, type(estimator)))
+        if not hasattr(estimator, 'fit') or \
+           not (hasattr(estimator, 'predict') or hasattr(estimator, 'score')):
+            raise TypeError("estimator should a be an estimator implementing"
+                            " 'fit' and 'predict' or 'score' methods,"
+                            " %s (type %s) was passed" %
+                            (estimator, type(estimator)))
         if loss_func is None and score_func is None:
-            assert hasattr(estimator, 'score'), ValueError(
+            if not hasattr(estimator, 'score'):
+                raise TypeError(
                     "If no loss_func is specified, the estimator passed "
                     "should have a 'score' method. The estimator %s "
                     "does not." % estimator)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -347,15 +347,11 @@ class GridSearchCV(BaseEstimator):
 
         # Note: we do not use max(out) to make ties deterministic even if
         # comparison on estimator instances is not deterministic
-        best_score = None
+        best_score = -np.inf
         for score, estimator in scores:
-            if best_score is None:
+            if score > best_score:
                 best_score = score
                 best_estimator = estimator
-            else:
-                if score > best_score:
-                    best_score = score
-                    best_estimator = estimator
 
         if best_score is None:
             raise ValueError('Best score could not be found')

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -379,12 +379,12 @@ class GridSearchCV(BaseEstimator):
         return self
 
     def score(self, X, y=None):
-        if hasattr(self.best_estimator, 'score'):
-             return self.best_estimator.score(X, y)
+        if hasattr(self.best_estimator_, 'score'):
+             return self.best_estimator_.score(X, y)
         if self.score_func is None:
             raise ValueError("No score function explicitly defined, "
                              "and the estimator doesn't provide one %s"
-                             % self.best_estimator)
+                             % self.best_estimator_)
         y_predicted = self.predict(X)
         return self.score_func(y, y_predicted)
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -288,7 +288,7 @@ class BaseSGD(BaseEstimator):
         if n_classes > 2:
             # allocate coef_ for multi-class
             if coef_init is not None:
-                coef_init = np.asarray(coef_init)
+                coef_init = np.asarray(coef_init, order="C")
                 if coef_init.shape != (n_classes, n_features):
                     raise ValueError("Provided coef_ does not match dataset. ")
                 self.coef_ = coef_init
@@ -298,7 +298,7 @@ class BaseSGD(BaseEstimator):
 
             # allocate intercept_ for multi-class
             if intercept_init is not None:
-                intercept_init = np.asarray(intercept_init)
+                intercept_init = np.asarray(intercept_init, order="C")
                 if intercept_init.shape != (n_classes, ):
                     raise ValueError("Provided intercept_init " \
                                      "does not match dataset.")

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -253,8 +253,9 @@ class BaseDiscreteNB(BaseNB):
             Y *= array2d(sample_weight).T
 
         if class_prior:
-            assert len(class_prior) == n_classes, \
-                   'Number of priors must match number of classes'
+            if len(class_prior) != n_classes:
+                raise ValueError(
+                        "Number of priors must match number of classes")
             self.class_log_prior_ = np.log(class_prior)
         elif self.fit_prior:
             # empirical prior, with sample_weight taken into account

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -432,7 +432,7 @@ class BaseLibLinear(BaseEstimator):
         """
 
         X = atleast2d_or_csr(X, dtype=np.float64, order="C")
-        y = np.asarray(y, dtype=np.int32)
+        y = np.asarray(y, dtype=np.int32).ravel()
         self._sparse = sp.isspmatrix(X)
 
         self.class_weight, self.class_weight_label = \

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -51,9 +51,9 @@ y = np.arange(10) / 2
 
 def test_kfold():
     # Check that errors are raise if there is not enough samples
-    assert_raises(AssertionError, cross_validation.KFold, 3, 4)
+    assert_raises(ValueError, cross_validation.KFold, 3, 4)
     y = [0, 0, 1, 1, 2]
-    assert_raises(AssertionError, cross_validation.StratifiedKFold, y, 3)
+    assert_raises(ValueError, cross_validation.StratifiedKFold, y, 3)
 
 
 def test_cross_val_score():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -88,16 +88,14 @@ def test_grid_search_sparse_score_func():
 
     clf = LinearSVC()
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
-    # XXX: set refit to False due to a random bug when True (default)
-    cv.set_params(refit=False).fit(X_[:180], y_[:180])
+    cv.fit(X_[:180], y_[:180])
     y_pred = cv.predict(X_[180:])
     C = cv.best_estimator_.C
 
     X_ = sp.csr_matrix(X_)
     clf = LinearSVC()
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
-    # XXX: set refit to False due to a random bug when True (default)
-    cv.set_params(refit=False).fit(X_[:180], y_[:180])
+    cv.fit(X_[:180], y_[:180])
     y_pred2 = cv.predict(X_[180:])
     C2 = cv.best_estimator_.C
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -41,12 +41,15 @@ y = np.array([1, 1, 2, 2])
 def test_grid_search():
     """Test that the best estimator contains the right value for foo_param"""
     clf = MockClassifier()
-    cross_validation = GridSearchCV(clf, {'foo_param': [1, 2, 3]})
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]})
     # make sure it selects the smallest parameter in case of ties
-    assert_equal(cross_validation.fit(X, y).best_estimator_.foo_param, 2)
+    grid_search.fit(X, y)
+    assert_equal(grid_search.best_estimator_.foo_param, 2)
 
     for i, foo_i in enumerate([1, 2, 3]):
-        assert cross_validation.grid_scores_[i][0] == {'foo_param': foo_i}
+        assert grid_search.grid_scores_[i][0] == {'foo_param': foo_i}
+    # Smoke test the score:
+    grid_search.score(X, y)
 
 
 def test_grid_search_error():
@@ -100,6 +103,9 @@ def test_grid_search_sparse_score_func():
 
     assert_array_equal(y_pred, y_pred2)
     assert_equal(C, C2)
+    # Smoke test the score
+    #np.testing.assert_allclose(f1_score(cv.predict(X_[:180]), y[:180]),
+    #                        cv.score(X_[:180], y[:180]))
 
 
 class BrokenClassifier(BaseEstimator):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -116,4 +116,6 @@ def test_sample_weight():
             [0, 0, 1],
             sample_weight=[1, 1, 4])
     assert_array_equal(clf.predict([1, 0]), [1])
-    assert_array_almost_equal(np.exp(clf.intercept_), [1 / 3., 2 / 3.])
+    positive_prior = np.exp(clf.intercept_)
+    assert_array_almost_equal([1 - positive_prior, positive_prior],
+                              [1 / 3., 2 / 3.])


### PR DESCRIPTION
Here are a few tiny changes to SGD and ElasticNet / Lasso which should make using warm-start much more convenient on a regularization path. Now you can do the following:

``` python
clf = SGDClassifier(warm_start=True)
best_alpha = None
best_score = -np.inf
# from more regularized to less regularized
for alpha in (1.0, 0.1, 0.01):
    clf.set_params(alpha=alpha)
    clf.fit(X, y)
    score = clf.score(X_val, y_val)
    if score > best_score:
        best_score = score
        best_alpha = alpha   
```

I think this way of doing is intuitive and, importantly, it doesn't rely on the internal parameters of the classifiers. You can clone the best estimator if you need to, too.

On the other hand, if you set `warm_start=False`, which is the default, the subsequent call to fit(X, y) erase the previous model.

SGDClassifier has now a partial_fit(X, y) method too but it has the following differences:
- X can be a subset of the entire dataset.
- It makes only one epoch over X.
- It saves the current state of the learning rate and start from there, while with warm-start, fit starts with a fresh learning rate.

Mathieu
