### PR TITLE
MRG renamed ``min_n`` and ``max_n`` parameters in CountVectorizer 

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -186,9 +186,10 @@ reasonable (please see  the :ref:`reference documentation
   >>> vectorizer
   CountVectorizer(analyzer='word', binary=False, charset='utf-8',
           charset_error='strict', dtype=<type 'long'>, input='content',
-          lowercase=True, max_df=1.0, max_features=None, max_n=1, min_n=1,
-          preprocessor=None, stop_words=None, strip_accents=None,
-          token_pattern=u'\\b\\w\\w+\\b', tokenizer=None, vocabulary=None)
+          lowercase=True, max_df=1.0, max_features=None, max_n=None,
+          min_n=None, ngram_range=(1, 1), preprocessor=None, stop_words=None,
+          strip_accents=None, token_pattern=u'\\b\\w\\w+\\b', tokenizer=None,
+          vocabulary=None)
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
 corpus of text documents::
@@ -244,7 +245,7 @@ we lose the information that the last document is an interogative form. To
 preserve some of the local ordering information we can extract 2-grams
 of words in addition to the 1-grams (the word themselvs)::
 
-  >>> bigram_vectorizer = CountVectorizer(min_n=1, max_n=2,
+  >>> bigram_vectorizer = CountVectorizer(ngram_range=(1, 2),
   ...                                     token_pattern=ur'\b\w+\b')
   >>> analyze = bigram_vectorizer.build_analyzer()
   >>> analyze('Bi-grams are cool!')

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,10 @@ API changes summary
      necessary for early-stopping in which case the tree is not
      completely built.
 
+   - In :class:`feature_extraction.text.CountVectorizer` the parameters
+     ``min_n`` and ``max_n`` were joined to the parameter ``bounds_n`` to
+     enable grid-searching both at once.
+
 .. _changes_0_11:
 
 0.11

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -88,7 +88,7 @@ API changes summary
      completely built.
 
    - In :class:`feature_extraction.text.CountVectorizer` the parameters
-     ``min_n`` and ``max_n`` were joined to the parameter ``bounds_n`` to
+     ``min_n`` and ``max_n`` were joined to the parameter ``n_gram_range`` to
      enable grid-searching both at once.
 
 .. _changes_0_11:

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -193,7 +193,7 @@ def test_char_ngram_analyzer():
 
 def test_char_wb_ngram_analyzer():
     cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
-                           min_n=3, max_n=6).build_analyzer()
+                           ngram_range=(3, 6)).build_analyzer()
 
     text = "This \n\tis a test, really.\n\n I met Harry yesterday"
     expected = [u' th', u'thi', u'his', u'is ', u' thi']
@@ -203,7 +203,7 @@ def test_char_wb_ngram_analyzer():
     assert_equal(cnga(text)[-5:], expected)
 
     cnga = CountVectorizer(input='file', analyzer='char_wb',
-                           min_n=3, max_n=6).build_analyzer()
+                           ngram_range=(3, 6)).build_analyzer()
     text = StringIO("A test with a file-like object!")
     expected = [u' a ', u' te', u'tes', u'est', u'st ', u' tes']
     assert_equal(cnga(text)[:6], expected)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -141,7 +141,7 @@ def test_word_analyzer_unigrams():
 
 def test_word_analyzer_unigrams_and_bigrams():
     wa = CountVectorizer(analyzer="word", strip_accents='unicode',
-                         bounds_n=(1, 2)).build_analyzer()
+                         ngram_range=(1, 2)).build_analyzer()
 
     text = u"J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
     expected = [u'ai', u'mange', u'du', u'kangourou', u'ce', u'midi', u'etait',
@@ -159,17 +159,17 @@ def test_unicode_decode_error():
 
     # Then let the Analyzer try to decode it as ascii. It should fail,
     # because we have given it an incorrect charset.
-    wa = CountVectorizer(min_n=1, max_n=2, charset='ascii').build_analyzer()
+    wa = CountVectorizer(ngram_range=(1, 2), charset='ascii').build_analyzer()
     assert_raises(UnicodeDecodeError, wa, text_bytes)
 
-    ca = CountVectorizer(analyzer='char', min_n=3, max_n=6,
+    ca = CountVectorizer(analyzer='char', ngram_range=(3, 6),
                          charset='ascii').build_analyzer()
     assert_raises(UnicodeDecodeError, ca, text_bytes)
 
 
 def test_char_ngram_analyzer():
     cnga = CountVectorizer(analyzer='char', strip_accents='unicode',
-                           min_n=3, max_n=6).build_analyzer()
+                           ngram_range=(3, 6)).build_analyzer()
 
     text = u"J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon"
     expected = [u"j'a", u"'ai", u'ai ', u'i m', u' ma']
@@ -185,7 +185,7 @@ def test_char_ngram_analyzer():
     assert_equal(cnga(text)[-5:], expected)
 
     cnga = CountVectorizer(input='file', analyzer='char',
-                           min_n=3, max_n=6).build_analyzer()
+                           ngram_range=(3, 6)).build_analyzer()
     text = StringIO("This is a test with a file-like object!")
     expected = [u'thi', u'his', u'is ', u's i', u' is']
     assert_equal(cnga(text)[:5], expected)
@@ -423,7 +423,7 @@ def test_vectorizer_max_features():
 
 def test_vectorizer_max_df():
     test_data = [u'abc', u'dea']  # the letter a occurs in both strings
-    vect = CountVectorizer(analyzer='char', min_n=1, max_n=1, max_df=1.0)
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     vect.fit(test_data)
     assert_true(u'a' in vect.vocabulary_.keys())
     assert_equals(len(vect.vocabulary_.keys()), 5)
@@ -437,7 +437,7 @@ def test_vectorizer_max_df():
 def test_binary_occurrences():
     # by default multiple occurrences are counted as longs
     test_data = [u'aaabc', u'abbde']
-    vect = CountVectorizer(analyzer='char', min_n=1, max_n=1, max_df=1.0)
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal(['a', 'b', 'c', 'd', 'e'], vect.get_feature_names())
     assert_array_equal([[3, 1, 1, 0, 0],
@@ -445,14 +445,14 @@ def test_binary_occurrences():
 
     # using boolean features, we can fetch the binary occurrence info
     # instead.
-    vect = CountVectorizer(analyzer='char', min_n=1, max_n=1, max_df=1.0,
+    vect = CountVectorizer(analyzer='char', max_df=1.0,
                            binary=True)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal([[1, 1, 1, 0, 0],
                         [1, 1, 0, 1, 1]], X)
 
     # check the ability to change the dtype
-    vect = CountVectorizer(analyzer='char', min_n=1, max_n=1, max_df=1.0,
+    vect = CountVectorizer(analyzer='char', max_df=1.0,
                            binary=True, dtype=np.float32)
     X_sparse = vect.fit_transform(test_data)
     assert_equal(X_sparse.dtype, np.float32)
@@ -494,7 +494,7 @@ def test_count_vectorizer_pipeline_grid_selection():
                          ('svc', LinearSVC())])
 
     parameters = {
-        'vect__max_n': (1, 2),
+        'vect__ngram_range': [(1, 1), (1, 2)],
         'svc__loss': ('l1', 'l2')
     }
 
@@ -512,7 +512,7 @@ def test_count_vectorizer_pipeline_grid_selection():
     # to 100% accuracy models
     assert_equal(grid_search.best_score_, 1.0)
     best_vectorizer = grid_search.best_estimator_.named_steps['vect']
-    assert_equal(best_vectorizer.max_n, 1)
+    assert_equal(best_vectorizer.ngram_range, (1, 1))
 
 
 def test_vectorizer_pipeline_grid_selection():
@@ -532,7 +532,7 @@ def test_vectorizer_pipeline_grid_selection():
                          ('svc', LinearSVC())])
 
     parameters = {
-        'vect__max_n': (1, 2),
+        'vect__ngram_range': [(1, 1), (1, 2)],
         'vect__norm': ('l1', 'l2'),
         'svc__loss': ('l1', 'l2'),
     }
@@ -551,7 +551,7 @@ def test_vectorizer_pipeline_grid_selection():
     # to 100% accuracy models
     assert_equal(grid_search.best_score_, 1.0)
     best_vectorizer = grid_search.best_estimator_.named_steps['vect']
-    assert_equal(best_vectorizer.max_n, 1)
+    assert_equal(best_vectorizer.ngram_range, (1, 1))
     assert_equal(best_vectorizer.norm, 'l2')
     assert_false(best_vectorizer.fixed_vocabulary)
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -141,7 +141,7 @@ def test_word_analyzer_unigrams():
 
 def test_word_analyzer_unigrams_and_bigrams():
     wa = CountVectorizer(analyzer="word", strip_accents='unicode',
-                         min_n=1, max_n=2).build_analyzer()
+                         bounds_n=(1, 2)).build_analyzer()
 
     text = u"J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
     expected = [u'ai', u'mange', u'du', u'kangourou', u'ce', u'midi', u'etait',

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -280,11 +280,12 @@ class CountVectorizer(BaseEstimator):
         # normalize white spaces
         text_document = self._white_spaces.sub(u" ", text_document)
 
+        min_n, max_n = self.ngram_range
         ngrams = []
         for w in text_document.split():
             w = u' ' + w + u' '
             w_len = len(w)
-            for n in xrange(self.min_n, self.max_n + 1):
+            for n in xrange(min_n, max_n + 1):
                 offset = 0
                 ngrams.append(w[offset:offset + n])
                 while offset + n < w_len:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -211,6 +211,8 @@ class CountVectorizer(BaseEstimator):
                 'ngram_range instead.')
             if min_n is None:
                 min_n = 1
+            if max_n is None:
+                max_n = min_n
             ngram_range = (min_n, max_n)
         self.ngram_range = ngram_range
         if vocabulary is not None:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -132,7 +132,7 @@ class CountVectorizer(BaseEstimator):
         Override the string tokenization step while preserving the
         preprocessing and n-grams generation steps.
 
-    bounds_n: tuple (min_n, max_n)
+    ngram_range: tuple (min_n, max_n)
         The lower and upper boundary of the range of n-values for different
         n-grams to be extracted. All values of n such that min_n <= n <= max_n
         will be used.
@@ -190,7 +190,7 @@ class CountVectorizer(BaseEstimator):
                  charset_error='strict', strip_accents=None,
                  lowercase=True, preprocessor=None, tokenizer=None,
                  stop_words=None, token_pattern=ur"\b\w\w+\b",
-                 bounds_n=(1, 1),
+                 ngram_range=(1, 1),
                  min_n=None, max_n=None, analyzer='word',
                  max_df=1.0, max_features=None,
                  vocabulary=None, binary=False, dtype=long):
@@ -208,11 +208,11 @@ class CountVectorizer(BaseEstimator):
         self.max_features = max_features
         if not (max_n is None) or not (min_n is None):
             warnings.warn('Parameters max_n and min_n are deprecated. Use '
-                'bounds_n instead.')
+                'ngram_range instead.')
             if min_n is None:
                 min_n = 1
-            bounds_n = (min_n, max_n)
-        self.bounds_n = bounds_n
+            ngram_range = (min_n, max_n)
+        self.ngram_range = ngram_range
         if vocabulary is not None:
             self.fixed_vocabulary = True
             if not isinstance(vocabulary, Mapping):
@@ -245,7 +245,7 @@ class CountVectorizer(BaseEstimator):
             tokens = [w for w in tokens if w not in stop_words]
 
         # handle token n-grams
-        min_n, max_n = self.bounds_n
+        min_n, max_n = self.ngram_range
         if max_n != 1:
             original_tokens = tokens
             tokens = []
@@ -264,7 +264,7 @@ class CountVectorizer(BaseEstimator):
 
         text_len = len(text_document)
         ngrams = []
-        min_n, max_n = self.bounds_n
+        min_n, max_n = self.ngram_range
         for n in xrange(min_n, min(max_n + 1, text_len + 1)):
             for i in xrange(text_len - n + 1):
                 ngrams.append(text_document[i: i + n])
@@ -715,7 +715,7 @@ class TfidfVectorizer(CountVectorizer):
         preprocessing and n-grams generation steps.
 
 
-    bounds_n: tuple (min_n, max_n)
+    ngram_range: tuple (min_n, max_n)
         The lower and upper boundary of the range of n-values for different
         n-grams to be extracted. All values of n such that min_n <= n <= max_n
         will be used.
@@ -796,7 +796,7 @@ class TfidfVectorizer(CountVectorizer):
                  charset_error='strict', strip_accents=None, lowercase=True,
                  preprocessor=None, tokenizer=None, analyzer='word',
                  stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
-                 max_n=None, bounds_n=(1, 1), max_df=1.0, max_features=None,
+                 max_n=None, ngram_range=(1, 1), max_df=1.0, max_features=None,
                  vocabulary=None, binary=False, dtype=long, norm='l2',
                  use_idf=True, smooth_idf=True, sublinear_tf=False):
 
@@ -805,7 +805,7 @@ class TfidfVectorizer(CountVectorizer):
             strip_accents=strip_accents, lowercase=lowercase,
             preprocessor=preprocessor, tokenizer=tokenizer, analyzer=analyzer,
             stop_words=stop_words, token_pattern=token_pattern, min_n=min_n,
-            max_n=max_n, bounds_n=bounds_n, max_df=max_df,
+            max_n=max_n, ngram_range=ngram_range, max_df=max_df,
             max_features=max_features, vocabulary=vocabulary, binary=False,
             dtype=dtype)
 
@@ -895,7 +895,7 @@ class Vectorizer(TfidfVectorizer):
                 charset_error='strict', strip_accents=None, lowercase=True,
                 preprocessor=None, tokenizer=None, analyzer='word',
                 stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
-                max_n=None, bounds_n=(1, 1), max_df=1.0, max_features=None,
+                max_n=None, ngram_range=(1, 1), max_df=1.0, max_features=None,
                 vocabulary=None, binary=False, dtype=long, norm='l2',
                 use_idf=True, smooth_idf=True, sublinear_tf=False):
         warnings.warn("Vectorizer is deprecated in 0.11 and will be removed"


### PR DESCRIPTION
To make grid-searching them together possible.
cc @agramfort and @ogrisel
