### PR TITLE
MRG: enh in OvR, use constant predictor if one class always present or never.

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -20,6 +20,7 @@ improves.
 # License: BSD Style.
 
 import numpy as np
+import warnings
 
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MetaEstimatorMixin
@@ -32,7 +33,9 @@ def _fit_binary(estimator, X, y):
     """Fit a single binary estimator."""
     unique_y = np.unique(y)
     if len(unique_y) == 1:
-        estimator = ConstantPredictor().fit(X, unique_y)
+        warnings.warn("Label %s is present in all training examples." %
+                str(unique_y))
+        estimator = _ConstantPredictor().fit(X, unique_y)
     else:
         estimator = clone(estimator)
         print(X, y)
@@ -76,16 +79,16 @@ def predict_ovr(estimators, label_binarizer, X):
     return label_binarizer.inverse_transform(Y.T, threshold=thresh)
 
 
-class ConstantPredictor(BaseEstimator):
+class _ConstantPredictor(BaseEstimator):
     def fit(self, X, y):
         self.y_ = y
         return self
 
     def predict(self, X):
-        return self.y_ * np.ones(X.shape[0])
+        return np.repeat(self.y_, X.shape[0])
 
     def decision_function(self, X):
-        return self.y_ * np.ones(X.shape[0])
+        return np.repeat(self.y_, X.shape[0])
 
 
 class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -30,8 +30,13 @@ from .utils import check_random_state
 
 def _fit_binary(estimator, X, y):
     """Fit a single binary estimator."""
-    estimator = clone(estimator)
-    estimator.fit(X, y)
+    unique_y = np.unique(y)
+    if len(unique_y) == 1:
+        estimator = ConstantPredictor().fit(X, unique_y)
+    else:
+        estimator = clone(estimator)
+        print(X, y)
+        estimator.fit(X, y)
     return estimator
 
 
@@ -69,6 +74,18 @@ def predict_ovr(estimators, label_binarizer, X):
     e = estimators[0]
     thresh = 0 if hasattr(e, "decision_function") and is_classifier(e) else .5
     return label_binarizer.inverse_transform(Y.T, threshold=thresh)
+
+
+class ConstantPredictor(BaseEstimator):
+    def fit(self, X, y):
+        self.y_ = y
+        return self
+
+    def predict(self, X):
+        return self.y_ * np.ones(X.shape[0])
+
+    def decision_function(self, X):
+        return self.y_ * np.ones(X.shape[0])
 
 
 class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import warnings
 
 from numpy.testing import assert_array_equal
 from nose.tools import assert_equal
@@ -76,10 +77,11 @@ def test_ovr_always_present():
     X = np.ones((10, 2))
     X[:5, :] = 0
     y = [[int(i >= 5), 2, 3] for i in xrange(10)]
-    ovr = OneVsRestClassifier(DecisionTreeClassifier())
-    ovr.fit(X, y)
-    y_pred = ovr.predict(X)
-    assert_array_equal(np.array(y_pred), np.array(y))
+    with warnings.catch_warnings(record=True) as w:
+        ovr = OneVsRestClassifier(DecisionTreeClassifier())
+        ovr.fit(X, y)
+        y_pred = ovr.predict(X)
+        assert_array_equal(np.array(y_pred), np.array(y))
 
 
 def test_ovr_multilabel():
@@ -198,18 +200,18 @@ def test_ecoc_exceptions():
 
 def test_ecoc_fit_predict():
     # A classifier which implements decision_function.
-    ecoc = OutputCodeClassifier(LinearSVC(), code_size=2)
+    ecoc = OutputCodeClassifier(LinearSVC(), code_size=2, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 2)
 
     # A classifier which implements predict_proba.
-    ecoc = OutputCodeClassifier(MultinomialNB(), code_size=2)
+    ecoc = OutputCodeClassifier(MultinomialNB(), code_size=2, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 2)
 
 
 def test_ecoc_gridsearch():
-    ecoc = OutputCodeClassifier(LinearSVC())
+    ecoc = OutputCodeClassifier(LinearSVC(), random_state=0)
     Cs = [0.1, 0.5, 0.8]
     cv = GridSearchCV(ecoc, {'estimator__C': Cs})
     cv.fit(iris.data, iris.target)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -71,6 +71,17 @@ def test_ovr_fit_predict():
     assert_true(np.mean(iris.target == pred) >= 0.65)
 
 
+def test_ovr_always_present():
+    # Test that ovr works with classes that are always present or absent
+    X = np.ones((10, 2))
+    X[:5, :] = 0
+    y = [[int(i >= 5), 2, 3] for i in xrange(10)]
+    ovr = OneVsRestClassifier(DecisionTreeClassifier())
+    ovr.fit(X, y)
+    y_pred = ovr.predict(X)
+    assert_array_equal(np.array(y_pred), np.array(y))
+
+
 def test_ovr_multilabel():
     # Toy dataset where features correspond directly to labels.
     X = np.array([[0, 4, 5], [0, 5, 0], [3, 3, 3], [4, 0, 6], [6, 0, 0]])


### PR DESCRIPTION
Closes #559.

This solution seemed easier than working with the matrix produced by LabelBinarizer.
Another possibility would be to modify LabelBinarizer to take care of the issue.

Both issues have their caveats:
this solution:
If someone iterates over the estimators and expects them to be of a certain type, they will run into trouble
(for example if they expect them all to have a coef to find some feature importance).

LabelBinarizer solution:
The number of estimators is unexpected and the mapping between classes and estimators is somewhere hidden in the LabelBinarizer, where the user will probably not suspect it.

Oh and the _trivial_ solution by modifying `fit_ovr` and `predict_ovr` has the same drawbacks as doing it in label binarizer, only it is more ugly.

I'm open to suggestions, though.
