### PR TITLE
FIX: this fixes issues #746 ProbabilisticPCA minor things

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -309,24 +309,24 @@ class ProbabilisticPCA(PCA):
 
         Parameters
         ----------
-        X : array of shape(n_samples, n_dim)
+        X : array of shape(n_samples, n_features)
             The data to fit
 
         homoscedastic : bool, optional,
             If True, average variance across remaining dimensions
         """
         PCA.fit(self, X)
-        self.dim = X.shape[1]
+        n_features = X.shape[1]
         Xr = X - self.mean_
         Xr -= np.dot(np.dot(Xr, self.components_.T), self.components_)
         n_samples = X.shape[0]
-        if self.dim <= self.n_components:
-            delta = np.zeros(self.dim)
+        if n_features <= self.n_components:
+            delta = np.zeros(n_features)
         elif homoscedastic:
-            delta = (Xr ** 2).sum() * np.ones(self.dim) \
-                    / (n_samples * self.dim)
+            delta = (Xr ** 2).sum() * np.ones(n_features) \
+                    / (n_samples * n_features)
         else:
-            delta = (Xr ** 2).mean(0) / (self.dim - self.n_components)
+            delta = (Xr ** 2).mean(0) / (n_features - self.n_components)
         self.covariance_ = np.diag(delta)
         for k in range(self.n_components):
             add_cov = np.outer(self.components_[k], self.components_[k])
@@ -338,7 +338,7 @@ class ProbabilisticPCA(PCA):
 
         Parameters
         ----------
-        X: array of shape(n_samples, n_dim)
+        X: array of shape(n_samples, n_features)
             The data to test
 
         Returns
@@ -347,12 +347,12 @@ class ProbabilisticPCA(PCA):
             log-likelihood of each row of X under the current model
         """
         Xr = X - self.mean_
+        n_features = X.shape[1]
         log_like = np.zeros(X.shape[0])
         self.precision_ = linalg.inv(self.covariance_)
-        for i in range(X.shape[0]):
-            log_like[i] = -.5 * np.dot(np.dot(self.precision_, Xr[i]), Xr[i])
-        log_like += fast_logdet(self.precision_) - \
-                                    self.dim / 2 * np.log(2 * np.pi)
+        log_like = -.5 * (Xr * (np.dot(Xr, self.precision_))).sum(axis=1);
+        log_like += -.5 * fast_logdet(self.covariance_) - \
+                                    n_features / 2 * np.log(2 * np.pi)
         return log_like
 
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -7,7 +7,9 @@
 # License: BSD Style.
 
 import numpy as np
+import warnings
 from scipy import linalg
+from math import log
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import array2d, check_random_state, as_float_array
@@ -317,6 +319,7 @@ class ProbabilisticPCA(PCA):
         """
         PCA.fit(self, X)
         n_features = X.shape[1]
+        self._dim  = n_features
         Xr = X - self.mean_
         Xr -= np.dot(np.dot(Xr, self.components_.T), self.components_)
         n_samples = X.shape[0]
@@ -333,6 +336,14 @@ class ProbabilisticPCA(PCA):
             self.covariance_ += self.explained_variance_[k] * add_cov
         return self
 
+    @property
+    def dim(self):
+        warnings.warn("Using dim is deprecated"
+                "since version 0.12, and backward compatibility "
+                "won't be maintained from version 0.14 onward. ",
+                DeprecationWarning, stacklevel=2)
+        return self._dim       
+    
     def score(self, X, y=None):
         """Return a score associated to new data
 
@@ -351,8 +362,8 @@ class ProbabilisticPCA(PCA):
         log_like = np.zeros(X.shape[0])
         self.precision_ = linalg.inv(self.covariance_)
         log_like = -.5 * (Xr * (np.dot(Xr, self.precision_))).sum(axis=1);
-        log_like += -.5 * fast_logdet(self.covariance_) - \
-                                    n_features / 2 * np.log(2 * np.pi)
+        log_like -= .5 * (fast_logdet(self.covariance_) + \
+                                    n_features * log(2 * np.pi))
         return log_like
 
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -295,7 +295,7 @@ def test_probabilistic_pca_1():
     ppca = ProbabilisticPCA(n_components=2)
     ppca.fit(X)
     ll1 = ppca.score(X)
-    h = 0.5 * np.log(2 * np.pi * np.exp(1) / 0.1 ** 2) * p
+    h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
     np.testing.assert_almost_equal(ll1.mean() / h, 1, 0)
 
 


### PR DESCRIPTION
Fix the issues opened here: https://github.com/scikit-learn/scikit-learn/issues/746
1. It uses a non-stanard 'dim' attribute : change every dim to n_features, including in the doc strings
2. The score function has an unnecessary loop : use matrix multiplication to calculate the log likelihood, no loop any more
3. Sign error fixed. The test script(test_probabilistic_pca_1) also contains an error similar to this one, fixed as well. 

Passed `test_probabilistic_pca_{1,2,3,4}`.

@amueller
