### PR TITLE
WIP GBRT with built-in cross-validation

### DIFF
--- a/sklearn/ensemble/__init__.py
+++ b/sklearn/ensemble/__init__.py
@@ -10,3 +10,5 @@ from .forest import ExtraTreesClassifier
 from .forest import ExtraTreesRegressor
 from .gradient_boosting import GradientBoostingClassifier
 from .gradient_boosting import GradientBoostingRegressor
+from .gradient_boosting import GradientBoostingClassifierCV
+from .gradient_boosting import GradientBoostingRegressorCV

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -663,7 +663,7 @@ class BaseGradientBoosting(BaseEnsemble):
                              "call `fit` before `feature_importances_`.")
         total_sum = np.zeros((self.n_features, ), dtype=np.float64)
         for stage in self.estimators_:
-            stage_sum = sum(tree.compute_feature_importances(method='squared')
+            stage_sum = sum(tree.compute_feature_importances(method='gini')
                             for tree in stage) / len(stage)
             total_sum += stage_sum
 


### PR DESCRIPTION
Two new classes `GradientBoostingClassifierCV` and `GradientBoostingRegressorCV` which pick `n_estimators` based on cross-validation. 

`GradientBoostingClassifierCV` fits a `GradientBoostingClassifier` with `max_estimators` for each fold; it picks `n_estimators` based on the min deviance averaged over all test sets. Finally, it trains the model on the whole training set using the found `n_estimators`. 

`GradientBoostingClassifierCV` is implemented as a `GradientBoostingClassifier` decorator. It soley implements `fit`, otherwise it delegates to `GradientBoostingClassifier` (see `__getattr__` and `__setattr__`).
The current implementation might pose some problems if the client uses `isinstance` rather than duck typing: a `GradientBoostingClassifierCV` instance is not an instance of `GradientBoostingClassifier`. I would really appreciate any remarks/feedback to this issue. 

I tried to adhere the interface of `RidgeCV`. 

Additionally, I refactored the prediction routines in order to remove code duplication. `staged_predict` and `staged_predict_proba` has been added to `GradientBoostingClassifier`. 

Limitations:
- It is currently hard-wired to pick `n_estimtors` based on deviance (no support for custom loss function yet) - is this needed?
- No joblib support yet
- Only cross-validation support - should we add held-out and OOB estimation too?
