### PR TITLE
Fix issue #1239 confusion matrix fails when y_pred,y_true contains unexpected labels(not-exist in labels)

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -65,12 +65,13 @@ def confusion_matrix(y_true, y_pred, labels=None):
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
     # convert yt, yp into index
-    y_pred = np.array([label_to_ind[x] for x in y_pred])
-    y_true = np.array([label_to_ind[x] for x in y_true])
+    y_pred = np.array([label_to_ind.get(x,n_labels+1) for x in y_pred])
+    y_true = np.array([label_to_ind.get(x,n_labels+1) for x in y_true])
 
-    # intersect y_pred, y_true with labels
-    y_pred = y_pred[y_pred < n_labels]
-    y_true = y_true[y_true < n_labels]
+    # intersect y_pred, y_true with labels, eliminate items not in labels
+    ind = np.logical_and(y_pred < n_labels, y_true < n_labels)
+    y_pred = y_pred[ind]
+    y_true = y_true[ind]
 
     CM = np.asarray(coo_matrix((np.ones(y_true.shape[0]),
                                     (y_true, y_pred)),

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -65,8 +65,8 @@ def confusion_matrix(y_true, y_pred, labels=None):
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
     # convert yt, yp into index
-    y_pred = np.array([label_to_ind.get(x,n_labels+1) for x in y_pred])
-    y_true = np.array([label_to_ind.get(x,n_labels+1) for x in y_true])
+    y_pred = np.array([label_to_ind.get(x, n_labels + 1) for x in y_pred])
+    y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])
 
     # intersect y_pred, y_true with labels, eliminate items not in labels
     ind = np.logical_and(y_pred < n_labels, y_true < n_labels)

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -299,16 +299,17 @@ def test_confusion_matrix_multiclass():
                             [5, 20,  5]])
 
 
-def test_confusion_matrix_multiclass_nonexist_label():
-    """Test confusion matrix - multi-class case with non-existing labels"""
+def test_confusion_matrix_multiclass_subset_labels():
+    """Test confusion matrix - multi-class case with subset of labels"""
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    # compute confusion matrix with default labels introspection
+    # compute confusion matrix with only first two labels considered
     cm = confusion_matrix(y_true, y_pred, labels=[0, 1])
     assert_array_equal(cm, [[23, 2],
                             [5,  5]])
 
-    # compute confusion matrix with explicit label ordering
+    # compute confusion matrix with explicit label ordering for only subset
+    # of labels
     cm = confusion_matrix(y_true, y_pred, labels=[2, 1])
     assert_array_equal(cm, [[18,  2],
                             [20,  5]])

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -299,6 +299,21 @@ def test_confusion_matrix_multiclass():
                             [5, 20,  5]])
 
 
+def test_confusion_matrix_multiclass_nonexist_label():
+    """Test confusion matrix - multi-class case with non-existing labels"""
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    # compute confusion matrix with default labels introspection
+    cm = confusion_matrix(y_true, y_pred, labels=[0, 1])
+    assert_array_equal(cm, [[23, 2],
+                            [5,  5]])
+
+    # compute confusion matrix with explicit label ordering
+    cm = confusion_matrix(y_true, y_pred, labels=[2, 1])
+    assert_array_equal(cm, [[18,  2],
+                            [20,  5]])
+
+
 def test_classification_report():
     """Test performance report"""
     iris = datasets.load_iris()
@@ -387,9 +402,9 @@ def test_symmetry():
     assert_almost_equal(mean_squared_error(y_true, y_pred),
                         mean_squared_error(y_pred, y_true))
     # not symmetric
-    assert_true(explained_variance_score(y_true, y_pred) != \
+    assert_true(explained_variance_score(y_true, y_pred) !=
             explained_variance_score(y_pred, y_true))
-    assert_true(r2_score(y_true, y_pred) != \
+    assert_true(r2_score(y_true, y_pred) !=
             r2_score(y_pred, y_true))
     # FIXME: precision and recall aren't symmetric either
 


### PR DESCRIPTION
The issue #1239 is from when `y_pred` or `y_true` contains unexpected labels not present in `labels`. The problem comes occurs labels is explicitly given rather than calculated from `y_pred` and `y_true`. 

As the docstring says, the returned matrix should be `[n_classes, n_classes]` where `n_classes` is equal to shape of `labels`, so the fix is just eliminate the labels not exist in `labels`. A test is added to address this issue.
