### PR TITLE
MRG bugfix in SVM: classifier behavior with only one class present

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -80,6 +80,7 @@ def test_inconsistent_input():
     rng = np.random.RandomState(0)
     X_ = rng.random_sample((5, 10))
     y_ = np.ones(X_.shape[0])
+    y_[0] = 0
 
     clf = logistic.LogisticRegression()
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -151,6 +151,10 @@ class BaseLibSVM(BaseEstimator):
         X = atleast2d_or_csr(X, dtype=np.float64, order='C')
         y = np.asarray(y, dtype=np.float64, order='C')
 
+        if self.impl != "one_class" and len(np.unique(y)) < 2:
+            raise ValueError("The number of classes has to be greater than"
+                    " one.")
+
         if class_weight != None:
             warnings.warn("'class_weight' is now an initialization parameter."
                     "Using it in the 'fit' method is deprecated.",
@@ -635,6 +639,9 @@ class BaseLibLinear(BaseEstimator):
         self : object
             Returns self.
         """
+        if len(np.unique(y)) < 2:
+            raise ValueError("The number of classes has to be greater than"
+                    " one.")
 
         if class_weight != None:
             warnings.warn("'class_weight' is now an initialization parameter."

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -151,8 +151,6 @@ def test_classifiers_one_label():
     for name, Clf in classifiers:
         if Clf in dont_test or Clf in meta_estimators:
             continue
-        if Clf in [MultinomialNB]:
-            continue
         # catch deprecation warnings
         with warnings.catch_warnings(record=True):
             clf = Clf()


### PR DESCRIPTION
This PR checks the behavior of all classifiers regarding training with only one class. The classifier should either yield a constant predictor or raise a sensible error message.

It fixes a bug in the SVMs which yielded garbage results (and now raise a `ValueError`).
