### PR TITLE
MRG added min_df keyword to CountVectorizer, default=2

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -182,11 +182,11 @@ This model has many parameters, however the default values are quite
 reasonable (please see  the :ref:`reference documentation
 <text_feature_extraction_ref>` for the details)::
 
-  >>> vectorizer = CountVectorizer()
-  >>> vectorizer
+  >>> vectorizer = CountVectorizer(min_df=1)
+  >>> vectorizer                            # doctest: +NORMALIZE_WHITESPACE
   CountVectorizer(analyzer='word', binary=False, charset='utf-8',
           charset_error='strict', dtype=<type 'long'>, input='content',
-          lowercase=True, max_df=1.0, max_features=None, max_n=None,
+          lowercase=True, max_df=1.0, max_features=None, max_n=None, min_df=1,
           min_n=None, ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=u'\\b\\w\\w+\\b', tokenizer=None,
           vocabulary=None)
@@ -246,7 +246,7 @@ preserve some of the local ordering information we can extract 2-grams
 of words in addition to the 1-grams (the word themselvs)::
 
   >>> bigram_vectorizer = CountVectorizer(ngram_range=(1, 2),
-  ...                                     token_pattern=ur'\b\w+\b')
+  ...                                     token_pattern=ur'\b\w+\b', min_df=1)
   >>> analyze = bigram_vectorizer.build_analyzer()
   >>> analyze('Bi-grams are cool!')
   [u'bi', u'grams', u'are', u'cool', u'bi grams', u'grams are', u'are cool']
@@ -341,7 +341,7 @@ class called :class:`TfidfVectorizer` that combines all the option of
 :class:`CountVectorizer` and :class:`TfidfTransformer` in a single model::
 
   >>> from sklearn.feature_extraction.text import TfidfVectorizer
-  >>> vectorizer = TfidfVectorizer()
+  >>> vectorizer = TfidfVectorizer(min_df=1)
   >>> vectorizer.fit_transform(corpus)
   ...                                       # doctest: +NORMALIZE_WHITESPACE
   <4x9 sparse matrix of type '<type 'numpy.float64'>'
@@ -410,7 +410,7 @@ A character 2-gram representation, however, would find the documents
 matching in 4 out of 8 features, which may help the preferred classifier
 decide better::
 
-  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', ngram_range=(2, 2))
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', ngram_range=(2, 2), min_df=1)
   >>> counts = ngram_vectorizer.fit_transform(['words', 'wprds'])
   >>> ngram_vectorizer.get_feature_names()
   [u' w', u'ds', u'or', u'pr', u'rd', u's ', u'wo', u'wp']
@@ -423,7 +423,7 @@ only from characters inside word boundaries (padded with space on each
 side). The ``'char'`` analyzer, alternatively, creates n-grams that
 span across words::
 
-  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', ngram_range=(5, 5))
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char_wb', ngram_range=(5, 5), min_df=1)
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
   ...                                         # doctest: +NORMALIZE_WHITESPACE
   <1x4 sparse matrix of type '<type 'numpy.int64'>'
@@ -431,7 +431,7 @@ span across words::
   >>> ngram_vectorizer.get_feature_names()
   [u' fox ', u' jump', u'jumpy', u'umpy ']
 
-  >>> ngram_vectorizer = CountVectorizer(analyzer='char', ngram_range=(5, 5))
+  >>> ngram_vectorizer = CountVectorizer(analyzer='char', ngram_range=(5, 5), min_df=1)
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
   ...                                         # doctest: +NORMALIZE_WHITESPACE
   <1x5 sparse matrix of type '<type 'numpy.int64'>'

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -317,7 +317,7 @@ def test_vectorizer():
     n_train = len(ALL_FOOD_DOCS) - 1
 
     # test without vocabulary
-    v1 = CountVectorizer(max_df=0.5)
+    v1 = CountVectorizer(max_df=0.5, min_df=1)
     counts_train = v1.fit_transform(train_data)
     if hasattr(counts_train, 'tocsr'):
         counts_train = counts_train.tocsr()
