### PR TITLE
FIX : ICA with small n_components and whiten=False (fix for #697)

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -8,6 +8,7 @@ Independent Component Analysis, by  Hyvarinen et al.
 # Author: Pierre Lafaye de Micheaux, Stefan van der Walt, Gael Varoquaux,
 #         Bertrand Thirion, Alexandre Gramfort
 # License: BSD 3 clause
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -129,11 +130,11 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     algorithm : {'parallel', 'deflation'}, optional
         Apply a parallel or deflational FASTICA algorithm.
     whiten: boolean, optional
-        If true perform an initial whitening of the data. Do not set to
-        false unless the data is already white, as you will get incorrect
-        results.
-        If whiten is true, the data is assumed to have already been
+        If True perform an initial whitening of the data.
+        If False, the data is assumed to have already been
         preprocessed: it should be centered, normed and white.
+        Otherwise you will get incorrect results.
+        In this case the parameter n_components will be ignored.
     fun : string or function, optional
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
@@ -246,6 +247,10 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
                          '(one of logcosh, exp or cube) or a function')
 
     n, p = X.shape
+
+    if whiten == False and n_components is not None:
+        n_components = None
+        warnings.warn('Ignoring n_components with whiten=False.')
 
     if n_components is None:
         n_components = min(n, p)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -1,7 +1,7 @@
 """
 Test the fastica algorithm.
 """
-
+import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal
 from nose.tools import assert_true
@@ -114,8 +114,11 @@ def test_fastica_nowhiten():
     ica.get_mixing_matrix()
 
     # test for issue #697
-    ica = FastICA(n_components=1, whiten=False)
-    ica.fit(m)  # should raise warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ica = FastICA(n_components=1, whiten=False)
+        ica.fit(m)  # should raise warning
+        assert_true(len(w) == 1)  # 1 warning should be raised
 
 
 def test_non_square_fastica(add_noise=False):

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -113,6 +113,10 @@ def test_fastica_nowhiten():
     ica.fit(m)
     ica.get_mixing_matrix()
 
+    # test for issue #697
+    ica = FastICA(n_components=1, whiten=False)
+    ica.fit(m)  # should raise warning
+
 
 def test_non_square_fastica(add_noise=False):
     """ Test the FastICA algorithm on very simple data.


### PR DESCRIPTION
here is a fix for #697 (this code is not super clean but at least it does not break anymore)

I am wondering if PCA should not be used to whiten the data.

@GaelVaroquaux please take a look
