### PR TITLE
MRG sparse matrix support in univariate feature selection

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -262,6 +262,9 @@ Helper Functions
   matrices support integer indices only while numpy arrays support both
   boolean masks and integer indices).
 
+- :func:`safe_sqr`: Helper function for unified squaring (``**2``) of
+  array-likes, matrices and sparse matrices.
+
 
 Hash Functions
 ==============

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -46,30 +46,14 @@ def test_f_classif():
                                class_sep=10, shuffle=False, random_state=0)
 
     F, pv = f_classif(X, y)
+    F_sparse,  pv_sparse = f_classif(sparse.csr_matrix(X), y)
     assert(F > 0).all()
     assert(pv > 0).all()
     assert(pv < 1).all()
     assert(pv[:5] < 0.05).all()
     assert(pv[5:] > 1.e-4).all()
-
-
-def test_f_classif_sparse():
-    """
-    Test whether the F test yields meaningful results
-    on a simple simulated classification problem
-    """
-    X, y = make_classification(n_samples=200, n_features=20,
-                               n_informative=3, n_redundant=2,
-                               n_repeated=0, n_classes=8,
-                               n_clusters_per_class=1, flip_y=0.0,
-                               class_sep=10, shuffle=False, random_state=0)
-
-    F, pv = f_classif(sparse.csr_matrix(X), y)
-    assert(F > 0).all()
-    assert(pv > 0).all()
-    assert(pv < 1).all()
-    assert(pv[:5] < 0.05).all()
-    assert(pv[5:] > 1.e-4).all()
+    assert_array_almost_equal(F_sparse, F)
+    assert_array_almost_equal(pv_sparse, pv)
 
 
 def test_f_regression():
@@ -87,21 +71,11 @@ def test_f_regression():
     assert(pv[:5] < 0.05).all()
     assert(pv[5:] > 1.e-4).all()
 
-
-def test_f_regression_sparse():
-    """
-    Test whether the F test yields meaningful results
-    on a simple simulated regression problem
-    """
-    X, y = make_regression(n_samples=200, n_features=20,
-        n_informative=5, shuffle=False, random_state=0)
-
-    F, pv = f_regression(sparse.csr_matrix(X), y, center=False)
-    assert(F > 0).all()
-    assert(pv > 0).all()
-    assert(pv < 1).all()
-    assert(pv[:5] < 0.05).all()
-    assert(pv[5:] > 1.e-4).all()
+    # again without centering, compare with sparse
+    F, pv = f_regression(X, y, center=False)
+    F_sparse, pv_sparse = f_regression(sparse.csr_matrix(X), y, center=False)
+    assert_array_almost_equal(F_sparse, F)
+    assert_array_almost_equal(pv_sparse, pv)
 
 
 def test_f_regression_input_dtype():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -9,7 +9,7 @@ from sklearn.feature_selection import (chi2, f_classif, f_oneway, f_regression,
 from nose.tools import assert_equal, assert_true
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from scipy import stats
+from scipy import stats, sparse
 from sklearn.datasets.samples_generator import make_classification, \
                                                      make_regression
 
@@ -39,13 +39,32 @@ def test_f_classif():
     Test whether the F test yields meaningful results
     on a simple simulated classification problem
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
-    F, pv = f_classif(X, Y)
+    F, pv = f_classif(X, y)
+    assert(F > 0).all()
+    assert(pv > 0).all()
+    assert(pv < 1).all()
+    assert(pv[:5] < 0.05).all()
+    assert(pv[5:] > 1.e-4).all()
+
+
+def test_f_classif_sparse():
+    """
+    Test whether the F test yields meaningful results
+    on a simple simulated classification problem
+    """
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    F, pv = f_classif(sparse.csr_matrix(X), y)
     assert(F > 0).all()
     assert(pv > 0).all()
     assert(pv < 1).all()
@@ -58,10 +77,26 @@ def test_f_regression():
     Test whether the F test yields meaningful results
     on a simple simulated regression problem
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
         n_informative=5, shuffle=False, random_state=0)
 
