### PR TITLE
MRG: Radius-based classifier: raise exception, if no neighbors found

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -34,6 +34,23 @@ def _check_weights(weights):
                          "'distance', or a callable function")
 
 
+def _dist_to_weight(dist):
+    """ Calculates weights from distances. Replaces line
+    "weights = 1. / dist", which gives warning div by zeros,
+    if one sample in dist is zero.
+
+    Takes dist matrix, which can be multidimensional.
+    Returns weights matrix of same dimension."""
+
+    # Dist could be multidimensional, flatten it so it's values
+    # can be looped.
+    dist_values = dist.ravel()
+    retval = np.zeros(len(dist_values))
+    for i, d in enumerate(dist_values):
+        retval[i] = (1.0 / d) if (d != 0.0) else np.inf
+    return retval.reshape(dist.shape)
+
+
 def _get_weights(dist, weights):
     """Get the weights from an array of distances and a parameter ``weights``
 
@@ -46,7 +63,7 @@ def _get_weights(dist, weights):
         if weights in (None, 'uniform'):
             return None
         elif weights == 'distance':
-            return [1. / d for d in dist]
+            return [_dist_to_weight(d) for d in dist]
         elif callable(weights):
             return [weights(d) for d in dist]
         else:
@@ -56,7 +73,7 @@ def _get_weights(dist, weights):
         if weights in (None, 'uniform'):
             return None
         elif weights == 'distance':
-            return 1. / dist
+            return _dist_to_weight(dist)
         elif callable(weights):
             return weights(dist)
         else:

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -240,6 +240,12 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
         neigh_dist, neigh_ind = self.radius_neighbors(X)
         pred_labels = [self._y[ind] for ind in neigh_ind]
 
+        for pl in pred_labels:
+            # Check that all have at least 1 neighbor
+            if len(pl) < 1:
+                raise ValueError('no neighbors found for a test sample, '
+                                 'try using larger radius or removing '
+                                 'outliers')
         weights = _get_weights(neigh_dist, self.weights)
 
         if weights is None:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -204,22 +204,49 @@ def test_radius_neighbors_classifier_when_no_neighbors():
     """ Test radius-based classifier when no neighbors found.
     In this case it should rise an informative exception """
 
-    X = [[1.0, 1.0], [2.0, 2.0]]
-    y = [1, 2]
+    X = np.array([[1.0, 1.0], [2.0, 2.0]])
+    y = np.array([1, 2])
     radius = 0.1
-    # Test point (1.4, 1.4) has no neighbors in this radius
-    z = [[1.01, 1.01], [1.4, 1.4]]
+
+    z1 = np.array([[1.01, 1.01], [2.01, 2.01]])  # no outliers
+    z2 = np.array([[1.01, 1.01], [1.4, 1.4]])    # one outlier
 
     weight_func = lambda d: d ** -2
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
             clf = neighbors.RadiusNeighborsClassifier(radius=radius,
+                                                      weights=weights,
                                                       algorithm=algorithm)
             clf.fit(X, y)
-            assert_raises(ValueError,
-                          clf.predict,
-                          z)
+            clf.predict(z1)
+            assert_raises(ValueError, clf.predict, z2)
+
+
+def test_radius_neighbors_classifier_outlier_labeling():
+    """ Test radius-based classifier when no neighbors found and outliers
+    are labeled. """
+
+    X = np.array([[1.0, 1.0], [2.0, 2.0]])
+    y = np.array([1, 2])
+    radius = 0.1
+
+    z1 = np.array([[1.01, 1.01], [2.01, 2.01]])  # no outliers
+    z2 = np.array([[1.01, 1.01], [1.4, 1.4]])    # one outlier
+    correct_labels1 = np.array([1, 2])
+    correct_labels2 = np.array([1, -1])
+
+    weight_func = lambda d: d ** -2
+
+    for algorithm in ALGORITHMS:
+        for weights in ['uniform', 'distance', weight_func]:
+            clf = neighbors.RadiusNeighborsClassifier(radius=radius,
+                                                      weights=weights,
+                                                      algorithm=algorithm,
+                                                      outlier_label=-1)
+            clf.fit(X, y)
+            assert_array_equal(correct_labels1, clf.predict(z1))
+            assert_array_equal(correct_labels2, clf.predict(z2))
 
 
 def test_kneighbors_classifier_sparse(n_samples=40,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -200,6 +200,28 @@ def test_radius_neighbors_classifier(n_samples=40,
             assert_array_equal(y_pred, y[:n_test_pts])
 
 
+def test_radius_neighbors_classifier_when_no_neighbors():
+    """ Test radius-based classifier when no neighbors found.
+    In this case it should rise an informative exception """
+
+    X = [[1.0, 1.0], [2.0, 2.0]]
+    y = [1, 2]
+    radius = 0.1
+    # Test point (1.4, 1.4) has no neighbors in this radius
+    z = [[1.01, 1.01], [1.4, 1.4]]
+
+    weight_func = lambda d: d ** -2
+
+    for algorithm in ALGORITHMS:
+        for weights in ['uniform', 'distance', weight_func]:
+            clf = neighbors.RadiusNeighborsClassifier(radius=radius,
+                                                      algorithm=algorithm)
+            clf.fit(X, y)
+            assert_raises(ValueError,
+                          clf.predict,
+                          z)
+
+
 def test_kneighbors_classifier_sparse(n_samples=40,
                                       n_features=5,
                                       n_test_pts=10,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -22,6 +22,20 @@ ALGORITHMS = ('ball_tree', 'brute', 'kd_tree', 'auto')
 P = (1, 2, 3, 4, np.inf)
 
 
+def _weight_func(dist):
+    """ Weight function to replace lambda d: d ** -2.
+    The lambda function is not valid because:
+    if d==0 then 0^-2 is not valid. """
+
+    # Dist could be multidimensional, flatten it so all values
+    # can be looped
+    dist_values = dist.ravel()
+    retval = np.zeros(len(dist_values))
+    for i, d in enumerate(dist_values):
+        retval[i] = (d ** -2) if (d != 0.0) else np.inf
+    return retval.reshape(dist.shape)
+
+
 def test_warn_on_equidistant(n_samples=100, n_features=3, k=3):
     """test the production of a warning if equidistant points are discarded"""
     X = np.random.random(size=(n_samples, n_features))
@@ -164,7 +178,7 @@ def test_kneighbors_classifier(n_samples=40,
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = ((X ** 2).sum(axis=1) < .25).astype(np.int)
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
@@ -187,7 +201,7 @@ def test_radius_neighbors_classifier(n_samples=40,
     X = 2 * rng.rand(n_samples, n_features) - 1
     y = ((X ** 2).sum(axis=1) < .25).astype(np.int)
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
@@ -211,7 +225,7 @@ def test_radius_neighbors_classifier_when_no_neighbors():
     z1 = np.array([[1.01, 1.01], [2.01, 2.01]])  # no outliers
     z2 = np.array([[1.01, 1.01], [1.4, 1.4]])    # one outlier
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
@@ -236,7 +250,7 @@ def test_radius_neighbors_classifier_outlier_labeling():
     correct_labels1 = np.array([1, 2])
     correct_labels2 = np.array([1, -1])
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
@@ -247,6 +261,27 @@ def test_radius_neighbors_classifier_outlier_labeling():
             clf.fit(X, y)
             assert_array_equal(correct_labels1, clf.predict(z1))
             assert_array_equal(correct_labels2, clf.predict(z2))
+
+
+def test_radius_neighbors_classifier_zero_distance():
+    """ Test radius-based classifier, when distance to a sample is zero. """
+
+    X = np.array([[1.0, 1.0], [2.0, 2.0]])
+    y = np.array([1, 2])
+    radius = 0.1
+
+    z1 = np.array([[1.01, 1.01], [2.0, 2.0]])
+    correct_labels1 = np.array([1, 2])
+
+    weight_func = _weight_func
+
+    for algorithm in ALGORITHMS:
+        for weights in ['uniform', 'distance', weight_func]:
+            clf = neighbors.RadiusNeighborsClassifier(radius=radius,
+                                                      weights=weights,
+                                                      algorithm=algorithm)
+            clf.fit(X, y)
+            assert_array_equal(correct_labels1, clf.predict(z1))
 
 
 def test_kneighbors_classifier_sparse(n_samples=40,
@@ -286,7 +321,7 @@ def test_kneighbors_regressor(n_samples=40,
 
     y_target = y[:n_test_pts]
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:
@@ -312,7 +347,7 @@ def test_radius_neighbors_regressor(n_samples=40,
 
     y_target = y[:n_test_pts]
 
-    weight_func = lambda d: d ** -2
+    weight_func = _weight_func
 
     for algorithm in ALGORITHMS:
         for weights in ['uniform', 'distance', weight_func]:


### PR DESCRIPTION
Previously radius based classifier continued execution and crashed later, see issue # 760. Now it is better so user will know why program crashes.

It would be even better, if it could print in the error message: what is the minimum radius so that all samples have at least 1 neighbor? I don't know how it should be done, one possibility is using brute force like in RadiusNeighborsMixin.radius_neighbors(), but I guess if there are lots of samples, it can take long to calculate..
