### PR TITLE
MRG rename rho to l1_ratio

### DIFF
--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -63,7 +63,7 @@ for the training samples::
     >>> clf = SGDClassifier(loss="hinge", penalty="l2")
     >>> clf.fit(X, y)
     SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
-           fit_intercept=True, l1_ratio=0.25, learning_rate='optimal',
+           fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
            loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
            rho=None, seed=0, shuffle=False, verbose=0, warm_start=False)
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -63,9 +63,9 @@ for the training samples::
     >>> clf = SGDClassifier(loss="hinge", penalty="l2")
     >>> clf.fit(X, y)
     SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
-           fit_intercept=True, learning_rate='optimal', loss='hinge', n_iter=5,
-           n_jobs=1, penalty='l2', power_t=0.5, rho=0.85, seed=0,
-           shuffle=False, verbose=0, warm_start=False)
+           fit_intercept=True, l1_ratio=0.25, learning_rate='optimal',
+           loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
+           rho=None, seed=0, shuffle=False, verbose=0, warm_start=False)
 
 
 After being fitted, the model can then be used to predict new values::

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,10 @@ API changes summary
    - Replaced `rho` in :class:`linear_model.ElasticNet` and
      :class:`linear_model.SGDClassifier` by ``l1_ratio``. The `rho` parameter
      had different meanings; ``l1_ratio`` was introduced to avoid confusion.
+     It has the same meaning as previously rho in
+     :class:`linear_model.ElasticNet` and ``(1-rho)`` in
+     :class:`linear_model.SGDClassifier`,
+
 
 .. _changes_0_12.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -72,6 +72,10 @@ API changes summary
      :class:`cross_validation.StratifiedShuffleSplit`,
      :func:`utils.randomized_range_finder` and :func:`utils.randomized_svd`.
 
+   - Replaced `rho` in :class:`linear_model.ElasticNet` and
+     :class:`linear_model.SGDClassifier` by ``l1_ratio``. The `rho` parameter
+     had different meanings; ``l1_ratio`` was introduced to avoid confusion.
+
 .. _changes_0_12.1:
 
 0.12.1

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -35,7 +35,8 @@ class ElasticNet(LinearModel, RegressorMixin):
     Minimizes the objective function::
 
             1 / (2 * n_samples) * ||y - Xw||^2_2 +
-            + alpha * rho * ||w||_1 + 0.5 * alpha * (1 - rho) * ||w||^2_2
+            + alpha * l1_ratio * ||w||_1
+            + 0.5 * alpha * (1 - l1_ratio) * ||w||^2_2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to::
@@ -44,12 +45,12 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     where::
 
-            alpha = a + b and rho = a / (a + b)
+            alpha = a + b and l1_ratio = a / (a + b)
 
-    The parameter rho corresponds to alpha in the glmnet R package while
-    alpha corresponds to the lambda parameter in glmnet. Specifically, rho =
-    1 is the lasso penalty. Currently, rho <= 0.01 is not reliable, unless
-    you supply your own sequence of alpha.
+    The parameter l1_ratio corresponds to alpha in the glmnet R package while
+    alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio
+    = 1 is the lasso penalty. Currently, l1_ratio <= 0.01 is not reliable,
+    unless you supply your own sequence of alpha.
 
     Parameters
     ----------
@@ -62,10 +63,11 @@ class ElasticNet(LinearModel, RegressorMixin):
         reasons, using alpha = 0 is with the Lasso object is not advised
         and you should prefer the LinearRegression object.
 
