### PR TITLE
MRG: Added test coverage for Spectral Clustering

### DIFF
--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -189,9 +189,6 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None, mode=None,
     labels: array of integers, shape: n_samples
         The labels of the clusters.
 
-    centers: array of integers, shape: k
-        The indices of the cluster centers
-
     References
     ----------
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -68,13 +68,14 @@ def spectral_embedding(adjacency, n_components=8, mode=None,
         amg_loaded = True
     except ImportError:
         amg_loaded = False
+        if mode == "amg":
+            raise ValueError("The mode was set to 'amg', but pyamg is "
+                             "not available.")
 
     random_state = check_random_state(random_state)
 
     n_nodes = adjacency.shape[0]
     # XXX: Should we check that the matrices given is symmetric
-    if not amg_loaded:
-        warnings.warn('pyamg not available, using scipy.sparse')
     if mode is None:
         mode = 'arpack'
     laplacian, dd = graph_laplacian(adjacency,

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -69,6 +69,22 @@ def test_spectral_amg_mode():
                       n_components=len(centers), random_state=0, mode="amg")
 
 
+def test_spectral_unknown_mode():
+    # Test that SpectralClustering fails with an unknown mode set.
+    centers = np.array([
+        [0., 0., 0.],
+        [10., 10., 10.],
+        [20., 20., 20.],
+    ])
+    X, true_labels = make_blobs(n_samples=100, centers=centers,
+                                cluster_std=1., random_state=42)
+    D = pairwise_distances(X)  # Distance matrix
+    S = np.max(D) - D  # Similarity matrix
+    S = sparse.coo_matrix(S)
+    assert_raises(ValueError, spectral_clustering, S, n_clusters=2,
+                  random_state=0, mode="<unknown>")
+
+
 def test_spectral_clustering_sparse():
     # We need a large matrice, or the lobpcg solver will fallback to its
     # non-sparse and buggy mode

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -42,7 +42,7 @@ def test_spectral_clustering():
 def test_spectral_amg_mode():
     # Test the amg mode of SpectralClustering
     centers = np.array([
-        [ 0.,  0.,  0.],
+        [0., 0., 0.],
         [10., 10., 10.],
         [20., 20., 20.],
     ])


### PR DESCRIPTION
Adds a test for the "amg" mode for Spectral Clustering.

All of the uncovered lines in spectral.py are either warnings or code branches if pyamg isn't available.

I wasn't sure about MRG or WIP. Functionally, this works, but I feel like the test can be better written.