@@ -373,7 +373,7 @@ def test_vectorizer():
     # test the direct tfidf vectorizer
     # (equivalent to term count vectorizer + tfidf transformer)
     train_data = iter(ALL_FOOD_DOCS[:-1])
-    tv = TfidfVectorizer(norm='l1')
+    tv = TfidfVectorizer(norm='l1', min_df=1)
     assert_false(tv.fixed_vocabulary)
 
     tv.max_df = v1.max_df
@@ -390,7 +390,7 @@ def test_vectorizer():
 
 
 def test_feature_names():
-    cv = CountVectorizer(max_df=0.5)
+    cv = CountVectorizer(max_df=0.5, min_df=1)
     X = cv.fit_transform(ALL_FOOD_DOCS)
 
     n_samples, n_features = X.shape
@@ -423,7 +423,7 @@ def test_vectorizer_max_features():
 
 def test_vectorizer_max_df():
     test_data = [u'abc', u'dea']  # the letter a occurs in both strings
-    vect = CountVectorizer(analyzer='char', max_df=1.0)
+    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
     vect.fit(test_data)
     assert_true(u'a' in vect.vocabulary_.keys())
     assert_equals(len(vect.vocabulary_.keys()), 5)
@@ -433,11 +433,35 @@ def test_vectorizer_max_df():
     assert_true(u'a' not in vect.vocabulary_.keys())  # 'a' is ignored
     assert_equals(len(vect.vocabulary_.keys()), 4)  # the others remain
 
