### PR TITLE
MRG rename parameter "multi_class" of LinearSVC to "crammer_singer"

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -135,9 +135,9 @@ two classes, only one model is trained::
 
     >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-    intercept_scaling=1, loss='l2', multi_class=False, penalty='l2',
-    scale_C=True, tol=0.0001)
+    LinearSVC(C=1.0, class_weight=None, crammer_singer=False, dual=True,
+    fit_intercept=True, intercept_scaling=1, loss='l2', multi_class=None,
+    penalty='l2', scale_C=True, tol=0.0001)
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
     4

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -135,9 +135,9 @@ two classes, only one model is trained::
 
     >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, crammer_singer=False, dual=True,
-    fit_intercept=True, intercept_scaling=1, loss='l2', multi_class=None,
-    penalty='l2', scale_C=True, tol=0.0001)
+    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
+    intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
+    scale_C=True, tol=0.0001)
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
     4
@@ -145,8 +145,9 @@ two classes, only one model is trained::
 See :ref:`svm_mathematical_formulation` for a complete description of
 the decision function.
 Note that the :class:`LinearSVC` also implements an alternative multi-class
-strategy, the so-called multi-class SVM formulated by Crammer and Singer,
-by using the option "crammer_singer". This method is rarely used in practice.
+strategy, the so-called multi-class SVM formulated by Crammer and Singer, by
+using the option "multi_class='crammer_singer'". This method is rarely used in
+practice.
 
 For "one-vs-rest" :class:`LinearSVC` the attributes ``coef_`` and ``intercept_``
 have the shape ``[n_class, n_features]`` and ``[n_class]`` respectively.

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -144,10 +144,13 @@ two classes, only one model is trained::
 
 See :ref:`svm_mathematical_formulation` for a complete description of
 the decision function.
+
 Note that the :class:`LinearSVC` also implements an alternative multi-class
 strategy, the so-called multi-class SVM formulated by Crammer and Singer, by
-using the option "multi_class='crammer_singer'". This method is rarely used in
-practice.
+using the option "multi_class='crammer_singer'". This method is consistent,
+which is not true for one-vs-rest classification.
+In practice, on-vs-rest classification is usually preferred, since the results
+are mostly similar, but the runtime is significantly less.
 
 For "one-vs-rest" :class:`LinearSVC` the attributes ``coef_`` and ``intercept_``
 have the shape ``[n_class, n_features]`` and ``[n_class]`` respectively.

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -144,6 +144,9 @@ two classes, only one model is trained::
 
 See :ref:`svm_mathematical_formulation` for a complete description of
 the decision function.
+Note that the :class:`LinearSVC` also implements an alternative multi-class
+strategy, the so-called multi-class SVM formulated by Crammer and Singer,
+by using the option "crammer_singer". This method is rarely used in practice.
 
 For "one-vs-rest" :class:`LinearSVC` the attributes ``coef_`` and ``intercept_``
 have the shape ``[n_class, n_features]`` and ``[n_class]`` respectively.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,9 @@ API changes summary
      models. This allows to have a regularization parameter independent
      of the number of samples. The scale_C parameter will disappear in v0.12.
 
+   - In :class:`svm.LinearSVC`, the `multi_class` parameter was renamed
+     to `crammer_singer` to avoid confusion.
+
 .. _changes_0_10:
 
 0.10

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,8 +87,9 @@ API changes summary
      models. This allows to have a regularization parameter independent
      of the number of samples. The scale_C parameter will disappear in v0.12.
 
-   - In :class:`svm.LinearSVC`, the `multi_class` parameter was renamed
-     to `crammer_singer` to avoid confusion.
+   - In :class:`svm.LinearSVC`, the meaning of the `multi_class` parameter changed.
+     Options now are 'ovr' and 'crammer_singer', with 'ovr' being the default.
+     This does not change the default behavior but hopefully is less confusing.
 
 .. _changes_0_10:
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -566,8 +566,8 @@ class BaseLibLinear(BaseEstimator):
         }
 
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
-            multi_class=None, crammer_singer=False, fit_intercept=True,
-            intercept_scaling=1, scale_C=True, class_weight=None):
+            multi_class='ovr', fit_intercept=True, intercept_scaling=1,
+            scale_C=True, class_weight=None):
         self.penalty = penalty
         self.loss = loss
         self.dual = dual
