### PR TITLE
MRG After 0.12: Remove scikits.learn namespace

### DIFF
--- a/scikits/__init__.py
+++ b/scikits/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/scikits/learn/__init__.py
+++ b/scikits/learn/__init__.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn import *
-from sklearn import __version__

--- a/scikits/learn/ball_tree.py
+++ b/scikits/learn/ball_tree.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.neighbors.ball_tree import *

--- a/scikits/learn/base.py
+++ b/scikits/learn/base.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.base import *

--- a/scikits/learn/cluster/__init__.py
+++ b/scikits/learn/cluster/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.cluster import *

--- a/scikits/learn/cross_val.py
+++ b/scikits/learn/cross_val.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.cross_validation import *

--- a/scikits/learn/datasets/__init__.py
+++ b/scikits/learn/datasets/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.datasets import *

--- a/scikits/learn/datasets/base.py
+++ b/scikits/learn/datasets/base.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn is deprecated, please use sklearn')
-from sklearn.datasets.base import *

--- a/scikits/learn/decomposition/__init__.py
+++ b/scikits/learn/decomposition/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.decomposition import *

--- a/scikits/learn/externals/joblib.py
+++ b/scikits/learn/externals/joblib.py
@@ -1,2 +1,0 @@
-from sklearn.externals.joblib import *
-

--- a/scikits/learn/feature_extraction/image.py
+++ b/scikits/learn/feature_extraction/image.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.feature_extraction.image import *
-

--- a/scikits/learn/feature_extraction/text.py
+++ b/scikits/learn/feature_extraction/text.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.feature_extraction.text import *
-

--- a/scikits/learn/grid_search.py
+++ b/scikits/learn/grid_search.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.grid_search import *

--- a/scikits/learn/label_propagation.py
+++ b/scikits/learn/label_propagation.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.semi_supervised.label_propagation import *

--- a/scikits/learn/lda.py
+++ b/scikits/learn/lda.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.lda import *

--- a/scikits/learn/linear_model/__init__.py
+++ b/scikits/learn/linear_model/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.linear_model import *

--- a/scikits/learn/metrics/__init__.py
+++ b/scikits/learn/metrics/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.metrics import *

--- a/scikits/learn/naive_bayes.py
+++ b/scikits/learn/naive_bayes.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.naive_bayes import *

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.neighbors import *

--- a/scikits/learn/pipeline.py
+++ b/scikits/learn/pipeline.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.pipeline import *

--- a/scikits/learn/qda.py
+++ b/scikits/learn/qda.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.qda import *

--- a/scikits/learn/svm/__init__.py
+++ b/scikits/learn/svm/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.svm import *

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,7 @@ def configuration(parent_package='', top_path=None):
         os.remove('MANIFEST')
 
     from numpy.distutils.misc_util import Configuration
-    config = Configuration(None, parent_package, top_path,
-        namespace_packages=['scikits'])
-
-    config.add_subpackage('scikits.learn')
-    config.add_data_files('scikits/__init__.py')
+    config = Configuration(None, parent_package, top_path)
 
     config.add_subpackage('sklearn')
 


### PR DESCRIPTION
I thought it might be time to remove scikits.learn. - I added a warning for 0.12, so maybe just keep the pr open?
The deprecation warning said that sklearn.ball_tree and sklearn.cross_val will go in 0.11 so I guess they can go now, too.

This PR is more to open discussion - after ICML of course ;)
