### PR TITLE
fix docstring example in mldata

### DIFF
--- a/sklearn/datasets/mldata.py
+++ b/sklearn/datasets/mldata.py
@@ -85,11 +85,11 @@ def fetch_mldata(dataname, target_name='label', data_name='data',
     >>> print(iris.data[0])
     [-0.555556  0.25     -0.864407 -0.916667]
 
-    Load the 'leukemia' dataset from mldata.org, which respects the
-    sklearn axes convention:
-    >>> leuk = fetch_mldata('leukemia', transpose_data=False)
+    Load the 'leukemia' dataset from mldata.org, which needs to be transposed
+    to respects the sklearn axes convention:
+    >>> leuk = fetch_mldata('leukemia', transpose_data=True)
     >>> print(leuk.data.shape[0])
-    7129
+    72
 
     Load an alternative 'iris' dataset, which has different names for the
     columns:


### PR DESCRIPTION
According to http://mldata.org/repository/data/viewslug/leukemia/
7129 is the number of features and not
samples. It should therefore be ''transpose_data=True'' 

confirmed by :
http://www.inf.ed.ac.uk/teaching/courses/dme/html/datasets0405.html
7129 is the number of genes / features.
