### PR TITLE
MRG corrected warning for always present labels. ugh

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -272,14 +272,14 @@ matrix from a list of multi-class labels::
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])
-    array([[ 1.,  0.,  0.,  0.],
-           [ 0.,  0.,  0.,  1.]])
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 1]])
 
 :class:`LabelBinarizer` also supports multiple labels per instance::
 
     >>> lb.fit_transform([(1, 2), (3,)])
-    array([[ 1.,  1.,  0.],
-           [ 0.,  0.,  1.]])
+    array([[1, 1, 0],
+           [0, 0, 1]])
     >>> lb.classes_
     array([1, 2, 3])
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -33,8 +33,12 @@ def _fit_binary(estimator, X, y, classes):
     """Fit a single binary estimator."""
     unique_y = np.unique(y)
     if len(unique_y) == 1:
+        if y[0] == -1:
+            c = 0
+        else:
+            c = y[0]
         warnings.warn("Label %s is present in all training examples." %
-                str(classes[unique_y[0]]))
+                str(classes[c]))
         estimator = _ConstantPredictor().fit(X, unique_y)
     else:
         estimator = clone(estimator)
@@ -362,7 +366,7 @@ def fit_ecoc(estimator, X, y, code_size=1.5, random_state=None):
             dtype=np.int)
 
     estimators = [_fit_binary(estimator, X, Y[:, i],
-        classes=["not %s" % str(code_book[:, i]), code_book[:, i]])
+        classes=["not ouput code %d" % i, "output code %d" % i])
                   for i in range(Y.shape[1])]
 
     return estimators, classes, code_book

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -728,9 +728,9 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                 # nothing to do as y is already a label indicator matrix
                 return y
 
-            Y = np.zeros((len(y), len(self.classes_)))
+            Y = np.zeros((len(y), len(self.classes_)), dtype=np.int)
         else:
-            Y = np.zeros((len(y), 1))
+            Y = np.zeros((len(y), 1), dtype=np.int)
 
         Y += self.neg_label
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -660,12 +660,12 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])
-    array([[ 1.,  0.,  0.,  0.],
-           [ 0.,  0.,  0.,  1.]])
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 1]])
 
     >>> lb.fit_transform([(1, 2), (3,)])
-    array([[ 1.,  1.,  0.],
-           [ 0.,  0.,  1.]])
+    array([[1, 1, 0],
+           [0, 0, 1]])
     >>> lb.classes_
     array([1, 2, 3])
     """


### PR DESCRIPTION
This corrects the error in the warning that @mbondel pointed out.

It also makes `LabelBinarizer` return `np.int`. I figured that was sensible. Is this ok for everybody?
Should this go into `whatsnew.rst`?

There is one small issue, though, that is a bit weird.
ECOC produces binary labels `[-1, 1]` which means that the error message will always say "label xxx always present`` and never "label not xxx always present".

@mbondel I didn't understand why the ECOC sometimes produces `[0, 1]` and sometimes `[-1, 1]`.
In principal all estimators should be agnostic to what the labels actually are.
