### PR TITLE
MRG: change naive bayes' ``self._classes`` attr to ``self.classes_``

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -32,6 +32,11 @@ class BaseNB(BaseEstimator, ClassifierMixin):
 
     __metaclass__ = ABCMeta
 
+    @property
+    @deprecated("to be removed in v0.12; use ``classes_`` instead.")
+    def _classes(self):
+        return self.classes_
+
     @abstractmethod
     def _joint_log_likelihood(self, X):
         """Compute the unnormalized posterior log probability of X
@@ -153,7 +158,7 @@ class GaussianNB(BaseNB):
         X = np.asarray(X)
         y = np.asarray(y)
 
-        self._classes = unique_y = np.unique(y)
+        self.classes_ = unique_y = np.unique(y)
         n_classes = unique_y.shape[0]
         _, n_features = X.shape
 
@@ -169,7 +174,7 @@ class GaussianNB(BaseNB):
     def _joint_log_likelihood(self, X):
         X = array2d(X)
         joint_log_likelihood = []
-        for i in xrange(np.size(self._classes)):
+        for i in xrange(np.size(self.classes_)):
             jointi = np.log(self.class_prior_[i])
             n_ij = - 0.5 * np.sum(np.log(np.pi * self.sigma_[i, :]))
             n_ij -= 0.5 * np.sum(((X - self.theta_[i, :]) ** 2) / \
@@ -237,8 +242,8 @@ class BaseDiscreteNB(BaseNB):
 
         labelbin = LabelBinarizer()
         Y = labelbin.fit_transform(y)
-        self._classes = labelbin.classes_
-        n_classes = len(self._classes)
+        self.classes_ = labelbin.classes_
+        n_classes = len(self.classes_)
         if Y.shape[1] == 1:
             Y = np.concatenate((1 - Y, Y), axis=1)
 
@@ -288,11 +293,11 @@ class BaseDiscreteNB(BaseNB):
     # XXX The following is a stopgap measure; we need to set the dimensions
     # of class_log_prior_ and feature_log_prob_ correctly.
     def _get_coef(self):
-        return self.feature_log_prob_[1] if len(self._classes) == 2 \
+        return self.feature_log_prob_[1] if len(self.classes_) == 2 \
                                          else self.feature_log_prob_
 
     def _get_intercept(self):
-        return self.class_log_prior_[1] if len(self._classes) == 2 \
+        return self.class_log_prior_[1] if len(self.classes_) == 2 \
                                         else self.class_log_prior_
 
     coef_ = property(_get_coef)


### PR DESCRIPTION
changed naive bayes' `self._classes` attr to `self.classes_` to adhere to sklearn naming convention. Set self._classes deprecated (rm in 0.12).
