### PR TITLE
Simpler seeding for parallel kmeans in #596

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -814,7 +814,7 @@ cluster analysis.
   >>> labels = kmeans_model.labels_
   >>> metrics.silhouette_score(X, labels, metric='euclidean')  
   ...                                                      # doctest: +ELLIPSIS
-  0.5525...
+  0.55...
 
 .. topic:: References
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -272,15 +272,13 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
                 best_inertia = inertia
     else:
         # parallelisation of k-means runs
-        seed_max = np.iinfo(np.int).max
-        seed = random_state.randint(seed_max)
         results = Parallel(n_jobs=n_jobs, verbose=0)(
             delayed(_kmeans_single)(X, k, max_iter=max_iter, init=init,
                                     verbose=verbose, tol=tol,
                                     precompute_distances=precompute_distances,
                                     x_squared_norms=x_squared_norms,
                                     # Change seed to ensure variety
-                                    random_state=np.random.RandomState(seed+i))
+                                    random_state=update_state(random_state))
             for i in range(n_init))
         # Get results with the lowest inertia
         labels, inertia, centers = zip(*results)
@@ -294,6 +292,11 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
         best_centers += X_mean
 
     return best_centers, best_labels, best_inertia
+
+
+def update_state(random_state):
+    random_state.randint(np.iinfo(np.int).max)
+    return random_state
 
 
 def _kmeans_single(X, k, max_iter=300, init='k-means++', verbose=False,

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -14,7 +14,6 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
-import operator
 
 from ..base import BaseEstimator
 from ..metrics.pairwise import euclidean_distances
@@ -26,7 +25,6 @@ from ..utils import as_float_array
 from ..utils import safe_asarray
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
-from ..externals.joblib.parallel import cpu_count
 
 from . import _k_means
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -268,7 +268,8 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
                 best_labels = labels.copy()
                 best_centers = centers.copy()
                 best_inertia = inertia
-    else: # parallelisation of k-means runs
+    else:
+        # parallelisation of k-means runs
         if n_jobs < 0:
             n_jobs = max(cpu_count() + 1 + n_jobs, 1)
         results = Parallel(n_jobs=n_jobs, verbose=0)(
@@ -321,13 +322,13 @@ def _kmeans_single(X, k, max_iter=300, init='k-means++', verbose=False,
 
     tol: float, optional
         The relative increment in the results before declaring convergence.
-    
+
     verbose: boolean, optional
         Verbosity mode
 
     x_squared_norms: array, optional
         Precomputed x_squared_norms. Calculated if not given.
-        
+
     random_state: integer or numpy.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -154,6 +154,12 @@ def test_k_means_plus_plus_init():
     _check_fitted_model(k_means)
 
 
+def test_k_means_plus_plus_init_2_jobs():
+    k_means = KMeans(init="k-means++", k=n_clusters, n_jobs=2,
+                     random_state=42).fit(X)
+    _check_fitted_model(k_means)
+
+
 def test_k_means_plus_plus_init_sparse():
     k_means = KMeans(init="k-means++", k=n_clusters, random_state=42)
     k_means.fit(X_csr)


### PR DESCRIPTION
I added a test to. I check that the seed for each _kmeans_single call were different from one another using a print statement and it seems to work fine.
