### PR TITLE
Add verbose parameter to SVMs (fixes #250)

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -85,7 +85,7 @@ training samples::
     >>> clf.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
     SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.5, kernel='rbf', probability=False, scale_C=True, shrinking=True,
-    tol=0.001)
+    tol=0.001, verbose=False)
 
 After being fitted, the model can then be used to predict new values::
 
@@ -124,7 +124,7 @@ classifiers are constructed and each one trains data from two classes::
     >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
     SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=1.0, kernel='rbf', probability=False, scale_C=True, shrinking=True,
-    tol=0.001)
+    tol=0.001, verbose=False)
     >>> dec = clf.decision_function([[1]])
     >>> dec.shape[1] # 4 classes: 4*3/2 = 6
     6
@@ -271,7 +271,7 @@ floating point values instead of integer values::
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
     SVR(C=None, cache_size=200, coef0=0.0, degree=3,
     epsilon=0.1, gamma=0.5, kernel='rbf', probability=False, scale_C=True,
-    shrinking=True, tol=0.001)
+    shrinking=True, tol=0.001, verbose=False)
     >>> clf.predict([[1, 1]])
     array([ 1.5])
 
@@ -469,7 +469,7 @@ vectors and the test vectors must be provided.
     >>> clf.fit(gram, y) # doctest: +NORMALIZE_WHITESPACE
     SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.0, kernel='precomputed', probability=False, scale_C=True,
-    shrinking=True, tol=0.001)
+    shrinking=True, tol=0.001, verbose=False)
     >>> # predict on training examples
     >>> clf.predict(gram)
     array([ 0.,  1.])

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -154,7 +154,7 @@ one::
   >>> clf.fit(digits.data[:-1], digits.target[:-1])
   SVC(C=100.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.001, kernel='rbf', probability=False, scale_C=True,
-    shrinking=True, tol=0.001)
+    shrinking=True, tol=0.001, verbose=False)
 
 Now you can predict new values, in particular, we can ask to the
 classifier what is the digit of our last image in the `digits` dataset,
@@ -191,7 +191,7 @@ persistence model, namely `pickle <http://docs.python.org/library/pickle.html>`_
   >>> clf.fit(X, y)
   SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
     gamma=0.25, kernel='rbf', probability=False, scale_C=True,
