### PR TITLE
FIX for issue #884 and improve contingency matrix built efficiency

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -75,7 +75,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None):
                                         dtype=np.int).todense())
     if eps is not None:
         # Must be a float matrix to accept float eps
-        contingency = np.array(contingency.todense(), dtype='float') + eps
+        contingency = np.array(contingency, dtype='float') + eps
     return contingency
 
 

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -5,7 +5,6 @@ better.
 """
 
 # Authors: Olivier Grisel <olivier.grisel@ensta.org>
-#          Wei LI         <kuantkid@gmail.com>
 # License: BSD Style.
 
 from math import log
@@ -66,13 +65,14 @@ def contingency_matrix(labels_true, labels_pred, eps=None):
         in predicted class j. If eps is None, the dtype of this array will be
         integer. If eps is given, the dtype will be float.
     """
-    classes, class_idx = np.unique(labels_true, return_inverse = True);
-    clusters, cluster_idx = np.unique(labels_pred, return_inverse = True);
+    classes, class_idx = np.unique(labels_true, return_inverse=True)
+    clusters, cluster_idx = np.unique(labels_pred, return_inverse=True)
     n_classes = classes.shape[0]
     n_clusters = clusters.shape[0]
-    contingency = np.asarray(coo_matrix((np.ones(class_idx.shape[0]),(class_idx, cluster_idx))
-                            ,shape=(n_classes, n_clusters)
-                            ,dtype=np.int).todense());
+    contingency = np.asarray(coo_matrix((np.ones(class_idx.shape[0]),
+                                         (class_idx, cluster_idx)),
+                                        shape=(n_classes, n_clusters),
+                                        dtype=np.int).todense())
     if eps is not None:
         # Must be a float matrix to accept float eps
         contingency = np.array(contingency.todense(), dtype='float') + eps
@@ -549,11 +549,12 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
     contingency_sum = np.sum(contingency)
     pi = np.sum(contingency, axis=1)
     pj = np.sum(contingency, axis=0)
-    sumpi = pi.sum()
-    sumpj = pj.sum()
     outer = np.outer(pi, pj)
     nnz = contingency != 0.0
-    mi = (contingency[nnz]/contingency_sum) * (np.log(contingency[nnz]) - np.log(contingency_sum)) + (contingency[nnz]/contingency_sum) *(-np.log(outer[nnz]) + np.log(sumpi) + np.log(sumpj))
+    mi = ((contingency[nnz] / contingency_sum) *
+          (np.log(contingency[nnz]) - log(contingency_sum))
+          + (contingency[nnz] / contingency_sum) *
+          (-np.log(outer[nnz]) + log(pi.sum()) + log(pj.sum())))
     return mi.sum()
 
 
@@ -778,5 +779,5 @@ def entropy(labels):
     label_idx = unique(labels, return_inverse=True)[1]
     pi = np.bincount(label_idx).astype(np.float)
     pi = pi[pi > 0]
-    pisum = np.sum(pi)
-    return -np.sum((pi/pisum) * (np.log(pi) - np.log(pisum)))
+    pi_sum = np.sum(pi)
+    return -np.sum((pi / pi_sum) * (np.log(pi) - log(pi_sum)))

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -309,21 +309,21 @@ def homogeneity_score(labels_true, labels_pred):
     Non-pefect labelings that futher split classes into more clusters can be
     perfectly homogeneous::
 
-      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
-                                            [0, 0, 1, 2])) # doctest: +ELLIPSIS
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 0, 1, 2]))
+      ...                                                  # doctest: +ELLIPSIS
       1.0...
-      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
-                                            [0, 1, 2, 3])) # doctest: +ELLIPSIS
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 1, 2, 3]))
+      ...                                                  # doctest: +ELLIPSIS
       1.0...
 
     Clusters that include samples from different classes do not make for an
     homogeneous labeling::
 
-      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
-                                            [0, 1, 0, 1])) # doctest: +ELLIPSIS
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 1, 0, 1]))
+      ...                                                  # doctest: +ELLIPSIS
       0.0...
