### PR TITLE
MRG DOC move references from Notes to References section in docstrings

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -45,10 +45,10 @@ def affinity_propagation(S, p=None, convit=30, max_iter=200, damping=0.5,
     -----
     See examples/plot_affinity_propagation.py for an example.
 
-    **References**:
+    References
+    ----------
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
-
     """
     S = as_float_array(S, copy=copy)
 
@@ -188,13 +188,14 @@ class AffinityPropagation(BaseEstimator):
     -----
     See examples/plot_affinity_propagation.py for an example.
 
-    **References**:
+    The algorithmic complexity of affinity propagation is quadratic
+    in the number of points.
+
+    References
+    ----------
 
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
-
-    The algorithmic complexity of affinity propagation is quadratic
-    in the number of points.
     """
 
     def __init__(self, damping=.5, max_iter=200, convit=30, copy=True):

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -54,7 +54,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
     -----
     See examples/plot_dbscan.py for an example.
 
-    **References**:
+    References
+    ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, “A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise”.
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
@@ -152,7 +153,8 @@ class DBSCAN(BaseEstimator):
     -----
     See examples/plot_dbscan.py for an example.
 
-    **References**:
+    References
+    ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, “A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise”.
     In: Proceedings of the 2nd International Conference on Knowledge Discovery

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -245,7 +245,8 @@ class MeanShift(BaseEstimator):
     Note that the estimate_bandwidth function is much less scalable than
     the mean shift algorithm and will be the bottleneck if it is used.
 
-    **References**:
+    References
+    ----------
 
     Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward
     feature space analysis". IEEE Transactions on Pattern Analysis and

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -192,9 +192,8 @@ def spectral_clustering(affinity, k=8, n_components=None, mode=None,
     centers: array of integers, shape: k
         The indices of the cluster centers
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik
@@ -260,9 +259,8 @@ class SpectralClustering(BaseEstimator):
     `labels_` :
         Labels of each point
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -61,9 +61,8 @@ class OutlierDetectionMixin(ClassifierMixin):
           ensures a compatibility with other outlier detection tools
           such as the One-Class SVM.
 
-        Notes
-        -----
-        **References**:
+        References
+        ----------
 
         [1] Wilson, E. B., & Hilferty, M. M. (1931).
             The distribution of chi-square.

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -62,9 +62,8 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
       A mask for the `n_support` observations whose scatter matrix has
       minimum determinant
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [Rouseeuw1999] A Fast Algorithm for the Minimum Covariance Determinant
        Estimator, 1999, American Statistical Association and the American
@@ -198,9 +197,8 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
     best_supports: array-like, shape (select, n_samples)
       The `select` best supports found in the data set (`X`)
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     .. [Rouseeuw1999] A Fast Algorithm for the Minimum Covariance Determinant
        Estimator, 1999, American Statistical Association and the American
        Society for Quality, TECHNOMETRICS
@@ -282,7 +280,8 @@ def fast_mcd(X, support_fraction=None,
     the correction and reweighting steps described in [Rouseeuw1999],
     see the MinCovDet object.
 
-    **References**:
+    References
+    ----------
 
     .. [Rouseeuw1999] A Fast Algorithm for the Minimum Covariance
        Determinant Estimator, 1999, American Statistical Association
@@ -468,10 +467,8 @@ class MinCovDet(EmpiricalCovariance):
         A mask of the observations that have been used to compute
         the robust estimates of location and shape.
 
-    Notes
-    -----
-
-    **References**:
+    References
+    ----------
 
     .. [Rouseeuw1984] `P. J. Rousseeuw. Least median of squares regression.
        J. Am Stat Ass, 79:871, 1984.`

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -239,7 +239,8 @@ class LedoitWolf(EmpiricalCovariance):
     where mu = trace(cov) / n_features
     and shinkage is given by the Ledoit and Wolf formula (see References)
 
-    **References**:
+    References
+    ----------
     "A Well-Conditioned Estimator for Large-Dimensional Covariance Matrices",
     Ledoit and Wolf, Journal of Multivariate Analysis, Volume 88, Issue 2,
     February 2004, pages 365-411.
@@ -380,7 +381,8 @@ class OAS(EmpiricalCovariance):
     where mu = trace(cov) / n_features
     and shinkage is given by the OAS formula (see References)
 
-    **References**:
+    References
+    ----------
     "Shrinkage Algorithms for MMSE Covariance Estimation"
     Chen et al., IEEE Trans. on Sign. Proc., Volume 58, Issue 10, October 2010.
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -99,7 +99,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     The algorithm is adapted from Guyon [1] and was designed to generate
     the "Madelon" dataset.
 
-    **References**:
+    References
+    ----------
 
     .. [1] I. Guyon, "Design of experiments for the NIPS 2003 variable
            selection benchmark", 2003.
@@ -565,9 +566,8 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
     y : array of shape [n_samples]
         The output values.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -629,9 +629,8 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
     y : array of shape [n_samples]
         The output values.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -697,9 +696,8 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
     y : array of shape [n_samples]
         The output values.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] J. Friedman, "Multivariate adaptive regression splines", The Annals
            of Statistics 19 (1), pages 1-67, 1991.
@@ -882,9 +880,8 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
     y : array of shape [n_samples]
         The output values.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] G. Celeux, M. El Anbari, J.-M. Marin, C. P. Robert,
            "Regularization in regression: comparing Bayesian and frequentist
@@ -1014,7 +1011,8 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
     -----
     The algorithm is from Marsland [1].
 
-    **References**:
+    References
+    ----------
 
     .. [1] S. Marsland, "Machine Learning: An Algorithmic Perpsective",
            Chapter 10, 2009.

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -72,7 +72,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     `X_transformed_fit_`:
         Projection of the fitted data on the kernel principal components
 
-    **References**:
+    References
+    ----------
     Kernel PCA was intoduced in:
         Bernhard Schoelkopf, Alexander J. Smola,
         and Klaus-Robert Mueller. 1999. Kernel principal
@@ -231,7 +232,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         -------
         X_new: array-like, shape (n_samples, n_features)
 
-        **References**:
+        References
+        ----------
         "Learning to Find Pre-Images", G BakIr et al, 2004.
         """
         if not self.fit_inverse_transform:

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -414,9 +414,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
     PCA
     ProbabilisticPCA
 
-    Notes
-    -------
-    **References**:
+    References
+    ----------
 
     .. [Halko2009] `Finding structure with randomness: Stochastic algorithms
       for constructing approximate matrix decompositions Halko, et al., 2009

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -505,9 +505,8 @@ class RandomForestClassifier(ForestClassifier):
         set.
 
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
 
@@ -641,9 +640,8 @@ class RandomForestRegressor(ForestRegressor):
 
 
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
 
@@ -777,9 +775,8 @@ class ExtraTreesClassifier(ForestClassifier):
         Decision function computed with out-of-bag estimate on the training
         set.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.
@@ -916,9 +913,8 @@ class ExtraTreesRegressor(ForestRegressor):
     `oob_prediction_` : array, shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -522,9 +522,8 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     sublinear_tf : boolean, optional
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [Yates2011] `R. Baeza-Yates and B. Ribeiro-Neto (2011). Modern
                    Information Retrieval. Addison Wesley, pp. 68–74.`

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -76,9 +76,8 @@ class RFE(BaseEstimator):
     >>> selector.ranking_
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] Guyon, I., Weston, J., Barnhill, S., & Vapnik, V., "Gene selection
            for cancer classification using support vector machines",
@@ -256,9 +255,8 @@ class RFECV(RFE):
     >>> selector.ranking_
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] Guyon, I., Weston, J., Barnhill, S., & Vapnik, V., "Gene selection
            for cancer classification using support vector machines",

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -61,9 +61,8 @@ def f_oneway(*args):
     See ``scipy.stats.f_oneway`` that should give the same results while
     being less efficient.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
            Statistics". Chapter 14.

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -181,7 +181,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
     The presentation implementation is based on a translation of the DACE
     Matlab toolbox, see reference [NLNS2002]_.
 
-    **References**:
+    References
+    ----------
 
     .. [NLNS2002] `H.B. Nielsen, S.N. Lophaven, H. B. Nielsen and J.
         Sondergaard.  DACE - A MATLAB Kriging Toolbox.` (2002)

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -268,8 +268,8 @@ class RandomizedLasso(BaseRandomizedLinearModel):
     -----
     See examples/linear_model/plot_sparse_recovery.py for an example.
 
-    **References**:
-
+    References
+    ----------
     Stability selection
     Nicolai Meinshausen, Peter Buhlmann
     Journal of the Royal Statistical Society: Series B
@@ -425,8 +425,8 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
     -----
     See examples/linear_model/plot_randomized_lasso.py for an example.
 
-    **References**:
-
+    References
+    ----------
     Stability selection
     Nicolai Meinshausen, Peter Buhlmann
     Journal of the Royal Statistical Society: Series B

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -346,7 +346,8 @@ class _RidgeGCV(LinearModel):
 
     looe = y - loov = c / diag(G)
 
-    **References**:
+    References
+    ----------
     http://cbcl.mit.edu/projects/cbcl/publications/ps/MIT-CSAIL-TR-2007-025.pdf
     http://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf
     """

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -68,9 +68,8 @@ class Isomap(BaseEstimator):
     `dist_matrix_` : array-like, shape (n_samples, n_samples)
         Stores the geodesic distance matrix of training data
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     [1] Tenenbaum, J.B.; De Silva, V.; & Langford, J.C. A global geometric
         framework for nonlinear dimensionality reduction. Science 290 (5500)

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -221,14 +221,14 @@ def locally_linear_embedding(
 
     method : {'standard', 'hessian', 'modified', 'ltsa'}
         standard : use the standard locally linear embedding algorithm.
-                   see reference [Roweis2000]_
+                   see reference [1]_
         hessian  : use the Hessian eigenmap method.  This method requires
                    n_neighbors > out_dim * (1 + (out_dim + 1) / 2.
-                   see reference [Donoho2003]_
+                   see reference [2]_
         modified : use the modified locally linear embedding algorithm.
-                   see reference [Zhang2007]_
+                   see reference [3]_
         ltsa     : use local tangent space alignment algorithm
-                   see reference [Zhang2004]_
+                   see reference [4]_
 
     hessian_tol : float, optional
         Tolerance for Hessian eigenmapping method.
@@ -250,21 +250,20 @@ def locally_linear_embedding(
         Reconstruction error for the embedding vectors. Equivalent to
         ``norm(Y - W Y, 'fro')**2``, where W are the reconstruction weights.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
-      .. [Roweis2000] `Roweis, S. & Saul, L. Nonlinear dimensionality reduction
-          by locally linear embedding.  Science 290:2323 (2000).`
-      .. [Donoho2003] `Donoho, D. & Grimes, C. Hessian eigenmaps: Locally
-          linear embedding techniques for high-dimensional data.
-          Proc Natl Acad Sci U S A.  100:5591 (2003).`
-      .. [Zhang2007] `Zhang, Z. & Wang, J. MLLE: Modified Locally Linear
-          Embedding Using Multiple Weights.`
-          http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.70.382
-      .. [Zhang2004] `Zhang, Z. & Zha, H. Principal manifolds and nonlinear
-          dimensionality reduction via tangent space alignment.
-          Journal of Shanghai Univ.  8:406 (2004)`
+    .. [1] `Roweis, S. & Saul, L. Nonlinear dimensionality reduction
+        by locally linear embedding.  Science 290:2323 (2000).`
+    .. [2] `Donoho, D. & Grimes, C. Hessian eigenmaps: Locally
+        linear embedding techniques for high-dimensional data.
+        Proc Natl Acad Sci U S A.  100:5591 (2003).`
+    .. [3] `Zhang, Z. & Wang, J. MLLE: Modified Locally Linear
+        Embedding Using Multiple Weights.`
+        http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.70.382
+    .. [4] `Zhang, Z. & Zha, H. Principal manifolds and nonlinear
+        dimensionality reduction via tangent space alignment.
+        Journal of Shanghai Univ.  8:406 (2004)`
     """
     if eigen_solver not in ('auto', 'arpack', 'dense'):
         raise ValueError("unrecognized eigen_solver '%s'" % eigen_solver)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -147,9 +147,8 @@ def adjusted_rand_score(labels_true, labels_pred):
       >>> adjusted_rand_score([0, 0, 0, 0], [0, 1, 2, 3])
       0.0
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [Hubert1985] `L. Hubert and P. Arabie, Comparing Partitions,
       Journal of Classification 1985`
@@ -301,9 +300,8 @@ def homogeneity_score(labels_true, labels_pred):
     homogeneity: float
        score between 0.0 and 1.0. 1.0 stands for perfectly homogeneous labeling
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] Andrew Rosenberg and Julia Hirschberg `V-Measure: A conditional
         entropy-based external cluster evaluation measure`, 2007
@@ -369,9 +367,8 @@ def completeness_score(labels_true, labels_pred):
     completeness: float
        score between 0.0 and 1.0. 1.0 stands for perfectly complete labeling
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] Andrew Rosenberg and Julia Hirschberg `V-Measure: A conditional
         entropy-based external cluster evaluation measure`, 2007
@@ -440,9 +437,8 @@ def v_measure_score(labels_true, labels_pred):
     completeness: float
        score between 0.0 and 1.0. 1.0 stands for perfectly complete labeling
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [Rosenberg2007] `V-Measure: A conditional entropy-based external cluster
         evaluation measure Andrew Rosenberg and Julia Hirschberg, 2007`

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -61,9 +61,8 @@ def silhouette_score(X, labels, metric='euclidean',
     silhouette : float
         Mean Silhouette Coefficient for all samples.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Peter J. Rousseeuw (1987). "Silhouettes: a Graphical Aid to the
         Interpretation and Validation of Cluster Analysis". Computational
@@ -125,9 +124,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     silhouette : array, shape = [n_samples]
         Silhouette Coefficient for each samples.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Peter J. Rousseeuw (1987). "Silhouettes: a Graphical Aid to the
         Interpretation and Validation of Cluster Analysis". Computational

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -48,11 +48,9 @@ def confusion_matrix(y_true, y_pred, labels=None):
     CM : array, shape = [n_classes, n_classes]
         confusion matrix
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     http://en.wikipedia.org/wiki/Confusion_matrix
-
     """
     if labels is None:
         labels = unique_labels(y_true, y_pred)
@@ -106,9 +104,8 @@ def roc_curve(y_true, y_score):
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     http://en.wikipedia.org/wiki/Receiver_operating_characteristic
 
     """
@@ -373,9 +370,8 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
         fbeta_score of the positive class in binary classification or weighted
         average of the fbeta_score of each class for the multiclass task.
 
-    Notes
-    -----
-    **References:**
+    References
+    ----------
     R. Baeza-Yates and B. Ribeiro-Neto (2011). Modern Information Retrieval.
     Addison Wesley, pp. 327-328.
 
@@ -441,9 +437,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
         f1_score of the positive class in binary classification or weighted
         average of the f1_scores of each class for the multiclass task
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     http://en.wikipedia.org/wiki/F1_score
 
     """
@@ -516,9 +511,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     f1_score: array, shape = [n_unique_labels], dtype = np.double
     support: array, shape = [n_unique_labels], dtype = np.long
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     http://en.wikipedia.org/wiki/Precision_and_recall
 
     """
@@ -823,7 +817,8 @@ def r2_score(y_true, y_pred):
     -----
     This is not a symmetric function.
 
-    **References**:
+    References
+    ----------
     http://en.wikipedia.org/wiki/Coefficient_of_determination
     """
     y_true, y_pred = check_arrays(y_true, y_pred)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -385,24 +385,23 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin):
     `code_book_` : numpy array of shape [n_classes, code_size]
         Binary array containing the code of each class.
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
-     * [1] "Solving multiclass learning problems via error-correcting ouput
-        codes",
-        Dietterich T., Bakiri G.,
-        Journal of Artificial Intelligence Research 2,
-        1995.
+    .. [1] "Solving multiclass learning problems via error-correcting output
+       codes",
+       Dietterich T., Bakiri G.,
+       Journal of Artificial Intelligence Research 2,
+       1995.
 
-     * [2] "The error coding method and PICTs",
-        James G., Hastie T.,
-        Journal of Computational and Graphical statistics 7,
-        1998.
+    .. [2] "The error coding method and PICTs",
+       James G., Hastie T.,
+       Journal of Computational and Graphical statistics 7,
+       1998.
 
-     * [3] "The Elements of Statistical Learning",
-        Hastie T., Tibshirani R., Friedman J., page 606 (second-edition)
-        2008.
+    .. [3] "The Elements of Statistical Learning",
+       Hastie T., Tibshirani R., Friedman J., page 606 (second-edition)
+       2008.
     """
 
     def __init__(self, estimator, code_size=1.5, random_state=None):

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -399,9 +399,8 @@ class BernoulliNB(BaseDiscreteNB):
     >>> print clf.predict(X[2])
     [3]
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     C.D. Manning, P. Raghavan and H. Schütze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234–265.

--- a/sklearn/pls.py
+++ b/sklearn/pls.py
@@ -172,9 +172,8 @@ class _PLS(BaseEstimator):
     coefs: array, [p, q]
         The coefficients of the linear model: Y = X coefs + Err
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -478,9 +477,8 @@ class PLSRegression(_PLS):
            scale=True, tol=1e-06)
     >>> Y_pred = pls2.predict(X)
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -585,9 +583,8 @@ class PLSCanonical(_PLS):
            scale=True, tol=1e-06)
     >>> X_c, Y_c = plsca.transform(X, Y)
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of
@@ -696,9 +693,8 @@ class CCA(_PLS):
             scale=True, tol=1e-06)
     >>> X_c, Y_c = cca.transform(X, Y)
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     Jacob A. Wegelin. A survey of Partial Least Squares (PLS) methods, with
     emphasis on the two-block case. Technical Report 371, Department of

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -601,7 +601,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         The feature mportances (the higher, the more important the feature).
         The importance I(f) of a feature f is computed as the (normalized)
         total reduction of error brought by that feature. It is also known as
-        the Gini importance [4].
+        the Gini importance [4]_.
 
         .. math::
 
@@ -611,9 +611,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
     --------
     DecisionTreeRegressor
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] http://en.wikipedia.org/wiki/Decision_tree_learning
 
@@ -762,7 +761,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         The feature mportances (the higher, the more important the feature).
         The importance I(f) of a feature f is computed as the (normalized)
         total reduction of error brought by that feature. It is also known as
-        the Gini importance [4].
+        the Gini importance [4]_.
 
         .. math::
 
@@ -772,9 +771,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     --------
     DecisionTreeClassifier
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] http://en.wikipedia.org/wiki/Decision_tree_learning
 
@@ -838,9 +836,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     --------
     ExtraTreeRegressor, ExtraTreesClassifier, ExtraTreesRegressor
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.
@@ -885,9 +882,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     sklearn.ensemble.ExtraTreesRegressor : An ensemble of extra-trees for
         regression
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.

--- a/sklearn/utils/arpack.py
+++ b/sklearn/utils/arpack.py
@@ -1172,8 +1172,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     ZNEUPD, functions which use the Implicitly Restarted Arnoldi Method to
     find the eigenvalues and eigenvectors [2]_.
 
-    **References**:
-
+    References
+    ----------
     .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
@@ -1410,9 +1410,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     >>> vecs.shape
     (13, 6)
 
-    Notes
-    -----
-    **References**:
+    References
+    ----------
     .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -164,8 +164,8 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iterations=0,
     computations. It is particularly fast on large matrices on which
     you wish to extract only a small number of components.
 
-    **References**:
-
+    References
+    ----------
     * Finding structure with randomness: Stochastic algorithms for constructing
       approximate matrix decompositions
       Halko, et al., 2009 http://arxiv.org/abs/arXiv:0909.4061


### PR DESCRIPTION
For some reason, having a
`References
----------------`
section in the docstrings didn't work at some point.

Now it does. Don't ask me.

It looks better and is the "right" way to do it.
