### PR TITLE
feature_extraction.text.CountVectorizer analyzer 'char_nospace'

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -415,6 +415,21 @@ decide better.
   array([[1, 1, 1, 0, 1, 1, 1, 0],
          [1, 1, 0, 1, 1, 1, 0, 1]])
 
+In above example, ``'char_wb`` analyzer is used, which creates n-grams
+only from characters inside word boundaries (padded with space on each
+side). The ``'char'`` analyzer, alternatively, creates n-grams that
+span across words.
+
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', min_n=5, max_n=5)
+  >>> ngram_vectorizer.fit_transform(['jumpy fox'])
+  >>> ngram_vectorizer.vocabulary_.keys()
+  [u' fox ', u' jump', u'umpy ', u'jumpy']
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char', min_n=5, max_n=5)
+  >>> ngram_vectorizer.fit_transform(['jumpy fox'])
+  >>> ngram_vectorizer.vocabulary_.keys()
+  [u'jumpy', u'y fox', u'py fo', u'umpy ', u'mpy f']
+
+
 While some local positioning information can be preserved by extracting
 n-grams instead of individual words, bag of words and bag of n-grams
 destroy most of the inner structure of the document and hence most of

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -388,8 +388,35 @@ using :ref:`NMF`:
 Limitations of the Bag of Words representation
 ----------------------------------------------
 
+A collection of unigrams (what bag of words is) cannot capture phrases
+and multi-word expressions, effectively disregarding any word order
+dependence. Additionally, bag of words model doesn't account for potential
+misspellings or word derivations.
+
+N-grams to the rescue! Instead of building a simple collection of
+unigrams (n=1), one might prefer a collection of bigrams (n=2), where
+occurances of pairs of consecutive words are counted.
+
+One might consider a collection of character n-grams instead, a
+representation resiliant against misspellings and derivations.
+
+For example, let's say we're dealing with a corpus of two documents:
+``['words', 'wprds']``. The second document contains a misspelling
+of the word 'words'.
+A simple bag of words representation would consider these two as
+very distinct documents, differing in both of the two possible features.
+A character 2-gram representation, however, would find the documents
+matching in 4 out of 8 features, which may help the preferred classifier
+decide better.
+
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', min_n=2, max_n=2)
+  >>> counts = ngram_vectorizer.fit_transform(['words', 'wprds'])
+  >>> counts.toarray().astype(int)
+  array([[1, 1, 1, 0, 1, 1, 1, 0],
+         [1, 1, 0, 1, 1, 1, 0, 1]])
+
 While some local positioning information can be preserved by extracting
-n-grams instead of individual words, Bag of Words and Bag of n-grams
+n-grams instead of individual words, bag of words and bag of n-grams
 destroy most of the inner structure of the document and hence most of
 the meaning carried by that internal structure.
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -191,6 +191,24 @@ def test_char_ngram_analyzer():
     assert_equal(cnga(text)[:5], expected)
 
 
+def test_char_nospace_ngram_analyzer():
+    cnga = CountVectorizer(analyzer='char_nospace', strip_accents='unicode',
+                           min_n=3, max_n=6).build_analyzer()
+
+    text = "This \n\tis a test, really.\n\n I met Harry yesterday"
+    expected = [u'thi', u'his', u'this', u'is', u'a']
+    assert_equal(cnga(text)[:5], expected)
+
+    expected = [u'erday', u'yester', u'esterd', u'sterda', u'terday']
+    assert_equal(cnga(text)[-5:], expected)
+
+    cnga = CountVectorizer(input='file', analyzer='char_nospace',
+                           min_n=3, max_n=6).build_analyzer()
+    text = StringIO("A test with a file-like object!")
+    expected = [u'a', u'tes', u'est', u'test', u'wit']
+    assert_equal(cnga(text)[:5], expected)
+
+
 def test_countvectorizer_custom_vocabulary():
     vocab = {"pizza": 0, "beer": 1}
     terms = set(vocab.keys())

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -196,17 +196,17 @@ def test_char_nospace_ngram_analyzer():
                            min_n=3, max_n=6).build_analyzer()
 
     text = "This \n\tis a test, really.\n\n I met Harry yesterday"
