### PR TITLE
WIP Grid search convenience class.

### DIFF
--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -1,0 +1,46 @@
+"""
+=====================================================
+Visualizing results of high dimensional grid searches
+=====================================================
+
+Often one is faced with combining feature extraction, feature selection
+and classification into a complex pipeline.
+Each individual step usually has many tunable parameters.  Finding the
+important parameters for a given task and picking robust settings is often
+hard.
+
+This example show how to visualize results of a grid search with
+many interacting parameters.
+The ``DecisionTreeClassifier`` is a good model for a complex pipeline as there
+are many parameters to tweak, but only few have significant influence.
+"""
+print __doc__
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from sklearn.datasets import load_digits
+from sklearn.grid_search import GridSearchCV
+from sklearn.tree import DecisionTreeClassifier
+
+iris = load_digits()
+X, y = iris.data, iris.target
+
+param_grid = {'max_depth': np.arange(1, 10, 2), 'min_samples_leaf': [1, 5, 10],
+              'min_samples_split': [1, 5, 10],
+              'max_features': [1, 10, 30, 40, 64]}
+
+grid_search = GridSearchCV(DecisionTreeClassifier(), param_grid=param_grid,
+                            cv=3)
+grid_search.fit(X, y)
+
+results = grid_search.scores_
+
+fig, axes = plt.subplots(2, 2)
+axes = axes.ravel()
+
+for ax, param in zip(axes, results.params):
+    ax.errorbar(results.values[param], results.accumulated_mean(param, 'max'),
+            yerr=results.accumulated_std(param, 'max'))
+    ax.set_title(param)
+plt.show()

--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -16,31 +16,28 @@ are many parameters to tweak, but only few have significant influence.
 """
 print __doc__
 
-import numpy as np
 import matplotlib.pyplot as plt
 
-from sklearn.datasets import load_digits
+from sklearn.datasets import make_classification
 from sklearn.grid_search import GridSearchCV
 from sklearn.tree import DecisionTreeClassifier
 
-iris = load_digits()
-X, y = iris.data, iris.target
+X, y = make_classification(n_samples=100, n_features=10)
 
-param_grid = {'max_depth': np.arange(1, 10, 2), 'min_samples_leaf': [1, 5, 10],
-              'min_samples_split': [1, 5, 10],
-              'max_features': [1, 10, 30, 40, 64]}
+param_grid = {'max_depth': range(1, 8), 'min_samples_leaf': [1, 2, 3, 4, 5],
+        'max_features': [1, 3, 5, 8, 10]}
 
 grid_search = GridSearchCV(DecisionTreeClassifier(), param_grid=param_grid,
-                            cv=3)
+                            cv=5)
 grid_search.fit(X, y)
 
 results = grid_search.scores_
 
-fig, axes = plt.subplots(2, 2)
+fig, axes = plt.subplots(1, 3)
 axes = axes.ravel()
 
 for ax, param in zip(axes, results.params):
-    ax.errorbar(results.values[param], results.accumulated_mean(param, 'max'),
-            yerr=results.accumulated_std(param, 'max'))
+    means, errors = results.accumulated(param, 'mean')
+    ax.errorbar(results.values[param], means, yerr=errors)
     ax.set_title(param)
 plt.show()

--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -24,18 +24,17 @@ from sklearn.tree import DecisionTreeClassifier
 
 X, y = make_classification(n_samples=100, n_features=10)
 
-param_grid = {'max_depth': range(1, 8), 'min_samples_leaf': [1, 2, 3, 4],
+param_grid = {'max_depth': range(1, 8), 'min_samples_split': [1, 2, 3, 4],
         'max_features': [1, 3, 5, 8, 10]}
 
 grid_search = GridSearchCV(DecisionTreeClassifier(), param_grid=param_grid,
-                            cv=5)
+        cv=5)
 grid_search.fit(X, y)
 
 results = grid_search.scores_
 
 fig, axes = plt.subplots(1, 3)
 axes = axes.ravel()
-
 for ax, param in zip(axes, results.params):
     means, errors = results.accumulated(param, 'max')
     ax.errorbar(results.values[param], means, yerr=errors)

--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -12,7 +12,7 @@ hard.
 This example show how to visualize results of a grid search with
 many interacting parameters.
 The ``DecisionTreeClassifier`` is a good model for a complex pipeline as there
-are many parameters to tweak, but only few have significant influence.
+are many parameters to tweak, but often only few have significant influence.
 """
 print __doc__
 
