### PR TITLE
MRG Sgd clone fix

### DIFF
--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -148,7 +148,7 @@ def test_gridsearch_pipeline_precomputed():
                         random_state=0)
     kpca = KernelPCA(kernel="precomputed", n_components=2)
     pipeline = Pipeline([("kernel_pca", kpca), ("Perceptron", Perceptron())])
-    param_grid = dict(Perceptron__n_iter=np.arange(5))
+    param_grid = dict(Perceptron__n_iter=np.arange(1, 5))
     grid_search = GridSearchCV(pipeline, cv=3, param_grid=param_grid)
     X_kernel = rbf_kernel(X, gamma=10)
     grid_search.fit(X_kernel, y)

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -36,6 +36,9 @@ SPARSE_INTERCEPT_DECAY = 0.01
 """For sparse data intercept updates are scaled by this decay factor to avoid
 intercept oscillation."""
 
+DEFAULT_EPSILON = 0.1
+"""Default value of ``epsilon`` parameter. """
+
 
 class BaseSGD(BaseEstimator):
     """Base class for SGD classification and regression."""
@@ -46,43 +49,31 @@ class BaseSGD(BaseEstimator):
                  rho=0.85, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=0.1, seed=0, learning_rate="optimal",
                  eta0=0.0, power_t=0.5, warm_start=False):
-        self.loss = str(loss)
-        self.penalty = str(penalty).lower()
-        self.learning_rate = str(learning_rate)
-
-        # raises ValueError if not registered
-        self.get_penalty_type(self.penalty)
-        self.get_learning_rate_type(self.learning_rate)
-
-        self.epsilon = float(epsilon)
-        self.alpha = float(alpha)
-        if self.alpha < 0.0:
-            raise ValueError("alpha must be greater than zero")
-        self.rho = float(rho)
-        if self.rho < 0.0 or self.rho > 1.0:
-            raise ValueError("rho must be in [0, 1]")
-        self.fit_intercept = bool(fit_intercept)
-        self.n_iter = int(n_iter)
-        if self.n_iter <= 0:
-            raise ValueError("n_iter must be greater than zero")
-        if not isinstance(shuffle, bool):
-            raise ValueError("shuffle must be either True or False")
-        self.shuffle = bool(shuffle)
+        self.loss = loss
+        self.penalty = penalty
+        self.learning_rate = learning_rate
+        self.epsilon = epsilon
+        self.alpha = alpha
+        self.rho = rho
+        self.fit_intercept = fit_intercept
+        self.n_iter = n_iter
+        self.shuffle = shuffle
         self.seed = seed
-        self.verbose = int(verbose)
-
-        self.eta0 = float(eta0)
-        self.power_t = float(power_t)
-        if self.learning_rate != "optimal":
-            if eta0 <= 0.0:
-                raise ValueError("eta0 must be greater than 0.0")
-        self.coef_ = None
+        self.verbose = verbose
+        self.eta0 = eta0
+        self.power_t = power_t
         self.warm_start = warm_start
 
-        #self._init_t()
+        self._validate_params()
+
+        self.coef_ = None
         # iteration count for learning rate schedule
         # must not be int (e.g. if ``learning_rate=='optimal'``)
         self.t_ = None
+
+    def set_params(self, *args, **kwargs):
+        super(BaseSGD, self).set_params(*args, **kwargs)
+        self._validate_params()
 
     @abstractmethod
     def fit(self, X, y):
@@ -91,6 +82,27 @@ class BaseSGD(BaseEstimator):
     @abstractmethod
     def predict(self, X):
         """Predict using model."""
