### PR TITLE
Ward clustering fails if connectivity is not item assignable and there is more than one component

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -76,15 +76,16 @@ def ward_tree(X, connectivity=None, n_components=None, copy=True):
         children_ = out[:, :2].astype(np.int)
         return children_, 1, n_samples
 
-    # convert connectivity matrix to LIL eventually with a copy
+    # Compute the number of nodes
+    if n_components is None:
+        n_components, labels = cs_graph_components(connectivity)
+
+    # Convert connectivity matrix to LIL with a copy if needed
     if sparse.isspmatrix_lil(connectivity) and copy:
         connectivity = connectivity.copy()
     else:
         connectivity = connectivity.tolil()
 
-    # Compute the number of nodes
-    if n_components is None:
-        n_components, labels = cs_graph_components(connectivity)
     if n_components > 1:
         warnings.warn("the number of connected components of the"
         " connectivity matrix is %d > 1. Completing it to avoid"

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -137,7 +137,7 @@ def test_connectivity_popagation():
     ward.fit(X)
 
 
-def test_connectivity_fixing_bug():
+def test_connectivity_fixing_non_lil():
     """
     Check non regression of a bug if a non item assignable connectivity is
     provided with more than one component.

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -136,6 +136,21 @@ def test_connectivity_popagation():
     # IndexError
     ward.fit(X)
 
+
+def test_connectivity_fixing_bug():
+    """
+    Check non regression of a bug if a non item assignable connectivity is
+    provided with more than one component.
+    """
+    # create dummy data
+    x = np.array([[0, 0], [1, 1]])
+    # create a mask with several components to force connectivity fixing
+    m = np.array([[True, False], [False, True]])
+    c = grid_to_graph(n_x=2, n_y=2, mask=m)
+    w = Ward(connectivity=c)
+    w.fit(x)
+
+
 if __name__ == '__main__':
     import nose
     nose.run(argv=['', __file__])


### PR DESCRIPTION
In the ward, prior to launch the algorithm itself, the number of components of the connectivity matrix is checked and if there is more than one, _fix_connectivty is called to join them inplace.

The problem is raised if the connectivity matrix does not support item assignment like coo matrix. It is necessary to transform it into a lil matrix before, so I have put the copy of the matrix before component checking. I have also put apart the non-connected case for the sake of clarity.
