### PR TITLE
minkowski p-distance in sklearn.neighbors

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -33,8 +33,8 @@ handwritten digits or satellite image scenes. It is often successful
 in classification situations where the decision boundary is very irregular.
 
 The classes in :mod:`sklearn.neighbors` can handle either Numpy arrays or
-`scipy.sparse` matrices as input.  It currently supports only the Euclidean
-distance metric.
+`scipy.sparse` matrices as input.  Arbitrary Minkowski metrics are supported 
+for searches.
 
 
 Unsupervised Nearest Neighbors

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -95,7 +95,7 @@ Scikit-learn documentation for more information about this type of classifier.)
     >>> from sklearn.neighbors import KNeighborsClassifier
     >>> knn = KNeighborsClassifier()
     >>> knn.fit(iris_X_train, iris_y_train)
-    KNeighborsClassifier(algorithm='auto', leaf_size=30, n_neighbors=5,
+    KNeighborsClassifier(algorithm='auto', leaf_size=30, n_neighbors=5, p=2,
                warn_on_equidistant=True, weights='uniform')
     >>> knn.predict(iris_X_test)
     array([1, 2, 1, 0, 0, 0, 2, 1, 2, 0])

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -209,6 +209,8 @@ class KNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
                 dist = pairwise_distances(X, self._fit_X, 'euclidean', squared=False)
+            elif self.p == np.inf:
+                dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
                 dist = pairwise_distances(X, self._fit_X, 'minkowski', p=self.p)
             # XXX: should be implemented with a partial sort
@@ -378,6 +380,8 @@ class RadiusNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
                 dist = pairwise_distances(X, self._fit_X, 'euclidean', squared=False)
+            elif self.p == np.inf:
+                dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
                 dist = pairwise_distances(X, self._fit_X, 'minkowski', p=self.p)
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -209,7 +209,7 @@ class KNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
                 dist = pairwise_distances(X, self._fit_X, 'euclidean',
-                                          squared=False)
+                                          squared=True)
             elif self.p == np.inf:
                 dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
@@ -226,7 +226,10 @@ class KNeighborsMixin(object):
             neigh_ind = neigh_ind[:, :n_neighbors]
             if return_distance:
                 j = np.arange(neigh_ind.shape[0])[:, None]
-                return dist[j, neigh_ind], neigh_ind
+                if self.p == 2:
+                    return np.sqrt(dist[j, neigh_ind]), neigh_ind
+                else:
+                    return dist[j, neigh_ind], neigh_ind
             else:
                 return neigh_ind
         elif self._fit_method == 'ball_tree':
@@ -382,7 +385,8 @@ class RadiusNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
                 dist = pairwise_distances(X, self._fit_X, 'euclidean',
-                                          squared=False)
+                                          squared=True)
+                radius *= radius
             elif self.p == np.inf:
                 dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
@@ -402,9 +406,14 @@ class RadiusNeighborsMixin(object):
                 dtype_F = object
 
             if return_distance:
-                dist = np.array([d[neigh_ind[i]] \
-                                     for i, d in enumerate(dist)],
-                                dtype=dtype_F)
+                if self.p == 2:
+                    dist = np.array([np.sqrt(d[neigh_ind[i]]) \
+                                        for i, d in enumerate(dist)],
+                                    dtype=dtype_F)
+                else:
+                    dist = np.array([d[neigh_ind[i]] \
+                                         for i, d in enumerate(dist)],
+                                    dtype=dtype_F)
                 return dist, neigh_ind
             else:
                 return neigh_ind

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -208,11 +208,13 @@ class KNeighborsMixin(object):
             if self.p == 1:
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
-                dist = pairwise_distances(X, self._fit_X, 'euclidean', squared=False)
+                dist = pairwise_distances(X, self._fit_X, 'euclidean',
+                                          squared=False)
             elif self.p == np.inf:
                 dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
-                dist = pairwise_distances(X, self._fit_X, 'minkowski', p=self.p)
+                dist = pairwise_distances(X, self._fit_X, 'minkowski',
+                                          p=self.p)
             # XXX: should be implemented with a partial sort
             neigh_ind = dist.argsort(axis=1)
             if self.warn_on_equidistant and n_neighbors < self._fit_X.shape[0]:
@@ -379,11 +381,13 @@ class RadiusNeighborsMixin(object):
             if self.p == 1:
                 dist = pairwise_distances(X, self._fit_X, 'manhattan')
             elif self.p == 2:
