### PR TITLE
MRG: Speedups in covariance

### DIFF
--- a/examples/linear_model/plot_sparse_recovery.py
+++ b/examples/linear_model/plot_sparse_recovery.py
@@ -53,6 +53,7 @@ from sklearn.feature_selection import f_regression
 from sklearn.preprocessing import Scaler
 from sklearn.metrics import auc, precision_recall_curve
 from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.utils.extmath import pinvh
 
 
 def mutual_incoherence(X_relevant, X_irelevant):
@@ -60,7 +61,7 @@ def mutual_incoherence(X_relevant, X_irelevant):
     """
     projector = np.dot(
                     np.dot(X_irelevant.T, X_relevant),
-                    linalg.pinv(np.dot(X_relevant.T, X_relevant))
+                    pinvh(np.dot(X_relevant.T, X_relevant))
                     )
     return np.max(np.abs(projector).sum(axis=1))
 

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -13,11 +13,16 @@ Maximum likelihood covariance estimator.
 from __future__ import division
 import warnings
 import numpy as np
+from scipy.linalg.lapack import get_lapack_funcs
 from scipy import linalg
 
 from ..base import BaseEstimator
 from ..utils import array2d
 from ..utils.extmath import fast_logdet
+
+getri, getrf = get_lapack_funcs(('getri', 'getrf'),
+                                (np.empty((), dtype=np.float64),
+                                 np.empty((), dtype=np.float64)))
 
 
 def log_likelihood(emp_cov, precision):
@@ -113,7 +118,9 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = linalg.pinv(covariance)
+            lu, piv, _ = getrf(np.dot(covariance.T, covariance), True)
+            self.precision_, _ = getri(lu, piv, overwrite_lu=True)
+            self.precision_ = np.dot(covariance, self.precision_)
         else:
             self.precision_ = None
 
@@ -129,7 +136,9 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = linalg.pinv(self.covariance_)
+            lu, piv, _ = getrf(np.dot(self.covariance_.T, self.covariance_))
+            precision, _ = getri(lu, piv, overwrite_lu=True)
+            precision = np.dot(self.covariance_, precision)
         return precision
 
     def fit(self, X):

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -17,7 +17,7 @@ from scipy import linalg
 
 from ..base import BaseEstimator
 from ..utils import array2d
-from ..utils.extmath import fast_logdet, symmetric_pinv
+from ..utils.extmath import fast_logdet, pinvh
 
 
 def log_likelihood(emp_cov, precision):
@@ -113,7 +113,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = symmetric_pinv(covariance)
+            self.precision_ = pinvh(covariance)
         else:
             self.precision_ = None
 
@@ -129,7 +129,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = symmetric_pinv(self.covariance_)
+            precision = pinvh(self.covariance_)
         return precision
 
     def fit(self, X):

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -20,6 +20,7 @@ from ..base import BaseEstimator
 from ..utils import array2d
 from ..utils.extmath import fast_logdet
 
+# import useful Lapack function to speedup matrices inversions
 getri, getrf = get_lapack_funcs(('getri', 'getrf'),
                                 (np.empty((), dtype=np.float64),
                                  np.empty((), dtype=np.float64)))
@@ -118,6 +119,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
+            # get precision matrix an optimized way
             lu, piv, _ = getrf(np.dot(covariance.T, covariance), True)
             self.precision_, _ = getri(lu, piv, overwrite_lu=True)
             self.precision_ = np.dot(covariance, self.precision_)
@@ -136,6 +138,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
+            # get precision matrix an optimized way
             lu, piv, _ = getrf(np.dot(self.covariance_.T, self.covariance_))
             precision, _ = getri(lu, piv, overwrite_lu=True)
             precision = np.dot(self.covariance_, precision)

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -17,7 +17,7 @@ from scipy import linalg
 
 from ..base import BaseEstimator
 from ..utils import array2d
-from ..utils.extmath import fast_logdet, fast_pinv
+from ..utils.extmath import fast_logdet, symmetric_pinv
 
 
 def log_likelihood(emp_cov, precision):
@@ -113,7 +113,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = fast_pinv(covariance)
+            self.precision_ = symmetric_pinv(covariance)
         else:
             self.precision_ = None
 
@@ -129,7 +129,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = fast_pinv(self.covariance_)
+            precision = symmetric_pinv(self.covariance_)
         return precision
 
     def fit(self, X):

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -17,6 +17,7 @@ from .empirical_covariance_ import empirical_covariance, \
                 EmpiricalCovariance, log_likelihood
 
 from ..utils import ConvergenceWarning
+from ..utils.extmath import fast_pinv
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..cross_validation import check_cv, cross_val_score
@@ -143,7 +144,7 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
     covariance_ *= 0.95
     diagonal = emp_cov.flat[::n_features + 1]
     covariance_.flat[::n_features + 1] = diagonal
-    precision_ = linalg.pinv(covariance_)
+    precision_ = fast_pinv(covariance_)
 
     indices = np.arange(n_features)
     costs = list()

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -17,7 +17,7 @@ from .empirical_covariance_ import empirical_covariance, \
                 EmpiricalCovariance, log_likelihood
 
 from ..utils import ConvergenceWarning
-from ..utils.extmath import fast_pinv
+from ..utils.extmath import symmetric_pinv
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..cross_validation import check_cv, cross_val_score
@@ -144,7 +144,7 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
     covariance_ *= 0.95
     diagonal = emp_cov.flat[::n_features + 1]
     covariance_.flat[::n_features + 1] = diagonal
-    precision_ = fast_pinv(covariance_)
+    precision_ = symmetric_pinv(covariance_)
 
     indices = np.arange(n_features)
     costs = list()

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -17,7 +17,7 @@ from .empirical_covariance_ import empirical_covariance, \
                 EmpiricalCovariance, log_likelihood
 
 from ..utils import ConvergenceWarning
-from ..utils.extmath import symmetric_pinv
+from ..utils.extmath import pinvh
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
 from ..cross_validation import check_cv, cross_val_score
@@ -144,7 +144,7 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
     covariance_ *= 0.95
     diagonal = emp_cov.flat[::n_features + 1]
     covariance_.flat[::n_features + 1] = diagonal
-    precision_ = symmetric_pinv(covariance_)
+    precision_ = pinvh(covariance_)
 
     indices = np.arange(n_features)
     costs = list()

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -13,7 +13,7 @@ from scipy import linalg
 from scipy.stats import chi2
 
 from . import empirical_covariance, EmpiricalCovariance
-from ..utils.extmath import fast_logdet, symmetric_pinv
+from ..utils.extmath import fast_logdet, pinvh
 from ..utils import check_random_state
 
 
@@ -85,7 +85,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         location = initial_estimates[0]
         covariance = initial_estimates[1]
         # run a special iteration for that case (to get an initial support)
-        precision = symmetric_pinv(covariance)
+        precision = pinvh(covariance)
         X_centered = X - location
         dist = (np.dot(X_centered, precision) * X_centered).sum(1)
         # compute new estimates
@@ -104,7 +104,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         previous_det = det
         previous_support = support
         # compute a new support from the full data set mahalanobis distances
-        precision = symmetric_pinv(covariance)
+        precision = pinvh(covariance)
         X_centered = X - location
         dist = (np.dot(X_centered, precision) * X_centered).sum(axis=1)
         # compute new estimates
@@ -344,7 +344,7 @@ def fast_mcd(X, support_fraction=None,
         covariance = np.asarray([[np.var(X[support])]])
         location = np.array([location])
         # get precision matrix an optimized way
-        precision = symmetric_pinv(covariance)
+        precision = pinvh(covariance)
         dist = (np.dot(X_centered, precision) \
                     * (X_centered)).sum(axis=1)
 
@@ -545,7 +545,7 @@ class MinCovDet(EmpiricalCovariance):
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
             # get precision matrix an optimized way
-            precision = symmetric_pinv(raw_covariance)
+            precision = pinvh(raw_covariance)
             raw_dist = np.sum(np.dot(X, precision) * X, 1)
         self.raw_location_ = raw_location
         self.raw_covariance_ = raw_covariance

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -117,7 +117,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         remaining_iterations -= 1
 
     previous_dist = dist
-    dist = (np.dot(X - location, linalg.pinv(covariance)) \
+    dist = (np.dot(X - location, precision) \
                 * (X - location)).sum(axis=1)
     # Catch computation errors
     if np.isinf(det):

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -17,6 +17,7 @@ from . import empirical_covariance, EmpiricalCovariance
 from ..utils.extmath import fast_logdet
 from ..utils import check_random_state
 
+# import useful Lapack function to speedup matrices inversions
 getri, getrf = get_lapack_funcs(('getri', 'getrf'),
                                 (np.empty((), dtype=np.float64),
                                  np.empty((), dtype=np.float64)))
@@ -352,6 +353,7 @@ def fast_mcd(X, support_fraction=None,
         support[np.argsort(np.abs(X - location), axis=0)[:n_support]] = True
         covariance = np.asarray([[np.var(X[support])]])
         location = np.array([location])
+        # get precision matrix an optimized way
         lu, piv, _ = getrf(np.dot(covariance.T, covariance), False)
         precision, _ = getri(lu, piv, overwrite_lu=True)
         precision = np.dot(covariance, precision)
@@ -554,6 +556,7 @@ class MinCovDet(EmpiricalCovariance):
             raw_location = np.zeros(n_features)
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
+            # get precision matrix an optimized way
             lu, piv, _ = getrf(np.dot(raw_covariance.T, raw_covariance), False)
             precision, _ = getri(lu, piv, overwrite_lu=True)
             precision = np.dot(raw_covariance, precision)

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -343,7 +343,7 @@ def fast_mcd(X, support_fraction=None,
         support[np.argsort(np.abs(X - location), axis=0)[:n_support]] = True
         covariance = np.asarray([[np.var(X[support])]])
         location = np.array([location])
-        # get precision matrix an optimized way
+        # get precision matrix in an optimized way
         precision = pinvh(covariance)
         dist = (np.dot(X_centered, precision) \
                     * (X_centered)).sum(axis=1)
@@ -544,7 +544,7 @@ class MinCovDet(EmpiricalCovariance):
             raw_location = np.zeros(n_features)
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
-            # get precision matrix an optimized way
+            # get precision matrix in an optimized way
             precision = pinvh(raw_covariance)
             raw_dist = np.sum(np.dot(X, precision) * X, 1)
         self.raw_location_ = raw_location

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -13,7 +13,7 @@ from scipy import linalg
 from scipy.stats import chi2
 
 from . import empirical_covariance, EmpiricalCovariance
-from ..utils.extmath import fast_logdet, fast_pinv
+from ..utils.extmath import fast_logdet, symmetric_pinv
 from ..utils import check_random_state
 
 
@@ -85,7 +85,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         location = initial_estimates[0]
         covariance = initial_estimates[1]
         # run a special iteration for that case (to get an initial support)
-        precision = fast_pinv(covariance)
+        precision = symmetric_pinv(covariance)
         X_centered = X - location
         dist = (np.dot(X_centered, precision) * X_centered).sum(1)
         # compute new estimates
@@ -104,7 +104,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         previous_det = det
         previous_support = support
         # compute a new support from the full data set mahalanobis distances
-        precision = fast_pinv(covariance)
+        precision = symmetric_pinv(covariance)
         X_centered = X - location
         dist = (np.dot(X_centered, precision) * X_centered).sum(axis=1)
         # compute new estimates
@@ -343,7 +343,7 @@ def fast_mcd(X, support_fraction=None,
         support[np.argsort(np.abs(X - location), axis=0)[:n_support]] = True
         covariance = np.asarray([[np.var(X[support])]])
         location = np.array([location])
-        precision = fast_pinv(covariance)
+        precision = symmetric_pinv(covariance)
         dist = (np.dot(X_centered, precision) \
                     * (X_centered)).sum(axis=1)
 
@@ -543,7 +543,7 @@ class MinCovDet(EmpiricalCovariance):
             raw_location = np.zeros(n_features)
             raw_covariance = self._nonrobust_covariance(
                     X[raw_support], assume_centered=True)
-            precision = fast_pinv(raw_covariance)
+            precision = symmetric_pinv(raw_covariance)
             raw_dist = np.sum(np.dot(X, precision) * X, 1)
         self.raw_location_ = raw_location
         self.raw_covariance_ = raw_covariance

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -11,7 +11,7 @@ from scipy import linalg
 
 from .base import LinearModel
 from ..base import RegressorMixin
-from ..utils.extmath import fast_logdet
+from ..utils.extmath import fast_logdet, pinvh
 from ..utils import check_arrays
 
 
@@ -382,7 +382,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         ### Iterative procedure of ARDRegression
         for iter_ in range(self.n_iter):
             ### Compute mu and sigma (using Woodbury matrix identity)
-            sigma_ = linalg.pinv(np.eye(n_samples) / alpha_ +
+            sigma_ = pinvh(np.eye(n_samples) / alpha_ +
                           np.dot(X[:, keep_lambda] *
                           np.reshape(1. / lambda_[keep_lambda], [1, -1]),
                           X[:, keep_lambda].T))

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -16,7 +16,7 @@ from scipy import linalg
 from scipy.spatial.distance import cdist
 
 from ..utils import check_random_state
-from ..utils.extmath import norm, logsumexp
+from ..utils.extmath import norm, logsumexp, pinvh
 from .. import cluster
 from .gmm import GMM
 
@@ -215,7 +215,7 @@ class DPGMM(GMM):
             return [self.precs_] * self.n_components
 
     def _get_covars(self):
-        return [linalg.pinv(c) for c in self._get_precisions()]
+        return [pinvh(c) for c in self._get_precisions()]
 
     def _set_covars(self, covars):
         raise NotImplementedError("""The variational algorithm does
