### PR TITLE
MRG: New solver for Ridge

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -144,7 +144,7 @@ efficiently process ``scipy.sparse`` data.
 - :func:`sparsefuncs.inplace_csr_column_scale`: can be used to multiply the
   columns of a CSR matrix by a constant scale (one scale per column).
   Used for scaling features to unit standard deviation in
-  :class:`sklearn.preprocessing.Scaler`.
+  :class:`sklearn.preprocessing.StandardScaler`.
 
 
 Graph Routines

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -836,12 +836,13 @@ Pairwise metrics
    :toctree: generated/
    :template: class.rst
 
-   preprocessing.Scaler
-   preprocessing.Normalizer
    preprocessing.Binarizer
+   preprocessing.KernelCenterer
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder
-   preprocessing.KernelCenterer
+   preprocessing.MinMaxScaler
+   preprocessing.Normalizer
+   preprocessing.StandardScaler
 
 .. autosummary::
    :toctree: generated/

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -101,8 +101,9 @@ its `coef\_` member::
 
     >>> from sklearn import linear_model
     >>> clf = linear_model.Ridge (alpha = .5)
-    >>> clf.fit ([[0, 0], [0, 0], [1, 1]], [0, .1, 1])
-    Ridge(alpha=0.5, copy_X=True, fit_intercept=True, normalize=False, tol=0.001)
+    >>> clf.fit ([[0, 0], [0, 0], [1, 1]], [0, .1, 1]) # doctest: +NORMALIZE_WHITESPACE
+    Ridge(alpha=0.5, copy_X=True, fit_intercept=True, max_iter=None,
+          normalize=False, solver='auto', tol=0.001)
     >>> clf.coef_
     array([ 0.34545455,  0.34545455])
     >>> clf.intercept_ #doctest: +ELLIPSIS

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -427,7 +427,7 @@ Tips on practical use
 
 * Make sure the same scale is used over all features. Because manifold
   learning methods are based on a nearest-neighbor search, the algorithm
-  may perform poorly otherwise.  See :ref:`Scaler <preprocessing_scaler>`
+  may perform poorly otherwise.  See :ref:`StandardScaler <preprocessing_scaler>`
   for convenient ways of scaling heterogeneous data.
 
 * The reconstruction error computed by each routine can be used to choose

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -64,15 +64,15 @@ Scaled data has zero mean and unit variance::
 ..    >>> print_options = np.set_printoptions(print_options)
 
 The ``preprocessing`` module further provides a utility class
-:class:`Scaler` that implements the ``Transformer`` API to compute
+:class:`StandardScaler` that implements the ``Transformer`` API to compute
 the mean and standard deviation on a training set so as to be
 able to later reapply the same transformation on the testing set.
 This class is hence suitable for use in the early steps of a
 :class:`sklearn.pipeline.Pipeline`::
 
-  >>> scaler = preprocessing.Scaler().fit(X)
+  >>> scaler = preprocessing.StandardScaler().fit(X)
   >>> scaler
-  Scaler(copy=True, with_mean=True, with_std=True)
+  StandardScaler(copy=True, with_mean=True, with_std=True)
 
   >>> scaler.mean_                                      # doctest: +ELLIPSIS
   array([ 1. ...,  0. ...,  0.33...])
@@ -94,7 +94,7 @@ same way it did on the training set::
 
 It is possible to disable either centering or scaling by either
 passing ``with_mean=False`` or ``with_std=False`` to the constructor
-of :class:`Scaler`.
+of :class:`StandardScaler`.
 
 
 .. topic:: References:
@@ -115,7 +115,7 @@ of :class:`Scaler`.
 
 .. topic:: Sparse input
 
-  :func:`scale` and :class:`Scaler` accept ``scipy.sparse`` matrices
+  :func:`scale` and :class:`StandardScaler` accept ``scipy.sparse`` matrices
   as input **only when with_mean=False is explicitly passed to the
   constructor**. Otherwise a ``ValueError`` will be raised as
   silently centering would break the sparsity and would often crash the
@@ -132,7 +132,7 @@ of :class:`Scaler`.
 
 .. topic:: Scaling target variables in regression
 
-    :func:`scale` and :class:`Scaler` work out-of-the-box with 1d arrays.
+    :func:`scale` and :class:`StandardScaler` work out-of-the-box with 1d arrays.
     This is very useful for scaling the target / response variables used
     for regression.
 
@@ -243,7 +243,7 @@ It is possible to adjust the threshold of the binarizer::
          [ 1.,  0.,  0.],
          [ 0.,  0.,  0.]])
 
-As for the :class:`Scaler` and :class:`Normalizer` classes, the
+As for the :class:`StandardScaler` and :class:`Normalizer` classes, the
 preprocessing module provides a companion function :func:`binarize`
 to be used when the transformer API is not necessary.
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -229,10 +229,10 @@ Tips on Practical Use
     attribute on the input vector X to [0,1] or [-1,+1], or standardize
     it to have mean 0 and variance 1. Note that the *same* scaling
     must be applied to the test vector to obtain meaningful
-    results. This can be easily done using :class:`Scaler`::
+    results. This can be easily done using :class:`StandardScaler`::
 
-      from sklearn.preprocessing import Scaler
-      scaler = Scaler()
+      from sklearn.preprocessing import StandardScaler
+      scaler = StandardScaler()
       scaler.fit(X_train)  # Don't cheat - fit only on training data
       X_train = scaler.transform(X_train)
       X_test = scaler.transform(X_test)  # apply same transformation to test data

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,8 +11,12 @@ Changelog
    - :class:`feature_selection.SelectPercentile` now breaks ties
      deterministically instead of returning all equally ranked features.
 
-   - Ridge regression and ridge classification fitting no longer has
-     quadratic memory complexity.
+   - Ridge regression and ridge classification fitting with ``sparse_cg`` solver
+     no longer has quadratic memory complexity, by `Lars Buitinck`_ and
+     `Fabian Pedregosa`_.
+
+   - Ridge regression and ridge classification now support a new fast solver
+     called ``lsqr``, by `Mathieu Blondel`_.
 
    - Speed up of :func:`metrics.precision_recall_curve` by Conrad Lee.
 
