### PR TITLE
Ledoitwolf computation

### DIFF
--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -47,19 +47,16 @@ from sklearn.covariance import LedoitWolf, OAS, ShrunkCovariance, \
 
 # Ledoit-Wolf optimal shrinkage coefficient estimate
 lw = LedoitWolf()
-loglik_lw = lw.fit(X_train, assume_centered=True).score(
-    X_test, assume_centered=True)
+loglik_lw = lw.fit(X_train).score(X_test)
 
 # OAS coefficient estimate
 oa = OAS()
-loglik_oa = oa.fit(X_train, assume_centered=True).score(
-    X_test, assume_centered=True)
+loglik_oa = oa.fit(X_train).score(X_test)
 
 # spanning a range of possible shrinkage coefficient values
 shrinkages = np.logspace(-3, 0, 30)
-negative_logliks = [-ShrunkCovariance(shrinkage=s).fit(
-        X_train, assume_centered=True).score(X_test, assume_centered=True) \
-                         for s in shrinkages]
+negative_logliks = [-ShrunkCovariance(shrinkage=s).fit(X_train).score(X_test)
+                     for s in shrinkages]
 
 # getting the likelihood under the real model
 real_cov = np.dot(coloring_matrix.T, coloring_matrix)

--- a/examples/covariance/plot_lw_vs_oas.py
+++ b/examples/covariance/plot_lw_vs_oas.py
@@ -47,12 +47,12 @@ for i, n_samples in enumerate(n_samples_range):
             np.random.normal(size=(n_samples, n_features)), coloring_matrix.T)
 
         lw = LedoitWolf(store_precision=False)
-        lw.fit(X, assume_centered=True)
+        lw.fit(X)
         lw_mse[i, j] = lw.error_norm(real_cov, scaling=False)
         lw_shrinkage[i, j] = lw.shrinkage_
 
         oa = OAS(store_precision=False)
-        oa.fit(X, assume_centered=True)
+        oa.fit(X)
         oa_mse[i, j] = oa.error_norm(real_cov, scaling=False)
         oa_shrinkage[i, j] = oa.shrinkage_
 

--- a/examples/covariance/plot_outlier_detection.py
+++ b/examples/covariance/plot_outlier_detection.py
@@ -35,7 +35,7 @@ from sklearn.covariance import EllipticEnvelope
 
 # Example settings
 n_samples = 200
-outliers_fraction = 0.1
+outliers_fraction = 0.25
 clusters_separation = [0, 1, 2]
 
 # define two outlier detection tools to be compared

--- a/examples/covariance/plot_outlier_detection.py
+++ b/examples/covariance/plot_outlier_detection.py
@@ -35,7 +35,7 @@ from sklearn.covariance import EllipticEnvelope
 
 # Example settings
 n_samples = 200
-outliers_fraction = 0.25
+outliers_fraction = 0.1
 clusters_separation = [0, 1, 2]
 
 # define two outlier detection tools to be compared
@@ -51,7 +51,6 @@ n_inliers = int((1. - outliers_fraction) * n_samples)
 n_outliers = int(outliers_fraction * n_samples)
 ground_truth = np.ones(n_samples, dtype=int)
 ground_truth[-n_outliers:] = 0
-
 
 # Fit the problem with varying cluster separation
 for i, offset in enumerate(clusters_separation):

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -9,7 +9,7 @@ Models.
 from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
     log_likelihood
 from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
-    ledoit_wolf, LedoitWolf, oas, OAS
+    ledoit_wolf, ledoit_wolf_shrinkage, LedoitWolf, oas, OAS
 from .robust_covariance import fast_mcd, MinCovDet
 from .graph_lasso_ import graph_lasso, GraphLasso, GraphLassoCV
 from .outlier_detection import EllipticEnvelope, EllipticEnvelop

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -75,6 +75,11 @@ class EmpiricalCovariance(BaseEstimator):
     ----------
     store_precision : bool
         Specifies if the estimated precision is stored
+    assume_centered: bool
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False (default), data are centered before computation.
 
     Attributes
     ----------
