### PR TITLE
fix error in unwhitened case of ica

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -252,7 +252,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     if whiten:
         # Centering the columns (ie the variables)
-        X = X - X.mean(axis=-1)[:, np.newaxis]
+        X = X - X.mean(axis= -1)[:, np.newaxis]
 
         # Whitening and preprocessing by PCA
         u, d, _ = linalg.svd(X, full_matrices=False)
@@ -263,12 +263,12 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         X1 = np.dot(K, X)
         # see (13.6) p.267 Here X1 is white and data
         # in X has been projected onto a subspace by PCA
+        X1 *= np.sqrt(p)
     else:
         # X must be casted to floats to avoid typing issues with numpy
         # 2.0 and the line below
         X1 = as_float_array(X, copy=True)
-    X1 *= np.sqrt(p)
-
+    
     if w_init is None:
         w_init = np.random.normal(size=(n_components, n_components))
     else:


### PR DESCRIPTION
scaling of variance by samplesize should not be applied to prewhitened data because it belongs to the whitening itself
e.g. https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/decomposition/pca.py#L213

see also my initial comment https://github.com/scikit-learn/scikit-learn/pull/243#issuecomment-1555860
(sorry that i did not brought this to an end)
