### PR TITLE
Scaler bugfix

### DIFF
--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -204,7 +204,6 @@ class Scaler(BaseEstimator, TransformerMixin):
             _, var = mean_variance_axis0(X)
             self.std_ = np.sqrt(var)
             self.std_[var == 0.0] = 1.0
-            inplace_csr_column_scale(X, 1 / self.std_)
             return self
         else:
             X = np.asarray(X)

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -146,6 +146,7 @@ def test_scaler_without_centering():
     assert_true(X_csr_scaled_back is not X_csr_scaled)
     assert_array_almost_equal(X_scaled_back, X)
 
+
 def test_scaler_without_copy():
     """Check that Scaler.fit does not change input"""
     rng = np.random.RandomState(42)
@@ -154,13 +155,12 @@ def test_scaler_without_copy():
     X_csr = sp.csr_matrix(X)
 
     X_copy = X.copy()
-    scaler = Scaler(copy=False).fit(X)
+    Scaler(copy=False).fit(X)
     assert_array_equal(X, X_copy)
 
     X_csr_copy = X_csr.copy()
-    assert_array_equal(X_csr.todense(), X_csr_copy.todense())
-    scaler = Scaler(with_mean=False, copy=False).fit(X_csr)
-    assert_array_equal(X_csr.todense(), X_csr_copy.todense())
+    Scaler(with_mean=False, copy=False).fit(X_csr)
+    assert_array_equal(X_csr.toarray(), X_csr_copy.toarray())
 
 
 def test_scale_sparse_with_mean_raise_exception():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -146,6 +146,22 @@ def test_scaler_without_centering():
     assert_true(X_csr_scaled_back is not X_csr_scaled)
     assert_array_almost_equal(X_scaled_back, X)
 
+def test_scaler_without_copy():
+    """Check that Scaler.fit does not change input"""
+    rng = np.random.RandomState(42)
+    X = rng.randn(4, 5)
+    X[:, 0] = 0.0  # first feature is always of zero
+    X_csr = sp.csr_matrix(X)
+
+    X_copy = X.copy()
+    scaler = Scaler(copy=False).fit(X)
+    assert_array_equal(X, X_copy)
+
+    X_csr_copy = X_csr.copy()
+    assert_array_equal(X_csr.todense(), X_csr_copy.todense())
+    scaler = Scaler(with_mean=False, copy=False).fit(X_csr)
+    assert_array_equal(X_csr.todense(), X_csr_copy.todense())
+
 
 def test_scale_sparse_with_mean_raise_exception():
     rng = np.random.RandomState(42)


### PR DESCRIPTION
Here's a new test that fails with the current version:
Scaler(with_mean=False, copy=False).fit(X) changes X if it is sparse - which shouldn't be happening.

The second commit removes the guilty line.

Please review.
