### PR TITLE
roc_curve fix

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,10 @@ Changelog
 API changes summary
 -------------------
 
+   - In :class:`metrics.roc_curve`, the `thresholds` array is now returned
+     with it's order reversed, in order to keep it consitant with the order
+     of the returned `fpr` and `tpr`.
+
    - In :class:`hmm` objects, like :class:`hmm.GaussianHMM`, 
      :class:`hmm.MultinomialHMM`, etc., all parameters must be passed to the 
      object when initialising it and not through ``fit``. Now ``fit`` will 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,7 +27,7 @@ API changes summary
 -------------------
 
    - In :class:`metrics.roc_curve`, the `thresholds` array is now returned
-     with it's order reversed, in order to keep it consitant with the order
+     with it's order reversed, in order to keep it consistent with the order
      of the returned `fpr` and `tpr`.
 
    - In :class:`hmm` objects, like :class:`hmm.GaussianHMM`, 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -172,7 +172,7 @@ def roc_curve(y_true, y_score):
         fpr = np.array([0.0, fpr[0], 1.0])
         tpr = np.array([0.0, tpr[0], 1.0])
 
-    return fpr, tpr, (thresholds[::-1])
+    return fpr, tpr, thresholds[::-1]
 
 
 def auc(x, y):

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -172,7 +172,7 @@ def roc_curve(y_true, y_score):
         fpr = np.array([0.0, fpr[0], 1.0])
         tpr = np.array([0.0, tpr[0], 1.0])
 
-    return fpr, tpr, thresholds
+    return fpr, tpr, (thresholds[::-1])
 
 
 def auc(x, y):

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -103,7 +103,13 @@ def roc_curve(y_true, y_score):
         True Positive Rates
 
     thresholds : array, shape = [>2]
-        Thresholds on y_score used to compute fpr and tpr
+        Thresholds on y_score used to compute fpr and tpr.
+
+        *Note*: Since the thresholds are sorted from low to high values,
+        they are reversed upon returning them to ensure they
+        correspond to both fpr and tpr, which are sorted in reversed order
+        during their calculation.
+        
 
     Examples
     --------

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -91,7 +91,7 @@ def test_roc_returns_consistency():
         p = np.sum(y_true)
         tpr_correct.append(1.0 * tp / p)
 
-    # compare tpr and tpr_correct to see if the thresholds' order was correctq
+    # compare tpr and tpr_correct to see if the thresholds' order was correct
     assert_array_almost_equal(tpr, tpr_correct, decimal=2)
 
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -78,6 +78,22 @@ def test_roc_curve():
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.80, decimal=2)
 
+def test_roc_returns_consistency():
+    """Test whether the returned threshold matches up with tpr"""
+    # make small toy dataset
+    y_true, _, probas_pred = make_prediction(binary=True)
+    fpr, tpr, thresholds = roc_curve(y_true, probas_pred)
+    
+    # use the given thresholds to determine the tpr
+    tpr_correct = []
+    for t in range(len(thresholds)):
+        tp = np.sum((probas_pred >= thresholds[t]) & y_true)
+        p = np.sum(y_true)
+        tpr_correct.append(1.0 * tp / p)
+
+    # compare tpr and tpr_correct to see if the thresholds' order was correctq
+    assert_array_almost_equal(tpr, tpr_correct, decimal=2)
+
 
 @raises(ValueError)
 def test_roc_curve_multi():


### PR DESCRIPTION
Simple fix for problem mentioned in #922

reversed the order of thresholds array.. 
Played around with it a bit and it appears to fix the bug, as suggested by @staigerc

Please let me know if you're fine with how I did this, or if you'd prefer not having
the reversal happen in the return statement. Then I'll change it quick

:v:
