### PR TITLE
WIP: Changed GMM's API to suite rest of sklearn

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -85,6 +85,10 @@ Changelog
 API changes summary
 -------------------
 
+   - In :class:`mixture.GMM`, :class:`mixture.DPGMM` and :class:`mixture.VBGMM`,
+     parameters must be passed to an object when initialising it and not through
+     ``fit``. Now ``fit`` will only accept the data as an input parameter.
+   
    - `NeighborsClassifier` and `NeighborsRegressor` are gone in the module
      :ref:`neighbors`. Use the classes :class:`KNeighborsClassifier`,
      :class:`RadiusNeighborsClassifier`, :class:`KNeighborsRegressor`

--- a/examples/mixture/plot_gmm_classifier.py
+++ b/examples/mixture/plot_gmm_classifier.py
@@ -65,7 +65,8 @@ y_test = iris.target[test_index]
 n_classes = len(np.unique(y_train))
 
 # Try GMMs using different types of covariances.
-classifiers = dict((x, GMM(n_components=n_classes, covariance_type=x))
+classifiers = dict((x, GMM(n_components=n_classes, covariance_type=x, 
+                    init_params='wc', n_iter=20))
                     for x in ['spherical', 'diag', 'tied', 'full'])
 
 n_classifiers = len(classifiers)
@@ -82,7 +83,7 @@ for index, (name, classifier) in enumerate(classifiers.iteritems()):
                                   for i in xrange(n_classes)])
 
     # Train the other parameters using the EM algorithm.
-    classifier.fit(X_train, init_params='wc', n_iter=20)
+    classifier.fit(X_train)
 
     h = pl.subplot(2, n_classifiers / 2, index + 1)
     make_ellipses(classifier, h)

--- a/examples/mixture/plot_gmm_classifier.py
+++ b/examples/mixture/plot_gmm_classifier.py
@@ -65,9 +65,9 @@ y_test = iris.target[test_index]
 n_classes = len(np.unique(y_train))
 
 # Try GMMs using different types of covariances.
-classifiers = dict((x, GMM(n_components=n_classes, covariance_type=x, 
-                    init_params='wc', n_iter=20))
-                    for x in ['spherical', 'diag', 'tied', 'full'])
+classifiers = dict((covar_type, GMM(n_components=n_classes, 
+                    covariance_type=covar_type, init_params='wc', n_iter=20))
+                    for covar_type in ['spherical', 'diag', 'tied', 'full'])
 
 n_classifiers = len(classifiers)
 

--- a/examples/mixture/plot_gmm_sin.py
+++ b/examples/mixture/plot_gmm_sin.py
@@ -43,8 +43,8 @@ color_iter = itertools.cycle(['r', 'g', 'b', 'c', 'm'])
 for i, (clf, title) in enumerate([
         (mixture.GMM(n_components=10, covariance_type='full', n_iter=100), \
              "Expectation-maximization"),
-        (mixture.DPGMM(n_components=10, covariance_type='full', alpha=0.01),
-         "Dirichlet Process,alpha=0.01"),
+        (mixture.DPGMM(n_components=10, covariance_type='full', alpha=0.01,
+              n_iter=100), "Dirichlet Process,alpha=0.01"),
         (mixture.DPGMM(n_components=10, covariance_type='diag', alpha=100.),
          "Dirichlet Process,alpha=100.")
         ]):