-    F, pv = f_regression(X, Y)
+    F, pv = f_regression(X, y)
+    assert(F > 0).all()
+    assert(pv > 0).all()
+    assert(pv < 1).all()
+    assert(pv[:5] < 0.05).all()
+    assert(pv[5:] > 1.e-4).all()
+
+
+def test_f_regression_sparse():
+    """
+    Test whether the F test yields meaningful results
+    on a simple simulated regression problem
+    """
+    X, y = make_regression(n_samples=200, n_features=20,
+        n_informative=5, shuffle=False, random_state=0)
+
+    F, pv = f_regression(sparse.csr_matrix(X), y, center=False)
     assert(F > 0).all()
     assert(pv > 0).all()
     assert(pv < 1).all()
@@ -89,13 +124,13 @@ def test_f_classif_multi_class():
     Test whether the F test yields meaningful results
     on a simple simulated classification problem
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
-    F, pv = f_classif(X, Y)
+    F, pv = f_classif(X, y)
     assert(F > 0).all()
     assert(pv > 0).all()
     assert(pv < 1).all()
@@ -109,17 +144,40 @@ def test_select_percentile_classif():
     gets the correct items in a simple classification problem
     with the percentile heuristic
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
     univariate_filter = SelectPercentile(f_classif, percentile=25)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_classif, mode='percentile',
-                    param=25).fit(X, Y).transform(X)
+                    param=25).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
+    support = univariate_filter.get_support()
+    gtruth = np.zeros(20)
+    gtruth[:5] = 1
+    assert_array_equal(support, gtruth)
+
+
+def test_select_percentile_classif_sparse():
+    """
+    Test whether the relative univariate feature selection
+    gets the correct items in a simple classification problem
+    with the percentile heuristic
+    """
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+    X = sparse.csr_matrix(X)
+    univariate_filter = SelectPercentile(f_classif, percentile=25)
+    X_r = univariate_filter.fit(X, y).transform(X)
+    X_r2 = GenericUnivariateSelect(f_classif, mode='percentile',
+                    param=25).fit(X, y).transform(X)
+    assert_array_equal(X_r.toarray(), X_r2.toarray())
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
     gtruth[:5] = 1
@@ -135,16 +193,16 @@ def test_select_kbest_classif():
     gets the correct items in a simple classification problem
     with the k best heuristic
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
     univariate_filter = SelectKBest(f_classif, k=5)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_classif, mode='k_best',
-                    param=5).fit(X, Y).transform(X)
+                    param=5).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -158,16 +216,16 @@ def test_select_fpr_classif():
     gets the correct items in a simple classification problem
     with the fpr heuristic
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
     univariate_filter = SelectFpr(f_classif, alpha=0.0001)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_classif, mode='fpr',
-                    param=0.0001).fit(X, Y).transform(X)
+                    param=0.0001).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -181,16 +239,16 @@ def test_select_fdr_classif():
     gets the correct items in a simple classification problem
     with the fpr heuristic
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
     univariate_filter = SelectFdr(f_classif, alpha=0.0001)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_classif, mode='fdr',
-                    param=0.0001).fit(X, Y).transform(X)
+                    param=0.0001).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -204,16 +262,16 @@ def test_select_fwe_classif():
     gets the correct items in a simple classification problem
     with the fpr heuristic
     """
-    X, Y = make_classification(n_samples=200, n_features=20,
+    X, y = make_classification(n_samples=200, n_features=20,
                                n_informative=3, n_redundant=2,
                                n_repeated=0, n_classes=8,
                                n_clusters_per_class=1, flip_y=0.0,
                                class_sep=10, shuffle=False, random_state=0)
 
     univariate_filter = SelectFwe(f_classif, alpha=0.01)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_classif, mode='fwe',
-                    param=0.01).fit(X, Y).transform(X)
+                    param=0.01).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -230,13 +288,13 @@ def test_select_percentile_regression():
     gets the correct items in a simple regression problem
     with the percentile heuristic
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectPercentile(f_regression, percentile=25)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='percentile',
-                    param=25).fit(X, Y).transform(X)
+                    param=25).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -252,13 +310,13 @@ def test_select_percentile_regression_full():
     Test whether the relative univariate feature selection
     selects all features when '100%' is asked.
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectPercentile(f_regression, percentile=100)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='percentile',
-                    param=100).fit(X, Y).transform(X)
+                    param=100).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.ones(20)
@@ -271,13 +329,13 @@ def test_select_kbest_regression():
     gets the correct items in a simple regression problem
     with the k best heuristic
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectKBest(f_regression, k=5)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='k_best',
-                    param=5).fit(X, Y).transform(X)
+                    param=5).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -291,13 +349,13 @@ def test_select_fpr_regression():
     gets the correct items in a simple regression problem
     with the fpr heuristic
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectFpr(f_regression, alpha=0.01)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='fpr',
-                    param=0.01).fit(X, Y).transform(X)
+                    param=0.01).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -312,13 +370,13 @@ def test_select_fdr_regression():
     gets the correct items in a simple regression problem
     with the fdr heuristic
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectFdr(f_regression, alpha=0.01)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='fdr',
-                    param=0.01).fit(X, Y).transform(X)
+                    param=0.01).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
@@ -332,13 +390,13 @@ def test_select_fwe_regression():
     gets the correct items in a simple regression problem
     with the fwe heuristic
     """
