### PR TITLE
DOC Added SGDCLassifier support only binary prediction probabilites.

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -565,6 +565,8 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
     def predict_proba(self, X):
         """Predict class membership probability
 
+        Prediction probabilities are only supported for binary classification.
+
         Parameters
         ----------
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]


### PR DESCRIPTION
I updated documentation of SGDClassifier that it supports only binary predictive_probabilities.