-    shrinking=True, tol=0.001)
+    shrinking=True, tol=0.001, verbose=False)
 
   >>> import pickle
   >>> s = pickle.dumps(clf)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -75,7 +75,7 @@ class BaseLibSVM(BaseEstimator):
 
     def __init__(self, impl, kernel, degree, gamma, coef0,
                  tol, C, nu, epsilon, shrinking, probability, cache_size,
-                 scale_C, sparse, class_weight):
+                 scale_C, sparse, class_weight, verbose):
 
         if not impl in LIBSVM_IMPL:
             raise ValueError("impl should be one of %s, %s was given" % (
@@ -104,6 +104,7 @@ class BaseLibSVM(BaseEstimator):
         self.scale_C = scale_C
         self.sparse = sparse
         self.class_weight = class_weight
+        self.verbose = verbose
 
     def fit(self, X, y, class_weight=None, sample_weight=None):
         """Fit the SVM model according to the given training data.
@@ -186,6 +187,8 @@ class BaseLibSVM(BaseEstimator):
         epsilon = self.epsilon
         if epsilon is None:
             epsilon = 0.1
+
+        libsvm.set_verbosity_wrap(self.verbose)
 
         # we don't pass **self.get_params() to allow subclasses to
         # add other parameters to __init__
@@ -278,6 +281,8 @@ class BaseLibSVM(BaseEstimator):
             C = C / float(X.shape[0])
 
         self.scaled_C_ = C
+
+        libsvm_sparse.set_verbosity_wrap(self.verbose)
 
         self.support_vectors_, dual_coef_data, self.intercept_, self.label_, \
             self.n_support_, self.probA_, self.probB_ = \

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -255,7 +255,7 @@ class SVC(BaseLibSVM, ClassifierMixin):
 
         super(SVC, self).__init__('c_svc', kernel, degree, gamma, coef0, tol,
                 C, 0., 0., shrinking, probability, cache_size, scale_C,
-                sparse="auto", class_weight=class_weight)
+                "auto", class_weight)
 
 
 class NuSVC(BaseLibSVM, ClassifierMixin):
@@ -371,7 +371,7 @@ class NuSVC(BaseLibSVM, ClassifierMixin):
 
         super(NuSVC, self).__init__('nu_svc', kernel, degree, gamma, coef0,
                 tol, 0., nu, 0., shrinking, probability, cache_size,
-                scale_C=True, sparse="auto", class_weight=None)
+                True, "auto", None)
 
 
 class SVR(BaseLibSVM, RegressorMixin):
@@ -478,7 +478,7 @@ class SVR(BaseLibSVM, RegressorMixin):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
                 tol, C, 0., epsilon, shrinking, probability, cache_size,
-                scale_C, sparse="auto", class_weight=None)
+                scale_C, "auto", None)
 
 
 class NuSVR(BaseLibSVM, RegressorMixin):
@@ -590,7 +590,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
         super(NuSVR, self).__init__('nu_svr', kernel, degree, gamma, coef0,
                 tol, C, nu, 0., shrinking, probability, cache_size, scale_C,
-                sparse="auto", class_weight=None)
+                "auto", None)
 
 
 class OneClassSVM(BaseLibSVM):
@@ -668,7 +668,7 @@ class OneClassSVM(BaseLibSVM):
 
         super(OneClassSVM, self).__init__('one_class', kernel, degree, gamma,
                 coef0, tol, 0., nu, 0., shrinking, False, cache_size,
-                scale_C=True, sparse="auto", class_weight=None)
+                True, "auto", None)
 
     def fit(self, X, sample_weight=None, **params):
         """

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -192,6 +192,11 @@ class SVC(BaseLibSVM, ClassifierMixin):
         of the number of samples. To match libsvm commandline one should use
         scale_C=False. WARNING: scale_C will disappear in version 0.12.
 
+    verbose : bool, default: False
+        Enable verbose output. Note that this setting takes advantage of a
+        per-process runtime setting in libsvm that, if enabled, may not work
+        properly in a multithreaded context.
+
     Attributes
     ----------
     `support_` : array-like, shape = [n_SV]
@@ -233,7 +238,7 @@ class SVC(BaseLibSVM, ClassifierMixin):
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
             gamma=0.5, kernel='rbf', probability=False, scale_C=True,
-            shrinking=True, tol=0.001)
+            shrinking=True, tol=0.001, verbose=False)
     >>> print clf.predict([[-0.8, -1]])
     [ 1.]
 
@@ -251,11 +256,12 @@ class SVC(BaseLibSVM, ClassifierMixin):
 
     def __init__(self, C=None, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
-                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None):
+                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None,
+                 verbose=False):
 
         super(SVC, self).__init__('c_svc', kernel, degree, gamma, coef0, tol,
                 C, 0., 0., shrinking, probability, cache_size, scale_C,
-                "auto", class_weight)
+                "auto", class_weight, verbose)
 
 
 class NuSVC(BaseLibSVM, ClassifierMixin):
@@ -310,6 +316,11 @@ class NuSVC(BaseLibSVM, ClassifierMixin):
         automatically adjust weights inversely proportional to
         class frequencies.
 
+    verbose : bool, default: False
+        Enable verbose output. Note that this setting takes advantage of a
+        per-process runtime setting in libsvm that, if enabled, may not work
+        properly in a multithreaded context.
+
 
     Attributes
     ----------
@@ -351,7 +362,7 @@ class NuSVC(BaseLibSVM, ClassifierMixin):
     >>> clf = NuSVC()
     >>> clf.fit(X, y)
     NuSVC(cache_size=200, coef0=0.0, degree=3, gamma=0.5, kernel='rbf', nu=0.5,
-       probability=False, shrinking=True, tol=0.001)
+       probability=False, shrinking=True, tol=0.001, verbose=False)
     >>> print clf.predict([[-0.8, -1]])
     [ 1.]
 
@@ -367,11 +378,11 @@ class NuSVC(BaseLibSVM, ClassifierMixin):
 
     def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
-                 tol=1e-3, cache_size=200):
+                 tol=1e-3, cache_size=200, verbose=False):
 
         super(NuSVC, self).__init__('nu_svc', kernel, degree, gamma, coef0,
                 tol, 0., nu, 0., shrinking, probability, cache_size,
-                True, "auto", None)
+                True, "auto", None, verbose)
 
 
 class SVR(BaseLibSVM, RegressorMixin):