@@ -87,19 +92,6 @@ class EmpiricalCovariance(BaseEstimator):
 
     """
     def __init__(self, store_precision=True, assume_centered=False):
-        """
-
-        Parameters
-        ----------
-        store_precision: bool
-          Specify if the estimated precision is stored
-        assume_centered: Boolean
-          If True, data are not centered before computation.
-          Useful when working with data whose mean is almost, but not exactly
-          zero.
-          If False, data are centered before computation.
-
-        """
         self.store_precision = store_precision
         self.assume_centered = assume_centered
 
@@ -164,6 +156,12 @@ class EmpiricalCovariance(BaseEstimator):
         X_test : array-like, shape = [n_samples, n_features]
             Test data of which we compute the likelihood, where n_samples is
             the number of samples and n_features is the number of features.
+        assume_centered: bool
+            If True, data in X_test are not centered before computation.
+            Useful when working with data whose mean is almost, but not
+            exactly zero.
+            If False, data in X_test are centered before computation.
+            Note that `assume_centered` != self.assume_centered.
 
         Returns
         -------
@@ -247,6 +245,7 @@ class EmpiricalCovariance(BaseEstimator):
           If `assume_centered` is True (default), one may want to center them
           using a location estimate first. Otherwise, the observations will
           be removed their empirical mean.
+          Note that `assume_centered` != self.assume_centered.
 
         Returns
         -------

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -228,7 +228,7 @@ class EmpiricalCovariance(BaseEstimator):
 
         return result
 
-    def mahalanobis(self, observations):
+    def mahalanobis(self, observations, assume_centered=False):
         """Computes the mahalanobis distances of given observations.
 
         The provided observations are assumed to be centered. One may want to
@@ -238,6 +238,11 @@ class EmpiricalCovariance(BaseEstimator):
         ----------
         observations: array-like, shape = [n_observations, n_features]
           The observations, the Mahalanobis distances of the which we compute.
+        assume_centered: bool,
+          Whether or not to consider the observations are centered.
+          If `assume_centered` is True (default), one may want to center them
+          using a location estimate first. Otherwise, the observations will
+          be removed their empirical mean.
 
         Returns
         -------
@@ -252,6 +257,8 @@ class EmpiricalCovariance(BaseEstimator):
             precision = linalg.pinv(self.covariance_)
 
         # compute mahalanobis distances
+        if not assume_centered:
+            observations = observations - self.location_
         mahalanobis_dist = np.sum(
             np.dot(observations, precision) * observations, 1)
 

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -116,14 +116,18 @@ class EmpiricalCovariance(BaseEstimator):
           is computed.
 
         """
-        covariance = array2d(covariance)
-        # set covariance
-        self.covariance_ = covariance
-        # set precision
-        if self.store_precision:
-            self.precision_ = linalg.pinv(covariance)
-        else:
+        if covariance is None:
+            self.covariance_ = None
             self.precision_ = None
+        else:
+            covariance = array2d(covariance)
+            # set covariance
+            self.covariance_ = covariance
+            # set precision
+            if self.store_precision:
+                self.precision_ = linalg.pinv(covariance)
+            else:
+                self.precision_ = None
 
     def fit(self, X):
         """Fits the Maximum Likelihood Estimator covariance model

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -39,14 +39,14 @@ class OutlierDetectionMixin(ClassifierMixin):
         self.contamination = contamination
         self.threshold = None
 
-    def decision_function(self, X, raw_mahalanobis=False):
+    def decision_function(self, X, raw_values=False):
         """Compute the decision function of the given observations.
 
         Parameters
         ----------
         X: array-like, shape (n_samples, n_features)
 
-        raw_mahalanobis: bool
+        raw_values: bool
             Whether or not to consider raw Mahalanobis distances as the
             decision function. Must be False (default) for compatibility
             with the others outlier detection tools.
@@ -55,17 +55,16 @@ class OutlierDetectionMixin(ClassifierMixin):
         -------
         decision: array-like, shape (n_samples, )
             The values of the decision function for each observations.
-            It is equal to the Mahalanobis distances if `raw_mahalanobis`
-            is True. By default (``raw_mahalanobis=True``), it is equal
+            It is equal to the Mahalanobis distances if `raw_values`
+            is True. By default (``raw_values=True``), it is equal
             to the cubic root of the shifted Mahalanobis distances.
             In that case, the threshold for being an outlier is 0, which
             ensures a compatibility with other outlier detection tools
             such as the One-Class SVM.
 
         """
-        X_centered = X - self.location_
-        mahal_dist = self.mahalanobis(X_centered)
-        if raw_mahalanobis:
+        mahal_dist = self.mahalanobis(X)
+        if raw_values:
             decision = mahal_dist
         else:
             if self.threshold is None:
@@ -95,7 +94,7 @@ class OutlierDetectionMixin(ClassifierMixin):
             raise Exception("Please fit data before predicting")
         is_inlier = -np.ones(X.shape[0], dtype=int)
         if self.contamination is not None:
-            values = self.decision_function(X, raw_mahalanobis=True)
+            values = self.decision_function(X, raw_values=True)
             is_inlier[values <= self.threshold] = 1
         else:
             raise NotImplemented("You must provide a contamination rate.")

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -173,10 +173,8 @@ class EllipticEnvelope(OutlierDetectionMixin, MinCovDet):
         """
         """
         MinCovDet.fit(self, X)
-        X_centered = X - self.location_
-        values = self.mahalanobis(X_centered)
         self.threshold = sp.stats.scoreatpercentile(
-            values, 100. * (1. - self.contamination))
+            self.dist_, 100. * (1. - self.contamination))
 
         return self
 

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -119,6 +119,12 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
     previous_dist = dist
     dist = (np.dot(X - location, linalg.pinv(covariance)) \
                 * (X - location)).sum(axis=1)
+    # Catch computation errors
+    if np.isinf(det):
+        raise ValueError(
+            "Singular covariance matrix. "
+            "Please check that the covariance matrix corresponding "
+            "to the dataset is full rank.")
     # Check convergence
     if np.allclose(det, previous_det):
         # c_step procedure converged