-      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
-                                            [0, 0, 0, 0])) # doctest: +ELLIPSIS
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1], [0, 0, 0, 0]))
+      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     """
@@ -454,36 +454,36 @@ def v_measure_score(labels_true, labels_pred):
     Labelings that assign all classes members to the same clusters
     are complete be not homogeneous, hence penalized::
 
-      >>> print("%.6f" % v_measure_score([0, 0, 1, 2],\
-                                         [0, 0, 1, 1])) # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 2], [0, 0, 1, 1]))
+      ...                                                  # doctest: +ELLIPSIS
       0.8...
-      >>> print("%.6f" % v_measure_score([0, 1, 2, 3],\
-                                         [0, 0, 1, 1])) # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 1, 2, 3], [0, 0, 1, 1]))
+      ...                                                  # doctest: +ELLIPSIS
       0.66...
 
     Labelings that have pure clusters with members coming from the same
     classes are homogeneous but un-necessary splits harms completeness
     and thus penalize V-measure as well::
 
-      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
-                                         [0, 0, 1, 2]))  # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 1, 2]))
+      ...                                                  # doctest: +ELLIPSIS
       0.8...
-      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
-                                         [0, 1, 2, 3]))  # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 1, 2, 3]))
+      ...                                                  # doctest: +ELLIPSIS
       0.66...
 
     If classes members are completly splitted across different clusters,
     the assignment is totally in-complete, hence the v-measure is null::
 
-      >>> print("%.6f" % v_measure_score([0, 0, 0, 0],\
-                                         [0, 1, 2, 3]))  # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 0, 0], [0, 1, 2, 3]))
+      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     Clusters that include samples from totally different classes totally
     destroy the homogeneity of the labeling, hence::
 
-      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
-                                         [0, 0, 0, 0])) # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 0, 0]))
+      ...                                                  # doctest: +ELLIPSIS
       0.0...
 
     """

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -70,9 +70,9 @@ def contingency_matrix(labels_true, labels_pred, eps=None):
     clusters, cluster_idx = np.unique(labels_pred, return_inverse = True);
     n_classes = classes.shape[0]
     n_clusters = clusters.shape[0]
-    contingency = coo_matrix((np.ones(class_idx.shape[0]),(class_idx, cluster_idx))
+    contingency = np.asarray(coo_matrix((np.ones(class_idx.shape[0]),(class_idx, cluster_idx))
                             ,shape=(n_classes, n_clusters)
-                            ,dtype=np.uint8).todense();
+                            ,dtype=np.int).todense());
     if eps is not None:
         # Must be a float matrix to accept float eps
         contingency = np.array(contingency.todense(), dtype='float') + eps
@@ -553,7 +553,7 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
     sumpj = pj.sum()
     outer = np.outer(pi, pj)
     nnz = contingency != 0.0
-    mi = (contingency[nnz]/contingency_sum) * (np.log2(contingency[nnz]) - np.log2(contingency_sum) - np.log2(outer[nnz]) + np.log2(sumpi) + np.log2(sumpj))
+    mi = (contingency[nnz]/contingency_sum) * (np.log(contingency[nnz]) - np.log(contingency_sum)) + (contingency[nnz]/contingency_sum) *(-np.log(outer[nnz]) + np.log(sumpi) + np.log(sumpj))
     return mi.sum()
 
 
@@ -778,5 +778,5 @@ def entropy(labels):
     label_idx = unique(labels, return_inverse=True)[1]
     pi = np.bincount(label_idx).astype(np.float)
     pi = pi[pi > 0]
-    pi /= np.sum(pi)
-    return -np.sum(pi * np.log(pi))
+    pisum = np.sum(pi)
+    return -np.sum((pi/pisum) * (np.log(pi) - np.log(pisum)))

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -72,8 +72,9 @@ def contingency_matrix(labels_true, labels_pred, eps=None):
     clusters, cluster_idx = np.unique(labels_pred, return_inverse=True)
     n_classes = classes.shape[0]
     n_clusters = clusters.shape[0]