-    X, Y = make_regression(n_samples=200, n_features=20,
+    X, y = make_regression(n_samples=200, n_features=20,
                            n_informative=5, shuffle=False, random_state=0)
 
     univariate_filter = SelectFwe(f_regression, alpha=0.01)
-    X_r = univariate_filter.fit(X, Y).transform(X)
+    X_r = univariate_filter.fit(X, y).transform(X)
     X_r2 = GenericUnivariateSelect(f_regression, mode='fwe',
-                    param=0.01).fit(X, Y).transform(X)
+                    param=0.01).fit(X, y).transform(X)
     assert_array_equal(X_r, X_r2)
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -92,6 +92,7 @@ def f_oneway(*args):
     msb = ssbn / float(dfbn)
     msw = sswn / float(dfwn)
     f = msb / msw
+    # flatten matrix to vector in sparse case
     f = np.asarray(f).ravel()
     prob = stats.fprob(dfbn, dfwn, f)
     return f, prob
@@ -202,7 +203,7 @@ def f_regression(X, y, center=True):
     """
     if issparse(X) and center:
         raise ValueError("center=True only allowed for dense data")
-    X, y = check_arrays(X, y, dtype=np.float, )
+    X, y = check_arrays(X, y, dtype=np.float)
     y = y.ravel()
     if center:
         y = y - np.mean(y)
@@ -210,10 +211,7 @@ def f_regression(X, y, center=True):
         X -= X.mean(axis=0)
 
     # compute the correlation
-    if issparse(X):
-        corr = y * X
-    else:
-        corr = np.dot(y, X)
+    corr = safe_sparse_dot(y, X)
     corr /= np.asarray(np.sqrt(safe_sqr(X).sum(axis=0))).ravel()
     corr /= np.asarray(np.sqrt(safe_sqr(y).sum())).ravel()
 

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -109,9 +109,9 @@ def f_classif(X, y):
 
     Returns
     -------
-    F : array shape = [n_features,],
+    F : array, shape = [n_features,]
         The set of F values
-    pval : array shape = [n_features,],
+    pval : array, shape = [n_features,]
         The set of p-values
     """
     X, y = check_arrays(X, y)
@@ -145,9 +145,9 @@ def chi2(X, y):
 
     Returns
     -------
-    chi2 : array shape = [n_features,]
+    chi2 : array, shape = [n_features,]
         chi2 statistics of each feature
-    pval : array shape = [n_features,]
+    pval : array, shape = [n_features,]
         p-values of each feature
 
     Notes
@@ -195,9 +195,9 @@ def f_regression(X, y, center=True):
 
     Returns
     -------
-    F : array of shape (m),
+    F : array, shape=[m,]
         The set of F values
-    pval : array of shape(m)
+    pval : array, shape=[m,]
         The set of p-values
     """
     if issparse(X) and center:

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -13,7 +13,8 @@ from scipy.sparse import issparse
 
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import LabelBinarizer
-from ..utils import array2d, atleast2d_or_csr, deprecated, as_float_array
+from ..utils import array2d, atleast2d_or_csr, deprecated, \
+        check_arrays, safe_asarray, safe_sqr
 from ..utils.extmath import safe_sparse_dot
 
 ######################################################################
@@ -72,13 +73,14 @@ def f_oneway(*args):
 
     """
     n_classes = len(args)
