### PR TITLE
FIX: typo for default init_size in MiniBatchKMeans

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1012,7 +1012,7 @@ class MiniBatchKMeans(KMeans):
             batch_size = chunk_size
         self.batch_size = batch_size
         self.compute_labels = compute_labels
-        self.init_size = batch_size if init_size is None else 3 * init_size
+        self.init_size = 3 * batch_size if init_size is None else init_size
 
     def fit(self, X, y=None):
         """Compute the centroids on X by chunking it into mini-batches.

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -256,6 +256,20 @@ def test_mini_batch_k_means_random_init_partial_fit():
     assert_equal(v_measure_score(true_labels, labels), 1.0)
 
 
+def test_minibatch_default_init_size():
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+                                 random_state=42).fit(X)
+    assert_equal(mb_k_means.init_size, 3 * mb_k_means.batch_size)
+    _check_fitted_model(mb_k_means)
+
+
+def test_minibatch_set_init_size():
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+                                 init_size=666, random_state=42).fit(X)
+    assert_equal(mb_k_means.init_size, 666)
+    _check_fitted_model(mb_k_means)
+
+
 def test_k_means_invalid_init():
     k_means = KMeans(init="invalid", n_init=1, k=n_clusters)
     assert_raises(ValueError, k_means.fit, X)


### PR DESCRIPTION
According to the docstring, the default value for `init_size` should be `3 * batch_size`.

The typo made the default to be `batch_size` and if `init_size` was not `None`, it was muliplied by 3!
