### PR TITLE
MRG: Lars drop for good

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -244,21 +244,26 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         least_squares, info = solve_cholesky(L[:n_active, :n_active],
                                sign_active[:n_active], lower=True)
 
-        # is this really needed ?
-        AA = 1. / np.sqrt(np.sum(least_squares * sign_active[:n_active]))
+        if least_squares.size == 1 and least_squares == 0:
+            # This happens because sign_active[:n_active] = 0
+            least_squares[...] = 1
+            AA = 1.
+        else:
+            # is this really needed ?
+            AA = 1. / np.sqrt(np.sum(least_squares * sign_active[:n_active]))
 
-        if not np.isfinite(AA):
-            # L is too ill-conditioned
-            i = 0
-            L_ = L[:n_active, :n_active].copy()
-            while not np.isfinite(AA):
-                L_.flat[::n_active + 1] += (2 ** i) * eps
-                least_squares, info = solve_cholesky(L_,
-                                    sign_active[:n_active], lower=True)
-                tmp = max(np.sum(least_squares * sign_active[:n_active]), eps)
-                AA = 1. / np.sqrt(tmp)
-                i += 1
-        least_squares *= AA
+            if not np.isfinite(AA):
+                # L is too ill-conditioned
+                i = 0
+                L_ = L[:n_active, :n_active].copy()
+                while not np.isfinite(AA):
+                    L_.flat[::n_active + 1] += (2 ** i) * eps
+                    least_squares, info = solve_cholesky(L_,
+                                        sign_active[:n_active], lower=True)
+                    tmp = max(np.sum(least_squares * sign_active[:n_active]), eps)
+                    AA = 1. / np.sqrt(tmp)
+                    i += 1
+            least_squares *= AA
 
         if Gram is None:
             # equiangular direction of variables in the active set

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -229,7 +229,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                     'Stopping the LARS path early, after %i iterations, '
                     'i.e. alpha=%.3f, '
                     'with an active set of %i regressors, and '
-                    'the smallest eigenvalue being %.3f')
+                    'the small cholesky pivot element being %.3f')
                     % (n_iter, alphas[n_iter], n_active, diag)
                     )
                 break

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -221,12 +221,17 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             if verbose > 1:
                 print "%s\t\t%s\t\t%s\t\t%s\t\t%s" % (n_iter, active[-1], '',
                                                             n_active, C)
-            if np.log(diag) < -10:
-                # The system is becoming too ill-conditionned.
+            if diag < 1e-7:
+                # The system is becoming too ill-conditioned.
                 # We have degenerate vectors in our active set.
                 # Time to bail out.
-                warnings.warn('Regressors in active set degenerate'
-                    'Stopping the LARS path early.')
+                warnings.warn(('Regressors in active set degenerate. '
+                    'Stopping the LARS path early, after %i iterations, '
+                    'i.e. alpha=%.3f, '
+                    'with an active set of %i regressors, and '
+                    'the smallest eigenvalue being %.3f')
+                    % (n_iter, alphas[n_iter], n_active, diag)
+                    )
                 break
 
         # least squares solution
@@ -237,7 +242,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         AA = 1. / np.sqrt(np.sum(least_squares * sign_active[:n_active]))
 
         if not np.isfinite(AA):
-            # L is too ill-conditionned
+            # L is too ill-conditioned
             i = 0
             L_ = L[:n_active, :n_active].copy()
             while not np.isfinite(AA):

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -272,7 +272,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                     L_.flat[::n_active + 1] += (2 ** i) * eps
                     least_squares, info = solve_cholesky(L_,
                                         sign_active[:n_active], lower=True)
-                    tmp = max(np.sum(least_squares * sign_active[:n_active]), eps)
+                    tmp = max(np.sum(least_squares * sign_active[:n_active]),
+                              eps)
                     AA = 1. / np.sqrt(tmp)
                     i += 1
             least_squares *= AA

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -221,6 +221,14 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             if verbose > 1:
                 print "%s\t\t%s\t\t%s\t\t%s\t\t%s" % (n_iter, active[-1], '',
                                                             n_active, C)
+            if np.log(diag) < -10:
+                # The system is becoming too ill-conditionned.
+                # We have degenerate vectors in our active set.
+                # Time to bail out.
+                warnings.warn('Regressors in active set degenerate'
+                    'Stopping the LARS path early.')
+                break
+
         # least squares solution
         least_squares, info = solve_cholesky(L[:n_active, :n_active],
                                sign_active[:n_active], lower=True)

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -174,6 +174,18 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 coefs[n_iter] = coef
             break
 
