### PR TITLE
MRG: 'ignore' in feature_extraction/text.py

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -121,9 +121,15 @@ def test_word_analyzer_unigrams_and_bigrams():
 
 def test_unicode_decode_error():
     # decode_error default to strict, so this should fail
-    wa = WordNGramAnalyzer(min_n=1, max_n=2, stop_words=None, charset='ascii')
+    # First, encode (as bytes) a unicode string.
     text = u"J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
-    assert_raises(UnicodeDecodeError, wa.analyze, text)
+    text_bytes =  text.encode('utf-8')
+    # Then let the Analyzer try to decode it as ascii. It should fail,
+    # because we have given it an incorrect charset.
+    wa = WordNGramAnalyzer(min_n=1, max_n=2, stop_words=None, charset='ascii')
+    assert_raises(UnicodeDecodeError, wa.analyze, text_bytes)
+    ca = CharNGramAnalyzer(min_n=1, max_n=2, charset='ascii')
+    assert_raises(UnicodeDecodeError, ca.analyze, text_bytes)
 
 
 def test_char_ngram_analyzer():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -119,6 +119,13 @@ def test_word_analyzer_unigrams_and_bigrams():
     assert_equal(wa.analyze(text), expected)
 
 
+def test_unicode_decode_error():
+    # decode_error default to strict, so this should fail
+    wa = WordNGramAnalyzer(min_n=1, max_n=2, stop_words=None, charset='ascii')
+    text = u"J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
+    assert_raises(UnicodeDecodeError, wa.analyze, text)
+
+
 def test_char_ngram_analyzer():
     cnga = CharNGramAnalyzer(min_n=3, max_n=6)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -223,7 +223,7 @@ class CharNGramAnalyzer(BaseEstimator):
 
     Because of this, it can be considered a basic morphological analyzer.
 
-    
+
     Parameters
     ----------
     charset: string

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -138,6 +138,33 @@ class WordNGramAnalyzer(BaseEstimator):
     stop words or a collection of strings. Note that stop word filtering is
     performed after preprocessing, which may include accent stripping.
 
+    Parameters
+    ----------
+    charset: string
+        If bytes are given to analyze, this charset is used to decode.
+    min_n: integer
+        The lower boundary of the range of n-values for different n-grams to be
+        extracted.
+    max_n: integer
+        The upper boundary of the range of n-values for different n-grams to be
+        extracted. All values of n such that min_n <= n <= max_n will be used.
+    preprocessor: callable
+        A callable that preprocesses the text document before tokens are
+        extracted.
+    stop_words: string, list, or None
+        If a string, it is passed to _check_stop_list and the appropriate stop
+        list is returned. The default is "english" and is currently the only
+        supported string value.
+        If a list, that list is assumed to contain stop words, all of which
+        will be removed from the resulting tokens.
+        If None, no stop words will be used.
+    token_pattern: string
+        Regular expression denoting what constitutes a "token".
+    charset_error: string
+        Instruction on what to do if a byte sequence is given to analyze that
+        contains characters not of the given `charset`. By default, it is
+        'strict', meaning that a UnicodeDecodeError will be raised. Other
+        values are 'ignore' and 'replace'.
     """
 
     def __init__(self, charset='utf-8', min_n=1, max_n=1,
@@ -195,6 +222,26 @@ class CharNGramAnalyzer(BaseEstimator):
     such as Chinese and German for instance.
 
     Because of this, it can be considered a basic morphological analyzer.
+
+    
+    Parameters
+    ----------
+    charset: string
+        If bytes are given to analyze, this charset is used to decode.
+    min_n: integer
+        The lower boundary of the range of n-values for different n-grams to be
+        extracted.
+    max_n: integer
+        The upper boundary of the range of n-values for different n-grams to be
+        extracted. All values of n such that min_n <= n <= max_n will be used.
+    preprocessor: callable
+        A callable that preprocesses the text document before tokens are
+        extracted.
+    charset_error: string
+        Instruction on what to do if a byte sequence is given to analyze that
+        contains characters not of the given `charset`. By default, it is
+        'strict', meaning that a UnicodeDecodeError will be raised. Other
+        values are 'ignore' and 'replace'.
     """
 
     white_spaces = re.compile(ur"\s\s+")

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2,6 +2,7 @@
 # Authors: Olivier Grisel <olivier.grisel@ensta.org>
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
+#          Robert Layton <robertlayton@gmail.com>
 #
 # License: BSD Style.
 """
@@ -136,20 +137,21 @@ class WordNGramAnalyzer(BaseEstimator):
     The stop words argument may be "english" for a built-in list of English
     stop words or a collection of strings. Note that stop word filtering is
     performed after preprocessing, which may include accent stripping.
+
     """
 
     def __init__(self, charset='utf-8', min_n=1, max_n=1,
                  preprocessor=DEFAULT_PREPROCESSOR,
                  stop_words="english",
                  token_pattern=DEFAULT_TOKEN_PATTERN,
-                 unicode_error='strict'):
+                 decode_error='strict'):
         self.charset = charset
         self.stop_words = _check_stop_list(stop_words)
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
         self.token_pattern = token_pattern