-    rho : float
-        The ElasticNet mixing parameter, with 0 < rho <= 1. For rho = 0
-        the penalty is an L2 penalty. For rho = 1 it is an L1 penalty.
-        For 0 < rho < 1, the penalty is a combination of L1 and L2
+    l1_ratio : float
+        The ElasticNet mixing parameter, with 0 < l1_ratio <= 1. For
+        l1_ratio = 0 the penalty is an L2 penalty. For l1_ratio = 1 it is an L1
+        penalty.  For 0 < l1_ratio < 1, the penalty is a combination of L1 and
+        L2.
 
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -123,11 +125,15 @@ class ElasticNet(LinearModel, RegressorMixin):
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a fortran contiguous numpy array.
     """
-    def __init__(self, alpha=1.0, rho=0.5, fit_intercept=True,
-                 normalize=False, precompute='auto', max_iter=1000,
-                 copy_X=True, tol=1e-4, warm_start=False, positive=False):
+    def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
+            normalize=False, precompute='auto', max_iter=1000, copy_X=True,
+            tol=1e-4, warm_start=False, positive=False, rho=None):
         self.alpha = alpha
-        self.rho = rho
+        self.l1_ratio = l1_ratio
+        if rho is not None:
+            self.l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
         self.coef_ = None
         self.fit_intercept = fit_intercept
         self.normalize = normalize
@@ -203,8 +209,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         dual_gap_ = np.empty(n_targets)
         eps_ = np.empty(n_targets)
 
-        l1_reg = self.alpha * self.rho * n_samples
-        l2_reg = self.alpha * (1.0 - self.rho) * n_samples
+        l1_reg = self.alpha * self.l1_ratio * n_samples
+        l2_reg = self.alpha * (1.0 - self.l1_ratio) * n_samples
 
         # precompute if n_samples > n_features
         if hasattr(precompute, '__array__'):
@@ -267,8 +273,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         dual_gap_ = np.empty(n_targets)
         eps_ = np.empty(n_targets)
 
-        l1_reg = self.alpha * self.rho * n_samples
-        l2_reg = self.alpha * (1.0 - self.rho) * n_samples
+        l1_reg = self.alpha * self.l1_ratio * n_samples
+        l2_reg = self.alpha * (1.0 - self.l1_ratio) * n_samples
 
         for k in xrange(n_targets):
             coef_[k, :], dual_gap_[k], eps_[k] = \
@@ -341,7 +347,7 @@ class Lasso(ElasticNet):
         (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
     Technically the Lasso model is optimizing the same objective function as
-    the Elastic Net with rho=1.0 (no L2 penalty).
+    the Elastic Net with l1_ratio=1.0 (no L2 penalty).
 
     Parameters
     ----------
@@ -438,7 +444,7 @@ class Lasso(ElasticNet):
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  precompute='auto', copy_X=True, max_iter=1000,
                  tol=1e-4, warm_start=False, positive=False):
-        super(Lasso, self).__init__(alpha=alpha, rho=1.0,
+        super(Lasso, self).__init__(alpha=alpha, l1_ratio=1.0,
                             fit_intercept=fit_intercept, normalize=normalize,
                             precompute=precompute, copy_X=copy_X,
                             max_iter=max_iter, tol=tol, warm_start=warm_start,
@@ -523,22 +529,23 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     LassoLarsCV
     sklearn.decomposition.sparse_encode
     """
-    return enet_path(X, y, rho=1., eps=eps, n_alphas=n_alphas, alphas=alphas,
-                     precompute=precompute, Xy=Xy,
-                     fit_intercept=fit_intercept, normalize=normalize,
-                     copy_X=copy_X, verbose=verbose, **params)
+    return enet_path(X, y, l1_ratio=1., eps=eps, n_alphas=n_alphas,
+            alphas=alphas, precompute=precompute, Xy=Xy,
+            fit_intercept=fit_intercept, normalize=normalize, copy_X=copy_X,
+            verbose=verbose, **params)
 
 
-def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
+def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
               precompute='auto', Xy=None, fit_intercept=True,
-              normalize=False, copy_X=True, verbose=False,
+              normalize=False, copy_X=True, verbose=False, rho=None,
               **params):
     """Compute Elastic-Net path with coordinate descent
 
     The Elastic Net optimization function is::
 
         1 / (2 * n_samples) * ||y - Xw||^2_2 +
-        + alpha * rho * ||w||_1 + 0.5 * alpha * (1 - rho) * ||w||^2_2
+        + alpha * l1_ratio * ||w||_1
+        + 0.5 * alpha * (1 - l1_ratio) * ||w||^2_2
 
     Parameters
     ----------
@@ -549,9 +556,9 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     y : ndarray, shape = (n_samples,)
         Target values
 
-    rho : float, optional
+    l1_ratio : float, optional
         float between 0 and 1 passed to ElasticNet (scaling between
-        l1 and l2 penalties). rho=1 corresponds to the Lasso
+        l1 and l2 penalties). l1_ratio=1 corresponds to the Lasso
 
     eps : float
         Length of the path. eps=1e-3 means that
@@ -601,6 +608,12 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     ElasticNet
     ElasticNetCV
     """
+
+    if rho is not None:
+        l1_ratio = rho
+        warnings.warn("rho was renamed to l1_ratio and will be removed "
+                "in 0.15", DeprecationWarning)
+
     X = atleast2d_or_csc(X, dtype=np.float64, order='F',
                         copy=copy_X and fit_intercept)
     # From now on X can be touched inplace
@@ -632,7 +645,7 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     n_samples = X.shape[0]
     if alphas is None:
-        alpha_max = np.abs(Xy).max() / (n_samples * rho)
+        alpha_max = np.abs(Xy).max() / (n_samples * l1_ratio)
         alphas = np.logspace(np.log10(alpha_max * eps), np.log10(alpha_max),
                              num=n_alphas)[::-1]
     else:
@@ -642,7 +655,7 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     n_alphas = len(alphas)
     for i, alpha in enumerate(alphas):