@@ -31,6 +35,8 @@ API changes summary
    - GMMs no longer have ``decode`` and ``rvs`` methods. Use the ``score``,
      ``predict`` or ``sample`` methods instead.
 
+   - The ``solver`` option in Ridge regression and classification is now
+     deprecated and will be removed in v0.14.
 
 .. _changes_0_12:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,8 +35,9 @@ API changes summary
    - GMMs no longer have ``decode`` and ``rvs`` methods. Use the ``score``,
      ``predict`` or ``sample`` methods instead.
 
-   - The ``solver`` option in Ridge regression and classification is now
-     deprecated and will be removed in v0.14.
+   - The ``solver`` fit option in Ridge regression and classification is now
+     deprecated and will be removed in v0.14. Use the constructor option
+     instead.
 
 .. _changes_0_12:
 

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -30,7 +30,7 @@ import pylab as pl
 from sklearn import cluster, datasets
 from sklearn.metrics import euclidean_distances
 from sklearn.neighbors import kneighbors_graph
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 
 np.random.seed(0)
 
@@ -55,7 +55,7 @@ for i_dataset, dataset in enumerate([noisy_circles, noisy_moons, blobs,
                 no_structure]):
     X, y = dataset
     # normalize dataset for easier parameter selection
-    X = Scaler().fit_transform(X)
+    X = StandardScaler().fit_transform(X)
 
     # estimate bandwidth for mean shift
     bandwidth = cluster.estimate_bandwidth(X, quantile=0.3)

--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -191,7 +191,7 @@ def benchmark(clf):
 
 
 results = []
