### PR TITLE
add dual_gap_ and eps_ to Enet and Lasso docstring 

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -112,10 +112,11 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     `dual_gap_` : float
         the current fit is guaranteed to be epsilon-suboptimal with
-        epsilon := dual_gap_
+        epsilon := `dual_gap_`
 
     `eps_` : float
-        eps_ := tol * norm(y, 2)^2
+        `eps_` is used to check if the fit converged to the requested
+        `tol`
 
     Notes
     -----
@@ -398,10 +399,11 @@ class Lasso(ElasticNet):
 
     `dual_gap_` : float
         the current fit is guaranteed to be epsilon-suboptimal with
-        epsilon := dual_gap_
+        epsilon := `dual_gap_`
 
     `eps_` : float
-        eps_ := tol * norm(y, 2)^2
+        `eps_` is used to check if the fit converged to the requested
+        `tol`
 
     Examples
     --------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -110,6 +110,13 @@ class ElasticNet(LinearModel, RegressorMixin):
     `intercept_` : float | array, shape = (n_targets,)
         independent term in decision function.
 
+    `dual_gap_` : float
+        the current fit is guaranteed to be epsilon-suboptimal with
+        epsilon := dual_gap_
+
+    `eps_` : float
+        eps_ := tol * norm(y, 2)^2
+
     Notes
     -----
     To avoid unnecessary memory duplication the X argument of the fit method
@@ -388,6 +395,13 @@ class Lasso(ElasticNet):
 
     `intercept_` : float
         independent term in decision function.
+
+    `dual_gap_` : float
+        the current fit is guaranteed to be epsilon-suboptimal with
+        epsilon := dual_gap_
+
+    `eps_` : float
+        eps_ := tol * norm(y, 2)^2
 
     Examples
     --------


### PR DESCRIPTION
I think `dual_gap_` can be interesting for the user and should therefore
be mentioned in the docstring.

I'm not so sure about the usefulness of `eps_`:

```
    `eps_` : float
        eps_ := tol * norm(y, 2)^2
```

Why is `eps_` not just a local variable? It appear to me that it's 
only used once to check if the solver converged with required tol (L234).

Best, 
Immanuel