-        model = ElasticNet(alpha=alpha, rho=rho,
+        model = ElasticNet(alpha=alpha, l1_ratio=l1_ratio,
             fit_intercept=fit_intercept if sparse.isspmatrix(X) else False,
             precompute=precompute)
         model.set_params(**params)
@@ -662,16 +675,16 @@ def enet_path(X, y, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
     return models
 
 
-def _path_residuals(X, y, train, test, path, path_params, rho=1):
+def _path_residuals(X, y, train, test, path, path_params, l1_ratio=1):
     this_mses = list()
-    if 'rho' in path_params:
-        path_params['rho'] = rho
+    if 'l1_ratio' in path_params:
+        path_params['l1_ratio'] = l1_ratio
     models_train = path(X[train], y[train], **path_params)
     this_mses = np.empty(len(models_train))
     for i_model, model in enumerate(models_train):
         y_ = model.predict(X[test])
         this_mses[i_model] = ((y_ - y[test]) ** 2).mean()
-    return this_mses, rho
+    return this_mses, l1_ratio
 
 
 class LinearModelCV(LinearModel):
@@ -720,12 +733,12 @@ class LinearModelCV(LinearModel):
 
         # All LinearModelCV parameters except 'cv' are acceptable
         path_params = self.get_params()
-        if 'rho' in path_params:
-            rhos = np.atleast_1d(path_params['rho'])
-            # For the first path, we need to set rho
-            path_params['rho'] = rhos[0]
+        if 'l1_ratio' in path_params:
+            l1_ratios = np.atleast_1d(path_params['l1_ratio'])
+            # For the first path, we need to set l1_ratio
+            path_params['l1_ratio'] = l1_ratios[0]
         else:
-            rhos = [1, ]
+            l1_ratios = [1, ]
         path_params.pop('cv', None)
         path_params.pop('n_jobs', None)
 
@@ -748,12 +761,12 @@ class LinearModelCV(LinearModel):
         all_mse_paths = list()
 
         # We do a double for loop folded in one, in order to be able to
-        # iterate in parallel on rho and folds
-        for rho, mse_alphas in itertools.groupby(
+        # iterate in parallel on l1_ratio and folds
+        for l1_ratio, mse_alphas in itertools.groupby(
                     Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                         delayed(_path_residuals)(X, y, train, test,
-                                    self.path, path_params, rho=rho)
-                            for rho in rhos for train, test in folds
+                                    self.path, path_params, l1_ratio=l1_ratio)
+                            for l1_ratio in l1_ratios for train, test in folds
                     ), operator.itemgetter(1)):
 
             mse_alphas = [m[0] for m in mse_alphas]
@@ -764,14 +777,14 @@ class LinearModelCV(LinearModel):
             all_mse_paths.append(mse_alphas.T)
             if this_best_mse < best_mse:
                 model = models[i_best_alpha]
-                best_rho = rho
+                best_l1_ratio = l1_ratio
 
-        if hasattr(model, 'rho'):
-            if model.rho != best_rho:
+        if hasattr(model, 'l1_ratio'):
+            if model.l1_ratio != best_l1_ratio:
                 # Need to refit the model
-                model.rho = best_rho
+                model.l1_ratio = best_l1_ratio
                 model.fit(X, y)
-            self.rho_ = model.rho
+            self.l1_ratio_ = model.l1_ratio
         self.coef_ = model.coef_
         self.intercept_ = model.intercept_
         self.alpha_ = model.alpha
@@ -779,6 +792,12 @@ class LinearModelCV(LinearModel):
         self.coef_path_ = np.asarray([model.coef_ for model in models])
         self.mse_path_ = np.squeeze(all_mse_paths)
         return self
+
+    @property
+    def rho_(self):
+        warnings.warn("rho was renamed to l1_ratio and will be removed "
+                "in 0.15", DeprecationWarning)
+        return self.l1_ratio_
 
     @property
     def alpha(self):
@@ -885,15 +904,15 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
     Parameters
     ----------
-    rho : float, optional
+    l1_ratio : float, optional
         float between 0 and 1 passed to ElasticNet (scaling between
-        l1 and l2 penalties). For rho = 0
-        the penalty is an L2 penalty. For rho = 1 it is an L1 penalty.
-        For 0 < rho < 1, the penalty is a combination of L1 and L2
+        l1 and l2 penalties). For l1_ratio = 0
+        the penalty is an L2 penalty. For l1_ratio = 1 it is an L1 penalty.
+        For 0 < l1_ratio < 1, the penalty is a combination of L1 and L2
         This parameter can be a list, in which case the different
         values are tested by cross-validation and the one giving the best
         prediction score is used. Note that a good choice of list of
-        values for rho is often to put more values close to 1
+        values for l1_ratio is often to put more values close to 1
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in [.1, .5, .7,
         .9, .95, .99, 1]
 
@@ -933,26 +952,26 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     n_jobs : integer, optional
         Number of CPUs to use during the cross validation. If '-1', use
         all the CPUs. Note that this is used only if multiple values for
-        rho are given.
+        l1_ratio are given.
 
     Attributes
     ----------
     `alpha_` : float
         The amount of penalization choosen by cross validation
 
-    `rho_` : float
+    `l1_ratio_` : float
         The compromise between l1 and l2 penalization choosen by
         cross validation
 
     `coef_` : array, shape = (n_features,)