+    # absolute count: if in more than one
+    vect.max_df = 1
+    vect.fit(test_data)
+    assert_true(u'a' not in vect.vocabulary_.keys())  # 'a' is ignored
+    assert_equals(len(vect.vocabulary_.keys()), 4)  # the others remain
+
+
+def test_vectorizer_min_df():
+    test_data = [u'abc', u'dea', u'eat']  # the letter a occurs in both strings
+    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
+    vect.fit(test_data)
+    assert_true(u'a' in vect.vocabulary_.keys())
+    assert_equals(len(vect.vocabulary_.keys()), 6)
+
+    vect.min_df = 2
+    vect.fit(test_data)
+    assert_true(u'c' not in vect.vocabulary_.keys())  # 'c' is ignored
+    assert_equals(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+
+    vect.min_df = .5
+    vect.fit(test_data)
+    assert_true(u'c' not in vect.vocabulary_.keys())  # 'c' is ignored
+    assert_equals(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+
 
 def test_binary_occurrences():
     # by default multiple occurrences are counted as longs
     test_data = [u'aaabc', u'abbde']
-    vect = CountVectorizer(analyzer='char', max_df=1.0)
+    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal(['a', 'b', 'c', 'd', 'e'], vect.get_feature_names())
     assert_array_equal([[3, 1, 1, 0, 0],
@@ -446,7 +470,7 @@ def test_binary_occurrences():
     # using boolean features, we can fetch the binary occurrence info
     # instead.
     vect = CountVectorizer(analyzer='char', max_df=1.0,
-                           binary=True)
+                           binary=True, min_df=1)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal([[1, 1, 1, 0, 0],
                         [1, 1, 0, 1, 1]], X)
@@ -461,7 +485,7 @@ def test_binary_occurrences():
 def test_vectorizer_inverse_transform():
     # raw documents
     data = ALL_FOOD_DOCS
-    for vectorizer in (TfidfVectorizer(), CountVectorizer()):
+    for vectorizer in (TfidfVectorizer(min_df=1), CountVectorizer(min_df=1)):
         transformed_data = vectorizer.fit_transform(data)
         inversed_data = vectorizer.inverse_transform(transformed_data)
         analyze = vectorizer.build_analyzer()
@@ -528,7 +552,7 @@ def test_vectorizer_pipeline_grid_selection():
     y_train = y[1:-1]
     y_test = np.array([y[0], y[-1]])
 
-    pipeline = Pipeline([('vect', TfidfVectorizer()),
+    pipeline = Pipeline([('vect', TfidfVectorizer(min_df=1)),
                          ('svc', LinearSVC())])
 
     parameters = {

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -459,8 +459,10 @@ class CountVectorizer(BaseEstimator):
         max_df = self.max_df
         min_df = self.min_df
 
-        max_doc_count = max_df if isinstance(max_df, int) else max_df * n_doc
-        min_doc_count = min_df if isinstance(min_df, int) else min_df * n_doc
+        max_doc_count = (max_df if isinstance(max_df, (int, np.integer))
+                                else max_df * n_doc)
+        min_doc_count = (min_df if isinstance(min_df,  (int, np.integer))
+                                else min_df * n_doc)
 
         # filter out stop words: terms that occur in almost all documents
         if max_doc_count < n_doc or min_doc_count > 1:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -161,7 +161,16 @@ class CountVectorizer(BaseEstimator):
     max_df : float in range [0.0, 1.0], optional, 1.0 by default
         When building the vocabulary ignore terms that have a term frequency
         strictly higher than the given threshold (corpus specific stop words).
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
+        This parameter is ignored if vocabulary is not None.
 
+    min_df : int or float in range [0.0, 1.0], optional, 2 by default
+        When building the vocabulary ignore terms that have a term frequency
+        strictly lower than the given threshold. This value is also called
+        cut-off in the literature.
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
         This parameter is ignored if vocabulary is not None.
 
     max_features : optional, None by default
@@ -192,7 +201,7 @@ class CountVectorizer(BaseEstimator):
                  stop_words=None, token_pattern=ur"\b\w\w+\b",
                  ngram_range=(1, 1),
                  min_n=None, max_n=None, analyzer='word',
-                 max_df=1.0, max_features=None,
+                 max_df=1.0, min_df=2, max_features=None,
                  vocabulary=None, binary=False, dtype=long):
         self.input = input
         self.charset = charset
@@ -205,6 +214,7 @@ class CountVectorizer(BaseEstimator):
         self.token_pattern = token_pattern
         self.stop_words = stop_words
         self.max_df = max_df
+        self.min_df = min_df
         self.max_features = max_features
         if not (max_n is None) or not (min_n is None):
             warnings.warn('Parameters max_n and min_n are deprecated. Use '
@@ -432,9 +442,6 @@ class CountVectorizer(BaseEstimator):
         # document)
         document_counts = Counter()
 
-        max_df = self.max_df
-        max_features = self.max_features
-
         analyze = self.build_analyzer()
 
         # TODO: parallelize the following loop with joblib?
@@ -443,18 +450,22 @@ class CountVectorizer(BaseEstimator):
             term_count_current = Counter(analyze(doc))
             term_counts.update(term_count_current)
 
-            if max_df < 1.0:
-                document_counts.update(term_count_current.iterkeys())
+            document_counts.update(term_count_current.iterkeys())
 
             term_counts_per_doc.append(term_count_current)
 
         n_doc = len(term_counts_per_doc)
+        max_features = self.max_features
+        max_df = self.max_df
+        min_df = self.min_df
+
+        max_doc_count = max_df if isinstance(max_df, int) else max_df * n_doc
+        min_doc_count = min_df if isinstance(min_df, int) else min_df * n_doc
 
         # filter out stop words: terms that occur in almost all documents
-        if max_df < 1.0:
-            max_document_count = max_df * n_doc
+        if max_doc_count < n_doc or min_doc_count > 1:
             stop_words = set(t for t, dc in document_counts.iteritems()
-                               if dc > max_document_count)
+                               if dc > max_doc_count or dc < min_doc_count)
         else:
             stop_words = set()
 
@@ -747,7 +758,16 @@ class TfidfVectorizer(CountVectorizer):
     max_df : float in range [0.0, 1.0], optional, 1.0 by default
         When building the vocabulary ignore terms that have a term frequency
         strictly higher than the given threshold (corpus specific stop words).
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
+        This parameter is ignored if vocabulary is not None.
 
+    min_df : int or float in range [0.0, 1.0], optional, 2 by default
+        When building the vocabulary ignore terms that have a term frequency
+        strictly lower than the given threshold.
+        This value is also called cut-off in the literature.
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
         This parameter is ignored if vocabulary is not None.
 
     max_features : optional, None by default
@@ -796,19 +816,19 @@ class TfidfVectorizer(CountVectorizer):
     """
 
     def __init__(self, input='content', charset='utf-8',
-                 charset_error='strict', strip_accents=None, lowercase=True,
-                 preprocessor=None, tokenizer=None, analyzer='word',
-                 stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
-                 max_n=None, ngram_range=(1, 1), max_df=1.0, max_features=None,
-                 vocabulary=None, binary=False, dtype=long, norm='l2',
-                 use_idf=True, smooth_idf=True, sublinear_tf=False):
+            charset_error='strict', strip_accents=None, lowercase=True,
+            preprocessor=None, tokenizer=None, analyzer='word',
+            stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
+            max_n=None, ngram_range=(1, 1), max_df=1.0, min_df=2,
+            max_features=None, vocabulary=None, binary=False, dtype=long,
+            norm='l2', use_idf=True, smooth_idf=True, sublinear_tf=False):
 
         super(TfidfVectorizer, self).__init__(
             input=input, charset=charset, charset_error=charset_error,
             strip_accents=strip_accents, lowercase=lowercase,
             preprocessor=preprocessor, tokenizer=tokenizer, analyzer=analyzer,
             stop_words=stop_words, token_pattern=token_pattern, min_n=min_n,
-            max_n=max_n, ngram_range=ngram_range, max_df=max_df,
+            max_n=max_n, ngram_range=ngram_range, max_df=max_df, min_df=min_df,
             max_features=max_features, vocabulary=vocabulary, binary=False,
             dtype=dtype)
 
@@ -895,12 +915,12 @@ class Vectorizer(TfidfVectorizer):
     """Vectorizer is deprecated in 0.11, use TfidfVectorizer instead"""
 
     def __init__(self, input='content', charset='utf-8',
-                charset_error='strict', strip_accents=None, lowercase=True,
-                preprocessor=None, tokenizer=None, analyzer='word',
-                stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
-                max_n=None, ngram_range=(1, 1), max_df=1.0, max_features=None,
-                vocabulary=None, binary=False, dtype=long, norm='l2',
-                use_idf=True, smooth_idf=True, sublinear_tf=False):
+            charset_error='strict', strip_accents=None, lowercase=True,
+            preprocessor=None, tokenizer=None, analyzer='word',
+            stop_words=None, token_pattern=ur"\b\w\w+\b", min_n=None,
+            max_n=None, ngram_range=(1, 1), max_df=1.0, min_df=2,
+            max_features=None, vocabulary=None, binary=False, dtype=long,
+            norm='l2', use_idf=True, smooth_idf=True, sublinear_tf=False):
         warnings.warn("Vectorizer is deprecated in 0.11 and will be removed"
                      " in 0.13. Please use TfidfVectorizer instead.",
                       category=DeprecationWarning)
@@ -909,7 +929,7 @@ class Vectorizer(TfidfVectorizer):
             strip_accents=strip_accents, lowercase=lowercase,
             preprocessor=preprocessor, tokenizer=tokenizer, analyzer=analyzer,
             stop_words=stop_words, token_pattern=token_pattern, min_n=min_n,
-            max_n=max_n, max_df=max_df, max_features=max_features,
-            vocabulary=vocabulary, binary=False, dtype=dtype,
-            norm=norm, use_idf=use_idf, smooth_idf=smooth_idf,
+            max_n=max_n, max_df=max_df, min_df=min_df,
+            max_features=max_features, vocabulary=vocabulary, binary=False,
+            dtype=dtype, norm=norm, use_idf=use_idf, smooth_idf=smooth_idf,
             sublinear_tf=sublinear_tf)


### PR DESCRIPTION
This is a resurrection of #348.
As this was before @ogrisel's rewrite, I just wrote it from scratch.
I used the float/int convention that is now widely used throughout the scikit (for example in cv).

I took the liberty of making the default for `min_df` two, as I feel that is still very conservative and should always improve performance. I corrected all the doctests for that.
This does change results compared to previous versions and if someone is -1, I can set the default back to one.
