### PR TITLE
MRG build CSR instead of COO matrix in DictVectorizer and use array.array

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,6 +44,9 @@ API changes summary
      deprecated and will be removed in v0.14. Use the constructor option
      instead.
 
+   - :class:`DictVectorizer` now returns sparse matrices in the CSR format,
+     instead of COO.
+
 .. _changes_0_12:
 
 0.12

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -30,7 +30,7 @@ def test_dictvectorizer():
             assert_equal(v.inverse_transform(X), D)
 
             if sparse:
-                # COO matrices can't be compared for equality
+                # CSR matrices can't be compared for equality
                 assert_array_equal(X.A, v.transform(D).A)
             else:
                 assert_array_equal(X, v.transform(D))


### PR DESCRIPTION
Somewhat related to #1135 which also tries to leverage `array.array`, and which is still on my TODO list for reviewing and merging.

This one should be pretty uncontroversial, except for the fact that we haven't ever used `array.array` before and it isn't really NumPy-friendly (little control over the `itemsize` of an array).