@@ -428,6 +439,11 @@ class SVR(BaseLibSVM, RegressorMixin):
         of the number of samples. To match libsvm commandline one should use
         scale_C=False. WARNING: scale_C will disappear in version 0.12.
 
+    verbose : bool, default: False
+        Enable verbose output. Note that this setting takes advantage of a
+        per-process runtime setting in libsvm that, if enabled, may not work
+        properly in a multithreaded context.
+
     Attributes
     ----------
     `support_` : array-like, shape = [n_SV]
@@ -463,7 +479,8 @@ class SVR(BaseLibSVM, RegressorMixin):
     >>> clf = SVR(C=1.0, epsilon=0.2)
     >>> clf.fit(X, y)
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma=0.2,
-      kernel='rbf', probability=False, scale_C=True, shrinking=True, tol=0.001)
+      kernel='rbf', probability=False, scale_C=True, shrinking=True, tol=0.001,
+      verbose=False)
 
     See also
     --------
@@ -474,11 +491,12 @@ class SVR(BaseLibSVM, RegressorMixin):
     """
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0,
                  tol=1e-3, C=None, epsilon=0.1, shrinking=True,
-                 probability=False, cache_size=200, scale_C=True):
+                 probability=False, cache_size=200, scale_C=True,
+                 verbose=False):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
                 tol, C, 0., epsilon, shrinking, probability, cache_size,
-                scale_C, "auto", None)
+                scale_C, "auto", None, verbose)
 
 
 class NuSVR(BaseLibSVM, RegressorMixin):
@@ -536,6 +554,11 @@ class NuSVR(BaseLibSVM, RegressorMixin):
         of the number of samples. To match libsvm commandline one should use
         scale_C=False. WARNING: scale_C will disappear in version 0.12.
 
+    verbose : bool, default: False
+        Enable verbose output. Note that this setting takes advantage of a
+        per-process runtime setting in libsvm that, if enabled, may not work
+        properly in a multithreaded context.
+
     Attributes
     ----------
     `support_` : array-like, shape = [n_SV]
@@ -571,7 +594,8 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     >>> clf = NuSVR(C=1.0, nu=0.1)
     >>> clf.fit(X, y)
     NuSVR(C=1.0, cache_size=200, coef0=0.0, degree=3, gamma=0.2, kernel='rbf',
-       nu=0.1, probability=False, scale_C=True, shrinking=True, tol=0.001)
+       nu=0.1, probability=False, scale_C=True, shrinking=True, tol=0.001,
+       verbose=False)
 
     See also
     --------
@@ -586,11 +610,11 @@ class NuSVR(BaseLibSVM, RegressorMixin):
     def __init__(self, nu=0.5, C=None, kernel='rbf', degree=3,
                  gamma=0.0, coef0=0.0, shrinking=True,
                  probability=False, tol=1e-3, cache_size=200,
-                 scale_C=True):
+                 scale_C=True, verbose=False):
 
         super(NuSVR, self).__init__('nu_svr', kernel, degree, gamma, coef0,
                 tol, C, nu, 0., shrinking, probability, cache_size, scale_C,
-                "auto", None)
+                "auto", None, verbose)
 
 
 class OneClassSVM(BaseLibSVM):
@@ -638,6 +662,11 @@ class OneClassSVM(BaseLibSVM):
         of the number of samples. To match libsvm commandline one should use
         scale_C=False. WARNING: scale_C will disappear in version 0.12.
 
+    verbose : bool, default: False
+        Enable verbose output. Note that this setting takes advantage of a
+        per-process runtime setting in libsvm that, if enabled, may not work
+        properly in a multithreaded context.
+
     Attributes
     ----------
     `support_` : array-like, shape = [n_SV]
@@ -664,11 +693,11 @@ class OneClassSVM(BaseLibSVM):
 
     """
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0, tol=1e-3,
-                 nu=0.5, shrinking=True, cache_size=200):
+                 nu=0.5, shrinking=True, cache_size=200, verbose=False):
 
         super(OneClassSVM, self).__init__('one_class', kernel, degree, gamma,
                 coef0, tol, 0., nu, 0., shrinking, False, cache_size,
-                True, "auto", None)
+                True, "auto", None, verbose)
 
     def fit(self, X, sample_weight=None, **params):
         """

--- a/sklearn/svm/sparse/base.py
+++ b/sklearn/svm/sparse/base.py
@@ -7,7 +7,7 @@ from ..base import BaseLibSVM
 class SparseBaseLibSVM(BaseLibSVM):
     def __init__(self, impl, kernel, degree, gamma, coef0,
                  tol, C, nu, epsilon, shrinking, probability, cache_size,
-                 scale_C, class_weight):
+                 scale_C, class_weight, verbose):
 
         assert kernel in self._sparse_kernels, \
                "kernel should be one of %s, "\
@@ -15,7 +15,7 @@ class SparseBaseLibSVM(BaseLibSVM):
 
         super(SparseBaseLibSVM, self).__init__(impl, kernel, degree, gamma,
                 coef0, tol, C, nu, epsilon, shrinking, probability, cache_size,
-                scale_C, True, class_weight)
+                scale_C, True, class_weight, verbose)
 
     def fit(self, X, y, sample_weight=None):
         X = scipy.sparse.csr_matrix(X, dtype=np.float64)

--- a/sklearn/svm/sparse/base.py
+++ b/sklearn/svm/sparse/base.py
@@ -15,7 +15,7 @@ class SparseBaseLibSVM(BaseLibSVM):
 
         super(SparseBaseLibSVM, self).__init__(impl, kernel, degree, gamma,
                 coef0, tol, C, nu, epsilon, shrinking, probability, cache_size,
-                scale_C, sparse=True, class_weight=class_weight)
+                scale_C, True, class_weight)
 
     def fit(self, X, y, sample_weight=None):
         X = scipy.sparse.csr_matrix(X, dtype=np.float64)

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -105,7 +105,7 @@ class SVR(SparseBaseLibSVM, RegressorMixin):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
                                   tol, C, 0., epsilon, shrinking, probability,
-                                  cache_size, scale_C, class_weight=None)
+                                  cache_size, scale_C, None)
 
 
 class NuSVR(SparseBaseLibSVM, RegressorMixin):
@@ -140,7 +140,7 @@ class NuSVR(SparseBaseLibSVM, RegressorMixin):
 
         super(NuSVR, self).__init__('nu_svr', kernel, degree, gamma, coef0,
                 tol, C, nu, epsilon, shrinking, probability, cache_size,
-                scale_C, class_weight=None)
+                scale_C, None)
 
 
 class OneClassSVM(SparseBaseLibSVM):

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -25,18 +25,19 @@ class SVC(SparseBaseLibSVM, ClassifierMixin):
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     SVC(C=None, cache_size=200, class_weight=None, coef0=0.0, degree=3,
             gamma=0.5, kernel='rbf', probability=False, scale_C=True,
-            shrinking=True, tol=0.001)
+            shrinking=True, tol=0.001, verbose=False)
     >>> print clf.predict([[-0.8, -1]])
     [ 1.]
     """
 
     def __init__(self, C=None, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
-                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None):
+                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None,
+                 verbose=False):
 
         super(SVC, self).__init__('c_svc', kernel, degree, gamma, coef0, tol,
                                   C, 0., 0., shrinking, probability,
-                                  cache_size, scale_C, class_weight)
+                                  cache_size, scale_C, class_weight, verbose)
 
 
 class NuSVC(SparseBaseLibSVM, ClassifierMixin):