@@ -523,6 +529,10 @@ class MinCovDet(EmpiricalCovariance):
         """
         self.random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
+        # check that the empirical covariance is full rank
+        if (linalg.svdvals(np.dot(X.T, X)) > 1e-8).sum() != n_features:
+            warnings.warn("The covariance matrix associated to your dataset " \
+                              "is not full rank")
         # compute and store raw estimates
         raw_location, raw_covariance, raw_support, raw_dist = fast_mcd(
                 X, support_fraction=self.support_fraction,

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -116,26 +116,29 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         # update remaining iterations for early stopping
         remaining_iterations -= 1
 
+    previous_dist = dist
+    dist = (np.dot(X - location, linalg.pinv(covariance)) \
+                * (X - location)).sum(axis=1)
     # Check convergence
     if np.allclose(det, previous_det):
         # c_step procedure converged
         if verbose:
             print "Optimal couple (location, covariance) found before" \
                 "ending iterations (%d left)" % (remaining_iterations)
-        results = location, covariance, det, support
+        results = location, covariance, det, support, dist
     elif det > previous_det:
         # determinant has increased (should not happen)
         warnings.warn("Warning! det > previous_det (%.15f > %.15f)" \
                           % (det, previous_det), RuntimeWarning)
         results = previous_location, previous_covariance, \
-            previous_det, previous_support
+            previous_det, previous_support, previous_dist
 
     # Check early stopping
     if remaining_iterations == 0:
         if verbose:
             print 'Maximum number of iterations reached'
         det = fast_logdet(covariance)
-        results = location, covariance, det, support
+        results = location, covariance, det, support, dist
 
     return results
 
@@ -235,15 +238,16 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
                     initial_estimates=initial_estimates, verbose=verbose,
                     cov_computation_method=cov_computation_method,
                     random_state=random_state))
-    all_locations_sub, all_covariances_sub, all_dets_sub, all_supports_sub = \
-                                     zip(*all_estimates)
+    all_locs_sub, all_covs_sub, all_dets_sub, all_supports_sub, all_ds_sub = \
+        zip(*all_estimates)
     # find the `n_best` best results among the `n_trials` ones
     index_best = np.argsort(all_dets_sub)[:select]
-    best_locations = np.asarray(all_locations_sub)[index_best]
-    best_covariances = np.asarray(all_covariances_sub)[index_best]
+    best_locations = np.asarray(all_locs_sub)[index_best]
+    best_covariances = np.asarray(all_covs_sub)[index_best]
     best_supports = np.asarray(all_supports_sub)[index_best]
+    best_ds = np.asarray(all_ds_sub)[index_best]
 
-    return best_locations, best_covariances, best_supports
+    return best_locations, best_covariances, best_supports, best_ds
 
 
 def fast_mcd(X, support_fraction=None,
@@ -329,9 +333,12 @@ def fast_mcd(X, support_fraction=None,
         location = 0.5 * (X_sorted[n_support + halves_start]
                           + X_sorted[halves_start]).mean()
         support = np.zeros(n_samples).astype(bool)
+        X_centered = X - location
         support[np.argsort(np.abs(X - location), axis=0)[:n_support]] = True
         covariance = np.asarray([[np.var(X[support])]])
         location = np.array([location])
+        dist = (np.dot(X_centered, linalg.pinv(covariance)) \
+                    * (X_centered)).sum(axis=1)
 
     ### Starting FastMCD algorithm for p-dimensional case
     if (n_samples > 500) and (n_features > 1):
@@ -353,7 +360,7 @@ def fast_mcd(X, support_fraction=None,
             low_bound = i * n_samples_subsets
             high_bound = low_bound + n_samples_subsets
             current_subset = X[samples_shuffle[low_bound:high_bound]]
-            best_locations_sub, best_covariances_sub, _ = select_candidates(
+            best_locations_sub, best_covariances_sub, _, _ = select_candidates(
                 current_subset, h_subset, n_trials,
                 select=n_best_sub, n_iter=2,
                 cov_computation_method=cov_computation_method,
@@ -370,10 +377,11 @@ def fast_mcd(X, support_fraction=None,
         else:
             n_best_merged = 1
         # find the best couples (location, covariance) on the merged set
-        locations_merged, covariances_merged, supports_merged = \
+        selection = random_state.permutation(n_samples)[:n_samples_merged]
+        locations_merged, covariances_merged, supports_merged, d = \
             select_candidates(
-                X[random_state.permutation(n_samples)[:n_samples_merged]],
-                h_merged, n_trials=(all_best_locations, all_best_covariances),
+                X[selection], h_merged,
+                n_trials=(all_best_locations, all_best_covariances),
                 select=n_best_merged,
                 cov_computation_method=cov_computation_method,
                 random_state=random_state)
@@ -382,10 +390,13 @@ def fast_mcd(X, support_fraction=None,
             # directly get the best couple (location, covariance)
             location = locations_merged[0]
             covariance = covariances_merged[0]
-            support = supports_merged[0]
+            support = np.zeros(n_samples, dtype=bool)
+            dist = np.zeros(n_samples)
+            support[selection] = supports_merged[0]
+            dist[selection] = d[0]
         else:
             # select the best couple on the full dataset
-            locations_full, covariances_full, supports_full = \
+            locations_full, covariances_full, supports_full, d = \
                 select_candidates(
                     X, n_support,
                     n_trials=(locations_merged, covariances_merged),
@@ -395,25 +406,27 @@ def fast_mcd(X, support_fraction=None,
             location = locations_full[0]
             covariance = covariances_full[0]
             support = supports_full[0]
+            dist = d[0]
     elif n_features > 1:
         ## 1. Find the 10 best couples (location, covariance)
         ## considering two iterations
         n_trials = 30
         n_best = 10
-        locations_best, covariances_best, _ = select_candidates(
+        locations_best, covariances_best, _, _ = select_candidates(
             X, n_support, n_trials=n_trials, select=n_best, n_iter=2,
             cov_computation_method=cov_computation_method,
             random_state=random_state)
         ## 2. Select the best couple on the full dataset amongst the 10
-        locations_full, covariances_full, supports_full = select_candidates(
+        locations_full, covariances_full, supports_full, d = select_candidates(
             X, n_support, n_trials=(locations_best, covariances_best),
             select=1, cov_computation_method=cov_computation_method,
             random_state=random_state)
         location = locations_full[0]
         covariance = covariances_full[0]
         support = supports_full[0]
+        dist = d[0]
 
-    return location, covariance, support
+    return location, covariance, support, dist
 
 
 class MinCovDet(EmpiricalCovariance):
@@ -467,6 +480,10 @@ class MinCovDet(EmpiricalCovariance):
         A mask of the observations that have been used to compute
         the robust estimates of location and shape.
 
+    `dist_`: array-like, shape (n_samples,)
+        Mahalanobis distances of the training set (on which `fit` is called)
+        observations.
+
     References
     ----------
 
@@ -507,7 +524,7 @@ class MinCovDet(EmpiricalCovariance):
         self.random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # compute and store raw estimates
-        raw_location, raw_covariance, raw_support = fast_mcd(
+        raw_location, raw_covariance, raw_support, raw_dist = fast_mcd(
                 X, support_fraction=self.support_fraction,
                 cov_computation_method=self._nonrobust_covariance,
                 random_state=self.random_state)
@@ -515,11 +532,13 @@ class MinCovDet(EmpiricalCovariance):
             raw_location = np.zeros(n_features)
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
+            raw_dist = np.sum(np.dot(X, linalg.pinv(raw_covariance)) * X, 1)
         self.raw_location_ = raw_location
         self.raw_covariance_ = raw_covariance
         self.raw_support_ = raw_support
         self.location_ = raw_location
         self.support_ = raw_support
+        self.dist_ = raw_dist
         # obtain consistency at normal models
         self.correct_covariance(X)
         # reweight estimator
@@ -546,13 +565,9 @@ class MinCovDet(EmpiricalCovariance):
           Corrected robust covariance estimate.
 
         """