@@ -332,7 +332,7 @@ class DPGMM(GMM):
             for k in xrange(self.n_components):
                     diff = X - self.means_[k]
                     self.scale_ += np.dot(diff.T, z[:, k:k + 1] * diff)
-            self.scale_ = linalg.pinv(self.scale_)
+            self.scale_ = pinvh(self.scale_)
             self.precs_ = self.dof_ * self.scale_
             self.det_scale_ = linalg.det(self.scale_)
             self.bound_prec_ = 0.5 * wishart_log_det(
@@ -346,7 +346,7 @@ class DPGMM(GMM):
                 self.scale_[k] = (sum_resp + 1) * np.identity(n_features)
                 diff = X - self.means_[k]
                 self.scale_[k] += np.dot(diff.T, z[:, k:k + 1] * diff)
-                self.scale_[k] = linalg.pinv(self.scale_[k])
+                self.scale_[k] = pinvh(self.scale_[k])
                 self.precs_[k] = self.dof_[k] * self.scale_[k]
                 self.det_scale_[k] = linalg.det(self.scale_[k])
                 self.bound_prec_[k] = 0.5 * wishart_log_det(self.dof_[k],

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -14,7 +14,7 @@ import warnings
 
 from ..base import BaseEstimator
 from ..utils import check_random_state, deprecated
-from ..utils.extmath import logsumexp
+from ..utils.extmath import logsumexp, pinvh
 from .. import cluster
 
 EPS = np.finfo(float).eps
@@ -615,7 +615,7 @@ def _log_multivariate_normal_density_tied(X, means, covars):
     """Compute Gaussian log-density at X for a tied model"""
     from scipy import linalg
     n_samples, n_dim = X.shape
-    icv = linalg.pinv(covars)
+    icv = pinvh(covars)
     lpr = -0.5 * (n_dim * np.log(2 * np.pi) + np.log(linalg.det(covars) + 0.1)
                   + np.sum(X * np.dot(X, icv), 1)[:, np.newaxis]
                   - 2 * np.dot(np.dot(X, icv), means.T)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -362,8 +362,7 @@ def symmetric_pinv(a, cond=None, rcond=None):
     cutoff = cond * np.maximum.reduce(s)
     psigma_diag = np.zeros(n, dtype=t)
     i_cutoff = np.searchsorted(s, cutoff)
-    psigma_diag[i_cutoff:] = 1.0 / np.conjugate(s[i_cutoff:])
+    psigma_diag[i_cutoff:] = 1.0 / s[i_cutoff:]
     #XXX: use lapack/blas routines for dot
     #XXX: above comment is from scipy, but I (@vene)'ll take a look
-    return np.transpose(np.conjugate(np.dot(u * psigma_diag,
-                                            u.T.conjugate())))
+    return np.dot(u * psigma_diag, u.T)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -6,6 +6,7 @@ Extended math utilities.
 
 import numpy as np
 from scipy import linalg
+from scipy.linalg.lapack import get_lapack_funcs
 
 from . import check_random_state
 from . import deprecated
@@ -305,3 +306,11 @@ def weighted_mode(a, w, axis=0):
         oldcounts = np.maximum(counts, oldcounts)
         oldmostfreq = mostfrequent
     return mostfrequent, oldcounts
+
+
+def fast_pinv(X):
+    try:
+        ret = np.dot(linalg.inv(np.dot(X.T, X), overwrite_a=True), X.T)
+    except linalg.LinAlgError:
+        ret = linalg.pinv2(X)
+    return ret

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -307,38 +307,41 @@ def weighted_mode(a, w, axis=0):
     return mostfrequent, oldcounts
 
 
-def symmetric_pinv(a, cond=None, rcond=None):
-    """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
+def pinvh(a, cond=None, rcond=None, lower=True):
+    """Compute the (Moore-Penrose) pseudo-inverse of a hermetian matrix.
 
     Calculate a generalized inverse of a symmetric matrix using its
     eigenvalue decomposition and including all 'large' eigenvalues.
 
-    Inspired by ``scipy.linalg.pinv2``, credited to Pearu Peterson and Travis
-    Oliphant.
-
     Parameters
     ----------
     a : array, shape (N, N)
-        Symmetric matrix to be pseudo-inverted
+        Real symmetric or complex hermetian matrix to be pseudo-inverted
     cond, rcond : float or None
         Cutoff for 'small' eigenvalues.
         Singular values smaller than rcond * largest_eigenvalue are considered
         zero.
 
         If None or -1, suitable machine precision is used.
+    lower : boolean
+        Whether the pertinent array data is taken from the lower or upper
+        triangle of a. (Default: lower)
 
     Returns
     -------
     B : array, shape (N, N)
 
-    Raises LinAlgError if eigenvalue does not converge
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue does not converge
 
     Examples
     --------
     >>> from numpy import *
     >>> a = random.randn(9, 6)
     >>> a = np.dot(a, a.T)
-    >>> B = symmetric_pinv(a)
+    >>> B = pinvh(a)
     >>> allclose(a, dot(a, dot(B, a)))
     True
     >>> allclose(B, dot(B, dot(a, B)))
@@ -346,21 +349,18 @@ def symmetric_pinv(a, cond=None, rcond=None):
 
     """
     a = np.asarray_chkfinite(a)
-    s, u = linalg.eigh(a)
-    # eigh returns eigvals in reverse order, but this doesn't affect anything.
+    s, u = linalg.eigh(a, lower=lower)
 
-    t = u.dtype.char
     if rcond is not None:
         cond = rcond
     if cond in [None, -1]:
-        eps = np.finfo(np.float).eps
-        feps = np.finfo(np.single).eps
-        _array_precision = {'f': 0, 'd': 1, 'F': 0, 'D': 1}
-        cond = {0: feps * 1e3, 1: eps * 1e6}[_array_precision[t]]
-    n = a.shape[0]
-    cutoff = cond * np.maximum.reduce(s)
-    psigma_diag = np.zeros(n, dtype=t)
-    i_cutoff = np.searchsorted(s, cutoff)
-    psigma_diag[i_cutoff:] = 1.0 / s[i_cutoff:]
-    #XXX: use lapack/blas routines for dot
-    return np.dot(u * psigma_diag, u.T)
+        t = u.dtype.char.lower()
+        factor = {'f': 1E3, 'd': 1E6}
+        cond = factor[t] * np.finfo(t).eps
+
+    # unlike svd case, eigh can lead to negative eigenvalues
+    above_cutoff = (abs(s) > cond * np.max(abs(s)))
+    psigma_diag = np.zeros_like(s)
+    psigma_diag[above_cutoff] = 1.0 / s[above_cutoff]
+
+    return np.dot(u * psigma_diag, np.conjugate(u).T)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -360,11 +360,9 @@ def symmetric_pinv(a, cond=None, rcond=None):
         cond = {0: feps * 1e3, 1: eps * 1e6}[_array_precision[t]]
     n = a.shape[0]
     cutoff = cond * np.maximum.reduce(s)
-    psigma = np.zeros((n, n), t)
-    for i in range(len(s)):
-        if s[i] > cutoff:
-            psigma[i, i] = 1.0 / np.conjugate(s[i])
+    psigma = np.zeros(n, t)
+    above_cutoff = np.where(s > cutoff)
+    psigma[above_cutoff] = 1.0 / np.conjugate(s[above_cutoff])
     #XXX: use lapack/blas routines for dot
     #XXX: above comment is from scipy, but I (@vene)'ll take a look
-    return np.transpose(np.conjugate(np.dot(np.dot(u, psigma),
-                                     u.T.conjugate())))
+    return np.transpose(np.conjugate(np.dot(u * psigma, u.T.conjugate())))

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -6,7 +6,6 @@ Extended math utilities.
 
 import numpy as np
 from scipy import linalg
-from scipy.linalg.lapack import get_lapack_funcs
 
 from . import check_random_state
 from . import deprecated

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -360,11 +360,10 @@ def symmetric_pinv(a, cond=None, rcond=None):
         cond = {0: feps * 1e3, 1: eps * 1e6}[_array_precision[t]]
     n = a.shape[0]
     cutoff = cond * np.maximum.reduce(s)
-    psigma = np.zeros((n, n), t)
-    for i in range(len(s)):
-        if s[i] > cutoff:
-            psigma[i, i] = 1.0 / np.conjugate(s[i])
+    psigma_diag = np.zeros(n, dtype=t)
+    i_cutoff = np.searchsorted(s, cutoff)
+    psigma_diag[i_cutoff:] = 1.0 / np.conjugate(s[i_cutoff:])
     #XXX: use lapack/blas routines for dot
     #XXX: above comment is from scipy, but I (@vene)'ll take a look
-    return np.transpose(np.conjugate(np.dot(np.dot(u, psigma),
-                                     u.T.conjugate())))
+    return np.transpose(np.conjugate(np.dot(u * psigma_diag,
+                                            u.T.conjugate())))

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -1,13 +1,17 @@
-from nose.tools import assert_equal, assert_raises, assert_true
 import warnings
 
 import numpy as np
 import scipy.sparse as sp
+from scipy.linalg import pinv2
+
+from nose.tools import assert_equal, assert_raises, assert_true
+from numpy.testing import assert_almost_equal
 
 from sklearn.utils import check_random_state
 from sklearn.utils import deprecated
 from sklearn.utils import resample
 from sklearn.utils import safe_mask
+from sklearn.utils.extmath import symmetric_pinv
 
 
 def test_make_rng():
@@ -87,3 +91,9 @@ def test_safe_mask():
 
     mask = safe_mask(X_csr, mask)
     assert_equal(X_csr[mask].shape[0], 3)
+
+
+def test_symmetric_pinv():
+    a = np.random.randn(5, 3)
+    a = np.dot(a, a.T)  # symmetric singular matrix
+    assert_almost_equal(pinv2(a), symmetric_pinv(a))

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -93,7 +93,27 @@ def test_safe_mask():
     assert_equal(X_csr[mask].shape[0], 3)
 
 
-def test_pinvh():
-    a = np.random.randn(5, 3)
-    a = np.dot(a, a.T)  # symmetric singular matrix
-    assert_almost_equal(pinv2(a), pinvh(a))
+def test_pinvh_simple_real():
+    a = np.array([[1, 2, 3], [4, 5, 6.], [7, 8, 10]])
+    a = np.dot(a, a.T)
+    a_pinv = pinvh(a)
+    assert_almost_equal(np.dot(a, a_pinv), np.eye(3))
+
+
+def test_pinvh_nonpositive():
+    a = np.array([[1, 2, 3], [4, 5, 6.], [7, 8, 9]])
+    a = np.dot(a, a.T)
+    u, s, vt = np.linalg.svd(a)
+    s[0] *= -1
+    a = np.dot(u * s, vt)  # a is now symmetric non-positive and singular
+    a_pinv = pinv2(a)
+    a_pinvh = pinvh(a)
+    assert_almost_equal(a_pinv, a_pinvh)
+
+
+def test_pinvh_simple_complex():
+    a = (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+         + 1j * np.array([[10, 8, 7], [6, 5, 4], [3, 2, 1]]))
+    a = np.dot(a, a.conj().T)
+    a_pinv = pinvh(a)
+    assert_almost_equal(np.dot(a, a_pinv), np.eye(3))

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -94,14 +94,14 @@ def test_safe_mask():
 
 
 def test_pinvh_simple_real():
-    a = np.array([[1, 2, 3], [4, 5, 6.], [7, 8, 10]])
+    a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=np.float64)
     a = np.dot(a, a.T)
     a_pinv = pinvh(a)
     assert_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
 
 def test_pinvh_nonpositive():
-    a = np.array([[1, 2, 3], [4, 5, 6.], [7, 8, 9]])
+    a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float64)
     a = np.dot(a, a.T)
     u, s, vt = np.linalg.svd(a)
     s[0] *= -1

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -11,7 +11,7 @@ from sklearn.utils import check_random_state
 from sklearn.utils import deprecated
 from sklearn.utils import resample
 from sklearn.utils import safe_mask
-from sklearn.utils.extmath import symmetric_pinv
+from sklearn.utils.extmath import pinvh
 
 
 def test_make_rng():
@@ -93,7 +93,7 @@ def test_safe_mask():
     assert_equal(X_csr[mask].shape[0], 3)
 
 
-def test_symmetric_pinv():
+def test_pinvh():
     a = np.random.randn(5, 3)
     a = np.dot(a, a.T)  # symmetric singular matrix
-    assert_almost_equal(pinv2(a), symmetric_pinv(a))
+    assert_almost_equal(pinv2(a), pinvh(a))


### PR DESCRIPTION
With this simple change I get a 1.6 speedup on running MinCovDet for a 100x100 matrix.

I have also turned the `pinv` calls to a new `symmetric_pinv` function based on `linalg.eigh` for a considerable speedup. All tests pass.

Timings for MinCovDet on a 100x100 symmetric euclidean distance matrix:
Before: 1.24s
Without final inversion: 0.76s (1.6x faster)
With LAPACK calls: 0.28 (4.4x faster) (but alas, wrong)
With symmetric_pinv: 0.37  (3.3x faster)
With vectorized symmetric_pinv: 0.34