-    # using coo_matrix to accelerate calculation of contingency matrix
-    # it can accelerate 2d-histogram like construction
+    # Using coo_matrix to accelerate simple histogram calculation,
+    # i.e. bins are consecutive integers
+    # Currently, coo_matrix is faster than histogram2d for simple cases
     contingency = np.asarray(coo_matrix((np.ones(class_idx.shape[0]),
                                          (class_idx, cluster_idx)),
                                         shape=(n_classes, n_clusters),

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -309,18 +309,22 @@ def homogeneity_score(labels_true, labels_pred):
     Non-pefect labelings that futher split classes into more clusters can be
     perfectly homogeneous::
 
-      >>> homogeneity_score([0, 0, 1, 1], [0, 0, 1, 2])
-      1.0
-      >>> homogeneity_score([0, 0, 1, 1], [0, 1, 2, 3])
-      1.0
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
+                                            [0, 0, 1, 2])) # doctest: +ELLIPSIS
+      1.0...
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
+                                            [0, 1, 2, 3])) # doctest: +ELLIPSIS
+      1.0...
 
     Clusters that include samples from different classes do not make for an
     homogeneous labeling::
 
-      >>> homogeneity_score([0, 0, 1, 1], [0, 1, 0, 1])
-      0.0
-      >>> homogeneity_score([0, 0, 1, 1], [0, 0, 0, 0])
-      0.0
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
+                                            [0, 1, 0, 1])) # doctest: +ELLIPSIS
+      0.0...
+      >>> print ("%.6f" % homogeneity_score([0, 0, 1, 1],\
+                                            [0, 0, 0, 0])) # doctest: +ELLIPSIS
+      0.0...
 
     """
     return homogeneity_completeness_v_measure(labels_true, labels_pred)[0]
@@ -376,17 +380,17 @@ def completeness_score(labels_true, labels_pred):
     Non-pefect labelings that assign all classes members to the same clusters
     are still complete::
 
-      >>> completeness_score([0, 0, 1, 1], [0, 0, 0, 0])
+      >>> print completeness_score([0, 0, 1, 1], [0, 0, 0, 0])
       1.0
-      >>> completeness_score([0, 1, 2, 3], [0, 0, 1, 1])
+      >>> print completeness_score([0, 1, 2, 3], [0, 0, 1, 1])
       1.0
 
     If classes members are splitted across different clusters, the
     assignment cannot be complete::
 
-      >>> completeness_score([0, 0, 1, 1], [0, 1, 0, 1])
+      >>> print completeness_score([0, 0, 1, 1], [0, 1, 0, 1])
       0.0
-      >>> completeness_score([0, 0, 0, 0], [0, 1, 2, 3])
+      >>> print completeness_score([0, 0, 0, 0], [0, 1, 2, 3])
       0.0
 
     """
@@ -450,31 +454,37 @@ def v_measure_score(labels_true, labels_pred):
     Labelings that assign all classes members to the same clusters
     are complete be not homogeneous, hence penalized::
 
-      >>> v_measure_score([0, 0, 1, 2], [0, 0, 1, 1])     # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 2],\
+                                         [0, 0, 1, 1])) # doctest: +ELLIPSIS
       0.8...
-      >>> v_measure_score([0, 1, 2, 3], [0, 0, 1, 1])     # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 1, 2, 3],\
+                                         [0, 0, 1, 1])) # doctest: +ELLIPSIS
       0.66...
 
     Labelings that have pure clusters with members coming from the same
     classes are homogeneous but un-necessary splits harms completeness
     and thus penalize V-measure as well::
 
-      >>> v_measure_score([0, 0, 1, 1], [0, 0, 1, 2])     # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
+                                         [0, 0, 1, 2]))  # doctest: +ELLIPSIS
       0.8...
-      >>> v_measure_score([0, 0, 1, 1], [0, 1, 2, 3])     # doctest: +ELLIPSIS
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
+                                         [0, 1, 2, 3]))  # doctest: +ELLIPSIS
       0.66...
 
     If classes members are completly splitted across different clusters,
     the assignment is totally in-complete, hence the v-measure is null::
 
-      >>> v_measure_score([0, 0, 0, 0], [0, 1, 2, 3])
-      0.0
+      >>> print("%.6f" % v_measure_score([0, 0, 0, 0],\
+                                         [0, 1, 2, 3]))  # doctest: +ELLIPSIS
+      0.0...
 
     Clusters that include samples from totally different classes totally
     destroy the homogeneity of the labeling, hence::
 
