### PR TITLE
FIX: make GridSearchCV work with precomputed kernels

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -95,9 +95,15 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
             ind = np.arange(X.shape[0])
             train = ind[train]
             test = ind[test]
-        if getattr(base_clf, 'kernel', '') == 'precomputed' and not hasattr(base_clf, 'kernel_function'):
+        if hasattr(base_clf, 'kernel_function'):
+            # cannot compute the kernel values with custom function
+            err_msg = 'Cannot use a custom kernel function.'
+            err_msg += 'Precompute the kernel matrix instead.'
+            raise ValueError(err_msg)
+        if getattr(base_clf, 'kernel', '') == 'precomputed':
             # X is a precomputed square kernel matrix
-            assert X.shape[0] == X.shape[1], "X should be a square kernel matrix"
+            if X.shape[0] != X.shape[1]:
+                raise ValueError("X should be a square kernel matrix")
             X_train = X[np.ix_(train, train)]
             X_test = X[np.ix_(test, train)]
         else:

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -95,8 +95,14 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
             ind = np.arange(X.shape[0])
             train = ind[train]
             test = ind[test]
-        X_train = X[train]
-        X_test = X[test]
+        if getattr(base_clf, 'kernel', '') == 'precomputed' and not hasattr(base_clf, 'kernel_function'):
+            # X is a precomputed square kernel matrix
+            assert X.shape[0] == X.shape[1], "X should be a square kernel matrix"
+            X_train = X[np.ix_(train, train)]
+            X_test = X[np.ix_(test, train)]
+        else:
+            X_train = X[train]
+            X_test = X[test]
     if y is not None:
         y_test = y[test]
         y_train = y[train]

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -97,9 +97,9 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
             test = ind[test]
         if hasattr(base_clf, 'kernel_function'):
             # cannot compute the kernel values with custom function
-            err_msg = 'Cannot use a custom kernel function.'
-            err_msg += 'Precompute the kernel matrix instead.'
-            raise ValueError(err_msg)
+            raise ValueError(
+                "Cannot use a custom kernel function. "
+                "Precompute the kernel matrix instead.")
         if getattr(base_clf, 'kernel', '') == 'precomputed':
             # X is a precomputed square kernel matrix
             if X.shape[0] != X.shape[1]:

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -11,7 +11,7 @@ import scipy.sparse as sp
 from sklearn.base import BaseEstimator
 from sklearn.grid_search import GridSearchCV
 from sklearn.datasets.samples_generator import make_classification
-from sklearn.svm import LinearSVC
+from sklearn.svm import LinearSVC, SVC
 from sklearn.metrics import f1_score, precision_score
 
 
@@ -104,6 +104,19 @@ def test_grid_search_sparse_score_func():
     # Smoke test the score
     #np.testing.assert_allclose(f1_score(cv.predict(X_[:180]), y[:180]),
     #                        cv.score(X_[:180], y[:180]))
+
+
+def test_grid_search_precomputed_kernel():
+    """Test that grid search works when the input features are given in the
+    form of a precomputed kernel matrix """
+    X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
+
+    # compute the kernel matrix corresponding to the linear kernel
+    K = np.dot(X_, X_.T)
+
+    clf = SVC(kernel='precomputed')
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]})
+    cv.fit(K, y_)
 
 
 class BrokenClassifier(BaseEstimator):

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -111,12 +111,42 @@ def test_grid_search_precomputed_kernel():
     form of a precomputed kernel matrix """
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
-    # compute the kernel matrix corresponding to the linear kernel
-    K = np.dot(X_, X_.T)
+    # compute the training kernel matrix corresponding to the linear kernel
+    K_train = np.dot(X_[:180], X_[:180].T)
+    y_train = y_[:180]
 
     clf = SVC(kernel='precomputed')
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]})
-    cv.fit(K, y_)
+    cv.fit(K_train, y_train)
+
+    assert_true(cv.best_score >= 0)
+
+    # compute the test kernel matrix
+    K_test = np.dot(X_[180:], X_[:180].T)
+    y_test = y_[180:]
+
+    y_pred = cv.predict(K_test)
+
+    assert_true(np.mean(y_pred == y_test) >= 0)
+
+
+def test_grid_search_precomputed_kernel_error_nonsquare():
+    """Test that grid search returns an error with a non-square precomputed
+    training kernel matrix"""
+    K_train = np.zeros((10, 20))
+    y_train = np.ones((10, ))
+    clf = SVC(kernel='precomputed')
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]})
+    assert_raises(ValueError, cv.fit, K_train, y_train)
+
+
+def test_grid_search_precomputed_kernel_error_kernel_function():
+    """Test that grid search returns an error when using a kernel_function"""
+    X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
+    kernel_function = lambda x1, x2: np.dot(x1, x2.T)
+    clf = SVC(kernel=kernel_function)
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]})
+    assert_raises(ValueError, cv.fit, X_, y_)
 
 
 class BrokenClassifier(BaseEstimator):


### PR DESCRIPTION
Simple fix (+test) based on checking whether `base_clf.kernel == 'precomputed'`
