### PR TITLE
CountVectorizerBuffered

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -25,6 +25,7 @@ from ..utils.fixes import Counter
 from .stop_words import ENGLISH_STOP_WORDS
 
 __all__ = ['CountVectorizer',
+           'CountVectorizerBuffered',
            'ENGLISH_STOP_WORDS',
            'TfidfTransformer',
            'TfidfVectorizer',
@@ -82,7 +83,6 @@ def _check_stop_list(stop):
         raise ValueError("not a built-in stop list: %s" % stop)
     else:               # assume it's a collection
         return stop
-
 
 class CountVectorizer(BaseEstimator):
     """Convert a collection of raw documents to a matrix of token counts
@@ -568,6 +568,343 @@ class CountVectorizer(BaseEstimator):
 
         return [t for t, i in sorted(self.vocabulary_.iteritems(),
                                      key=itemgetter(1))]
+
+class CountVectorizerBuffered(CountVectorizer):
+    """Convert a collection of raw documents to a matrix of token counts
+
+    This implementation produces a sparse representation of the counts using
+    scipy.sparse.coo_matrix.
+
+    If you do not provide an a-priori dictionary and you do not use an analyzer
+    that does some kind of feature selection then the number of features will
+    be equal to the vocabulary size found by analysing the data. The default
+    analyzer does simple stop word filtering for English.
+
+    Parameters
+    ----------
+    input: string {'filename', 'file', 'content'}
+        If filename, the sequence passed as an argument to fit is
+        expected to be a list of filenames that need reading to fetch
+        the raw content to analyze.
+
+        If 'file', the sequence items must have 'read' method (file-like
+        object) it is called to fetch the bytes in memory.
+
+        Otherwise the input is expected to be the sequence strings or
+        bytes items are expected to be analyzed directly.
+
+    charset: string, 'utf-8' by default.
+        If bytes or files are given to analyze, this charset is used to
+        decode.
+
+    charset_error: {'strict', 'ignore', 'replace'}
+        Instruction on what to do if a byte sequence is given to analyze that
+        contains characters not of the given `charset`. By default, it is
+        'strict', meaning that a UnicodeDecodeError will be raised. Other
+        values are 'ignore' and 'replace'.
+
+    strip_accents: {'ascii', 'unicode', None}
+        Remove accents during the preprocessing step.
+        'ascii' is a fast method that only works on characters that have
+        an direct ASCII mapping.
+        'unicode' is a slightly slower method that works on any characters.
+        None (default) does nothing.
+
+    analyzer: string, {'word', 'char', 'char_wb'} or callable
+        Whether the feature should be made of word or character n-grams.
+        Option 'char_wb' creates character n-grams only from text inside
+        word boundaries.
+
+        If a callable is passed it is used to extract the sequence of features
+        out of the raw, unprocessed input.
+
+    preprocessor: callable or None (default)
+        Override the preprocessing (string transformation) stage while
+        preserving the tokenizing and n-grams generation steps.
+
+    tokenizer: callable or None (default)
+        Override the string tokenization step while preserving the
+        preprocessing and n-grams generation steps.
+
+    ngram_range: tuple (min_n, max_n)
+        The lower and upper boundary of the range of n-values for different
+        n-grams to be extracted. All values of n such that min_n <= n <= max_n
+        will be used.
+
+    stop_words: string {'english'}, list, or None (default)
+        If a string, it is passed to _check_stop_list and the appropriate stop
+        list is returned is currently the only
+        supported string value.
+
+        If a list, that list is assumed to contain stop words, all of which
+        will be removed from the resulting tokens.
+
+        If None, no stop words will be used. max_df can be set to a value
+        in the range [0.7, 1.0) to automatically detect and filter stop
+        words based on intra corpus document frequency of terms.
+
+    lowercase: boolean, default True
+        Convert all characters to lowercase befor tokenizing.
+
+    token_pattern: string
+        Regular expression denoting what constitutes a "token", only used
+        if `tokenize == 'word'`. The default regexp select tokens of 2
+        or more letters characters (punctuation is completely ignored
+        and always treated as a token separator).
+
+    max_df : float in range [0.0, 1.0] or int, optional, 1.0 by default
+        When building the vocabulary ignore terms that have a term frequency
+        strictly higher than the given threshold (corpus specific stop words).
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
+        This parameter is ignored if vocabulary is not None.
+
+    min_df : float in range [0.0, 1.0] or int, optional, 2 by default
+        When building the vocabulary ignore terms that have a term frequency
+        strictly lower than the given threshold. This value is also called
+        cut-off in the literature.
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
+        This parameter is ignored if vocabulary is not None.
+
+    max_features : optional, None by default
+        If not None, build a vocabulary that only consider the top
+        max_features ordered by term frequency across the corpus.
+
+        This parameter is ignored if vocabulary is not None.
+
+    vocabulary: Mapping or iterable, optional
+        Either a Mapping (e.g., a dict) where keys are terms and values are
+        indices in the feature matrix, or an iterable over terms. If not
+        given, a vocabulary is determined from the input documents.
+
+    binary: boolean, False by default.
+        If True, all non zero counts are set to 1. This is useful for discrete
+        probabilistic models that model binary events rather than integer
+        counts.
+
+    dtype: type, optional
+        Type of the matrix returned by fit_transform() or transform().
+    
+    docs_buffer: int, 5000 by default
+        Build for each docs_buffer documents a sparse matrix of token counts.
+    """
+
+    def __init__(self, input='content', charset='utf-8',
+                 charset_error='strict', strip_accents=None,
+                 lowercase=True, preprocessor=None, tokenizer=None,
+                 stop_words=None, token_pattern=ur"\b\w\w+\b",
+                 ngram_range=(1, 1),
+                 min_n=None, max_n=None, analyzer='word',
+                 max_df=1.0, min_df=None, max_features=None,
+                 vocabulary=None, binary=False, dtype=long,
+                 docs_buffer=5000):
+        super(CountVectorizerBuffered, self).__init__(
+            input=input, charset=charset, charset_error=charset_error,
+            strip_accents=strip_accents, lowercase=lowercase,
+            preprocessor=preprocessor, tokenizer=tokenizer, analyzer=analyzer,
+            stop_words=stop_words, token_pattern=token_pattern, min_n=min_n,
+            max_n=max_n, ngram_range=ngram_range, max_df=max_df, min_df=min_df,
+            max_features=max_features, vocabulary=vocabulary, binary=False,
+            dtype=dtype)
+
+        self._docs_buffer = docs_buffer
+
+    def _term_count_dicts_to_matrix(self, term_count_dicts):
+        i_indices = []
+        j_indices = []
+        values = []
+        vocabulary = self.vocabulary_
+
+        for i, term_count_dict in enumerate(term_count_dicts):
+            for term, count in term_count_dict.iteritems():
+                j = vocabulary.get(term)
+                if j is not None:
+                    i_indices.append(i)
+                    j_indices.append(j)
+                    values.append(count)
+            # free memory as we go
+            term_count_dict.clear()
+
+        #shape = (len(term_count_dicts), max(vocabulary.itervalues()) + 1)
+        shape = (len(term_count_dicts), self._vocabulary_max_dim)
+        spmatrix = sp.coo_matrix((values, (i_indices, j_indices)),
+                                 shape=shape, dtype=self.dtype)
+        if self.binary:
+            spmatrix.data.fill(1)
+        return spmatrix
+
+    def fit(self, raw_documents, y=None):
+        """Learn a vocabulary dictionary of all tokens in the raw documents
+
+        Parameters
+        ----------
+        raw_documents: iterable
+            an iterable which yields either str, unicode or file objects
+
+        Returns
+        -------
+        self
+        """
+        self.vocabulary_ = {}
+        term_counts = Counter()
+
+        # term counts across entire corpus (count each term maximum once per
+        # document)
+        document_counts = Counter()
+
+        analyze = self.build_analyzer()
+
+        for n_doc, doc in enumerate(raw_documents):
+            term_count_current = Counter(analyze(doc))
+            term_counts.update(term_count_current)
+            document_counts.update(term_count_current.iterkeys())
+
+        max_features = self.max_features
+        max_df = self.max_df
+        min_df = self.min_df
+        if min_df is None:
+            min_df = 2
+
+        max_doc_count = (max_df if isinstance(max_df, (int, np.integer))
+                                else max_df * n_doc)
+        min_doc_count = (min_df if isinstance(min_df,  (int, np.integer))
+                                else min_df * n_doc)
+
+        # filter out stop words: terms that occur in almost all documents
+        if max_doc_count < n_doc or min_doc_count > 1:
+            stop_words = set(t for t, dc in document_counts.iteritems()
+                               if dc > max_doc_count or dc < min_doc_count)
+        else:
+            stop_words = set()
+
+        # list the terms that should be part of the vocabulary
+        if max_features is None:
+            terms = set(term_counts) - stop_words
+        else:
+            # extract the most frequent terms for the vocabulary
+            terms = set()
+            for t, tc in term_counts.most_common():
+                if t not in stop_words:
+                    terms.add(t)
+                if len(terms) >= max_features:
+                    break
+
+        # store the learned stop words to make it easier to debug the value of
+        # max_df
+        self.max_df_stop_words_ = stop_words
+
+        # store map from term name to feature integer index: we sort the term
+        # to have reproducible outcome for the vocabulary structure: otherwise
+        # the mapping from feature name to indices might depend on the memory
+        # layout of the machine. Furthermore sorted terms might make it
+        # possible to perform binary search in the feature names array.
+        self.vocabulary_ = dict(((t, i) for i, t in enumerate(sorted(terms))))
+
+        self.fixed_vocabulary = True
+        try:
+            self._vocabulary_max_dim = max(self.vocabulary_.itervalues()) + 1
+        except ValueError, err:
+            self._vocabulary_max_dim = 1
+
+        return self
+
+    def _merge_feature_matrices(self, matrices):
+        """Merge a list of sparse matrices.
+
+        Merging the complete list at once is faster, because the time
+        needed to merge (big_matrix, small_matrix) is much higher than
+        the time needed to merge (small_matrix, small_matrix)."""
+        max_dim = self._vocabulary_max_dim
+        for i, matrix in enumerate(matrices):
+            rows_num, dims_num = matrix.shape
+            if max_dim > dims_num:
+                matrices[i] = sp.hstack((matrix,
+                    sp.coo_matrix((rows_num, max_dim - dims_num))))
+        return sp.vstack(matrices, dtype=self.dtype)
+
+    def _update_vocabulary(self, term_count_current):
+        for current_term in term_count_current.iterkeys():
+            if current_term not in self.vocabulary_:
+                self.vocabulary_[current_term] = self._vocabulary_max_dim
+                self._vocabulary_max_dim += 1
+
+    def _get_feature_matrix(self, raw_documents):
+        """Turn an iterator of raw_documents into a matrix of token counts.
+
+        Build for each self._docs_buffer documents a small feature_matrix
+        and return the complete feature_matrix by merging all small
+        matrices."""
+        if not self.fixed_vocabulary:
+            self.vocabulary_ = vocabulary = {}
+            self._vocabulary_max_dim = 0
+
+        # result of document conversion to term count dicts
+        term_counts_per_doc = []
+        sp_feature_matrices = []
+
+        analyze = self.build_analyzer()
+
+        for n_doc, doc in enumerate(raw_documents):
+            term_count_current = Counter(analyze(doc))
+            term_counts_per_doc.append(term_count_current)
+
+            if not self.fixed_vocabulary:
+                self._update_vocabulary(term_count_current)
+
+            if n_doc > 0 and n_doc % self._docs_buffer == 0:
+                feature_matrix = self._term_count_dicts_to_matrix(term_counts_per_doc)
+                sp_feature_matrices.append(feature_matrix)
+                term_counts_per_doc = []
+        
+        if len(term_counts_per_doc) > 0:
+            feature_matrix = self._term_count_dicts_to_matrix(term_counts_per_doc)
+            sp_feature_matrices.append(feature_matrix)
+
+        return self._merge_feature_matrices(sp_feature_matrices)
+
+    def fit_transform(self, raw_documents, y=None):
+        """Learn the vocabulary dictionary and return the count vectors
+
+        This is more efficient than calling fit followed by transform.
+
+        Parameters
+        ----------
+        raw_documents: iterable
+            an iterable which yields either str, unicode or file objects
+
+        Returns
+        -------
+        vectors: array, [n_samples, n_features]
+        """
+        if self.max_features is not None:
+            raise ValueError("to use max_features, you have to call fit + transform!")
+
+        if self.max_df < 1.0:
+            raise ValueError("to use max_df < 1.0, you have to call fit + transform!")
+
+        if self.min_df is not None:
+            raise ValueError("to use min_df, you have to call fit + transform!")
+
+        return self._get_feature_matrix(raw_documents)
+
+    def transform(self, raw_documents):
+        """Extract token counts out of raw text documents using the vocabulary
+        fitted with fit or the one provided in the constructor.
+
+        Parameters
+        ----------
+        raw_documents: iterable
+            an iterable which yields either str, unicode or file objects
+
+        Returns
+        -------
+        vectors: sparse matrix, [n_samples, n_features]
+        """
+        if not hasattr(self, 'vocabulary_') or len(self.vocabulary_) == 0:
+            raise ValueError("Vocabulary wasn't fitted or is empty!")
+
+        return self._get_feature_matrix(raw_documents)
 
 
 class TfidfTransformer(BaseEstimator, TransformerMixin):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -709,6 +709,11 @@ class CountVectorizerBuffered(CountVectorizer):
             dtype=dtype)
 
         self._docs_buffer = docs_buffer
+        if self.fixed_vocabulary:
+            try:
+                self._vocabulary_max_dim = max(self.vocabulary_.itervalues()) + 1
+            except ValueError, err:
+                self._vocabulary_max_dim = 1
 
     def _term_count_dicts_to_matrix(self, term_count_dicts):
         i_indices = []


### PR DESCRIPTION
Ran out of memory with CountVectorizer (having 3.4 million documents with 3.5Gb data and only 8Gb RAM) . The problem is that CountVectorizer stores term_counts_per_doc for all documents before creating the sparse coo_matrix.

So i wrote a new class CountVectorizerBuffered, which creates a partial sparse feature matrix for every 5K documents and merges the partial feature matrices in the end. This fixes the memory issue, but it also  alters the behavior of the class, which makes it kind of incompatible with CountVectorizer. For example it's not possible to set max_df, min_df or max_features and then simply call fit_transform, because fit_transform doesn't have the required token statistics for that. Therefore you now have to call fit before transform if you want to use max_df, min_df or max_features.

I thought about replacing CountVectorizer with CountVectorizerBuffered and i have a branch (countvectorizer) in which i did, but this breaks a lot of test-cases... well, i'm not sure what to do here.