-for clf, name in ((RidgeClassifier(tol=1e-1), "Ridge Classifier"),
+for clf, name in ((RidgeClassifier(tol=1e-1, solver="lsqr"), "Ridge Classifier"),
                   (Perceptron(n_iter=50), "Perceptron"),
                   (KNeighborsClassifier(n_neighbors=10), "kNN")):
     print 80 * '='

--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -191,7 +191,7 @@ def benchmark(clf):
 
 
 results = []
-for clf, name in ((RidgeClassifier(tol=1e-1, solver="lsqr"), "Ridge Classifier"),
+for clf, name in ((RidgeClassifier(tol=1e-2, solver="lsqr"), "Ridge Classifier"),
                   (Perceptron(n_iter=50), "Perceptron"),
                   (KNeighborsClassifier(n_neighbors=10), "kNN")):
     print 80 * '='

--- a/examples/linear_model/plot_logistic_l1_l2_sparsity.py
+++ b/examples/linear_model/plot_logistic_l1_l2_sparsity.py
@@ -25,12 +25,12 @@ import pylab as pl
 
 from sklearn.linear_model import LogisticRegression
 from sklearn import datasets
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 
 digits = datasets.load_digits()
 
 X, y = digits.data, digits.target
-X = Scaler().fit_transform(X)
+X = StandardScaler().fit_transform(X)
 
 # classify small against large digits
 y = (y > 4).astype(np.int)

--- a/examples/linear_model/plot_sparse_recovery.py
+++ b/examples/linear_model/plot_sparse_recovery.py
@@ -50,7 +50,7 @@ from scipy import linalg
 from sklearn.linear_model import RandomizedLasso, lasso_stability_path, \
                                  LassoLarsCV
 from sklearn.feature_selection import f_regression
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import auc, precision_recall_curve
 from sklearn.ensemble import ExtraTreesRegressor
 from sklearn.utils.extmath import pinvh
@@ -97,7 +97,7 @@ for conditionning in (1, 1e-4):
     # Keep [Wainwright2006] (26c) constant
     X[:n_relevant_features] /= np.abs(
             linalg.svdvals(X[:n_relevant_features])).max()
-    X = Scaler().fit_transform(X.copy())
+    X = StandardScaler().fit_transform(X.copy())
 
     # The output variable
     y = np.dot(X, coef)

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -25,7 +25,7 @@ import numpy as np
 import pylab as pl
 
 from sklearn.svm import SVC
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 from sklearn.datasets import load_iris
 from sklearn.cross_validation import StratifiedKFold
 from sklearn.grid_search import GridSearchCV
@@ -49,7 +49,7 @@ Y_2d -= 1
 # instead of fitting the transformation on the training set and
 # just applying it on the test set.
 
-scaler = Scaler()
+scaler = StandardScaler()
 
 X = scaler.fit_transform(X)
 X_2d = scaler.fit_transform(X_2d)

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -243,7 +243,7 @@ def csr_row_norm_l2(X, squared=True):
     """Get L2 norm of each row in CSR matrix X.
 
     TODO: refactor me in the sklearn.utils.sparsefuncs module once the CSR
-    sklearn.preprocessing.Scaler has been refactored as well.
+    sklearn.preprocessing.StandardScaler has been refactored as well.
     """
     cdef:
         unsigned int n_samples = X.shape[0]

--- a/sklearn/linear_model/isotonic_regression_.py
+++ b/sklearn/linear_model/isotonic_regression_.py
@@ -43,10 +43,8 @@ def isotonic_regression(y, weight=None, y_min=None, y_max=None):
 
     References
     ----------
-    Isotonic Median Regression: A Linear Programming Approach
-    Nilotpal Chakravarti
-    Mathematics of Operations Research
-    Vol. 14, No. 2 (May, 1989), pp. 303-308
+    "Active set algorithms for isotonic regression; A unifying framework" 
+    by Michael J. Best and Nilotpal Chakravarti, section 3.
     """
     if weight is None:
         weight = np.ones(len(y), dtype=y.dtype)

--- a/sklearn/linear_model/isotonic_regression_.py
+++ b/sklearn/linear_model/isotonic_regression_.py
@@ -43,7 +43,7 @@ def isotonic_regression(y, weight=None, y_min=None, y_max=None):
 
     References
     ----------
-    "Active set algorithms for isotonic regression; A unifying framework" 
+    "Active set algorithms for isotonic regression; A unifying framework"
     by Michael J. Best and Nilotpal Chakravarti, section 3.
     """
     if weight is None:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -118,9 +118,12 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             y1 = y
         coefs = np.empty((y1.shape[1], n_features))
 
+        # According to the lsqr documentation, alpha = damp^2.
+        sqrt_alpha = np.sqrt(alpha)
+
         for i in range(y1.shape[1]):
             y_column = y1[:, i]
-            coefs[i] = sp_linalg.lsqr(X, y_column, damp=alpha,
+            coefs[i] = sp_linalg.lsqr(X, y_column, damp=sqrt_alpha,
                                       atol=tol, btol=tol, iter_lim=max_iter)[0]
 
         if y.ndim == 1:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -158,6 +158,7 @@ class _BaseRidge(LinearModel):
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.copy_X = copy_X
+        self.max_iter = max_iter
         self.tol = tol
         self.solver = solver
 
@@ -169,8 +170,12 @@ class _BaseRidge(LinearModel):
            self._center_data(X, y, self.fit_intercept,
                    self.normalize, self.copy_X)
 
-        self.coef_ = ridge_regression(X, y, self.alpha, sample_weight,
-                                      solver, self.tol)
+        self.coef_ = ridge_regression(X, y,
+                                      alpha=self.alpha,
+                                      sample_weight=sample_weight,
+                                      solver=solver,
+                                      max_iter=self.max_iter,
+                                      tol=self.tol)
         self._set_intercept(X_mean, y_mean, X_std)
         return self
 
@@ -233,9 +238,10 @@ class Ridge(_BaseRidge, RegressorMixin):
        tol=0.001)
     """
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
-                 copy_X=True, tol=1e-3, solver="auto"):
+                 copy_X=True, max_iter=None, tol=1e-3, solver="auto"):
         super(Ridge, self).__init__(alpha=alpha, fit_intercept=fit_intercept,
-              normalize=normalize, copy_X=copy_X, tol=tol, solver=solver)
+                                    normalize=normalize, copy_X=copy_X,
+                                    max_iter=max_iter, tol=tol, solver=solver)
 
     def fit(self, X, y, sample_weight=1.0, solver=None):
         """Fit Ridge regression model

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -43,12 +43,14 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
     sample_weight : float or numpy array of shape [n_samples]
         Individual weights for each sample
 
-    solver : {'auto', 'dense_cholesky', 'sparse_cg'}, optional
-        Solver to use in the computational routines. 'dense_cholesky'
-        will use the standard scipy.linalg.solve function, 'sparse_cg'
-        will use the conjugate gradient solver as found in
+    solver : {'auto', 'dense_cholesky', 'lsqr', 'sparse_cg'}
+        Solver to use in the computational
+        routines. 'dense_cholesky' will use the standard
+        scipy.linalg.solve function, 'sparse_cg' will use the
+        conjugate gradient solver as found in
         scipy.sparse.linalg.cg while 'auto' will chose the most
-        appropriate depending on the matrix X.
+        appropriate depending on the matrix X. 'lsqr' uses
+        a direct regularized least-squares routine provided by scipy.
 
     tol: float
         Precision of the solution.
@@ -197,20 +199,29 @@ class Ridge(_BaseRidge, RegressorMixin):
         ``(2*C)^-1`` in other linear models such as LogisticRegression or
         LinearSVC.
 
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
+
     fit_intercept : boolean
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (e.g. data is expected to be already centered).
 
-    normalize : boolean, optional
-        If True, the regressors X are normalized
-
-    copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten.
-
     max_iter : int, optional
         Maximum number of iterations for conjugate gradient solver.
         The default value is determined by scipy.sparse.linalg.
+
+    normalize : boolean, optional
+        If True, the regressors X are normalized
+
+    solver : {'auto', 'dense_cholesky', 'lsqr', 'sparse_cg'}
+        Solver to use in the computational
+        routines. 'dense_cholesky' will use the standard
+        scipy.linalg.solve function, 'sparse_cg' will use the
+        conjugate gradient solver as found in
+        scipy.sparse.linalg.cg while 'auto' will chose the most
+        appropriate depending on the matrix X. 'lsqr' uses
+        a direct regularized least-squares routine provided by scipy.
 
     tol : float
         Precision of the solution.
@@ -234,8 +245,8 @@ class Ridge(_BaseRidge, RegressorMixin):
     >>> X = np.random.randn(n_samples, n_features)
     >>> clf = Ridge(alpha=1.0)
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    Ridge(alpha=1.0, copy_X=True, fit_intercept=True, normalize=False,
-       tol=0.001)
+    Ridge(alpha=1.0, copy_X=True, fit_intercept=True, max_iter=None,
+          normalize=False, solver='auto', tol=0.001)
     """
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto"):
@@ -256,14 +267,6 @@ class Ridge(_BaseRidge, RegressorMixin):
 
         sample_weight : float or numpy array of shape [n_samples]
             Individual weights for each sample
-
-        solver : {'auto', 'dense_cholesky', 'sparse_cg'}
-            Solver to use in the computational
-            routines. 'dense_cholesky' will use the standard
-            scipy.linalg.solve function, 'sparse_cg' will use the
-            conjugate gradient solver as found in
-            scipy.sparse.linalg.cg while 'auto' will chose the most
-            appropriate depending on the matrix X.
 
         Returns
         -------
@@ -291,28 +294,37 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         ``(2*C)^-1`` in other linear models such as LogisticRegression or
         LinearSVC.
 
+    class_weight : dict, optional
+        Weights associated with classes in the form
+        {class_label : weight}. If not given, all classes are
+        supposed to have weight one.
+
+    copy_X : boolean, optional, default True
+        If True, X will be copied; else, it may be overwritten.
+
     fit_intercept : boolean
         Whether to calculate the intercept for this model. If set to false, no
         intercept will be used in calculations (e.g. data is expected to be
         already centered).
 
-    normalize : boolean, optional
-        If True, the regressors X are normalized
-
-    copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten.
-
     max_iter : int, optional
         Maximum number of iterations for conjugate gradient solver.
         The default value is determined by scipy.sparse.linalg.
 
+    normalize : boolean, optional
+        If True, the regressors X are normalized
+
+    solver : {'auto', 'dense_cholesky', 'lsqr', 'sparse_cg'}
+        Solver to use in the computational
+        routines. 'dense_cholesky' will use the standard
+        scipy.linalg.solve function, 'sparse_cg' will use the
+        conjugate gradient solver as found in
+        scipy.sparse.linalg.cg while 'auto' will chose the most
+        appropriate depending on the matrix X. 'lsqr' uses
+        a direct regularized least-squares routine provided by scipy.
+
     tol : float
         Precision of the solution.
-
-    class_weight : dict, optional
-        Weights associated with classes in the form
-        {class_label : weight}. If not given, all classes are
-        supposed to have weight one.
 
     Attributes
     ----------
@@ -347,14 +359,6 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
         y : array-like, shape = [n_samples]
             Target values
-
-        solver : {'auto', 'dense_cholesky', 'sparse_cg'}
-            Solver to use in the computational
-            routines. 'dense_cholesky' will use the standard
-            scipy.linalg.solve function, 'sparse_cg' will use the
-            conjugate gradient solver as found in
-            scipy.sparse.linalg.cg while 'auto' will chose the most
-            appropriate depending on the matrix X.
 
         Returns
         -------

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -76,7 +76,15 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         else:
             solver = 'sparse_cg'
 
-    if solver == 'sparse_cg' and not has_sw:
+    elif solver == 'lsqr' and not hasattr(sp_linalg, 'lsqr'):
+        warnings.warn("""lsqr not available on this machine, falling back
+                      to sparse_cg.""")
+        solver = 'sparse_cg'
+
+    if has_sw:
+        solver = 'dense_cholesky'
+
+    if solver == 'sparse_cg':
         # gradient descent
         X1 = sp_linalg.aslinearoperator(X)
         if y.ndim == 1:
@@ -112,7 +120,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             coefs = np.ravel(coefs)
         return coefs
-    elif solver == "lsqr" and not has_sw:
+    elif solver == "lsqr":
         if y.ndim == 1:
             y1 = np.reshape(y, (-1, 1))
         else:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -44,13 +44,23 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         Individual weights for each sample
 
     solver : {'auto', 'dense_cholesky', 'lsqr', 'sparse_cg'}
-        Solver to use in the computational
-        routines. 'dense_cholesky' will use the standard
-        scipy.linalg.solve function, 'sparse_cg' will use the
-        conjugate gradient solver as found in
-        scipy.sparse.linalg.cg while 'auto' will chose the most
-        appropriate depending on the matrix X. 'lsqr' uses
-        a direct regularized least-squares routine provided by scipy.
+        Solver to use in the computational routines:
+
+        - 'auto' chooses the solver automatically based on the type of data.
+
+        - 'dense_cholesky' uses the standard scipy.linalg.solve function to
+          obtain a closed-form solution.
+
+        - 'sparse_cg' uses the conjugate gradient solver as found in
+          scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
+          more appropriate than 'dense_cholesky' for large-scale data
+          (possibility to set `tol` and `max_iter`).
+
+        - 'lsqr' uses the dedicated regularized least-squares routine
+          scipy.sparse.linalg.lsqr. It is the fatest but may not be available in
+          old scipy versions. It also uses an iterative procedure.
+
+        All three solvers support both dense and sparse data.
 
     tol: float
         Precision of the solution.
@@ -224,13 +234,23 @@ class Ridge(_BaseRidge, RegressorMixin):
         If True, the regressors X are normalized
 
     solver : {'auto', 'dense_cholesky', 'lsqr', 'sparse_cg'}
-        Solver to use in the computational
-        routines. 'dense_cholesky' will use the standard
-        scipy.linalg.solve function, 'sparse_cg' will use the
-        conjugate gradient solver as found in
-        scipy.sparse.linalg.cg while 'auto' will chose the most
-        appropriate depending on the matrix X. 'lsqr' uses
-        a direct regularized least-squares routine provided by scipy.
+        Solver to use in the computational routines:
+
+        - 'auto' chooses the solver automatically based on the type of data.
+
+        - 'dense_cholesky' uses the standard scipy.linalg.solve function to
+          obtain a closed-form solution.
+
+        - 'sparse_cg' uses the conjugate gradient solver as found in
+          scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
+          more appropriate than 'dense_cholesky' for large-scale data
+          (possibility to set `tol` and `max_iter`).
+
+        - 'lsqr' uses the dedicated regularized least-squares routine
+          scipy.sparse.linalg.lsqr. It is the fatest but may not be available in
+          old scipy versions. It also uses an iterative procedure.
+
+        All three solvers support both dense and sparse data.
 
     tol : float
         Precision of the solution.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -104,13 +104,18 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             y1 = y
         coefs = np.empty((y1.shape[1], n_features))
 
+        if n_features > n_samples:
+            def mv(x):
+                return X1.matvec(X1.rmatvec(x)) + alpha * x
+        else:
+            def mv(x):
+                return X1.rmatvec(X1.matvec(x)) + alpha * x
+
         for i in range(y1.shape[1]):
             y_column = y1[:, i]
             if n_features > n_samples:
                 # kernel ridge
                 # w = X.T * inv(X X^t + alpha*Id) y
-                def mv(x):
-                    return X1.matvec(X1.rmatvec(x)) + alpha * x
                 C = sp_linalg.LinearOperator(
                     (n_samples, n_samples), matvec=mv, dtype=X.dtype)
                 coef, info = sp_linalg.cg(C, y_column, tol=tol)
@@ -118,8 +123,6 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             else:
                 # ridge
                 # w = inv(X^t X + alpha*Id) * X.T y
-                def mv(x):
-                    return X1.rmatvec(X1.matvec(x)) + alpha * x
                 y_column = X1.rmatvec(y_column)
                 C = sp_linalg.LinearOperator(
                     (n_features, n_features), matvec=mv, dtype=X.dtype)
@@ -130,6 +133,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
 
         if y.ndim == 1:
             coefs = np.ravel(coefs)
+
         return coefs
     elif solver == "lsqr":
         if y.ndim == 1:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -30,7 +30,8 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
 
     Parameters
     ----------
-    X : {array-like, sparse matrix, LinearOperator}, shape = [n_samples, n_features]
+    X : {array-like, sparse matrix, LinearOperator},
+        shape = [n_samples, n_features]
         Training data
 
     y : array-like, shape = [n_samples] or [n_samples, n_responses]
@@ -57,8 +58,8 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
           (possibility to set `tol` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
-          scipy.sparse.linalg.lsqr. It is the fatest but may not be available in
-          old scipy versions. It also uses an iterative procedure.
+          scipy.sparse.linalg.lsqr. It is the fatest but may not be available
+          in old scipy versions. It also uses an iterative procedure.
 
         All three solvers support both dense and sparse data.
 
@@ -247,8 +248,8 @@ class Ridge(_BaseRidge, RegressorMixin):
           (possibility to set `tol` and `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
-          scipy.sparse.linalg.lsqr. It is the fatest but may not be available in
-          old scipy versions. It also uses an iterative procedure.
+          scipy.sparse.linalg.lsqr. It is the fatest but may not be available
+          in old scipy versions. It also uses an iterative procedure.
 
         All three solvers support both dense and sparse data.
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -109,6 +109,22 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             coefs = np.ravel(coefs)
         return coefs
+    elif solver == "lsqr":
+        if y.ndim == 1:
+            y1 = np.reshape(y, (-1, 1))
+        else:
+            y1 = y
+        coefs = np.empty((y1.shape[1], n_features))
+
+        for i in range(y1.shape[1]):
+            y_column = y1[:, i]
+            coefs[i] = sp_linalg.lsqr(X, y_column, damp=alpha,
+                                      atol=tol, btol=tol, iter_lim=max_iter)[0]
+
+        if y.ndim == 1:
+            coefs = np.ravel(coefs)
+
+        return coefs
     else:
         # normal equations (cholesky) method
         if sparse.issparse(X):

--- a/sklearn/linear_model/tests/test_randomized_l1.py
+++ b/sklearn/linear_model/tests/test_randomized_l1.py
@@ -8,12 +8,12 @@ from sklearn.linear_model.randomized_l1 import lasso_stability_path, \
         RandomizedLasso, RandomizedLogisticRegression
 from sklearn.datasets import load_diabetes, load_iris
 from sklearn.feature_selection import f_regression, f_classif
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 
 diabetes = load_diabetes()
 X = diabetes.data
 y = diabetes.target
-X = Scaler().fit_transform(X)
+X = StandardScaler().fit_transform(X)
 X = X[:, [2, 3, 6, 7, 8]]
 
 # test that the feature score of the best features

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -42,29 +42,30 @@ def test_ridge():
     """
     alpha = 1.0
 
-    # With more samples than features
-    n_samples, n_features = 6, 5
-    y = rng.randn(n_samples)
-    X = rng.randn(n_samples, n_features)
+    for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
+        # With more samples than features
+        n_samples, n_features = 6, 5
+        y = rng.randn(n_samples)
+        X = rng.randn(n_samples, n_features)
 
-    ridge = Ridge(alpha=alpha)
-    ridge.fit(X, y)
-    assert_equal(ridge.coef_.shape, (X.shape[1], ))
-    assert_greater(ridge.score(X, y), 0.5)
+        ridge = Ridge(alpha=alpha, solver=solver)
+        ridge.fit(X, y)
+        assert_equal(ridge.coef_.shape, (X.shape[1], ))
+        assert_greater(ridge.score(X, y), 0.47)
 
-    ridge.fit(X, y, sample_weight=np.ones(n_samples))
-    assert_greater(ridge.score(X, y), 0.5)
+        ridge.fit(X, y, sample_weight=np.ones(n_samples))
+        assert_greater(ridge.score(X, y), 0.47)
 
-    # With more features than samples
-    n_samples, n_features = 5, 10
-    y = rng.randn(n_samples)
-    X = rng.randn(n_samples, n_features)
-    ridge = Ridge(alpha=alpha)
-    ridge.fit(X, y)
-    assert_greater(ridge.score(X, y), .9)
+        # With more features than samples
+        n_samples, n_features = 5, 10
+        y = rng.randn(n_samples)
+        X = rng.randn(n_samples, n_features)
+        ridge = Ridge(alpha=alpha, solver=solver)
+        ridge.fit(X, y)
+        assert_greater(ridge.score(X, y), .9)
 
-    ridge.fit(X, y, sample_weight=np.ones(n_samples))
-    assert_greater(ridge.score(X, y), 0.9)
+        ridge.fit(X, y, sample_weight=np.ones(n_samples))
+        assert_greater(ridge.score(X, y), 0.9)
 
 
 def test_ridge_shapes():

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -10,10 +10,9 @@ of Gaussian Mixture Models.
 #         Bertrand Thirion <bertrand.thirion@inria.fr>
 
 import numpy as np
-import warnings
 
 from ..base import BaseEstimator
-from ..utils import check_random_state, deprecated
+from ..utils import check_random_state
 from ..utils.extmath import logsumexp, pinvh
 from .. import cluster
 

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -60,7 +60,8 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
       >>> neigh.fit(samples)  #doctest: +ELLIPSIS
       NearestNeighbors(...)
 
-      >>> neigh.kneighbors([[0, 0, 1.3]], 2, return_distance=False) #doctest: +ELLIPSIS
+      >>> neigh.kneighbors([[0, 0, 1.3]], 2, return_distance=False)
+      ... #doctest: +ELLIPSIS
       array([[2, 0]]...)
 
       >>> neigh.radius_neighbors([0, 0, 1.3], 0.4, return_distance=False)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -23,7 +23,7 @@ __all__ = ['Binarizer',
            'LabelBinarizer',
            'LabelEncoder',
            'Normalizer',
-           'Scaler',
+           'StandardScaler',
            'binarize',
            'normalize',
            'scale']
@@ -96,7 +96,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
     See also
     --------
-    :class:`sklearn.preprocessing.Scaler` to perform centering and
+    :class:`sklearn.preprocessing.StandardScaler` to perform centering and
     scaling using the ``Transformer`` API (e.g. as part of a preprocessing
     :class:`sklearn.pipeline.Pipeline`)
     """
@@ -148,8 +148,6 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     This standardization is often used as an alternative to zero mean,
     unit variance scaling.
-    It is in particular useful for sparse positive data, as it retains the
-    sparsity structure of the data (if scaled between zero and some number).
 
     Parameters
     ----------
@@ -158,8 +156,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     copy : boolean, optional, default is True
         Set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix and if axis is 1).
+        copy (if the input is already a numpy array).
 
     Attributes
     ----------
@@ -930,7 +927,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
     """Center a kernel matrix
 
     This is equivalent to centering phi(X) with
-    sklearn.preprocessing.Scaler(with_std=False).
+    sklearn.preprocessing.StandardScaler(with_std=False).
     """
 
     def fit(self, K, y=None):

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -175,6 +175,14 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         self.copy = copy
 
     def fit(self, X, y=None):
+        """Compute the minimum and maximum to be used for later scaling.
+
+        Parameters
+        ----------
+        X : array-like, shape [n_samples, n_features]
+            The data used to compute the per-feature minimum and maximum
+            used for later scaling along the features axis.
+        """
         X = check_arrays(X, sparse_format="dense", copy=self.copy)[0]
         feature_range = self.feature_range
         if feature_range[0] >= feature_range[1]:
@@ -187,6 +195,13 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X):
+        """Scaling features of X according to feature_range.
+
+        Parameters
+        ----------
+        X : array-like with shape [n_samples, n_features]
+            Input data that will be transformed.
+        """
         X = check_arrays(X, sparse_format="dense", copy=self.copy)[0]
         X *= self.scale_
         X += self.min_
@@ -251,7 +266,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         self.copy = copy
 
     def fit(self, X, y=None):
-        """Compute the mean and std to be used for later scaling
+        """Compute the mean and std to be used for later scaling.
 
         Parameters
         ----------

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -18,7 +18,7 @@ from sklearn.utils.testing import assert_greater
 from sklearn.base import clone, ClassifierMixin, RegressorMixin, \
         TransformerMixin, ClusterMixin
 from sklearn.utils import shuffle
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler, Scaler
 #from sklearn.cross_validation import train_test_split
 from sklearn.datasets import load_iris, load_boston, make_blobs
 from sklearn.metrics import zero_one_score, adjusted_rand_score
@@ -117,7 +117,7 @@ def test_transformers():
     X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
             random_state=0, n_features=2, cluster_std=0.1)
     n_samples, n_features = X.shape
-    X = Scaler().fit_transform(X)
+    X = StandardScaler().fit_transform(X)
     X -= X.min()
 
     succeeded = True
@@ -196,7 +196,7 @@ def test_transformers_sparse_data():
             continue
         # catch deprecation warnings
         with warnings.catch_warnings(record=True):
-            if Trans is Scaler:
+            if Trans in [Scaler, StandardScaler]:
                 trans = Trans(with_mean=False)
             else:
                 trans = Trans()
@@ -267,7 +267,7 @@ def test_clustering():
     X, y = iris.data, iris.target
     X, y = shuffle(X, y, random_state=7)
     n_samples, n_features = X.shape
-    X = Scaler().fit_transform(X)
+    X = StandardScaler().fit_transform(X)
     for name, Alg in clustering:
         if Alg is WardAgglomeration:
             # this is clustering on the features
@@ -308,7 +308,7 @@ def test_classifiers_train():
     iris = load_iris()
     X_m, y_m = iris.data, iris.target
     X_m, y_m = shuffle(X_m, y_m, random_state=7)
-    X_m = Scaler().fit_transform(X_m)
+    X_m = StandardScaler().fit_transform(X_m)
     # generate binary problem from multi-class one
     y_b = y_m[y_m != 2]
     X_b = X_m[y_m != 2]
@@ -378,7 +378,7 @@ def test_classifiers_classes():
     iris = load_iris()
     X, y = iris.data, iris.target
     X, y = shuffle(X, y, random_state=7)
-    X = Scaler().fit_transform(X)
+    X = StandardScaler().fit_transform(X)
     y = 2 * y + 1
     # TODO: make work with next line :)
     #y = y.astype(np.str)
@@ -409,7 +409,7 @@ def test_regressors_int():
     boston = load_boston()
     X, y = boston.data, boston.target
     X, y = shuffle(X, y, random_state=0)
-    X = Scaler().fit_transform(X)
+    X = StandardScaler().fit_transform(X)
     y = np.random.randint(2, size=X.shape[0])
     for name, Reg in regressors:
         if Reg in dont_test or Reg in meta_estimators or Reg in (CCA,):
@@ -449,8 +449,8 @@ def test_regressors_train():
     X, y = shuffle(X, y, random_state=0)
     # TODO: test with intercept
     # TODO: test with multiple responses
-    X = Scaler().fit_transform(X)
-    y = Scaler().fit_transform(y)
+    X = StandardScaler().fit_transform(X)
+    y = StandardScaler().fit_transform(y)
     succeeded = True
     for name, Reg in regressors:
         if Reg in dont_test or Reg in meta_estimators:

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.decomposition.pca import PCA, RandomizedPCA
 from sklearn.datasets import load_iris
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import StandardScaler
 
 
 class IncorrectT(BaseEstimator):
@@ -152,7 +152,7 @@ def test_pipeline_methods_preprocessing_svm():
     y = iris.target
     n_samples = X.shape[0]
     n_classes = len(np.unique(y))
-    scaler = Scaler()
+    scaler = StandardScaler()
     pca = RandomizedPCA(n_components=2, whiten=True)
     clf = SVC(probability=True)
 

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -16,8 +16,9 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import Normalizer
 from sklearn.preprocessing import normalize
-from sklearn.preprocessing import Scaler
+from sklearn.preprocessing import UnitVarianceScaler
 from sklearn.preprocessing import scale
+from sklearn.preprocessing import MinMaxScaler
 
 from sklearn import datasets
 from sklearn.linear_model.stochastic_gradient import SGDClassifier
@@ -37,7 +38,7 @@ def test_scaler_1d():
     X = rng.randn(5)
     X_orig_copy = X.copy()
 
-    scaler = Scaler()
+    scaler = UnitVarianceScaler()
     X_scaled = scaler.fit(X).transform(X, copy=False)
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
@@ -48,7 +49,7 @@ def test_scaler_1d():
 
     # Test with 1D list
     X = [0., 1., 2, 0.4, 1.]
-    scaler = Scaler()
+    scaler = UnitVarianceScaler()
     X_scaled = scaler.fit(X).transform(X, copy=False)
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
@@ -64,7 +65,7 @@ def test_scaler_2d_arrays():
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
 
-    scaler = Scaler()
+    scaler = UnitVarianceScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
 
@@ -98,7 +99,7 @@ def test_scaler_2d_arrays():
 
     X = rng.randn(4, 5)
     X[:, 0] = 1.0  # first feature is a constant, non zero feature
-    scaler = Scaler()
+    scaler = UnitVarianceScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
     assert_array_almost_equal(X_scaled.mean(axis=0), 5 * [0.0])
@@ -107,17 +108,37 @@ def test_scaler_2d_arrays():
     assert_true(X_scaled is not X)
 
 
+def test_min_max_scaler():
+    X = iris.data
+    scaler = MinMaxScaler()
+    # default params
+    X_trans = scaler.fit_transform(X)
+    assert_equal(X_trans.min(axis=1), 0)
+    assert_equal(X_trans.max(axis=1), 1)
+
+    # not default params
+    scaler = MinMaxScaler(feature_range=(1, 2))
+    X_trans = scaler.fit_transform(X)
+    assert_equal(X_trans.min(axis=1), 1)
+    assert_equal(X_trans.max(axis=1), 2)
+
+    # sparse
+    X_trans = scaler.fit_transform(sp.csr_matrix(X))
+    assert_equal(X_trans.min(axis=1), 1)
+    assert_equal(X_trans.max(axis=1), 2)
+
+
 def test_scaler_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
     X_csr = sp.csr_matrix(X)
 
-    scaler = Scaler(with_mean=False).fit(X)
+    scaler = UnitVarianceScaler(with_mean=False).fit(X)
     X_scaled = scaler.transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
 
-    scaler_csr = Scaler(with_mean=False).fit(X_csr)
+    scaler_csr = UnitVarianceScaler(with_mean=False).fit(X_csr)
     X_csr_scaled = scaler_csr.transform(X_csr, copy=True)
     assert_false(np.any(np.isnan(X_csr_scaled.data)))
 
@@ -148,18 +169,18 @@ def test_scaler_without_centering():
 
 
 def test_scaler_without_copy():
-    """Check that Scaler.fit does not change input"""
+    """Check that UnitVarianceScaler.fit does not change input"""
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
     X_csr = sp.csr_matrix(X)
 
     X_copy = X.copy()
-    Scaler(copy=False).fit(X)
+    UnitVarianceScaler(copy=False).fit(X)
     assert_array_equal(X, X_copy)
 
     X_csr_copy = X_csr.copy()
-    Scaler(with_mean=False, copy=False).fit(X_csr)
+    UnitVarianceScaler(with_mean=False, copy=False).fit(X_csr)
     assert_array_equal(X_csr.toarray(), X_csr_copy.toarray())
 
 
@@ -170,10 +191,10 @@ def test_scale_sparse_with_mean_raise_exception():
 
     # check scaling and fit with direct calls on sparse data
     assert_raises(ValueError, scale, X_csr, with_mean=True)
-    assert_raises(ValueError, Scaler(with_mean=True).fit, X_csr)
+    assert_raises(ValueError, UnitVarianceScaler(with_mean=True).fit, X_csr)
 
     # check transform and inverse_transform after a fit on a dense array
-    scaler = Scaler(with_mean=True).fit(X)
+    scaler = UnitVarianceScaler(with_mean=True).fit(X)
     assert_raises(ValueError, scaler.transform, X_csr)
 
     X_transformed_csr = sp.csr_matrix(scaler.transform(X))
@@ -497,10 +518,11 @@ def test_label_binarizer_multilabel_unlabeled():
 
 
 def test_center_kernel():
-    """Test that KernelCenterer is equivalent to Scaler in feature space"""
+    """Test that KernelCenterer is equivalent to UnitVarianceScaler
+       in feature space"""
     rng = np.random.RandomState(0)
     X_fit = rng.random_sample((5, 4))
-    scaler = Scaler(with_std=False)
+    scaler = UnitVarianceScaler(with_std=False)
     scaler.fit(X_fit)
     X_fit_centered = scaler.transform(X_fit)
     K_fit = np.dot(X_fit, X_fit.T)
@@ -523,7 +545,7 @@ def test_center_kernel():
 def test_fit_transform():
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
-    for obj in ((Scaler(), Normalizer(), Binarizer())):
+    for obj in ((UnitVarianceScaler(), Normalizer(), Binarizer())):
         X_transformed = obj.fit(X).transform(X)
         X_transformed2 = obj.fit_transform(X)
         assert_array_equal(X_transformed, X_transformed2)

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import Normalizer
 from sklearn.preprocessing import normalize
-from sklearn.preprocessing import UnitVarianceScaler
+from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import scale
 from sklearn.preprocessing import MinMaxScaler
 
@@ -38,7 +38,7 @@ def test_scaler_1d():
     X = rng.randn(5)
     X_orig_copy = X.copy()
 
-    scaler = UnitVarianceScaler()
+    scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=False)
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
@@ -49,7 +49,7 @@ def test_scaler_1d():
 
     # Test with 1D list
     X = [0., 1., 2, 0.4, 1.]
-    scaler = UnitVarianceScaler()
+    scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=False)
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
@@ -65,7 +65,7 @@ def test_scaler_2d_arrays():
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
 
-    scaler = UnitVarianceScaler()
+    scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
 
@@ -99,7 +99,7 @@ def test_scaler_2d_arrays():
 
     X = rng.randn(4, 5)
     X[:, 0] = 1.0  # first feature is a constant, non zero feature
-    scaler = UnitVarianceScaler()
+    scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
     assert_array_almost_equal(X_scaled.mean(axis=0), 5 * [0.0])
@@ -113,19 +113,14 @@ def test_min_max_scaler():
     scaler = MinMaxScaler()
     # default params
     X_trans = scaler.fit_transform(X)
-    assert_equal(X_trans.min(axis=1), 0)
-    assert_equal(X_trans.max(axis=1), 1)
+    assert_equal(X_trans.min(axis=0), 0)
+    assert_equal(X_trans.max(axis=0), 1)
 
     # not default params
     scaler = MinMaxScaler(feature_range=(1, 2))
     X_trans = scaler.fit_transform(X)
-    assert_equal(X_trans.min(axis=1), 1)
-    assert_equal(X_trans.max(axis=1), 2)
-
-    # sparse
-    X_trans = scaler.fit_transform(sp.csr_matrix(X))
-    assert_equal(X_trans.min(axis=1), 1)
-    assert_equal(X_trans.max(axis=1), 2)
+    assert_equal(X_trans.min(axis=0), 1)
+    assert_equal(X_trans.max(axis=0), 2)
 
 
 def test_scaler_without_centering():
@@ -134,11 +129,11 @@ def test_scaler_without_centering():
     X[:, 0] = 0.0  # first feature is always of zero
     X_csr = sp.csr_matrix(X)
 
-    scaler = UnitVarianceScaler(with_mean=False).fit(X)
+    scaler = StandardScaler(with_mean=False).fit(X)
     X_scaled = scaler.transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
 
-    scaler_csr = UnitVarianceScaler(with_mean=False).fit(X_csr)
+    scaler_csr = StandardScaler(with_mean=False).fit(X_csr)
     X_csr_scaled = scaler_csr.transform(X_csr, copy=True)
     assert_false(np.any(np.isnan(X_csr_scaled.data)))
 
@@ -169,18 +164,18 @@ def test_scaler_without_centering():
 
 
 def test_scaler_without_copy():
-    """Check that UnitVarianceScaler.fit does not change input"""
+    """Check that StandardScaler.fit does not change input"""
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
     X_csr = sp.csr_matrix(X)
 
     X_copy = X.copy()
-    UnitVarianceScaler(copy=False).fit(X)
+    StandardScaler(copy=False).fit(X)
     assert_array_equal(X, X_copy)
 
     X_csr_copy = X_csr.copy()
-    UnitVarianceScaler(with_mean=False, copy=False).fit(X_csr)
+    StandardScaler(with_mean=False, copy=False).fit(X_csr)
     assert_array_equal(X_csr.toarray(), X_csr_copy.toarray())
 
 
@@ -191,10 +186,10 @@ def test_scale_sparse_with_mean_raise_exception():
 
     # check scaling and fit with direct calls on sparse data
     assert_raises(ValueError, scale, X_csr, with_mean=True)
-    assert_raises(ValueError, UnitVarianceScaler(with_mean=True).fit, X_csr)
+    assert_raises(ValueError, StandardScaler(with_mean=True).fit, X_csr)
 
     # check transform and inverse_transform after a fit on a dense array
-    scaler = UnitVarianceScaler(with_mean=True).fit(X)
+    scaler = StandardScaler(with_mean=True).fit(X)
     assert_raises(ValueError, scaler.transform, X_csr)
 
     X_transformed_csr = sp.csr_matrix(scaler.transform(X))
@@ -518,11 +513,11 @@ def test_label_binarizer_multilabel_unlabeled():
 
 
 def test_center_kernel():
-    """Test that KernelCenterer is equivalent to UnitVarianceScaler
+    """Test that KernelCenterer is equivalent to StandardScaler
        in feature space"""
     rng = np.random.RandomState(0)
     X_fit = rng.random_sample((5, 4))
-    scaler = UnitVarianceScaler(with_std=False)
+    scaler = StandardScaler(with_std=False)
     scaler.fit(X_fit)
     X_fit_centered = scaler.transform(X_fit)
     K_fit = np.dot(X_fit, X_fit.T)
@@ -545,7 +540,7 @@ def test_center_kernel():
 def test_fit_transform():
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
-    for obj in ((UnitVarianceScaler(), Normalizer(), Binarizer())):
+    for obj in ((StandardScaler(), Normalizer(), Binarizer())):
         X_transformed = obj.fit(X).transform(X)
         X_transformed2 = obj.fit_transform(X)
         assert_array_equal(X_transformed, X_transformed2)


### PR DESCRIPTION
I've added the `lsqr` solver I mentioned on the mailing-list. On my box, it's 8 times faster than the recently merged improvements, on the news20 example.

For sample_weight, the solution I gave on the mailing-list (multiply both X and y by sqrt(sample_weight)) should work but involves some work, especially in the sparse case (need to implement `inplace_csr_row_scale`). So I suggest this is addressed in a separate PR.