-        parameter vector (w in the cost function formula)
+        Parameter vector (w in the cost function formula),
 
     `intercept_` : float
-        independent term in decision function.
+        Independent term in the decision function.
 
-    `mse_path_` : array, shape = (n_rho, n_alpha, n_folds)
-        mean square error for the test set on each fold, varying rho and
-        alpha
+    `mse_path_` : array, shape = (n_l1_ratio, n_alpha, n_folds)
+        Mean square error for the test set on each fold, varying l1_ratio and
+        alpha.
 
     Notes
     -----
@@ -962,12 +981,13 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a fortran contiguous numpy array.
 
-    The parameter rho corresponds to alpha in the glmnet R package
+    The parameter l1_ratio corresponds to alpha in the glmnet R package
     while alpha corresponds to the lambda parameter in glmnet.
     More specifically, the optimization objective is::
 
         1 / (2 * n_samples) * ||y - Xw||^2_2 +
-        + alpha * rho * ||w||_1 + 0.5 * alpha * (1 - rho) * ||w||^2_2
+        + alpha * l1_ratio * ||w||_1
+        + 0.5 * alpha * (1 - l1_ratio) * ||w||^2_2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to::
@@ -976,7 +996,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
     for::
 
-        alpha = a + b and rho = a / (a + b)
+        alpha = a + b and l1_ratio = a / (a + b).
 
     See also
     --------
@@ -986,11 +1006,15 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     """
     path = staticmethod(enet_path)
 
-    def __init__(self, rho=0.5, eps=1e-3, n_alphas=100, alphas=None,
+    def __init__(self, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                  fit_intercept=True, normalize=False, precompute='auto',
                  max_iter=1000, tol=1e-4, cv=None, copy_X=True,
-                 verbose=0, n_jobs=1):
-        self.rho = rho
+                 verbose=0, n_jobs=1, rho=None):
+        self.l1_ratio = l1_ratio
+        if rho is not None:
+            self.l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
         self.eps = eps
         self.n_alphas = n_alphas
         self.alphas = alphas
@@ -1014,7 +1038,8 @@ class MultiTaskElasticNet(Lasso):
     The optimization objective for Lasso is::
 
         (1 / (2 * n_samples)) * ||Y - XW||^Fro_2
-        + alpha * rho * ||W||_21 + 0.5 * alpha * (1 - rho) * ||W||_Fro^2
+        + alpha * l1_ratio * ||W||_21
+        + 0.5 * alpha * (1 - l1_ratio) * ||W||_Fro^2
 
     Where::
 
@@ -1027,10 +1052,11 @@ class MultiTaskElasticNet(Lasso):
     alpha : float, optional
         Constant that multiplies the L1/L2 term. Defaults to 1.0
 
-    rho : float
-        The ElasticNet mixing parameter, with 0 < rho <= 1. For rho = 0
-        the penalty is an L1/L2 penalty. For rho = 1 it is an L1 penalty.
-        For 0 < rho < 1, the penalty is a combination of L1/L2 and L2
+    l1_ratio : float
+        The ElasticNet mixing parameter, with 0 < l1_ratio <= 1.
+        For l1_ratio = 0 the penalty is an L1/L2 penalty. For l1_ratio = 1 it
+        is an L1 penalty.
+        For 0 < l1_ratio < 1, the penalty is a combination of L1/L2 and L2.
 
     fit_intercept : boolean
         whether to calculate the intercept for this model. If set
@@ -1072,7 +1098,7 @@ class MultiTaskElasticNet(Lasso):
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
     ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNet(alpha=0.1, copy_X=True, fit_intercept=True,
-            max_iter=1000, normalize=False, rho=0.5, tol=0.0001,
+            max_iter=1000, normalize=False, l1_ratio=0.5, tol=0.0001,
             warm_start=False)
     >>> print clf.coef_
     [[ 0.45663524  0.45612256]
@@ -1091,8 +1117,14 @@ class MultiTaskElasticNet(Lasso):
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a fortran contiguous numpy array.
     """
-    def __init__(self, alpha=1.0, rho=0.5, fit_intercept=True, normalize=False,
-                 copy_X=True, max_iter=1000, tol=1e-4, warm_start=False):
+    def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
+            normalize=False, copy_X=True, max_iter=1000, tol=1e-4,
+            warm_start=False, rho=None):
+        self.l1_ratio = l1_ratio
+        if rho is not None:
+            self.l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
         self.alpha = alpha
         self.coef_ = None
         self.fit_intercept = fit_intercept
@@ -1101,7 +1133,6 @@ class MultiTaskElasticNet(Lasso):
         self.copy_X = copy_X
         self.tol = tol
         self.warm_start = warm_start