-      >>> v_measure_score([0, 0, 1, 1], [0, 0, 0, 0])
-      0.0
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1],\
+                                         [0, 0, 0, 0])) # doctest: +ELLIPSIS
+      0.0...
 
     """
     return homogeneity_completeness_v_measure(labels_true, labels_pred)[2]

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -19,6 +19,8 @@ from ...utils.fixes import unique
 
 # the exact version if faster for k == 2: use it by default globally in
 # this module instead of the float approximate variant
+
+
 def comb2(n):
     return comb(n, 2, exact=1)
 
@@ -234,13 +236,13 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred):
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
 
     if len(labels_true) == 0:
-        return 1.0,1.0,1.0
+        return 1.0, 1.0, 1.0
 
     entropy_C = entropy(labels_true)
     entropy_K = entropy(labels_pred)
 
     MI = mutual_info_score(labels_true, labels_pred)
-    
+
     homogeneity = MI / (entropy_C) if entropy_C else 1.0
     completeness = MI / (entropy_K) if entropy_K else 1.0
 

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -541,6 +541,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
     contingency_nm = contingency[nnz]
     log_contingency_nm = np.log(contingency_nm)
     contingency_nm /= contingency_sum
+    # log(a / b) should be calculated as log(a) - log(b) for
+    # possible loss of precision
     log_outer = -np.log(outer[nnz]) + log(pi.sum()) + log(pj.sum())
     mi = (contingency_nm * (log_contingency_nm - log(contingency_sum))
           + contingency_nm * log_outer)
@@ -772,4 +774,6 @@ def entropy(labels):
     pi = np.bincount(label_idx).astype(np.float)
     pi = pi[pi > 0]
     pi_sum = np.sum(pi)
+    # log(a / b) should be calculated as log(a) - log(b) for
+    # possible loss of precision
     return -np.sum((pi / pi_sum) * (np.log(pi) - log(pi_sum)))

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -245,11 +245,13 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred):
     n_C = [float(np.sum(labels_true == c)) for c in classes]
     n_K = [float(np.sum(labels_pred == k)) for k in clusters]
 
-    for i in xrange(len(classes)):
-        entropy_C -= n_C[i] / n_samples * log(n_C[i] / n_samples)
+    # for i in xrange(len(classes)):
+    #     entropy_C -= n_C[i] / n_samples * log(n_C[i] / n_samples)
 
-    for j in xrange(len(clusters)):
-        entropy_K -= n_K[j] / n_samples * log(n_K[j] / n_samples)
+    # for j in xrange(len(clusters)):
+    #     entropy_K -= n_K[j] / n_samples * log(n_K[j] / n_samples)
+    entropy_C = entropy(labels_true)
+    entropy_K = entropy(labels_pred)
 
     for i, c in enumerate(classes):
         for j, k in enumerate(clusters):
@@ -260,6 +262,23 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred):
                 # turn label assignments into contribution to entropies
                 entropy_C_given_K -= n_CK / n_samples * log(n_CK / n_K[j])
                 entropy_K_given_C -= n_CK / n_samples * log(n_CK / n_C[i])
+    con = np.matrix(contingency_matrix(labels_true, labels_pred), dtype=np.float)
+
+    print con
+
+    a = con / con.sum(axis=0)
+    b = con / con.sum(axis=1)
+    print a
+    print b
+    a = a[a!=0.0]
+    b = b[b!=0.0]
+    print a
+    print b
+    print np.vdot(a, np.log(a)) / n_samples
+    print np.vdot(b, np.log(b)) / n_samples
+
+    print entropy_C_given_K
+    print entropy_K_given_C
 
     homogeneity = 1.0 - entropy_C_given_K / entropy_C if entropy_C else 1.0
     completeness = 1.0 - entropy_K_given_C / entropy_K if entropy_K else 1.0
@@ -776,6 +795,8 @@ def expected_mutual_information(contingency, n_samples):
 
 def entropy(labels):
     """Calculates the entropy for a labeling."""
+    if len(labels) == 0:
+        return 1.0
     label_idx = unique(labels, return_inverse=True)[1]
     pi = np.bincount(label_idx).astype(np.float)
     pi = pi[pi > 0]

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -180,7 +180,7 @@ def test_exactly_zero_info_score():
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
 
 
-def test_v_measure_and_mi(seed=36):
+def test_v_measure_and_mutual_information(seed=36):
     """Check relation between v_measure, entropy and mutual information"""
     for i in np.logspace(1, 4, 4):
         random_state = np.random.RandomState(seed)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -180,11 +180,12 @@ def test_exactly_zero_info_score():
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
 
 
-def test_v_measure_and_mi():
+def test_v_measure_and_mi(seed = 36):
     """Check relation between v_measure, entropy and and mi"""
     for i in np.logspace(1, 4, 4):
-        labels_a, labels_b = np.random.random_integers(0, 10, i),\
-            np.random.random_integers(0, 10, i)
+        random_state = np.random.RandomState(seed)
+        labels_a, labels_b = random_state.random_integers(0, 10, i),\
+            random_state.random_integers(0, 10, i)
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -181,7 +181,7 @@ def test_exactly_zero_info_score():
 
 
 def test_v_measure_and_mi():
-    """Check relation between v_measure, entropy and and mi's relation"""
+    """Check relation between v_measure, entropy and and mi"""
     for i in np.logspace(1, 4, 4):
         labels_a, labels_b = np.random.random_integers(0, 10, i),\
             np.random.random_integers(0, 10, i)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -181,7 +181,7 @@ def test_exactly_zero_info_score():
 
 
 def test_v_measure_and_mi(seed=36):
