### PR TITLE
MRG raise ValueError in r2_score when given only a single sample.

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -911,6 +911,9 @@ def r2_score(y_true, y_pred):
     http://en.wikipedia.org/wiki/Coefficient_of_determination
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
+    if len(y_true) == 1:
+        raise ValueError("r2_score can only be computed given more than one"
+                " sample.")
     numerator = ((y_true - y_pred) ** 2).sum()
     denominator = ((y_true - y_true.mean()) ** 2).sum()
     if denominator == 0.0:

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -2,7 +2,7 @@ import random
 import numpy as np
 
 from nose.tools import raises
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_raises
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_equal, assert_almost_equal
@@ -369,7 +369,12 @@ def test_losses_at_limits():
     # test limit cases
     assert_almost_equal(mean_squared_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(explained_variance_score([0.], [0.]), 1.00, 2)
-    assert_almost_equal(r2_score([0.], [0.]), 1.00, 2)
+    assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
+
+
+def test_r2_one_case_error():
+    # test whether r2_score raises error given one point
+    assert_raises(ValueError, r2_score, [0], [0])
 
 
 def test_symmetry():


### PR DESCRIPTION
Closes #1054.