-        self.rho = rho
 
     def fit(self, X, y, Xy=None, coef_init=None):
         """Fit MultiTaskLasso model with coordinate descent
@@ -1148,8 +1179,8 @@ class MultiTaskElasticNet(Lasso):
         else:
             self.coef_ = coef_init
 
-        l1_reg = self.alpha * self.rho * n_samples
-        l2_reg = self.alpha * (1.0 - self.rho) * n_samples
+        l1_reg = self.alpha * self.l1_ratio * n_samples
+        l2_reg = self.alpha * (1.0 - self.l1_ratio) * n_samples
 
         self.coef_ = np.asfortranarray(self.coef_)  # coef contiguous in memory
 
@@ -1256,4 +1287,4 @@ class MultiTaskLasso(MultiTaskElasticNet):
         self.copy_X = copy_X
         self.tol = tol
         self.warm_start = warm_start
-        self.rho = 1.0
+        self.l1_ratio = 1.0

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1098,7 +1098,7 @@ class MultiTaskElasticNet(Lasso):
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]])
     ... #doctest: +NORMALIZE_WHITESPACE
     MultiTaskElasticNet(alpha=0.1, copy_X=True, fit_intercept=True,
-            max_iter=1000, normalize=False, l1_ratio=0.5, tol=0.0001,
+            l1_ratio=0.5, max_iter=1000, normalize=False, rho=None, tol=0.0001,
             warm_start=False)
     >>> print clf.coef_
     [[ 0.45663524  0.45612256]

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -88,7 +88,7 @@ class Perceptron(SGDClassifier):
                  n_jobs=1, seed=0, class_weight=None, warm_start=False):
         super(Perceptron, self).__init__(loss="perceptron",
                                          penalty=penalty,
-                                         alpha=alpha, rho=0,
+                                         alpha=alpha, l1_ratio=0,
                                          fit_intercept=fit_intercept,
                                          n_iter=n_iter,
                                          shuffle=shuffle,

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -46,7 +46,7 @@ class BaseSGD(BaseEstimator):
     __metaclass__ = ABCMeta
 
     def __init__(self, loss, penalty='l2', alpha=0.0001,
-                 l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=0.1, seed=0, learning_rate="optimal",
                  eta0=0.0, power_t=0.5, warm_start=False, rho=None):
         self.loss = loss
@@ -56,7 +56,7 @@ class BaseSGD(BaseEstimator):
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         if rho is not None:
-            self.l1_ratio = rho
+            self.l1_ratio = 1 - rho
             warnings.warn("rho was renamed to l1_ratio and will be removed "
                     "in 0.15", DeprecationWarning)
         self.fit_intercept = fit_intercept
@@ -273,7 +273,7 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     l1_ratio : float
         The Elastic Net mixing parameter, with 0 < l1_ratio <= 1.
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
-        Defaults to 0.25.
+        Defaults to 0.15.
 
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -343,9 +343,9 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     >>> clf.fit(X, Y)
     ... #doctest: +NORMALIZE_WHITESPACE
     SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
-            fit_intercept=True, learning_rate='optimal', loss='hinge',
-            n_iter=5, n_jobs=1, penalty='l2', power_t=0.5, l1_ratio=0.25,
-            seed=0, shuffle=False, verbose=0, warm_start=False)
+            fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
+            loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
+            rho=None, seed=0, shuffle=False, verbose=0, warm_start=False)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 
@@ -366,7 +366,7 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     }
 
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001,
-                 l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=DEFAULT_EPSILON, n_jobs=1, seed=0,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
                  class_weight=None, warm_start=False, rho=None):
@@ -716,7 +716,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     l1_ratio : float
         The Elastic Net mixing parameter, with 0 < l1_ratio <= 1.
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
-        Defaults to 0.25.
+        Defaults to 0.15.
 
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -776,9 +776,9 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     >>> clf = linear_model.SGDRegressor()
     >>> clf.fit(X, y)
     SGDRegressor(alpha=0.0001, epsilon=0.1, eta0=0.01, fit_intercept=True,
-           learning_rate='invscaling', loss='squared_loss', n_iter=5, p=None,
-           penalty='l2', power_t=0.25, l1_ratio=0.25, seed=0, shuffle=False,
-           verbose=0, warm_start=False)
+           l1_ratio=0.15, learning_rate='invscaling', loss='squared_loss',
+           n_iter=5, p=None, penalty='l2', power_t=0.25, rho=None, seed=0,
+           shuffle=False, verbose=0, warm_start=False)
 
     See also
     --------
@@ -793,7 +793,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     }
 
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
-            l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
+            l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
             verbose=0, epsilon=DEFAULT_EPSILON, p=None, seed=0,
             learning_rate="invscaling", eta0=0.01, power_t=0.25,
             warm_start=False, rho=None):

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -46,15 +46,19 @@ class BaseSGD(BaseEstimator):
     __metaclass__ = ABCMeta
 
     def __init__(self, loss, penalty='l2', alpha=0.0001,
-                 rho=0.85, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=0.1, seed=0, learning_rate="optimal",
-                 eta0=0.0, power_t=0.5, warm_start=False):
+                 eta0=0.0, power_t=0.5, warm_start=False, rho=None):
         self.loss = loss
         self.penalty = penalty
         self.learning_rate = learning_rate
         self.epsilon = epsilon
         self.alpha = alpha
-        self.rho = rho
+        self.l1_ratio = l1_ratio
+        if rho is not None:
+            self.l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
         self.fit_intercept = fit_intercept
         self.n_iter = n_iter
         self.shuffle = shuffle
@@ -85,8 +89,8 @@ class BaseSGD(BaseEstimator):
             raise ValueError("shuffle must be either True or False")
         if self.n_iter <= 0:
             raise ValueError("n_iter must be greater than zero")
-        if not (0.0 <= self.rho <= 1.0):
-            raise ValueError("rho must be in [0, 1]")
+        if not (0.0 <= self.l1_ratio <= 1.0):
+            raise ValueError("l1_ratio must be in [0, 1]")
         if self.alpha < 0.0:
             raise ValueError("alpha must be greater than zero")
         if self.learning_rate != "optimal":
@@ -266,9 +270,10 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     alpha : float
         Constant that multiplies the regularization term. Defaults to 0.0001
 
-    rho : float
-        The Elastic Net mixing parameter, with 0 < rho <= 1.
-        Defaults to 0.85.
+    l1_ratio : float
+        The Elastic Net mixing parameter, with 0 < l1_ratio <= 1.
+        l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
+        Defaults to 0.25.
 
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -339,8 +344,8 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     ... #doctest: +NORMALIZE_WHITESPACE
     SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
             fit_intercept=True, learning_rate='optimal', loss='hinge',
-            n_iter=5, n_jobs=1, penalty='l2', power_t=0.5, rho=0.85, seed=0,
-            shuffle=False, verbose=0, warm_start=False)
+            n_iter=5, n_jobs=1, penalty='l2', power_t=0.5, l1_ratio=0.25,
+            seed=0, shuffle=False, verbose=0, warm_start=False)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 
@@ -361,12 +366,17 @@ class SGDClassifier(BaseSGD, LinearClassifierMixin, SelectorMixin):
     }
 
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001,
-                 rho=0.85, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=DEFAULT_EPSILON, n_jobs=1, seed=0,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
-                 class_weight=None, warm_start=False):
+                 class_weight=None, warm_start=False, rho=None):
+
+        if rho is not None:
+            self.l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
         super(SGDClassifier, self).__init__(loss=loss, penalty=penalty,
-                                            alpha=alpha, rho=rho,
+                                            alpha=alpha, l1_ratio=l1_ratio,
                                             fit_intercept=fit_intercept,
                                             n_iter=n_iter, shuffle=shuffle,
                                             verbose=verbose, epsilon=epsilon,
@@ -662,7 +672,7 @@ def fit_binary(est, i, X, y, n_iter, pos_weight, neg_weight,
     learning_rate_type = est._get_learning_rate_type(est.learning_rate)
 
     return plain_sgd(coef, intercept, est.loss_function,
-                     penalty_type, est.alpha, est.rho,
+                     penalty_type, est.alpha, est.l1_ratio,
                      dataset, n_iter, int(est.fit_intercept),
                      int(est.verbose), int(est.shuffle), est.seed,
                      pos_weight, neg_weight,
@@ -703,9 +713,10 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     alpha : float
         Constant that multiplies the regularization term. Defaults to 0.0001
 
-    rho : float
-        The Elastic Net mixing parameter, with 0 < rho <= 1.
-        Defaults to 0.85.
+    l1_ratio : float
+        The Elastic Net mixing parameter, with 0 < l1_ratio <= 1.
+        l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
+        Defaults to 0.25.
 
     fit_intercept: bool
         Whether the intercept should be estimated or not. If False, the
@@ -766,7 +777,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     >>> clf.fit(X, y)
     SGDRegressor(alpha=0.0001, epsilon=0.1, eta0=0.01, fit_intercept=True,
            learning_rate='invscaling', loss='squared_loss', n_iter=5, p=None,
-           penalty='l2', power_t=0.25, rho=0.85, seed=0, shuffle=False,
+           penalty='l2', power_t=0.25, l1_ratio=0.25, seed=0, shuffle=False,
            verbose=0, warm_start=False)
 
     See also
@@ -782,10 +793,14 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
     }
 
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
-            rho=0.85, fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
-            epsilon=DEFAULT_EPSILON, p=None, seed=0,
-            learning_rate="invscaling", eta0=0.01,
-            power_t=0.25, warm_start=False):
+            l1_ratio=0.25, fit_intercept=True, n_iter=5, shuffle=False,
+            verbose=0, epsilon=DEFAULT_EPSILON, p=None, seed=0,
+            learning_rate="invscaling", eta0=0.01, power_t=0.25,
+            warm_start=False, rho=None):
+        if rho is not None:
+            l1_ratio = rho
+            warnings.warn("rho was renamed to l1_ratio and will be removed "
+                    "in 0.15", DeprecationWarning)
 
         if p is not None:
             warnings.warn("Using 'p' is deprecated and will be removed in "
@@ -795,7 +810,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
             epsilon = p
 
         super(SGDRegressor, self).__init__(loss=loss, penalty=penalty,
-                                           alpha=alpha, rho=rho,
+                                           alpha=alpha, l1_ratio=l1_ratio,
                                            fit_intercept=fit_intercept,
                                            n_iter=n_iter, shuffle=shuffle,
                                            verbose=verbose, epsilon=epsilon,
@@ -933,7 +948,7 @@ class SGDRegressor(BaseSGD, RegressorMixin, SelectorMixin):
                                           self.intercept_[0],
                                           loss_function,
                                           penalty_type,
-                                          self.alpha, self.rho,
+                                          self.alpha, self.l1_ratio,
                                           dataset,
                                           n_iter,
                                           int(self.fit_intercept),

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -79,7 +79,7 @@ def test_lasso_toy():
 
 def test_enet_toy():
     """