-        self.unicode_error = unicode_error
+        self.decode_error = decode_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -159,7 +161,7 @@ class WordNGramAnalyzer(BaseEstimator):
 
         if isinstance(text_document, bytes):
             text_document = text_document.decode(self.charset,
-                                                 self.unicode_error)
+                                                 self.decode_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 
@@ -198,12 +200,12 @@ class CharNGramAnalyzer(BaseEstimator):
     white_spaces = re.compile(ur"\s\s+")
 
     def __init__(self, charset='utf-8', preprocessor=DEFAULT_PREPROCESSOR,
-                 min_n=3, max_n=6, unicode_error='strict'):
+                 min_n=3, max_n=6, decode_error='strict'):
         self.charset = charset
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
-        self.unicode_error = unicode_error
+        self.decode_error = decode_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -213,7 +215,7 @@ class CharNGramAnalyzer(BaseEstimator):
 
         if isinstance(text_document, bytes):
             text_document = text_document.decode(self.charset,
-                                                 self.unicode_error)
+                                                 self.decode_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -140,6 +140,7 @@ class WordNGramAnalyzer(BaseEstimator):
 
     Parameters
     ----------
+    
     charset: string
         If bytes are given to analyze, this charset is used to decode.
     min_n: integer
@@ -293,6 +294,7 @@ class CountVectorizer(BaseEstimator):
 
     Parameters
     ----------
+    
     analyzer: WordNGramAnalyzer or CharNGramAnalyzer, optional
 
     vocabulary: dict or iterable, optional

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -140,7 +140,6 @@ class WordNGramAnalyzer(BaseEstimator):
 
     Parameters
     ----------
-    
     charset: string
         If bytes are given to analyze, this charset is used to decode.
     min_n: integer
@@ -294,7 +293,6 @@ class CountVectorizer(BaseEstimator):
 
     Parameters
     ----------
-    
     analyzer: WordNGramAnalyzer or CharNGramAnalyzer, optional
 
     vocabulary: dict or iterable, optional

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -141,13 +141,15 @@ class WordNGramAnalyzer(BaseEstimator):
     def __init__(self, charset='utf-8', min_n=1, max_n=1,
                  preprocessor=DEFAULT_PREPROCESSOR,
                  stop_words="english",
-                 token_pattern=DEFAULT_TOKEN_PATTERN):
+                 token_pattern=DEFAULT_TOKEN_PATTERN,
+                 unicode_error='strict'):
         self.charset = charset
         self.stop_words = _check_stop_list(stop_words)
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
         self.token_pattern = token_pattern
+        self.unicode_error = unicode_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -156,7 +158,8 @@ class WordNGramAnalyzer(BaseEstimator):
             text_document = text_document.read()
 
         if isinstance(text_document, bytes):