-        X_centered = data - self.raw_location_
-        dist = np.sum(
-            np.dot(X_centered, linalg.pinv(self.raw_covariance_)) * X_centered,
-            1)
-        correction = np.median(dist) / chi2(data.shape[1]).isf(0.5)
+        correction = np.median(self.dist_) / chi2(data.shape[1]).isf(0.5)
         covariance_corrected = self.raw_covariance_ * correction
-        self._set_estimates(covariance_corrected)
+        self.dist_ /= correction
         return covariance_corrected
 
     def reweight_covariance(self, data):
@@ -581,16 +596,7 @@ class MinCovDet(EmpiricalCovariance):
 
         """
         n_samples, n_features = data.shape
-        X_centered = data - self.location_
-        if self.store_precision:
-            precision = self.precision_
-        else:
-            precision = linalg.pinv(self.covariance_)
-
-        dist = np.sum(
-            np.dot(X_centered, precision) * X_centered,
-            1)
-        mask = dist < chi2(n_features).isf(0.025)
+        mask = self.dist_ < chi2(n_features).isf(0.025)
         if self.assume_centered:
             location_reweighted = np.zeros(n_features)
         else:
@@ -602,4 +608,7 @@ class MinCovDet(EmpiricalCovariance):
         self._set_estimates(covariance_reweighted)
         self.location_ = location_reweighted
         self.support_ = support_reweighted
+        X_centered = data - self.location_
+        self.dist_ = np.sum(
+            np.dot(X_centered, self.get_precision()) * X_centered, 1)
         return location_reweighted, covariance_reweighted, support_reweighted

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -96,11 +96,13 @@ class ShrunkCovariance(EmpiricalCovariance):
     where mu = trace(cov) / n_features
 
     """
-    def __init__(self, store_precision=True, shrinkage=0.1):
-        self.store_precision = store_precision
+    def __init__(self, store_precision=True, assume_centered=False,
+                 shrinkage=0.1):
+        EmpiricalCovariance.__init__(self, store_precision=store_precision,
+                                     assume_centered=assume_centered)
         self.shrinkage = shrinkage
 
-    def fit(self, X, assume_centered=False):
+    def fit(self, X):
         """ Fits the shrunk covariance model
         according to the given training data and parameters.
 
@@ -122,9 +124,8 @@ class ShrunkCovariance(EmpiricalCovariance):
             Returns self.
 
         """
-        empirical_cov = empirical_covariance(
-            X, assume_centered=assume_centered)
-        covariance = shrunk_covariance(empirical_cov, self.shrinkage)
+        EmpiricalCovariance.fit(self, X)
+        covariance = shrunk_covariance(self.covariance_, self.shrinkage)
         self._set_estimates(covariance)
 
         return self
@@ -307,12 +308,17 @@ class LedoitWolf(EmpiricalCovariance):
     ----------
     store_precision : bool
         Specify if the estimated precision is stored
+    assume_centered: bool
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False (default), data are centered before computation.
     block_size: int,
-      Size of the blocks into which the covariance matrix will be split
-      during its Ledoit-Wolf estimation.
-      If n_features > `block_size`, an error will be raised since the
-      shrunk covariance matrix will be considered as too large regarding
-      the available memory.
+        Size of the blocks into which the covariance matrix will be split
+        during its Ledoit-Wolf estimation.
+        If n_features > `block_size`, an error will be raised since the
+        shrunk covariance matrix will be considered as too large regarding
+        the available memory.
 
     Attributes
     ----------
@@ -344,11 +350,13 @@ class LedoitWolf(EmpiricalCovariance):
     February 2004, pages 365-411.
 
     """
-    def __init__(self, store_precision=True, block_size=1000):
-        EmpiricalCovariance.__init__(self, store_precision=store_precision)
+    def __init__(self, store_precision=True, assume_centered=False,
+                 block_size=1000):
+        EmpiricalCovariance.__init__(self, store_precision=store_precision,
+                                     assume_centered=assume_centered)
         self.block_size = block_size
 
-    def fit(self, X, assume_centered=False):
+    def fit(self, X):
         """ Fits the Ledoit-Wolf shrunk covariance model
         according to the given training data and parameters.
 