-    Test ElasticNet for various parameters of alpha and rho.
+    Test ElasticNet for various parameters of alpha and l1_ratio.
 
     Actualy, the parameters alpha = 0 should not be alowed. However,
     we test it as a border case.
@@ -92,14 +92,14 @@ def test_enet_toy():
     T = [[2.], [3.], [4.]]  # test sample
 
     # this should be the same as lasso
-    clf = ElasticNet(alpha=1e-8, rho=1.0)
+    clf = ElasticNet(alpha=1e-8, l1_ratio=1.0)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [1])
     assert_array_almost_equal(pred, [2, 3, 4])
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.3, max_iter=100,
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.3, max_iter=100,
                      precompute=False)
     clf.fit(X, Y)
     pred = clf.predict(T)
@@ -121,7 +121,7 @@ def test_enet_toy():
     assert_array_almost_equal(pred, [1.0163, 1.5245, 2.0327], decimal=3)
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.5)
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.5)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.45454], 3)
@@ -186,17 +186,17 @@ def test_enet_path():
         # Here we have a small number of iterations, and thus the
         # ElasticNet might not converge. This is to speed up tests
         warnings.simplefilter("ignore", UserWarning)
-        clf = ElasticNetCV(n_alphas=5, eps=2e-3, rho=[0.9, 0.95], cv=3,
+        clf = ElasticNetCV(n_alphas=5, eps=2e-3, l1_ratio=[0.9, 0.95], cv=3,
                            max_iter=max_iter)
         clf.fit(X, y)
         assert_almost_equal(clf.alpha_, 0.002, 2)
-        assert_equal(clf.rho_, 0.95)
+        assert_equal(clf.l1_ratio_, 0.95)
 
-        clf = ElasticNetCV(n_alphas=5, eps=2e-3, rho=[0.9, 0.95], cv=3,
+        clf = ElasticNetCV(n_alphas=5, eps=2e-3, l1_ratio=[0.9, 0.95], cv=3,
                            max_iter=max_iter, precompute=True)
         clf.fit(X, y)
     assert_almost_equal(clf.alpha_, 0.002, 2)
-    assert_equal(clf.rho_, 0.95)
+    assert_equal(clf.l1_ratio_, 0.95)
 
     # test set
     assert_greater(clf.score(X_test, y_test), 0.99)
@@ -207,9 +207,9 @@ def test_path_parameters():
     max_iter = 50
 
     clf = ElasticNetCV(n_alphas=50, eps=1e-3, max_iter=max_iter,
-                       rho=0.5)
+                       l1_ratio=0.5)
     clf.fit(X, y)  # new params
-    assert_almost_equal(0.5, clf.rho)
+    assert_almost_equal(0.5, clf.l1_ratio)
     assert_equal(50, clf.n_alphas)
     assert_equal(50, len(clf.alphas_))
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -183,7 +183,7 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
     @raises(ValueError)
     def test_sgd_bad_penalty(self):
         """Check whether expected ValueError on bad penalty"""
-        self.factory(penalty='foobar', rho=0.85)
+        self.factory(penalty='foobar', l1_ratio=0.85)
 
     @raises(ValueError)
     def test_sgd_bad_loss(self):
@@ -549,7 +549,7 @@ class DenseSGDRegressorTestCase(unittest.TestCase):
     @raises(ValueError)
     def test_sgd_bad_penalty(self):
         """Check whether expected ValueError on bad penalty"""
-        self.factory(penalty='foobar', rho=0.85)
+        self.factory(penalty='foobar', l1_ratio=0.85)
 
     @raises(ValueError)
     def test_sgd_bad_loss(self):
@@ -643,15 +643,16 @@ class DenseSGDRegressorTestCase(unittest.TestCase):
 
         # XXX: alpha = 0.1 seems to cause convergence problems
         for alpha in [0.01, 0.001]:
-            for rho in [0.5, 0.8, 1.0]:
-                cd = linear_model.ElasticNet(alpha=alpha, rho=rho,
+            for l1_ratio in [0.5, 0.8, 1.0]:
+                cd = linear_model.ElasticNet(alpha=alpha, l1_ratio=l1_ratio,
                                              fit_intercept=False)
                 cd.fit(X, y)
                 sgd = self.factory(penalty='elasticnet', n_iter=50,
-                                   alpha=alpha, rho=rho, fit_intercept=False)
+                        alpha=alpha, l1_ratio=l1_ratio, fit_intercept=False)
                 sgd.fit(X, y)
                 err_msg = ("cd and sgd did not converge to comparable "
-                           "results for alpha=%f and rho=%f" % (alpha, rho))
+                        "results for alpha=%f and l1_ratio=%f"
+                        % (alpha, l1_ratio))
                 assert_almost_equal(cd.coef_, sgd.coef_, decimal=2,
                                     err_msg=err_msg)
 

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -47,7 +47,7 @@ def test_lasso_zero():
 
 
 def test_enet_toy_list_input():
