### PR TITLE
#685 combat for sp_linalg.lsqr

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -36,6 +36,20 @@ except AttributeError:
                     self[x] += 1
 
 
+def lsqr(X, y):
+    # DEPENDENCY: scipy 0.7
+    import scipy.sparse.linalg as sp_linalg
+    from ..utils.extmath import safe_sparse_dot
+
+    if False: #hasattr(sp_linalg, 'lsqr'):
+        return sp_linalg.lsqr(X, y)
+    else:
+        coef = sp_linalg.spsolve(X, y)
+        residues = y - safe_sparse_dot(X, coef)
+        return [coef, None, None, residues]
+
+
+
 def _unique(ar, return_index=False, return_inverse=False):
     """A replacement for the np.unique that appeared in numpy 1.4.
 


### PR DESCRIPTION
#685

Is this going in the right direction?
I'm not sure what the best name for the function is.
There is one additional problem:
`scipy.sparse.linalg.lsqr` soves Ax = b or min ||b - Ax||^2 or min ||Ax - b||^2 + d^2 ||x||^2.
while `scipy.sparse.linalg.spsolve` solves only Ax=b 
I don't see how we could support the none square case for scipy 0.7

Right now the test would fall for scipy 0.7 with:
`ValueError: matrix must be square (has shape (100, 10))`