-    """Check relation between v_measure, entropy and and mi"""
+    """Check relation between v_measure, entropy and mutual information"""
     for i in np.logspace(1, 4, 4):
         random_state = np.random.RandomState(seed)
         labels_a, labels_b = random_state.random_integers(0, 10, i),\

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -167,3 +167,19 @@ def test_adjusted_mutual_info_score():
 def test_entropy():
     ent = entropy([0, 0, 42.])
     assert_almost_equal(ent, 0.6365141, 5)
+
+def test_exactly_zero_info_score():
+    """Check numerical stabability when information is exactly zero"""
+    for i in np.logspace(1, 4, 4):
+        labels_a, labels_b = np.ones(i, dtype=np.int), np.arange(i, dtype=np.int)
+        assert_equal(normalized_mutual_info_score(labels_a,labels_b),0.0)
+        assert_equal(v_measure_score(labels_a,labels_b),0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a,labels_b),0.0)
+        assert_equal(normalized_mutual_info_score(labels_a,labels_b),0.0)
+    
+def test_nmi_equal_v_measure():
+    """Check the nmi and v_measure are equal"""
+    for i in np.logspace(1, 4, 4):
+        labels_a, labels_b = np.random.random_integers(0, int(i/5)+1, i), np.arange(i, dtype=np.int)
+        assert_equal(normalized_mutual_info_score(labels_a,labels_b),v_measure_score(labels_a,labels_b))
+    

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -172,8 +172,8 @@ def test_entropy():
 def test_exactly_zero_info_score():
     """Check numerical stabability when information is exactly zero"""
     for i in np.logspace(1, 4, 4):
-        labels_a, labels_b = np.ones(i, dtype=np.int),
-        np.arange(i, dtype=np.int)
+        labels_a, labels_b = np.ones(i, dtype=np.int),\
+            np.arange(i, dtype=np.int)
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
         assert_equal(v_measure_score(labels_a, labels_b), 0.0)
         assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -178,3 +178,13 @@ def test_exactly_zero_info_score():
         assert_equal(v_measure_score(labels_a, labels_b), 0.0)
         assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+
+
+def test_v_measure_and_mi():
+    """Check relation between v_measure, entropy and and mi's relation"""
+    for i in np.logspace(1, 4, 4):
+        labels_a, labels_b = np.random.random_integers(0, 10, i),\
+            np.random.random_integers(0, 10, i)
+        assert_almost_equal(v_measure_score(labels_a, labels_b),
+                            2.0 * mutual_info_score(labels_a, labels_b) /
+                            (entropy(labels_a) + entropy(labels_b)), 0)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -180,7 +180,7 @@ def test_exactly_zero_info_score():
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
 
 
-def test_v_measure_and_mi(seed = 36):
+def test_v_measure_and_mi(seed=36):
     """Check relation between v_measure, entropy and and mi"""
     for i in np.logspace(1, 4, 4):
         random_state = np.random.RandomState(seed)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -176,10 +176,3 @@ def test_exactly_zero_info_score():
         assert_equal(v_measure_score(labels_a,labels_b),0.0)
         assert_equal(adjusted_mutual_info_score(labels_a,labels_b),0.0)
         assert_equal(normalized_mutual_info_score(labels_a,labels_b),0.0)