-    n_samples_per_class = np.array([len(a) for a in args])
+    args = [safe_asarray(a) for a in args]
+    n_samples_per_class = np.array([a.shape[0] for a in args])
     n_samples = np.sum(n_samples_per_class)
     ss_alldata = reduce(lambda x, y: x + y,
-            [np.sum(a ** 2, axis=0) for a in args])
-    sums_args = [np.sum(a, axis=0) for a in args]
-    square_of_sums_alldata = reduce(lambda x, y: x + y, sums_args) ** 2
-    square_of_sums_args = [s ** 2 for s in sums_args]
+            [safe_sqr(a).sum(axis=0) for a in args])
+    sums_args = [a.sum(axis=0) for a in args]
+    square_of_sums_alldata = safe_sqr(reduce(lambda x, y: x + y, sums_args))
+    square_of_sums_args = [safe_sqr(s) for s in sums_args]
     sstot = ss_alldata - square_of_sums_alldata / float(n_samples)
     ssbn = 0.
     for k, _ in enumerate(args):
@@ -90,8 +92,8 @@ def f_oneway(*args):
     msb = ssbn / float(dfbn)
     msw = sswn / float(dfwn)
     f = msb / msw
-    prob = stats.fprob(dfbn, dfwn, f)
-    return f, prob
+    prob = np.asarray(stats.fprob(dfbn, dfwn, f))
+    return f, prob.ravel()
 
 
 def f_classif(X, y):
@@ -111,9 +113,11 @@ def f_classif(X, y):
     pval : array of shape(m),
         The set of p-values
     """
-    X = array2d(X)
-    y = np.asarray(y).ravel()
-    args = [X[y == k] for k in np.unique(y)]
+    X, y = check_arrays(X, y)
+    if issparse(X):
+        args = [X[np.where(y == k)[0]] for k in np.unique(y)]
+    else:
+        args = [X[y == k] for k in np.unique(y)]
     return f_oneway(*args)
 
 
@@ -179,7 +183,7 @@ def f_regression(X, y, center=True):
         The data matrix
 
     center : True, bool,
-        If true, X and y are centered
+        If true, X and y will be centered
 
     Returns
     -------
@@ -188,17 +192,22 @@ def f_regression(X, y, center=True):
     pval : array of shape(m)
         The set of p-values
     """
-    y = as_float_array(y, copy=False).ravel()
-    X = as_float_array(X, copy=False)  # copy only if center
+    if issparse(X) and center:
+        raise ValueError("center=True only allowed for dense data")
+    X, y = check_arrays(X, y, dtype=np.float, )
+    y = y.ravel()
     if center:
         y = y - np.mean(y)
         X = X.copy('F')  # faster in fortran
-        X -= np.mean(X, axis=0)
+        X -= X.mean(axis=0)
 
     # compute the correlation
-    corr = np.dot(y, X)
-    corr /= np.sqrt(np.sum(X ** 2, 0))
-    corr /= np.sqrt(np.sum(y ** 2))
+    if issparse(X):
+        corr = y * X
+    else:
+        corr = np.dot(y, X)
+    corr /= np.asarray(np.sqrt(safe_sqr(X).sum(axis=0))).ravel()
+    corr /= np.asarray(np.sqrt(safe_sqr(y).sum())).ravel()
 
     # convert to p-value
     dof = y.size - 2

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -33,7 +33,7 @@ def f_oneway(*args):
 
     Parameters
     ----------
-    sample1, sample2, ... : array_like
+    sample1, sample2, ... : array_like, sparse matrices
         The sample measurements should be given as arguments.
 
     Returns
@@ -102,16 +102,16 @@ def f_classif(X, y):
 
     Parameters
     ----------
-    X : array of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} shape = [n_samples, n_features]
         The set of regressors that will tested sequentially
     y : array of shape(n_samples)
         The data matrix
 
     Returns
     -------
-    F : array of shape (m),
+    F : array shape = [n_features,],
         The set of F values
-    pval : array of shape(m),
+    pval : array shape = [n_features,],
         The set of p-values
     """
     X, y = check_arrays(X, y)
@@ -125,15 +125,15 @@ def f_classif(X, y):
 def chi2(X, y):
     """Compute χ² (chi-squared) statistic for each class/feature combination.
 
-    This transformer can be used to select the n_features features with the
+    This score can be used to select the n_features features with the
     highest values for the χ² (chi-square) statistic from either boolean or
     multinomially distributed data (e.g., term counts in document
     classification) relative to the classes.
 
     Recall that the χ² statistic measures dependence between stochastic
