### PR TITLE
Faster confusion_matrix implementation

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -58,12 +58,11 @@ def confusion_matrix(y_true, y_pred, labels=None):
         labels = np.asarray(labels, dtype=np.int)
 
     n_labels = labels.size
+    label_to_ind = dict((y, x) for x, y in enumerate(labels))
 
-    CM = np.empty((n_labels, n_labels), dtype=np.long)
-    for i, label_i in enumerate(labels):
-        for j, label_j in enumerate(labels):
-            CM[i, j] = np.sum(
-                np.logical_and(y_true == label_i, y_pred == label_j))
+    CM = np.zeros((n_labels, n_labels), dtype=np.long)
+    for yt, yp in zip(y_true, y_pred):
+        CM[label_to_ind[yt], label_to_ind[yp]] += 1
 
     return CM
 


### PR DESCRIPTION
The current implementation is unnecessarily slow O(L^2M) with the proposed implementation as O(M) (if we ignore the O(L^2) memory creation overhead) where
L: Number of labels
M: Number of inputs
