### PR TITLE
FIX renamed what was `components_` to `sources_`

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -334,8 +334,10 @@ class FastICA(BaseEstimator):
 
     Attributes
     ----------
-    `components_` : 2D array, [n_components, n_samples]
+    `components_` : 2D array, [n_components, n_features]
         The unmixing matrix
+    `sources_`: 2D array, [n_samples, n_components]
+        The estimated latent sources of the data.
 
     Notes
     -----
@@ -372,7 +374,7 @@ class FastICA(BaseEstimator):
             self.components_ = np.dot(unmixing_, whitening_)
         else:
             self.components_ = unmixing_
-        self.components_ = sources_
+        self.sources_ = sources_
         return self
 
     def transform(self, X):


### PR DESCRIPTION
This PR fixes a bug I introduced in 02d1d85566bd8b6a35bc744d25b7b3a797f6a364.
There was already an undocumented attribute named `components_` that contained the sources.

This broke the whole thing.
Interestingly none of the tests found that, only noticed it through an example.

Should I add another warning that the meaning of `components_` changed?

That would be a warning that would be issued every time FastICA is used, though, as `components_`
is used internally. This would be quite ugly.

Any idea on how to add tests that would have got that?
