### PR TITLE
MRG arbitraty labels for Neighbors classifiers. Fixes problem from ml.

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -577,7 +577,7 @@ class SupervisedIntegerMixin(object):
             Target values, array of integer values.
         """
         X, y = check_arrays(X, y, sparse_format="csr")
-        self._classes, self._y = unique(y, return_inverse=True)
+        self.classes_, self._y = unique(y, return_inverse=True)
         return self._fit(X)
 
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -16,6 +16,7 @@ from .ball_tree import BallTree
 from ..base import BaseEstimator
 from ..metrics import pairwise_distances
 from ..utils import safe_asarray, atleast2d_or_csr, check_arrays
+from ..utils.fixes import unique
 
 
 class NeighborsWarning(UserWarning):
@@ -576,8 +577,7 @@ class SupervisedIntegerMixin(object):
             Target values, array of integer values.
         """
         X, y = check_arrays(X, y, sparse_format="csr")
-        self._y = y
-        self._classes = np.sort(np.unique(y))
+        self._classes, self._y = unique(y, return_inverse=True)
         return self._fit(X)
 
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -138,7 +138,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         else:
             mode, _ = weighted_mode(pred_labels, weights, axis=1)
 
-        return mode.flatten().astype(np.int)
+        return self._classes[mode.flatten().astype(np.int)]
 
     def predict_proba(self, X):
         """Return probability estimates for the test data X.

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -312,10 +312,10 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                                for (pl, w) in zip(pred_labels, weights)],
                               dtype=np.int)
 
-        modes = mode.flatten().astype(np.int)
+        mode = mode.flatten().astype(np.int)
         # map indices to classes
-        prediction = self.classes_.take(modes)
+        prediction = self.classes_.take(mode)
         if self.outlier_label:
             # reset outlier label
-            prediction[modes == outlier_label] = self.outlier_label
+            prediction[mode == outlier_label] = self.outlier_label
         return prediction

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -138,7 +138,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         else:
             mode, _ = weighted_mode(pred_labels, weights, axis=1)
 
-        return self._classes[mode.flatten().astype(np.int)]
+        return self.classes_.take(mode.flatten().astype(np.int))
 
     def predict_proba(self, X):
         """Return probability estimates for the test data X.
@@ -164,19 +164,12 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if weights is None:
             weights = np.ones_like(pred_labels)
 
-        probabilities = np.zeros((X.shape[0], self._classes.size))
-
-        # Translate class label to a column index in probabilities array.
-        # This may not be needed provided classes labels are guaranteed to be
-        # np.arange(n_classes) (e.g. consecutive and starting with 0)
-        pred_indices = pred_labels.copy()
-        for k, c in enumerate(self._classes):
-            pred_indices[pred_labels == c] = k
+        probabilities = np.zeros((X.shape[0], self.classes_.size))
 
         # a simple ':' index doesn't work right
         all_rows = np.arange(X.shape[0])
 
-        for i, idx in enumerate(pred_indices.T):  # loop is O(n_neighbors)
+        for i, idx in enumerate(pred_labels.T):  # loop is O(n_neighbors)
             probabilities[all_rows, idx] += weights[:, i]
 
         # normalize 'votes' into real [0,1] probabilities
@@ -319,4 +312,10 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                                for (pl, w) in zip(pred_labels, weights)],
                               dtype=np.int)
 
-        return mode.flatten().astype(np.int)
+        modes = mode.flatten().astype(np.int)
+        # map indices to classes
+        prediction = self.classes_.take(modes)
+        if self.outlier_label:
+            # reset outlier label
+            prediction[modes == outlier_label] = self.outlier_label
+        return prediction

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -189,6 +189,23 @@ def test_kneighbors_classifier(n_samples=40,
             assert_array_equal(y_pred, y[:n_test_pts])
 
 
+def test_kneighbors_classifier_float_labels(n_samples=40,
+                               n_features=5,
+                               n_test_pts=10,
+                               n_neighbors=5,
+                               random_state=0):
+    """Test k-neighbors classification"""
+    rng = np.random.RandomState(random_state)
+    X = 2 * rng.rand(n_samples, n_features) - 1
+    y = ((X ** 2).sum(axis=1) < .5).astype(np.int)
+
+    knn = neighbors.KNeighborsClassifier(n_neighbors=n_neighbors)
+    knn.fit(X, y.astype(np.float))
+    epsilon = 1e-5 * (2 * rng.rand(1, n_features) - 1)
+    y_pred = knn.predict(X[:n_test_pts] + epsilon)
+    assert_array_equal(y_pred, y[:n_test_pts])
+
+
 def test_kneighbors_classifier_predict_proba():
     """Test KNeighborsClassifier.predict_proba() method"""
     X = np.array([[0, 2, 0],


### PR DESCRIPTION
Uses the `self.classes, y = unique(y)` idiom.
Makes the code shorter and more robust.