@@ -575,15 +575,7 @@ class BaseLibLinear(BaseEstimator):
         self.C = C
         self.fit_intercept = fit_intercept
         self.intercept_scaling = intercept_scaling
-        if not multi_class is None:
-            warnings.warn("The `multi_class` parameter was renamed "
-                    "to `crammer_singer` to avoid confusion. "
-                    "Please note that this parameter is not neccessary "
-                    "for multi-class classification.\n"
-                    "`multi_class` is deprecated and will be removed "
-                    " in version 0.12.")
-
-        self.crammer_singer = crammer_singer
+        self.multi_class = multi_class
         self.scale_C = scale_C
         self.class_weight = class_weight
 
@@ -599,14 +591,17 @@ class BaseLibLinear(BaseEstimator):
         """Find the liblinear magic number for the solver.
 
         This number depends on the values of the following attributes:
-          - crammer_singer
+          - multi_class
           - penalty
           - loss
           - dual
         """
-        if self.crammer_singer:
+        if self.multi_class == 'crammer_singer':
             solver_type = 'MC_SVC'
         else:
+            if self.multi_class != 'ovr':
+                raise ValueError("`multi_class` must be one of `ovr`, "
+                        "`crammer_singer`")
             solver_type = "P%s_L%s_D%d" % (
                 self.penalty.upper(), self.loss.upper(), int(self.dual))
         if not solver_type in self._solver_type_dict:

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -566,8 +566,8 @@ class BaseLibLinear(BaseEstimator):
         }
 
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
-                 multi_class=False, fit_intercept=True, intercept_scaling=1,
-                 scale_C=True, class_weight=None):
+            multi_class=None, crammer_singer=False, fit_intercept=True,
+            intercept_scaling=1, scale_C=True, class_weight=None):
         self.penalty = penalty
         self.loss = loss
         self.dual = dual
@@ -575,7 +575,15 @@ class BaseLibLinear(BaseEstimator):
         self.C = C
         self.fit_intercept = fit_intercept
         self.intercept_scaling = intercept_scaling
-        self.multi_class = multi_class
+        if not multi_class is None:
+            warnings.warn("The `multi_class` parameter was renamed "
+                    "to `crammer_singer` to avoid confusion. "
+                    "Please note that this parameter is not neccessary "
+                    "for multi-class classification.\n"
+                    "`multi_class` is deprecated and will be removed "
+                    " in version 0.12.")
+
+        self.crammer_singer = crammer_singer
         self.scale_C = scale_C
         self.class_weight = class_weight
 
@@ -591,12 +599,12 @@ class BaseLibLinear(BaseEstimator):
         """Find the liblinear magic number for the solver.
 
         This number depends on the values of the following attributes:
-          - multi_class
+          - crammer_singer
           - penalty
           - loss
           - dual
         """
