### PR TITLE
Change of exception text because of ambiguous message

### DIFF
--- a/scikits/learn/gaussian_process/gaussian_process.py
+++ b/scikits/learn/gaussian_process/gaussian_process.py
@@ -311,7 +311,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         D, ij = compute_componentwise_l1_cross_distances(X)
         if np.min(np.sum(np.abs(D), axis=1)) == 0. \
                                     and self.corr != correlation.pure_nugget:
-            raise Exception("Multiple X are not allowed")
+            raise Exception("Multiple input features cannot have the same value")
 
         # Regression matrix and parameters
         F = self.regr(X)


### PR DESCRIPTION
...rom: "Multiple X are not allowed" to: "Multiple input features cannot have the same value"
