### PR TITLE
DOC: add tutorial links

### DIFF
--- a/doc/tutorial/astronomy/placeholder.txt
+++ b/doc/tutorial/astronomy/placeholder.txt
@@ -1,1 +1,0 @@
-placeholder for later from jakevdp's repo

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -32,7 +32,15 @@ Tutorials: From the bottom up with scikit-learn
 
    statistical_inference/index.rst
 
-.. note:: **Videos**
+.. topic:: **External Tutorials**
+    
+    There are several online tutorials available which are geared toward
+    specific subject areas:
+
+    - `Machine Learning for NeuroImaging in Python <http://nisl.github.com/>`_
+    - `Machine Learning for Astronomical Data Analysis <http://astroml.github.com/sklearn_tutorial/>`_
+
+.. topic:: **Videos**
 
     Videos with tutorials can also be found in the :ref:`videos` section.
 


### PR DESCRIPTION
Small update to the tutorial documentation.
The main reason I'm doing a PR rather than just merging the changes is to find out if people know of other tutorials out there that should be added to the list of links.