-        if self.multi_class:
+        if self.crammer_singer:
             solver_type = 'MC_SVC'
         else:
             solver_type = "P%s_L%s_D%d" % (

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -35,11 +35,15 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
     tol: float, optional (default=1e-4)
         Tolerance for stopping criteria
 
-    crammer_singer: boolean, optional (default=False)
-        Perform multi-class SVM as per Cramer and Singer.  Please note that
-        this parameter is not necessary for multi-class classification and is
-        rarely used in practice.
-        If active, the options loss, penalty and dual will be ignored.
+    multi_class: string, 'ovr' or 'crammer_singer' (default='ovr')
+        Determines the multi-class strategy if `y` contains more then
+        two classes.
+        `ovr` trains n_classes one-vs-rest classifiers, while `crammer_singer`
+        optimizes a joint objective over all classes.
+        While `crammer_singer` is interesting from an theoretical perspective,
+        it is seldom used in practice and rarely leads to better performance.
+        If `crammer_singer` is choosen, the options loss, penalty and dual will
+        be ignored.
 
     fit_intercept : boolean, optional (default=True)
         Whether to calculate the intercept for this model. If set

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -40,8 +40,9 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
         two classes.
         `ovr` trains n_classes one-vs-rest classifiers, while `crammer_singer`
         optimizes a joint objective over all classes.
-        While `crammer_singer` is interesting from an theoretical perspective,
-        it is seldom used in practice and rarely leads to better performance.
+        While `crammer_singer` is interesting from an theoretical perspective 
+        as it is consistent it is seldom used in practice and rarely leads to
+        better accuracy and is more expensive to compute.
         If `crammer_singer` is choosen, the options loss, penalty and dual will
         be ignored.
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -35,9 +35,11 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
     tol: float, optional (default=1e-4)
         Tolerance for stopping criteria
 
-    multi_class: boolean, optional (default=False)
-        Perform multi-class SVM as per Cramer and Singer. If active,
-        the options loss, penalty and dual will be ignored.
+    crammer_singer: boolean, optional (default=False)
+        Perform multi-class SVM as per Cramer and Singer.  Please note that
+        this parameter is not necessary for multi-class classification and is
+        rarely used in practice.
+        If active, the options loss, penalty and dual will be ignored.
 
     fit_intercept : boolean, optional (default=True)
         Whether to calculate the intercept for this model. If set

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -36,7 +36,7 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
         Tolerance for stopping criteria
 
     multi_class: string, 'ovr' or 'crammer_singer' (default='ovr')
-        Determines the multi-class strategy if `y` contains more then
+        Determines the multi-class strategy if `y` contains more than
         two classes.
         `ovr` trains n_classes one-vs-rest classifiers, while `crammer_singer`
         optimizes a joint objective over all classes.

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -437,7 +437,7 @@ def test_LinearSVC():
 def test_LinearSVC_crammer_singer():
     """Test LinearSVC with crammer_singer multi-class svm"""
     ovr_clf = svm.LinearSVC(C=len(iris.data)).fit(iris.data, iris.target)
-    cs_clf = svm.LinearSVC(C=len(iris.data), crammer_singer=True)
+    cs_clf = svm.LinearSVC(C=len(iris.data), multi_class='crammer_singer')
     cs_clf.fit(iris.data, iris.target)
 
     # similar prediction for ovr and crammer-singer:

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -441,13 +441,15 @@ def test_LinearSVC_crammer_singer():
     cs_clf.fit(iris.data, iris.target)
 
     # similar prediction for ovr and crammer-singer:
-    assert_true((ovr_clf.predict(iris.data) == cs_clf.predict(iris.data)).mean() > .9)
+    assert_true((ovr_clf.predict(iris.data) ==
+        cs_clf.predict(iris.data)).mean() > .9)
 
     # classifiers shouldn't be the same
     assert_true((ovr_clf.coef_ != cs_clf.coef_).all())
 
     # test decision function
-    assert_array_equal(cs_clf.predict(iris.data), np.argmax(cs_clf.decision_function(iris.data), axis=1))
+    assert_array_equal(cs_clf.predict(iris.data),
+            np.argmax(cs_clf.decision_function(iris.data), axis=1))
     dec_func = np.dot(iris.data, cs_clf.coef_.T) + cs_clf.intercept_
     assert_array_almost_equal(dec_func, cs_clf.decision_function(iris.data))
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -434,6 +434,24 @@ def test_LinearSVC():
     assert_array_equal(res, true_result)
 
 
+def test_LinearSVC_crammer_singer():
+    """Test LinearSVC with crammer_singer multi-class svm"""
+    ovr_clf = svm.LinearSVC(C=len(iris.data)).fit(iris.data, iris.target)
+    cs_clf = svm.LinearSVC(C=len(iris.data), crammer_singer=True)
+    cs_clf.fit(iris.data, iris.target)
+
+    # similar prediction for ovr and crammer-singer:
+    assert_true((ovr_clf.predict(iris.data) == cs_clf.predict(iris.data)).mean() > .9)
+
+    # classifiers shouldn't be the same
+    assert_true((ovr_clf.coef_ != cs_clf.coef_).all())
+
+    # test decision function
+    assert_array_equal(cs_clf.predict(iris.data), np.argmax(cs_clf.decision_function(iris.data), axis=1))
+    dec_func = np.dot(iris.data, cs_clf.coef_.T) + cs_clf.intercept_
+    assert_array_almost_equal(dec_func, cs_clf.decision_function(iris.data))
+
+
 def test_LinearSVC_iris():
     """
     Test that LinearSVC gives plausible predictions on the iris dataset


### PR DESCRIPTION
After reading issue #657, I felt like "multi_class" is a bad name for the Crammer-Singer option of the LinearSVC. Many people want to do multi-class classification. Only few want or even know about Crammer-Singer SVMs.
To avoid confusion, I think it would be good to rename the option and make a bit more explicit that this is not needed for multi-class classification.
Also, I had the impression that the Crammer-Singer SVM was not tested that much, so I tried to come up with some tests.
