### PR TITLE
MRG: Spectral fix

### DIFF
--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -15,22 +15,22 @@ from ..neighbors import kneighbors_graph
 from .k_means_ import k_means
 
 def _set_diag(laplacian, value):
-    """ Set the diagonal of the laplacian matrix and convert it to a
-        sparse format well suited for eigenvalue decomposition
+    """Set the diagonal of the laplacian matrix and convert it to a
+    sparse format well suited for eigenvalue decomposition
 
-        Parameters
-        ==========
-        laplacian: array or sparse matrix
-            The graph laplacian
-        value: float
-            The value of the diagonal
+    Parameters
+    ----------
+    laplacian: array or sparse matrix
+        The graph laplacian
+    value: float
+        The value of the diagonal
 
-        Returns
-        =======
-        laplacian: array of sparse matrix
-            An array of matrix in a form that is well suited to fast
-            eigenvalue decomposition, depending on the band width of the
-            matrix.
+    Returns
+    -------
+    laplacian: array of sparse matrix
+        An array of matrix in a form that is well suited to fast
+        eigenvalue decomposition, depending on the band width of the
+        matrix.
     """
     from scipy import sparse
     n_nodes = laplacian.shape[0]
@@ -161,7 +161,6 @@ def spectral_embedding(adjacency, n_components=8, mode=None,
         ml = smoothed_aggregation_solver(laplacian.tocsr())
         M = ml.aspreconditioner()
         X = random_state.rand(laplacian.shape[0], n_components)
-        #X[:, 0] = 1. / dd.ravel()
         X[:, 0] = dd.ravel()
         lambdas, diffusion_map = lobpcg(laplacian, X, M=M, tol=1.e-12,
                                         largest=False)

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -125,8 +125,9 @@ def spectral_embedding(adjacency, n_components=8, mode=None,
     laplacian, dd = graph_laplacian(adjacency,
                                     normed=True, return_diag=True)
     if (mode == 'arpack'
-        or mode != 'lobpcg' and (not sparse.isspmatrix(laplacian)
-        or n_nodes < 5 * n_components)):
+        or mode != 'lobpcg' and
+            (not sparse.isspmatrix(laplacian)
+             or n_nodes < 5 * n_components)):
         # lobpcg used with mode='amg' has bugs for low number of nodes
         laplacian = _set_diag(laplacian, 0)
 

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -6,13 +6,13 @@ import warnings
 
 import numpy as np
 
-
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import check_random_state
 from ..utils.graph import graph_laplacian
 from ..metrics.pairwise import rbf_kernel
 from ..neighbors import kneighbors_graph
 from .k_means_ import k_means
+
 
 def _set_diag(laplacian, value):
     """Set the diagonal of the laplacian matrix and convert it to a

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -149,8 +149,7 @@ def spectral_embedding(adjacency, n_components=8, mode=None,
         X = random_state.rand(laplacian.shape[0], n_components + 4)
         X[:, 0] = 1. / dd.ravel()
         lambdas, diffusion_map = lobpcg(laplacian, X, tol=1e-15,
-                                        largest=False, maxiter=2000,
-                                        verbosityLevel=20)
+                                        largest=False, maxiter=2000)
         embedding = diffusion_map.T[:n_components] * dd
         if embedding.shape[0] == 1:
             raise ValueError

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -25,21 +25,22 @@ def test_spectral_clustering():
                   [0, 0, 0, 1, 2, 4, 1],
                  ])
 
-    for mat in (S, sparse.csr_matrix(S)):
-        model = SpectralClustering(random_state=0, n_clusters=2,
-                affinity='precomputed').fit(mat)
-        labels = model.labels_
-        if labels[0] == 0:
-            labels = 1 - labels
+    for mode in ('arpack', 'lobpcg'):
+        for mat in (S, sparse.csr_matrix(S)):
+            model = SpectralClustering(random_state=0, n_clusters=2,
+                    affinity='precomputed', mode=mode).fit(mat)
+            labels = model.labels_
+            if labels[0] == 0:
+                labels = 1 - labels
 
-        assert_equal(labels, [1, 1, 1, 0, 0, 0, 0])
+            assert_equal(labels, [1, 1, 1, 0, 0, 0, 0])
 
-        model_copy = loads(dumps(model))
-        assert_equal(model_copy.n_clusters, model.n_clusters)
-        assert_equal(model_copy.mode, model.mode)
-        assert_equal(model_copy.random_state.get_state(),
-                     model.random_state.get_state())
-        assert_equal(model_copy.labels_, model.labels_)
+            model_copy = loads(dumps(model))
+            assert_equal(model_copy.n_clusters, model.n_clusters)
+            assert_equal(model_copy.mode, model.mode)
+            assert_equal(model_copy.random_state.get_state(),
+                        model.random_state.get_state())
+            assert_equal(model_copy.labels_, model.labels_)
 
 
 def test_spectral_amg_mode():

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -90,7 +90,6 @@ def test_spectral_unknown_mode():
 def test_spectral_clustering_sparse():
     # We need a large matrice, or the lobpcg solver will fallback to its
     # non-sparse and buggy mode
-    raise nose.SkipTest("XFailed Test")
     S = np.array([[1, 5, 2, 2, 1, 0, 0, 0, 0, 0],
                   [5, 1, 3, 2, 1, 0, 0, 0, 0, 0],
                   [2, 3, 1, 1, 1, 0, 0, 0, 0, 0],


### PR DESCRIPTION
Fixes to numerical stability in spectral embedding.

The key to the numerical stability is to avoid arpack when it fails and switch to lobpcg or symeig depending on the size of the problem.
