### PR TITLE
MRG Cluster k rename

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -894,7 +894,7 @@ cluster analysis.
 
   >>> import numpy as np
   >>> from sklearn.cluster import KMeans
-  >>> kmeans_model = KMeans(k=3, random_state=1).fit(X)
+  >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
   >>> metrics.silhouette_score(X, labels, metric='euclidean')  
   ...                                                      # doctest: +ELLIPSIS

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -37,9 +37,9 @@ algorithms. The simplest clustering algorithm is the
     >>> X_iris = iris.data
     >>> y_iris = iris.target
 
-    >>> k_means = cluster.KMeans(k=3)
+    >>> k_means = cluster.KMeans(n_clusters=3)
     >>> k_means.fit(X_iris) # doctest: +ELLIPSIS
-    KMeans(copy_x=True, init='k-means++', k=3, max_iter=300,...
+    KMeans(copy_x=True, init='k-means++', ...
     >>> print k_means.labels_[::10]
     [1 1 1 1 1 0 0 0 0 0 2 2 2 2 2]
     >>> print y_iris[::10]
@@ -117,9 +117,9 @@ algorithms. The simplest clustering algorithm is the
         ...    from scipy import misc
         ...    lena = misc.lena()
     	>>> X = lena.reshape((-1, 1)) # We need an (n_sample, n_feature) array
-    	>>> k_means = cluster.KMeans(k=5, n_init=1)
+    	>>> k_means = cluster.KMeans(n_clusters=5, n_init=1)
     	>>> k_means.fit(X) # doctest: +ELLIPSIS
-    	KMeans(copy_x=True, init='k-means++', k=5, ...
+    	KMeans(copy_x=True, init='k-means++', ...
     	>>> values = k_means.cluster_centers_.squeeze()
     	>>> labels = k_means.labels_
     	>>> lena_compressed = np.choose(labels, values)

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -70,9 +70,9 @@ for i_dataset, dataset in enumerate([noisy_circles, noisy_moons, blobs,
 
     # create clustering estimators
     ms = cluster.MeanShift(bandwidth=bandwidth, bin_seeding=True)
-    two_means = cluster.MiniBatchKMeans(k=2)
+    two_means = cluster.MiniBatchKMeans(n_clusters=2)
     ward_five = cluster.Ward(n_clusters=2, connectivity=connectivity)
-    spectral = cluster.SpectralClustering(k=2, mode='arpack')
+    spectral = cluster.SpectralClustering(n_clusters=2, mode='arpack')
     dbscan = cluster.DBSCAN(eps=.2)
     affinity_propagation = cluster.AffinityPropagation(damping=.9)
 

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -38,9 +38,9 @@ iris = datasets.load_iris()
 X = iris.data
 y = iris.target
 
-estimators = {'k_means_iris_3': KMeans(n_cluster=3),
-              'k_means_iris_8': KMeans(n_cluster=8),
-              'k_means_iris_bad_init': KMeans(n_cluster=3, n_init=1, init='random'),
+estimators = {'k_means_iris_3': KMeans(n_clusters=3),
+              'k_means_iris_8': KMeans(n_clusters=8),
+              'k_means_iris_bad_init': KMeans(n_clusters=3, n_init=1, init='random'),
              }
 
 

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -38,9 +38,9 @@ iris = datasets.load_iris()
 X = iris.data
 y = iris.target
 
-estimators = {'k_means_iris_3': KMeans(k=3),
-              'k_means_iris_8': KMeans(k=8),
-              'k_means_iris_bad_init': KMeans(k=3, n_init=1, init='random'),
+estimators = {'k_means_iris_3': KMeans(n_cluster=3),
+              'k_means_iris_8': KMeans(n_cluster=8),
+              'k_means_iris_bad_init': KMeans(n_cluster=3, n_init=1, init='random'),
              }
 
 

--- a/examples/cluster/plot_color_quantization.py
+++ b/examples/cluster/plot_color_quantization.py
@@ -51,7 +51,7 @@ image_array = np.reshape(china, (w * h, d))
 print "Fitting estimator on a small sub-sample of the data"
 t0 = time()
 image_array_sample = shuffle(image_array, random_state=0)[:1000]
-kmeans = KMeans(n_cluster=n_colors, random_state=0).fit(image_array_sample)
+kmeans = KMeans(n_clusters=n_colors, random_state=0).fit(image_array_sample)
 print "done in %0.3fs." % (time() - t0)
 
 # Get labels for all points

--- a/examples/cluster/plot_color_quantization.py
+++ b/examples/cluster/plot_color_quantization.py
@@ -51,7 +51,7 @@ image_array = np.reshape(china, (w * h, d))
 print "Fitting estimator on a small sub-sample of the data"
 t0 = time()
 image_array_sample = shuffle(image_array, random_state=0)[:1000]
-kmeans = KMeans(k=n_colors, random_state=0).fit(image_array_sample)
+kmeans = KMeans(n_cluster=n_colors, random_state=0).fit(image_array_sample)
 print "done in %0.3fs." % (time() - t0)
 
 # Get labels for all points

--- a/examples/cluster/plot_kmeans_digits.py
+++ b/examples/cluster/plot_kmeans_digits.py
@@ -72,16 +72,16 @@ def bench_k_means(estimator, name, data):
                                   sample_size=sample_size),
          )
 
-bench_k_means(KMeans(init='k-means++', k=n_digits, n_init=10),
+bench_k_means(KMeans(init='k-means++', n_clusters=n_digits, n_init=10),
               name="k-means++", data=data)
 
-bench_k_means(KMeans(init='random', k=n_digits, n_init=10),
+bench_k_means(KMeans(init='random', n_clusters=n_digits, n_init=10),
               name="random", data=data)
 
 # in this case the seeding of the centers is deterministic, hence we run the
 # kmeans algorithm only once with n_init=1
 pca = PCA(n_components=n_digits).fit(data)
-bench_k_means(KMeans(init=pca.components_, k=n_digits, n_init=1),
+bench_k_means(KMeans(init=pca.components_, n_clusters=n_digits, n_init=1),
               name="PCA-based",
               data=data)
 print 79 * '_'
@@ -90,7 +90,8 @@ print 79 * '_'
 # Visualize the results on PCA-reduced data
 
 reduced_data = PCA(n_components=2).fit_transform(data)
-kmeans = KMeans(init='k-means++', k=n_digits, n_init=10).fit(reduced_data)
+kmeans = KMeans(init='k-means++', n_clusters=n_digits, n_init=10)
+kmeans.fit(reduced_data)
 
 # Step size of the mesh. Decrease to increase the quality of the VQ.
 h = .02     # point in the mesh [x_min, m_max]x[y_min, y_max].

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -87,11 +87,8 @@ for factory, init, params in cases:
     for run_id in range(n_runs):
         X, y = make_data(run_id, n_samples_per_center, grid_size, scale)
         for i, n_init in enumerate(n_init_range):
-            km = factory(k=n_clusters,
-                         init=init,
-                         random_state=run_id,
-                         n_init=n_init,
-                         **params).fit(X)
+            km = factory(n_clusters=n_clusters, init=init, random_state=run_id,
+                    n_init=n_init, **params).fit(X)
             inertia[i, run_id] = km.inertia_
     p = pl.errorbar(n_init_range, inertia.mean(axis=1), inertia.std(axis=1))
     plots.append(p[0])
@@ -105,7 +102,7 @@ pl.title("Mean inertia for various k-means init across %d runs" % n_runs)
 # Part 2: Qualitative visual inspection of the convergence
 
 X, y = make_data(random_state, n_samples_per_center, grid_size, scale)
-km = MiniBatchKMeans(k=n_clusters, init='random', n_init=1,
+km = MiniBatchKMeans(n_clusters=n_clusters, init='random', n_init=1,
                      random_state=random_state).fit(X)
 
 fig = pl.figure()

--- a/examples/cluster/plot_lena_compress.py
+++ b/examples/cluster/plot_lena_compress.py
@@ -33,7 +33,7 @@ except AttributeError:
     from scipy import misc
     lena = misc.lena()
 X = lena.reshape((-1, 1))  # We need an (n_sample, n_feature) array
-k_means = cluster.KMeans(k=n_clusters, n_init=4)
+k_means = cluster.KMeans(n_clusters=n_clusters, n_init=4)
 k_means.fit(X)
 values = k_means.cluster_centers_.squeeze()
 labels = k_means.labels_

--- a/examples/cluster/plot_lena_segmentation.py
+++ b/examples/cluster/plot_lena_segmentation.py
@@ -41,7 +41,7 @@ graph.data = np.exp(-beta * graph.data / lena.std()) + eps
 # Apply spectral clustering (this step goes much faster if you have pyamg
 # installed)
 N_REGIONS = 11
-labels = spectral_clustering(graph, n_cluster=N_REGIONS)
+labels = spectral_clustering(graph, n_clusters=N_REGIONS)
 labels = labels.reshape(lena.shape)
 
 ###############################################################################

--- a/examples/cluster/plot_lena_segmentation.py
+++ b/examples/cluster/plot_lena_segmentation.py
@@ -41,7 +41,7 @@ graph.data = np.exp(-beta * graph.data / lena.std()) + eps
 # Apply spectral clustering (this step goes much faster if you have pyamg
 # installed)
 N_REGIONS = 11
-labels = spectral_clustering(graph, k=N_REGIONS)
+labels = spectral_clustering(graph, n_cluster=N_REGIONS)
 labels = labels.reshape(lena.shape)
 
 ###############################################################################

--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -35,7 +35,7 @@ X, labels_true = make_blobs(n_samples=3000, centers=centers, cluster_std=0.7)
 ##############################################################################
 # Compute clustering with Means
 
-k_means = KMeans(init='k-means++', n_cluster=3, n_init=10)
+k_means = KMeans(init='k-means++', n_clusters=3, n_init=10)
 t0 = time.time()
 k_means.fit(X)
 t_batch = time.time() - t0
@@ -46,7 +46,7 @@ k_means_labels_unique = np.unique(k_means_labels)
 ##############################################################################
 # Compute clustering with MiniBatchKMeans
 
-mbk = MiniBatchKMeans(init='k-means++', n_cluster=3, batch_size=batch_size,
+mbk = MiniBatchKMeans(init='k-means++', n_clusters=3, batch_size=batch_size,
                       n_init=10, max_no_improvement=10, verbose=0)
 t0 = time.time()
 mbk.fit(X)

--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -35,7 +35,7 @@ X, labels_true = make_blobs(n_samples=3000, centers=centers, cluster_std=0.7)
 ##############################################################################
 # Compute clustering with Means
 
-k_means = KMeans(init='k-means++', k=3, n_init=10)
+k_means = KMeans(init='k-means++', n_cluster=3, n_init=10)
 t0 = time.time()
 k_means.fit(X)
 t_batch = time.time() - t0
@@ -46,7 +46,7 @@ k_means_labels_unique = np.unique(k_means_labels)
 ##############################################################################
 # Compute clustering with MiniBatchKMeans
 
-mbk = MiniBatchKMeans(init='k-means++', k=3, batch_size=batch_size,
+mbk = MiniBatchKMeans(init='k-means++', n_cluster=3, batch_size=batch_size,
                       n_init=10, max_no_improvement=10, verbose=0)
 t0 = time.time()
 mbk.fit(X)

--- a/examples/cluster/plot_segmentation_toy.py
+++ b/examples/cluster/plot_segmentation_toy.py
@@ -70,7 +70,7 @@ graph.data = np.exp(-graph.data / graph.data.std())
 
 # Force the solver to be arpack, since amg is numerically
 # unstable on this example
-labels = spectral_clustering(graph, k=4, mode='arpack')
+labels = spectral_clustering(graph, n_cluster=4, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 
@@ -88,7 +88,7 @@ img += 1 + 0.2 * np.random.randn(*img.shape)
 graph = image.img_to_graph(img, mask=mask)
 graph.data = np.exp(-graph.data / graph.data.std())
 
-labels = spectral_clustering(graph, k=2, mode='arpack')
+labels = spectral_clustering(graph, n_cluster=2, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 

--- a/examples/cluster/plot_segmentation_toy.py
+++ b/examples/cluster/plot_segmentation_toy.py
@@ -70,7 +70,7 @@ graph.data = np.exp(-graph.data / graph.data.std())
 
 # Force the solver to be arpack, since amg is numerically
 # unstable on this example
-labels = spectral_clustering(graph, n_cluster=4, mode='arpack')
+labels = spectral_clustering(graph, n_clusters=4, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 
@@ -88,7 +88,7 @@ img += 1 + 0.2 * np.random.randn(*img.shape)
 graph = image.img_to_graph(img, mask=mask)
 graph.data = np.exp(-graph.data / graph.data.std())
 
-labels = spectral_clustering(graph, n_cluster=2, mode='arpack')
+labels = spectral_clustering(graph, n_clusters=2, mode='arpack')
 label_im = -np.ones(mask.shape)
 label_im[mask] = labels
 

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -93,8 +93,8 @@ estimators = [
      True, False),
 
     ('Cluster centers - MiniBatchKMeans',
-     MiniBatchKMeans(k=n_components, tol=1e-3, batch_size=20, max_iter=50,
-                     random_state=rng),
+     MiniBatchKMeans(n_cluster=n_components, tol=1e-3, batch_size=20,
+         max_iter=50, random_state=rng),
      True, False)
 ]
 

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -88,11 +88,12 @@ print
 # Do the actual clustering
 
 if opts.minibatch:
-    km = MiniBatchKMeans(k=true_k, init='k-means++', n_init=1,
+    km = MiniBatchKMeans(n_clusters=true_k, init='k-means++', n_init=1,
                          init_size=1000,
                          batch_size=1000, verbose=1)
 else:
-    km = KMeans(k=true_k, init='random', max_iter=100, n_init=1, verbose=1)
+    km = KMeans(n_clusters=true_k, init='random', max_iter=100, n_init=1,
+            verbose=1)
 
 print "Clustering sparse data with %s" % km
 t0 = time()

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -689,12 +689,8 @@ class KMeans(BaseEstimator):
             n_clusters = init.shape[0]
             init = np.asanyarray(init, dtype=np.float64)
 
-        if not k is None:
-            n_clusters = k
-            warnings.warn("Parameter k was renamed to n_clusters",
-                    DeprecationWarning)
-
         self.n_clusters = n_clusters
+        self.k = k
         self.init = init
         self.max_iter = max_iter
         self.tol = tol
@@ -735,11 +731,19 @@ class KMeans(BaseEstimator):
 
     def fit(self, X, y=None):
         """Compute k-means"""
+
+        if not self.k is None:
+            n_clusters = self.k
+            warnings.warn("Parameter k was renamed to n_clusters",
+                    DeprecationWarning)
+        else:
+            n_clusters = self.n_clusters
+
         self.random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)
 
         self.cluster_centers_, self.labels_, self.inertia_ = k_means(
-            X, n_clusters=self.n_clusters, init=self.init, n_init=self.n_init,
+            X, n_clusters=n_clusters, init=self.init, n_init=self.n_init,
             max_iter=self.max_iter, verbose=self.verbose,
             precompute_distances=self.precompute_distances,
             tol=self.tol, random_state=self.random_state, copy_x=self.copy_x,

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -33,8 +33,9 @@ from . import _k_means
 # Initialization heuristic
 
 
-def k_init(X, k, n_local_trials=None, random_state=None, x_squared_norms=None):
-    """Init k seeds according to k-means++
+def _k_init(X, n_clusters, n_local_trials=None, random_state=None,
+        x_squared_norms=None):
+    """Init n_clusters seeds according to k-means++
 
     Parameters
     -----------
@@ -42,7 +43,7 @@ def k_init(X, k, n_local_trials=None, random_state=None, x_squared_norms=None):
         The data to pick seeds for. To avoid memory copy, the input data
         should be double precision (dtype=np.float64).
 
-    k: integer
+    n_clusters: integer
         The number of seeds to choose
 
     n_local_trials: integer, optional
@@ -73,14 +74,14 @@ def k_init(X, k, n_local_trials=None, random_state=None, x_squared_norms=None):
     n_samples, n_features = X.shape
     random_state = check_random_state(random_state)
 
-    centers = np.empty((k, n_features))
+    centers = np.empty((n_clusters, n_features))
 
     # Set the number of local seeding trials if none is given
     if n_local_trials is None:
         # This is what Arthur/Vassilvitskii tried, but did not report
         # specific results for other than mentioning in the conclusion
         # that it helped.
-        n_local_trials = 2 + int(np.log(k))
+        n_local_trials = 2 + int(np.log(n_clusters))
 
     # Pick first center randomly
     center_id = random_state.randint(n_samples)
@@ -96,8 +97,8 @@ def k_init(X, k, n_local_trials=None, random_state=None, x_squared_norms=None):
         centers[0], X, Y_norm_squared=x_squared_norms, squared=True)
     current_pot = closest_dist_sq.sum()
 
-    # Pick the remaining k-1 points
-    for c in xrange(1, k):
+    # Pick the remaining n_clusters-1 points
+    for c in xrange(1, n_clusters):
         # Choose center candidates by sampling with probability proportional
         # to the squared distance to the closest existing center
         rand_vals = random_state.random_sample(n_local_trials) * current_pot
@@ -147,9 +148,9 @@ def _tolerance(X, tol):
     return np.mean(variances) * tol
 
 
-def k_means(X, k, init='k-means++', precompute_distances=True,
+def k_means(X, n_clusters, init='k-means++', precompute_distances=True,
             n_init=10, max_iter=300, verbose=False,
-            tol=1e-4, random_state=None, copy_x=True, n_jobs=1):
+            tol=1e-4, random_state=None, copy_x=True, n_jobs=1, k=None):
     """K-means clustering algorithm.
 
     Parameters
@@ -157,7 +158,7 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
     X: array-like of floats, shape (n_samples, n_features)
         The observations to cluster.
 
-    k: int
+    n_clusters: int
         The number of clusters to form as well as the number of
         centroids to generate.
 
@@ -229,6 +230,11 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
     """
     random_state = check_random_state(random_state)
 
+    if not k is None:
+        n_clusters = k
+        warnings.warn("Parameter k was renamed to n_clusters",
+                DeprecationWarning)
+
     best_inertia = np.infty
     X = as_float_array(X, copy=copy_x)
     tol = _tolerance(X, tol)
@@ -260,7 +266,7 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
         for it in range(n_init):
             # run a k-means once
             labels, inertia, centers = _kmeans_single(
-                X, k, max_iter=max_iter, init=init, verbose=verbose,
+                X, n_clusters, max_iter=max_iter, init=init, verbose=verbose,
                 precompute_distances=precompute_distances, tol=tol,
                 x_squared_norms=x_squared_norms, random_state=random_state)
             # determine if these results are the best so far
@@ -272,10 +278,10 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
         # parallelisation of k-means runs
         seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
         results = Parallel(n_jobs=n_jobs, verbose=0)(
-            delayed(_kmeans_single)(X, k, max_iter=max_iter, init=init,
-                                    verbose=verbose, tol=tol,
-                                    precompute_distances=precompute_distances,
-                                    x_squared_norms=x_squared_norms,
+            delayed(_kmeans_single)(X, n_clusters, max_iter=max_iter,
+                init=init, verbose=verbose, tol=tol,
+                precompute_distances=precompute_distances,
+                x_squared_norms=x_squared_norms,
                                     # Change seed to ensure variety
                                     random_state=seed)
             for seed in seeds)
@@ -293,9 +299,9 @@ def k_means(X, k, init='k-means++', precompute_distances=True,
     return best_centers, best_labels, best_inertia
 
 
-def _kmeans_single(X, k, max_iter=300, init='k-means++', verbose=False,
-                   x_squared_norms=None, random_state=None, tol=1e-4,
-                   precompute_distances=True):
+def _kmeans_single(X, n_clusters, max_iter=300, init='k-means++',
+        verbose=False, x_squared_norms=None, random_state=None, tol=1e-4,
+        precompute_distances=True):
     """A single run of k-means, assumes preparation completed prior.
 
     Parameters
@@ -358,7 +364,7 @@ def _kmeans_single(X, k, max_iter=300, init='k-means++', verbose=False,
         x_squared_norms = _squared_norms(X)
     best_labels, best_inertia, best_centers = None, None, None
     # init
-    centers = _init_centroids(X, k, init, random_state=random_state,
+    centers = _init_centroids(X, n_clusters, init, random_state=random_state,
                               x_squared_norms=x_squared_norms)
     if verbose:
         print 'Initialization complete'
@@ -377,7 +383,7 @@ def _kmeans_single(X, k, max_iter=300, init='k-means++', verbose=False,
                                 distances=distances)
 
         # computation of the means is also called the M-step of EM
-        centers = _centers(X, labels, k, distances)
+        centers = _centers(X, labels, n_clusters, distances)
 
         if verbose:
             print 'Iteration %i, inertia %s' % (i, inertia)
@@ -565,7 +571,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
                 "n_samples=%d should be larger than k=%d" % (init_size, k))
 
     if init == 'k-means++':
-        centers = k_init(X, k,
+        centers = _k_init(X, k,
                         random_state=random_state,
                         x_squared_norms=x_squared_norms)
     elif init == 'random':
@@ -591,7 +597,7 @@ class KMeans(BaseEstimator):
     Parameters
     ----------
 
-    k : int, optional, default: 8
+    n_clusters : int, optional, default: 8
         The number of clusters to form as well as the number of
         centroids to generate.
 
@@ -675,15 +681,20 @@ class KMeans(BaseEstimator):
 
     """
 
-    def __init__(self, k=8, init='k-means++', n_init=10, max_iter=300,
+    def __init__(self, n_clusters=8, init='k-means++', n_init=10, max_iter=300,
                  tol=1e-4, precompute_distances=True,
-                 verbose=0, random_state=None, copy_x=True, n_jobs=1):
+                 verbose=0, random_state=None, copy_x=True, n_jobs=1, k=None):
 
         if hasattr(init, '__array__'):
-            k = init.shape[0]
+            n_clusters = init.shape[0]
             init = np.asanyarray(init, dtype=np.float64)
 
-        self.k = k
+        if not k is None:
+            n_clusters = k
+            warnings.warn("Parameter k was renamed to n_clusters",
+                    DeprecationWarning)
+
+        self.n_clusters = n_clusters
         self.init = init
         self.max_iter = max_iter
         self.tol = tol
@@ -697,9 +708,9 @@ class KMeans(BaseEstimator):
     def _check_fit_data(self, X):
         """Verify that the number of samples given is larger than k"""
         X = atleast2d_or_csr(X, dtype=np.float64)
-        if X.shape[0] < self.k:
-            raise ValueError("n_samples=%d should be >= k=%d" % (
-                X.shape[0], self.k))
+        if X.shape[0] < self.n_clusters:
+            raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
+                X.shape[0], self.n_clusters))
         return X
 
     def _check_test_data(self, X):
@@ -728,7 +739,7 @@ class KMeans(BaseEstimator):
         X = self._check_fit_data(X)
 
         self.cluster_centers_, self.labels_, self.inertia_ = k_means(
-            X, k=self.k, init=self.init, n_init=self.n_init,
+            X, n_clusters=self.n_clusters, init=self.init, n_init=self.n_init,
             max_iter=self.max_iter, verbose=self.verbose,
             precompute_distances=self.precompute_distances,
             tol=self.tol, random_state=self.random_state, copy_x=self.copy_x,
@@ -945,7 +956,7 @@ class MiniBatchKMeans(KMeans):
     Parameters
     ----------
 
-    k : int, optional, default: 8
+    n_clusters : int, optional, default: 8
         The number of clusters to form as well as the number of
         centroids to generate.
 
@@ -1021,14 +1032,14 @@ class MiniBatchKMeans(KMeans):
     See http://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf
     """
 
-    def __init__(self, k=8, init='k-means++', max_iter=100,
+    def __init__(self, n_clusters=8, init='k-means++', max_iter=100,
                  batch_size=100, verbose=0, compute_labels=True,
                  random_state=None, tol=0.0, max_no_improvement=10,
-                 init_size=None, n_init=3, chunk_size=None):
+                 init_size=None, n_init=3, chunk_size=None, k=None):
 
-        super(MiniBatchKMeans, self).__init__(k=k, init=init,
+        super(MiniBatchKMeans, self).__init__(n_clusters=n_clusters, init=init,
               max_iter=max_iter, verbose=verbose, random_state=random_state,
-              tol=tol, n_init=n_init)
+              tol=tol, n_init=n_init, k=k)
 
         self.max_no_improvement = max_no_improvement
         if chunk_size is not None:
@@ -1052,7 +1063,7 @@ class MiniBatchKMeans(KMeans):
         X = check_arrays(X, sparse_format="csr", copy=False,
                          check_ccontiguous=True, dtype=np.float64)[0]
         n_samples, n_features = X.shape
-        if n_samples < self.k:
+        if n_samples < self.n_clusters:
             raise ValueError("Number of samples smaller than number "\
                              "of clusters.")
 
@@ -1096,7 +1107,7 @@ class MiniBatchKMeans(KMeans):
             if self.verbose:
                 print "Init %d/%d with method: %s" % (
                     init_idx + 1, self.n_init, self.init)
-            counts = np.zeros(self.k, dtype=np.int32)
+            counts = np.zeros(self.n_clusters, dtype=np.int32)
 
             # TODO: once the `k_means` function works with sparse input we
             # should refactor the following init to use it instead.
@@ -1104,7 +1115,7 @@ class MiniBatchKMeans(KMeans):
             # Initialize the centers using only a fraction of the data as we
             # expect n_samples to be very large when using MiniBatchKMeans
             cluster_centers = _init_centroids(
-                X, self.k, self.init,
+                X, self.n_clusters, self.init,
                 random_state=self.random_state,
                 x_squared_norms=x_squared_norms,
                 init_size=init_size)
@@ -1184,10 +1195,10 @@ class MiniBatchKMeans(KMeans):
             # this is the first call partial_fit on this object:
             # initialize the cluster centers
             self.cluster_centers_ = _init_centroids(
-                X, self.k, self.init, random_state=self.random_state,
+                X, self.n_clusters, self.init, random_state=self.random_state,
                 x_squared_norms=x_squared_norms, init_size=self.init_size)
 
-            self.counts_ = np.zeros(self.k, dtype=np.int32)
+            self.counts_ = np.zeros(self.n_clusters, dtype=np.int32)
 
         _mini_batch_step(X, x_squared_norms, self.cluster_centers_,
                          self.counts_, np.zeros(0, np.double), 0)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -166,7 +166,8 @@ def _check_fitted_model(km):
 
 
 def test_k_means_plus_plus_init():
-    k_means = KMeans(init="k-means++", k=n_clusters, random_state=42).fit(X)
+    k_means = KMeans(init="k-means++", n_clusters=n_clusters,
+            random_state=42).fit(X)
     _check_fitted_model(k_means)
 
 
@@ -181,62 +182,64 @@ def _get_mac_os_version():
 def test_k_means_plus_plus_init_2_jobs():
     if _get_mac_os_version() == '10.7':
         raise SkipTest('Multi-process bug in Mac OS X Lion (see issue #636)')
-    k_means = KMeans(init="k-means++", k=n_clusters, n_jobs=2,
+    k_means = KMeans(init="k-means++", n_clusters=n_clusters, n_jobs=2,
                      random_state=42).fit(X)
     _check_fitted_model(k_means)
 
 
 def test_k_means_plus_plus_init_sparse():
-    k_means = KMeans(init="k-means++", k=n_clusters, random_state=42)
+    k_means = KMeans(init="k-means++", n_clusters=n_clusters, random_state=42)
     k_means.fit(X_csr)
     _check_fitted_model(k_means)
 
 
 def test_k_means_random_init():
-    k_means = KMeans(init="random", k=n_clusters, random_state=42).fit(X)
+    k_means = KMeans(init="random", n_clusters=n_clusters, random_state=42)
+    k_means.fit(X)
     _check_fitted_model(k_means)
 
 
 def test_k_means_random_init_sparse():
-    k_means = KMeans(init="random", k=n_clusters, random_state=42).fit(X_csr)
+    k_means = KMeans(init="random", n_clusters=n_clusters, random_state=42)
+    k_means.fit(X_csr)
     _check_fitted_model(k_means)
 
 
 def test_k_means_plus_plus_init_not_precomputed():
-    k_means = KMeans(init="k-means++", k=n_clusters, random_state=42,
+    k_means = KMeans(init="k-means++", n_clusters=n_clusters, random_state=42,
                      precompute_distances=False).fit(X)
     _check_fitted_model(k_means)
 
 
 def test_k_means_random_init_not_precomputed():
-    k_means = KMeans(init="random", k=n_clusters, random_state=42,
+    k_means = KMeans(init="random", n_clusters=n_clusters, random_state=42,
                      precompute_distances=False).fit(X)
     _check_fitted_model(k_means)
 
 
 def test_k_means_perfect_init():
-    k_means = KMeans(init=centers.copy(), k=n_clusters, random_state=42,
-                     n_init=1)
+    k_means = KMeans(init=centers.copy(), n_clusters=n_clusters,
+            random_state=42, n_init=1)
     k_means.fit(X)
     _check_fitted_model(k_means)
 
 
 def test_mb_k_means_plus_plus_init_dense_array():
-    mb_k_means = MiniBatchKMeans(init="k-means++", k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init="k-means++", n_clusters=n_clusters,
                                  random_state=42)
     mb_k_means.fit(X)
     _check_fitted_model(mb_k_means)
 
 
 def test_mb_k_means_plus_plus_init_sparse_matrix():
-    mb_k_means = MiniBatchKMeans(init="k-means++", k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init="k-means++", n_clusters=n_clusters,
                                  random_state=42)
     mb_k_means.fit(X_csr)
     _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_init_with_large_k():
-    mb_k_means = MiniBatchKMeans(init='k-means++', init_size=10, k=20)
+    mb_k_means = MiniBatchKMeans(init='k-means++', init_size=10, n_clusters=20)
     # Check that a warning is raised, as the number clusters is larger
     # than the init_size
     with warnings.catch_warnings(record=True) as warn_queue:
@@ -247,26 +250,26 @@ def test_minibatch_init_with_large_k():
 
 def test_minibatch_k_means_random_init_dense_array():
     # increase n_init to make random init stable enough
-    mb_k_means = MiniBatchKMeans(init="random", k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init="random", n_clusters=n_clusters,
                                  random_state=42, n_init=10).fit(X)
     _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_k_means_random_init_sparse_csr():
     # increase n_init to make random init stable enough
-    mb_k_means = MiniBatchKMeans(init="random", k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init="random", n_clusters=n_clusters,
                                  random_state=42, n_init=10).fit(X_csr)
     _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_k_means_perfect_init_dense_array():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
                                  random_state=42).fit(X)
     _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_k_means_perfect_init_sparse_csr():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
                                  random_state=42).fit(X_csr)
     _check_fitted_model(mb_k_means)
 
@@ -281,7 +284,7 @@ def test_sparse_mb_k_means_callable_init():
 
 
 def test_mini_batch_k_means_random_init_partial_fit():
-    km = MiniBatchKMeans(k=n_clusters, init="random", random_state=42)
+    km = MiniBatchKMeans(n_clusters=n_clusters, init="random", random_state=42)
 
     # use the partial_fit API for online learning
     for X_minibatch in np.array_split(X, 10):
@@ -293,14 +296,14 @@ def test_mini_batch_k_means_random_init_partial_fit():
 
 
 def test_minibatch_default_init_size():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
                                  batch_size=10, random_state=42).fit(X)
     assert_equal(mb_k_means.init_size_, 3 * mb_k_means.batch_size)
     _check_fitted_model(mb_k_means)
 
 
 def test_minibatch_set_init_size():
-    mb_k_means = MiniBatchKMeans(init=centers.copy(), k=n_clusters,
+    mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
                                  init_size=666, random_state=42).fit(X)
     assert_equal(mb_k_means.init_size, 666)
     assert_equal(mb_k_means.init_size_, n_samples)
@@ -308,19 +311,20 @@ def test_minibatch_set_init_size():
 
 
 def test_k_means_invalid_init():
-    k_means = KMeans(init="invalid", n_init=1, k=n_clusters)
+    k_means = KMeans(init="invalid", n_init=1, n_clusters=n_clusters)
     assert_raises(ValueError, k_means.fit, X)
 
 
 def test_mini_match_k_means_invalid_init():
-    k_means = MiniBatchKMeans(init="invalid", n_init=1, k=n_clusters)
+    k_means = MiniBatchKMeans(init="invalid", n_init=1, n_clusters=n_clusters)
     assert_raises(ValueError, k_means.fit, X)
 
 
 def test_k_means_copyx():
     """Check if copy_x=False returns nearly equal X after de-centering."""
     my_X = X.copy()
-    k_means = KMeans(copy_x=False, k=n_clusters, random_state=42).fit(my_X)
+    k_means = KMeans(copy_x=False, n_clusters=n_clusters, random_state=42)
+    k_means.fit(my_X)
     _check_fitted_model(k_means)
 
     # check if my_X is centered
@@ -337,7 +341,7 @@ def test_k_means_non_collapsed():
     """
     my_X = np.array([[1.1, 1.1], [0.9, 1.1], [1.1, 0.9], [0.9, 1.1]])
     array_init = np.array([[1.0, 1.0], [5.0, 5.0], [-5.0, -5.0]])
-    k_means = KMeans(init=array_init, k=3, random_state=42, n_init=1)
+    k_means = KMeans(init=array_init, n_clusters=3, random_state=42, n_init=1)
     k_means.fit(my_X)
 
     # centers must not been collapsed
@@ -350,7 +354,7 @@ def test_k_means_non_collapsed():
 
 
 def test_predict():
-    k_means = KMeans(k=n_clusters, random_state=42)
+    k_means = KMeans(n_clusters=n_clusters, random_state=42)
 
     k_means.fit(X)
 
@@ -368,13 +372,15 @@ def test_predict():
 
 
 def test_score():
-    s1 = KMeans(k=n_clusters, max_iter=1, random_state=42).fit(X).score(X)
-    s2 = KMeans(k=n_clusters, max_iter=10, random_state=42).fit(X).score(X)
+    km1 = KMeans(n_clusters=n_clusters, max_iter=1, random_state=42)
+    s1 = km1.fit(X).score(X)
+    km2 = KMeans(n_clusters=n_clusters, max_iter=10, random_state=42)
+    s2 = km2.fit(X).score(X)
     assert_greater(s2, s1)
 
 
 def test_predict_minibatch_dense_input():
-    mb_k_means = MiniBatchKMeans(k=n_clusters, random_state=40).fit(X)
+    mb_k_means = MiniBatchKMeans(n_clusters=n_clusters, random_state=40).fit(X)
 
     # sanity check: predict centroid labels
     pred = mb_k_means.predict(mb_k_means.cluster_centers_)
@@ -386,7 +392,7 @@ def test_predict_minibatch_dense_input():
 
 
 def test_predict_minibatch_kmeanspp_init_sparse_input():
-    mb_k_means = MiniBatchKMeans(k=n_clusters, init='k-means++',
+    mb_k_means = MiniBatchKMeans(n_clusters=n_clusters, init='k-means++',
                                  n_init=10).fit(X_csr)
 
     # sanity check: re-predict labeling for training set samples
@@ -402,7 +408,7 @@ def test_predict_minibatch_kmeanspp_init_sparse_input():
 
 
 def test_predict_minibatch_random_init_sparse_input():
-    mb_k_means = MiniBatchKMeans(k=n_clusters, init='random',
+    mb_k_means = MiniBatchKMeans(n_clusters=n_clusters, init='random',
                                  n_init=10).fit(X_csr)
 
     # sanity check: re-predict labeling for training set samples
@@ -424,18 +430,19 @@ def test_input_dtypes():
     init_int = X_int[:2]
 
     fitted_models = [
-        KMeans(k=2).fit(X_list),
-        KMeans(k=2).fit(X_int),
-        KMeans(k=2, init=init_int, n_init=1).fit(X_list),
-        KMeans(k=2, init=init_int, n_init=1).fit(X_int),
+        KMeans(n_clusters=2).fit(X_list),
+        KMeans(n_clusters=2).fit(X_int),
+        KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_list),
+        KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_int),
         # mini batch kmeans is very unstable on such a small dataset hence
         # we use many inits
-        MiniBatchKMeans(k=2, n_init=10, batch_size=2).fit(X_list),
-        MiniBatchKMeans(k=2, n_init=10, batch_size=2).fit(X_int),
-        MiniBatchKMeans(k=2, n_init=10, batch_size=2).fit(X_int_csr),
-        MiniBatchKMeans(k=2, batch_size=2, init=init_int).fit(X_list),
-        MiniBatchKMeans(k=2, batch_size=2, init=init_int).fit(X_int),
-        MiniBatchKMeans(k=2, batch_size=2, init=init_int).fit(X_int_csr),
+        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_list),
+        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int),
+        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int_csr),
+        MiniBatchKMeans(n_clusters=2, batch_size=2, init=init_int).fit(X_list),
+        MiniBatchKMeans(n_clusters=2, batch_size=2, init=init_int).fit(X_int),
+        MiniBatchKMeans(n_clusters=2, batch_size=2,
+            init=init_int).fit(X_int_csr),
     ]
     expected_labels = [0, 1, 1, 0, 0, 1]
     scores = np.array([v_measure_score(expected_labels, km.labels_)
@@ -444,7 +451,7 @@ def test_input_dtypes():
 
 
 def test_transform():
-    k_means = KMeans(k=n_clusters)
+    k_means = KMeans(n_clusters=n_clusters)
     k_means.fit(X)
     X_new = k_means.transform(k_means.cluster_centers_)
 
@@ -462,7 +469,7 @@ def test_n_init():
     inertia = np.zeros((len(n_init_range), n_runs))
     for i, n_init in enumerate(n_init_range):
         for j in range(n_runs):
-            km = KMeans(k=n_clusters, init="random", n_init=n_init,
+            km = KMeans(n_clusters=n_clusters, init="random", n_init=n_init,
                         random_state=j).fit(X)
             inertia[i, j] = km.inertia_
 

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -22,7 +22,7 @@ def test_spectral_clustering():
                  ])
 
     for mat in (S, sparse.csr_matrix(S)):
-        model = SpectralClustering(random_state=0, k=2).fit(mat)
+        model = SpectralClustering(random_state=0, n_clusters=2).fit(mat)
         labels = model.labels_
         if labels[0] == 0:
             labels = 1 - labels
@@ -30,7 +30,7 @@ def test_spectral_clustering():
         assert_equal(labels, [1, 1, 1, 0, 0, 0, 0])
 
         model_copy = loads(dumps(model))
-        assert_equal(model_copy.k, model.k)
+        assert_equal(model_copy.n_clusters, model.n_clusters)
         assert_equal(model_copy.mode, model.mode)
         assert_equal(model_copy.random_state.get_state(),
                      model.random_state.get_state())
@@ -55,7 +55,7 @@ def test_spectral_clustering_sparse():
 
     S = sparse.coo_matrix(S)
 
-    labels = SpectralClustering(random_state=0, k=2).fit(S).labels_
+    labels = SpectralClustering(random_state=0, n_clusters=2).fit(S).labels_
     if labels[0] == 0:
         labels = 1 - labels
 

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -719,7 +719,7 @@ class GaussianHMM(_BaseHMM):
 
         if 'm' in params:
             self._means_ = cluster.KMeans(
-                k=self.n_components).fit(obs[0]).cluster_centers_
+                n_clusters=self.n_components).fit(obs[0]).cluster_centers_
         if 'c' in params:
             cv = np.cov(obs[0].T)
             if not cv.shape:


### PR DESCRIPTION
Fixes issue #844. Renaming parameter `k` in KMeans, MiniBatchKMeans and SpectralClustering to `n_clusters`.