-    variables, so a transformer based on this function "weeds out" the features
-    that are the most likely to be independent of class and therefore
-    irrelevant for classification.
+    variables, so using this function "weeds out" the features that are the
+    most likely to be independent of class and therefore irrelevant for
+    classification.
 
     Parameters
     ----------
@@ -143,8 +143,15 @@ def chi2(X, y):
     y : array-like, shape = n_samples
         Target vector (class labels).
 
+    Returns
+    -------
+    chi2 : array shape = [n_features,]
+        chi2 statistics of each feature
+    pval : array shape = [n_features,]
+        p-values of each feature
+
     Notes
-    ----------
+    -----
     Complexity of this algorithm is O(n_classes * n_features).
     """
 
@@ -178,7 +185,7 @@ def f_regression(X, y, center=True):
 
     Parameters
     ----------
-    X : array of shape (n_samples, n_features)
+    X : {array-like, sparse matrix}  shape = [n_samples, n_features]
         The set of regressors that will tested sequentially
     y : array of shape(n_samples)
         The data matrix

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -14,7 +14,7 @@ from scipy.sparse import issparse
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import LabelBinarizer
 from ..utils import array2d, atleast2d_or_csr, deprecated, \
-        check_arrays, safe_asarray, safe_sqr
+        check_arrays, safe_asarray, safe_sqr, safe_mask
 from ..utils.extmath import safe_sparse_dot
 
 ######################################################################
@@ -116,10 +116,7 @@ def f_classif(X, y):
         The set of p-values
     """
     X, y = check_arrays(X, y)
-    if issparse(X):
-        args = [X[np.where(y == k)[0]] for k in np.unique(y)]
-    else:
-        args = [X[y == k] for k in np.unique(y)]
+    args = [X[safe_mask(X, y == k)] for k in np.unique(y)]
     return f_oneway(*args)
 
 

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -92,8 +92,9 @@ def f_oneway(*args):
     msb = ssbn / float(dfbn)
     msw = sswn / float(dfwn)
     f = msb / msw
-    prob = np.asarray(stats.fprob(dfbn, dfwn, f))
-    return f, prob.ravel()
+    f = np.asarray(f).ravel()
+    prob = stats.fprob(dfbn, dfwn, f)
+    return f, prob
 
 
 def f_classif(X, y):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -284,7 +284,7 @@ def shuffle(*arrays, **options):
     return resample(*arrays, **options)
 
 
-def safe_sqr(X):
+def safe_sqr(X, copy=True):
     """Element wise squaring of array-likes and sparse matrices.
 
     Parameters
@@ -297,11 +297,15 @@ def safe_sqr(X):
     """
     X = safe_asarray(X)
     if issparse(X):
-        X_ = X.copy()
-        X_.data **= 2
+        if copy:
+            X = X.copy()
+        X.data **= 2
     else:
-        X_ = X ** 2
-    return X_
+        if copy:
+            X = X ** 2
+        else:
+            X **= 2
+    return X
 
 
 def gen_even_slices(n, n_packs):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -3,6 +3,7 @@ The :mod:`sklearn.utils` module includes various utilites.
 """
 
 import numpy as np
+from scipy.sparse import issparse
 import warnings
 
 from .validation import *
@@ -281,6 +282,26 @@ def shuffle(*arrays, **options):
     """
     options['replace'] = False
     return resample(*arrays, **options)
+
+
+def safe_sqr(X):
+    """Element wise squaring of array-likes and sparse matrices.
+
+    Parameters
+    ----------
+    X : array like, matrix, sparse matrix
+
+    Returns
+    -------
+    X ** 2 : element wise square
+    """
+    X = safe_asarray(X)
+    if issparse(X):
+        X_ = X.copy()
+        X_.data **= 2
+    else:
+        X_ = X ** 2
+    return X_
 
 
 def gen_even_slices(n, n_packs):


### PR DESCRIPTION
This PR adds sparse matrix support to ``f_classif" and "f_regression" univariate feature selection.

I'm not very good with sparse stuff, so any suggestions are more then welcome.

I added a utility function that computes the element wise square of an array-like or sparse matrix and put it in utils.
I hope this is not nonsense but seemed the simplest thing to do. Is there a better way to to element-wise operations in sparse matrices?
Also I'm not sure if there might be a better place for the function in on of the submodules and whether it should be documented in the developers docs.
