### PR TITLE
MRG WEBSITE: make example gallery look even better!

### DIFF
--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -513,3 +513,11 @@ div.warning-wrapper {
 div.warning-wrapper p {
     margin: 0;
 }
+
+/* ------- Fix maximum size of thumbnails in example gallery -------------- */
+div#examples.section .figure img {
+    max-width: 160px;
+    max-height: 160px;
+    display: block;
+    margin: auto;
+}


### PR DESCRIPTION
This is a minor css enhancement for the example gallery.
It makes the thumbnails fit, in case they are too big (look at "Comparison of Manifold Learning methods" before) and centers the thumbnails.
Tested on Firefox nightly (13.0a1) and chromium. Would be great if someone could test it under opera/safari/ie before merging.