-                dist = pairwise_distances(X, self._fit_X, 'euclidean', squared=False)
+                dist = pairwise_distances(X, self._fit_X, 'euclidean',
+                                          squared=False)
             elif self.p == np.inf:
                 dist = pairwise_distances(X, self._fit_X, 'chebyshev')
             else:
-                dist = pairwise_distances(X, self._fit_X, 'minkowski', p=self.p)
+                dist = pairwise_distances(X, self._fit_X, 'minkowski',
+                                          p=self.p)
 
             neigh_ind = [np.where(d < radius)[0] for d in dist]
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -68,6 +68,12 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         ordering of the training data.
         If the fit method is ``'kd_tree'``, no warnings will be generated.
 
+    p: integer, optional (default = 2)
+        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
+        When p = 1, this is equivalent to using manhattan_distance,
+        and euclidean_distance for p = 2. For arbitrary p,
+        minkowski_distance is used.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]
@@ -174,6 +180,12 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         speed of the construction and query, as well as the memory
         required to store the tree.  The optimal value depends on the
         nature of the problem.
+        
+    p: integer, optional (default = 2)
+        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
+        When p = 1, this is equivalent to using manhattan_distance,
+        and euclidean_distance for p = 2. For arbitrary p,
+        minkowski_distance is used.
 
     Examples
     --------

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -97,11 +97,12 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
     def __init__(self, n_neighbors=5,
                  weights='uniform',
                  algorithm='auto', leaf_size=30,
-                 warn_on_equidistant=True):
+                 warn_on_equidistant=True, p=2):
         self._init_params(n_neighbors=n_neighbors,
                           algorithm=algorithm,
                           leaf_size=leaf_size,
-                          warn_on_equidistant=warn_on_equidistant)
+                          warn_on_equidistant=warn_on_equidistant,
+                          p=p)
         self.weights = _check_weights(weights)
 
     def predict(self, X):