@@ -358,12 +366,6 @@ class LedoitWolf(EmpiricalCovariance):
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
 
-        assume_centered: Boolean
-          If True, data are not centered before computation.
-          Usefull to work with data whose mean is significantly equal to
-          zero but is not exactly zero.
-          If False, data are centered before computation.
-
         Returns
         -------
         self : object
@@ -371,8 +373,10 @@ class LedoitWolf(EmpiricalCovariance):
 
         """
         # only return the shrunk covariance if it is not too big
+        EmpiricalCovariance.fit(self, X)
         covariance, shrinkage = ledoit_wolf(
-            X, assume_centered=assume_centered, block_size=self.block_size)
+            X - self.location_, assume_centered=True,
+            block_size=self.block_size)
         self.shrinkage_ = shrinkage
         self._set_estimates(covariance)
 
@@ -388,13 +392,13 @@ def oas(X, assume_centered=False):
     Parameters
     ----------
     X: array-like, shape (n_samples, n_features)
-      Data from which to compute the covariance estimate
+        Data from which to compute the covariance estimate
 
     assume_centered: boolean
-      If True, data are not centered before computation.
-      Usefull to work with data whose mean is significantly equal to
-      zero but is not exactly zero.
-      If False, data are centered before computation.
+        If True, data are not centered before computation.
+        Usefull to work with data whose mean is significantly equal to
+        zero but is not exactly zero.
+        If False, data are centered before computation.
 
     Returns
     -------
@@ -460,7 +464,12 @@ class OAS(EmpiricalCovariance):
     Parameters
     ----------
     store_precision : bool
-        Specify if the estimated precision is stored
+        Specify if the estimated precision is stored.
+    assume_centered: bool
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False (default), data are centered before computation.
 
     Attributes
     ----------
@@ -491,7 +500,7 @@ class OAS(EmpiricalCovariance):
     Chen et al., IEEE Trans. on Sign. Proc., Volume 58, Issue 10, October 2010.
 
     """
-    def fit(self, X, assume_centered=False):
+    def fit(self, X):
         """ Fits the Oracle Approximating Shrinkage covariance model
         according to the given training data and parameters.
 
@@ -501,19 +510,14 @@ class OAS(EmpiricalCovariance):
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
 
-        assume_centered: boolean
-          If True, data are not centered before computation.
-          Usefull to work with data whose mean is significantly equal to
-          zero but is not exactly zero.
-          If False, data are centered before computation.
-
         Returns
         -------
         self : object
             Returns self.
 
         """
-        covariance, shrinkage = oas(X, assume_centered=assume_centered)
+        EmpiricalCovariance.fit(self, X)
+        covariance, shrinkage = oas(X - self.location_, assume_centered=True)
         self.shrinkage_ = shrinkage
         self._set_estimates(covariance)
 

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -35,7 +35,7 @@ def test_covariance():
     assert_almost_equal(
         cov.error_norm(empirical_covariance(X), squared=False), 0)
     # Mahalanobis distances computation test
-    mahal_dist = cov.mahalanobis(X)
+    mahal_dist = cov.mahalanobis(X, assume_centered=True)
     assert(np.amax(mahal_dist) < 250)
     assert(np.amin(mahal_dist) > 50)
 

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from sklearn import datasets
 from sklearn.covariance import empirical_covariance, EmpiricalCovariance, \
-    ShrunkCovariance, shrunk_covariance, LedoitWolf, ledoit_wolf, OAS, oas
+    ShrunkCovariance, shrunk_covariance, \
+    LedoitWolf, ledoit_wolf, ledoit_wolf_shrinkage, OAS, oas
 
 X = datasets.load_iris().data
 X_1d = X[:, 0]
@@ -97,6 +98,9 @@ def test_ledoit_wolf():
     lw.fit(X, assume_centered=True)
     assert_almost_equal(lw.shrinkage_, 0.00192, 4)
     assert_almost_equal(lw.score(X, assume_centered=True), -2.89795, 4)
+    assert_almost_equal(lw.shrinkage_,
+                        ledoit_wolf_shrinkage(X, assume_centered=True))
+    assert_almost_equal(lw.shrinkage_, ledoit_wolf(X, assume_centered=True)[1])
     # compare shrunk covariance obtained from data and from MLE estimate
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X,
                                                         assume_centered=True)
@@ -128,6 +132,8 @@ def test_ledoit_wolf():
     lw = LedoitWolf()
     lw.fit(X)
     assert_almost_equal(lw.shrinkage_, 0.007582, 4)
+    assert_almost_equal(lw.shrinkage_, ledoit_wolf_shrinkage(X))
+    assert_almost_equal(lw.shrinkage_, ledoit_wolf(X)[1])
     assert_almost_equal(lw.score(X), 2.243483, 4)
     # compare shrunk covariance obtained from data and from MLE estimate
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X)

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -36,9 +36,10 @@ def test_covariance():
     assert_almost_equal(
         cov.error_norm(empirical_covariance(X), squared=False), 0)
     # Mahalanobis distances computation test
-    mahal_dist = cov.mahalanobis(X, assume_centered=True)
-    assert(np.amax(mahal_dist) < 250)
-    assert(np.amin(mahal_dist) > 50)
+    mahal_dist = cov.mahalanobis(X)
+    print np.amin(mahal_dist), np.amax(mahal_dist)
+    assert(np.amax(mahal_dist) < 20)
+    assert(np.amin(mahal_dist) > 0)
 
     # test with n_features = 1
     X_1d = X[:, 0].reshape((-1, 1))
@@ -94,27 +95,26 @@ def test_ledoit_wolf():
 
     """
     # test shrinkage coeff on a simple data set
-    lw = LedoitWolf()
-    lw.fit(X, assume_centered=True)
+    lw = LedoitWolf(assume_centered=True)
+    lw.fit(X)
     assert_almost_equal(lw.shrinkage_, 0.00192, 4)
-    assert_almost_equal(lw.score(X, assume_centered=True), -2.89795, 4)
+    assert_almost_equal(lw.score(X), -2.89795, 4)
     assert_almost_equal(lw.shrinkage_,
                         ledoit_wolf_shrinkage(X, assume_centered=True))
-    assert_almost_equal(lw.shrinkage_, ledoit_wolf(X, assume_centered=True)[1])
     # compare shrunk covariance obtained from data and from MLE estimate
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X,
                                                         assume_centered=True)
     assert_array_almost_equal(lw_cov_from_mle, lw.covariance_, 4)
     assert_almost_equal(lw_shinkrage_from_mle, lw.shrinkage_)
     # compare estimates given by LW and ShrunkCovariance
-    scov = ShrunkCovariance(shrinkage=lw.shrinkage_)
-    scov.fit(X, assume_centered=True)
+    scov = ShrunkCovariance(shrinkage=lw.shrinkage_, assume_centered=True)
+    scov.fit(X)
     assert_array_almost_equal(scov.covariance_, lw.covariance_, 4)
 
     # test with n_features = 1
     X_1d = X[:, 0].reshape((-1, 1))
-    lw = LedoitWolf()
-    lw.fit(X_1d, assume_centered=True)
+    lw = LedoitWolf(assume_centered=True)
+    lw.fit(X_1d)
     lw_cov_from_mle, lw_shinkrage_from_mle = ledoit_wolf(X_1d,
                                                          assume_centered=True)
     assert_array_almost_equal(lw_cov_from_mle, lw.covariance_, 4)
@@ -122,9 +122,9 @@ def test_ledoit_wolf():
     assert_array_almost_equal((X_1d ** 2).sum() / n_samples, lw.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
-    lw = LedoitWolf(store_precision=False)
-    lw.fit(X, assume_centered=True)
-    assert_almost_equal(lw.score(X, assume_centered=True), -2.89795, 4)
+    lw = LedoitWolf(store_precision=False, assume_centered=True)
+    lw.fit(X)
+    assert_almost_equal(lw.score(X), -2.89795, 4)
     assert(lw.precision_ is None)
 
     # Same tests without assuming centered data
@@ -165,32 +165,32 @@ def test_oas():
 
     """
     # test shrinkage coeff on a simple data set
-    oa = OAS()
-    oa.fit(X, assume_centered=True)
+    oa = OAS(assume_centered=True)
+    oa.fit(X)
     assert_almost_equal(oa.shrinkage_, 0.018740, 4)