+
+    def _validate_params(self):
+        """Validate input params. """
+        if not isinstance(self.shuffle, bool):
+            raise ValueError("shuffle must be either True or False")
+        if self.n_iter <= 0:
+            raise ValueError("n_iter must be greater than zero")
+        if not (0.0 <= self.rho <= 1.0):
+            raise ValueError("rho must be in [0, 1]")
+        if self.alpha < 0.0:
+            raise ValueError("alpha must be greater than zero")
+        if self.learning_rate != "optimal":
+            if self.eta0 <= 0.0:
+                raise ValueError("eta0 must be greater than 0.0")
+
+        # raises ValueError if not registered
+        self._get_penalty_type(self.penalty)
+        self._get_learning_rate_type(self.learning_rate)
+
+        if self.loss not in self.loss_functions:
+            raise ValueError("The loss %s is not supported. " % self.loss)
 
     def _init_t(self, loss_function):
         """Initialize iteration counter attr ``t_``.
@@ -111,18 +123,21 @@ class BaseSGD(BaseEstimator):
         try:
             loss_ = self.loss_functions[loss]
             loss_class, args = loss_[0], loss_[1:]
+            if loss in ('huber', 'epsilon_insensitive'):
+                args = (self.epsilon, )
             return loss_class(*args)
         except KeyError:
             raise ValueError("The loss %s is not supported. " % loss)
 
-    def get_learning_rate_type(self, learning_rate):
+    def _get_learning_rate_type(self, learning_rate):
         try:
             return LEARNING_RATE_TYPES[learning_rate]
         except KeyError:
             raise ValueError("learning rate %s"
                              "is not supported. " % learning_rate)
 
-    def get_penalty_type(self, penalty):
+    def _get_penalty_type(self, penalty):
+        penalty = str(penalty).lower()
         try:
             return PENALTY_TYPES[penalty]
         except KeyError:
@@ -338,9 +353,20 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
     LinearSVC, LogisticRegression, Perceptron
 
     """
+
+    loss_functions = {
+        "hinge": (Hinge, 1.0),
+        "perceptron": (Hinge, 0.0),
+        "log": (Log, ),
+        "modified_huber": (ModifiedHuber, ),
+        "squared_loss": (SquaredLoss, ),
+        "huber": (Huber, DEFAULT_EPSILON),
+        "epsilon_insensitive": (EpsilonInsensitive, DEFAULT_EPSILON),
+    }
+
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001,
                  rho=0.85, fit_intercept=True, n_iter=5, shuffle=False,
