### PR TITLE
optimisations to Ridge Regression GCV

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,10 @@ Changelog
      with `decision_function`; for ``kernel==linear``, `coef_` was fixed
      in the the one-vs-one case, by `Andreas Müller`_.
 
+   - Performance improvements to efficient leave-one-out cross-validated
+     Ridge regression, esp. for the ``n_samples > n_features`` case, in
+     :class:`linear_model.RidgeCV`, by Reuben Fletcher-Costin.
+
 
 
 API changes summary

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -394,7 +394,7 @@ class _RidgeGCV(LinearModel):
         # handle case where y is 2-d
         if len(y.shape) != 1:
             G_diag = G_diag[:, np.newaxis]
-        return (c / G_diag) + y, c
+        return y - (c / G_diag), c
 
     def _pre_compute_svd(self, X, y):
         n_samples, n_features = X.shape
@@ -419,7 +419,7 @@ class _RidgeGCV(LinearModel):
         if len(y.shape) != 1:
             # handle case when y is 2-d
             G_diag = G_diag[:, np.newaxis]
-        return (c / G_diag) + y, c
+        return y - (c / G_diag), c
 
     def fit(self, X, y, sample_weight=1.0):
         """Fit Ridge regression model

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -402,7 +402,9 @@ class _RidgeGCV(LinearModel):
         return y - (c / G_diag), c
 
     def _pre_compute_svd(self, X, y):
-        n_samples, n_features = X.shape
+        from scipy import sparse
+        if sparse.issparse(X) and hasattr(X, 'toarray'):
+            X = X.toarray()
         U, s, _ = np.linalg.svd(X, full_matrices = 0)
         v = s ** 2
         UT_y = np.dot(U.T, y)

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -2,8 +2,10 @@
 Ridge regression
 """
 
-# Author: Mathieu Blondel <mathieu@mblondel.org>
+# Author:   Mathieu Blondel <mathieu@mblondel.org>
+#           Reuben Fletcher-Costin <reuben.fletchercostin@gmail.com>
 # License: Simplified BSD
+
 
 import numpy as np
 
