### PR TITLE
Fixed docstring for C param in BaseLibLinear/SVM subclasses.

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -27,9 +27,9 @@ class LogisticRegression(BaseLibLinear, ClassifierMixin, SelectorMixin):
         implemented for l2 penalty. Prefer dual=False when
         n_samples > n_features.
 
-    C : float or None, optional (default=None)
+    C : float, optional (default=1.0)
         Specifies the strength of the regularization. The smaller it is
-        the bigger in the regularization. If None then C is set to n_samples.
+        the bigger is the regularization.
 
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -84,6 +84,12 @@ class BaseLibSVM(BaseEstimator):
             raise ValueError("impl should be one of %s, %s was given" % (
                 LIBSVM_IMPL, impl))
 
+        if C is None:
+            warnings.warn("Using 'None' for C of BaseLibSVM"
+                    "is deprecated. Setting C=1.0.",
+                    DeprecationWarning)
+            C = 1.0
+
         self.impl = impl
         self.kernel = kernel
         self.degree = degree
@@ -546,6 +552,13 @@ class BaseLibLinear(BaseEstimator):
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
             multi_class='ovr', fit_intercept=True, intercept_scaling=1,
             class_weight=None, verbose=0):
+
+        if C is None:
+            warnings.warn("Using 'None' for C of BaseLibLinear"
+                    "is deprecated. Setting C=1.0.",
+                    DeprecationWarning)
+            C = 1.0
+
         self.penalty = penalty
         self.loss = loss
         self.dual = dual

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -85,8 +85,10 @@ class BaseLibSVM(BaseEstimator):
                 LIBSVM_IMPL, impl))
 
         if C is None:
-            warnings.warn("Using 'None' for C of BaseLibSVM"
-                    "is deprecated. Setting C=1.0.",
+            warnings.warn("Using 'None' for C of BaseLibSVM is deprecated "
+                    "since version 0.12, and backward compatibility "
+                    "won't be maintained from version 0.14 onward. "
+                    "Setting C=1.0.",
                     DeprecationWarning)
             C = 1.0
 
@@ -554,8 +556,10 @@ class BaseLibLinear(BaseEstimator):
             class_weight=None, verbose=0):
 
         if C is None:
-            warnings.warn("Using 'None' for C of BaseLibLinear"
-                    "is deprecated. Setting C=1.0.",
+            warnings.warn("Using 'None' for C of BaseLibLinear is deprecated "
+                    "since version 0.12, and backward compatibility "
+                    "won't be maintained from version 0.14 onward. "
+                    "Setting C=1.0.",
                     DeprecationWarning)
             C = 1.0
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -16,9 +16,8 @@ class LinearSVC(BaseLibLinear, ClassifierMixin, SelectorMixin):
 
     Parameters
     ----------
-    C : float or None, optional (default=None)
-        Penalty parameter C of the error term. If None then C is set
-        to n_samples.
+    C : float, optional (default=1.0)
+        Penalty parameter C of the error term.
 
     loss : string, 'l1' or 'l2' (default='l2')
         Specifies the loss function. 'l1' is the hinge loss (standard SVM)
@@ -150,9 +149,8 @@ class SVC(BaseSVC):
 
     Parameters
     ----------
-    C : float or None, optional (default=None)
-        Penalty parameter C of the error term. If None then C is set
-        to n_samples.
+    C : float, optional (default=1.0)
+        Penalty parameter C of the error term.
 
     kernel : string, optional (default='rbf')
          Specifies the kernel type to be used in the algorithm.
@@ -387,9 +385,8 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     Parameters
     ----------
-    C : float or None, optional (default=None)
-        penalty parameter C of the error term. If None then C is set
-        to n_samples.
+    C : float, optional (default=1.0)
+        penalty parameter C of the error term.
 
     epsilon : float, optional (default=0.1)
          epsilon in the epsilon-SVR model. It specifies the epsilon-tube
@@ -494,9 +491,8 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     Parameters
     ----------
-    C : float or None, optional (default=None)
-        penalty parameter C of the error term. If None then C is set
-        to n_samples.
+    C : float, optional (default=1.0)
+        penalty parameter C of the error term.
 
     nu : float, optional
         An upper bound on the fraction of training errors and a lower bound of


### PR DESCRIPTION
And added deprecation warning.