--- a/examples/mixture/plot_gmm_sin.py
+++ b/examples/mixture/plot_gmm_sin.py
@@ -43,9 +43,11 @@ color_iter = itertools.cycle(['r', 'g', 'b', 'c', 'm'])
 for i, (clf, title) in enumerate([
         (mixture.GMM(n_components=10, covariance_type='full', n_iter=100), \
              "Expectation-maximization"),
-        (mixture.DPGMM(n_components=10, covariance_type='full', alpha=0.01,
-              n_iter=100), "Dirichlet Process,alpha=0.01"),
-        (mixture.DPGMM(n_components=10, covariance_type='diag', alpha=100.),
+        (mixture.DPGMM(n_components=10, covariance_type='full', 
+                       alpha=0.01, n_iter=100),
+         "Dirichlet Process,alpha=0.01"),
+        (mixture.DPGMM(n_components=10, covariance_type='diag', 
+                       alpha=100., n_iter=100),
          "Dirichlet Process,alpha=100.")
         ]):
 

--- a/examples/mixture/plot_gmm_sin.py
+++ b/examples/mixture/plot_gmm_sin.py
@@ -41,7 +41,7 @@ color_iter = itertools.cycle(['r', 'g', 'b', 'c', 'm'])
 
 
 for i, (clf, title) in enumerate([
-        (mixture.GMM(n_components=10, covariance_type='full'), \
+        (mixture.GMM(n_components=10, covariance_type='full', n_iter=100), \
              "Expectation-maximization"),
         (mixture.DPGMM(n_components=10, covariance_type='full', alpha=0.01),
          "Dirichlet Process,alpha=0.01"),
@@ -49,7 +49,7 @@ for i, (clf, title) in enumerate([
          "Dirichlet Process,alpha=100.")
         ]):
 
-    clf.fit(X, n_iter=100)
+    clf.fit(X)
     splot = pl.subplot(3, 1, 1 + i)
     Y_ = clf.predict(X)
     for i, (mean, covar, color) in enumerate(zip(

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -952,10 +952,11 @@ class GMMHMM(_BaseHMM):
     >>> GMMHMM(n_components=2, n_mix=10, covariance_type='diag')
     ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     GMMHMM(algorithm='viterbi', covariance_type='diag', covars_prior=0.01,
-        gmms=[GMM(covariance_type=None, min_covar=0.001, n_components=10,
-        random_state=None, thresh=0.01), GMM(covariance_type=None,
-        min_covar=0.001, n_components=10, random_state=None, thresh=0.01)],
-        n_components=2, n_mix=10, random_state=None, startprob=None,
+        gmms=[GMM(covariance_type=None, init_params='wmc', min_covar=0.001, 
+        n_components=10, n_init=1, n_iter=100, params='wmc', random_state=None, 
+        thresh=0.01), GMM(covariance_type=None, init_params='wmc', min_covar=0.001, 
+        n_components=10, n_init=1, n_iter=100, params='wmc', random_state=None, 
+        thresh=0.01)], n_components=2, n_mix=10, random_state=None, startprob=None,
         startprob_prior=1.0, transmat=None, transmat_prior=1.0)
 
     See Also

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -654,10 +654,11 @@ class VBGMM(DPGMM):
 
     def __init__(self, n_components=1, covariance_type='diag', alpha=1.0,
                  random_state=None, thresh=1e-2, verbose=False,
-                 min_covar=None):
+                 min_covar=None, n_iter=10, params='wmc', init_params='wmc'):
         super(VBGMM, self).__init__(
             n_components, covariance_type, random_state=random_state,
-            thresh=thresh, verbose=verbose, min_covar=min_covar)
+            thresh=thresh, verbose=verbose, min_covar=min_covar,
+            n_iter=n_iter, params=params, init_params=init_params)
         self.alpha = float(alpha) / n_components
 
     def eval(self, X):

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -148,6 +148,16 @@ class DPGMM(GMM):
 
     thresh : float, optional
         Convergence threshold.
+    n_iter : int, optional
+        Maximum number of iterations to perform before convergence.
+    params : string, optional
+        Controls which parameters are updated in the training
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+    init_params : string, optional
+        Controls which parameters are updated in the initialization
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
     Attributes
     ----------
@@ -469,25 +479,15 @@ class DPGMM(GMM):
 
         A initialization step is performed before entering the em
         algorithm. If you want to avoid this step, set the keyword
-        argument init_params to the empty string ''. Likewise, if you
-        would like just to do an initialization, call this method with
-        n_iter=0.
+        argument init_params to the empty string '' when when creating
+        the object. Likewise, if you would like just to do an 
+        initialization, set n_iter=0.
 
         Parameters
         ----------
         X : array_like, shape (n, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single data point.
-        n_iter : int, optional
-             Maximum number of iterations to perform before convergence.
-        params : string, optional
-            Controls which parameters are updated in the training
-            process.  Can contain any combination of 'w' for weights,
-            'm' for means, and 'c' for covars.  Defaults to 'wmc'.
-        init_params : string, optional
-            Controls which parameters are updated in the initialization
-            process.  Can contain any combination of 'w' for weights,
-            'm' for means, and 'c' for covars.  Defaults to 'wmc'.
         """
         self.random_state = check_random_state(self.random_state)
         if kwargs:

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -458,21 +458,21 @@ class GMM(BaseEstimator):
                 'GMM estimation with %s components, but got only %s samples' %
                 (self.n_components, X.shape[0]))
         if kwargs:
-            warnings.warn("Setting paramters in the 'fit' method is deprecated"
+            warnings.warn("Setting parameters in the 'fit' method is deprecated"
                     "Set it on initialization instead.",
                     DeprecationWarning)
             # initialisations for in case the user still adds parameters to fit
             # so things don't break
-            if kwargs.has_key('n_init'):
+            if kwargs['n_init']:
                 if kwargs['n_init'] < 1:
                     raise ValueError('GMM estimation requires at least one run')
                 else:
                     self.n_init = kwargs['n_init']
-            if kwargs.has_key('n_iter'):
+            if kwargs['n_iter']:
                 self.n_iter =  kwargs['n_iter']
-            if kwargs.has_key('params'):
+            if kwargs.['params']:
                 self.params = kwargs['params']
-            if kwargs.has_key('init_params'):
+            if kwargs.['init_params']:
                 self.init_params = kwargs['init_params']
             
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -470,9 +470,9 @@ class GMM(BaseEstimator):
                     self.n_init = kwargs['n_init']
             if kwargs['n_iter']:
                 self.n_iter =  kwargs['n_iter']
-            if kwargs.['params']:
+            if kwargs['params']:
                 self.params = kwargs['params']
-            if kwargs.['init_params']:
+            if kwargs['init_params']:
                 self.init_params = kwargs['init_params']
             
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -458,7 +458,7 @@ class GMM(BaseEstimator):
                 'GMM estimation with %s components, but got only %s samples' %
                 (self.n_components, X.shape[0]))
         if kwargs:
-            warnings.warn("Setting paremters in the 'fit' method is deprecated"
+            warnings.warn("Setting paramters in the 'fit' method is deprecated"
                     "Set it on initialization instead.",
                     DeprecationWarning)
             # initialisations for in case the user still adds parameters to fit

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -463,16 +463,16 @@ class GMM(BaseEstimator):
                     DeprecationWarning)
             # initialisations for in case the user still adds parameters to fit
             # so things don't break
-            if kwargs['n_init']:
+            if 'n_iter' in kwargs:
+                self.n_iter =  kwargs['n_iter']
+            if 'n_init' in kwargs:
                 if kwargs['n_init'] < 1:
                     raise ValueError('GMM estimation requires at least one run')
                 else:
                     self.n_init = kwargs['n_init']
-            if kwargs['n_iter']:
-                self.n_iter =  kwargs['n_iter']
-            if kwargs['params']:
+            if 'params' in kwargs:
                 self.params = kwargs['params']
-            if kwargs['init_params']:
+            if 'init_params' in kwargs:
                 self.init_params = kwargs['init_params']
             
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -136,6 +136,22 @@ class GMM(BaseEstimator):
     thresh : float, optional
         Convergence threshold.
 
+    n_iter : int, optional
+        Number of EM iterations to perform.
+
+    n_init : int, optional
+        Number of initializations to perform. the best results is kept
+
+    params : string, optional
+        Controls which parameters are updated in the training
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+
+    init_params : string, optional
+        Controls which parameters are updated in the initialization
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+
     Attributes
     ----------
     covariance_type : string
@@ -423,31 +439,15 @@ class GMM(BaseEstimator):
 
         A initialization step is performed before entering the em
         algorithm. If you want to avoid this step, set the keyword
-        argument init_params to the empty string ''. Likewise, if you
-        would like just to do an initialization, call this method with
-        n_iter=0.
+        argument init_params to the empty string '' when creating the 
+        GMM object. Likewise, if you would like just to do an 
+        initialization, set n_iter=0.
 
         Parameters
         ----------
         X : array_like, shape (n, n_features)
             List of n_features-dimensional data points.  Each row
-            corresponds to a single data point.
-
-        n_iter : int, optional
-            Number of EM iterations to perform.
-
-        n_init : int, optional
-            number of initializations to perform. the best results is kept
-
-        params : string, optional
-            Controls which parameters are updated in the training
-            process.  Can contain any combination of 'w' for weights,
-            'm' for means, and 'c' for covars.  Defaults to 'wmc'.
-
-        init_params : string, optional
-            Controls which parameters are updated in the initialization
-            process.  Can contain any combination of 'w' for weights,
-            'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+            corresponds to a single data point.       
         """
         ## initialization step
         X = np.asarray(X)


### PR DESCRIPTION
- parameters not to be set via `fit` anymore
- parameters are to be set in `__init__`
- previous way of doing it set as deprecated with warning

Notes:
- fixed three docstrings to match new signature
- no errors/failures during `make`
- Examples that still use 'fit' in the old way will still
  work - must still fix
- must still update the documentation on this change

---

It seems to be working well and passes all the tests.
The examples still work - these I'll still change to match this update if you guys are 
all happy with it - but it's still compatible with them.

Please let me know if you can advise on whether I've done this correctly or if you have suggestions on how to improve.
Once everyone is happy with it,  i'll fix up the examples too and get going on updating the docs.
Just want some confirmation that code-wise it's correct

Regards
J
