### PR TITLE
ENH: train_size and test_size in ShuffleSplit (#721)

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -33,7 +33,7 @@ We can now quickly sample a training set while holding out 40% of the
 data for testing (evaluating) our classifier::
 
   >>> X_train, X_test, y_train, y_test = cross_validation.train_test_split(
-  ...     iris.data, iris.target, test_fraction=0.4, random_state=0)
+  ...     iris.data, iris.target, test_size=0.4, random_state=0)
 
   >>> X_train.shape, y_train.shape
   ((90, 4), (90,))
@@ -103,7 +103,7 @@ validation iterator instead, for instance::
 
   >>> n_samples = iris.data.shape[0]
   >>> cv = cross_validation.ShuffleSplit(n_samples, n_iterations=3,
-  ...     test_fraction=0.3, random_state=0)
+  ...     test_size=0.3, random_state=0)
 
   >>> cross_validation.cross_val_score(clf, iris.data, iris.target, cv=cv)
   ...                                                     # doctest: +ELLIPSIS
@@ -339,12 +339,12 @@ generator.
 
 Here is a usage example::
 
-  >>> ss = cross_validation.ShuffleSplit(5, n_iterations=3, test_fraction=0.25,
+  >>> ss = cross_validation.ShuffleSplit(5, n_iterations=3, test_size=0.25,
   ...     random_state=0)
   >>> len(ss)
   3
   >>> print ss                                            # doctest: +ELLIPSIS
-  ShuffleSplit(5, n_iterations=3, test_fraction=0.25, indices=True, ...)
+  ShuffleSplit(5, n_iterations=3, test_size=0.25, indices=True, ...)
 
   >>> for train_index, test_index in ss:
   ...    print train_index, test_index

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -82,6 +82,9 @@ Changelog
       ``shrink_threshold`` parameter, which implements shrunken centroid
       classification, by `Robert Layton`_.
 
+   - Classes in :ref:`neighbors` now support arbitrary Minkowski metric for 
+     nearest neighbors searches. The metric can be specified by argument ``p``.
+
 API changes summary
 -------------------
 
@@ -152,6 +155,15 @@ API changes summary
    - Beam pruning option in :class:`_BaseHMM` module is removed since it is
      difficult to be Cythonized. If you are interested, you can look in the
      history codes by git.
+
+   - Options in class :class:`ShuffleSplit` are now consistent with
+     :class:`StratifiedShuffleSplit`. Options ``test_fraction`` and
+     ``train_fraction`` are deprecated and renamed to ``test_size`` and
+     ``train_size`` and can accept both ``float`` and ``int``.
+
+   - Argument ``p`` added to classes in :ref:`neighbors` to specify an 
+     arbitrary Minkowski metric for nearest neighbors searches.
+
 
 .. _changes_0_10:
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -796,38 +796,40 @@ class ShuffleSplit(object):
 
 
 def _validate_shuffle_split(n, test_size, train_size):
-    if isinstance(test_size, float) and test_size >= 1.:
+    if isinstance(test_size, (float, np.floating)) and test_size >= 1.:
         raise ValueError(
             'test_size=%f should be smaller '
             'than 1.0 or be an integer' % test_size)
-    elif isinstance(test_size, int) and test_size >= n:
+    elif isinstance(test_size, (int, long, np.integer)) and test_size >= n:
         raise ValueError(
             'test_size=%d should be smaller '
             'than the number of samples %d' % (test_size, n))
 
     if train_size is not None:
-        if isinstance(train_size, float):
+        if isinstance(train_size, (float, np.floating)):
             if train_size >= 1.:
                 raise ValueError("train_size=%f should be smaller "
                                  "than 1.0 or be an integer" % train_size)
-            elif isinstance(test_size, float) and train_size + test_size > 1.:
+            elif isinstance(test_size, (float, np.floating)) and \
+                    train_size + test_size > 1.:
                 raise ValueError('The sum of test_size and train_size = %f, '
                                  'should be smaller than 1.0. Reduce '
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
 
-        elif isinstance(train_size, int):
+        elif isinstance(train_size, (int, long, np.integer)):
             if train_size >= n:
                 raise ValueError("train_size=%d should be smaller "
                                  "than the number of samples %d" %
                                  (train_size, n))
-            elif isinstance(test_size, int) and train_size + test_size >= n:
+            elif isinstance(test_size, (int, long, np.integer)) and \
+                    train_size + test_size >= n:
                 raise ValueError('The sum of train_size and test_size = %d, '
                                  'should be smaller than the number of '
                                  'samples %d. Reduce test_size and/or '
                                  'train_size.' % (train_size + test_size, n))
 
-    if isinstance(test_size, float):
+    if isinstance(test_size, (float, np.floating)):
         n_test = ceil(test_size * n)
     else:
         n_test = float(test_size)
@@ -835,7 +837,7 @@ def _validate_shuffle_split(n, test_size, train_size):
     if train_size is None:
         n_train = n - n_test
     else:
-        if isinstance(train_size, float):
+        if isinstance(train_size, (float, np.floating)):
             n_train = floor(train_size * n)
         else:
             n_train = float(train_size)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -796,40 +796,39 @@ class ShuffleSplit(object):
 
 
 def _validate_shuffle_split(n, test_size, train_size):
-    if isinstance(test_size, (float, np.floating)) and test_size >= 1.:
-        raise ValueError(
-            'test_size=%f should be smaller '
-            'than 1.0 or be an integer' % test_size)
-    elif isinstance(test_size, (int, long, np.integer)) and test_size >= n:
-        raise ValueError(
-            'test_size=%d should be smaller '
-            'than the number of samples %d' % (test_size, n))
+    if np.asarray(test_size).dtype.kind == 'f':
+        if test_size >= 1.:
+            raise ValueError(
+                'test_size=%f should be smaller '
+                'than 1.0 or be an integer' % test_size)
+    elif np.asarray(test_size).dtype.kind == 'i':
+        if test_size >= n:
+            raise ValueError(
+                'test_size=%d should be smaller '
+                'than the number of samples %d' % (test_size, n))
+    else:
+        raise ValueError("Invalid value for test_size: %r" % test_size)
 
     if train_size is not None:
-        if isinstance(train_size, (float, np.floating)):
+        if np.asarray(train_size).dtype.kind == 'f':
             if train_size >= 1.:
                 raise ValueError("train_size=%f should be smaller "
                                  "than 1.0 or be an integer" % train_size)
-            elif isinstance(test_size, (float, np.floating)) and \
+            elif np.asarray(test_size).dtype.kind == 'f' and \
                     train_size + test_size > 1.:
                 raise ValueError('The sum of test_size and train_size = %f, '
                                  'should be smaller than 1.0. Reduce '
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
-
-        elif isinstance(train_size, (int, long, np.integer)):
+        elif np.asarray(train_size).dtype.kind == 'i':
             if train_size >= n:
                 raise ValueError("train_size=%d should be smaller "
                                  "than the number of samples %d" %
                                  (train_size, n))
-            elif isinstance(test_size, (int, long, np.integer)) and \
-                    train_size + test_size >= n:
-                raise ValueError('The sum of train_size and test_size = %d, '
-                                 'should be smaller than the number of '
-                                 'samples %d. Reduce test_size and/or '
-                                 'train_size.' % (train_size + test_size, n))
+        else:
+            raise ValueError("Invalid value for train_size: %r" % train_size)
 
-    if isinstance(test_size, (float, np.floating)):
+    if np.asarray(test_size).dtype.kind == 'f':
         n_test = ceil(test_size * n)
     else:
         n_test = float(test_size)
@@ -837,7 +836,7 @@ def _validate_shuffle_split(n, test_size, train_size):
     if train_size is None:
         n_train = n - n_test
     else:
-        if isinstance(train_size, (float, np.floating)):
+        if np.asarray(train_size).dtype.kind == 'f':
             n_train = floor(train_size * n)
         else:
             n_train = float(train_size)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -745,11 +745,13 @@ class ShuffleSplit(object):
 
         if test_fraction is not None:
             warnings.warn(
-                "test_fraction is deprecated in 0.11, use test_size instead")
+                "test_fraction is deprecated in 0.11 and scheduled for "
+                "removal in 0.12, use test_size instead")
             test_size = test_fraction
         if train_fraction is not None:
             warnings.warn(
-                "train_fraction is deprecated in 0.11, use train_size instead")
+                "train_fraction is deprecated in 0.11 and scheduled for "
+                "removal in 0.12, use train_size instead")
             train_size = train_fraction
 
         self.test_size = test_size
@@ -1256,14 +1258,16 @@ def train_test_split(*arrays, **options):
     test_fraction = options.pop('test_fraction', None)
     if test_fraction is not None:
         warnings.warn(
-            "test_fraction is deprecated in 0.11, use test_size instead")
+            "test_fraction is deprecated in 0.11 and scheduled for "
+            "removal in 0.12, use test_size instead")
     else:
         test_fraction = 0.25
 
     train_fraction = options.pop('train_fraction', None)
     if train_fraction is not None:
         warnings.warn(
-            "train_fraction is deprecated in 0.11, use train_size instead")
+            "train_fraction is deprecated in 0.11 and scheduled for "
+            "removal in 0.12, use train_size instead")
 
     test_size = options.pop('test_size', test_fraction)
     train_size = options.pop('train_size', train_fraction)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -92,6 +92,20 @@ def test_shuffle_kfold():
         assert_array_equal(all_folds, ind)
 
 
