### PR TITLE
MRG remove ball_tree and cross_val namespaces

### DIFF
--- a/sklearn/ball_tree.py
+++ b/sklearn/ball_tree.py
@@ -1,6 +1,0 @@
-import warnings
-from .neighbors import BallTree
-
-warnings.warn("BallTree has been moved to sklearn.neighbors.BallTree in v0.9 "
-              "sklearn.ball_tree will be removed in v0.11",
-              category=DeprecationWarning)

--- a/sklearn/cross_val.py
+++ b/sklearn/cross_val.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('sklearn.cross_val namespace is deprecated in version 0.9'
-              ' and will be removed in version 0.11.'
-              ' Please use sklearn.cross_validation instead.')
-from cross_validation import *


### PR DESCRIPTION
Sort of reissue of this: #647, but not removing scikits.learn namespace.