-    
-def test_nmi_equal_v_measure():
-    """Check the nmi and v_measure are equal"""
-    for i in np.logspace(1, 4, 4):
-        labels_a, labels_b = np.random.random_integers(0, int(i/5)+1, i), np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a,labels_b),v_measure_score(labels_a,labels_b))
-    

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -168,11 +168,13 @@ def test_entropy():
     ent = entropy([0, 0, 42.])
     assert_almost_equal(ent, 0.6365141, 5)
 
+
 def test_exactly_zero_info_score():
     """Check numerical stabability when information is exactly zero"""
     for i in np.logspace(1, 4, 4):
-        labels_a, labels_b = np.ones(i, dtype=np.int), np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a,labels_b),0.0)
-        assert_equal(v_measure_score(labels_a,labels_b),0.0)
-        assert_equal(adjusted_mutual_info_score(labels_a,labels_b),0.0)
-        assert_equal(normalized_mutual_info_score(labels_a,labels_b),0.0)
+        labels_a, labels_b = np.ones(i, dtype=np.int),
+        np.arange(i, dtype=np.int)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(v_measure_score(labels_a, labels_b), 0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -79,19 +79,6 @@ def confusion_matrix(y_true, y_pred, labels=None):
                                dtype=np.int).todense())
     return CM
 
-    if n_labels >= 15:
-        CM = np.zeros((n_labels, n_labels), dtype=np.long)
-        for yt, yp in zip(y_true, y_pred):
-            CM[label_to_ind[yt], label_to_ind[yp]] += 1
-    else:
-        CM = np.empty((n_labels, n_labels), dtype=np.long)
-        for i, label_i in enumerate(labels):
-            for j, label_j in enumerate(labels):
-                CM[i, j] = np.sum(
-                    np.logical_and(y_true == label_i, y_pred == label_j))
-
-    return CM
-
 
 def roc_curve(y_true, y_score):
     """compute Receiver operating characteristic (ROC)


### PR DESCRIPTION
I think(I am not so sure) that the log operation breaks for `log(a/b)`, as the division/multiplication will have possible loss of precision, and `log(a/b)` should be written as `log(a) - log(b)`. This causes the issue #884

For example in issue #776 @ogrisel:
1.`normalized_mutual_info_score([1, 1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6])` Will be zero
2. `for i in np.logspace(1, 4, 4):
    print normalized_mutual_info_score(np.ones(i, dtype=np.int), np.arange(i, dtype=np.int))`
Will be all zero

Another is to use `coo_matrix` to accelerate the built of the contingency matrix, A quick test is shown below.

Using coo_matrix
coo_matrix is similar to matlab's `accumarray`, and I think it is more efficient to calculate :-).
`%timeit contingency = contingency_matrix(random_integers(1,10000,(1,1000000))[0],
                                                                          random_integers(1,10000,(1,1000000))[0])
1 loops, best of 3: 604 ms per loop`
Using original python dict
`%timeit contingency = contingency_matrix(random_integers(1,10000,(1,1000000))[0],
                                                                          random_integers(1,10000,(1,1000000))[0])
1 loops, best of 3: 1.84 s per loop`

Further issue is that when using dict, `contingency = contingency_matrix(random_integers(1,10,(1,100)),random_integers(1,10,(1,100)))` such code will fail as the ndarray not hashable, a check for the input string should be made.

One thing remaining is that, the contigency_matrix is usually (if not all the time) sparse, so use sparse operation should further accelearte expecially calculate the `x * log(x)` with dealing the `0log0` case as we can get out the non-zero items with no cost than dense matrix. But currently I put a `todense()` for the contingency matrix. I will further fix it if decided to use coo_matrix :-)
