### PR TITLE
Print running time as a floating-point number with two decimals.

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -66,7 +66,7 @@ plot_rst_template = """
 .. literalinclude:: %(fname)s
     :lines: %(end_row)s-
 
-**Total running time of the example:** %(time_elapsed) 4i seconds
+**Total running time of the example:** %(time_elapsed) .2f seconds
     """
 
 # The following strings are used when we have several pictures: we use


### PR DESCRIPTION
Otherwise printing it as integer truncates the result and prints
'0 seconds' on most example.
