### PR TITLE
MRG: Fix predict_proba w/ sparse matrix regression

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -608,7 +608,7 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
 
         Returns
         -------
-        array, shape = [n_samples] if n_classes == 2 else raises Exception
+        array, shape = [n_samples, n_classes]
             Contains the membership probabilities of the positive class.
 
         References

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -571,6 +571,12 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
             The signed 'distances' to the hyperplane(s).
         """
         X = atleast2d_or_csr(X)
+        return self._decision_function(X)
+
+    def _decision_function(self, X):
+        """predict decision function assuming that X is either sparse
+        matrix or array-like.
+        """
         scores = safe_sparse_dot(X, self.coef_.T) + self.intercept_
         if self.classes_.shape[0] == 2:
             return np.ravel(scores)
@@ -622,12 +628,13 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
             raise NotImplementedError("predict_(log_)proba only supported"
                                       " for binary classification")
 
-        proba = np.ones((len(X), 2), dtype=np.float64)
+        X = atleast2d_or_csr(X)
+        proba = np.ones((X.shape[0], 2), dtype=np.float64)
         if self.loss == "log":
-            proba[:, 1] = 1.0 / (1.0 + np.exp(-self.decision_function(X)))
+            proba[:, 1] = 1.0 / (1.0 + np.exp(-self._decision_function(X)))
         elif self.loss == "modified_huber":
             proba[:, 1] = np.minimum(1, np.maximum(-1,
-                                                   self.decision_function(X)))
+                                                   self._decision_function(X)))
             proba[:, 1] += 1
             proba[:, 1] /= 2
         else:

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -597,10 +597,9 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
         return self.classes_[np.ravel(indices)]
 
     def predict_proba(self, X):
-        """Predict class membership probability
+        """Probability estimates
 
-
-        Prediction probabilities are only supported for binary classification.
+        Probability estimates are only supported for binary classification.
 
         Parameters
         ----------
@@ -609,7 +608,8 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
         Returns
         -------
         array, shape = [n_samples, n_classes]
-            Contains the membership probabilities of the positive class.
+            Returns the probability of the sample for each class in the model,
+            where classes are ordered as they are in self.classes_.
 
         References
         ----------
@@ -636,6 +636,24 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
                                       "(%s given)" % self.loss)
         proba[:, 0] -= proba[:, 1]
         return proba
+
+    def predict_log_proba(self, X):
+        """Log of probability estimates.
+
+        Log probability estimates are only supported for binary classification.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+
+        Returns
+        -------
+        T : array-like, shape = [n_samples, n_classes]
+            Returns the log-probabilities of the sample for each class in
+            the model, where classes are ordered by arithmetical
+            order.
+        """
+        return np.log(self.predict_proba(X))
 
     def _fit_binary(self, X, y, sample_weight, n_iter):
         """Fit a binary classifier on X and y. """

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -574,8 +574,9 @@ class SGDClassifier(BaseSGD, ClassifierMixin, SelectorMixin):
         return self._decision_function(X)
 
     def _decision_function(self, X):
-        """predict decision function assuming that X is either sparse
-        matrix or array-like.
+        """Compute decision function values for each sample in X.
+
+        X is assumed to be either sparse matrix or array-like.
         """
         scores = safe_sparse_dot(X, self.coef_.T) + self.intercept_
         if self.classes_.shape[0] == 2:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -29,6 +29,10 @@ class SparseSGDClassifier(SGDClassifier):
         X = sp.csr_matrix(X)
         return SGDClassifier.decision_function(self, X, *args, **kw)
 
+    def predict_proba(self, X, *args, **kw):
+        X = sp.csr_matrix(X)
+        return SGDClassifier.predict_proba(self, X, *args, **kw)
+
 
 class SparseSGDRegressor(SGDRegressor):
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -33,6 +33,10 @@ class SparseSGDClassifier(SGDClassifier):
         X = sp.csr_matrix(X)
         return SGDClassifier.predict_proba(self, X, *args, **kw)
 
+    def predict_log_proba(self, X, *args, **kw):
+        X = sp.csr_matrix(X)
+        return SGDClassifier.predict_log_proba(self, X, *args, **kw)
+
 
 class SparseSGDRegressor(SGDRegressor):
 
@@ -291,6 +295,11 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
             assert_true(p[0, 1] > 0.5)
             p = clf.predict_proba([-1, -1])
             assert_true(p[0, 1] < 0.5)
+
+            p = clf.predict_log_proba([3, 2])
+            assert_true(p[0, 1] > p[0, 0])
+            p = clf.predict_log_proba([-1, -1])
+            assert_true(p[0, 1] < p[0, 0])
 
     def test_sgd_l1(self):
         """Test L1 regularization"""


### PR DESCRIPTION
This PR fixes the `SGDClassifier.predict_proba` w/ sparse matrix regression. 

The regression was introduced in #1030 and, thus, release 0.12 where I used `len` to get the number of rows of matrix X. Even thought `predict_proba` was covered by a number of tests, the test suite used a trick automatically test for dense and sparse inputs, however, `predict_proba` was not exposed to the sparse inputs.
