### PR TITLE
MRG rm deprecated stuff, including the scikits.learn package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include *.rst
 include test.py
-include scikits/__init__.py
 recursive-include doc *
 recursive-include examples *
 recursive-include sklearn *.c *.h *.pyx

--- a/README-py3k.rst
+++ b/README-py3k.rst
@@ -16,7 +16,7 @@ of these is:
 To generate python3 compatible sources for selected modules, run the
 2to3 tool on the module::
 
-    2to3 -wn --no-diffs scikits/learn/$module
+    2to3 -wn --no-diffs sklearn/$module
 
 If you would like to help with porting to python3, please propose
 yourself in the scikit-learn mailing list:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -106,4 +106,4 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 download-data:
-	python -c "from scikits.learn.datasets.lfw import check_fetch_lfw; check_fetch_lfw()"
+	python -c "from sklearn.datasets.lfw import check_fetch_lfw; check_fetch_lfw()"

--- a/doc/datasets/twenty_newsgroups_fixture.py
+++ b/doc/datasets/twenty_newsgroups_fixture.py
@@ -6,7 +6,7 @@ and cached in the past.
 from os.path import exists
 from os.path import join
 from nose import SkipTest
-from scikits.learn.datasets import get_data_home
+from sklearn.datasets import get_data_home
 
 
 def setup_module(module):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,9 @@ Changelog
 API changes summary
 -------------------
 
+   - The old ``scikits.learn`` package has disappeared; all code should import
+     from ``sklearn`` instead, which was introduced in 0.9.
+
    - In :class:`metrics.roc_curve`, the `thresholds` array is now returned
      with it's order reversed, in order to keep it consistent with the order
      of the returned `fpr` and `tpr`.

--- a/scikits/__init__.py
+++ b/scikits/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/scikits/learn/__init__.py
+++ b/scikits/learn/__init__.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn import *
-from sklearn import __version__

--- a/scikits/learn/ball_tree.py
+++ b/scikits/learn/ball_tree.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.neighbors.ball_tree import *

--- a/scikits/learn/base.py
+++ b/scikits/learn/base.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.base import *

--- a/scikits/learn/cluster/__init__.py
+++ b/scikits/learn/cluster/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.cluster import *

--- a/scikits/learn/cross_val.py
+++ b/scikits/learn/cross_val.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.cross_validation import *

--- a/scikits/learn/datasets/__init__.py
+++ b/scikits/learn/datasets/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.datasets import *

--- a/scikits/learn/datasets/base.py
+++ b/scikits/learn/datasets/base.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn is deprecated, please use sklearn')
-from sklearn.datasets.base import *

--- a/scikits/learn/decomposition/__init__.py
+++ b/scikits/learn/decomposition/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.decomposition import *

--- a/scikits/learn/externals/joblib.py
+++ b/scikits/learn/externals/joblib.py
@@ -1,2 +1,0 @@
-from sklearn.externals.joblib import *
-

--- a/scikits/learn/feature_extraction/image.py
+++ b/scikits/learn/feature_extraction/image.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.feature_extraction.image import *
-

--- a/scikits/learn/feature_extraction/text.py
+++ b/scikits/learn/feature_extraction/text.py
@@ -1,5 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.feature_extraction.text import *
-

--- a/scikits/learn/grid_search.py
+++ b/scikits/learn/grid_search.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.grid_search import *

--- a/scikits/learn/label_propagation.py
+++ b/scikits/learn/label_propagation.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.semi_supervised.label_propagation import *

--- a/scikits/learn/lda.py
+++ b/scikits/learn/lda.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.lda import *

--- a/scikits/learn/linear_model/__init__.py
+++ b/scikits/learn/linear_model/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.linear_model import *

--- a/scikits/learn/metrics/__init__.py
+++ b/scikits/learn/metrics/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.metrics import *

--- a/scikits/learn/mixture/__init__.py
+++ b/scikits/learn/mixture/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.mixture import *

--- a/scikits/learn/naive_bayes.py
+++ b/scikits/learn/naive_bayes.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.naive_bayes import *

--- a/scikits/learn/neighbors.py
+++ b/scikits/learn/neighbors.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.neighbors import *

--- a/scikits/learn/pipeline.py
+++ b/scikits/learn/pipeline.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.pipeline import *

--- a/scikits/learn/qda.py
+++ b/scikits/learn/qda.py
@@ -1,3 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated, please use sklearn instead')
-from sklearn.qda import *

--- a/scikits/learn/svm/__init__.py
+++ b/scikits/learn/svm/__init__.py
@@ -1,4 +1,0 @@
-import warnings
-warnings.warn('scikits.learn namespace is deprecated and will be removed in '
-        '0.12, please use sklearn instead')
-from sklearn.svm import *

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,12 @@ def configuration(parent_package='', top_path=None):
         os.remove('MANIFEST')
 
     from numpy.distutils.misc_util import Configuration
-    config = Configuration(None, parent_package, top_path,
-        namespace_packages=['scikits'])
-
-    config.add_subpackage('scikits.learn')
-    config.add_data_files('scikits/__init__.py')
+    config = Configuration(None, parent_package, top_path)
 
     config.add_subpackage('sklearn')
 
     return config
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
According to the deprecation warnings, it's time to get rid of `scikits.learn`. This needs some more testing, and I'd like to get rid of some more old code.
