### PR TITLE
MRG Kfold parameter rename

### DIFF
--- a/benchmarks/bench_plot_svd.py
+++ b/benchmarks/bench_plot_svd.py
@@ -12,7 +12,7 @@ from sklearn.utils.extmath import randomized_svd
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
-def compute_bench(samples_range, features_range, n_iterations=3, rank=50):
+def compute_bench(samples_range, features_range, n_iter=3, rank=50):
 
     it = 0
 
@@ -36,19 +36,19 @@ def compute_bench(samples_range, features_range, n_iterations=3, rank=50):
             results['scipy svd'].append(time() - tstart)
 
             gc.collect()
-            print "benching scikit-learn randomized_svd: n_iterations=0"
+            print "benching scikit-learn randomized_svd: n_iter=0"
             tstart = time()
-            randomized_svd(X, rank, n_iterations=0)
-            results['scikit-learn randomized_svd (n_iterations=0)'].append(
+            randomized_svd(X, rank, n_iter=0)
+            results['scikit-learn randomized_svd (n_iter=0)'].append(
                 time() - tstart)
 
             gc.collect()
-            print ("benching scikit-learn randomized_svd: n_iterations=%d "
-                   % n_iterations)
+            print ("benching scikit-learn randomized_svd: n_iter=%d "
+                   % n_iter)
             tstart = time()
-            randomized_svd(X, rank, n_iterations=n_iterations)
-            results['scikit-learn randomized_svd (n_iterations=%d)'
-                    % n_iterations].append(time() - tstart)
+            randomized_svd(X, rank, n_iter=n_iter)
+            results['scikit-learn randomized_svd (n_iter=%d)'
+                    % n_iter].append(time() - tstart)
 
     return results
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -156,9 +156,9 @@ Example of 2-fold::
   >>> X = np.array([[0., 0.], [1., 1.], [-1., -1.], [2., 2.]])
   >>> Y = np.array([0, 1, 0, 1])
 
-  >>> kf = KFold(len(Y), 2, indices=False)
+  >>> kf = KFold(len(Y), n_folds=2, indices=False)
   >>> print kf
-  sklearn.cross_validation.KFold(n=4, k=2)
+  sklearn.cross_validation.KFold(n=4, n_folds=2)
 
   >>> for train, test in kf:
   ...     print train, test
@@ -178,7 +178,7 @@ when creating the cross-validation procedure::
   >>> X = np.array([[0., 0.], [1., 1.], [-1., -1.], [2., 2.]])
   >>> Y = np.array([0, 1, 0, 1])
 
-  >>> kf = KFold(len(Y), 2, indices=True)
+  >>> kf = KFold(len(Y), n_folds=2, indices=True)
   >>> for train, test in kf:
   ...    print train, test
   [2 3] [0 1]
@@ -206,7 +206,7 @@ Example of stratified 2-fold::
 
   >>> skf = StratifiedKFold(Y, 2)
   >>> print skf
-  sklearn.cross_validation.StratifiedKFold(labels=[0 0 0 1 1 1 0], k=2)
+  sklearn.cross_validation.StratifiedKFold(labels=[0 0 0 1 1 1 0], n_folds=2)
 
   >>> for train, test in skf:
   ...     print train, test
@@ -390,7 +390,7 @@ smaller than the total dataset if it is very large.
   >>> len(bs)
   3
   >>> print bs
-  Bootstrap(9, n_bootstraps=3, train_size=5, test_size=4, random_state=0)
+  Bootstrap(9, n_iterations=3, train_size=5, test_size=4, random_state=0)
 
   >>> for train_index, test_index in bs:
   ...    print train_index, test_index

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -102,7 +102,7 @@ It is also possible to use othe cross validation strategies by passing a cross
 validation iterator instead, for instance::
 
   >>> n_samples = iris.data.shape[0]
-  >>> cv = cross_validation.ShuffleSplit(n_samples, n_iterations=3,
+  >>> cv = cross_validation.ShuffleSplit(n_samples, n_iter=3,
   ...     test_size=0.3, random_state=0)
 
   >>> cross_validation.cross_val_score(clf, iris.data, iris.target, cv=cv)
@@ -339,12 +339,12 @@ generator.
 
 Here is a usage example::
 
-  >>> ss = cross_validation.ShuffleSplit(5, n_iterations=3, test_size=0.25,
+  >>> ss = cross_validation.ShuffleSplit(5, n_iter=3, test_size=0.25,
   ...     random_state=0)
   >>> len(ss)
   3
   >>> print ss                                            # doctest: +ELLIPSIS
-  ShuffleSplit(5, n_iterations=3, test_size=0.25, indices=True, ...)
+  ShuffleSplit(5, n_iter=3, test_size=0.25, indices=True, ...)
 
   >>> for train_index, test_index in ss:
   ...    print train_index, test_index
@@ -390,7 +390,7 @@ smaller than the total dataset if it is very large.
   >>> len(bs)
   3
   >>> print bs
-  Bootstrap(9, n_iterations=3, train_size=5, test_size=4, random_state=0)
+  Bootstrap(9, n_iter=3, train_size=5, test_size=4, random_state=0)
 
   >>> for train_index, test_index in bs:
   ...    print train_index, test_index

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -57,7 +57,7 @@ The `sklearn` exposes cross-validation generators to generate list
 of indices for this purpose::
 
     >>> from sklearn import cross_validation
-    >>> k_fold = cross_validation.KFold(n=6, k=3, indices=True)
+    >>> k_fold = cross_validation.KFold(n=6, n_folds=3, indices=True)
     >>> for train_indices, test_indices in k_fold:
     ...      print 'Train: %s | test: %s' % (train_indices, test_indices)
     Train: [2 3 4 5] | test: [0 1]
@@ -66,7 +66,7 @@ of indices for this purpose::
 
 The cross-validation can then be implemented easily::
 
-    >>> kfold = cross_validation.KFold(len(X_digits), k=3)
+    >>> kfold = cross_validation.KFold(len(X_digits), n_folds=3)
     >>> [svc.fit(X_digits[train], y_digits[train]).score(X_digits[test], y_digits[test])
     ...          for train, test in kfold]
     [0.93489148580968284, 0.95659432387312182, 0.93989983305509184]

--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -172,7 +172,7 @@ names = dict((i, name) for name, i in index_map.iteritems())
 
 print "Computing the principal singular vectors using randomized_svd"
 t0 = time()
-U, s, V = randomized_svd(X, 5, n_iterations=3)
+U, s, V = randomized_svd(X, 5, n_iter=3)
 print "done in %0.3fs" % (time() - t0)
 
 # print the names of the wikipedia related strongest compenents of the the

--- a/examples/mixture/plot_gmm_classifier.py
+++ b/examples/mixture/plot_gmm_classifier.py
@@ -52,7 +52,7 @@ iris = datasets.load_iris()
 
 # Break up the dataset into non-overlapping training (75%) and testing
 # (25%) sets.
-skf = StratifiedKFold(iris.target, k=4)
+skf = StratifiedKFold(iris.target, n_folds=4)
 # Only take the first fold.
 train_index, test_index = next(iter(skf))
 

--- a/examples/plot_roc_crossval.py
+++ b/examples/plot_roc_crossval.py
@@ -34,7 +34,7 @@ X = np.c_[X, np.random.randn(n_samples, 200 * n_features)]
 # Classification and ROC analysis
 
 # Run classifier with crossvalidation and plot ROC curves
-cv = StratifiedKFold(y, k=6)
+cv = StratifiedKFold(y, n_folds=6)
 classifier = svm.SVC(kernel='linear', probability=True)
 
 mean_tpr = 0.0

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -64,8 +64,8 @@ X_2d = scaler.fit_transform(X_2d)
 C_range = 10.0 ** np.arange(-2, 9)
 gamma_range = 10.0 ** np.arange(-5, 4)
 param_grid = dict(gamma=gamma_range, C=C_range)
-
-grid = GridSearchCV(SVC(), param_grid=param_grid, cv=StratifiedKFold(y=Y, k=3))
+cv = StratifiedKFold(y=Y, n_folds=3)
+grid = GridSearchCV(SVC(), param_grid=param_grid, cv=cv)
 grid.fit(X, Y)
 
 print("The best classifier is: ", grid.best_estimator_)

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -128,7 +128,7 @@ for fignum, (clf, cs, X, y) in enumerate(clf_sets):
         # reduce the variance
         grid = GridSearchCV(clf, refit=False, param_grid=param_grid,
                         cv=ShuffleSplit(n=n_samples, train_size=train_size,
-                                        n_iterations=250, random_state=1))
+                                        n_iter=250, random_state=1))
         grid.fit(X, y)
         scores = [x[1] for x in grid.grid_scores_]
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -897,7 +897,7 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
     return inertia, squared_diff
 
 
-def _mini_batch_convergence(model, iteration_idx, n_iterations, tol,
+def _mini_batch_convergence(model, iteration_idx, n_iter, tol,
                             n_samples, centers_squared_diff, batch_inertia,
                             context, verbose=0):
     """Helper function to encapsulte the early stopping logic"""
@@ -926,7 +926,7 @@ def _mini_batch_convergence(model, iteration_idx, n_iterations, tol,
         progress_msg = (
             'Minibatch iteration %d/%d:'
             'mean batch inertia: %f, ewa inertia: %f ' % (
-                iteration_idx + 1, n_iterations, batch_inertia,
+                iteration_idx + 1, n_iter, batch_inertia,
                 ewa_inertia))
         print progress_msg
 
@@ -935,7 +935,7 @@ def _mini_batch_convergence(model, iteration_idx, n_iterations, tol,
     if tol > 0.0 and ewa_diff < tol:
         if verbose:
             print 'Converged (small centers change) at iteration %d/%d' % (
-                iteration_idx + 1, n_iterations)
+                iteration_idx + 1, n_iter)
         return True
 
     # Early stopping heuristic due to lack of improvement on smoothed inertia
@@ -952,7 +952,7 @@ def _mini_batch_convergence(model, iteration_idx, n_iterations, tol,
         if verbose:
             print ('Converged (lack of improvement in inertia)'
                    ' at iteration %d/%d' % (
-                       iteration_idx + 1, n_iterations))
+                       iteration_idx + 1, n_iter))
         return True
 
     # update the convergence context to maintain state across sucessive calls:
@@ -1102,7 +1102,7 @@ class MiniBatchKMeans(KMeans):
 
         distances = np.zeros(self.batch_size, dtype=np.float64)
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
-        n_iterations = int(self.max_iter * n_batches)
+        n_iter = int(self.max_iter * n_batches)
 
         init_size = self.init_size
         if init_size is None:
@@ -1158,7 +1158,7 @@ class MiniBatchKMeans(KMeans):
 
         # Perform the iterative optimization untill the final convergence
         # criterion
-        for iteration_idx in xrange(n_iterations):
+        for iteration_idx in xrange(n_iter):
 
             # Sample the minibatch from the full dataset
             minibatch_indices = self.random_state.random_integers(
@@ -1172,7 +1172,7 @@ class MiniBatchKMeans(KMeans):
 
             # Monitor the convergence and do early stopping if necessary
             if _mini_batch_convergence(
-                self, iteration_idx, n_iterations, tol, n_samples,
+                self, iteration_idx, n_iter, tol, n_samples,
                 centers_squared_diff, batch_inertia, convergence_context,
                 verbose=self.verbose):
                 break

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -574,7 +574,7 @@ class Bootstrap(object):
     """Random sampling with replacement cross-validation iterator
 
     Provides train/test indices to split data in train test sets
-    while resampling the input n_iterations times: each time a new
+    while resampling the input n_iter times: each time a new
     random split of the data is performed and then samples are drawn
     (with replacement) on each side of the split to build the training
     and test sets.
@@ -592,7 +592,7 @@ class Bootstrap(object):
     n : int
         Total number of elements in the dataset.
 
-    n_iterations : int (default is 3)
+    n_iter : int (default is 3)
         Number of bootstrapping iterations
 
     train_size : int or float (default is 0.5)
@@ -623,7 +623,7 @@ class Bootstrap(object):
     >>> len(bs)
     3
     >>> print(bs)
-    Bootstrap(9, n_iterations=3, train_size=5, test_size=4, random_state=0)
+    Bootstrap(9, n_iter=3, train_size=5, test_size=4, random_state=0)
     >>> for train_index, test_index in bs:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
     ...
@@ -639,14 +639,14 @@ class Bootstrap(object):
     # Static marker to be able to introspect the CV type
     indices = True
 
-    def __init__(self, n, n_iterations=3, train_size=.5, test_size=None,
+    def __init__(self, n, n_iter=3, train_size=.5, test_size=None,
                  random_state=None, n_bootstraps=None):
         self.n = n
         if n_bootstraps is not None:
-            warnings.warn("n_bootstraps was renamed to n_iterations and will "
-                          "be removed in 0.15.", DeprecationWarning)
-            n_iterations = n_bootstraps
-        self.n_iterations = n_iterations
+            warnings.warn("n_bootstraps was renamed to n_iter and will "
+                          "be removed in 0.16.", DeprecationWarning)
+            n_iter = n_bootstraps
+        self.n_iter = n_iter
         if (isinstance(train_size, (float, np.floating)) and train_size >= 0.0
                             and train_size <= 1.0):
             self.train_size = ceil(train_size * n)
@@ -676,7 +676,7 @@ class Bootstrap(object):
 
     def __iter__(self):
         rng = check_random_state(self.random_state)
-        for i in range(self.n_iterations):
+        for i in range(self.n_iter):
             # random partition
             permutation = rng.permutation(self.n)
             ind_train = permutation[:self.train_size]
@@ -691,18 +691,18 @@ class Bootstrap(object):
             yield ind_train[train], ind_test[test]
 
     def __repr__(self):
-        return ('%s(%d, n_iterations=%d, train_size=%d, test_size=%d, '
+        return ('%s(%d, n_iter=%d, train_size=%d, test_size=%d, '
                 'random_state=%d)' % (
                     self.__class__.__name__,
                     self.n,
-                    self.n_iterations,
+                    self.n_iter,
                     self.train_size,
                     self.test_size,
                     self.random_state,
                 ))
 
     def __len__(self):
-        return self.n_iterations
+        return self.n_iter
 
 
 class ShuffleSplit(object):
@@ -719,7 +719,7 @@ class ShuffleSplit(object):
     n : int
         Total number of elements in the dataset.
 
-    n_iterations : int (default 10)
+    n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
     test_size : float (default 0.1) or int
@@ -744,13 +744,13 @@ class ShuffleSplit(object):
     Examples
     --------
     >>> from sklearn import cross_validation
-    >>> rs = cross_validation.ShuffleSplit(4, n_iterations=3,
+    >>> rs = cross_validation.ShuffleSplit(4, n_iter=3,
     ...     test_size=.25, random_state=0)
     >>> len(rs)
     3
     >>> print(rs)
     ... # doctest: +ELLIPSIS
-    ShuffleSplit(4, n_iterations=3, test_size=0.25, indices=True, ...)
+    ShuffleSplit(4, n_iter=3, test_size=0.25, indices=True, ...)
     >>> for train_index, test_index in rs:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
     ...
@@ -758,7 +758,7 @@ class ShuffleSplit(object):
     TRAIN: [2 1 3] TEST: [0]
     TRAIN: [0 2 1] TEST: [3]
 
-    >>> rs = cross_validation.ShuffleSplit(4, n_iterations=3,
+    >>> rs = cross_validation.ShuffleSplit(4, n_iter=3,
     ...     train_size=0.5, test_size=.25, random_state=0)
     >>> for train_index, test_index in rs:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
@@ -772,10 +772,14 @@ class ShuffleSplit(object):
     Bootstrap: cross-validation using re-sampling with replacement.
     """
 
-    def __init__(self, n, n_iterations=10, test_size=0.1,
-                 train_size=None, indices=True, random_state=None):
+    def __init__(self, n, n_iter=10, test_size=0.1, train_size=None,
+            indices=True, random_state=None, n_iterations=None):
         self.n = n
-        self.n_iterations = n_iterations
+        self.n_iter = n_iter
+        if n_iterations is not None:
+            warnings.warn("n_iterations was renamed to n_iter for consistency "
+                    " and will be removed in 0.16.")
+            self.n_iter = n_iterations
         self.test_size = test_size
         self.train_size = train_size
         self.random_state = random_state
@@ -787,7 +791,7 @@ class ShuffleSplit(object):
 
     def __iter__(self):
         rng = check_random_state(self.random_state)
-        for i in range(self.n_iterations):
+        for i in range(self.n_iter):
             # random partition
             permutation = rng.permutation(self.n)
             ind_test = permutation[:self.n_test]
@@ -803,18 +807,18 @@ class ShuffleSplit(object):
                 yield train_mask, test_mask
 
     def __repr__(self):
-        return ('%s(%d, n_iterations=%d, test_size=%s, indices=%s, '
+        return ('%s(%d, n_iter=%d, test_size=%s, indices=%s, '
                 'random_state=%s)' % (
                     self.__class__.__name__,
                     self.n,
-                    self.n_iterations,
+                    self.n_iter,
                     str(self.test_size),
                     self.indices,
                     self.random_state,
                 ))
 
     def __len__(self):
-        return self.n_iterations
+        return self.n_iter
 
 
 def _validate_shuffle_split(n, test_size, train_size):
@@ -914,7 +918,7 @@ class StratifiedShuffleSplit(object):
     y : array, [n_samples]
         Labels of samples.
 
-    n_iterations : int (default 10)
+    n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
     test_size : float (default 0.1) or int
@@ -942,7 +946,7 @@ class StratifiedShuffleSplit(object):
     >>> len(sss)
     3
     >>> print(sss)       # doctest: +ELLIPSIS
-    StratifiedShuffleSplit(labels=[0 0 1 1], n_iterations=3, ...)
+    StratifiedShuffleSplit(labels=[0 0 1 1], n_iter=3, ...)
     >>> for train_index, test_index in sss:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -952,12 +956,16 @@ class StratifiedShuffleSplit(object):
     TRAIN: [0 2] TEST: [3 1]
     """
 
-    def __init__(self, y, n_iterations=10, test_size=0.1,
-                 train_size=None, indices=True, random_state=None):
+    def __init__(self, y, n_iter=10, test_size=0.1, train_size=None,
+            indices=True, random_state=None, n_iterations=None):
 
         self.y = np.array(y)
         self.n = self.y.size
-        self.n_iterations = n_iterations
+        self.n_iter = n_iter
+        if n_iterations is not None:
+            warnings.warn("n_iterations was renamed to n_iter for consistency "
+                   " and will be removed in 0.16.")
+            self.n_iter = n_iterations
         self.test_size = test_size
         self.train_size = train_size
         self.random_state = random_state
@@ -973,7 +981,7 @@ class StratifiedShuffleSplit(object):
         t_i = np.minimum(cls_count - n_i,
                          np.round(self.n_test * p_i).astype(int))
 
-        for n in range(self.n_iterations):
+        for n in range(self.n_iter):
             train = []
             test = []
 
@@ -998,18 +1006,18 @@ class StratifiedShuffleSplit(object):
                 yield train_m, test_m
 
     def __repr__(self):
-        return ('%s(labels=%s, n_iterations=%d, test_size=%s, indices=%s, '
+        return ('%s(labels=%s, n_iter=%d, test_size=%s, indices=%s, '
                 'random_state=%s)' % (
                     self.__class__.__name__,
                     self.y,
-                    self.n_iterations,
+                    self.n_iter,
                     str(self.test_size),
                     self.indices,
                     self.random_state,
                 ))
 
     def __len__(self):
-        return self.n_iterations
+        return self.n_iter
 
 
 ##############################################################################

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -52,10 +52,10 @@ class LeaveOneOut(object):
 
     Parameters
     ----------
-    n: int
-        Total number of elements
+    n : int
+        Total number of elements in dataset.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -81,7 +81,7 @@ class LeaveOneOut(object):
     [[1 2]] [[3 4]] [1] [2]
 
     See also
-    ========
+    --------
     LeaveOneLabelOut for splitting the data according to explicit,
     domain-specific stratification of the dataset.
     """
@@ -126,13 +126,13 @@ class LeavePOut(object):
 
     Parameters
     ----------
-    n: int
-        Total number of elements
+    n : int
+        Total number of elements in dataset.
 
-    p: int
-        Size of the test sets
+    p : int
+        Size of the test sets.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -200,7 +200,7 @@ def _validate_kfold(k, n_samples):
 
 
 class KFold(object):
-    """K-Folds cross validation iterator
+    """K-Folds cross validation iterator.
 
     Provides train/test indices to split data in train test sets. Split
     dataset into k consecutive folds (without shuffling).
@@ -210,21 +210,21 @@ class KFold(object):
 
     Parameters
     ----------
-    n: int
-        Total number of elements
+    n : int
+        Total number of elements.
 
     n_folds : int
         Number of folds.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
 
-    shuffle: boolean, optional
-        whether to shuffle the data before splitting into batches
+    shuffle : boolean, optional
+        Whether to shuffle the data before splitting into batches.
 
-    random_state: int or RandomState
+    random_state : int or RandomState
             Pseudo number generator state used for random sampling.
 
     Examples
@@ -316,13 +316,13 @@ class StratifiedKFold(object):
 
     Parameters
     ----------
-    y: array, [n_samples]
-        Samples to split in K folds
+    y : array-like, [n_samples]
+        Samples to split in K folds.
 
     n_folds : int
         Number of folds.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -414,7 +414,7 @@ class LeaveOneLabelOut(object):
         Arbitrary domain-specific stratification of the data to be used
         to draw the splits.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -499,7 +499,7 @@ class LeavePLabelOut(object):
     p : int
         Number of samples to leave out in the test split.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -574,7 +574,7 @@ class Bootstrap(object):
     """Random sampling with replacement cross-validation iterator
 
     Provides train/test indices to split data in train test sets
-    while resampling the input n_bootstraps times: each time a new
+    while resampling the input n_iterations times: each time a new
     random split of the data is performed and then samples are drawn
     (with replacement) on each side of the split to build the training
     and test sets.
@@ -911,7 +911,7 @@ class StratifiedShuffleSplit(object):
 
     Parameters
     ----------
-    y: array, [n_samples]
+    y : array, [n_samples]
         Labels of samples.
 
     n_iterations : int (default 10)
@@ -928,7 +928,7 @@ class StratifiedShuffleSplit(object):
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test fraction.
 
-    indices: boolean, optional (default True)
+    indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
         mask array. Integer indices are required when dealing with sparse
         matrices, since those cannot be indexed by boolean masks.
@@ -1044,36 +1044,37 @@ def cross_val_score(estimator, X, y=None, score_func=None, cv=None, n_jobs=1,
 
     Parameters
     ----------
-    estimator: estimator object implementing 'fit'
-        The object to use to fit the data
+    estimator : estimator object implementing 'fit'
+        The object to use to fit the data.
 
-    X: array-like of shape at least 2D
+    X : array-like of shape at least 2D
         The data to fit.
 
-    y: array-like, optional
+    y : array-like, optional
         The target variable to try to predict in the case of
         supervised learning.
 
-    score_func: callable, optional
-        callable, has priority over the score function in the estimator.
+    score_func : callable, optional
+        Score function to use for evaluation.
+        Has priority over the score function in the estimator.
         In a non-supervised setting, where y is None, it takes the test
         data (X_test) as its only argument. In a supervised setting it takes
         the test target (y_true) and the test prediction (y_pred) as arguments.
 
-    cv: cross-validation generator, optional
+    cv : cross-validation generator, optional
         A cross-validation generator. If None, a 3-fold cross
         validation is used or 3-fold stratified cross-validation
         when y is supplied and estimator is a classifier.
 
-    n_jobs: integer, optional
+    n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    verbose: integer, optional
-        The verbosity level
+    verbose : integer, optional
+        The verbosity level.
 
     fit_params : dict, optional
-        parameters to pass to the fit method
+        Parameters to pass to the fit method of the estimator.
     """
     X, y = check_arrays(X, y, sparse_format='csr')
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
@@ -1120,20 +1121,20 @@ def check_cv(cv, X=None, y=None, classifier=False):
 
     Parameters
     ----------
-    cv: an integer, a cv generator instance, or None
+    cv : int, a cv generator instance, or None
         The input specifying which cv generator to use. It can be an
         integer, in which case it is the number of folds in a KFold,
         None, in which case 3 fold is used, or another object, that
         will then be used as a cv generator.
 
-    X: 2D ndarray
-        the data the cross-val object will be applied on
+    X : array-like
+        The data the cross-val object will be applied on.
 
-    y: 1D ndarray
-        the target variable for a supervised learning problem
+    y : array-like
+        The target variable for a supervised learning problem.
 
-    classifier: boolean optional
-        whether the task is a classification task, in which case
+    classifier : boolean optional
+        Whether the task is a classification task, in which case
         stratified KFold will be used.
     """
     is_sparse = sp.issparse(X)
@@ -1161,17 +1162,17 @@ def permutation_test_score(estimator, X, y, score_func, cv=None,
 
     Parameters
     ----------
-    estimator: estimator object implementing 'fit'
-        The object to use to fit the data
+    estimator : estimator object implementing 'fit'
+        The object to use to fit the data.
 
-    X: array-like of shape at least 2D
+    X : array-like of shape at least 2D
         The data to fit.
 
-    y: array-like
+    y : array-like
         The target variable to try to predict in the case of
         supervised learning.
 
-    score_func: callable
+    score_func : callable
         Callable taking as arguments the test targets (y_test) and
         the predicted targets (y_pred) and returns a float. The score
         functions are expected to return a bigger value for a better result
@@ -1181,32 +1182,32 @@ def permutation_test_score(estimator, X, y, score_func, cv=None,
     cv : integer or crossvalidation generator, optional
         If an integer is passed, it is the number of fold (default 3).
         Specific crossvalidation objects can be passed, see
-        sklearn.cross_validation module for the list of possible objects
+        sklearn.cross_validation module for the list of possible objects.
 
-    n_jobs: integer, optional
+    n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    labels: array-like of shape [n_samples] (optional)
+    labels : array-like of shape [n_samples] (optional)
         Labels constrain the permutation among groups of samples with
         a same label.
 
-    random_state: RandomState or an int seed (0 by default)
+    random_state : RandomState or an int seed (0 by default)
         A random number generator instance to define the state of the
         random permutations generator.
 
-    verbose: integer, optional
-        The verbosity level
+    verbose : integer, optional
+        The verbosity level.
 
     Returns
     -------
-    score: float
+    score : float
         The true score without permuting targets.
 
     permutation_scores : array, shape = [n_permutations]
         The scores obtained for each permutations.
 
-    pvalue: float
+    pvalue : float
         The returned value equals p-value if `score_func` returns bigger
         numbers for better scores (e.g., zero_one). If `score_func` is rather a
         loss function (i.e. when lower is better such as with

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -213,7 +213,7 @@ class KFold(object):
     n : int
         Total number of elements.
 
-    n_folds : int
+    n_folds : int, default=3
         Number of folds.
 
     indices : boolean, optional (default True)
@@ -232,11 +232,11 @@ class KFold(object):
     >>> from sklearn import cross_validation
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4])
-    >>> kf = cross_validation.KFold(4, k=2)
+    >>> kf = cross_validation.KFold(4, n_folds=2)
     >>> len(kf)
     2
     >>> print(kf)
-    sklearn.cross_validation.KFold(n=4, k=2)
+    sklearn.cross_validation.KFold(n=4, n_folds=2)
     >>> for train_index, test_index in kf:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -256,7 +256,7 @@ class KFold(object):
     classification tasks).
     """
 
-    def __init__(self, n, n_folds, indices=True, shuffle=False,
+    def __init__(self, n, n_folds=3, indices=True, shuffle=False,
             random_state=None, k=None):
         if k is not None:
             warnings.warn("The parameter k was renamed to n_folds and will be"
@@ -319,7 +319,7 @@ class StratifiedKFold(object):
     y : array-like, [n_samples]
         Samples to split in K folds.
 
-    n_folds : int
+    n_folds : int, default=3
         Number of folds.
 
     indices : boolean, optional (default True)
@@ -332,11 +332,11 @@ class StratifiedKFold(object):
     >>> from sklearn import cross_validation
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
-    >>> skf = cross_validation.StratifiedKFold(y, k=2)
+    >>> skf = cross_validation.StratifiedKFold(y, n_folds=2)
     >>> len(skf)
     2
     >>> print(skf)
-    sklearn.cross_validation.StratifiedKFold(labels=[0 0 1 1], k=2)
+    sklearn.cross_validation.StratifiedKFold(labels=[0 0 1 1], n_folds=2)
     >>> for train_index, test_index in skf:
     ...    print("TRAIN: %s TEST: %s" % (train_index, test_index))
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -350,7 +350,7 @@ class StratifiedKFold(object):
     complementary.
     """
 
-    def __init__(self, y, n_folds, indices=True, k=None):
+    def __init__(self, y, n_folds=3, indices=True, k=None):
         if k is not None:
             warnings.warn("The parameter k was renamed to n_folds and will be"
                     " removed in 0.15.", DeprecationWarning)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -485,7 +485,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
             n_components = self.n_components
 
         U, S, V = randomized_svd(X, n_components,
-                                 n_iterations=self.iterated_power,
+                                 n_iter=self.iterated_power,
                                  random_state=self.random_state)
 
         self.explained_variance_ = exp_var = (S ** 2) / n_samples

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -222,6 +222,6 @@ def test_X_as_list():
     y = np.array([0] * 5 + [1] * 5)
 
     clf = MockClassifier()
-    cv = KFold(n=len(X), k=3)
+    cv = KFold(n=len(X), n_folds=3)
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, cv=cv)
     grid_search.fit(X.tolist(), y).score(X, y)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -4,6 +4,7 @@ Extended math utilities.
 # Authors: G. Varoquaux, A. Gramfort, A. Passos, O. Grisel
 # License: BSD
 
+import warnings
 import numpy as np
 from scipy import linalg
 
@@ -78,7 +79,8 @@ def safe_sparse_dot(a, b, dense_output=False):
         return np.dot(a, b)
 
 
-def randomized_range_finder(A, size, n_iterations, random_state=None):
+def randomized_range_finder(A, size, n_iter, random_state=None,
+        n_iterations=None):
     """Computes an orthonormal matrix whose range approximates the range of A.
 
     Parameters
@@ -87,7 +89,7 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
         The input data matrix
     size: integer
         Size of the return array
-    n_iterations: integer
+    n_iter: integer
         Number of power iterations used to stabilize the result
     random_state: RandomState or an int seed (0 by default)
         A random number generator instance
@@ -106,6 +108,10 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
     approximate matrix decompositions
     Halko, et al., 2009 (arXiv:909) http://arxiv.org/pdf/0909.4061
     """
+    if n_iterations is not None:
+        warnings.warn("n_iterations was renamed to n_iter for consistency "
+                "and will be removed in 0.16.", DeprecationWarning)
+        n_iter = n_iterations
     random_state = check_random_state(random_state)
 
     # generating random gaussian vectors r with shape: (A.shape[1], size)
@@ -117,7 +123,7 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
 
     # perform power iterations with Y to further 'imprint' the top
     # singular vectors of A in Y
-    for i in xrange(n_iterations):
+    for i in xrange(n_iter):
         Y = safe_sparse_dot(A, safe_sparse_dot(A.T, Y))
 
     # extracting an orthonormal basis of the A range samples
@@ -125,8 +131,8 @@ def randomized_range_finder(A, size, n_iterations, random_state=None):
     return Q
 
 
-def randomized_svd(M, n_components, n_oversamples=10, n_iterations=0,
-                   transpose='auto', random_state=0):
+def randomized_svd(M, n_components, n_oversamples=10, n_iter=0,
+                   transpose='auto', random_state=0, n_iterations=None):
     """Computes a truncated randomized SVD
 
     Parameters
@@ -142,7 +148,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iterations=0,
         to ensure proper conditioning. The total number of random vectors
         used to find the range of M is n_components + n_oversamples.
 
-    n_iterations: int (default is 0)
+    n_iter: int (default is 0)
         Number of power iterations (can be used to deal with very noisy
         problems).
 
@@ -172,6 +178,11 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iterations=0,
     * A randomized algorithm for the decomposition of matrices
       Per-Gunnar Martinsson, Vladimir Rokhlin and Mark Tygert
     """
+    if n_iterations is not None:
+        warnings.warn("n_iterations was renamed to n_iter for consistency "
+                "and will be removed in 0.16.", DeprecationWarning)
+        n_iter = n_iterations
+
     random_state = check_random_state(random_state)
     n_random = n_components + n_oversamples
     n_samples, n_features = M.shape
@@ -182,7 +193,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iterations=0,
         # this implementation is a bit faster with smaller shape[1]
         M = M.T
 
-    Q = randomized_range_finder(M, n_random, n_iterations, random_state)
+    Q = randomized_range_finder(M, n_random, n_iter, random_state)
 
     # project M to the (k + p) dimensional space using the basis vectors
     B = safe_sparse_dot(Q.T, M)

--- a/sklearn/utils/tests/test_svd.py
+++ b/sklearn/utils/tests/test_svd.py
@@ -69,14 +69,14 @@ def test_randomized_svd_low_rank_with_noise():
 
     # compute the singular values of X using the fast approximate method
     # without the iterated power method
-    _, sa, _ = randomized_svd(X, k, n_iterations=0)
+    _, sa, _ = randomized_svd(X, k, n_iter=0)
 
     # the approximation does not tolerate the noise:
     assert_greater(np.abs(s[:k] - sa).max(), 0.05)
 
     # compute the singular values of X using the fast approximate method with
     # iterated power method
-    _, sap, _ = randomized_svd(X, k, n_iterations=5)
+    _, sap, _ = randomized_svd(X, k, n_iter=5)
 
     # the iterated power method is helping getting rid of the noise:
     assert_almost_equal(s[:k], sap, decimal=3)
@@ -100,14 +100,14 @@ def test_randomized_svd_infinite_rank():
 
     # compute the singular values of X using the fast approximate method
     # without the iterated power method
-    _, sa, _ = randomized_svd(X, k, n_iterations=0)
+    _, sa, _ = randomized_svd(X, k, n_iter=0)
 
     # the approximation does not tolerate the noise:
     assert_greater(np.abs(s[:k] - sa).max(), 0.1)
 
     # compute the singular values of X using the fast approximate method with
     # iterated power method
-    _, sap, _ = randomized_svd(X, k, n_iterations=5)
+    _, sap, _ = randomized_svd(X, k, n_iter=5)
 
     # the iterated power method is still managing to get most of the structure
     # at the requested rank
@@ -125,11 +125,11 @@ def test_randomized_svd_transpose_consistency():
         effective_rank=rank, tail_strength=0.5, random_state=0)
     assert_equal(X.shape, (n_samples, n_features))
 
-    U1, s1, V1 = randomized_svd(X, k, n_iterations=3, transpose=False,
+    U1, s1, V1 = randomized_svd(X, k, n_iter=3, transpose=False,
                                 random_state=0)
-    U2, s2, V2 = randomized_svd(X, k, n_iterations=3, transpose=True,
+    U2, s2, V2 = randomized_svd(X, k, n_iter=3, transpose=True,
                                 random_state=0)
-    U3, s3, V3 = randomized_svd(X, k, n_iterations=3, transpose='auto',
+    U3, s3, V3 = randomized_svd(X, k, n_iter=3, transpose='auto',
                                 random_state=0)
     U4, s4, V4 = linalg.svd(X, full_matrices=False)
 


### PR DESCRIPTION
Renames `k` to `n_folds` in `KFold` and `StratifiedKFold` cross validation.
Also renames `n_bootstraps` to `n_iterations` to go conform with other randomized samplers.
I'd like to have better names for `p` and `n`, too, if there are any suggestions.

Closes issue #1161.
