### PR TITLE
FIX in the makefile - we should delete pyc and so only from the source c...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ CTAGS ?= ctags
 all: clean inplace test
 
 clean-pyc:
-	find . -name "*.pyc" | xargs rm -f
+	find sklearn -name "*.pyc" | xargs rm -f
 
 clean-so:
-	find . -name "*.so" | xargs rm -f
-	find . -name "*.pyd" | xargs rm -f
+	find sklearn -name "*.so" | xargs rm -f
+	find sklearn -name "*.pyd" | xargs rm -f
 
 clean-build:
 	rm -rf build
@@ -43,7 +43,7 @@ test-coverage:
 test: test-code test-doc
 
 trailing-spaces:
-	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
+	find sklearn -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
 
 cython:
 	find sklearn -name "*.pyx" | xargs $(CYTHON)


### PR DESCRIPTION
...ode, and not from everything in the root folder.

Sometimes, people put there virtualenv sandbox in there, and it deletes all the so from the sandbox, hence forcing the developper to reinstall numpy and scipy each time they run a `make`.
