### PR TITLE
MRG: deterministic vocabulary_ for DictVectorizer

### DIFF
--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -45,8 +45,9 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     separator: string, optional
         Separator string used when constructing new features for one-hot
         coding.
-    sparse: boolean, optional
+    sparse: boolean, optional.
         Whether transform should produce scipy.sparse matrices.
+        True by default.
 
     Examples
     --------
@@ -55,13 +56,13 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     >>> D = [{'foo': 1, 'bar': 2}, {'foo': 3, 'baz': 1}]
     >>> X = v.fit_transform(D)
     >>> X
-    array([[ 1.,  2.,  0.],
-           [ 3.,  0.,  1.]])
+    array([[ 2.,  0.,  1.],
+           [ 0.,  1.,  3.]])
     >>> v.inverse_transform(X) == \
         [{'bar': 2.0, 'foo': 1.0}, {'baz': 1.0, 'foo': 3.0}]
     True
-    >>> v.transform({'foo': 4, 'quux': 3})
-    array([[ 4.,  0.,  0.]])
+    >>> v.transform({'foo': 4, 'unseen_feature': 3})
+    array([[ 0.,  0.,  4.]])
     """
 
     def __init__(self, dtype=np.float64, separator="=", sparse=True):
@@ -84,15 +85,20 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         self
         """
         X = _tosequence(X)
-        vocab = {}
 
+        # collect all the possible feature names
+        feature_names = set()
         for x in X:
             for f, v in x.iteritems():
                 if isinstance(v, basestring):
                     f = "%s%s%s" % (f, self.separator, v)
-                vocab.setdefault(f, len(vocab))
+                feature_names.add(f)
 
-        self.vocabulary_ = vocab
+        # sort the feature names to define the mapping
+        feature_names = list(feature_names)
+        feature_names.sort()
+        self.vocabulary_ = dict((f, i) for i, f in enumerate(feature_names))
+        self.feature_names_ = feature_names
 
         return self
 
@@ -142,7 +148,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         """
         X = atleast2d_or_csr(X)     # COO matrix is not subscriptable
 
-        names = self.get_feature_names()
+        names = self.feature_names_
         Xd = [dict_type() for _ in xrange(X.shape[0])]
 
         if sp.issparse(X):
@@ -222,8 +228,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         If one-of-K coding is applied to categorical features, this will
         include the constructed feature names but not the original ones.
         """
-        return [f for f, i in sorted(self.vocabulary_.iteritems(),
-                                     key=itemgetter(1))]
+        return self.feature_names_
 
     def restrict(self, support, indices=False):
         """Restrict the features to those in support.
@@ -239,11 +244,13 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         if not indices:
             support = np.where(support)[0]
 
-        names = self.get_feature_names()
+        names = self.feature_names_
         new_vocab = {}
         for i in support:
             new_vocab[names[i]] = len(new_vocab)
 
         self.vocabulary_ = new_vocab
+        self.feature_names_ = [f for f, i in sorted(new_vocab.iteritems(),
+                                                    key=itemgetter(1))]
 
         return self

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -1,10 +1,13 @@
 # Author: Lars Buitinck <L.J.Buitinck@uva.nl>
 # License: BSD-style.
 
+from random import Random
 import numpy as np
 import scipy.sparse as sp
 
-from nose.tools import assert_equal, assert_true, assert_false
+from nose.tools import assert_equal
+from nose.tools import assert_true
+from nose.tools import assert_false
 from numpy.testing import assert_array_equal
 
 from sklearn.feature_extraction import DictVectorizer
@@ -72,3 +75,18 @@ def test_unseen_features():
     X = v.transform({"push the pram a lot": 2})
 
     assert_array_equal(X, np.zeros((1, 2)))
+
+
+def test_deterministic_vocabulary():
+    # Generate equal dictionaries with different memory layouts
+    items = [("%03d" % i, i) for i in range(1000)]
+    rng = Random(42)
+    d_sorted = dict(items)
+    rng.shuffle(items)
+    d_shuffled = dict(items)
+
+    # check that the memory layout does not impact the resulting vocabulary
+    v_1 = DictVectorizer().fit([d_sorted])
+    v_2 = DictVectorizer().fit([d_shuffled])
+
+    assert_equal(v_1.vocabulary_, v_2.vocabulary_)


### PR DESCRIPTION
@larsmans I changed the default behavior of the `DictVectorizer` class to make sure that it generates a deterministic vocabulary. The old & faster behavior is still possible with `sort_feature=False`.

Also I rewrote a bit the narrative documentation to make it more noob-friendly.
