### PR TITLE
ENH in NMF only use svd initialization  n_components < n_features

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -251,9 +251,9 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Number of components, if n_components is not set all components
         are kept
 
-    init:  'nndsvd' |  'nndsvda' | 'nndsvdar' | int | RandomState
+    init:  'nndsvd' |  'nndsvda' | 'nndsvdar' | 'random'
         Method used to initialize the procedure.
-        Default: 'nndsvdar'
+        Default: 'nndsvdar' if n_components < n_features, otherwise random.
         Valid options::
 
             'nndsvd': Nonnegative Double Singular Value Decomposition (NNDSVD)
@@ -263,7 +263,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
             'nndsvdar': NNDSVD with zeros filled with small random values
                 (generally faster, less accurate alternative to NNDSVDa
                 for when sparsity is not desired)
-            int seed or RandomState: non-negative random matrices
+            'random': non-negative random matrices
 
     sparseness: 'data' | 'components' | None, default: None
         Where to enforce sparsity in the model.
@@ -285,6 +285,9 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
     nls_max_iter: int, default: 2000
         Number of iterations in NLS subproblem.
 
+    random_state : int or RandomState
+        Random number generator seed control.
+
     Attributes
     ----------
     `components_` : array, [n_components, n_features]
@@ -303,20 +306,23 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
     >>> import numpy as np
     >>> X = np.array([[1,1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
     >>> from sklearn.decomposition import ProjectedGradientNMF
-    >>> model = ProjectedGradientNMF(n_components=2, init=0)
+    >>> model = ProjectedGradientNMF(n_components=2, init='random',
+    ...                              random_state=0)
     >>> model.fit(X) #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    ProjectedGradientNMF(beta=1, eta=0.1, init=0, max_iter=200, n_components=2,
-                         nls_max_iter=2000, sparseness=None, tol=0.0001)
+    ProjectedGradientNMF(beta=1, eta=0.1, init='random', max_iter=200,
+            n_components=2, nls_max_iter=2000, random_state=0, sparseness=None,
+            tol=0.0001)
     >>> model.components_
     array([[ 0.77032744,  0.11118662],
            [ 0.38526873,  0.38228063]])
     >>> model.reconstruction_err_ #doctest: +ELLIPSIS
     0.00746...
-    >>> model = ProjectedGradientNMF(n_components=2, init=0,
-    ...                              sparseness='components')
+    >>> model = ProjectedGradientNMF(n_components=2,
+    ...              sparseness='components', init='random', random_state=0)
     >>> model.fit(X) #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    ProjectedGradientNMF(beta=1, eta=0.1, init=0, max_iter=200, n_components=2,
-               nls_max_iter=2000, sparseness='components', tol=0.0001)
+    ProjectedGradientNMF(beta=1, eta=0.1, init='random', max_iter=200,
+                n_components=2, nls_max_iter=2000, random_state=0,
+                sparseness='components', tol=0.0001)
     >>> model.components_
     array([[ 1.67481991,  0.29614922],
            [-0.        ,  0.4681982 ]])
@@ -345,8 +351,9 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, n_components=None, init="nndsvdar", sparseness=None,
-                 beta=1, eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000):
+    def __init__(self, n_components=None, init=None, sparseness=None, beta=1,
+            eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000,
+            random_state=None):
         self.n_components = n_components
         self.init = init
         self.tol = tol
@@ -359,32 +366,45 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         self.eta = eta
         self.max_iter = max_iter
         self.nls_max_iter = nls_max_iter
+        self.random_state = random_state
 
     def _init(self, X):
         n_samples, n_features = X.shape
+        init = self.init
+        if init is None:
+            if self.n_components < n_features:
+                init = 'nndsvd'
+            else:
+                init = 'random'
 
-        if self.init == 'nndsvd':
-            W, H = _initialize_nmf(X, self.n_components)
-        elif self.init == 'nndsvda':
-            W, H = _initialize_nmf(X, self.n_components, variant='a')
-        elif self.init == 'nndsvdar':
-            W, H = _initialize_nmf(X, self.n_components, variant='ar')
+        if isinstance(init, (int, np.integer, np.random.RandomState)):
+            random_state = check_random_state(init)
+            init = "random"
+            warnings.warn("Passing a random seed or generator as init "
+                "is deprecated and will be removed in 0.15. Use "
+                "init='random' and random_state instead.", DeprecationWarning)
         else:
-            try:
-                rng = check_random_state(self.init)
-                W = rng.randn(n_samples, self.n_components)
-                # we do not write np.abs(W, out=W) to stay compatible with
-                # numpy 1.5 and earlier where the 'out' keyword is not
-                # supported as a kwarg on ufuncs
-                np.abs(W, W)
-                H = rng.randn(self.n_components, n_features)
-                np.abs(H, H)
-            except ValueError:
-                raise ValueError(
-                    'Invalid init parameter: got %r instead of one of %r' %
-                    (self.init, (None, 'nndsvd', 'nndsvda', 'nndsvdar',
-                                 int, np.random.RandomState)))
+            random_state = self.random_state
 
+        if init == 'nndsvdar':
+            W, H = _initialize_nmf(X, self.n_components)
+        elif init == 'nndsvda':
+            W, H = _initialize_nmf(X, self.n_components, variant='a')
+        elif init == 'nndsvdar':
+            W, H = _initialize_nmf(X, self.n_components, variant='ar')
+        elif init == "random":
+            rng = check_random_state(random_state)
+            W = rng.randn(n_samples, self.n_components)
+            # we do not write np.abs(W, out=W) to stay compatible with
+            # numpy 1.5 and earlier where the 'out' keyword is not
+            # supported as a kwarg on ufuncs
+            np.abs(W, W)
+            H = rng.randn(self.n_components, n_features)
+            np.abs(H, H)
+        else:
+            raise ValueError(
+                'Invalid init parameter: got %r instead of one of %r' %
+                (self.init, (None, 'nndsvd', 'nndsvda', 'nndsvdar', 'random')))
         return W, H
 
     def _update_W(self, X, H, W, tolW):

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -386,7 +386,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         else:
             random_state = self.random_state
 
-        if init == 'nndsvdar':
+        if init == 'nndsvd':
             W, H = _initialize_nmf(X, self.n_components)
         elif init == 'nndsvda':
             W, H = _initialize_nmf(X, self.n_components, variant='a')
@@ -404,7 +404,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         else:
             raise ValueError(
                 'Invalid init parameter: got %r instead of one of %r' %
-                (self.init, (None, 'nndsvd', 'nndsvda', 'nndsvdar', 'random')))
+                (init, (None, 'nndsvd', 'nndsvda', 'nndsvdar', 'random')))
         return W, H
 
     def _update_W(self, X, H, W, tolW):

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -131,10 +131,12 @@ def test_sparse_input():
 
     A = np.abs(random_state.randn(10, 10))
     A[:, 2 * np.arange(5)] = 0
-    T1 = nmf.ProjectedGradientNMF(n_components=5, init=999).fit_transform(A)
+    T1 = nmf.ProjectedGradientNMF(n_components=5, init='random',
+                                  random_state=999).fit_transform(A)
 
     A = csr_matrix(A)
-    T2 = nmf.ProjectedGradientNMF(n_components=5, init=999).fit_transform(A)
+    T2 = nmf.ProjectedGradientNMF(n_components=5, init='random',
+                                  random_state=999).fit_transform(A)
     assert_array_almost_equal(T1, T2)
 
 

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .. import nmf
+from sklearn.decomposition import nmf
 from nose.tools import assert_true, assert_false, raises
 from numpy.testing import assert_array_almost_equal
 
@@ -106,6 +106,12 @@ def test_projgrad_nmf_transform():
     m = nmf.ProjectedGradientNMF(n_components=5, init='nndsvd')
     transf = m.fit_transform(A)
     assert_true(np.allclose(transf, m.transform(A), atol=1e-2, rtol=0))
+
+
+def test_n_components_greater_n_features():
+    """Smoke test for the case of more components than features."""
+    A = np.abs(random_state.randn(30, 10))
+    nmf.ProjectedGradientNMF(n_components=15, sparseness='data').fit(A)
 
 
 def test_projgrad_nmf_sparseness():


### PR DESCRIPTION
Since NMF can provide sparse solutions, n_components > n_features is often used. The current initialization breaks in this setting. I think the default values should work robustly, therefore the different initialization strategy in this case.

Closes issue #584.
