### PR TITLE
EasyFix: KNeighborsClassifier doesn't convert input to float

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -59,8 +59,9 @@ def check_pairwise_arrays(X, Y):
     given parameters are correct and safe to use.
 
     Specifically, this function first ensures that both X and Y are arrays,
-    then checkes that they are at least two dimensional. Finally, the function
-    checks that the size of the second dimension of the two arrays is equal.
+    then checks that they are at least two dimensional while ensuring that
+    their elements are floats. Finally, the function checks that the size
+    of the second dimension of the two arrays is equal.
 
     Parameters
     ----------
@@ -79,12 +80,13 @@ def check_pairwise_arrays(X, Y):
 
     """
     if Y is X or Y is None:
-        X = Y = safe_asarray(X)
+        X = safe_asarray(X)
+        X = Y = atleast2d_or_csr(X, dtype=np.float)
     else:
         X = safe_asarray(X)
         Y = safe_asarray(Y)
-    X = atleast2d_or_csr(X)
-    Y = atleast2d_or_csr(Y)
+        X = atleast2d_or_csr(X, dtype=np.float)
+        Y = atleast2d_or_csr(Y, dtype=np.float)
     if len(X.shape) < 2:
         raise ValueError("X is required to be at least two dimensional.")
     if len(Y.shape) < 2:
@@ -220,15 +222,15 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
     --------
     >>> from sklearn.metrics.pairwise import manhattan_distances
     >>> manhattan_distances(3, 3)#doctest:+ELLIPSIS
-    array([[0]]...)
+    array([[ 0.]])
     >>> manhattan_distances(3, 2)#doctest:+ELLIPSIS
-    array([[1]]...)
+    array([[ 1.]])
     >>> manhattan_distances(2, 3)#doctest:+ELLIPSIS
-    array([[1]]...)
+    array([[ 1.]])
     >>> manhattan_distances([[1, 2], [3, 4]],\
 		 [[1, 2], [0, 3]])#doctest:+ELLIPSIS
-    array([[0, 2],
-           [4, 4]]...)
+    array([[ 0.,  2.],
+           [ 4.,  4.]])
     >>> import numpy as np
     >>> X = np.ones((1, 2))
     >>> y = 2 * np.ones((2, 2))

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -18,6 +18,12 @@ perm = rng.permutation(iris.target.size)
 iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
+# load and shuffle digits
+digits = datasets.load_digits()
+perm = rng.permutation(digits.target.size)
+digits.data = digits.data[perm]
+digits.target = digits.target[perm]
+
 SPARSE_TYPES = (bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dok_matrix,
                 lil_matrix)
 SPARSE_OR_DENSE = SPARSE_TYPES + (np.asarray,)
@@ -34,8 +40,8 @@ def _weight_func(dist):
     # Dist could be multidimensional, flatten it so all values
     # can be looped
     with np.errstate(divide='ignore'):
-        retval = 1./dist
-    return retval**2
+        retval = 1. / dist
+    return retval ** 2
 
 
 def test_warn_on_equidistant(n_samples=100, n_features=3, k=3):
@@ -397,6 +403,29 @@ def test_neighbors_iris():
         rgs.fit(iris.data, iris.target)
         assert np.mean(
             rgs.predict(iris.data).round() == iris.target) > 0.95
+
+
+def test_neighbors_digits():
+    """Sanity check on the digits dataset
+
+    the 'brute' algorithm has been observed to fail if the input
+    dtype is uint8 due to overflow in distance calculations.
+    """
+
+    X = digits.data.astype('uint8')
+    Y = digits.target
+    (n_samples, n_features) = X.shape
+    train_test_boundary = int(n_samples * 0.8)
+    train = np.arange(0, train_test_boundary)
+    test = np.arange(train_test_boundary, n_samples)
+    (X_train, Y_train, X_test, Y_test) = X[train], Y[train], X[test], Y[test]
+
+    clf = neighbors.KNeighborsClassifier(n_neighbors=1, algorithm='brute',
+        warn_on_equidistant=False)
+    score_uint8 = clf.fit(X_train, Y_train).score(X_test, Y_test)
+    score_float = clf.fit(X_train.astype(float), Y_train).score(
+        X_test.astype(float), Y_test)
+    assert score_uint8 == score_float
 
 
 def test_kneighbors_graph():


### PR DESCRIPTION
In reference to [this issue](https://github.com/scikit-learn/scikit-learn/issues/852).  I've decided to place a conversion is `check_pairwise_arrays()` in sklearn/metrics/pairwise.py.  While I can imagine cases where this could result in a loss of information, I feel they must be extremely carefully constructed and can't imagine where they might appear in a real dataset.  If you believe there is a better way, let me know and I will happily change it.