-    expected = [u'thi', u'his', u'this', u'is', u'a']
+    expected = [u' th', u'thi', u'his', u'is ', u' thi']
     assert_equal(cnga(text)[:5], expected)
 
-    expected = [u'erday', u'yester', u'esterd', u'sterda', u'terday']
+    expected = [u'yester', u'esterd', u'sterda', u'terday', u'erday ']
     assert_equal(cnga(text)[-5:], expected)
 
     cnga = CountVectorizer(input='file', analyzer='char_nospace',
                            min_n=3, max_n=6).build_analyzer()
     text = StringIO("A test with a file-like object!")
-    expected = [u'a', u'tes', u'est', u'test', u'wit']
-    assert_equal(cnga(text)[:5], expected)
+    expected = [u' a ', u' te', u'tes', u'est', u'st ', u' tes']
+    assert_equal(cnga(text)[:6], expected)
 
 
 def test_countvectorizer_custom_vocabulary():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -191,8 +191,8 @@ def test_char_ngram_analyzer():
     assert_equal(cnga(text)[:5], expected)
 
 
-def test_char_nospace_ngram_analyzer():
-    cnga = CountVectorizer(analyzer='char_nospace', strip_accents='unicode',
+def test_char_wb_ngram_analyzer():
+    cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
                            min_n=3, max_n=6).build_analyzer()
 
     text = "This \n\tis a test, really.\n\n I met Harry yesterday"
@@ -202,7 +202,7 @@ def test_char_nospace_ngram_analyzer():
     expected = [u'yester', u'esterd', u'sterda', u'terday', u'erday ']
     assert_equal(cnga(text)[-5:], expected)
 
