### PR TITLE
MRG: Affinity propagation

### DIFF
--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -22,7 +22,7 @@ X, labels_true = make_blobs(n_samples=300, centers=centers, cluster_std=0.5,
 
 ##############################################################################
 # Compute Affinity Propagation
-af = AffinityPropagation(p=-50).fit(X)
+af = AffinityPropagation(preferences=-50).fit(X)
 cluster_centers_indices = af.cluster_centers_indices_
 labels = af.labels_
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -69,8 +69,8 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
     """
     S = as_float_array(S, copy=copy)
     if convit is not None:
-        warnings.warn("p is deprecated and will be removed in version 0.14. "
-                      "Use ``convergence_iteration`` instead",
+        warnings.warn("``convit`` is deprecated and will be removed in"
+                      "version 0.14. Use ``convergence_iteration`` instead",
                       DeprecationWarning)
         convergence_iteration = convit
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -26,7 +26,7 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
     S: array [n_samples, n_samples]
         Matrix of similarities between points
 
-    preference: array [n_samples,] or float, optional
+    preference: array [n_samples,] or float, optional, default: None
         Preferences for each point - points with larger values of
         preferences are more likely to be chosen as exemplars. The number of
         exemplars, i.e. of clusters, is influenced by the input preferences
@@ -35,18 +35,21 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
         number of clusters). For a smaller amount of clusters, this can be set
         to the minimum value of the similarities.
 
-    convergence_iteration : int, default: 15, optional
+    convergence_iteration: int, optional, default: 15
         Number of iterations with no change in the number
         of estimated clusters that stops the convergence.
 
-    damping : float, optional
-        Damping factor
+    max_iter: int, optional, default: 200
+        Maximum number of iterations
 
-    copy: boolean, optional
+    damping: float, optional, default: 200
+        Damping factor between 0.5 and 1.
+
+    copy: boolean, optional, default: True
         If copy is False, the affinity matrix is modified inplace by the
         algorithm, for memory efficiency
 
-    verbose: boolean, optional
+    verbose: boolean, optional, default: False
         The verbosity level
 
     Returns
@@ -188,32 +191,32 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
     Parameters
     ----------
-    damping : float, optional
-        Damping factor
+    damping: float, optional, default: 0.5
+        Damping factor between 0.5 and 1.
 
-    max_iter : int, optional
-        Maximum number of iterations
-
-    convergence_iteration : int, default: 15, optional
+    convergence_iteration: int, optional, default: 15
         Number of iterations with no change in the number
         of estimated clusters that stops the convergence.
 
-    copy : boolean, optional
-        Make a copy of input data. True by default.
+    max_iter: int, optional, default: 200
+        Maximum number of iterations
 
-    preference : array [n_samples,] or float, optional
+    copy: boolean, optional, default: True
+        Make a copy of input data.
+
+    preference: array [n_samples,] or float, optional, default: None
         Preferences for each point - points with larger values of
         preferences are more likely to be chosen as exemplars. The number
         of exemplars, ie of clusters, is influenced by the input
         preferences value. If the preferences are not passed as arguments,
         they will be set to the median of the input similarities.
 
-    affinity : string, optional, default=``euclidean``
+    affinity: string, optional, default=``euclidean``
         Which affinity to use. At the moment ``precomputed`` and
         ``euclidean`` are supported. ``euclidean`` uses the
         negative squared euclidean distance between points.
 
-    verbose: boolean, optional
+    verbose: boolean, optional, default: False
         Whether to be verbose.
 
 

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -15,7 +15,7 @@ from ..utils import as_float_array
 from ..metrics import euclidean_distances
 
 
-def affinity_propagation(S, preference=None, p=None, convit=30, max_iter=200,
+def affinity_propagation(S, preference=None, p=None, convit=15, max_iter=200,
         damping=0.5, copy=True, verbose=False):
     """Perform Affinity Propagation Clustering of data
 
@@ -33,6 +33,10 @@ def affinity_propagation(S, preference=None, p=None, convit=30, max_iter=200,
         set to the median of the input similarities (resulting in a moderate
         number of clusters). For a smaller amount of clusters, this can be set
         to the minimum value of the similarities.
+
+    convit : int, default: 15, optional
+        Number of iterations with no change in the number
+        of estimated clusters that stops the convergence.
 
     damping : float, optional
         Damping factor
@@ -183,7 +187,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     max_iter : int, optional
         Maximum number of iterations
 
-    convit : int, optional
+    convit : int, default: 15, optional
         Number of iterations with no change in the number
         of estimated clusters that stops the convergence.
 
@@ -231,7 +235,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     Between Data Points", Science Feb. 2007
     """
 
-    def __init__(self, damping=.5, max_iter=200, convit=30, copy=True,
+    def __init__(self, damping=.5, max_iter=200, convit=15, copy=True,
             preference=None, p=None, affinity='euclidean', verbose=False):
         self.damping = damping
         self.max_iter = max_iter

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -15,7 +15,7 @@ from ..utils import as_float_array
 from ..metrics import euclidean_distances
 
 
-def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
+def affinity_propagation(S, preference=None, p=None, convergence_iter=15,
         convit=None, max_iter=200,
         damping=0.5, copy=True, verbose=False):
     """Perform Affinity Propagation Clustering of data
@@ -35,7 +35,7 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
         number of clusters). For a smaller amount of clusters, this can be set
         to the minimum value of the similarities.
 
-    convergence_iteration: int, optional, default: 15
+    convergence_iter: int, optional, default: 15
         Number of iterations with no change in the number
         of estimated clusters that stops the convergence.
 
@@ -73,9 +73,9 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
     S = as_float_array(S, copy=copy)
     if convit is not None:
         warnings.warn("``convit`` is deprecated and will be removed in"
-                      "version 0.14. Use ``convergence_iteration`` instead",
+                      "version 0.14. Use ``convergence_iter`` instead",
                       DeprecationWarning)
-        convergence_iteration = convit
+        convergence_iter = convit
 
     n_samples = S.shape[0]
 
@@ -106,7 +106,7 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
          random_state.randn(n_samples, n_samples)
 
     # Execute parallel affinity propagation updates
-    e = np.zeros((n_samples, convergence_iteration))
+    e = np.zeros((n_samples, convergence_iter))
 
     ind = np.arange(n_samples)
 
@@ -143,12 +143,12 @@ def affinity_propagation(S, preference=None, p=None, convergence_iteration=15,
 
         # Check for convergence
         E = (np.diag(A) + np.diag(R)) > 0
-        e[:, it % convergence_iteration] = E
+        e[:, it % convergence_iter] = E
         K = np.sum(E, axis=0)
 
-        if it >= convergence_iteration:
+        if it >= convergence_iter:
             se = np.sum(e, axis=1)
-            unconverged = np.sum((se == convergence_iteration) +\
+            unconverged = np.sum((se == convergence_iter) +\
                                  (se == 0)) != n_samples
             if (not unconverged and (K > 0)) or (it == max_iter):
                 if verbose:
@@ -194,7 +194,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     damping: float, optional, default: 0.5
         Damping factor between 0.5 and 1.
 
-    convergence_iteration: int, optional, default: 15
+    convergence_iter: int, optional, default: 15
         Number of iterations with no change in the number
         of estimated clusters that stops the convergence.
 
@@ -245,19 +245,19 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     Between Data Points", Science Feb. 2007
     """
 
-    def __init__(self, damping=.5, max_iter=200, convergence_iteration=15,
+    def __init__(self, damping=.5, max_iter=200, convergence_iter=15,
             convit=None, copy=True,
             preference=None, p=None, affinity='euclidean', verbose=False):
 
         if convit is not None:
             warnings.warn("``convit`` is deprectaed and will be removed in "
-                          "version 0.14. Use ``convergence_iteration`` "
+                          "version 0.14. Use ``convergence_iter`` "
                           "instead", DeprecationWarning)
-            convergence_iteration = convit
+            convergence_iter = convit
 
         self.damping = damping
         self.max_iter = max_iter
-        self.convergence_iteration = convergence_iteration
+        self.convergence_iter = convergence_iter
         self.copy = copy
         self.verbose = verbose
         if not p is None:
@@ -300,6 +300,6 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         self.cluster_centers_indices_, self.labels_ = affinity_propagation(
                 self.affinity_matrix_, self.preference,
                 max_iter=self.max_iter,
-                convergence_iteration=self.convergence_iteration,
+                convergence_iter=self.convergence_iter,
                 damping=self.damping, copy=self.copy, verbose=self.verbose)
         return self


### PR DESCRIPTION
I've done very little on this code:
- change the example that used a deprecated API
- change the default value of convit, which was 3 times higher than the one mention in the paper. As a results, examples should run faster (it's still insanely slow on my laptop)
- renamed `convit` into `convergence_iteration` and deprecated the old interface

refs #1072