@@ -60,18 +61,19 @@ class NuSVC(SparseBaseLibSVM, ClassifierMixin):
     >>> clf.fit(X, y) #doctest: +NORMALIZE_WHITESPACE
     NuSVC(cache_size=200, class_weight=None, coef0=0.0, degree=3, gamma=0.5,
             kernel='rbf', nu=0.5, probability=False, scale_C=True,
-            shrinking=True, tol=0.001)
+            shrinking=True, tol=0.001, verbose=False)
     >>> print clf.predict([[-0.8, -1]])
     [ 1.]
     """
 
     def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma=0.0,
                  coef0=0.0, shrinking=True, probability=False,
-                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None):
+                 tol=1e-3, cache_size=200, scale_C=True, class_weight=None,
+                 verbose=False):
 
         super(NuSVC, self).__init__('nu_svc', kernel, degree, gamma, coef0,
                                     tol, 0., nu, 0., shrinking, probability,
-                                    cache_size, scale_C, class_weight)
+                                    cache_size, scale_C, class_weight, verbose)
 
 
 class SVR(SparseBaseLibSVM, RegressorMixin):
@@ -96,16 +98,18 @@ class SVR(SparseBaseLibSVM, RegressorMixin):
     >>> clf = SVR(C=1.0, epsilon=0.2)
     >>> clf.fit(X, y)
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma=0.2,
-      kernel='rbf', probability=False, scale_C=True, shrinking=True, tol=0.001)
+      kernel='rbf', probability=False, scale_C=True, shrinking=True, tol=0.001,
+      verbose=False)
     """
 
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0,
                  tol=1e-3, C=None, epsilon=0.1, shrinking=True,
