### PR TITLE
Added a note to the install documentation

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -19,7 +19,12 @@ There are different ways to get scikit-learn installed:
     latest-and-greatest features and aren't afraid of running
     brand-new code.
 
+.. note::
 
+    If you wish to contribute to the project, it's recommended you
+    :ref:`install the latest development version<install_bleeding_edge>`.
+
+.. note::
 
 .. _install_official_release:
 


### PR DESCRIPTION
Just under the different ways of getting scikit-learn installed - added a note to just clarify that if you wish to contribute, go straight for the development version.. It's just to be clear, so that people don't straight away install from source from the Download page and then get confused when they want to try and set it up for contributing with git/github.. Especially if somebody is new to git-hub.