+def test_shuffle_split():
+    ss1 = cval.ShuffleSplit(10, test_size=0.2, random_state=0)
+    ss2 = cval.ShuffleSplit(10, test_size=2, random_state=0)
+    ss3 = cval.ShuffleSplit(10, test_size=np.int32(2), random_state=0)
+    ss4 = cval.ShuffleSplit(10, test_size=long(2), random_state=0)
+    for t1, t2, t3, t4 in zip(ss1, ss2, ss3, ss4):
+        assert_array_equal(t1[0], t2[0])
+        assert_array_equal(t2[0], t3[0])
+        assert_array_equal(t3[0], t4[0])
+        assert_array_equal(t1[1], t2[1])
+        assert_array_equal(t2[1], t3[1])
+        assert_array_equal(t3[1], t4[1])
+
+
 def test_stratified_shuffle_split():
     y = np.asarray([0, 1, 1, 1, 2, 2, 2])
     # Check that error is raised if there is a class with only one sample

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -164,10 +164,10 @@ def test_shuffle_split_warnings():
     warnings_warn = warnings.warn
     warnings.warn = lambda msg: warn_queue.append(msg)
 
-    expected_message = ("test_fraction is deprecated in 0.11, use "
-                        "test_size instead",
-                        "train_fraction is deprecated in 0.11, use "
-                        "train_size instead")
+    expected_message = ("test_fraction is deprecated in 0.11 and scheduled "
+                        "for removal in 0.12, use test_size instead",
+                        "train_fraction is deprecated in 0.11 and scheduled "
+                        "for removal in 0.12, use train_size instead")
 
     cval.ShuffleSplit(10, 3, test_fraction=0.1)
     cval.ShuffleSplit(10, 3, train_fraction=0.1)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -315,6 +315,10 @@ def test_shufflesplit_errors():
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_fraction=1.0)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_fraction=0.1,
             train_fraction=0.95)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=11)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=10)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=8,
