### PR TITLE
ENH: Consider order in X for IsotonicRegression.

### DIFF
--- a/sklearn/linear_model/__init__.py
+++ b/sklearn/linear_model/__init__.py
@@ -26,7 +26,7 @@ from .omp import orthogonal_mp, orthogonal_mp_gram, OrthogonalMatchingPursuit
 from .perceptron import Perceptron
 from .randomized_l1 import RandomizedLasso, RandomizedLogisticRegression, \
                            lasso_stability_path
-from .isotonic_regression_ import IsotonicRegression
+from .isotonic_regression_ import IsotonicRegression, isotonic_regression
 
 __all__ = ['ARDRegression',
            'BayesianRidge',

--- a/sklearn/linear_model/isotonic_regression_.py
+++ b/sklearn/linear_model/isotonic_regression_.py
@@ -104,11 +104,13 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     The isotonic regression optimization problem is defined by::
         min sum w_i (y[i] - y_[i]) ** 2
 
-        subject to y_min = y_[1] <= y_[2] ... <= y_[n] = y_max
+        subject to y_[i] <= y_[j] whenever X[i] <= X[j]
+        and min(y_) = y_min, max(y_) = y_max
 
     where:
         - y[i] are inputs (real numbers)
         - y_[i] are fitted
+        - X specifies the order. If X is non-decreasing then y_ is non-decreasing.
         - w[i] are optional strictly positive weights (default to 1.0)
 
     Parameters
@@ -172,7 +174,11 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         y = as_float_array(y)
         self.X_ = as_float_array(X, copy=True)
         self._check_fit_data(self.X_, y, weight)
-        self.y_ = isotonic_regression(y, weight, self.y_min, self.y_max)
+        order = np.argsort(X)
+        order_inv = np.zeros(len(y), dtype=np.int)
+        order_inv[order] = np.arange(len(y))
+        result = isotonic_regression(y[order], weight, self.y_min, self.y_max)
+        self.y_ = result[order_inv]
         return self
 
     def transform(self, T):
@@ -192,8 +198,9 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if len(T.shape) != 1:
             raise ValueError("X should be a vector")
 
-        f = interpolate.interp1d(self.X_, self.y_, kind='linear',
-                                 bounds_error=True)
+        order = np.argsort(self.X_)
+        f = interpolate.interp1d(self.X_[order], self.y_[order], 
+            kind='linear', bounds_error=True)
         return f(T)
 
     def fit_transform(self, X, y, weight=None):

--- a/sklearn/linear_model/isotonic_regression_.py
+++ b/sklearn/linear_model/isotonic_regression_.py
@@ -161,14 +161,13 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         Returns
         -------
-        self; object
+        self: object
             returns an instance of self
 
         Note
         ----
-        X doesn't influence the result of `fit`. It is however stored
-        for future use, as `transform` needs X to interpolate new
-        input data.
+        X is stored for future use, as `transform` needs X to interpolate
+        new input data.
         """
         X, y, weight = check_arrays(X, y, weight, sparse_format='dense')
         y = as_float_array(y)
@@ -199,7 +198,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             raise ValueError("X should be a vector")
 
         order = np.argsort(self.X_)
-        f = interpolate.interp1d(self.X_[order], self.y_[order], 
+        f = interpolate.interp1d(self.X_[order], self.y_[order],
             kind='linear', bounds_error=True)
         return f(T)
 

--- a/sklearn/linear_model/tests/test_isotonic_regression.py
+++ b/sklearn/linear_model/tests/test_isotonic_regression.py
@@ -18,13 +18,12 @@ def test_isotonic_regression():
     assert_array_equal(ir.fit(x, y).transform(x), ir.fit_transform(x, y))
     assert_array_equal(ir.transform(x), ir.predict(x))
 
-    # check the same thing but permute the order
+    # check that it is immune to permutation
     perm = np.random.permutation(len(y))
-    x, y = x[perm], y[perm]
     ir = IsotonicRegression(y_min=0., y_max=1.)
-    ir.fit(x, y)
-    assert_array_equal(ir.fit(x, y).transform(x), ir.fit_transform(x, y))
-    assert_array_equal(ir.transform(x), ir.predict(x))
+    assert_array_equal(ir.fit(x[perm], y[perm]).y_, ir.fit(x, y).y_[perm])
+    assert_array_equal(ir.transform(x[perm]), ir.transform(x)[perm])
+
 
 def test_assert_raises_exceptions():
     ir = IsotonicRegression()

--- a/sklearn/linear_model/tests/test_isotonic_regression.py
+++ b/sklearn/linear_model/tests/test_isotonic_regression.py
@@ -21,7 +21,7 @@ def test_isotonic_regression():
     # check that it is immune to permutation
     perm = np.random.permutation(len(y))
     ir = IsotonicRegression(y_min=0., y_max=1.)
-    assert_array_equal(ir.fit(x[perm], y[perm]).y_, ir.fit(x, y).y_[perm])
+    assert_array_equal(ir.fit_transform(x[perm], y[perm]), ir.fit_transform(x, y)[perm])
     assert_array_equal(ir.transform(x[perm]), ir.transform(x)[perm])
 
 

--- a/sklearn/linear_model/tests/test_isotonic_regression.py
+++ b/sklearn/linear_model/tests/test_isotonic_regression.py
@@ -18,6 +18,13 @@ def test_isotonic_regression():
     assert_array_equal(ir.fit(x, y).transform(x), ir.fit_transform(x, y))
     assert_array_equal(ir.transform(x), ir.predict(x))
 
+    # check the same thing but permute the order
+    perm = np.random.permutation(len(y))
+    x, y = x[perm], y[perm]
+    ir = IsotonicRegression(y_min=0., y_max=1.)
+    ir.fit(x, y)
+    assert_array_equal(ir.fit(x, y).transform(x), ir.fit_transform(x, y))
+    assert_array_equal(ir.transform(x), ir.predict(x))
 
 def test_assert_raises_exceptions():
     ir = IsotonicRegression()


### PR DESCRIPTION
Before, IsotonicRegression assumed X was an increasing sequence. This
allows to shuffle both X, y (see the test) and obtain the same
result. This makes IsotonicRegression behave more like a standard
Regression (which is what I would expect).