+        if method == 'lasso' and n_iter > 0 and prev_alpha[0] < alpha[0]:
+            # alpha is increasing. This is because the updates of Cov are
+            # bringing in too much numerical error that is greater than
+            # than the remaining correlation with the
+            # regressors. Time to bail out
+            warnings.warn('Early stopping the lars path, as the residues '
+                'are small and the current value of alpha is no longer '
+                'well controled. %i iterations, alpha=%.3e, previous '
+                'alpha=%.3e, with an active set of %i regressors'
+                    % (n_iter, alpha, prev_alpha, n_active))
+            break
+
         if n_iter >= max_iter or n_active >= n_features:
             break
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -162,7 +162,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             prev_coef = coefs[n_iter - 1]
 
         alpha[0] = C / n_samples
-        if alpha[0] < alpha_min:  # early stopping
+        if alpha[0] <= alpha_min:  # early stopping
             # interpolation factor 0 <= ss < 1
             if n_iter > 0:
                 # In the first iteration, all alphas are zero, the formula
@@ -193,6 +193,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
             Cov[C_idx], Cov[0] = swap(Cov[C_idx], Cov[0])
             indices[n], indices[m] = indices[m], indices[n]
+            Cov_not_shortened = Cov
             Cov = Cov[1:]  # remove Cov[0]
 
             if Gram is None:
@@ -215,24 +216,29 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             diag = max(np.sqrt(np.abs(c - v)), eps)
             L[n_active, n_active] = diag
 
+            if diag < 1e-7:
+                # The system is becoming too ill-conditioned.
+                # We have degenerate vectors in our active set.
+                # We'll 'drop for good' the last regressor added
+                warnings.warn(('Regressors in active set degenerate. '
+                    'Dropping a regressor, after %i iterations, '
+                    'i.e. alpha=%.3e, '
+                    'with an active set of %i regressors, and '
+                    'the smallest cholesky pivot element being %.3e')
+                    % (n_iter, alphas[n_iter], n_active, diag)
+                    )
+                # XXX: need to figure a 'drop for good' way
+                Cov = Cov_not_shortened
+                Cov[0] = 0
+                Cov[C_idx], Cov[0] = swap(Cov[C_idx], Cov[0])
+                continue
+
             active.append(indices[n_active])
             n_active += 1
 
             if verbose > 1:
                 print "%s\t\t%s\t\t%s\t\t%s\t\t%s" % (n_iter, active[-1], '',
                                                             n_active, C)
