### PR TITLE
BF: lars -- assure quiting the loop in a degenerate case before crashing

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -232,7 +232,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             # L is too ill-conditionned
             i = 0
             L_ = L[:n_active, :n_active].copy()
-            while not np.isfinite(AA):
+            while not np.isfinite(AA) and i < 63:
                 L_.flat[::n_active + 1] += (2 ** i) * eps
                 least_squares, info = solve_cholesky(L_,
                                     sign_active[:n_active], lower=True)


### PR DESCRIPTION
if data is entirely degenerate (e.g. all Xs are 0s), then loop would eventually crash
due to:

TypeError: unsupported operand type(s) for *: long and numpy.float64

when i=63.  swapping product order in (2 *\* i) \* eps would allow to loop until 1023
but most probably with the same "success".  Thus it should be as sensible to quit
loop before crashing with a TypeError