-                 probability=False, cache_size=200, scale_C=True):
+                 probability=False, cache_size=200, scale_C=True,
+                 verbose=False):
 
         super(SVR, self).__init__('epsilon_svr', kernel, degree, gamma, coef0,
                                   tol, C, 0., epsilon, shrinking, probability,
-                                  cache_size, scale_C, None)
+                                  cache_size, scale_C, None, verbose)
 
 
 class NuSVR(SparseBaseLibSVM, RegressorMixin):
@@ -131,16 +135,17 @@ class NuSVR(SparseBaseLibSVM, RegressorMixin):
     >>> clf.fit(X, y)
     NuSVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.1, gamma=0.2,
        kernel='rbf', nu=0.1, probability=False, scale_C=True, shrinking=True,
-       tol=0.001)
+       tol=0.001, verbose=False)
     """
 
     def __init__(self, nu=0.5, C=None, kernel='rbf', degree=3,
                  gamma=0.0, coef0=0.0, shrinking=True, epsilon=0.1,
-                 probability=False, tol=1e-3, cache_size=200, scale_C=True):
+                 probability=False, tol=1e-3, cache_size=200, scale_C=True,
+                 verbose=False):
 
         super(NuSVR, self).__init__('nu_svr', kernel, degree, gamma, coef0,
                 tol, C, nu, epsilon, shrinking, probability, cache_size,
-                scale_C, None)
+                scale_C, None, verbose)
 
 
 class OneClassSVM(SparseBaseLibSVM):
@@ -157,11 +162,13 @@ class OneClassSVM(SparseBaseLibSVM):
 
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0,
                  tol=1e-3, nu=0.5, shrinking=True,
-                 probability=False, cache_size=200, scale_C=True):
+                 probability=False, cache_size=200, scale_C=True,
+                 verbose=False):
 
         super(OneClassSVM, self).__init__('one_class', kernel, degree, gamma,
                                           coef0, tol, 0.0, nu, 0.0, shrinking,
-                                          probability, cache_size, scale_C)
+                                          probability, cache_size, scale_C,
+                                          verbose)
 
     def fit(self, X, sample_weight=None):
         super(OneClassSVM, self).fit(


### PR DESCRIPTION
Add a verbose parameter to SVMs to get verbose output from libsvm
printed to stdout while fitting a model.

Note that this setting takes advantage of a per-process runtime setting
in libsvm that, if enabled, may not work properly in a multithreaded
context (the output may come out interleaved).

It works like this:

```
>>> from sklearn import svm
>>> X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
>>> Y = [1, 1, 1, 2, 2, 2]
>>> clf = svm.SVC().fit(X, Y)               # verbose=False
>>> clf = svm.SVC(verbose=True).fit(X, Y)   # verbose=True
.*.*
optimization finished, #iter = 17
obj = -1.492063, rho = 0.000025
nSV = 6, nBSV = 0
Total nSV = 6
```

Similarly for sparse SVMs:

```
>>> clf = svm.sparse.SVC().fit(X, Y)
>>> clf = svm.sparse.SVC(verbose=True).fit(X, Y)
.*.*
optimization finished, #iter = 17
obj = -1.492063, rho = 0.000025
nSV = 6, nBSV = 0
Total nSV = 6
```

I tried to write a test that captures and verifies stdout, but I was
unable to capture stdout with `sys.stdout = StringIO()` (I tried stderr
too). I'm assuming this is because the output is coming from C code
(svm/src/libsvm/libsvm_helper.c) rather than Python code.

A possible future improvement may be to allow the user to provide a
Python callback function that is passed the string to be printed. This
would provide more control over what gets printed where...