@@ -501,8 +503,7 @@ class RidgeCV(LinearModel):
     """Ridge regression with built-in cross-validation.
 
     By default, it performs Generalized Cross-Validation, which is a form of
-    efficient Leave-One-Out cross-validation. Currently, only the n_features >
-    n_samples case is handled efficiently.
+    efficient Leave-One-Out cross-validation.
 
     Parameters
     ----------

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -376,10 +376,14 @@ class _RidgeGCV(LinearModel):
             diag[i] = np.dot(Q[i, :], v_prime * Q[i, :])
         return diag
 
+    def _diag_dot(self, D, B):
+        # compute dot(diag(D), B) handling case if B is > 1d properly
+        return D[(slice(None), ) + (np.newaxis, ) * (len(B.shape) - 1)] * B
+
     def _errors(self, alpha, y, v, Q, QT_y):
         # don't construct matrix G, instead compute action on y & diagonal
         w = 1.0 / (v + alpha)
-        c = np.dot(Q, w * QT_y)
+        c = np.dot(Q, self._diag_dot(w, QT_y))
         G_diag = self._decomp_diag(w, Q)
         # handle case where y is 2-d
         if len(y.shape) != 1:
@@ -389,7 +393,7 @@ class _RidgeGCV(LinearModel):
     def _values(self, alpha, y, v, Q, QT_y):
         # don't construct matrix G, instead compute action on y & diagonal
         w = 1.0 / (v + alpha)
-        c = np.dot(Q, w * QT_y)
+        c = np.dot(Q, self._diag_dot(w, QT_y))
         G_diag = self._decomp_diag(w, Q)
         # handle case where y is 2-d
         if len(y.shape) != 1:
@@ -405,7 +409,7 @@ class _RidgeGCV(LinearModel):
 
     def _errors_svd(self, alpha, y, v, U, UT_y):
         w = ((v + alpha) ** -1) - (alpha ** -1)
-        c = np.dot(U, w * UT_y) + (alpha ** -1) * y
+        c = np.dot(U, self._diag_dot(w, UT_y)) + (alpha ** -1) * y
         G_diag = self._decomp_diag(w, U) + (alpha ** -1)
         if len(y.shape) != 1:
             # handle case where y is 2-d
@@ -414,7 +418,7 @@ class _RidgeGCV(LinearModel):
 
     def _values_svd(self, alpha, y, v, U, UT_y):
         w = ((v + alpha) ** -1) - (alpha ** -1)
-        c = np.dot(U, w * UT_y) + (alpha ** -1) * y
+        c = np.dot(U, self._diag_dot(w, UT_y)) + (alpha ** -1) * y
         G_diag = self._decomp_diag(w, U) + (alpha ** -1)
         if len(y.shape) != 1:
             # handle case when y is 2-d

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -123,9 +123,9 @@ def _test_ridge_loo(filter_):
     ridge = Ridge(fit_intercept=False)
 
     # generalized cross-validation (efficient leave-one-out)
-    K, v, Q, QT_y = ridge_gcv._pre_compute(X_diabetes, y_diabetes)
-    errors, c = ridge_gcv._errors(v, Q, QT_y, y_diabetes, 1.0)
-    values, c = ridge_gcv._values(K, v, Q, QT_y, y_diabetes, 1.0)
+    decomp = ridge_gcv._pre_compute(X_diabetes, y_diabetes)
+    errors, c = ridge_gcv._errors(1.0, y_diabetes, *decomp)
+    values, c = ridge_gcv._values(1.0, y_diabetes, *decomp)
 
     # brute-force leave-one-out: remove one example at a time
     errors2 = []
@@ -143,6 +143,16 @@ def _test_ridge_loo(filter_):
     # check that efficient and brute-force LOO give same results
     assert_almost_equal(errors, errors2)
     assert_almost_equal(values, values2)
+
+    # generalized cross-validation (efficient leave-one-out,
+    # SVD variation)
+    decomp = ridge_gcv._pre_compute_svd(X_diabetes, y_diabetes)
+    errors3, c = ridge_gcv._errors_svd(1.0, y_diabetes, *decomp)
+    values3, c = ridge_gcv._values_svd(1.0, y_diabetes, *decomp)
+
+    # check that efficient and SVD efficient LOO give same results
+    assert_almost_equal(errors, errors3)
+    assert_almost_equal(values, values3)
 
     # check best alpha
     ridge_gcv.fit(filter_(X_diabetes), y_diabetes)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -123,9 +123,9 @@ def _test_ridge_loo(filter_):
     ridge = Ridge(fit_intercept=False)
 
     # generalized cross-validation (efficient leave-one-out)
-    K, v, Q = ridge_gcv._pre_compute(X_diabetes, y_diabetes)
-    errors, c = ridge_gcv._errors(v, Q, y_diabetes, 1.0)
-    values, c = ridge_gcv._values(K, v, Q, y_diabetes, 1.0)
+    K, v, Q, QT_y = ridge_gcv._pre_compute(X_diabetes, y_diabetes)
+    errors, c = ridge_gcv._errors(v, Q, QT_y, y_diabetes, 1.0)
+    values, c = ridge_gcv._values(K, v, Q, QT_y, y_diabetes, 1.0)
 
     # brute-force leave-one-out: remove one example at a time
     errors2 = []


### PR DESCRIPTION
Hi all,

I've made a few optimisations to the ridge regression generalised cross validation (GCV) code:

These changes eliminate unnecessary construction of the explicit matrix G=dot(Q,dot(diag(1/(v+alpha)),Q.T)) when we just want dot(G, y) and diag(G) inside the _error method. Similarly inside the _values method, we can do the same thing to avoid explicitly constructing dot(K,G) = dot(Q, dot(diag(v/(v+alpha)), Q.T)).

I've tested the speedup on the "communities and crime" dataset (http://archive.ics.uci.edu/ml/datasets/Communities+and+Crime), and I get a ~ 11x speedup when using a small training set consisting of the first 398 rows. I expect the speedup is even more convincing for larger training sets.

The scripts I'm using to benchmark the code are here: https://gist.github.com/1893136

I should probably add a new test for this too.
