### PR TITLE
FIX: Add NORMALIZE_WHITESPACE to broken doctest

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -73,7 +73,7 @@ parameters or alternatively it uses the given parameters.
     >>> y = f(X).ravel()
     >>> x = np.atleast_2d(np.linspace(0, 10, 1000)).T
     >>> gp = gaussian_process.GaussianProcess(theta0=1e-2, thetaL=1e-4, thetaU=1e-1)
-    >>> gp.fit(X, y)  # doctest: +ELLIPSIS
+    >>> gp.fit(X, y)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
             normalize=True, nugget=array(2.22...-15),
             optimizer='fmin_cobyla', random_start=1,


### PR DESCRIPTION
Broken at least on OS X.
