### PR TITLE
COSMIT: Use np.array.fill for scalar values.

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -150,7 +150,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     if cluster_all:
         labels = idxs.flatten()
     else:
-        labels[:] = -1
+        labels.fill(-1)
         bool_selector = distances.flatten() <= bandwidth
         labels[bool_selector] = idxs.flatten()[bool_selector]
     return cluster_centers, labels

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -336,7 +336,7 @@ class CountVectorizer(BaseEstimator):
         spmatrix = sp.coo_matrix((values, (i_indices, j_indices)),
                                  shape=shape, dtype=self.dtype)
         if self.binary:
-            spmatrix.data[:] = 1
+            spmatrix.data.fill(1)
         return spmatrix
 
     def fit(self, raw_documents, y=None):

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -540,9 +540,9 @@ class _BaseHMM(BaseEstimator):
 
     def _init(self, obs, params):
         if 's' in params:
-            self.startprob_[:] = 1.0 / self.n_components
+            self.startprob_.fill(1.0 / self.n_components)
         if 't' in params:
-            self.transmat_[:] = 1.0 / self.n_components
+            self.transmat_.fill(1.0 / self.n_components)
 
     # Methods used by self.fit()
 


### PR DESCRIPTION
In the spirit of 999a749561fef6ba5d65f3d7f01c45f0461c35a6, I modified a few places that used scalar values to use `ndarray.fill(value)`.