-    assert_almost_equal(oa.score(X, assume_centered=True), -5.03605, 4)
+    assert_almost_equal(oa.score(X), -5.03605, 4)
     # compare shrunk covariance obtained from data and from MLE estimate
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X, assume_centered=True)
     assert_array_almost_equal(oa_cov_from_mle, oa.covariance_, 4)
     assert_almost_equal(oa_shinkrage_from_mle, oa.shrinkage_)
     # compare estimates given by OAS and ShrunkCovariance
-    scov = ShrunkCovariance(shrinkage=oa.shrinkage_)
-    scov.fit(X, assume_centered=True)
+    scov = ShrunkCovariance(shrinkage=oa.shrinkage_, assume_centered=True)
+    scov.fit(X)
     assert_array_almost_equal(scov.covariance_, oa.covariance_, 4)
 
     # test with n_features = 1
     X_1d = X[:, 0].reshape((-1, 1))
-    oa = OAS()
-    oa.fit(X_1d, assume_centered=True)
+    oa = OAS(assume_centered=True)
+    oa.fit(X_1d)
     oa_cov_from_mle, oa_shinkrage_from_mle = oas(X_1d, assume_centered=True)
     assert_array_almost_equal(oa_cov_from_mle, oa.covariance_, 4)
     assert_almost_equal(oa_shinkrage_from_mle, oa.shrinkage_)
     assert_array_almost_equal((X_1d ** 2).sum() / n_samples, oa.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
-    oa = OAS(store_precision=False)
-    oa.fit(X, assume_centered=True)
-    assert_almost_equal(oa.score(X, assume_centered=True), -5.03605, 4)
+    oa = OAS(store_precision=False, assume_centered=True)
+    oa.fit(X)
+    assert_almost_equal(oa.score(X), -5.03605, 4)
     assert(oa.precision_ is None)
 
     ### Same tests without assuming centered data

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -79,7 +79,7 @@ def test_outlier_detection():
     y_pred = clf.predict(X)
 
     assert_array_almost_equal(
-        clf.decision_function(X, raw_mahalanobis=True),
-        clf.mahalanobis(X - clf.location_))
+        clf.decision_function(X, raw_values=True),
+        clf.mahalanobis(X))
     assert_almost_equal(clf.score(X, np.ones(100)),
                         (100 - y_pred[y_pred == -1].size) / 100.)

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -30,10 +30,10 @@ def test_mcd():
     launch_mcd_on_dataset(100, 5, 40, 0.1, 0.1, 50)
 
     ### Medium data set
-    launch_mcd_on_dataset(1000, 5, 450, 1e-3, 1e-3, 540)
+    launch_mcd_on_dataset(1000, 5, 450, 0.1, 0.1, 540)
 
     ### Large data set
-    launch_mcd_on_dataset(1700, 5, 800, 1e-3, 1e-3, 870)
+    launch_mcd_on_dataset(1700, 5, 800, 0.1, 0.1, 870)
 
     ### 1D data set
     launch_mcd_on_dataset(500, 1, 100, 0.001, 0.001, 350)
@@ -66,6 +66,7 @@ def launch_mcd_on_dataset(
     error_cov = np.mean((empirical_covariance(pure_data) - S) ** 2)
     assert(error_cov < tol_cov)
     assert(np.sum(H) >= tol_support)
+    assert_array_almost_equal(mcd_fit.mahalanobis(data), mcd_fit.dist_)
 
 
 def test_outlier_detection():
@@ -79,7 +80,7 @@ def test_outlier_detection():
     y_pred = clf.predict(X)
 
     assert_array_almost_equal(
-        clf.decision_function(X, raw_values=True),
-        clf.mahalanobis(X))
+        clf.decision_function(X, raw_values=True), clf.mahalanobis(X))
+    assert_array_almost_equal(clf.mahalanobis(X), clf.dist_)
     assert_almost_equal(clf.score(X, np.ones(100)),
                         (100 - y_pred[y_pred == -1].size) / 100.)


### PR DESCRIPTION
LedoitWolf shrinkage estimation with large number of features does not create memory troubles again.

The construction of empirical covariance matrices is avoided by performing the computation with blocks.
As a consequence, the `ledoit_wolf` method will not always be able to return the shrunk covariance matrix (because it does not fit in memory) and will return None instead. The maximum size of a memory-allowed covariance matrix is controled by a new parameter of the `ledoit-wolf` method.

I tested up to n_features = 100,000 on my laptop, using a block size of 1000 and 1000 observations. No memory usage increase was observed while I could barely reach 10,000 features x 1,000 observations before on the same computer.
