### PR TITLE
API: use C=None by default in libsvm/liblinear bindings

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -83,7 +83,7 @@ training samples::
     >>> Y = [0, 1]
     >>> clf = svm.SVC()
     >>> clf.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.5, kernel='rbf', probability=False, scale_C=True, shrinking=True,
     tol=0.001)
 
@@ -122,7 +122,7 @@ classifiers are constructed and each one trains data from two classes::
     >>> Y = [0, 1, 2, 3]
     >>> clf = svm.SVC()
     >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=1.0, kernel='rbf', probability=False, scale_C=True, shrinking=True,
     tol=0.001)
     >>> dec = clf.decision_function([[1]])
@@ -135,7 +135,7 @@ two classes, only one model is trained::
 
     >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
-    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
+    LinearSVC(C=None, class_weight=None, dual=True, fit_intercept=True,
     intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
     scale_C=True, tol=0.0001)
     >>> dec = lin_clf.decision_function([[1]])
@@ -269,7 +269,7 @@ floating point values instead of integer values::
     >>> y = [0.5, 2.5]
     >>> clf = svm.SVR()
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    SVR(C=1.0, cache_size=200, coef0=0.0, degree=3,
+    SVR(C=None, cache_size=200, coef0=0.0, degree=3,
     epsilon=0.1, gamma=0.5, kernel='rbf', probability=False, scale_C=True,
     shrinking=True, tol=0.001)
     >>> clf.predict([[1, 1]])
@@ -467,7 +467,7 @@ vectors and the test vectors must be provided.
     >>> # linear kernel computation
     >>> gram = np.dot(X, X.T)
     >>> clf.fit(gram, y) # doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.0, kernel='precomputed', probability=False, scale_C=True,
     shrinking=True, tol=0.001)
     >>> # predict on training examples

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -189,8 +189,9 @@ persistence model, namely `pickle <http://docs.python.org/library/pickle.html>`_
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)
-  SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3, gamma=0.25,
-    kernel='rbf', probability=False, scale_C=True, shrinking=True, tol=0.001)
+  SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    gamma=0.25, kernel='rbf', probability=False, scale_C=True,
+    shrinking=True, tol=0.001)
 
   >>> import pickle
   >>> s = pickle.dumps(clf)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -224,7 +224,7 @@ class GridSearchCV(BaseEstimator):
     >>> clf.fit(iris.data, iris.target)
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     GridSearchCV(cv=None,
-        estimator=SVC(C=1.0, cache_size=..., coef0=..., degree=...,
+        estimator=SVC(C=None, cache_size=..., coef0=..., degree=...,
             gamma=..., kernel='rbf', probability=False,
             scale_C=True, shrinking=True, tol=...),
         fit_params={}, iid=True, loss_func=None, n_jobs=1,

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -66,6 +66,9 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
         intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True
 
+    `scaled_C_` : float
+        The C value passed to liblinear.
+
     See also
     --------
     LinearSVC

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -116,9 +116,7 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
         """
         X = self._validate_for_predict(X)
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         prob_wrap = (csr_predict_prob_wrap if self._sparse else
                 predict_prob_wrap)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -27,9 +27,9 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
         implemented for l2 penalty. Prefer dual=False when
         n_samples > n_features.
 
-    C : float
+    C : float or None, optional (default=None)
         Specifies the strength of the regularization. The smaller it is
-        the bigger in the regularization.
+        the bigger in the regularization. If None then C is set to n_samples.
 
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -88,7 +88,7 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
         http://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf
     """
 
-    def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
+    def __init__(self, penalty='l2', dual=False, tol=1e-4, C=None,
                  fit_intercept=True, intercept_scaling=1,
                  scale_C=True, class_weight=None):
 
@@ -115,10 +115,15 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
             order.
         """
         X = self._validate_for_predict(X)
+
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         prob_wrap = (csr_predict_prob_wrap if self._sparse else
                 predict_prob_wrap)
         probas = prob_wrap(X, self.raw_coef_, self._get_solver_type(),
-                           self.tol, self.C, self.class_weight_label_,
+                           self.tol, C, self.class_weight_label_,
                            self.class_weight_, self.label_, self._get_bias())
         return probas[:, np.argsort(self.label_)]
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -342,9 +342,7 @@ class BaseLibSVM(BaseEstimator):
         if epsilon == None:
             epsilon = 0.1
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         svm_type = LIBSVM_IMPL.index(self.impl)
         return libsvm.predict(
@@ -361,9 +359,7 @@ class BaseLibSVM(BaseEstimator):
         X = sp.csr_matrix(X, dtype=np.float64)
         kernel_type = self._sparse_kernels.index(self.kernel)
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         return libsvm_sparse.libsvm_sparse_predict(
                       X.data, X.indices, X.indptr,
@@ -422,9 +418,7 @@ class BaseLibSVM(BaseEstimator):
         if epsilon == None:
             epsilon = 0.1
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         svm_type = LIBSVM_IMPL.index(self.impl)
         pprob = libsvm.predict_proba(
@@ -508,9 +502,7 @@ class BaseLibSVM(BaseEstimator):
 
         X = array2d(X, dtype=np.float64, order="C")
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         epsilon = self.epsilon
         if epsilon == None:
@@ -709,9 +701,7 @@ class BaseLibLinear(BaseEstimator):
         X = self._validate_for_predict(X)
         self._check_n_features(X)
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         predict = liblinear.csr_predict_wrap if self._sparse \
                                              else liblinear.predict_wrap
@@ -735,9 +725,7 @@ class BaseLibLinear(BaseEstimator):
         X = self._validate_for_predict(X)
         self._check_n_features(X)
 
-        C = self.C
-        if C is None:
-            C = X.shape[0]  # just to avoid None
+        C = 0.0  # C is not useful here
 
         dfunc_wrap = liblinear.csr_decision_function_wrap \
                        if self._sparse \

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -180,6 +180,9 @@ class BaseLibSVM(BaseEstimator):
             C = X.shape[0]
         if getattr(self, 'scale_C', False):
             C = C / float(X.shape[0])
+
+        self.scaled_C_ = C
+
         epsilon = self.epsilon
         if epsilon is None:
             epsilon = 0.1
@@ -273,6 +276,8 @@ class BaseLibSVM(BaseEstimator):
             C = X.shape[0]
         if self.scale_C:
             C = C / float(X.shape[0])
+
+        self.scaled_C_ = C
 
         self.support_vectors_, dual_coef_data, self.intercept_, self.label_, \
             self.n_support_, self.probA_, self.probB_ = \
@@ -678,6 +683,7 @@ class BaseLibLinear(BaseEstimator):
         if self.scale_C:
             C = C / float(X.shape[0])
 
+        self.scaled_C_ = C
         train = liblinear.csr_train_wrap if self._sparse \
                                          else liblinear.train_wrap
         self.raw_coef_, self.label_ = train(X, y, self._get_solver_type(),

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -176,8 +176,10 @@ class BaseLibSVM(BaseEstimator):
 
         # set default parameters
         C = self.C
+        if C is None:
+            C = X.shape[0]
         if getattr(self, 'scale_C', False):
-            C = self.C / float(X.shape[0])
+            C = C / float(X.shape[0])
         epsilon = self.epsilon
         if epsilon is None:
             epsilon = 0.1
@@ -267,8 +269,10 @@ class BaseLibSVM(BaseEstimator):
             self.gamma = 1.0 / X.shape[1]
 
         C = self.C
+        if C is None:
+            C = X.shape[0]
         if self.scale_C:
-            C /= float(X.shape[0])
+            C = C / float(X.shape[0])
 
         self.support_vectors_, dual_coef_data, self.intercept_, self.label_, \
             self.n_support_, self.probA_, self.probB_ = \
@@ -338,13 +342,17 @@ class BaseLibSVM(BaseEstimator):
         if epsilon == None:
             epsilon = 0.1
 
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         svm_type = LIBSVM_IMPL.index(self.impl)
         return libsvm.predict(
             X, self.support_, self.support_vectors_, self.n_support_,
             self.dual_coef_, self._intercept_,
             self.label_, self.probA_, self.probB_,
             svm_type=svm_type,
-            kernel=self.kernel, C=self.C, nu=self.nu,
+            kernel=self.kernel, C=C, nu=self.nu,
             probability=self.probability, degree=self.degree,
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
@@ -352,6 +360,10 @@ class BaseLibSVM(BaseEstimator):
     def _sparse_predict(self, X):
         X = sp.csr_matrix(X, dtype=np.float64)
         kernel_type = self._sparse_kernels.index(self.kernel)
+
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
 
         return libsvm_sparse.libsvm_sparse_predict(
                       X.data, X.indices, X.indptr,
@@ -361,7 +373,7 @@ class BaseLibSVM(BaseEstimator):
                       self.dual_coef_.data, self._intercept_,
                       LIBSVM_IMPL.index(self.impl), kernel_type,
                       self.degree, self.gamma, self.coef0, self.tol,
-                      self.C, self.class_weight_label_, self.class_weight_,
+                      C, self.class_weight_label_, self.class_weight_,
                       self.nu, self.epsilon, self.shrinking,
                       self.probability, self.n_support_, self.label_,
                       self.probA_, self.probB_)
@@ -410,12 +422,16 @@ class BaseLibSVM(BaseEstimator):
         if epsilon == None:
             epsilon = 0.1
 
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         svm_type = LIBSVM_IMPL.index(self.impl)
         pprob = libsvm.predict_proba(
             X, self.support_, self.support_vectors_, self.n_support_,
             self.dual_coef_, self._intercept_, self.label_,
             self.probA_, self.probB_,
-            svm_type=svm_type, kernel=self.kernel, C=self.C, nu=self.nu,
+            svm_type=svm_type, kernel=self.kernel, C=C, nu=self.nu,
             probability=self.probability, degree=self.degree,
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
@@ -492,6 +508,10 @@ class BaseLibSVM(BaseEstimator):
 
         X = array2d(X, dtype=np.float64, order="C")
 
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         epsilon = self.epsilon
         if epsilon == None:
             epsilon = 0.1
@@ -500,7 +520,7 @@ class BaseLibSVM(BaseEstimator):
             self.dual_coef_, self._intercept_, self.label_,
             self.probA_, self.probB_,
             svm_type=LIBSVM_IMPL.index(self.impl),
-            kernel=self.kernel, C=self.C, nu=self.nu,
+            kernel=self.kernel, C=C, nu=self.nu,
             probability=self.probability, degree=self.degree,
             shrinking=self.shrinking, tol=self.tol, cache_size=self.cache_size,
             coef0=self.coef0, gamma=self.gamma, epsilon=epsilon)
@@ -565,7 +585,7 @@ class BaseLibLinear(BaseEstimator):
         'PL2_LLR_D1': 7,  # L2 penalty, logistic regression, dual form
         }
 
-    def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
+    def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=None,
             multi_class='ovr', fit_intercept=True, intercept_scaling=1,
             scale_C=True, class_weight=None):
         self.penalty = penalty
@@ -661,6 +681,8 @@ class BaseLibLinear(BaseEstimator):
                              (X.shape[0], y.shape[0]))
 
         C = self.C
+        if C is None:
+            C = X.shape[0]
         if self.scale_C:
             C = C / float(X.shape[0])
 
@@ -687,10 +709,14 @@ class BaseLibLinear(BaseEstimator):
         X = self._validate_for_predict(X)
         self._check_n_features(X)
 
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         predict = liblinear.csr_predict_wrap if self._sparse \
                                              else liblinear.predict_wrap
         return predict(X, self.raw_coef_, self._get_solver_type(), self.tol,
-                       self.C, self.class_weight_label_, self.class_weight_,
+                       C, self.class_weight_label_, self.class_weight_,
                        self.label_, self._get_bias())
 
     def decision_function(self, X):
@@ -709,12 +735,16 @@ class BaseLibLinear(BaseEstimator):
         X = self._validate_for_predict(X)
         self._check_n_features(X)
 
+        C = self.C
+        if C is None:
+            C = X.shape[0]  # just to avoid None
+
         dfunc_wrap = liblinear.csr_decision_function_wrap \
                        if self._sparse \
                        else liblinear.decision_function_wrap
 
         dec_func = dfunc_wrap(X, self.raw_coef_, self._get_solver_type(),
-                self.tol, self.C, self.class_weight_label_, self.class_weight_,
+                self.tol, C, self.class_weight_label_, self.class_weight_,
                 self.label_, self._get_bias())
 
         return dec_func

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -16,8 +16,9 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
 
     Parameters
     ----------
-    C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+    C : float or None, optional (default=None)
+        Penalty parameter C of the error term. If None then C is set
+        to n_samples.
 
     loss : string, 'l1' or 'l2' (default='l2')
         Specifies the loss function. 'l1' is the hinge loss (standard SVM)
@@ -142,8 +143,9 @@ class SVC(BaseLibSVM, ClassifierMixin):
 
     Parameters
     ----------
-    C : float, optional (default=1.0)
-        Penalty parameter C of the error term.
+    C : float or None, optional (default=None)
+        Penalty parameter C of the error term. If None then C is set
+        to n_samples.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.
@@ -223,7 +225,7 @@ class SVC(BaseLibSVM, ClassifierMixin):
     >>> from sklearn.svm import SVC
     >>> clf = SVC()
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
             gamma=0.5, kernel='rbf', probability=False, scale_C=True,
             shrinking=True, tol=0.001)
     >>> print clf.predict([[-0.8, -1]])
@@ -241,7 +243,7 @@ class SVC(BaseLibSVM, ClassifierMixin):
 
     """
 
-    def __init__(self, C=1.0, kernel='rbf', degree=3, gamma=0.0,
+    def __init__(self, C=None, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
                  tol=1e-3, cache_size=200, scale_C=True, class_weight=None):
 
@@ -372,8 +374,9 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     Parameters
     ----------
-    C : float, optional (default=1.0)
-        penalty parameter C of the error term.
+    C : float or None, optional (default=None)
+        penalty parameter C of the error term. If None then C is set
+        to n_samples.
 
     epsilon : float, optional (default=0.1)
          epsilon in the epsilon-SVR model. It specifies the epsilon-tube
@@ -458,7 +461,7 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     """
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0,
-                 tol=1e-3, C=1.0, epsilon=0.1, shrinking=True,
+                 tol=1e-3, C=None, epsilon=0.1, shrinking=True,
                  probability=False, cache_size=200, scale_C=True):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
@@ -477,8 +480,9 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     Parameters
     ----------
-    C : float, optional (default=1.0)
-        penalty parameter C of the error term.
+    C : float or None, optional (default=None)
+        penalty parameter C of the error term. If None then C is set
+        to n_samples.
 
     nu : float, optional
         An upper bound on the fraction of training errors and a lower bound of
@@ -564,7 +568,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         epsilon Support Vector Machine for regression implemented with libsvm.
     """
 
-    def __init__(self, nu=0.5, C=1.0, kernel='rbf', degree=3,
+    def __init__(self, nu=0.5, C=None, kernel='rbf', degree=3,
                  gamma=0.0, coef0=0.0, shrinking=True,
                  probability=False, tol=1e-3, cache_size=200,
                  scale_C=True):

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -88,6 +88,9 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
     `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
+    `scaled_C_` : float
+        The C value passed to liblinear.
+
     Notes
     -----
     The underlying C implementation uses a random number generator to
@@ -217,6 +220,9 @@ class SVC(BaseLibSVM, ClassifierMixin):
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
+    `scaled_C_` : float
+        The C value passed to libsvm.
+
     Examples
     --------
     >>> import numpy as np
@@ -333,6 +339,9 @@ class NuSVC(BaseLibSVM, ClassifierMixin):
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
+    `scaled_C_` : float
+        The C value passed to libsvm.
+
     Examples
     --------
     >>> import numpy as np
@@ -440,6 +449,9 @@ class SVR(BaseLibSVM, RegressorMixin):
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
+    `scaled_C_` : float
+        The C value passed to libsvm.
+
     Examples
     --------
     >>> from sklearn.svm import SVR
@@ -545,6 +557,9 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     `intercept_` : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
+    `scaled_C_` : float
+        The C value passed to libsvm.
+
     Examples
     --------
     >>> from sklearn.svm import NuSVR
@@ -643,6 +658,9 @@ class OneClassSVM(BaseLibSVM):
 
     `intercept_` : array, shape = [n_classes-1]
         Constants in decision function.
+
+    `scaled_C_` : float
+        The C value passed to libsvm.
 
     """
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0, tol=1e-3,

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -23,14 +23,14 @@ class SVC(SparseBaseLibSVM, ClassifierMixin):
     >>> from sklearn.svm.sparse import SVC
     >>> clf = SVC()
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
-    SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
+    SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
             gamma=0.5, kernel='rbf', probability=False, scale_C=True,
             shrinking=True, tol=0.001)
     >>> print clf.predict([[-0.8, -1]])
     [ 1.]
     """
 
-    def __init__(self, C=1.0, kernel='rbf', degree=3, gamma=0.0,
+    def __init__(self, C=None, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
                  tol=1e-3, cache_size=200, scale_C=True, class_weight=None):
 
@@ -100,7 +100,7 @@ class SVR(SparseBaseLibSVM, RegressorMixin):
     """
 
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0,
-                 tol=1e-3, C=1.0, epsilon=0.1, shrinking=True,
+                 tol=1e-3, C=None, epsilon=0.1, shrinking=True,
                  probability=False, cache_size=200, scale_C=True):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
@@ -134,7 +134,7 @@ class NuSVR(SparseBaseLibSVM, RegressorMixin):
        tol=0.001)
     """
 
-    def __init__(self, nu=0.5, C=1.0, kernel='rbf', degree=3,
+    def __init__(self, nu=0.5, C=None, kernel='rbf', degree=3,
                  gamma=0.0, coef0=0.0, shrinking=True, epsilon=0.1,
                  probability=False, tol=1e-3, cache_size=200, scale_C=True):
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -572,12 +572,14 @@ def test_c_samples_scaling():
     for clf in clfs:
         clf.set_params(scale_C=False)
         coef_ = clf.fit(X, y).coef_
+        assert_true(clf.C == clf.scaled_C_)
         coef2_ = clf.fit(X2, y2).coef_
         error_no_scale = linalg.norm(coef2_ - coef_) / linalg.norm(coef_)
         assert_true(error_no_scale > 1e-3)
 
         clf.set_params(scale_C=True)
         coef_ = clf.fit(X, y).coef_
+        assert_true(clf.C == clf.scaled_C_ * X.shape[0])
         coef2_ = clf.fit(X2, y2).coef_
         error_with_scale = linalg.norm(coef2_ - coef_) / linalg.norm(coef_)
         assert_true(error_with_scale < 1e-5)

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -268,7 +268,7 @@ def test_decision_function():
 
     """
     # multi class:
-    clf = svm.SVC(kernel='linear').fit(iris.data, iris.target)
+    clf = svm.SVC(kernel='linear', C=1.).fit(iris.data, iris.target)
 
     dec = np.dot(iris.data, clf.coef_.T) + clf.intercept_
 
@@ -566,8 +566,8 @@ def test_c_samples_scaling():
             svm.SVR(tol=1e-6, kernel='linear', C=100),
             svm.LinearSVC(tol=1e-6, C=0.1),
             linear_model.LogisticRegression(penalty='l1', tol=1e-6, C=100),
-            linear_model.LogisticRegression(penalty='l2', tol=1e-6),
-            svm.NuSVR(tol=1e-6, kernel='linear')]
+            linear_model.LogisticRegression(penalty='l2', tol=1e-6, C=1.),
+            svm.NuSVR(tol=1e-6, kernel='linear', C=1.)]
 
     for clf in clfs:
         clf.set_params(scale_C=False)
@@ -581,6 +581,20 @@ def test_c_samples_scaling():
         coef2_ = clf.fit(X2, y2).coef_
         error_with_scale = linalg.norm(coef2_ - coef_) / linalg.norm(coef_)
         assert_true(error_with_scale < 1e-5)
+
+
+def test_c_samples_scaling_default():
+    """Test C scaling : (C=1, scale_C=False) == (C=None, scale_C=True)
+    """
+    X = iris.data[iris.target != 2]
+    y = iris.target[iris.target != 2]
+
+    clf = svm.SVC(tol=1e-6, kernel='linear')
+    clf2 = svm.SVC(tol=1e-6, kernel='linear', C=1., scale_C=False)
+
+    coef_ = clf.fit(X, y).coef_
+    coef2_ = clf2.fit(X, y).coef_
+    assert_array_almost_equal(coef_, coef2_, 7)
 
 
 def test_nu_svc_samples_scaling():


### PR DESCRIPTION
use C=None by default in libsvm/liblinear bindings so:

(C=1, scale_C...=False) which is libsvm default  == (C=None, scale_C=True) which is the scikit default
