### PR TITLE
BF: GridSearchCV + unsupervised covariance shrinkage selection (example).

### DIFF
--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -80,7 +80,7 @@ shrunk} = (1-\alpha)\hat{\Sigma} + \alpha\frac{{\rm
 Tr}\hat{\Sigma}}{p}\rm Id`.  
 
 Choosing the amount of shrinkage, :math:`\alpha` amounts to setting a
-bias/variance tradeoff, and is discussed below.
+bias/variance trade-off, and is discussed below.
 
 .. topic:: Examples:
 
@@ -135,7 +135,7 @@ object to the same sample.
    :align: center
    :scale: 65%
 
-   Bias-variance tradeoff when setting the shrinkage: comparing the
+   Bias-variance trade-off when setting the shrinkage: comparing the
    choices of Ledoit-Wolf and OAS estimators
 
 [2] Chen et al., "Shrinkage Algorithms for MMSE Covariance Estimation",
@@ -269,7 +269,7 @@ Minimum Covariance Determinant
 ------------------------------
 
 The Minimum Covariance Determinant estimator is a robust estimator of
-a data set's covariance introduced by P.J.Rousseuw in [3].  The idea
+a data set's covariance introduced by P.J.Rousseeuw in [3].  The idea
 is to find a given proportion (h) of "good" observations which are not
 outliers and compute their empirical covariance matrix.  This
 empirical covariance matrix is then rescaled to compensate the
@@ -279,7 +279,7 @@ weights to observations according to their Mahalanobis distance,
 leading the a reweighted estimate of the covariance matrix of the data
 set ("reweighting step").
 
-Rousseuw and Van Driessen [4] developed the FastMCD algorithm in order
+Rousseeuw and Van Driessen [4] developed the FastMCD algorithm in order
 to compute the Minimum Covariance Determinant. This algorithm is used
 in scikit-learn when fitting an MCD object to data. The FastMCD
 algorithm also computes a robust estimate of the data set location at
@@ -321,7 +321,7 @@ ____
     :header-rows: 1
 
     * - Influence of outliers on location and covariance estimates
-      - Separating inliers from outliers using a Mahalonis distance
+      - Separating inliers from outliers using a Mahalanobis distance
 
     * - |robust_vs_emp|
       - |mahalanobis|

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -45,6 +45,8 @@ one may want to use the `assume_centered` parameter accurately.
      to data.
 
 
+.. _shrunk_covariance:
+
 Shrunk Covariance
 =================
 
@@ -57,24 +59,28 @@ eigenvalues of the covariance matrix, so the precision matrix obtained
 from its inversion is not accurate. Sometimes, it even occurs that the
 empirical covariance matrix cannot be inverted for numerical
 reasons. To avoid such an inversion problem, a transformation of the
-empirical covariance matrix has been introduced: the `shrinkage`. It
-consists in reducing the ratio between the smallest and the largest
-eigenvalue of the empirical covariance matrix. This can be done by
-simply shifting every eigenvalue according to a given offset, which is
-equivalent of finding the l2-penalized Maximum Likelihood Estimator of
-the covariance matrix, or by reducing the highest eigenvalue while
-increasing the smallest with the help of a convex transformation :
-:math:`\Sigma_{\rm shrunk} = (1-\alpha)\hat{\Sigma} +
-\alpha\frac{{\rm Tr}\hat{\Sigma}}{p}\rm Id`.  The latter approach has been
-implemented in scikit-learn.
+empirical covariance matrix has been introduced: the `shrinkage`. 
 
-A convex transformation (with a user-defined shrinkage coefficient)
-can be directly applied to a pre-computed covariance with the
-:func:`shrunk_covariance` method. Also, a shrunk estimator of the
-covariance can be fitted to data with a :class:`ShrunkCovariance`
-object and its :meth:`ShrunkCovariance.fit` method.  Again, depending
-whether the data are centered or not, the result will be different, so
-one may want to use the `assume_centered` parameter accurately.
+In the scikit-learn, this transformation (with a user-defined shrinkage
+coefficient) can be directly applied to a pre-computed covariance with
+the :func:`shrunk_covariance` method. Also, a shrunk estimator of the
+covariance can be fitted to data with a :class:`ShrunkCovariance` object
+and its :meth:`ShrunkCovariance.fit` method.  Again, depending whether
+the data are centered or not, the result will be different, so one may
+want to use the `assume_centered` parameter accurately.
+
+
+Mathematically, this shrinkage consists in reducing the ratio between the
+smallest and the largest eigenvalue of the empirical covariance matrix.
+It can be done by simply shifting every eigenvalue according to a given
+offset, which is equivalent of finding the l2-penalized Maximum
+Likelihood Estimator of the covariance matrix. In practice, shrinkage
+boils down to a simple a convex transformation : :math:`\Sigma_{\rm
+shrunk} = (1-\alpha)\hat{\Sigma} + \alpha\frac{{\rm
+Tr}\hat{\Sigma}}{p}\rm Id`.  
+
+Choosing the amount of shrinkage, :math:`\alpha` amounts to setting a
+bias/variance tradeoff, and is discussed below.
 
 .. topic:: Examples:
 
@@ -89,16 +95,12 @@ Ledoit-Wolf shrinkage
 In their 2004 paper [1], O. Ledoit and M. Wolf propose a formula so as
 to compute the optimal shrinkage coefficient :math:`\alpha` that
 minimizes the Mean Squared Error between the estimated and the real
-covariance matrix in terms of Frobenius norm.
+covariance matrix in.
 
 The Ledoit-Wolf estimator of the covariance matrix can be computed on
 a sample with the :meth:`ledoit_wolf` function of the
 `sklearn.covariance` package, or it can be otherwise obtained by
 fitting a :class:`LedoitWolf` object to the same sample.
-
-[1] O. Ledoit and M. Wolf, "A Well-Conditioned Estimator for Large-Dimensional
-    Covariance Matrices", Journal of Multivariate Analysis, Volume 88, Issue 2,
-    February 2004, pages 365-411.
 
 .. topic:: Examples:
 
@@ -107,11 +109,10 @@ fitting a :class:`LedoitWolf` object to the same sample.
      for visualizing the performances of the Ledoit-Wolf estimator in
      terms of likelihood.
 
-.. figure:: ../auto_examples/covariance/images/plot_covariance_estimation_1.png
-   :target: ../auto_examples/covariance/plot_covariance_estimation.html
-   :align: center
-   :scale: 65%
 
+[1] O. Ledoit and M. Wolf, "A Well-Conditioned Estimator for Large-Dimensional
+    Covariance Matrices", Journal of Multivariate Analysis, Volume 88, Issue 2,
+    February 2004, pages 365-411.
 
 .. _oracle_approximating_shrinkage:
 
@@ -127,11 +128,15 @@ Shrinkage Approximating estimator of the covariance.
 The OAS estimator of the covariance matrix can be computed on a sample
 with the :meth:`oas` function of the `sklearn.covariance`
 package, or it can be otherwise obtained by fitting an :class:`OAS`
-object to the same sample.  The formula we used to implement the OAS
-does not correspond to the one given in the article. It has been taken
-from the MATLAB program available from the author's webpage
-(https://tbayes.eecs.umich.edu/yilun/covestimation).
+object to the same sample.
 
+.. figure:: ../auto_examples/covariance/images/plot_covariance_estimation_1.png
+   :target: ../auto_examples/covariance/plot_covariance_estimation.html
+   :align: center
+   :scale: 65%
+
+   Bias-variance tradeoff when setting the shrinkage: comparing the
+   choices of Ledoit-Wolf and OAS estimators
 
 [2] Chen et al., "Shrinkage Algorithms for MMSE Covariance Estimation",
     IEEE Trans. on Sign. Proc., Volume 58, Issue 10, October 2010.
@@ -151,6 +156,7 @@ from the MATLAB program available from the author's webpage
    :target: ../auto_examples/covariance/plot_lw_vs_oas.html
    :align: center
    :scale: 75%
+
 
 .. _sparse_inverse_covariance:
 

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -1,50 +1,59 @@
 """
-===========================================
-Ledoit-Wolf vs Covariance simple estimation
-===========================================
+=======================================================================
+Shrinkage covariance estimation: LedoitWolf vs OAS and max-likelihood
+=======================================================================
 
-The usual covariance maximum likelihood estimator can be regularized
-in order to reduce its variance. This, in turn, introduces some bias.
-This example illustrates a regularization method called convex shrinkage that
-consists in replacing the maximum likelihood estimator by a convex
-combination of itself and an identity matrix (*). Various convex shrinkage-
-based covariance estimators are shown in the example.
+The usual estimator for covariance is the maximum likelihood estimator,
+:class:`sklearn.covariance.EmpiricalCovariance`. It is unbiased, i.e. it
+converges to the true (population) covariance when given many
+observations. However, it can also be beneficial to regularize it, in
+order to reduce its variance; this, in turn, introduces some bias. This
+example illustrates the simple regularization used in
+:ref:`shrunk_covariance` estimators. It particular, it focuses on how to
+set the amount of regularization, i.e. how to choose the bias-variance
+tradeoff.
 
-Ledoit and Wolf proposed a close formula to compute
-the asymptotical optimal shrinkage parameter (minimizing a MSE
-criterion), yielding the Ledoit-Wolf covariance estimate.
+Here we compare 3 approaches:
 
-Chen et al. proposed an improvement of the Ledoit-Wolf shrinkage
-parameter, the OAS coefficient, whose convergence is significantly
-better under the assumption that the data are gaussian.
+* Setting the parameter by cross-validating the likelihood on three folds
+  according to a grid of potential shrinkage parameters.
 
-In this example, we compute the likelihood of unseen data for
-different values of the shrinkage parameter, highlighting the LW and
-OAS estimates. The Ledoit-Wolf estimate stays close to the likelihood
-criterion optimal value, which is an artifact of the method since it
-is asymptotic and we are working with a small number of observations.
-The OAS estimate deviates from the likelihood criterion optimal value
-but better approximate the MSE optimal value, especially for a small
-number a observations.
-We also show the best shrunk estimate that we obtained by cross-validating
-the likelihood on three folds according to a grid of potential shrinkage
-parameters.
+* A close formula proposed by Ledoit and Wolf to compute
+  the asymptotical optimal regularization parameter (minimizing a MSE
+  criterion), yielding the :class:`sklearn.covariance.LedoitWolf`
+  covariance estimate.
 
-(*) Although any other structured target could be used instead, the
-identity matrix is the weakest assumption that can be made to regularize
-a covariance estimator.
+* An improvement of the Ledoit-Wolf shrinkage, the
+  :class:`sklearn.covariance.OAS`, proposed by Chen et al. Its
+  convergence is significantly better under the assumption that the data
+  are Gaussian, in particular for small samples.
 
+To quantify estimation error, we plot the likelihood of unseen data for
+different values of the shrinkage parameter. We also show the choices by
+cross-validation, or with the LedoitWolf and OAS estimates.
+
+Note that the maximum likelihood estimate corresponds to no shrinkage,
+and thus performs poorly. The Ledoit-Wolf estimate performs really well,
+as it is close to the optimal and is computational not costly. In this
+example, the OAS estimate is a bit further away. Interestingly, both
+approaches outperform cross-validation, which is significantly most
+computationally costly.
 """
 print __doc__
 
 import numpy as np
 import pylab as pl
 from scipy import linalg
-from matplotlib.patches import Polygon
+
+from sklearn.covariance import LedoitWolf, OAS, ShrunkCovariance, \
+    log_likelihood, empirical_covariance
+from sklearn.grid_search import GridSearchCV
+
 
 ###############################################################################
 # Generate sample data
-n_features, n_samples = 30, 20
+n_features, n_samples = 40, 20
+np.random.seed(42)
 base_X_train = np.random.normal(size=(n_samples, n_features))
 base_X_test = np.random.normal(size=(n_samples, n_features))
 
@@ -54,11 +63,26 @@ X_train = np.dot(base_X_train, coloring_matrix)
 X_test = np.dot(base_X_test, coloring_matrix)
 
 ###############################################################################
-# Compute Ledoit-Wolf and Covariances on a grid of shrinkages
+# Compute the likelihood on test data
 
-from sklearn.covariance import LedoitWolf, OAS, ShrunkCovariance, \
-    log_likelihood, empirical_covariance
-from sklearn.grid_search import GridSearchCV
+# spanning a range of possible shrinkage coefficient values
+shrinkages = np.logspace(-2, 0, 30)
+negative_logliks = [-ShrunkCovariance(shrinkage=s).fit(X_train).score(X_test)
+                     for s in shrinkages]
+
+# under the ground-truth model, which we would not have access to in real
+# settings
+real_cov = np.dot(coloring_matrix.T, coloring_matrix)
+emp_cov = empirical_covariance(X_train)
+loglik_real = -log_likelihood(emp_cov, linalg.inv(real_cov))
+
+###############################################################################
+# Compare different approaches to setting the parameter
+
+# GridSearch for an optimal shrinkage coefficient
+tuned_parameters = [{'shrinkage': shrinkages}]
+cv = GridSearchCV(ShrunkCovariance(), tuned_parameters)
+cv.fit(X_train)
 
 # Ledoit-Wolf optimal shrinkage coefficient estimate
 lw = LedoitWolf()
@@ -68,36 +92,17 @@ loglik_lw = lw.fit(X_train).score(X_test)
 oa = OAS()
 loglik_oa = oa.fit(X_train).score(X_test)
 
-# spanning a range of possible shrinkage coefficient values
-shrinkages = np.logspace(-2, 0, 30)
-negative_logliks = [-ShrunkCovariance(shrinkage=s).fit(X_train).score(X_test)
-                     for s in shrinkages]
-
-# GridSearch for an optimal shrinkage coefficient
-tuned_parameters = [{'shrinkage': shrinkages}]
-cv = GridSearchCV(ShrunkCovariance(), tuned_parameters)
-cv.fit(X_train)
-
-# getting the likelihood under the real model
-real_cov = np.dot(coloring_matrix.T, coloring_matrix)
-emp_cov = empirical_covariance(X_train)
-loglik_real = -log_likelihood(emp_cov, linalg.inv(real_cov))
-
 ###############################################################################
 # Plot results
 fig = pl.figure()
 pl.title("Regularized covariance: likelihood and shrinkage coefficient")
-pl.xlabel('Shrinkage')
-pl.ylabel('Negative log-likelihood')
+pl.xlabel('Regularizaton parameter: shrinkage coefficient')
+pl.ylabel('Error: negative log-likelihood on test data')
 # range shrinkage curve
 pl.loglog(shrinkages, negative_logliks, label="Negative log-likelihood")
 
-# real likelihood reference
-# BUG: hlines(..., linestyle='--') breaks on some older versions of matplotlib
-#pl.hlines(loglik_real, pl.xlim()[0], pl.xlim()[1], color='red',
-#          label="real covariance likelihood", linestyle='--')
 pl.plot(pl.xlim(), 2 * [loglik_real], '--r',
-        label="real covariance likelihood")
+        label="Real covariance likelihood")
 
 # adjust view
 lik_max = np.amax(negative_logliks)

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -20,6 +20,9 @@ is asymptotic and we are working with a small number of observations.
 The OAS estimate deviates from the likelihood criterion optimal value
 but better approximate the MSE optimal value, especially for a small
 number a observations.
+We also show the best shrunk estimate that we obtained by cross-validating
+the likelihood on three folds according to a grid of potential shrinkage
+parameters.
 
 """
 print __doc__
@@ -77,7 +80,7 @@ pl.title("Regularized covariance: likelihood and shrinkage coefficient")
 pl.xlabel('Shrinkage')
 pl.ylabel('Negative log-likelihood')
 # range shrinkage curve
-pl.loglog(shrinkages, negative_logliks)
+pl.loglog(shrinkages, negative_logliks, label="Negative log-likelihood")
 
 # real likelihood reference
 # BUG: hlines(..., linestyle='--') breaks on some older versions of matplotlib
@@ -116,9 +119,9 @@ ylim1_zoom = negative_logliks[np.argmin(np.abs(shrinkages - xlim0_zoom))]
 art = Polygon(
     np.asarray([
             [10 ** (0.57 * np.log10(xlim1 / xlim0) + np.log10(xlim0)),
-             10 ** (0.35 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
+             10 ** (0.3 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
             [10 ** (0.92 * np.log10(xlim1 / xlim0) + np.log10(xlim0)),
-             10 ** (0.35 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
+             10 ** (0.3 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
             [xlim1_zoom, ylim1_zoom], [xlim0_zoom, ylim1_zoom]]),
     color="#eeeeee")
 pl.axes().add_artist(art)
@@ -129,7 +132,7 @@ art2 = Polygon(
     facecolor="#eeeeee", edgecolor="#aaaaaa", linewidth=2)
 pl.axes().add_artist(art2)
 
-fig.add_axes([0.57, 0.35, 0.3, 0.3], axis_bgcolor="#eeeeee")
+fig.add_axes([0.57, 0.3, 0.3, 0.3], axis_bgcolor="#eeeeee")
 pl.loglog(shrinkages, negative_logliks)
 pl.plot(pl.xlim(), 2 * [loglik_real], '--r')
 pl.vlines(lw.shrinkage_, ylim0, -loglik_lw, color='magenta', linewidth=3)

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -9,9 +9,9 @@ converges to the true (population) covariance when given many
 observations. However, it can also be beneficial to regularize it, in
 order to reduce its variance; this, in turn, introduces some bias. This
 example illustrates the simple regularization used in
-:ref:`shrunk_covariance` estimators. It particular, it focuses on how to
+:ref:`shrunk_covariance` estimators. In particular, it focuses on how to
 set the amount of regularization, i.e. how to choose the bias-variance
-tradeoff.
+trade-off.
 
 Here we compare 3 approaches:
 
@@ -38,6 +38,7 @@ as it is close to the optimal and is computational not costly. In this
 example, the OAS estimate is a bit further away. Interestingly, both
 approaches outperform cross-validation, which is significantly most
 computationally costly.
+
 """
 print __doc__
 

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -3,8 +3,14 @@
 Ledoit-Wolf vs Covariance simple estimation
 ===========================================
 
-The usual covariance maximum likelihood estimate can be regularized
-using shrinkage. Ledoit and Wolf proposed a close formula to compute
+The usual covariance maximum likelihood estimator can be regularized
+in order to reduce its variance. This, in turn, introduces some bias.
+This example illustrates a regularization method called convex shrinkage that
+consists in replacing the maximum likelihood estimator by a convex
+combination of itself and an identity matrix (*). Various convex shrinkage-
+based covariance estimators are shown in the example.
+
+Ledoit and Wolf proposed a close formula to compute
 the asymptotical optimal shrinkage parameter (minimizing a MSE
 criterion), yielding the Ledoit-Wolf covariance estimate.
 
@@ -23,6 +29,10 @@ number a observations.
 We also show the best shrunk estimate that we obtained by cross-validating
 the likelihood on three folds according to a grid of potential shrinkage
 parameters.
+
+(*) Although any other structured target could be used instead, the
+identity matrix is the weakest assumption that can be made to regularize
+a covariance estimator.
 
 """
 print __doc__
@@ -59,7 +69,7 @@ oa = OAS()
 loglik_oa = oa.fit(X_train).score(X_test)
 
 # spanning a range of possible shrinkage coefficient values
-shrinkages = np.logspace(-3, 0, 30)
+shrinkages = np.logspace(-2, 0, 30)
 negative_logliks = [-ShrunkCovariance(shrinkage=s).fit(X_train).score(X_test)
                      for s in shrinkages]
 
@@ -92,56 +102,23 @@ pl.plot(pl.xlim(), 2 * [loglik_real], '--r',
 # adjust view
 lik_max = np.amax(negative_logliks)
 lik_min = np.amin(negative_logliks)
-ylim0 = lik_min - 5. * np.log((pl.ylim()[1] - pl.ylim()[0]))
-ylim1 = lik_max + 10. * np.log(lik_max - lik_min)
-xlim0 = shrinkages[0]
-xlim1 = shrinkages[-1]
+ymin = lik_min - 6. * np.log((pl.ylim()[1] - pl.ylim()[0]))
+ymax = lik_max + 10. * np.log(lik_max - lik_min)
+xmin = shrinkages[0]
+xmax = shrinkages[-1]
 # LW likelihood
-pl.vlines(lw.shrinkage_, ylim0, -loglik_lw, color='magenta',
+pl.vlines(lw.shrinkage_, ymin, -loglik_lw, color='magenta',
           linewidth=3, label='Ledoit-Wolf estimate')
 # OAS likelihood
-pl.vlines(oa.shrinkage_, ylim0, -loglik_oa, color='purple',
+pl.vlines(oa.shrinkage_, ymin, -loglik_oa, color='purple',
           linewidth=3, label='OAS estimate')
 # best CV estimator likelihood
-pl.vlines(cv.best_estimator_.shrinkage, ylim0,
+pl.vlines(cv.best_estimator_.shrinkage, ymin,
           -cv.best_estimator_.score(X_test), color='cyan',
           linewidth=3, label='Cross-validation best estimate')
 
-pl.ylim(ylim0, ylim1)
-pl.xlim(xlim0, xlim1)
+pl.ylim(ymin, ymax)
+pl.xlim(xmin, xmax)
 pl.legend()
-
-# Zoom on interesting part
-xlim0_zoom = shrinkages[-0.25 * shrinkages.size]
-xlim1_zoom = shrinkages[-1]
-ylim0_zoom = loglik_real - 5
-ylim1_zoom = negative_logliks[np.argmin(np.abs(shrinkages - xlim0_zoom))]
-art = Polygon(
-    np.asarray([
-            [10 ** (0.57 * np.log10(xlim1 / xlim0) + np.log10(xlim0)),
-             10 ** (0.3 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
-            [10 ** (0.92 * np.log10(xlim1 / xlim0) + np.log10(xlim0)),
-             10 ** (0.3 * np.log10(ylim1 / ylim0) + np.log10(ylim0))],
-            [xlim1_zoom, ylim1_zoom], [xlim0_zoom, ylim1_zoom]]),
-    color="#eeeeee")
-pl.axes().add_artist(art)
-
-art2 = Polygon(
-    np.asarray([[xlim0_zoom, ylim1_zoom], [xlim1_zoom, ylim1_zoom],
-                [xlim1_zoom, ylim0_zoom], [xlim0_zoom, ylim0_zoom]]),
-    facecolor="#eeeeee", edgecolor="#aaaaaa", linewidth=2)
-pl.axes().add_artist(art2)
-
-fig.add_axes([0.57, 0.3, 0.3, 0.3], axis_bgcolor="#eeeeee")
-pl.loglog(shrinkages, negative_logliks)
-pl.plot(pl.xlim(), 2 * [loglik_real], '--r')
-pl.vlines(lw.shrinkage_, ylim0, -loglik_lw, color='magenta', linewidth=3)
-pl.vlines(oa.shrinkage_, ylim0, -loglik_oa, color='purple', linewidth=3)
-pl.vlines(cv.best_estimator_.shrinkage, ylim0,
-          -cv.best_estimator_.score(X_test), color='cyan', linewidth=3)
-pl.xticks([])
-pl.yticks([])
-pl.ylim(ylim0_zoom, ylim1_zoom)
-pl.xlim(xlim0_zoom, xlim1_zoom)
 
 pl.show()

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -132,15 +132,16 @@ class EmpiricalCovariance(BaseEstimator):
             precision = pinvh(self.covariance_)
         return precision
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """Fits the Maximum Likelihood Estimator covariance model
         according to the given training data and parameters.
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Training data, where n_samples is the number of samples and
-            n_features is the number of features.
+        X: array-like, shape = [n_samples, n_features]
+          Training data, where n_samples is the number of samples and
+          n_features is the number of features.
+        y: not used, present for API consistence purpose.
 
         Returns
         -------
@@ -158,17 +159,18 @@ class EmpiricalCovariance(BaseEstimator):
 
         return self
 
-    def score(self, X_test):
+    def score(self, X_test, y=None):
         """Computes the log-likelihood of a gaussian data set with
         `self.covariance_` as an estimator of its covariance matrix.
 
         Parameters
         ----------
-        X_test : array-like, shape = [n_samples, n_features]
+        X_test: array-like, shape = [n_samples, n_features]
           Test data of which we compute the likelihood, where n_samples is
           the number of samples and n_features is the number of features.
           X_test is assumed to be drawn from the same distribution than
           tha data used in fit (including centering).
+        y: not used, present for API consistence purpose.
 
         Returns
         -------

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -171,7 +171,7 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
                            random_state=random_state)
         OutlierDetectionMixin.__init__(self, contamination=contamination)
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """
         """
         MinCovDet.fit(self, X)

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -544,7 +544,7 @@ class MinCovDet(EmpiricalCovariance):
         self.support_fraction = support_fraction
         self.random_state = random_state
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """Fits a Minimum Covariance Determinant with the FastMCD algorithm.
 
         Parameters
@@ -552,6 +552,7 @@ class MinCovDet(EmpiricalCovariance):
         X: array-like, shape = [n_samples, n_features]
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
+        y: not used, present for API consistence purpose.
 
         Returns
         -------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -102,15 +102,16 @@ class ShrunkCovariance(EmpiricalCovariance):
                                      assume_centered=assume_centered)
         self.shrinkage = shrinkage
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """ Fits the shrunk covariance model
         according to the given training data and parameters.
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X: array-like, shape = [n_samples, n_features]
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
+        y: not used, present for API consistence purpose.
 
         assume_centered: Boolean
           If True, data are not centered before computation.
@@ -120,8 +121,8 @@ class ShrunkCovariance(EmpiricalCovariance):
 
         Returns
         -------
-        self : object
-            Returns self.
+        self: object
+          Returns self.
 
         """
         # Not calling the parent object to fit, to avoid a potential
@@ -362,20 +363,21 @@ class LedoitWolf(EmpiricalCovariance):
                                      assume_centered=assume_centered)
         self.block_size = block_size
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """ Fits the Ledoit-Wolf shrunk covariance model
         according to the given training data and parameters.
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X: array-like, shape = [n_samples, n_features]
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
+        y: not used, present for API consistence purpose.
 
         Returns
         -------
-        self : object
-            Returns self.
+        self: object
+          Returns self.
 
         """
         # Not calling the parent object to fit, to avoid computing the
@@ -514,20 +516,21 @@ class OAS(EmpiricalCovariance):
     Chen et al., IEEE Trans. on Sign. Proc., Volume 58, Issue 10, October 2010.
 
     """
-    def fit(self, X):
+    def fit(self, X, y=None):
         """ Fits the Oracle Approximating Shrinkage covariance model
         according to the given training data and parameters.
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X: array-like, shape = [n_samples, n_features]
           Training data, where n_samples is the number of samples
           and n_features is the number of features.
+        y: not used, present for API consistence purpose.
 
         Returns
         -------
-        self : object
-            Returns self.
+        self: object
+          Returns self.
 
         """
         # Not calling the parent object to fit, to avoid computing the

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -427,6 +427,11 @@ def oas(X, assume_centered=False):
 
     where mu = trace(cov) / n_features
 
+    The formula we used to implement the OAS
+    does not correspond to the one given in the article. It has been taken
+    from the MATLAB program available from the author's webpage
+    (https://tbayes.eecs.umich.edu/yilun/covestimation).
+
     """
     X = np.asarray(X)
     # for only one feature, the result is the same whatever the shrinkage


### PR DESCRIPTION
Following @GaelVaroquaux's suggestion, I revisited the shrunk covariance example by adding an unsupervised GridSearchCV estimator selection.

This lead me to adapt grid_search.py since it broke when y=None (as far as I understood, a call to clf.fit was made with y=None but the latter argument may be unexpected). I decided to completely separate the case y==None and the complementary case. The tests did not break subsequently to my change so I guess it could be kept like that. Thoughts?

I took this opportunity to magnify the example. I'm quite proud of the result but I am afraid it breaks with some old versions of matplotlib.