-            if diag < 1e-7:
-                # The system is becoming too ill-conditioned.
-                # We have degenerate vectors in our active set.
-                # Time to bail out.
-                warnings.warn(('Regressors in active set degenerate. '
-                    'Stopping the LARS path early, after %i iterations, '
-                    'i.e. alpha=%.3f, '
-                    'with an active set of %i regressors, and '
-                    'the small cholesky pivot element being %.3f')
-                    % (n_iter, alphas[n_iter], n_active, diag)
-                    )
-                break
 
         # least squares solution
         least_squares, info = solve_cholesky(L[:n_active, :n_active],

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -174,18 +174,6 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 coefs[n_iter] = coef
             break
 
-        if method == 'lasso' and n_iter > 0 and prev_alpha[0] < alpha[0]:
-            # alpha is increasing. This is because the updates of Cov are
-            # bringing in too much numerical error that is greater than
-            # than the remaining correlation with the
-            # regressors. Time to bail out
-            warnings.warn('Early stopping the lars path, as the residues '
-                'are small and the current value of alpha is no longer '
-                'well controled. %i iterations, alpha=%.3e, previous '
-                'alpha=%.3e, with an active set of %i regressors'
-                    % (n_iter, alpha, prev_alpha, n_active))
-            break
-
         if n_iter >= max_iter or n_active >= n_features:
             break
 
@@ -251,6 +239,18 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             if verbose > 1:
                 print "%s\t\t%s\t\t%s\t\t%s\t\t%s" % (n_iter, active[-1], '',
                                                             n_active, C)
+
+        if method == 'lasso' and n_iter > 0 and prev_alpha[0] < alpha[0]:
+            # alpha is increasing. This is because the updates of Cov are
+            # bringing in too much numerical error that is greater than
+            # than the remaining correlation with the
+            # regressors. Time to bail out
+            warnings.warn('Early stopping the lars path, as the residues '
+                'are small and the current value of alpha is no longer '
+                'well controled. %i iterations, alpha=%.3e, previous '
+                'alpha=%.3e, with an active set of %i regressors'
+                    % (n_iter, alpha, prev_alpha, n_active))
+            break
 
         # least squares solution
         least_squares, info = solve_cholesky(L[:n_active, :n_active],

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -166,9 +166,9 @@ def test_no_path_all_precomputed():
 
 
 def test_singular_matrix():
-    """
-    Test when input is a singular matrix
-    """
+    # Test when input is a singular matrix
+    # In this test the "drop for good strategy" of lars_path is necessary
+    # to give a good answer
     X1 = np.array([[1, 1.], [1., 1.]])
     y1 = np.array([1, 1])
     with warnings.catch_warnings(record=True) as warning_list:

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -181,6 +181,9 @@ def test_singular_matrix():
 
 
 def test_rank_deficient_design():
+    # consistency test that checks that LARS Lasso is handling rank
+    # deficient input data (with n_features < rank) in the same way
+    # as coordinate descent Lasso
     y = [5, 0, 5]
     for X in (
                 [[  5,  0],

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -1,4 +1,7 @@
+import warnings
+
 import numpy as np
+from nose.tools import assert_equal
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
@@ -168,7 +171,12 @@ def test_singular_matrix():
     """
     X1 = np.array([[1, 1.], [1., 1.]])
     y1 = np.array([1, 1])
-    alphas, active, coef_path = linear_model.lars_path(X1, y1)
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always", UserWarning)
+        alphas, active, coef_path = linear_model.lars_path(X1, y1)
+    assert_equal(len(warning_list), 1)
+    assert_true('Stopping the LARS' in warning_list[0].message.args[0])
+
     assert_array_almost_equal(coef_path.T, [[0, 0], [1, 0]])
 
 
@@ -240,8 +248,8 @@ def test_lasso_lars_vs_lasso_cd_early_stopping(verbose=False):
         assert_less(error, 0.01)
 
 
-def test_lasso_lars_vs_lasso_cd_ill_conditionned():
-    # Test lasso lars on a very ill-conditionned design, and check that
+def test_lasso_lars_vs_lasso_cd_ill_conditioned():
+    # Test lasso lars on a very ill-conditioned design, and check that
     # it does not blow up, and stays somewhat close to a solution given
     # by the coordinate descent solver
     rng = np.random.RandomState(42)
@@ -257,16 +265,21 @@ def test_lasso_lars_vs_lasso_cd_ill_conditionned():
     w[supp] = np.sign(rng.randn(k, 1)) * (rng.rand(k, 1) + 1)
     y = np.dot(X, w)
     sigma = 0.2
-    y +=  sigma * rng.rand(*y.shape)
+    y += sigma * rng.rand(*y.shape)
     y = y.squeeze()
 
-    lars_alphas, _, lars_coef = linear_model.lars_path(X, y, method='lasso')
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always", UserWarning)
+        lars_alphas, _, lars_coef = linear_model.lars_path(X, y,
+                                                    method='lasso')
+    assert_equal(len(warning_list), 1)
+    assert_true('Stopping the LARS' in warning_list[0].message.args[0])
+
     lasso_coef = np.zeros((w.shape[0], len(lars_alphas)))
     for i, model in enumerate(linear_model.lasso_path(X, y,
                                 alphas=lars_alphas)):
-        lasso_coef[:,i] = model.coef_
+        lasso_coef[:, i] = model.coef_
     np.testing.assert_array_almost_equal(lars_coef, lasso_coef, decimal=1)
-
 
 
 def test_lars_add_features():

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -311,6 +311,25 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned():
     np.testing.assert_array_almost_equal(lars_coef, lasso_coef, decimal=1)
 
 
+def test_lars_drop_for_good():
+    # Create an ill-conditioned situation in which the LARS has to good
+    # far in the path to converge, and check that LARS and coordinate
+    # descent give the same answers
+    X = [[    10, 10,  0],
+         [-1e-32,  0,  0],
+         [     1,  1,  1]]
+    y = [100, -100, 1]
+    lars = linear_model.LassoLars(.001, normalize=False)
+    lars_coef_ = lars.fit(X, y).coef_
+    lars_obj = ((1./ (2. * 3.)) * linalg.norm(y - np.dot(X, lars_coef_)) ** 2
+                + .1 * linalg.norm(lars_coef_, 1))
+    coord_descent = linear_model.Lasso(.001, tol=1e-10, normalize=False)
+    cd_coef_ = coord_descent.fit(X, y).coef_
+    cd_obj = ((1./ (2. * 3.)) * linalg.norm(y - np.dot(X, cd_coef_)) ** 2
+                + .1 * linalg.norm(cd_coef_, 1))
+    np.testing.assert_allclose(lars_obj, cd_obj)
+
+
 def test_lars_add_features():
     """
     assure that at least some features get added if necessary

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -169,7 +169,7 @@ def test_singular_matrix():
     X1 = np.array([[1, 1.], [1., 1.]])
     y1 = np.array([1, 1])
     alphas, active, coef_path = linear_model.lars_path(X1, y1)
-    assert_array_almost_equal(coef_path.T, [[0, 0], [1, 0], [1, 0]])
+    assert_array_almost_equal(coef_path.T, [[0, 0], [1, 0]])
 
 
 def test_lasso_lars_vs_lasso_cd(verbose=False):
@@ -238,6 +238,35 @@ def test_lasso_lars_vs_lasso_cd_early_stopping(verbose=False):
         lasso_cd.fit(X, y)
         error = np.linalg.norm(lasso_path[:, -1] - lasso_cd.coef_)
         assert_less(error, 0.01)
+
+
+def test_lasso_lars_vs_lasso_cd_ill_conditionned():
+    # Test lasso lars on a very ill-conditionned design, and check that
+    # it does not blow up, and stays somewhat close to a solution given
+    # by the coordinate descent solver
+    rng = np.random.RandomState(42)
+
+    # Generate data
+    n, m = 80, 100
+    k = 5
+    X = rng.randn(n, m)
+    w = np.zeros((m, 1))
+    i = np.arange(0, m)
+    rng.shuffle(i)
+    supp = i[:k]
+    w[supp] = np.sign(rng.randn(k, 1)) * (rng.rand(k, 1) + 1)
+    y = np.dot(X, w)
+    sigma = 0.2
+    y +=  sigma * rng.rand(*y.shape)
+    y = y.squeeze()
+
+    lars_alphas, _, lars_coef = linear_model.lars_path(X, y, method='lasso')
+    lasso_coef = np.zeros((w.shape[0], len(lars_alphas)))
+    for i, model in enumerate(linear_model.lasso_path(X, y,
+                                alphas=lars_alphas)):
+        lasso_coef[:,i] = model.coef_
+    np.testing.assert_array_almost_equal(lars_coef, lasso_coef, decimal=1)
+
 
 
 def test_lars_add_features():

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -273,7 +273,8 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned():
         lars_alphas, _, lars_coef = linear_model.lars_path(X, y,
                                                     method='lasso')
     assert_true(len(warning_list) > 0)
-    assert_true('Dropping a regressor' in warning_list[0].message.args[0])
+    assert_true(('Dropping a regressor' in warning_list[0].message.args[0])
+                or ('Early stopping' in warning_list[0].message.args[0]))
 
     lasso_coef = np.zeros((w.shape[0], len(lars_alphas)))
     for i, model in enumerate(linear_model.lasso_path(X, y,

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -174,8 +174,8 @@ def test_singular_matrix():
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", UserWarning)
         alphas, active, coef_path = linear_model.lars_path(X1, y1)
-    assert_equal(len(warning_list), 1)
-    assert_true('Stopping the LARS' in warning_list[0].message.args[0])
+    assert_true(len(warning_list) > 0)
+    assert_true('Dropping a regressor' in warning_list[0].message.args[0])
 
     assert_array_almost_equal(coef_path.T, [[0, 0], [1, 0]])
 
@@ -272,12 +272,12 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned():
         warnings.simplefilter("always", UserWarning)
         lars_alphas, _, lars_coef = linear_model.lars_path(X, y,
                                                     method='lasso')
-    assert_equal(len(warning_list), 1)
-    assert_true('Stopping the LARS' in warning_list[0].message.args[0])
+    assert_true(len(warning_list) > 0)
+    assert_true('Dropping a regressor' in warning_list[0].message.args[0])
 
     lasso_coef = np.zeros((w.shape[0], len(lars_alphas)))
     for i, model in enumerate(linear_model.lasso_path(X, y,
-                                alphas=lars_alphas)):
+                                alphas=lars_alphas, tol=1e-6)):
         lasso_coef[:, i] = model.coef_
     np.testing.assert_array_almost_equal(lars_coef, lasso_coef, decimal=1)
 


### PR DESCRIPTION
For ill-conditioned design, this implements the strategy suggested by @fabianp and used in R to drop heavily correlated regressors.

This is a continuation of PR #1238, with a rebase and an addition of the new strategy.

However, there are two issues, one is that the X matrix is not full rank (has degenerate regressors) and that the lars cannot make good choices. The other one is that at the end of the path, numerical errors are bigger than the max residual, and thus no good path can be computed. This is seen because alpha than increases in the path. It tells us that it is time to stop the path.

This PR deals with both issues, and it solves the issue reported on the mailing list by Alejandro Weinstein and @NelleV
http://sourceforge.net/mailarchive/message.php?msg_id=29927302

@fabianp, @agramfort please review :)
