### PR TITLE
MRG Use scores, not p-values, for feature selection

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -17,12 +17,13 @@ Univariate feature selection
 
 Univariate feature selection works by selecting the best features based on
 univariate statistical tests. It can seen as a preprocessing step
-to an estimator. Scikit-Learn exposes feature selection routines
-a objects that implement the `transform` method:
+to an estimator. Scikit-learn exposes feature selection routines
+as objects that implement the `transform` method:
 
- * selecting the k-best features :class:`SelectKBest`
+ * :class:`SelectKBest` removes all but the `k` highest scoring features
 
- * setting a percentile of features to keep :class:`SelectPercentile`
+ * :class:`SelectPercentile` removes all but a user-specified highest scoring
+   percentile of features
 
  * using common univariate statistical tests for each feature:
    false positive rate :class:`SelectFpr`, false discovery rate

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,6 +14,12 @@ Changelog
    - :class:`feature_selection.SelectPercentile` now breaks ties
      deterministically instead of returning all equally ranked features.
 
+   - :class:`feature_selection.SelectKBest` and
+     :class:`feature_selection.SelectPercentile` are more numerically stable
+     since they use scores, rather than p-values, to rank results. This means
+     that they might sometimes select different features than they did
+     previously.
+
    - Ridge regression and ridge classification fitting with ``sparse_cg`` solver
      no longer has quadratic memory complexity, by `Lars Buitinck`_ and
      `Fabian Pedregosa`_.

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -2,12 +2,14 @@
 Todo: cross-check the F-value with stats model
 """
 
+import itertools
 import numpy as np
+from scipy import stats, sparse
 import warnings
 
 from nose.tools import assert_equal, assert_raises, assert_true
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from scipy import stats, sparse
+from sklearn.utils.testing import assert_not_in
 
 from sklearn.datasets.samples_generator import (make_classification,
                                                 make_regression)
@@ -402,7 +404,7 @@ def test_selectkbest_tiebreaking():
 
 
 def test_selectpercentile_tiebreaking():
-    """Test if SelectPercentile actually selects k features in case of ties.
+    """Test if SelectPercentile selects the right n_features in case of ties.
     """
     X = [[1, 0, 0], [0, 1, 1]]
     y = [0, 1]
@@ -413,3 +415,21 @@ def test_selectpercentile_tiebreaking():
 
         X2 = SelectPercentile(chi2, percentile=67).fit_transform(X, y)
         assert_equal(X2.shape[1], 2)
+
+
+def test_tied_pvalues():
+    """Test whether k-best and percentiles work with tied pvalues from chi2."""
+    # chi2 will return the same p-values for the following features, but it
+    # will return different scores.
+    X0 = np.array([[10000, 9999, 9998], [1, 1, 1]])
+    y = [0, 1]
+
+    for perm in itertools.permutations((0, 1, 2)):
+        X = X0[:, perm]
+        Xt = SelectKBest(chi2, k=2).fit_transform(X, y)
+        assert_equal(Xt.shape, (2, 2))
+        assert_not_in(9998, Xt)
+
+        Xt = SelectPercentile(chi2, percentile=67).fit_transform(X, y)
+        assert_equal(Xt.shape, (2, 2))
+        assert_not_in(9998, Xt)

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -527,9 +527,13 @@ class GenericUnivariateSelect(_AbstractUnivariateFilter):
                         }
 
     def __init__(self, score_func=f_classif, mode='percentile', param=1e-5):
+        if not callable(score_func):
+            raise TypeError(
+                "The score function should be a callable, %r (type %s) "
+                "was passed." % (score_func, type(score_func)))
         if mode not in self._selection_modes:
             raise ValueError(
-                "The mode passed should be one of %s, %r "
+                "The mode passed should be one of %s, %r, (type %s) "
                 "was passed." % (
                         self._selection_modes.keys(),
                         mode, type(mode)))


### PR DESCRIPTION
This solves the numerical stability issue that @amueller encountered some time ago: p-values, at least those returned by `chi2`, may contain ties even when the scores don't.

This also paves the way for score functions that are not based on significance tests, such as mutual information and infogain (whence the name of this branch, but I won't be pushing those in this PR).
