### PR TITLE
Next button

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -241,42 +241,21 @@
     {%- endif %}
     </div>
 
-
-{%- if pagename != 'index' %}
-{%- if parents %}
-<div class="rel">
-  {% else %}
-  <div class="rel rellarge">
+    {%- if pagename != 'index' %}
+    {%- if parents %}
+     <div class="rel">
+    {% else %}
+     <div class="rel rellarge">
     {% endif %}
-    
     {%- for rellink in rellinks[1:]|reverse %}
-    
     <div class='buttons'>
       <a href="{{ pathto(rellink[0]) }}">
         Next
       </a>  
     </div>
-    {%- if rellinks[-1] %}
-    <div class='buttons'>
-      <a href="{{ pathto(master_doc) }}">
-        Home
-      </a>  
-    </div>
-    {% endif %}
     {%- endfor %}
     {% endif %}
-  </div>
-
-
-
-
-
-
-   
-
-
-
-
+     </div>
 {%- endblock %}
 
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -48,11 +48,6 @@
    {%- endif %}
 
    
-   <div class='buttons'>
-       <a href="{{ pathto(master_doc) }}">
-          Next
-       </a>  
-   </div>
 
     <div class="header-wrapper">
       <div class="header">
@@ -97,6 +92,8 @@
     </div>
 {% endblock %}
 
+
+
 {% block content %}
     <div class="content-wrapper">
 
@@ -106,8 +103,8 @@
 	  {%- if parents %}
 	  <div class="rel">
 	   {% else %}
-	<div class="rel rellarge">
-	{% endif %}
+	   <div class="rel rellarge">
+	     {% endif %}
 	<!-- rellinks[1:] is an ugly hack to avoid link to module
 	    index  -->
 	{%- for rellink in rellinks[1:]|reverse %}
@@ -243,6 +240,43 @@
     </span>
     {%- endif %}
     </div>
+
+
+{%- if pagename != 'index' %}
+{%- if parents %}
+<div class="rel">
+  {% else %}
+  <div class="rel rellarge">
+    {% endif %}
+    
+    {%- for rellink in rellinks[1:]|reverse %}
+    
+    <div class='buttons'>
+      <a href="{{ pathto(rellink[0]) }}">
+        Next
+      </a>  
+    </div>
+    {%- if rellinks[-1] %}
+    <div class='buttons'>
+      <a href="{{ pathto(master_doc) }}">
+        Home
+      </a>  
+    </div>
+    {% endif %}
+    {%- endfor %}
+    {% endif %}
+  </div>
+
+
+
+
+
+
+   
+
+
+
+
 {%- endblock %}
 
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -245,14 +245,24 @@
      <div class="rel rellarge">
     {% endif %}
     {%- for rellink in rellinks[1:]|reverse %}
-    <div class='buttons'>
+    <div class="{{ loop.cycle('buttonPrevious', 'buttonNext') }}">
       <a href="{{ pathto(rellink[0]) }}">
-        Next
+        {{loop.cycle('Previous', 'Next')}}
       </a>  
     </div>
     {%- endfor %}
     {% endif %}
      </div>
+     <script type="text/javascript">
+       $("div.buttonNext, div.buttonPrevious").hover(
+           function () {
+               $(this).css('background-color', '#FF9C34');
+           },
+           function () {
+               $(this).css('background-color', '#A7D6E2');
+           }
+       );
+     </script>
 {%- endblock %}
 
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -46,6 +46,14 @@
            Latest stable version</a></p></p>
      </div>
    {%- endif %}
+
+   
+   <div class='buttons'>
+       <a href="{{ pathto(master_doc) }}">
+          Next
+       </a>  
+   </div>
+
     <div class="header-wrapper">
       <div class="header">
         {%- if logo %}

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -6,6 +6,7 @@
     (http://webylimonada.org)
 
     Update: Collapsable sidebar added - 13/03/2012 - Jaques Grobler
+    Update: Next-page button added - 16/03/2012 - Jaques Grobler
 
 
     :copyright: Fabian Pedregosa
@@ -46,8 +47,6 @@
            Latest stable version</a></p></p>
      </div>
    {%- endif %}
-
-   
 
     <div class="header-wrapper">
       <div class="header">
@@ -91,8 +90,6 @@
        </div>
     </div>
 {% endblock %}
-
-
 
 {% block content %}
     <div class="content-wrapper">

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -260,6 +260,18 @@ div#sidebarbutton {
 }
 {% endif %}
 
+div.buttons {
+    display: block;
+    border-top-left-radius: .8em;		
+    background-color: #FF9C34;
+    color: black;
+    padding: 7px 10px 5px 10px;
+    position: fixed;
+    bottom: 0;
+    right: 0; 
+}
+
+
 
 input {
     border: 1px solid #ccc;

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -260,17 +260,24 @@ div#sidebarbutton {
 }
 {% endif %}
 
-div.buttons {
+div.buttonPrevious, div.buttonNext {
     display: block;
-    border-top-left-radius: .8em;		
-    background-color: #FF9C34;
+    background-color: #A7D6E2;
     color: black;
     padding: 7px 10px 5px 10px;
     position: fixed;
     bottom: 0;
-    right: 0; 
 }
 
+div.buttonPrevious {
+    border-top-right-radius: .8em;		
+    right: 1; 
+}
+
+div.buttonNext {
+    border-top-left-radius: .8em;		
+    right: 0; 
+}
 
 
 input {


### PR DESCRIPTION
This addon puts a fixed next-page-button in the bottom-right corner of the screen.

It's purpose - 
Whilst presenting a tutorial or working through documentation, upon reaching the end of a page, one has to tediously scroll back to the top in order to choose _next_ from the sidebar.

This will thus allow one to work through the tutorial's current page, and when the bottom of the page is reached, simply hit the _next_ button to move ahead.. 

I'll be adding a online-html-build shortly.

I hope you find this useful.

**Update**: Online html-build available here: http://jaquesgrobler.github.com/Next_button-online/install.html
