### PR TITLE
FIX flip sign in decision function of LibSVM in binary case.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,11 @@ Changelog
      and introduced the new :func:`cross_validation.train_test_split`
      helper function by `Olivier Grisel`_
 
+   - :class:`svm.SVC` members `coef_` and `intercept_` changed sign for consistency
+     with `decision_function`; for ``kernel==linear``, `coef_` was fixed
+     in the the one-vs-one case, by `Andreas Müller`_.
+
+
 
 API changes summary
 -------------------

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -196,6 +196,10 @@ class BaseLibSVM(BaseEstimator):
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
 
+        self._intercept_ = self.intercept_.copy()
+        if len(self.label_) == 2:
+            self.intercept_ *= -1
+
     def _sparse_fit(self, X, y, class_weight=None, sample_weight=None):
         """
         Fit the SVM model according to the given training data and parameters.
@@ -274,6 +278,10 @@ class BaseLibSVM(BaseEstimator):
                  sample_weight, self.nu, self.cache_size, self.epsilon,
                  int(self.shrinking), int(self.probability))
 
+        self._intercept_ = self.intercept_.copy()
+        if len(self.label_) == 2:
+            self.intercept_ *= -1
+
         n_class = len(self.label_) - 1
         n_SV = self.support_vectors_.shape[0]
 
@@ -330,7 +338,7 @@ class BaseLibSVM(BaseEstimator):
         svm_type = LIBSVM_IMPL.index(self.impl)
         return libsvm.predict(
             X, self.support_, self.support_vectors_, self.n_support_,
-            self.dual_coef_, self.intercept_,
+            self.dual_coef_, self._intercept_,
             self.label_, self.probA_, self.probB_,
             svm_type=svm_type,
             kernel=self.kernel, C=self.C, nu=self.nu,
@@ -347,7 +355,7 @@ class BaseLibSVM(BaseEstimator):
                       self.support_vectors_.data,
                       self.support_vectors_.indices,
                       self.support_vectors_.indptr,
-                      self.dual_coef_.data, self.intercept_,
+                      self.dual_coef_.data, self._intercept_,
                       LIBSVM_IMPL.index(self.impl), kernel_type,
                       self.degree, self.gamma, self.coef0, self.tol,
                       self.C, self.class_weight_label, self.class_weight,
@@ -402,7 +410,7 @@ class BaseLibSVM(BaseEstimator):
         svm_type = LIBSVM_IMPL.index(self.impl)
         pprob = libsvm.predict_proba(
             X, self.support_, self.support_vectors_, self.n_support_,
-            self.dual_coef_, self.intercept_, self.label_,
+            self.dual_coef_, self._intercept_, self.label_,
             self.probA_, self.probB_,
             svm_type=svm_type, kernel=self.kernel, C=self.C, nu=self.nu,
             probability=self.probability, degree=self.degree,
@@ -429,7 +437,7 @@ class BaseLibSVM(BaseEstimator):
             self.support_vectors_.data,
             self.support_vectors_.indices,
             self.support_vectors_.indptr,
-            self.dual_coef_.data, self.intercept_,
+            self.dual_coef_.data, self._intercept_,
             LIBSVM_IMPL.index(self.impl), kernel_type,
             self.degree, self.gamma, self.coef0, self.tol,
             self.C, self.class_weight_label, self.class_weight,
@@ -486,13 +494,16 @@ class BaseLibSVM(BaseEstimator):
             epsilon = 0.1
         dec_func = libsvm.decision_function(
             X, self.support_, self.support_vectors_, self.n_support_,
-            self.dual_coef_, self.intercept_, self.label_,
+            self.dual_coef_, self._intercept_, self.label_,
             self.probA_, self.probB_,
             svm_type=LIBSVM_IMPL.index(self.impl),
             kernel=self.kernel, C=self.C, nu=self.nu,
             probability=self.probability, degree=self.degree,
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
+
+        if len(self.label_) == 2:
+            return -dec_func
 
         return dec_func
 
@@ -514,7 +525,7 @@ class BaseLibSVM(BaseEstimator):
 
         if self.dual_coef_.shape[0] == 1:
             # binary classifier
-            coef = safe_sparse_dot(self.dual_coef_, self.support_vectors_)
+            coef = -safe_sparse_dot(self.dual_coef_, self.support_vectors_)
         else:
             # 1vs1 classifier
             coef = _one_vs_one_coef(self.dual_coef_, self.n_support_,

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -197,7 +197,7 @@ class BaseLibSVM(BaseEstimator):
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
 
         self._intercept_ = self.intercept_.copy()
-        if len(self.label_) == 2:
+        if len(self.label_) == 2 and self.impl != 'one_class':
             self.intercept_ *= -1
 
     def _sparse_fit(self, X, y, class_weight=None, sample_weight=None):
@@ -279,7 +279,7 @@ class BaseLibSVM(BaseEstimator):
                  int(self.shrinking), int(self.probability))
 
         self._intercept_ = self.intercept_.copy()
-        if len(self.label_) == 2:
+        if len(self.label_) == 2 and self.impl != 'one_class':
             self.intercept_ *= -1
 
         n_class = len(self.label_) - 1
@@ -502,7 +502,7 @@ class BaseLibSVM(BaseEstimator):
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
 
-        if len(self.label_) == 2:
+        if len(self.label_) == 2 and self.impl != 'one_class':
             return -dec_func
 
         return dec_func

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -196,6 +196,8 @@ class BaseLibSVM(BaseEstimator):
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
 
+        # In binary case, we need to flip the sign of coef, intercept and
+        # decision function. Use self._intercept_ internally.
         self._intercept_ = self.intercept_.copy()
         if len(self.label_) == 2 and self.impl != 'one_class':
             self.intercept_ *= -1
@@ -278,6 +280,8 @@ class BaseLibSVM(BaseEstimator):
                  sample_weight, self.nu, self.cache_size, self.epsilon,
                  int(self.shrinking), int(self.probability))
 
+        # In binary case, we need to flip the sign of coef, intercept and
+        # decision function. Use self._intercept_ internally.
         self._intercept_ = self.intercept_.copy()
         if len(self.label_) == 2 and self.impl != 'one_class':
             self.intercept_ *= -1
@@ -502,6 +506,8 @@ class BaseLibSVM(BaseEstimator):
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
 
+        # In binary case, we need to flip the sign of coef, intercept and
+        # decision function.
         if len(self.label_) == 2 and self.impl != 'one_class':
             return -dec_func
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -275,17 +275,12 @@ def test_decision_function():
     assert_array_almost_equal(dec, clf.decision_function(iris.data))
 
     # binary:
-    X = [[2, 1],
-         [3, 1],
-         [1, 3],
-         [2, 3]]
-    y = [0, 0, 1, 1]
-    clf.fit(X, y)
+    clf.fit(X, Y)
     dec = np.dot(X, clf.coef_.T) + clf.intercept_
     prediction = clf.predict(X)
     assert_array_almost_equal(dec, clf.decision_function(X))
-    assert_array_almost_equal(prediction, (clf.decision_function(X) >
-        0).astype(np.int).ravel())
+    assert_array_almost_equal(prediction, clf.label_[(clf.decision_function(X) >
+        0).astype(np.int).ravel()])
 
 
 def test_weight():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -176,7 +176,7 @@ def test_oneclass():
     pred = clf.predict(T)
 
     assert_array_almost_equal(pred, [-1, -1, -1])
-    assert_array_almost_equal(clf.intercept_, [1.008], decimal=3)
+    assert_array_almost_equal(clf.intercept_, [-1.008], decimal=3)
     assert_array_almost_equal(clf.dual_coef_,
                               [[0.632, 0.233, 0.633, 0.234, 0.632, 0.633]],
                               decimal=3)
@@ -281,6 +281,9 @@ def test_decision_function():
     assert_array_almost_equal(dec, clf.decision_function(X))
     assert_array_almost_equal(prediction, clf.label_[(clf.decision_function(X) >
         0).astype(np.int).ravel()])
+    expected = np.array([[-1.        ], [-0.66666667], [-1.        ],
+        [ 0.66666667], [ 1.        ], [ 1.        ]])
+    assert_array_almost_equal(clf.decision_function(X), expected)
 
 
 def test_weight():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -7,12 +7,11 @@ TODO: remove hard coded numerical results when possible
 import numpy as np
 from scipy import linalg
 from numpy.testing import assert_array_equal, assert_array_almost_equal, \
-                          assert_almost_equal, assert_equal
+                          assert_almost_equal
 from nose.tools import assert_raises, assert_true
 
 from sklearn import svm, linear_model, datasets, metrics
 from sklearn.datasets.samples_generator import make_classification
-from sklearn.multiclass import OneVsRestClassifier
 from sklearn.utils import check_random_state
 
 # toy sample
@@ -613,13 +612,6 @@ def test_inheritance():
     clf.fit(iris.data, iris.target)
     clf.predict(iris.data[-1])
     clf.decision_function(iris.data[-1])
-
-
-def test_ovr_fit_predict_svc():
-    ovr = OneVsRestClassifier(svm.SVC())
-    ovr.fit(iris.data, iris.target)
-    assert_equal(len(ovr.estimators_), 3)
-    assert_true(ovr.score(iris.data, iris.target) > .9)
 
 
 if __name__ == '__main__':

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -15,6 +15,7 @@ from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import LinearRegression, Lasso, ElasticNet, Ridge
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.grid_search import GridSearchCV
+from  sklearn import svm
 from sklearn import datasets
 
 iris = datasets.load_iris()
@@ -92,6 +93,13 @@ def test_ovr_multilabel():
         y_pred = clf.predict([[0, 4, 4]])[0]
         assert_array_equal(y_pred, [0, 1, 1])
         assert_true(clf.multilabel_)
+
+
+def test_ovr_fit_predict_svc():
+    ovr = OneVsRestClassifier(svm.SVC())
+    ovr.fit(iris.data, iris.target)
+    assert_equal(len(ovr.estimators_), 3)
+    assert_true(ovr.score(iris.data, iris.target) > .9)
 
 
 def test_ovr_multilabel_dataset():


### PR DESCRIPTION
Addressing issue #630.
This is a dirty hack. Should be done in the libsvm.cpp, but couldn't figure out how. I'm open to suggestions.

Also: I'm not sure if the OneClassSVM case is handled right atm.
