### PR TITLE
DOC: fix value error text in Tree.compute_feature_importances.

### DIFF
--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -406,7 +406,7 @@ class Tree(object):
         else:
             raise ValueError(
                 'Invalid value for method. Allowed string '
-                'values are "gini", or "mse".')
+                'values are "gini", or "squared".')
 
         importances = np.zeros((self.n_features,), dtype=np.float64)
 


### PR DESCRIPTION
See issue #949, this fixes the `ValueError` text to match the code.
