### PR TITLE
Fixed a bug in GaussianNB (naive_bayes.py)

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -155,7 +155,7 @@ class GaussianNB(BaseNB):
 
         self.classes_ = unique_y = np.unique(y)
         n_classes = unique_y.shape[0]
-        _, n_features = X.shape
+        n_samples, n_features = X.shape
 
         self.theta_ = np.empty((n_classes, n_features))
         self.sigma_ = np.empty((n_classes, n_features))
@@ -163,7 +163,7 @@ class GaussianNB(BaseNB):
         for i, y_i in enumerate(unique_y):
             self.theta_[i, :] = np.mean(X[y == y_i, :], axis=0)
             self.sigma_[i, :] = np.var(X[y == y_i, :], axis=0)
-            self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_classes
+            self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_samples
         return self
 
     def _joint_log_likelihood(self, X):


### PR DESCRIPTION
In GaussianNB, the computation of the class priors was:

```
self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_classes
```

Which is wrong. Finding the probability of the class should be using;

```
self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_samples
```

with n_samples simply be:

```
n_samples, n_features = X.shape
```

I've fixed this issue in the code. 

The effect of this bug can be quite significant, because instead of probability (a value between 0 and 1), the class_prior_ is a (possible) large number (much larger than the probabilities of the different features), thus it can bias the results towards the class priors, with little value assigned to the actual features. 
