### PR TITLE
Mechanism to propagate optional estimator.fit arguments when using CV

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1013,10 +1013,13 @@ class StratifiedShuffleSplit(object):
 
 ##############################################################################
 
-def _cross_val_score(estimator, X, y, score_func, train, test, verbose, fit_params):
+def _cross_val_score(estimator, X, y, score_func, train, test, verbose,
+                     fit_params):
     """Inner loop for cross validation"""
     n_samples = X.shape[0] if sp.issparse(X) else len(X)
-    fit_params = dict([(k, np.array(v)[train] if len(v) == n_samples else v) for k, v in fit_params.items()])
+    fit_params = dict([(k, np.asarray(v)[train] if hasattr(v, '__len__') \
+                        and len(v) == n_samples else v) \
+                       for k, v in fit_params.items()])
     if y is None:
         estimator.fit(X[train], **fit_params)
         if score_func is None:

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1017,8 +1017,8 @@ def _cross_val_score(estimator, X, y, score_func, train, test, verbose,
                      fit_params):
     """Inner loop for cross validation"""
     n_samples = X.shape[0] if sp.issparse(X) else len(X)
-    fit_params = dict([(k, np.asarray(v)[train] if hasattr(v, '__len__') \
-                        and len(v) == n_samples else v) \
+    fit_params = dict([(k, np.asarray(v)[train]
+                        if hasattr(v, '__len__') and len(v) == n_samples else v)
                        for k, v in fit_params.items()])
     if y is None:
         estimator.fit(X[train], **fit_params)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1013,16 +1013,18 @@ class StratifiedShuffleSplit(object):
 
 ##############################################################################
 
-def _cross_val_score(estimator, X, y, score_func, train, test, verbose):
+def _cross_val_score(estimator, X, y, score_func, train, test, verbose, **fit_kwargs):
     """Inner loop for cross validation"""
+    n_samples = X.shape[0] if sp.issparse(X) else len(X)
+    fit_kwargs = dict([(k, np.array(v)[train] if len(v) == n_samples else v) for k, v in fit_kwargs.items()])
     if y is None:
-        estimator.fit(X[train])
+        estimator.fit(X[train], **fit_kwargs)
         if score_func is None:
             score = estimator.score(X[test])
         else:
             score = score_func(X[test])
     else:
-        estimator.fit(X[train], y[train])
+        estimator.fit(X[train], y[train], **fit_kwargs)
         if score_func is None:
             score = estimator.score(X[test], y[test])
         else:
@@ -1033,7 +1035,7 @@ def _cross_val_score(estimator, X, y, score_func, train, test, verbose):
 
 
 def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
-                    verbose=0):
+                    verbose=0, **fit_kwargs):
     """Evaluate a score by cross-validation
 
     Parameters
@@ -1065,6 +1067,9 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
 
     verbose: integer, optional
         The verbosity level
+
+    fit_kwargs: the optional keyword arguments to pass to the estimator's fit
+        method
     """
     X, y = check_arrays(X, y, sparse_format='csr')
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
@@ -1078,7 +1083,7 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
     # independent, and that it is pickle-able.
     scores = Parallel(n_jobs=n_jobs, verbose=verbose)(
                 delayed(_cross_val_score)(clone(estimator), X, y, score_func,
-                                          train, test, verbose)
+                                          train, test, verbose, **fit_kwargs)
                 for train, test in cv)
     return np.array(scores)
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1013,18 +1013,18 @@ class StratifiedShuffleSplit(object):
 
 ##############################################################################
 
-def _cross_val_score(estimator, X, y, score_func, train, test, verbose, **fit_kwargs):
+def _cross_val_score(estimator, X, y, score_func, train, test, verbose, fit_params):
     """Inner loop for cross validation"""
     n_samples = X.shape[0] if sp.issparse(X) else len(X)
-    fit_kwargs = dict([(k, np.array(v)[train] if len(v) == n_samples else v) for k, v in fit_kwargs.items()])
+    fit_params = dict([(k, np.array(v)[train] if len(v) == n_samples else v) for k, v in fit_params.items()])
     if y is None:
-        estimator.fit(X[train], **fit_kwargs)
+        estimator.fit(X[train], **fit_params)
         if score_func is None:
             score = estimator.score(X[test])
         else:
             score = score_func(X[test])
     else:
-        estimator.fit(X[train], y[train], **fit_kwargs)
+        estimator.fit(X[train], y[train], **fit_params)
         if score_func is None:
             score = estimator.score(X[test], y[test])
         else:
@@ -1035,7 +1035,7 @@ def _cross_val_score(estimator, X, y, score_func, train, test, verbose, **fit_kw
 
 
 def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
-                    verbose=0, **fit_kwargs):
+                    verbose=0, fit_params=None):
     """Evaluate a score by cross-validation
 
     Parameters
@@ -1068,8 +1068,8 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
     verbose: integer, optional
         The verbosity level
 
-    fit_kwargs: the optional keyword arguments to pass to the estimator's fit
-        method
+    fit_params : dict, optional
+        parameters to pass to the fit method
     """
     X, y = check_arrays(X, y, sparse_format='csr')
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
@@ -1081,9 +1081,10 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
                 "does not." % estimator)
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
+    fit_params = fit_params if fit_params is not None else {}
     scores = Parallel(n_jobs=n_jobs, verbose=verbose)(
                 delayed(_cross_val_score)(clone(estimator), X, y, score_func,
-                                          train, test, verbose, **fit_kwargs)
+                                          train, test, verbose, fit_params)
                 for train, test in cv)
     return np.array(scores)
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -33,8 +33,12 @@ class MockClassifier(BaseEstimator):
         self.a = a
 
     def fit(self, X, Y, sample_weight=None, class_prior=None):
-        assert sample_weight is None or sample_weight.shape[0] == X.shape[0]
-        assert class_prior is None or class_prior.shape[0] == len(np.unique(y))
+        assert_true(sample_weight is None or sample_weight.shape[0] == X.shape[0],
+        'MockClassifier extra fit_param sample_weight.shape[0] is {0}, should be {1}'
+        .format(sample_weight.shape[0], X.shape[0]))
+        assert_true(class_prior is None or class_prior.shape[0] == len(np.unique(y)),
+        'MockClassifier extra fit_param class_prior.shape[0] is {0}, should be {1}'
+        .format(class_prior.shape[0], len(np.unique(y))))
         return self
 
     def predict(self, T):

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -32,7 +32,9 @@ class MockClassifier(BaseEstimator):
     def __init__(self, a=0):
         self.a = a
 
-    def fit(self, X, Y):
+    def fit(self, X, Y, sample_weight=None, class_prior=None):
+        assert sample_weight is None or sample_weight.shape[0] == X.shape[0]
+        assert class_prior is None or class_prior.shape[0] == len(np.unique(y))
         return self
 
     def predict(self, T):
@@ -161,6 +163,15 @@ def test_cross_val_score():
         assert_array_equal(scores, clf.score(X_sparse, y))
 
 
+def test_cross_val_score_fit_params():
+    clf = MockClassifier()
+    n_samples = X.shape[0]
+    n_classes = len(np.unique(y))
+    fit_params = {'sample_weight': np.ones(n_samples),
+                  'class_prior': np.ones(n_classes) / n_classes}
+    cval.cross_val_score(clf, X, y, fit_params=fit_params)
+
+    
 def test_train_test_split_errors():
     assert_raises(ValueError, cval.train_test_split)
     assert_raises(ValueError, cval.train_test_split, range(3),


### PR DESCRIPTION
Instead of opening a feature request for this issue:

http://stackoverflow.com/questions/12131472/additional-fitting-parameters-for-cross-validation

I decided to propose a possible solution. In a nutshell, what it allows to do:

``` python
>>> import numpy as np
>>> from sklearn.cross_validation import cross_val_score
>>> from sklearn.naive_bayes import MultinomialNB
>>> n_samples, n_classes = 100, 5
>>> X = np.random.randint(10, size=(n_samples, n_samples))
>>> y = np.arange(n_classes)
>>> clf = MultinomialNB()
>>> print cross_val_score(clf, X, y, cv=5, 
                        class_prior=[0.2] * n_classes, # those two params will be   
                        sample_weight=[0.01] * n_samples) # propagated to clf.fit 
```

I'll admit that as a sklearn newbie, I may not be aware of all the possible effects this addition might have on other types of estimator (I only tested it in the context of a `MultinomialNB`). Also, it's quite possible that it could be generalized in a better way, as similar problems likely show up elsewhere in the codebase. Nevertheless, I thought it could be an easy and useful modification.