@@ -24,7 +24,7 @@ from sklearn.tree import DecisionTreeClassifier
 
 X, y = make_classification(n_samples=100, n_features=10)
 
-param_grid = {'max_depth': range(1, 8), 'min_samples_leaf': [1, 2, 3, 4, 5],
+param_grid = {'max_depth': range(1, 8), 'min_samples_leaf': [1, 2, 3, 4],
         'max_features': [1, 3, 5, 8, 10]}
 
 grid_search = GridSearchCV(DecisionTreeClassifier(), param_grid=param_grid,
@@ -37,7 +37,7 @@ fig, axes = plt.subplots(1, 3)
 axes = axes.ravel()
 
 for ax, param in zip(axes, results.params):
-    means, errors = results.accumulated(param, 'mean')
+    means, errors = results.accumulated(param, 'max')
     ax.errorbar(results.values[param], means, yerr=errors)
     ax.set_title(param)
 plt.show()

--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -16,7 +16,7 @@ are many parameters to tweak, but often only few have significant influence.
 """
 print __doc__
 
-import matplotlib.pyplot as plt
+import pylab as pl
 
 from sklearn.datasets import make_classification
 from sklearn.grid_search import GridSearchCV
@@ -31,12 +31,14 @@ grid_search = GridSearchCV(DecisionTreeClassifier(), param_grid=param_grid,
         cv=5)
 grid_search.fit(X, y)
 
-results = grid_search.scores_
+cv_scores = grid_search.scores_
 
-fig, axes = plt.subplots(1, 3)
+fig, axes = pl.subplots(1, 3)
 axes = axes.ravel()
-for ax, param in zip(axes, results.params):
-    means, errors = results.accumulated(param, 'max')
-    ax.errorbar(results.values[param], means, yerr=errors)
+for ax, param in zip(axes, cv_scores.params):
+    means, errors = cv_scores.accumulated(param, 'max')
+    ax.errorbar(cv_scores.values[param], means, yerr=errors)
     ax.set_title(param)
-plt.show()
+fig.set_size_inches((12, 4), forward=True)
+pl.subplots_adjust(left=0.05, right=0.95)
+pl.show()

--- a/examples/plot_grid_search.py
+++ b/examples/plot_grid_search.py
@@ -22,7 +22,7 @@ from sklearn.datasets import make_classification
 from sklearn.grid_search import GridSearchCV
 from sklearn.tree import DecisionTreeClassifier
 
-X, y = make_classification(n_samples=100, n_features=10)
+X, y = make_classification(n_samples=100, n_features=10, random_state=0)
 
 param_grid = {'max_depth': range(1, 8), 'min_samples_split': [1, 2, 3, 4],
         'max_features': [1, 3, 5, 8, 10]}
@@ -36,9 +36,11 @@ cv_scores = grid_search.scores_
 fig, axes = pl.subplots(1, 3)
 axes = axes.ravel()
 for ax, param in zip(axes, cv_scores.params):
-    means, errors = cv_scores.accumulated(param, 'max')
-    ax.errorbar(cv_scores.values[param], means, yerr=errors)
-    ax.set_title(param)
+    means, errors = cv_scores.accumulate(param, 'max')
+    ax.boxplot(cv_scores.values[param], means, yerr=errors)
+    ax.set_xlabel(param)
+    ax.set_ylabel("accuracy")
+    ax.set_ylim(0.6, 0.95)
 fig.set_size_inches((12, 4), forward=True)
-pl.subplots_adjust(left=0.05, right=0.95)
+pl.subplots_adjust(left=0.07, right=0.95, bottom=0.15, wspace=0.26)
 pl.show()

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -105,12 +105,7 @@ for (k, (C, gamma, clf)) in enumerate(classifiers):
     pl.axis('tight')
 
 # plot the scores of the grid
-# grid_scores_ contains parameter settings and scores
-score_dict = grid.grid_scores_
-
-# We extract just the scores
-scores = [x[1] for x in score_dict]
-scores = np.array(scores).reshape(len(C_range), len(gamma_range))
+scores = grid.scores_.mean()
 
 # draw heatmap of accuracy as a function of gamma and C
 pl.figure(figsize=(8, 6))

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -120,8 +120,8 @@ pl.yticks(np.arange(len(C_range)), C_range)
 
 fig, axes = pl.subplots(2, 1)
 for ax, param in zip(axes, results.params):
-    means, errors = results.accumulated(param, 'mean')
-    ax.errorbar(np.arange(len(results.values[param])), means,
+    maxs, errors = results.accumulated(param, 'max')
+    ax.errorbar(np.arange(len(results.values[param])), maxs,
             yerr=errors)
     ax.set_title(param)
 

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -105,7 +105,8 @@ for (k, (C, gamma, clf)) in enumerate(classifiers):
     pl.axis('tight')
 
 # plot the scores of the grid
-scores = grid.scores_.mean()
+results = grid.scores_
+scores = results.mean()
 
 # draw heatmap of accuracy as a function of gamma and C
 pl.figure(figsize=(8, 6))
@@ -116,5 +117,12 @@ pl.ylabel('C')
 pl.colorbar()
 pl.xticks(np.arange(len(gamma_range)), gamma_range, rotation=45)
 pl.yticks(np.arange(len(C_range)), C_range)
+
+fig, axes = pl.subplots(2, 1)
+for ax, param in zip(axes, results.params):
+    means, errors = results.accumulated(param, 'mean')
+    ax.errorbar(np.arange(len(results.values[param])), means,
+            yerr=errors)
+    ax.set_title(param)
 
 pl.show()

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -113,13 +113,14 @@ pl.subplots_adjust(left=0.05, right=0.95, bottom=0.15, top=0.95)
 pl.imshow(cv_scores.mean(), interpolation='nearest', cmap=pl.cm.spectral)
 pl.xlabel('gamma')
 pl.ylabel('C')
-pl.colorbar()
+cb = pl.colorbar()
+cb.set_label("Accuracy")
 pl.xticks(np.arange(len(gamma_range)), gamma_range, rotation=45)
 pl.yticks(np.arange(len(C_range)), C_range)
 
 fig, axes = pl.subplots(2, 1)
 for ax, param in zip(axes, cv_scores.params):
-    maxs, errors = cv_scores.accumulated(param, 'max')
+    maxs, errors = cv_scores.accumulate(param, 'max')
     ax.errorbar(np.arange(len(cv_scores.values[param])), maxs,
             yerr=errors)
     ax.set_title(param)

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -105,13 +105,12 @@ for (k, (C, gamma, clf)) in enumerate(classifiers):
     pl.axis('tight')
 
 # plot the scores of the grid
-results = grid.scores_
-scores = results.mean()
+cv_scores = grid.scores_
 
 # draw heatmap of accuracy as a function of gamma and C
 pl.figure(figsize=(8, 6))
 pl.subplots_adjust(left=0.05, right=0.95, bottom=0.15, top=0.95)
-pl.imshow(scores, interpolation='nearest', cmap=pl.cm.spectral)
+pl.imshow(cv_scores.mean(), interpolation='nearest', cmap=pl.cm.spectral)
 pl.xlabel('gamma')
 pl.ylabel('C')
 pl.colorbar()
@@ -119,9 +118,9 @@ pl.xticks(np.arange(len(gamma_range)), gamma_range, rotation=45)
 pl.yticks(np.arange(len(C_range)), C_range)
 
 fig, axes = pl.subplots(2, 1)
-for ax, param in zip(axes, results.params):
-    maxs, errors = results.accumulated(param, 'max')
-    ax.errorbar(np.arange(len(results.values[param])), maxs,
+for ax, param in zip(axes, cv_scores.params):
+    maxs, errors = cv_scores.accumulated(param, 'max')
+    ax.errorbar(np.arange(len(cv_scores.values[param])), maxs,
             yerr=errors)
     ax.set_title(param)
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -56,7 +56,7 @@ class ResultGrid(object):
         parameter grid."""
         return np.std(self.scores, axis=-1)
 
-    def accumulated_mean(self, param, kind="mean"):
+    def accumulated(self, param, kind="mean"):
         """Accumulates scores over all but one parameter.
 
         Useful for grid searches in many parameters, where
@@ -76,46 +76,23 @@ class ResultGrid(object):
             1d array of scores corresponding to the different settings
             of ``param``.
         """
-        return self._accumulate(self.mean(), param, kind)
-
-    def accumulated_std(self, param, kind="mean"):
-        """Accumulates standard deviations of scores over all but one
-        parameter.
-
-        Useful for grid searches in many parameters, where
-        the whole grid can not easily be visualized.
-
-        Parameters
-        ----------
-        param: string
-            Name of the parameter not to accumulate over.
-        kind: string, 'mean' or 'max'
-            Operation that is used to accumulate over all parameters
-            except ``param``.
-
-        Returns
-        -------
-        scores: ndarray
-            1d array of scores corresponding to the different settings
-            of ``param``.
-        """
-        return self._accumulate(self.std(), param, kind)
-
-    def _accumulate(self, X, param, kind):
         if kind == "mean":
-            acc_func = np.mean
+            pass
         elif kind == "max":
-            acc_func = np.max
+            raise NotImplementedError()
         else:
             raise ValueError("kind must be 'mean' or 'max', got %s." %
                     str(kind))
         index = self.params.index(param)
-        accumulated = self.scores
-        for i in xrange(index + 1, self.scores.ndim):
-            accumulated = acc_func(accumulated, axis=-1)
+        accumulated_mean = self.mean()
+        accumulated_std = self.std()
+        for i in xrange(index + 1, self.scores.ndim - 1):
+            accumulated_mean = np.mean(accumulated_mean, axis=-1)
+            accumulated_std = np.mean(accumulated_std, axis=-1)
         for i in xrange(0, index):
-            accumulated = acc_func(accumulated, axis=0)
-        return accumulated
+            accumulated_mean = np.mean(accumulated_mean, axis=0)
+            accumulated_std = np.mean(accumulated_std, axis=0)
+        return accumulated_mean, accumulated_std
 
 
 class IterGrid(object):

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -75,6 +75,8 @@ class ResultGrid(object):
         scores: ndarray
             1d array of scores corresponding to the different settings
             of ``param``.
+        errors: ndarray
+            1d array of standard deviations of scores.
         """
         index = self.params.index(param)
         # make interesting axis the first

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -545,8 +545,6 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
             self.scores_.append(ResultGrid(sorted_params, one_grid,
                                            score_array))
             start += n_entries
-        #from IPython.core.debugger import Tracer
-        #Tracer()()
 
         # often the list is just one grid. Make access easier
         if len(self.scores_) is 1:

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -76,23 +76,26 @@ class ResultGrid(object):
             1d array of scores corresponding to the different settings
             of ``param``.
         """
+        index = self.params.index(param)
+        # make interesting axis the first
+        accumulated_mean = np.rollaxis(self.mean(), index, 0)
+        accumulated_std = np.rollaxis(self.std(), index, 0)
         if kind == "mean":
-            pass
+            for i in xrange(1, self.scores.ndim - 1):
+                accumulated_mean = np.mean(accumulated_mean, axis=-1)
+                accumulated_std = np.mean(accumulated_std, axis=-1)
         elif kind == "max":
-            raise NotImplementedError()
+            for i in xrange(1, self.scores.ndim - 1):
+                max_inds = np.argmax(accumulated_mean, axis=-1)
+                inds = np.indices(max_inds.shape)
+                inds = np.vstack([inds, max_inds[np.newaxis]])
+                from IPython.core.debugger import Tracer
+                Tracer()()
+                accumulated_mean = accumulated_mean[gx, gy, max_inds]
+                accumulated_std = accumulated_std[gx, gy, max_inds]
         else:
             raise ValueError("kind must be 'mean' or 'max', got %s." %
                     str(kind))
-        index = self.params.index(param)
-        accumulated_mean = self.mean()
-        accumulated_std = self.std()
-        for i in xrange(index + 1, self.scores.ndim - 1):
-            accumulated_mean = np.mean(accumulated_mean, axis=-1)
-            accumulated_std = np.mean(accumulated_std, axis=-1)
-        for i in xrange(0, index):
-            accumulated_mean = np.mean(accumulated_mean, axis=0)
-            accumulated_std = np.mean(accumulated_std, axis=0)
-        return accumulated_mean, accumulated_std
 
 
 class IterGrid(object):

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -20,21 +20,86 @@ from .utils import check_arrays, safe_mask
 
 
 class ResultGrid(object):
+    """Provides easy access to grid search results.
+
+    This object is constructed by GridSearchCV and
+    provides an easy interface to evaluate the grid search
+    results.
+
+    Attributes
+    ----------
+    params: list of string
+        Lists parameters adjusted during grid-search
+        This is an alphabetical sorting of the keys
+        of the ``param_grid`` used in the GridSearchCV.
+    values: dict
+        This contains the values of the parameters
+        that were used during grid search.
+    scores: ndarray
+        Contains all the scores of all runs.
+        Each axis corresponds to the setting of one
+        parameter, in the order given in params.
+        The last axis corresponds to the folds.
+    """
+
     def __init__(self, params, values, scores):
         self.scores = scores
         self.params = params
         self.values = values
 
     def mean(self):
+        """Returns mean scores over folds for the whole parameter grid."""
         return np.mean(self.scores, axis=-1)
 
     def std(self):
+        """Returns standard deviation of scores over folds for the whole
+        parameter grid."""
         return np.std(self.scores, axis=-1)
 
     def accumulated_mean(self, param, kind="mean"):
+        """Accumulates scores over all but one parameter.
+
+        Useful for grid searches in many parameters, where
+        the whole grid can not easily be visualized.
+
+        Parameters
+        ----------
+        param: string
+            Name of the parameter not to accumulate over.
+        kind: string, 'mean' or 'max'
+            Operation that is used to accumulate over all parameters
+            except ``param``.
+
+        Returns
+        -------
+        scores: ndarray
+            1d array of scores corresponding to the different settings
+            of ``param``.
+        """
+
         return self._accumulate(self.mean(), param, kind)
 
     def accumulated_std(self, param, kind="mean"):
+        """Accumulates standard deviations of scores over all but one
+        parameter.
+
+        Useful for grid searches in many parameters, where
+        the whole grid can not easily be visualized.
+
+        Parameters
+        ----------
+        param: string
+            Name of the parameter not to accumulate over.
+        kind: string, 'mean' or 'max'
+            Operation that is used to accumulate over all parameters
+            except ``param``.
+
+        Returns
+        -------
+        scores: ndarray
+            1d array of scores corresponding to the different settings
+            of ``param``.
+        """
         return self._accumulate(self.std(), param, kind)
 
     def _accumulate(self, X, param, kind):

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -56,7 +56,7 @@ class ResultGrid(object):
         parameter grid."""
         return np.std(self.scores, axis=-1)
 
-    def accumulated(self, param, kind="max"):
+    def accumulate(self, param, kind="max"):
         """Accumulates scores over all but one parameter.
 
         Useful for grid searches in many parameters, where
@@ -177,7 +177,6 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, loss_func,
     else:
         X_train = X[safe_mask(X, train)]
         X_test = X[safe_mask(X, test)]
-
     if y is not None:
         y_test = y[safe_mask(y, test)]
         y_train = y[safe_mask(y, train)]
@@ -230,8 +229,8 @@ def _check_param_grid(param_grid):
                 raise ValueError("Parameter values should be a list.")
 
             if len(v) == 0:
-                raise ValueError("Parameter values should be a non-empty "
-                        "list.")
+                raise ValueError("Parameter values should be "
+                                 "a non-empty list.")
 
 
 def _has_one_grid_point(param_grid):
@@ -547,7 +546,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
             start += n_entries
 
         # often the list is just one grid. Make access easier
-        if len(self.scores_) is 1:
+        if len(self.scores_) == 1:
             self.scores_ = self.scores_[0]
 
         # old interface

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -76,7 +76,6 @@ class ResultGrid(object):
             1d array of scores corresponding to the different settings
             of ``param``.
         """
-
         return self._accumulate(self.mean(), param, kind)
 
     def accumulated_std(self, param, kind="mean"):
@@ -367,6 +366,10 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
 
     `best_params_` : dict
         Parameter setting that gave the best results on the hold out data.
+
+    `scores_`: list of ResultGrid
+        For each dict in ``param_grid`` this holds a ``ResultGrid`` that
+        provides easy analysis of the grid search scores.
 
     Notes
     ------

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -240,7 +240,9 @@ def test_result_grid():
     assert_equal(result.mean().shape, (4, 2))
     assert_equal(result.std().shape, (4, 2))
     assert_equal(result.scores.shape, (4, 2, 3))
-    assert_equal(len(result.accumulated_mean('max_depth')), 4)
+    means, errs = result.accumulated('max_depth')
+    assert_equal(len(means), 4)
+    assert_equal(len(errs), 4)
     assert_equal(len(result.values['max_depth']), 4)
 
 


### PR DESCRIPTION
This aims at closing #1020.

It introduces a new class to handle the output of GridSearchCV.
I don't like complexity but I haven't found a nice way to do this otherwise. If you have less complex solutions, please let me know.

Basically this transforms the dicts that are usually in `GridSearchCV.grid_scores_` (remember, this is in general a list of dictionaries) to a list of parameters (which is `sorted(param_grid.keys()`) and an array where
each axis corresponds to one parameter and the last corresponds to folds.
I think this is already an improvement.

The reason why I added the class is that I also want to marginalize parameters. I want to look at it even if I have 5 parameters to adjust. Maximizing over multiple axis is ugly so I wanted to class to handle this.

As always, any comments welcome.
I'll make an example to illustrate the usefulness now :)

Going back to wip as I think this should be designed with having non-grid evaluations of estimators in mind.