-                 verbose=0, epsilon=0.1, n_jobs=1, seed=0,
+                 verbose=0, epsilon=DEFAULT_EPSILON, n_jobs=1, seed=0,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
                  class_weight=None, warm_start=False):
         super(SGDClassifier, self).__init__(loss=loss, penalty=penalty,
@@ -355,18 +381,6 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
         self.class_weight = class_weight
         self.classes_ = None
         self.n_jobs = int(n_jobs)
-
-        self.loss_functions = {
-            "hinge": (Hinge, 1.0),
-            "perceptron": (Hinge, 0.0),
-            "log": (Log, ),
-            "modified_huber": (ModifiedHuber, ),
-            "squared_loss": (SquaredLoss, ),
-            "huber": (Huber, self.epsilon),
-            "epsilon_insensitive": (EpsilonInsensitive, self.epsilon),
-        }
-        if loss not in self.loss_functions:
-            raise ValueError("The loss %s is not supported. " % loss)
 
     @property
     @deprecated("to be removed in v0.13; use ``classes_`` instead.")
@@ -405,6 +419,8 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
 
         n_samples, n_features = X.shape
         _check_fit_data(X, y)
+
+        self._validate_params()
 
         if self.classes_ is None and classes is None:
             raise ValueError("classes must be passed on the first call "
@@ -678,13 +694,13 @@ def fit_binary(est, i, X, y, n_iter, pos_weight, neg_weight,
     assert y_i.shape[0] == y.shape[0] == sample_weight.shape[0]
     dataset, intercept_decay = _make_dataset(X, y_i, sample_weight)
 
-    penalty_type = est.get_penalty_type(est.penalty)
-    learning_rate_type = est.get_learning_rate_type(est.learning_rate)
+    penalty_type = est._get_penalty_type(est.penalty)
+    learning_rate_type = est._get_learning_rate_type(est.learning_rate)
 
     return plain_sgd(coef, intercept, est.loss_function,
                      penalty_type, est.alpha, est.rho,
-                     dataset, n_iter, est.fit_intercept,
-                     est.verbose, est.shuffle, est.seed,
+                     dataset, n_iter, int(est.fit_intercept),
+                     int(est.verbose), int(est.shuffle), est.seed,
                      pos_weight, neg_weight,
                      learning_rate_type, est.eta0,
                      est.power_t, est.t_, intercept_decay)
@@ -794,6 +810,13 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     Ridge, ElasticNet, Lasso, SVR
 
     """
+
+    loss_functions = {
+        "squared_loss": (SquaredLoss, ),
+        "huber": (Huber, DEFAULT_EPSILON),
+        "epsilon_insensitive": (EpsilonInsensitive, DEFAULT_EPSILON)
+    }
+
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
             rho=0.85, fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
             epsilon=0.1, p=None, seed=0, learning_rate="invscaling", eta0=0.01,
@@ -816,14 +839,6 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
                                            eta0=eta0, power_t=power_t,
                                            warm_start=False)
 
-        self.loss_functions = {
-            "squared_loss": (SquaredLoss, ),
-            "huber": (Huber, self.epsilon),
-            "epsilon_insensitive": (EpsilonInsensitive, self.epsilon)
-        }
-        if loss not in self.loss_functions:
-            raise ValueError("The loss %s is not supported. " % loss)
-
     def _partial_fit(self, X, y, n_iter, sample_weight=None,
                      coef_init=None, intercept_init=None):
         X, y = check_arrays(X, y, sparse_format="csr", copy=False,
@@ -832,6 +847,8 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
 
         n_samples, n_features = X.shape
         _check_fit_data(X, y)
+
+        self._validate_params()
 
         # Allocate datastructures from input arguments
         sample_weight = self._validate_sample_weight(sample_weight, n_samples)
@@ -901,8 +918,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
             self.coef_ = None
             self.intercept_ = None
 
-        # Need to re-initialize in case of multiple call to fit.
-        #self._init_t()
+        # Clear iteration count for multiple call to fit.
         self.t_ = None
 
         return self._partial_fit(X, y, self.n_iter, sample_weight,
@@ -942,8 +958,8 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
         dataset, intercept_decay = _make_dataset(X, y, sample_weight)
 
         loss_function = self.get_loss_function(self.loss)
-        penalty_type = self.get_penalty_type(self.penalty)
-        learning_rate_type = self.get_learning_rate_type(self.learning_rate)
+        penalty_type = self._get_penalty_type(self.penalty)
+        learning_rate_type = self._get_learning_rate_type(self.learning_rate)
 
         if self.t_ is None:
             self._init_t(loss_function)

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -118,7 +118,7 @@ class BaseSGD(BaseEstimator):
             # initialize t such that eta at first sample equals eta0
             self.t_ = 1.0 / (eta0 * self.alpha)
 
-    def get_loss_function(self, loss):
+    def _get_loss_function(self, loss):
         """Get concrete ``LossFunction`` object for str ``loss``. """
         try:
             loss_ = self.loss_functions[loss]
@@ -442,7 +442,7 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
             self._allocate_parameter_mem(n_classes, n_features,
                                          coef_init, intercept_init)
 
-        self.loss_function = self.get_loss_function(self.loss)
+        self.loss_function = self._get_loss_function(self.loss)
         if self.t_ is None:
             self._init_t(self.loss_function)
 
@@ -958,7 +958,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     def _fit_regressor(self, X, y, sample_weight, n_iter):
         dataset, intercept_decay = _make_dataset(X, y, sample_weight)
 
-        loss_function = self.get_loss_function(self.loss)
+        loss_function = self._get_loss_function(self.loss)
         penalty_type = self._get_penalty_type(self.penalty)
         learning_rate_type = self._get_learning_rate_type(self.learning_rate)
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -819,7 +819,8 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
 
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
             rho=0.85, fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
-            epsilon=0.1, p=None, seed=0, learning_rate="invscaling", eta0=0.01,
+            epsilon=DEFAULT_EPSILON, p=None, seed=0,
+            learning_rate="invscaling", eta0=0.01,
             power_t=0.25, warm_start=False):
 
         if p is not None:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -177,17 +177,6 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         """Check whether expected ValueError on bad penalty"""
         self.factory(penalty='foobar', rho=0.85)
 
-    def test_sgd_losses(self):
-        """Check whether losses and hyperparameters are set properly"""
-        clf = self.factory(loss='hinge')
-        assert_true(isinstance(clf.loss_function, linear_model.Hinge))
-
-        clf = self.factory(loss='log')
-        assert_true(isinstance(clf.loss_function, linear_model.Log))
-
-        clf = self.factory(loss='modified_huber')
-        assert_true(isinstance(clf.loss_function, linear_model.ModifiedHuber))
-
     @raises(ValueError)
     def test_sgd_bad_loss(self):
         """Check whether expected ValueError on bad loss"""
@@ -549,15 +538,6 @@ class DenseSGDRegressorTestCase(unittest.TestCase):
         """Check whether expected ValueError on bad penalty"""
         self.factory(penalty='foobar', rho=0.85)
 
-    def test_sgd_losses(self):
-        """Check whether losses and hyperparameters are set properly"""
-        clf = self.factory(loss='squared_loss')
-        assert_true(isinstance(clf.loss_function, linear_model.SquaredLoss))
-
-        clf = self.factory(loss='huber', epsilon=0.5)
-        assert_true(isinstance(clf.loss_function, linear_model.Huber))
-        assert_equal(clf.epsilon, 0.5)
-
     @raises(ValueError)
     def test_sgd_bad_loss(self):
         """Check whether expected ValueError on bad loss"""
@@ -701,6 +681,11 @@ class DenseSGDRegressorTestCase(unittest.TestCase):
 
     def test_partial_fit_equal_fit_invscaling(self):
         self._test_partial_fit_equal_fit("invscaling")
+
+    def test_loss_function_epsilon(self):
+        clf = self.factory(epsilon=0.9)
+        clf.set_params(epsilon=0.1)
+        assert clf.loss_functions['huber'][1] == 0.1
 
 
 class SparseSGDRegressorTestCase(DenseSGDRegressorTestCase):

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -8,6 +8,7 @@ from sklearn import linear_model, datasets, metrics
 from sklearn import preprocessing
 from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.utils.testing import assert_greater, assert_less
+from sklearn.base import clone
 
 import unittest
 from nose.tools import raises
@@ -143,6 +144,18 @@ class CommonTest(object):
 
         Y_ = np.c_[Y_, Y_]
         assert_raises(ValueError, clf.fit, X, Y_)
+
+    def test_clone(self):
+        """Test whether clone works ok. """
+        clf = self.factory(alpha=0.01, n_iter=5, penalty='l1')
+        clf = clone(clf)
+        clf.set_params(penalty='l2')
+        clf.fit(X, Y)
+
+        clf2 = self.factory(alpha=0.01, n_iter=5, penalty='l2')
+        clf2.fit(X, Y)
+
+        assert_array_equal(clf.coef_, clf2.coef_)
 
 
 class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):


### PR DESCRIPTION
The SGD\* object initialization does not work properly with `set_params` and thus `clone`. 

This PR moves input argument parsing and creation of helper classes (e.g. loss_function) to the `fit` (actually, `partial_fit`) methods. 

This PR addresses #1114.

The following issues need to be resolved:
- Factory for loss function objects (epsilon issue - see failing test)
- Should we do input argument checks in `__init__` or exclusively in `fit`?
- The sgd holds some opportunities for refactoring (code duplication, etc.)
