### PR TITLE
Fix warning in Example: "Sample pipeline for text feature extraction and evaluation"

### DIFF
--- a/examples/grid_search_text_feature_extraction.py
+++ b/examples/grid_search_text_feature_extraction.py
@@ -119,8 +119,8 @@ if __name__ == "__main__":
     print "done in %0.3fs" % (time() - t0)
     print
 
-    print "Best score: %0.3f" % grid_search.best_score
+    print "Best score: %0.3f" % grid_search.best_score_
     print "Best parameters set:"
-    best_parameters = grid_search.best_estimator.get_params()
+    best_parameters = grid_search.best_estimator_.get_params()
     for param_name in sorted(parameters.keys()):
         print "\t%s: %r" % (param_name, best_parameters[param_name])


### PR DESCRIPTION
Avoid warning by adding underscore to: `grid_search.best_estimator_` and `grid_search.best_score_`

```
Loading 20 newsgroups dataset for categories:
['alt.atheism', 'talk.religion.misc']
857 documents
2 categories

Performing grid search...
pipeline: ['vect', 'tfidf', 'clf']
parameters:
{'clf__alpha': (1e-05, 1e-06),
 'clf__penalty': ('l2', 'elasticnet'),
 'vect__max_df': (0.5, 0.75, 1.0),
 'vect__max_n': (1, 2)}
[Parallel(n_jobs=-1)]: Done   1 jobs       | elapsed:   35.0s
[Parallel(n_jobs=-1)]: Done  50 jobs       | elapsed:  2.3min
[Parallel(n_jobs=-1)]: Done  66 out of  72 | elapsed:  2.9min remaining:   15.9s
[Parallel(n_jobs=-1)]: Done  72 out of  72 | elapsed:  3.0min finished
done in 188.127s

Best score: 0.930
Best parameters set:
    clf__alpha: 1e-05
    clf__penalty: 'l2'
    vect__max_df: 1.0
    vect__max_n: 1
```

I noticed also that the doc string and terminal output don't fit together, since they estimate different parameters. I don't understand why the number of samples is different.
http://scikit-learn.org/dev/auto_examples/grid_search_text_feature_extraction.html
