### PR TITLE
MRG support opening compressed files in SVMlight reader

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,9 @@ Changelog
      predictions with the modified huber loss in :ref:`sgd`, by
      `Mathieu Blondel`_.
 
+   - SVMlight file format loader now detects compressed (gzip/bzip2) files and
+     decompresses them on the fly.
+
 .. _changes_0_11:
 
 0.11

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -15,8 +15,14 @@ libsvm command line programs.
 #          Olivier Grisel <olivier.grisel@ensta.org>
 # License: Simple BSD.
 
+from bz2 import BZ2File
+from contextlib import closing
+import gzip
+import os.path
+
 import numpy as np
 import scipy.sparse as sp
+
 from ._svmlight_format import _load_svmlight_file
 
 
@@ -85,10 +91,26 @@ def load_svmlight_file(f, n_features=None, dtype=np.float64,
                                      zero_based))
 
 
+def _gen_open(f):
+    if isinstance(f, int):  # file descriptor, supported in Python 3
+        return open(f, "rb")
+    elif not isinstance(f, basestring):
+        raise TypeError("expected {str, int, file-like}, got %s" % type(f))
+
+    _, ext = os.path.splitext(f)
+    if ext == ".gz":
+        return gzip.open(f, "rb")
+    elif ext == ".bz2":
+        return BZ2File(f, "rb")
+    else:
+        return open(f, "rb")
+
+
 def _open_and_load(f, dtype, multilabel, zero_based):
     if hasattr(f, "read"):
         return _load_svmlight_file(f, dtype, multilabel, zero_based)
-    with open(f, "rb") as f:
+    # XXX remove closing when Python 2.7+/3.1+ required
+    with closing(_gen_open(f)) as f:
         return _load_svmlight_file(f, dtype, multilabel, zero_based)
 
 

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -1,6 +1,10 @@
+from bz2 import BZ2File
+import gzip
+from io import BytesIO
 import numpy as np
 import os.path
-from io import BytesIO
+import shutil
+import tempfile
 
 from numpy.testing import assert_equal, assert_array_equal
 from nose.tools import raises
@@ -78,6 +82,28 @@ def test_load_svmlight_file_n_features():
                      (1, 5, 1.0), (1, 12, -3)):
 
         assert_equal(X[i, j], val)
+
+
+def test_load_compressed():
+    X, y = load_svmlight_file(datafile)
+
+    try:
+        tempdir = tempfile.mkdtemp(prefix="sklearn-test")
+
+        tmpgz = os.path.join(tempdir, "datafile.gz")
+        shutil.copyfileobj(open(datafile, "rb"), gzip.open(tmpgz, "wb"))
+        Xgz, ygz = load_svmlight_file(tmpgz)
+        assert_array_equal(X.toarray(), Xgz.toarray())
+        assert_array_equal(y, ygz)
+
+        tmpbz = os.path.join(tempdir, "datafile.bz2")
+        shutil.copyfileobj(open(datafile, "rb"), BZ2File(tmpbz, "wb"))
+        Xbz, ybz = load_svmlight_file(tmpgz)
+        assert_array_equal(X.toarray(), Xbz.toarray())
+        assert_array_equal(y, ybz)
+    except:
+        shutil.rmtree(tempdir)
+        raise
 
 
 @raises(ValueError)


### PR DESCRIPTION
Compressed file support for the SVMlight/LibSVM reader; supports gzip and bzip2. Many (all?) of the [datasets](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/) distributed by LibSVM's authors are compressed with bzip2.

If there are other places where compressed file support is useful, then the `_gen_open` function might be moved to `utils`.