-    """Test ElasticNet for various parameters of alpha and rho with list X"""
+    """Test ElasticNet for various values of alpha and l1_ratio with list X"""
 
     X = np.array([[-1], [0], [1]])
     X = sp.csc_matrix(X)
@@ -55,21 +55,21 @@ def test_enet_toy_list_input():
     T = np.array([[2], [3], [4]])  # test sample
 
     # this should be the same as unregularized least squares
-    clf = ElasticNet(alpha=0, rho=1.0)
+    clf = ElasticNet(alpha=0, l1_ratio=1.0)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [1])
     assert_array_almost_equal(pred, [2, 3, 4])
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.3, max_iter=1000)
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.3, max_iter=1000)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
     assert_array_almost_equal(pred, [1.0163,  1.5245,  2.0327], decimal=3)
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.5)
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.5)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.45454], 3)
@@ -78,7 +78,8 @@ def test_enet_toy_list_input():
 
 
 def test_enet_toy_explicit_sparse_input():
-    """Test ElasticNet for various parameters of alpha and rho with sparse X"""
+    """Test ElasticNet for various values of alpha and l1_ratio with sparse
+    X"""
 
     # training samples
     X = sp.lil_matrix((3, 1))
@@ -94,21 +95,21 @@ def test_enet_toy_explicit_sparse_input():
     T[2, 0] = 4
 
     # this should be the same as lasso
