### PR TITLE
Contributors Documentaion - A note on remotes..

### DIFF
--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -103,6 +103,16 @@ the web page of the repo, and click on 'Pull request' to send us a pull
 request. This will send an email to the commiters, but might also send an
 email to the mailing list in order to get more visibility.
 
+.. note::
+
+  In the above setup, your ``origin`` remote-repository points to 
+  YourLogin/scikit-learn.git. If you wish to `fetch/merge` from the main repository instead of your `forked` one, you'll need 
+  to add another remote to use instead of ``origin``. If we choose the name
+  ``upstream`` for it, the command will be::
+  
+	$ git remote add upstream git@github.com:scikit-learn/scikit-learn.git
+
+
 (If any of the above seems like magic to you, then look up the
 `Git documentation <http://git-scm.com/documentation>`_ on the web.)
 

--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -106,7 +106,8 @@ email to the mailing list in order to get more visibility.
 .. note::
 
   In the above setup, your ``origin`` remote-repository points to 
-  YourLogin/scikit-learn.git. If you wish to `fetch/merge` from the main repository instead of your `forked` one, you'll need 
+  YourLogin/scikit-learn.git. If you wish to `fetch/merge` from the main 
+  repository instead of your `forked` one, you'll need 
   to add another remote to use instead of ``origin``. If we choose the name
   ``upstream`` for it, the command will be::
   


### PR DESCRIPTION
In the contributors documentation, I inserted a note saying how to add an extra remote that links to the main master repository and not your own, should you wish to pull from there instead of your github repository.

I didn't find it entirely obvious the first time I set it all up on my system why one would want to make remotes to other things, so I thought it'd be good to add this note within the context of the documentation.

I feel it's in a good location too, seeing as the line 

 (If any of the above seems like magic to you, then look up the
 `Git documentation <http://git-scm.com/documentation>`_ on the web.)

follows it directly.

Please let me know if you think I can word it better or if you find this unnecessary.
J
