### PR TITLE
fixed SparsePCA.transform returning NaN for 0 feature in all samples. (fixes #615)

### DIFF
--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -144,7 +144,9 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         ridge_alpha = self.ridge_alpha if ridge_alpha is None else ridge_alpha
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,
                              solver='dense_cholesky')
-        U /= np.sqrt((U ** 2).sum(axis=0))
+        s = np.sqrt((U ** 2).sum(axis=0))
+        s[s == 0] = 1
+        U /= s
         return U
 
 

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_equal
 
 from nose import SkipTest
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_false
 
 from .. import SparsePCA, MiniBatchSparsePCA
 from ...utils import check_random_state
@@ -82,6 +82,17 @@ def test_fit_transform():
                            alpha=alpha)
     spca_lasso.fit(Y)
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
+
+
+def test_transform_nan():
+    """
+    Test that SparsePCA won't return NaN when there is 0 feature in all samples.
+    """
+    rng = np.random.RandomState(0)
+    Y, _, _ = generate_toy_data(3, 10, (8, 8), random_state=rng)  # wide array
+    Y[:,0] = 0
+    estimator = SparsePCA(n_components=8)
+    assert_false(np.any(np.isnan(estimator.fit_transform(Y))))
 
 
 def test_fit_transform_tall():


### PR DESCRIPTION
I fixed the division (#615) by first checking if there are any zeros in the denominator. This error happens only when all samples have output feature which is always 0. I set all zeros to 1 and the resulting division then will be 0/1, which yields the correct value: 0.

I know there are many ways how to fix this bug. At first I tried to replace the NaNs after the division, but numpy would print RuntimeWarning and I think it would be bad idea to turn them off. 