@@ -201,10 +202,11 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
     """
 
     def __init__(self, radius=1.0, weights='uniform',
-                 algorithm='auto', leaf_size=30):
+                 algorithm='auto', leaf_size=30, p=2):
         self._init_params(radius=radius,
                           algorithm=algorithm,
-                          leaf_size=leaf_size)
+                          leaf_size=leaf_size,
+                          p=p)
         self.weights = _check_weights(weights)
 
     def predict(self, X):

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -69,10 +69,10 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         If the fit method is ``'kd_tree'``, no warnings will be generated.
 
     p: integer, optional (default = 2)
-        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
-        When p = 1, this is equivalent to using manhattan_distance,
-        and euclidean_distance for p = 2. For arbitrary p,
-        minkowski_distance is used.
+        Parameter for the Minkowski metric from
+        sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
+        equivalent to using manhattan_distance, and euclidean_distance for
+        p = 2. For arbitrary p, minkowski_distance is used.
 
     Examples
     --------
@@ -180,12 +180,12 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         speed of the construction and query, as well as the memory
         required to store the tree.  The optimal value depends on the
         nature of the problem.
-        
+
     p: integer, optional (default = 2)
-        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
-        When p = 1, this is equivalent to using manhattan_distance,
-        and euclidean_distance for p = 2. For arbitrary p,
-        minkowski_distance is used.
+        Parameter for the Minkowski metric from
+        sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
+        equivalent to using manhattan_distance, and euclidean_distance for
+        p = 2. For arbitrary p, minkowski_distance is used.
 
     Examples
     --------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -70,6 +70,12 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
         ordering of the training data.
         If the fit method is ``'kd_tree'``, no warnings will be generated.
 
+    p: integer, optional (default = 2)
+        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
+        When p = 1, this is equivalent to using manhattan_distance,
+        and euclidean_distance for p = 2. For arbitrary p,
+        minkowski_distance is used.
+
     Examples
     --------
     >>> X = [[0], [1], [2], [3]]
@@ -177,6 +183,12 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
         speed of the construction and query, as well as the memory
         required to store the tree.  The optimal value depends on the
         nature of the problem.
+        
+    p: integer, optional (default = 2)
+        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
+        When p = 1, this is equivalent to using manhattan_distance,
+        and euclidean_distance for p = 2. For arbitrary p,
+        minkowski_distance is used.
 
     Examples
     --------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -71,10 +71,10 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
         If the fit method is ``'kd_tree'``, no warnings will be generated.
 
     p: integer, optional (default = 2)
-        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
-        When p = 1, this is equivalent to using manhattan_distance,
-        and euclidean_distance for p = 2. For arbitrary p,
-        minkowski_distance is used.
+        Parameter for the Minkowski metric from
+        sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
+        equivalent to using manhattan_distance, and euclidean_distance for
+        p = 2. For arbitrary p, minkowski_distance is used.
 
     Examples
     --------
@@ -103,7 +103,8 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     """
 
     def __init__(self, n_neighbors=5, weights='uniform',
-                 algorithm='auto', leaf_size=30, warn_on_equidistant=True, p=2):
+                 algorithm='auto', leaf_size=30, warn_on_equidistant=True,
+                 p=2):
         self._init_params(n_neighbors=n_neighbors,
                           algorithm=algorithm,
                           leaf_size=leaf_size,
@@ -183,12 +184,12 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
         speed of the construction and query, as well as the memory
         required to store the tree.  The optimal value depends on the
         nature of the problem.
-        
+
     p: integer, optional (default = 2)
-        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
-        When p = 1, this is equivalent to using manhattan_distance,
-        and euclidean_distance for p = 2. For arbitrary p,
-        minkowski_distance is used.
+        Parameter for the Minkowski metric from
+        sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
+        equivalent to using manhattan_distance, and euclidean_distance for
+        p = 2. For arbitrary p, minkowski_distance is used.
 
     Examples
     --------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -97,11 +97,12 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     """
 
     def __init__(self, n_neighbors=5, weights='uniform',
-                 algorithm='auto', leaf_size=30, warn_on_equidistant=True):
+                 algorithm='auto', leaf_size=30, warn_on_equidistant=True, p=2):
         self._init_params(n_neighbors=n_neighbors,
                           algorithm=algorithm,
                           leaf_size=leaf_size,
-                          warn_on_equidistant=warn_on_equidistant)
+                          warn_on_equidistant=warn_on_equidistant,
+                          p=p)
         self.weights = _check_weights(weights)
 
     def predict(self, X):
@@ -204,10 +205,11 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     """
 
     def __init__(self, radius=1.0, weights='uniform',
-                 algorithm='auto', leaf_size=30):
+                 algorithm='auto', leaf_size=30, p=2):
         self._init_params(radius=radius,
                           algorithm=algorithm,
-                          leaf_size=leaf_size)
+                          leaf_size=leaf_size,
+                          p=p)
         self.weights = _check_weights(weights)
 
     def predict(self, X):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -19,7 +19,7 @@ SPARSE_TYPES = (bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dok_matrix,
 SPARSE_OR_DENSE = SPARSE_TYPES + (np.asarray,)
 
 ALGORITHMS = ('ball_tree', 'brute', 'kd_tree', 'auto')
-P = (1, 2, 3, 4)
+P = (1, 2, 3, 4, np.inf)
 
 
 def test_warn_on_equidistant(n_samples=100, n_features=3, k=3):
@@ -141,6 +141,7 @@ def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,
                 j = d.argsort()
                 d[:] = d[j]
                 i[:] = i[j]
+                i1[:] = i1[j]
             results.append((dist, ind))
 
             assert_array_almost_equal(np.concatenate(list(ind)),

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -19,6 +19,7 @@ SPARSE_TYPES = (bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dok_matrix,
 SPARSE_OR_DENSE = SPARSE_TYPES + (np.asarray,)
 
 ALGORITHMS = ('ball_tree', 'brute', 'kd_tree', 'auto')
+P = (1, 2, 3, 4)
 
 
 def test_warn_on_equidistant(n_samples=100, n_features=3, k=3):
@@ -73,21 +74,24 @@ def test_unsupervised_kneighbors(n_samples=20, n_features=5,
 
     test = rng.rand(n_query_pts, n_features)
 
-    results_nodist = []
-    results = []
 
-    for algorithm in ALGORITHMS:
-        neigh = neighbors.NearestNeighbors(n_neighbors=n_neighbors,
-                                           algorithm=algorithm)
-        neigh.fit(X)
+    for p in P:
+        results_nodist = []
+        results = []
+        
+        for algorithm in ALGORITHMS:
+            neigh = neighbors.NearestNeighbors(n_neighbors=n_neighbors,
+                                               algorithm=algorithm,
+                                               p=p)
+            neigh.fit(X)
 
-        results_nodist.append(neigh.kneighbors(test, return_distance=False))
-        results.append(neigh.kneighbors(test, return_distance=True))
+            results_nodist.append(neigh.kneighbors(test, return_distance=False))
+            results.append(neigh.kneighbors(test, return_distance=True))
 
-    for i in range(len(results) - 1):
-        assert_array_almost_equal(results_nodist[i], results[i][1])
-        assert_array_almost_equal(results[i][0], results[i + 1][0])
-        assert_array_almost_equal(results[i][1], results[i + 1][1])
+        for i in range(len(results) - 1):
+            assert_array_almost_equal(results_nodist[i], results[i][1])
+            assert_array_almost_equal(results[i][0], results[i + 1][0])
+            assert_array_almost_equal(results[i][1], results[i + 1][1])
 
 
 def test_unsupervised_inputs():
@@ -119,32 +123,34 @@ def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,
 
     test = rng.rand(n_query_pts, n_features)
 
-    results = []
+    for p in P:
+        results = []
 
-    for algorithm in ALGORITHMS:
-        neigh = neighbors.NearestNeighbors(radius=radius,
-                                           algorithm=algorithm)
-        neigh.fit(X)
+        for algorithm in ALGORITHMS:
+            neigh = neighbors.NearestNeighbors(radius=radius,
+                                               algorithm=algorithm,
+                                               p=p)
+            neigh.fit(X)
 
-        ind1 = neigh.radius_neighbors(test, return_distance=False)
+            ind1 = neigh.radius_neighbors(test, return_distance=False)
 
-        # sort the results: this is not done automatically for
-        # radius searches
-        dist, ind = neigh.radius_neighbors(test, return_distance=True)
-        for (d, i, i1) in zip(dist, ind, ind1):
-            j = d.argsort()
-            d[:] = d[j]
-            i[:] = i[j]
-        results.append((dist, ind))
+            # sort the results: this is not done automatically for
+            # radius searches
+            dist, ind = neigh.radius_neighbors(test, return_distance=True)
+            for (d, i, i1) in zip(dist, ind, ind1):
+                j = d.argsort()
+                d[:] = d[j]
+                i[:] = i[j]
+            results.append((dist, ind))
 
-        assert_array_almost_equal(np.concatenate(list(ind)),
-                                  np.concatenate(list(ind1)))
+            assert_array_almost_equal(np.concatenate(list(ind)),
+                                      np.concatenate(list(ind1)))
 
-    for i in range(len(results) - 1):
-        assert_array_almost_equal(np.concatenate(list(results[i][0])),
-                                  np.concatenate(list(results[i + 1][0]))),
-        assert_array_almost_equal(np.concatenate(list(results[i][1])),
-                                  np.concatenate(list(results[i + 1][1])))
+        for i in range(len(results) - 1):
+            assert_array_almost_equal(np.concatenate(list(results[i][0])),
+                                      np.concatenate(list(results[i + 1][0]))),
+            assert_array_almost_equal(np.concatenate(list(results[i][1])),
+                                      np.concatenate(list(results[i + 1][1])))
 
 
 def test_kneighbors_classifier(n_samples=40,

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -78,9 +78,10 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
 
     def __init__(self, n_neighbors=5, radius=1.0,
                  algorithm='auto', leaf_size=30,
-                 warn_on_equidistant=True):
+                 warn_on_equidistant=True, p=2):
         self._init_params(n_neighbors=n_neighbors,
                           radius=radius,
                           algorithm=algorithm,
                           leaf_size=leaf_size,
-                          warn_on_equidistant=warn_on_equidistant)
+                          warn_on_equidistant=warn_on_equidistant,
+                          p=p)

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -44,6 +44,12 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         different labels, then the result will be dependent on the
         ordering of the training data.
         If the fit method is ``'kd_tree'``, no warnings will be generated.
+        
+    p: integer, optional (default = 2)
+        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
+        When p = 1, this is equivalent to using manhattan_distance,
+        and euclidean_distance for p = 2. For arbitrary p,
+        minkowski_distance is used.
 
     Examples
     --------

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -44,12 +44,12 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         different labels, then the result will be dependent on the
         ordering of the training data.
         If the fit method is ``'kd_tree'``, no warnings will be generated.
-        
+
     p: integer, optional (default = 2)
-        Parameter for the Minkowski metric from sklearn.metrics.pairwise.pairwise_distances.
-        When p = 1, this is equivalent to using manhattan_distance,
-        and euclidean_distance for p = 2. For arbitrary p,
-        minkowski_distance is used.
+        Parameter for the Minkowski metric from
+        sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
+        equivalent to using manhattan_distance, and euclidean_distance for
+        p = 2. For arbitrary p, minkowski_distance is used.
 
     Examples
     --------


### PR DESCRIPTION
Issue #351

I have added new value p to classes in sklearn.neighbors to support arbitrary Minkowski metrics for searches. For p=1 and p=2 sklearn implementations of manhattan and euclidean distances are used. For other values the minkowski distance from scipy is used.

I have also modified tests to check if the distances are same for all algorithms.