-    cnga = CountVectorizer(input='file', analyzer='char_nospace',
+    cnga = CountVectorizer(input='file', analyzer='char_wb',
                            min_n=3, max_n=6).build_analyzer()
     text = StringIO("A test with a file-like object!")
     expected = [u' a ', u' te', u'tes', u'est', u'st ', u' tes']

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -272,6 +272,7 @@ class CountVectorizer(BaseEstimator):
 
         ngrams = []
         for w in text_document.split():
+            w = ' {} '.format(w)
             w_len = len(w)
             for n in xrange(self.min_n, self.max_n + 1):
                 offset = 0

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -272,7 +272,7 @@ class CountVectorizer(BaseEstimator):
 
         ngrams = []
         for w in text_document.split():
-            w = u' {} '.format(w)
+            w = u' ' + w + u' '
             w_len = len(w)
             for n in xrange(self.min_n, self.max_n + 1):
                 offset = 0

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -118,7 +118,7 @@ class CountVectorizer(BaseEstimator):
 
     analyzer: string, {'word', 'char', 'char_nospace'} or callable
         Whether the feature should be made of word or character n-grams.
-        Option 'char_nspace' creates character n-grams only from text inside
+        Option 'char_nospace' creates character n-grams only from text inside
         word boundaries.
 
         If a callable is passed it is used to extract the sequence of features

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -272,7 +272,7 @@ class CountVectorizer(BaseEstimator):
 
         ngrams = []
         for w in text_document.split():
-            w = ' {} '.format(w)
+            w = u' {} '.format(w)
             w_len = len(w)
             for n in xrange(self.min_n, self.max_n + 1):
                 offset = 0

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -116,8 +116,10 @@ class CountVectorizer(BaseEstimator):
         'unicode' is a slightly slower method that works on any characters.
         None (default) does nothing.
 
-    analyzer: string, {'word', 'char'} or callable
+    analyzer: string, {'word', 'char', 'char_nospace'} or callable
         Whether the feature should be made of word or character n-grams.
+        Option 'char_nspace' creates character n-grams only from text inside
+        word boundaries.
 
         If a callable is passed it is used to extract the sequence of features
         out of the raw, unprocessed input.
@@ -260,6 +262,25 @@ class CountVectorizer(BaseEstimator):
                 ngrams.append(text_document[i: i + n])
         return ngrams
 
+    def _char_nospace_ngrams(self, text_document):
+        """Tokenize text_document into a sequence of character n-grams
+        excluding any whitespace (operating only inside word boundaries)"""
+        # normalize white spaces
+        text_document = self._white_spaces.sub(u" ", text_document)
+
+        ngrams = []
+        for w in text_document.split():
+            w_len = len(w)
+            for n in xrange(self.min_n, self.max_n + 1):
+                offset = 0
+                ngrams.append(w[offset:offset + n])
+                while offset + n < w_len:
+                    offset += 1
+                    ngrams.append(w[offset:offset + n])
+                if offset == 0:   # count a short word (w_len < n) only once
+                    break
+        return ngrams
+
     def build_preprocessor(self):
         """Return a function to preprocess the text before tokenization"""
         if self.preprocessor is not None:
@@ -310,6 +331,10 @@ class CountVectorizer(BaseEstimator):
 
         if self.analyzer == 'char':
             return lambda doc: self._char_ngrams(preprocess(self.decode(doc)))
+
+        elif self.analyzer == 'char_nospace':
+            return lambda doc: self._char_nospace_ngrams(
+                preprocess(self.decode(doc)))
 
         elif self.analyzer == 'word':
             stop_words = self.get_stop_words()

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -116,9 +116,9 @@ class CountVectorizer(BaseEstimator):
         'unicode' is a slightly slower method that works on any characters.
         None (default) does nothing.
 
-    analyzer: string, {'word', 'char', 'char_nospace'} or callable
+    analyzer: string, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
-        Option 'char_nospace' creates character n-grams only from text inside
+        Option 'char_wb' creates character n-grams only from text inside
         word boundaries.
 
         If a callable is passed it is used to extract the sequence of features
@@ -262,7 +262,7 @@ class CountVectorizer(BaseEstimator):
                 ngrams.append(text_document[i: i + n])
         return ngrams
 
-    def _char_nospace_ngrams(self, text_document):
+    def _char_wb_ngrams(self, text_document):
         """Whitespace sensitive char-n-gram tokenization.
 
         Tokenize text_document into a sequence of character n-grams
@@ -335,8 +335,8 @@ class CountVectorizer(BaseEstimator):
         if self.analyzer == 'char':
             return lambda doc: self._char_ngrams(preprocess(self.decode(doc)))
 
-        elif self.analyzer == 'char_nospace':
-            return lambda doc: self._char_nospace_ngrams(
+        elif self.analyzer == 'char_wb':
+            return lambda doc: self._char_wb_ngrams(
                 preprocess(self.decode(doc)))
 
         elif self.analyzer == 'word':

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -263,7 +263,9 @@ class CountVectorizer(BaseEstimator):
         return ngrams
 
     def _char_nospace_ngrams(self, text_document):
-        """Tokenize text_document into a sequence of character n-grams
+        """Whitespace sensitive char-n-gram tokenization.
+
+        Tokenize text_document into a sequence of character n-grams
         excluding any whitespace (operating only inside word boundaries)"""
         # normalize white spaces
         text_document = self._white_spaces.sub(u" ", text_document)


### PR DESCRIPTION
A new in-built analyzer that creates character n-grams but only inside word boundaries, e.g.
`'string translation'` to 5-grams: `['strin', 'tring', 'trans', 'ransl', 'ansla', 'nslat', 'slati', 'latio', 'ation']`

This produces substantially smaller feature sets (10MB vs 60MB in one of my corpora) while only slightly reducing the score with any of the default learners.
Produced n-grams still provide resilience to misspellings/cases/affixes/derivations, but they don't account for any word order (because they are bound to single words). Along with reduced dimensionality, this may be desired in some cases.

I have no references to attach, but the provided code seems to work.

I'm very open to suggestions regarding the analyzer keyword (currently `'char_nospace'`).
