### PR TITLE
FIX : pass random_state to kmeans in gmm.fit

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -425,7 +425,8 @@ class GMM(BaseEstimator):
         for _ in range(self.n_init):
             if 'm' in self.init_params or not hasattr(self, 'means_'):
                 self.means_ = cluster.KMeans(
-                    n_clusters=self.n_components).fit(X).cluster_centers_
+                    n_clusters=self.n_components,
+                    random_state=self.random_state).fit(X).cluster_centers_
 
             if 'w' in self.init_params or not hasattr(self, 'weights_'):
                 self.weights_ = np.tile(1.0 / self.n_components,


### PR DESCRIPTION
the random_state of gmm was not passed to K-Means in the init furing fit
