### PR TITLE
FIX : Fixed bug in single_source_shortest_path_length in sklearn.utils.graph

### DIFF
--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -27,7 +27,7 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
     Parameters
     ----------
     graph: sparse matrix or 2D array (preferably LIL matrix)
-        Adjency matrix of the graph
+        Adjacency matrix of the graph
     source : node label
        Starting node for path
     cutoff : integer, optional
@@ -61,8 +61,6 @@ def single_source_shortest_path_length(graph, source, cutoff=None):
             if v not in seen:
                 seen[v] = level     # set the level of vertex v
                 neighbors = np.array(graph.rows[v])
-                # Restrict to the upper triangle
-                neighbors = neighbors[neighbors > v]
                 next_level.update(neighbors)
         if cutoff is not None and cutoff <= level:
             break

--- a/sklearn/utils/tests/test_shortest_path.py
+++ b/sklearn/utils/tests/test_shortest_path.py
@@ -1,6 +1,9 @@
+from collections import defaultdict
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from sklearn.utils.graph import graph_shortest_path
+from sklearn.utils.graph import (graph_shortest_path, 
+                                 single_source_shortest_path_length)
 
 
 def floyd_warshall_slow(graph, directed=False):
@@ -61,6 +64,24 @@ def test_dijkstra():
         graph_py = floyd_warshall_slow(dist_matrix.copy(), directed)
 
         assert_array_almost_equal(graph_D, graph_py)
+        
+def test_shortest_path():
+    dist_matrix = generate_graph(20)
+    # We compare path length and not costs (-> set distances to 0 or 1)
+    dist_matrix[dist_matrix != 0] = 1
+    
+    for directed in (True, False):
+        if not directed:
+            dist_matrix = np.minimum(dist_matrix, dist_matrix.T)
+        
+        graph_py = floyd_warshall_slow(dist_matrix.copy(), directed)
+        for i in range(dist_matrix.shape[0]):
+            # Non-reachable nodes have distance 0 in graph_py
+            dist_dict = defaultdict(int)
+            dist_dict.update(single_source_shortest_path_length(dist_matrix, i))
+            
+            for j in range(graph_py[i].shape[0]):
+                assert_array_almost_equal(dist_dict[j], graph_py[i, j])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I believe the restriction of node v's neighbors to nodes with index w > v (neighbors = neighbors[neighbors > v]) in single_source_shortest_path_length is a bug (or I get something totally wrong). I also added a unit test test_shortest_path which fails with the restriction.
