### PR TITLE
Fixed data.filenames consistency issue when 'all' specified for 'subset' in fetch_20newsgroups

### DIFF
--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -26,6 +26,10 @@ def test_20news():
                  data.target_names[-2:])
     # Assert that we have only 0 and 1 as labels
     assert_equal(np.unique(data2cats.target).tolist(), [0, 1])
+    
+    # Check that the number of filenames is consistent with data/target
+    assert_equal(len(data2cats.filenames), len(data2cats.target))
+    assert_equal(len(data2cats.filenames), len(data2cats.data))
 
     # Check that the first entry of the reduced dataset corresponds to
     # the first entry of the corresponding category in the full dataset

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -153,13 +153,16 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     elif subset == 'all':
         data_lst = list()
         target = list()
+        filenames = list()
         for subset in ('train', 'test'):
             data = cache[subset]
             data_lst.extend(data.data)
             target.extend(data.target)
+            filenames.extend(data.filenames)
 
         data.data = data_lst
         data.target = np.array(target)
+        data.filenames = np.array(filenames)
         data.description = 'the 20 newsgroups by date dataset'
     else:
         raise ValueError(
@@ -171,6 +174,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         labels.sort()
         labels, categories = zip(*labels)
         mask = in1d(data.target, labels)
+        data.filenames = data.filenames[mask]
         data.target = data.target[mask]
         # searchsorted to have continuous labels
         data.target = np.searchsorted(labels, data.target)
@@ -184,6 +188,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         random_state = check_random_state(random_state)
         indices = np.arange(data.target.shape[0])
         random_state.shuffle(indices)
+        data.filenames = data.filenames[indices]
         data.target = data.target[indices]
         # Use an object array to shuffle: avoids memory copy
         data_lst = np.array(data.data, dtype=object)


### PR DESCRIPTION
Previously, 'filenames' was not modified, leading to it always containing the 'test' subset filenames when 'all' was specified, and not being modified at all during the category mask-ing and shuffling.
