### PR TITLE
BUG: fix atlas/blas detection

### DIFF
--- a/sklearn/cluster/setup.py
+++ b/sklearn/cluster/setup.py
@@ -10,8 +10,7 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.system_info import get_info
 
     blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or (
-        ('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', [])):
+    if (not blas_info):
         cblas_libs = ['cblas']
         blas_info.pop('libraries', None)
     else:

--- a/sklearn/linear_model/setup.py
+++ b/sklearn/linear_model/setup.py
@@ -9,8 +9,7 @@ def configuration(parent_package='', top_path=None):
 
     # cd fast needs CBLAS
     blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or (
-        ('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', [])):
+    if (not blas_info):
         cblas_libs = ['cblas']
         blas_info.pop('libraries', None)
     else:

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -52,8 +52,7 @@ def configuration(parent_package='', top_path=None):
 
     # some libs needs cblas, fortran-compiled BLAS will not be sufficient
     blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or (
-        ('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', [])):
+    if (not blas_info):
         config.add_library('cblas',
                            sources=[join('src', 'cblas', '*.c')])
         warnings.warn(BlasNotFoundError.__doc__)

--- a/sklearn/utils/setup.py
+++ b/sklearn/utils/setup.py
@@ -12,8 +12,7 @@ def configuration(parent_package='', top_path=None):
 
     # cd fast needs CBLAS
     blas_info = get_info('blas_opt', 0)
-    if (not blas_info) or (
-        ('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', [])):
+    if (not blas_info):
         cblas_libs = ['cblas']
         blas_info.pop('libraries', None)
     else:


### PR DESCRIPTION
ATLAS' detection in numpy is not necessarily reliable and does not always work (e.g. see Gentoo's patches [1,2]).

Removing the `('NO_ATLAS_INFO', 1) in blas_info.get('define_macros', []))` part enables sklearn to be properly compiled with ATLAS support on Gentoo & Gentoo Prefix (i.e. Gentoo in non-root user space).

Is this line just copied from numpy's setup? Does it have a purpose for sklearn? If not, then I believe we should merge this PR. 

Of course I am open to discussion ;-)

[1] http://gpo.zugaina.org/AJAX/Ebuild/2461610/View
[2] https://github.com/npinto/sekyfsr-gentoo-overlay/blob/master/dev-python/numpy/numpy-1.6.1-r1.ebuild#L79
