### PR TITLE
MRG Svm sparse/dense cleanup

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -84,7 +84,7 @@ training samples::
     >>> clf = svm.SVC()
     >>> clf.fit(X, Y)  # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
-    gamma=0.5, kernel='rbf', probability=False, shrinking=True, tol=0.001,
+    gamma=0.0, kernel='rbf', probability=False, shrinking=True, tol=0.001,
     verbose=False)
 
 After being fitted, the model can then be used to predict new values::
@@ -123,7 +123,7 @@ classifiers are constructed and each one trains data from two classes::
     >>> clf = svm.SVC()
     >>> clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
     SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3,
-    gamma=1.0, kernel='rbf', probability=False, shrinking=True,
+    gamma=0.0, kernel='rbf', probability=False, shrinking=True,
     tol=0.001, verbose=False)
     >>> dec = clf.decision_function([[1]])
     >>> dec.shape[1] # 4 classes: 4*3/2 = 6
@@ -270,7 +270,7 @@ floating point values instead of integer values::
     >>> clf = svm.SVR()
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
     SVR(C=1.0, cache_size=200, coef0=0.0, degree=3,
-    epsilon=0.1, gamma=0.5, kernel='rbf', probability=False, shrinking=True,
+    epsilon=0.1, gamma=0.0, kernel='rbf', probability=False, shrinking=True,
     tol=0.001, verbose=False)
     >>> clf.predict([[1, 1]])
     array([ 1.5])

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -204,7 +204,7 @@ persistence model, namely `pickle <http://docs.python.org/library/pickle.html>`_
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf.fit(X, y)
-  SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3, gamma=0.25,
+  SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0, degree=3, gamma=0.0,
     kernel='rbf', probability=False, shrinking=True, tol=0.001,
     verbose=False)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -131,10 +131,7 @@ class BaseLibSVM(BaseEstimator):
         else:
             self._sparse = self.sparse
 
-        if self._sparse:
-            X = sp.csr_matrix(X)
-        else:
-            X = np.asarray(X, dtype=np.float64, order='C')
+        X = atleast2d_or_csr(X, dtype=np.float64, order='C')
         y = np.asarray(y, dtype=np.float64, order='C')
 
         if class_weight != None:
@@ -165,8 +162,6 @@ class BaseLibSVM(BaseEstimator):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
-        self.shape_fit_ = X.shape
-
         if (self.kernel in ['poly', 'rbf']) and (self.gamma == 0):
             # if custom gamma is not provided ...
             self._gamma = 1.0 / X.shape[1]
@@ -181,6 +176,8 @@ class BaseLibSVM(BaseEstimator):
         if self.verbose:
             print '[LibSVM]',
         fit(X, y, sample_weight, solver_type, kernel)
+
+        self.shape_fit_ = X.shape
 
         # In binary case, we need to flip the sign of coef, intercept and
         # decision function. Use self._intercept_ internally.

--- a/sklearn/svm/sparse/classes.py
+++ b/sklearn/svm/sparse/classes.py
@@ -97,7 +97,7 @@ class SVR(SparseBaseLibSVM, RegressorMixin):
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = SVR(C=1.0, epsilon=0.2)
     >>> clf.fit(X, y)
-    SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma=0.2,
+    SVR(C=1.0, cache_size=200, coef0=0.0, degree=3, epsilon=0.2, gamma=0.0,
       kernel='rbf', probability=False, shrinking=True, tol=0.001,
       verbose=False)
     """


### PR DESCRIPTION
Inspired by #626 I dug around the SVM code and it seemed to me there was still some cleaning up to do after the implementation merge. Hope this makes it a bit better. Still need to add more tests....

Also, I noticed that having callable kernels in the sparse case seems not to be supported. Is that correct?
Not that our callable kernel option makes much sense at the moment any way ^^
