### PR TITLE
cross_validation.py: fixed bug in text of error message

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -325,10 +325,10 @@ class StratifiedKFold(object):
         _, y_sorted = unique(y, return_inverse=True)
         min_labels = np.min(np.bincount(y_sorted))
         if k > min_labels:
-            raise ValueError("Cannot have number of folds k=%d"
-                             " smaller than %d, the minimum"
-                             " number of labels for any class."
-                             % (k, min_labels))
+            raise ValueError("The least populated class in y has only %d"
+                             " members, which is too few. The minimum"
+                             " number of labels for any class cannot"
+                             " be less than k=%d." % (min_labels, k))
         self.y = y
         self.k = k
         self.indices = indices


### PR DESCRIPTION
This branch solves issue 663.  I make a small change to correct an error message.

In the initialization method of StratifiedKFold (in cross_validation.py), there is some code that makes sure that k is smaller than the number of entries in the least-populated class. I guess the idea is that each fold should contain at least one example from every class.

In the case that the least populated class has fewer entires than k, the error message says k should be smaller than the number of labels of the least populated class.  In fact, k should be larger.