-    clf = ElasticNet(alpha=0, rho=1.0)
+    clf = ElasticNet(alpha=0, l1_ratio=1.0)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [1])
     assert_array_almost_equal(pred, [2, 3, 4])
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.3, max_iter=1000)
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.3, max_iter=1000)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.50819], decimal=3)
     assert_array_almost_equal(pred, [1.0163,  1.5245,  2.0327], decimal=3)
     assert_almost_equal(clf.dual_gap_, 0)
 
-    clf = ElasticNet(alpha=0.5, rho=0.5)
+    clf = ElasticNet(alpha=0.5, l1_ratio=0.5)
     clf.fit(X, Y)
     pred = clf.predict(T)
     assert_array_almost_equal(clf.coef_, [0.45454], 3)
@@ -151,7 +152,7 @@ def _test_sparse_enet_not_as_toy_dataset(alpha, fit_intercept, positive):
     X_train, X_test = X[n_samples / 2:], X[:n_samples / 2]
     y_train, y_test = y[n_samples / 2:], y[:n_samples / 2]
 
-    s_clf = ElasticNet(alpha=alpha, rho=0.8, fit_intercept=fit_intercept,
+    s_clf = ElasticNet(alpha=alpha, l1_ratio=0.8, fit_intercept=fit_intercept,
                        max_iter=max_iter, tol=1e-7, positive=positive,
                        warm_start=True)
     s_clf.fit(X_train, y_train)
@@ -160,7 +161,7 @@ def _test_sparse_enet_not_as_toy_dataset(alpha, fit_intercept, positive):
     assert_greater(s_clf.score(X_test, y_test), 0.85)
 
     # check the convergence is the same as the dense version
-    d_clf = ElasticNet(alpha=alpha, rho=0.8, fit_intercept=fit_intercept,
+    d_clf = ElasticNet(alpha=alpha, l1_ratio=0.8, fit_intercept=fit_intercept,
                       max_iter=max_iter, tol=1e-7, positive=positive,
                       warm_start=True)
     d_clf.fit(X_train.todense(), y_train)
@@ -247,8 +248,8 @@ def test_path_parameters():
     max_iter = 50
     n_alphas = 10
     clf = ElasticNetCV(n_alphas=n_alphas, eps=1e-3, max_iter=max_iter,
-                       rho=0.5, fit_intercept=False)
+                       l1_ratio=0.5, fit_intercept=False)
     clf.fit(X, y)  # new params
-    assert_almost_equal(0.5, clf.rho)
+    assert_almost_equal(0.5, clf.l1_ratio)
     assert_equal(n_alphas, clf.n_alphas)
     assert_equal(n_alphas, len(clf.alphas_))


### PR DESCRIPTION
Renaming rho in ElasticNet and SGD to l1_ratio to get them to be the same.
Closes #1139.