-            text_document = text_document.decode(self.charset, 'ignore')
+            text_document = text_document.decode(self.charset,
+                                                 self.unicode_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 
@@ -195,11 +198,12 @@ class CharNGramAnalyzer(BaseEstimator):
     white_spaces = re.compile(ur"\s\s+")
 
     def __init__(self, charset='utf-8', preprocessor=DEFAULT_PREPROCESSOR,
-                 min_n=3, max_n=6):
+                 min_n=3, max_n=6, unicode_error='strict'):
         self.charset = charset
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
+        self.unicode_error = unicode_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -208,7 +212,8 @@ class CharNGramAnalyzer(BaseEstimator):
             text_document = text_document.read()
 
         if isinstance(text_document, bytes):
-            text_document = text_document.decode(self.charset, 'ignore')
+            text_document = text_document.decode(self.charset,
+                                                 self.unicode_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -144,14 +144,14 @@ class WordNGramAnalyzer(BaseEstimator):
                  preprocessor=DEFAULT_PREPROCESSOR,
                  stop_words="english",
                  token_pattern=DEFAULT_TOKEN_PATTERN,
-                 decode_error='strict'):
+                 charset_error='strict'):
         self.charset = charset
         self.stop_words = _check_stop_list(stop_words)
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
         self.token_pattern = token_pattern
-        self.decode_error = decode_error
+        self.charset_error = charset_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -161,7 +161,7 @@ class WordNGramAnalyzer(BaseEstimator):
 
         if isinstance(text_document, bytes):
             text_document = text_document.decode(self.charset,
-                                                 self.decode_error)
+                                                 self.charset_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 
@@ -200,12 +200,12 @@ class CharNGramAnalyzer(BaseEstimator):
     white_spaces = re.compile(ur"\s\s+")
 
     def __init__(self, charset='utf-8', preprocessor=DEFAULT_PREPROCESSOR,
-                 min_n=3, max_n=6, decode_error='strict'):
+                 min_n=3, max_n=6, charset_error='strict'):
         self.charset = charset
         self.min_n = min_n
         self.max_n = max_n
         self.preprocessor = preprocessor
-        self.decode_error = decode_error
+        self.charset_error = charset_error
 
     def analyze(self, text_document):
         """From documents to token"""
@@ -215,7 +215,7 @@ class CharNGramAnalyzer(BaseEstimator):
 
         if isinstance(text_document, bytes):
             text_document = text_document.decode(self.charset,
-                                                 self.decode_error)
+                                                 self.charset_error)
 
         text_document = self.preprocessor.preprocess(text_document)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -160,7 +160,7 @@ class WordNGramAnalyzer(BaseEstimator):
         If None, no stop words will be used.
     token_pattern: string
         Regular expression denoting what constitutes a "token".
-    charset_error: string
+    charset_error: {'strict', 'ignore', 'replace'}
         Instruction on what to do if a byte sequence is given to analyze that
         contains characters not of the given `charset`. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
@@ -237,7 +237,7 @@ class CharNGramAnalyzer(BaseEstimator):
     preprocessor: callable
         A callable that preprocesses the text document before tokens are
         extracted.
-    charset_error: string
+    charset_error: {'strict', 'ignore', 'replace'}
         Instruction on what to do if a byte sequence is given to analyze that
         contains characters not of the given `charset`. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other


### PR DESCRIPTION
Fixes issue #629:

When analysing documents, if a bytes array is given to one of the n-gram analyzers, it is decoded using a given charset. However the errors are set to 'ignore', which I feel may hide problems in codes (i.e. using the incorrect encoding may screw with results).

Location: in `feature_extraction.text.py`, lines 156 and 208, for classes WordNGramAnalyzer and CharNGramAnalyzer.

Fix: I'd like to add a keyword to the classes on what to do, default being 'error' rather than 'ignore' (i.e. if people want to ignore errors, they have to explicitly state so).
