### PR TITLE
FIX : make as_float_array keep fortran order on dense array when copy

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2,10 +2,10 @@
 Tests for input validation functions
 """
 
+from tempfile import NamedTemporaryFile
 import numpy as np
 from numpy.testing import assert_array_equal
 import scipy.sparse as sp
-from tempfile import NamedTemporaryFile
 from nose.tools import assert_raises, assert_true, assert_false
 
 from sklearn.utils import (array2d, as_float_array, atleast2d_or_csr,
@@ -31,6 +31,9 @@ def test_as_float_array():
     # Here, X is of the right type, it shouldn't be modified
     X = np.ones((3, 2), dtype=np.float32)
     assert_true(as_float_array(X, copy=False) is X)
+    # Test that if X is fortran ordered it stays
+    X = np.asfortranarray(X)
+    assert_true(np.isfortran(as_float_array(X, copy=True)))
 
 
 def test_check_arrays_exceptions():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -53,8 +53,10 @@ def as_float_array(X, copy=True):
     if isinstance(X, np.matrix) or (not isinstance(X, np.ndarray)
                                     and not sparse.issparse(X)):
         return safe_asarray(X, dtype=np.float64)
-    elif X.dtype in [np.float32, np.float64]:
+    elif sparse.issparse(X) and X.dtype in [np.float32, np.float64]:
         return X.copy() if copy else X
+    elif X.dtype in [np.float32, np.float64]:  # is numpy array
+        return X.copy('F' if X.flags['F_CONTIGUOUS'] else 'C') if copy else X
     else:
         return X.astype(np.float32 if X.dtype == np.int32 else np.float64)
 


### PR DESCRIPTION
issue raised by @ibayer for coordinate descent. Otherwise if X is fortran ordered 2 copies occur

this is a hot fix. A cleaner version should make use of array2d in coordinate_descent.py (no time now)