+            train_size=3)
 
 
 def test_shufflesplit_reproducible():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 from scipy.sparse import coo_matrix
 
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_equal
 from nose.tools import assert_raises
 
 from ..base import BaseEstimator
@@ -177,11 +177,12 @@ def test_shuffle_split_warnings():
     cval.ShuffleSplit(10, 3, train_fraction=0.1)
     cval.train_test_split(range(3), test_fraction=0.1)
     cval.train_test_split(range(3), train_fraction=0.1)
-    assert len(warn_queue) == 4
-    assert warn_queue[0] == expected_message[0]
-    assert warn_queue[1] == expected_message[1]
-    assert warn_queue[2] == expected_message[0]
-    assert warn_queue[3] == expected_message[1]
+
+    assert_equal(len(warn_queue), 4)
+    assert_equal(warn_queue[0], expected_message[0])
+    assert_equal(warn_queue[1], expected_message[1])
+    assert_equal(warn_queue[2], expected_message[0])
+    assert_equal(warn_queue[3], expected_message[1])
 
     # restore default behavior
     warnings.warn = warnings_warn

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -152,6 +152,10 @@ def test_train_test_split_errors():
     assert_raises(ValueError, cval.train_test_split, range(3),
             test_size=0.6, train_size=0.6)
     assert_raises(ValueError, cval.train_test_split, range(3),
+            test_size=np.float32(0.6), train_size=np.float32(0.6))
+    assert_raises(ValueError, cval.train_test_split, range(3),
+            test_size="wrong_type")
+    assert_raises(ValueError, cval.train_test_split, range(3),
             test_size=2, train_size=4)
     assert_raises(TypeError, cval.train_test_split, range(3),
             some_argument=1.1)


### PR DESCRIPTION
#721
- I have deprecated arguments test_fraction and train_fraction in ShuffleSplit and train_test_split and renamed them to test_size and train_size. 
- I have also modified documentation and tests (added one more to test deprecation warning). 
- I had to rewrite the argument checking a little to take in account that these values can now be integers. 

The deprecation warning is: "test_fraction is deprecated in 0.11, use test_size instead." Is it correct? I am not sure which version should be there.
