### PR TITLE
WIP: Classes support for all classifiers

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -272,6 +272,15 @@ def is_multilabel(y):
         or is_label_indicator_matrix(y)
 
 
+def is_iterable(y):
+    """Check if an item implements the __iter__ protocol."""
+    try:
+        iter(y)
+        return True
+    except:
+        return False
+
+
 ###############################################################################
 class ClassifierMixin(object):
     """Mixin class for all classifiers in scikit-learn"""
@@ -331,6 +340,10 @@ class ClassifierMixin(object):
                 self.classes_ = self.classes
             else:
                 self.classes_ = np.asarray([self.classes])
+
+            for x in self.classes_:
+                if not is_iterable(x):
+                    raise ValueError("classes in a multilabel class list must be sequences")
 
             self.classes_ = [np.unique(x) for x in self.classes_]
             self.n_classes_ = np.asarray([len(x) for x in self.classes_])

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -5,6 +5,7 @@
 import copy
 import inspect
 import numpy as np
+from collections import Sequence
 from scipy import sparse
 
 from .metrics import r2_score
@@ -259,16 +260,33 @@ class BaseEstimator(object):
 
 
 ###############################################################################
+def _is_label_indicator_matrix(y):
+    return hasattr(y, "shape") and len(y.shape) == 2
+
+
+def is_multilabel(y):
+    # the explicit check for ndarray is for forward compatibility; future
+    # versions of Numpy might want to register ndarray as a Sequence
+    return not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) \
+       and not isinstance(y[0], basestring) \
+        or _is_label_indicator_matrix(y)
+
+
+###############################################################################
 class ClassifierMixin(object):
     """Mixin class for all classifiers in scikit-learn"""
 
     def _check_classes(self, classes):
-        print classes
         """Common error checking for the prepare functions below."""
         if len(classes) is 0:
             raise ValueError("no output classes")
-        if len(classes) != len(set(classes)):
-            raise ValueError("duplicate class label")
+        if is_multilabel(classes):
+            for c in classes:
+                if len(c) != len(set(c)):
+                    raise ValueError("duplicate class label")
+        else:
+            if len(classes) != len(np.unique(classes)):
+                raise ValueError("duplicate class label")
 
     def _prepare_classes(self, y):
         """Set self.classes and self.y_inverse_"""
@@ -286,6 +304,44 @@ class ClassifierMixin(object):
                 raise ValueError("unknown classes in y vector: %s" % bad_classes)
             self.y_inverse_ = y_inverse
             self.n_classes_ = len(self.classes_)
+
+    def _prepare_multilabel_classes(self, y):
+        """Ensure that none of the output classes are different from
+        the ones that we expect if the constructor had a classes parameter.
+        """
+        y_classes = []
+        y_n_classes = []
+        self.n_outputs_ = y.shape[1]
+
+        for k in xrange(self.n_outputs_):
+            unique = np.unique(y[:, k])
+            y_classes.append(unique)
+            y_n_classes.append(unique.shape[0])
+
+        # discover classes
+        if self.classes is None:
+            self.classes_ = np.asarray(y_classes)
+            self.n_classes_ = np.asarray(y_n_classes)
+            self.n_outputs_ = len(y_classes)
+
+        # check known classes
+        else:
+            if is_multilabel(self.classes):
+                self.classes_ = self.classes
+            else:
+                self.classes_ = np.asarray([self.classes])
+
+            self.classes_ = [np.unique(x) for x in self.classes_]
+            self.n_classes_ = np.asarray([len(x) for x in self.classes_])
+            self.n_outputs_ = len(self.classes_)
+            for i in xrange(self.n_outputs_):
+                diff = set(y_classes[i]) - set(self.classes_[i])
+                if len(diff) > 0:
+                    raise ValueError("classes to constructor and fit don't match each other: %s" % diff)
+
+        for k in xrange(self.n_outputs_):
+            y[:, k] = np.searchsorted(self.classes_[k], y[:, k])
+        return y
 
     def _check_found_classes(self, found_classes):
         if self.classes is not None:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy import sparse
 
 from .metrics import r2_score
+from .utils.fixes import unique
 
 
 ###############################################################################
@@ -260,6 +261,24 @@ class BaseEstimator(object):
 ###############################################################################
 class ClassifierMixin(object):
     """Mixin class for all classifiers in scikit-learn"""
+
+    def _check_classes(self, classes):
+        print classes
+        """Common error checking for the prepare functions below."""
+        if len(classes) is 0:
+            raise ValueError("no output classes")
+        if len(classes) != len(set(classes)):
+            raise ValueError("duplicate class label")
+
+    def _prepare_classes(self, y):
+        """Set self.classes and self.y_inverse_"""
+        if self.classes is None:
+            self.classes_, self.y_inverse_ = unique(y, return_inverse=True)
+        else:
+            self._check_classes(self.classes)
+            self.classes_ = self.classes
+            assoc = {v:k for k,v in enumerate(y)}
+            self.y_inverse_ = np.array([assoc[k] for k in y])
 
     def score(self, X, y):
         """Returns the mean accuracy on the given test data and labels.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -190,6 +190,7 @@ class BaseForest(BaseEnsemble, SelectorMixin):
                        compute_importances=False,
                        oob_score=False,
                        n_jobs=1,
+                       classes=None,
                        random_state=None,
                        verbose=0):
         super(BaseForest, self).__init__(
@@ -202,11 +203,10 @@ class BaseForest(BaseEnsemble, SelectorMixin):
         self.oob_score = oob_score
         self.n_jobs = n_jobs
         self.random_state = random_state
+        self.classes = np.asarray(classes) if classes is not None else None
 
         self.n_features_ = None
         self.n_outputs_ = None
-        self.classes_ = None
-        self.n_classes_ = None
         self.feature_importances_ = None
 
         self.verbose = verbose
@@ -411,6 +411,7 @@ class ForestClassifier(BaseForest, ClassifierMixin):
                        compute_importances=False,
                        oob_score=False,
                        n_jobs=1,
+                       classes=None,
                        random_state=None,
                        verbose=0):
 
@@ -422,6 +423,7 @@ class ForestClassifier(BaseForest, ClassifierMixin):
             compute_importances=compute_importances,
             oob_score=oob_score,
             n_jobs=n_jobs,
+            classes=classes,
             random_state=random_state,
             verbose=verbose)
 
@@ -565,6 +567,7 @@ class ForestRegressor(BaseForest, RegressorMixin):
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
+            classes=None,
             verbose=verbose)
 
     def predict(self, X):
@@ -718,6 +721,7 @@ class RandomForestClassifier(ForestClassifier):
                        oob_score=False,
                        n_jobs=1,
                        random_state=None,
+                       classes=None,
                        verbose=0):
         super(RandomForestClassifier, self).__init__(
             base_estimator=DecisionTreeClassifier(),
@@ -730,6 +734,7 @@ class RandomForestClassifier(ForestClassifier):
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
+            classes=classes,
             verbose=verbose)
 
         self.criterion = criterion
@@ -997,6 +1002,7 @@ class ExtraTreesClassifier(ForestClassifier):
                        oob_score=False,
                        n_jobs=1,
                        random_state=None,
+                       classes=None,
                        verbose=0):
         super(ExtraTreesClassifier, self).__init__(
             base_estimator=ExtraTreeClassifier(),
@@ -1009,6 +1015,7 @@ class ExtraTreesClassifier(ForestClassifier):
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
+            classes=classes,
             verbose=verbose)
 
         self.criterion = criterion

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -74,6 +74,7 @@ def _parallel_build_trees(n_trees, forest, X, y,
         tree = forest._make_estimator(append=False)
         tree.set_params(compute_importances=forest.compute_importances)
         tree.set_params(random_state=check_random_state(seed))
+        tree.classes = forest.classes
 
         if forest.bootstrap:
             n_samples = X.shape[0]
@@ -285,12 +286,7 @@ class BaseForest(BaseEnsemble, SelectorMixin):
 
         if isinstance(self.base_estimator, ClassifierMixin):
             y = np.copy(y)
-
-            for k in xrange(self.n_outputs_):
-                unique = np.unique(y[:, k])
-                self.classes_.append(unique)
-                self.n_classes_.append(unique.shape[0])
-                y[:, k] = np.searchsorted(unique, y[:, k])
+            y = self._prepare_classes(y)
 
         if getattr(y, "dtype", None) != DTYPE or not y.flags.contiguous:
             y = np.ascontiguousarray(y, dtype=DOUBLE)

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -34,6 +34,9 @@ class BaseNB(BaseEstimator, ClassifierMixin):
 
     __metaclass__ = ABCMeta
 
+    def __init__(self, classes=None):
+        self.classes = np.asarray(classes) if classes is not None else None
+
     @abstractmethod
     def _joint_log_likelihood(self, X):
         """Compute the unnormalized posterior log probability of X
@@ -134,6 +137,9 @@ class GaussianNB(BaseNB):
     [1]
     """
 
+    def __init__(self, classes=None):
+        super(GaussianNB, self).__init__(classes)
+
     def fit(self, X, y):
         """Fit Gaussian Naive Bayes according to X, y
 
@@ -159,14 +165,13 @@ class GaussianNB(BaseNB):
         if n_samples != y.shape[0]:
             raise ValueError("X and y have incompatible shapes")
 
-        self.classes_ = unique_y = np.unique(y)
-        n_classes = unique_y.shape[0]
+        self._prepare_classes(y)
 
-        self.theta_ = np.zeros((n_classes, n_features))
-        self.sigma_ = np.zeros((n_classes, n_features))
-        self.class_prior_ = np.zeros(n_classes)
+        self.theta_ = np.zeros((self.n_classes_, n_features))
+        self.sigma_ = np.zeros((self.n_classes_, n_features))
+        self.class_prior_ = np.zeros(self.n_classes_)
         epsilon = 1e-9
-        for i, y_i in enumerate(unique_y):
+        for i, y_i in enumerate(self.classes_):
             self.theta_[i, :] = np.mean(X[y == y_i, :], axis=0)
             self.sigma_[i, :] = np.var(X[y == y_i, :], axis=0) + epsilon
             self.class_prior_[i] = np.float(np.sum(y == y_i)) / n_samples
@@ -183,6 +188,7 @@ class GaussianNB(BaseNB):
             joint_log_likelihood.append(jointi + n_ij)
 
         joint_log_likelihood = np.array(joint_log_likelihood).T
+        joint_log_likelihood[np.isnan(joint_log_likelihood)] = -np.inf
         return joint_log_likelihood
 
 
@@ -194,6 +200,9 @@ class BaseDiscreteNB(BaseNB):
     __init__
     _joint_log_likelihood(X) as per BaseNB
     """
+    def __init__(self, classes=None):
+        super(BaseDiscreteNB, self).__init__(classes)
+
 
     def fit(self, X, y, sample_weight=None, class_prior=None):
         """Fit Naive Bayes classifier according to X, y
@@ -221,10 +230,11 @@ class BaseDiscreteNB(BaseNB):
         """
         X = atleast2d_or_csr(X)
 
-        labelbin = LabelBinarizer()
+        labelbin = LabelBinarizer(classes=self.classes)
         Y = labelbin.fit_transform(y)
+        self._check_found_classes(labelbin.classes_)
         self.classes_ = labelbin.classes_
-        n_classes = len(self.classes_)
+        self.n_classes_ = len(self.classes_)
         if Y.shape[1] == 1:
             Y = np.concatenate((1 - Y, Y), axis=1)
 
@@ -238,8 +248,8 @@ class BaseDiscreteNB(BaseNB):
         if sample_weight is not None:
             Y *= array2d(sample_weight).T
 
-        if class_prior:
-            if len(class_prior) != n_classes:
+        if class_prior is not None:
+            if len(class_prior) != self.n_classes_:
                 raise ValueError(
                         "Number of priors must match number of classes")
             self.class_log_prior_ = np.log(class_prior)
@@ -248,7 +258,7 @@ class BaseDiscreteNB(BaseNB):
             y_freq = Y.sum(axis=0)
             self.class_log_prior_ = np.log(y_freq) - np.log(y_freq.sum())
         else:
-            self.class_log_prior_ = np.zeros(n_classes) - np.log(n_classes)
+            self.class_log_prior_ = np.zeros(self.n_classes_) - np.log(self.n_classes_)
 
         N_c, N_c_i = self._count(X, Y)
 
@@ -337,7 +347,8 @@ class MultinomialNB(BaseDiscreteNB):
     Tackling the poor assumptions of naive Bayes text classifiers, ICML.
     """
 
-    def __init__(self, alpha=1.0, fit_prior=True):
+    def __init__(self, alpha=1.0, fit_prior=True, classes=None):
+        super(MultinomialNB, self).__init__(classes)
         self.alpha = alpha
         self.fit_prior = fit_prior
 
@@ -401,7 +412,8 @@ class BernoulliNB(BaseDiscreteNB):
     naive Bayes -- Which naive Bayes? 3rd Conf. on Email and Anti-Spam (CEAS).
     """
 
-    def __init__(self, alpha=1.0, binarize=.0, fit_prior=True):
+    def __init__(self, alpha=1.0, binarize=.0, fit_prior=True, classes=None):
+        super(BernoulliNB, self).__init__(classes)
         self.alpha = alpha
         self.binarize = binarize
         self.fit_prior = fit_prior

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -14,7 +14,7 @@ import scipy.sparse as sp
 from .utils import check_arrays, array2d, atleast2d_or_csr
 from .utils import warn_if_not_float
 from .utils.fixes import unique
-from .base import BaseEstimator, TransformerMixin
+from .base import BaseEstimator, TransformerMixin, is_multilabel
 
 from .utils.sparsefuncs import inplace_csr_row_normalize_l1
 from .utils.sparsefuncs import inplace_csr_row_normalize_l2
@@ -943,7 +943,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         -------
         self : returns an instance of self.
         """
-        self.multilabel = _is_multilabel(y)
+        self.multilabel = is_multilabel(y)
         if self.classes is not None:
             self.classes_ = self.classes
         else:
@@ -986,14 +986,14 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Y += self.neg_label
 
-        y_is_multilabel = _is_multilabel(y)
+        y_is_multilabel = is_multilabel(y)
 
         if y_is_multilabel and not self.multilabel:
             raise ValueError("The object was not " +
                     "fitted with multilabel input!")
 
         elif self.multilabel:
-            if not _is_multilabel(y):
+            if not is_multilabel(y):
                 raise ValueError("y should be a list of label lists/tuples,"
                                  "got %r" % (y,))
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -14,7 +14,7 @@ import scipy.sparse as sp
 from .utils import check_arrays, array2d, atleast2d_or_csr
 from .utils import warn_if_not_float
 from .utils.fixes import unique
-from .base import BaseEstimator, TransformerMixin, is_multilabel
+from .base import BaseEstimator, TransformerMixin, is_multilabel, is_label_indicator_matrix
 
 from .utils.sparsefuncs import inplace_csr_row_normalize_l1
 from .utils.sparsefuncs import inplace_csr_row_normalize_l2
@@ -948,7 +948,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             self.classes_ = self.classes
         else:
             if self.multilabel:
-                self.indicator_matrix_ = _is_label_indicator_matrix(y)
+                self.indicator_matrix_ = is_label_indicator_matrix(y)
                 if self.indicator_matrix_:
                     self.classes_ = np.arange(y.shape[1])
                 else:
@@ -976,7 +976,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self._check_fitted()
 
         if self.multilabel or len(self.classes_) > 2:
-            if _is_label_indicator_matrix(y):
+            if is_label_indicator_matrix(y):
                 # nothing to do as y is already a label indicator matrix
                 return y
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -918,12 +918,13 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     array([1, 2, 3])
     """
 
-    def __init__(self, neg_label=0, pos_label=1):
+    def __init__(self, neg_label=0, pos_label=1, classes=None):
         if neg_label >= pos_label:
             raise ValueError("neg_label must be strictly less than pos_label.")
 
         self.neg_label = neg_label
         self.pos_label = pos_label
+        self.classes = np.asarray(classes) if classes is not None else None
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
@@ -943,14 +944,17 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         self.multilabel = _is_multilabel(y)
-        if self.multilabel:
-            self.indicator_matrix_ = _is_label_indicator_matrix(y)
-            if self.indicator_matrix_:
-                self.classes_ = np.arange(y.shape[1])
-            else:
-                self.classes_ = np.array(sorted(set.union(*map(set, y))))
+        if self.classes is not None:
+            self.classes_ = self.classes
         else:
-            self.classes_ = np.unique(y)
+            if self.multilabel:
+                self.indicator_matrix_ = _is_label_indicator_matrix(y)
+                if self.indicator_matrix_:
+                    self.classes_ = np.arange(y.shape[1])
+                else:
+                    self.classes_ = np.array(sorted(set.union(*map(set, y))))
+            else:
+                self.classes_ = np.unique(y)
         return self
 
     def transform(self, y):

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -86,13 +86,13 @@ def test_xor():
         clf.fit(X, y)
         assert_equal(clf.score(X, y), 1.0)
 
-    clf = tree.ExtraTreeClassifier()
-    clf.fit(X, y)
-    assert_equal(clf.score(X, y), 1.0)
+        clf = tree.ExtraTreeClassifier(classes=c)
+        clf.fit(X, y)
+        assert_equal(clf.score(X, y), 1.0)
 
-    clf = tree.ExtraTreeClassifier(max_features=1)
-    clf.fit(X, y)
-    assert_equal(clf.score(X, y), 1.0)
+        clf = tree.ExtraTreeClassifier(max_features=1, classes=c)
+        clf.fit(X, y)
+        assert_equal(clf.score(X, y), 1.0)
 
 
 def test_graphviz_toy():
@@ -377,13 +377,14 @@ def test_min_samples_leaf():
     y = iris.target
 
     for tree_class in [tree.DecisionTreeClassifier, tree.ExtraTreeClassifier]:
-        clf = tree_class(min_samples_leaf=5).fit(X, y)
+        for c in classes:
+            clf = tree_class(min_samples_leaf=5, classes=c).fit(X, y)
 
-        out = clf.tree_.apply(X)
-        node_counts = np.bincount(out)
-        leaf_count = node_counts[node_counts != 0]  # drop inner nodes
+            out = clf.tree_.apply(X)
+            node_counts = np.bincount(out)
+            leaf_count = node_counts[node_counts != 0]  # drop inner nodes
 
-        assert np.min(leaf_count) >= 5
+            assert np.min(leaf_count) >= 5
 
 
 def test_pickle():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_almost_equal
 from numpy.testing import assert_equal
 from nose.tools import assert_raises
 from nose.tools import assert_true
+from nose.tools import raises
 
 from sklearn import tree
 from sklearn import datasets
@@ -34,19 +35,21 @@ perm = rng.permutation(boston.target.size)
 boston.data = boston.data[perm]
 boston.target = boston.target[perm]
 
+classes = [None, [-3, -2, -1, 0, 1, 2, 3]]
 
 def test_classification_toy():
     """Check classification on a toy dataset."""
-    clf = tree.DecisionTreeClassifier()
-    clf.fit(X, y)
+    for c in classes:
+        clf = tree.DecisionTreeClassifier(classes=c)
+        clf.fit(X, y)
 
-    assert_array_equal(clf.predict(T), true_result)
+        assert_array_equal(clf.predict(T), true_result)
 
-    # With subsampling
-    clf = tree.DecisionTreeClassifier(max_features=1, random_state=1)
-    clf.fit(X, y)
+        # With subsampling
+        clf = tree.DecisionTreeClassifier(max_features=1, random_state=1, classes=c)
+        clf.fit(X, y)
 
-    assert_array_equal(clf.predict(T), true_result)
+        assert_array_equal(clf.predict(T), true_result)
 
 
 def test_regression_toy():
@@ -74,13 +77,14 @@ def test_xor():
     X = np.vstack([gridx.ravel(), gridy.ravel()]).T
     y = y.ravel()
 
-    clf = tree.DecisionTreeClassifier()
-    clf.fit(X, y)
-    assert_equal(clf.score(X, y), 1.0)
+    for c in classes:
+        clf = tree.DecisionTreeClassifier(classes=c)
+        clf.fit(X, y)
+        assert_equal(clf.score(X, y), 1.0)
 
-    clf = tree.DecisionTreeClassifier(max_features=1)
-    clf.fit(X, y)
-    assert_equal(clf.score(X, y), 1.0)
+        clf = tree.DecisionTreeClassifier(max_features=1, classes=c)
+        clf.fit(X, y)
+        assert_equal(clf.score(X, y), 1.0)
 
     clf = tree.ExtraTreeClassifier()
     clf.fit(X, y)
@@ -185,18 +189,24 @@ def test_boston():
 
 def test_probability():
     """Predict probabilities using DecisionTreeClassifier."""
-    clf = tree.DecisionTreeClassifier(max_depth=1, max_features=1,
-            random_state=42)
-    clf.fit(iris.data, iris.target)
+    for c in classes:
+        clf = tree.DecisionTreeClassifier(max_depth=1, max_features=1,
+                random_state=42, classes=c)
+        clf.fit(iris.data, iris.target)
 
-    prob_predict = clf.predict_proba(iris.data)
-    assert_array_almost_equal(
-        np.sum(prob_predict, 1), np.ones(iris.data.shape[0]))
-    assert np.mean(np.argmax(prob_predict, 1)
-                   == clf.predict(iris.data)) > 0.9
+        prob_predict = clf.predict_proba(iris.data)
+        assert_array_almost_equal(
+            np.sum(prob_predict, 1), np.ones(iris.data.shape[0]))
 
-    assert_almost_equal(clf.predict_proba(iris.data),
-                        np.exp(clf.predict_log_proba(iris.data)), 8)
+        if c is not None:
+            assert np.mean(np.asarray(c)[np.argmax(prob_predict, 1)]
+                       == clf.predict(iris.data)) > 0.9
+        else:
+            assert np.mean(np.argmax(prob_predict, 1)
+                       == clf.predict(iris.data)) > 0.9
+
+        assert_almost_equal(clf.predict_proba(iris.data),
+                            np.exp(clf.predict_log_proba(iris.data)), 8)
 
 
 def test_arrayrepr():
@@ -214,6 +224,12 @@ def test_pure_set():
     y = [1, 1, 1, 1, 1, 1]
 
     clf = tree.DecisionTreeClassifier().fit(X, y)
+    assert_array_equal(clf.predict(X), y)
+
+    clf = tree.DecisionTreeClassifier(classes=[1]).fit(X, y)
+    assert_array_equal(clf.predict(X), y)
+
+    clf = tree.DecisionTreeClassifier(classes=[-1,1]).fit(X, y)
     assert_array_equal(clf.predict(X), y)
 
     clf = tree.DecisionTreeRegressor().fit(X, y)
@@ -255,21 +271,21 @@ def test_importances():
                                         n_repeated=0,
                                         shuffle=False,
                                         random_state=0)
+    for c in classes:
+        clf = tree.DecisionTreeClassifier(compute_importances=True, classes=c)
+        clf.fit(X, y)
+        importances = clf.feature_importances_
+        n_important = sum(importances > 0.1)
 
-    clf = tree.DecisionTreeClassifier(compute_importances=True)
-    clf.fit(X, y)
-    importances = clf.feature_importances_
-    n_important = sum(importances > 0.1)
+        assert_equal(importances.shape[0], 10)
+        assert_equal(n_important, 3)
 
-    assert_equal(importances.shape[0], 10)
-    assert_equal(n_important, 3)
+        X_new = clf.transform(X, threshold="mean")
+        assert 0 < X_new.shape[1] < X.shape[1]
 
-    X_new = clf.transform(X, threshold="mean")
-    assert 0 < X_new.shape[1] < X.shape[1]
-
-    clf = tree.DecisionTreeClassifier()
-    clf.fit(X, y)
-    assert_true(clf.feature_importances_ is None)
+        clf = tree.DecisionTreeClassifier(classes=c)
+        clf.fit(X, y)
+        assert_true(clf.feature_importances_ is None)
 
 
 def test_error():
@@ -374,16 +390,17 @@ def test_pickle():
     import pickle
 
     # classification
-    obj = tree.DecisionTreeClassifier()
-    obj.fit(iris.data, iris.target)
-    score = obj.score(iris.data, iris.target)
-    s = pickle.dumps(obj)
+    for c in classes:
+        obj = tree.DecisionTreeClassifier(classes=c)
+        obj.fit(iris.data, iris.target)
+        score = obj.score(iris.data, iris.target)
+        s = pickle.dumps(obj)
 
-    obj2 = pickle.loads(s)
-    assert_equal(type(obj2), obj.__class__)
-    score2 = obj2.score(iris.data, iris.target)
-    assert score == score2, "Failed to generate same score " + \
-            " after pickling (classification) "
+        obj2 = pickle.loads(s)
+        assert_equal(type(obj2), obj.__class__)
+        score2 = obj2.score(iris.data, iris.target)
+        assert score == score2, "Failed to generate same score " + \
+                " after pickling (classification) "
 
     # regression
     obj = tree.DecisionTreeRegressor()
@@ -398,41 +415,42 @@ def test_pickle():
             " after pickling (regression) "
 
 
+X_multi = [[-2, -1],
+     [-1, -1],
+     [-1, -2],
+     [1, 1],
+     [1, 2],
+     [2, 1],
+     [-2, 1],
+     [-1, 1],
+     [-1, 2],
+     [2, -1],
+     [1, -1],
+     [1, -2]]
+
+y_multi = [[-1, 0],
+     [-1, 0],
+     [-1, 0],
+     [1, 1],
+     [1, 1],
+     [1, 1],
+     [-1, 2],
+     [-1, 2],
+     [-1, 2],
+     [1, 3],
+     [1, 3],
+     [1, 3]]
+
+
 def test_multioutput():
     """Check estimators on multi-output problems."""
-
-    X = [[-2, -1],
-         [-1, -1],
-         [-1, -2],
-         [1, 1],
-         [1, 2],
-         [2, 1],
-         [-2, 1],
-         [-1, 1],
-         [-1, 2],
-         [2, -1],
-         [1, -1],
-         [1, -2]]
-
-    y = [[-1, 0],
-         [-1, 0],
-         [-1, 0],
-         [1, 1],
-         [1, 1],
-         [1, 1],
-         [-1, 2],
-         [-1, 2],
-         [-1, 2],
-         [1, 3],
-         [1, 3],
-         [1, 3]]
 
     T = [[-1, -1], [1, 1], [-1, 1], [1, -1]]
     y_true = [[-1, 0], [1, 1], [-1, 2], [1, 3]]
 
     # toy classification problem
     clf = tree.DecisionTreeClassifier()
-    y_hat = clf.fit(X, y).predict(T)
+    y_hat = clf.fit(X_multi, y_multi).predict(T)
     assert_array_equal(y_hat, y_true)
     assert_equal(y_hat.shape, (4, 2))
 
@@ -446,11 +464,49 @@ def test_multioutput():
     assert_equal(log_proba[0].shape, (4, 2))
     assert_equal(log_proba[1].shape, (4, 4))
 
+
+    clf = tree.DecisionTreeClassifier(classes=[[-1,1],[0,1,2,3,4]])
+    y_hat = clf.fit(X_multi, y_multi).predict(T)
+    assert_array_equal(y_hat, y_true)
+    assert_equal(y_hat.shape, (4, 2))
+
+    proba = clf.predict_proba(T)
+    assert_equal(len(proba), 2)
+    assert_equal(proba[0].shape, (4, 2))
+    assert_equal(proba[1].shape, (4, 5))
+
+    log_proba = clf.predict_log_proba(T)
+    assert_equal(len(log_proba), 2)
+    assert_equal(log_proba[0].shape, (4, 2))
+    assert_equal(log_proba[1].shape, (4, 5))
+
+
     # toy regression problem
     clf = tree.DecisionTreeRegressor()
-    y_hat = clf.fit(X, y).predict(T)
+    y_hat = clf.fit(X_multi, y_multi).predict(T)
     assert_almost_equal(y_hat, y_true)
     assert_equal(y_hat.shape, (4, 2))
+
+@raises(ValueError)
+def test_fit_mismatch():
+    """Check that unknown labels in y in fit() throws an exception."""
+    clf = tree.DecisionTreeClassifier(classes=[[-1,1],[0,1,2]])
+    y_hat = clf.fit(X_multi, y_multi)
+
+@raises(ValueError)
+def test_duplicate_labels():
+    """Check that the duplicate labels case throws an exception."""
+    clf = tree.DecisionTreeClassifier(classes=[[-1,1,1],[0,1,2]])
+    y_hat = clf.fit(X_multi, y_multi)
+
+
+#@raises(ValueError)
+#def test_classes_shape():
+    #"""Check that all multi-output classes are lists."""
+    #clf = tree.DecisionTreeClassifier(classes=[[-1,1],9])
+    #y_hat = clf.fit(X_multi, y_multi)
+
+
 
 
 def test_sample_mask():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -501,11 +501,11 @@ def test_duplicate_labels():
     y_hat = clf.fit(X_multi, y_multi)
 
 
-#@raises(ValueError)
-#def test_classes_shape():
-    #"""Check that all multi-output classes are lists."""
-    #clf = tree.DecisionTreeClassifier(classes=[[-1,1],9])
-    #y_hat = clf.fit(X_multi, y_multi)
+@raises(ValueError)
+def test_classes_shape():
+    """Check that all multi-output classes are lists."""
+    clf = tree.DecisionTreeClassifier(classes=[[-1,1],9])
+    y_hat = clf.fit(X_multi, y_multi)
 
 
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -233,7 +233,7 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
 
         if is_classification:
             y = np.copy(y)
-            y = self._prepare_multilabel_classes(y)
+            y = self._prepare_classes(y)
         else:
             self.n_outputs_ = y.shape[1]
             self.classes_ = [None] * self.n_outputs_

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -690,7 +690,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
                        min_density=0.1,
                        max_features="auto",
                        compute_importances=False,
-                       random_state=None):
+                       random_state=None,
+                       classes=None):
         super(ExtraTreeClassifier, self).__init__(criterion,
                                                   max_depth,
                                                   min_samples_split,
@@ -698,7 +699,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
                                                   min_density,
                                                   max_features,
                                                   compute_importances,
-                                                  random_state)
+                                                  random_state,
+                                                  classes)
 
         self.find_split_ = _tree.TREE_SPLIT_RANDOM
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -14,7 +14,7 @@ from __future__ import division
 import numpy as np
 from abc import ABCMeta, abstractmethod
 
-from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
+from ..base import BaseEstimator, ClassifierMixin, RegressorMixin, is_multilabel
 from ..feature_selection.selector_mixin import SelectorMixin
 from ..utils import array2d, check_random_state
 from ..utils.validation import check_arrays
@@ -153,7 +153,8 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
                        min_density,
                        max_features,
                        compute_importances,
-                       random_state):
+                       random_state,
+                       classes):
         self.criterion = criterion
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
@@ -162,11 +163,10 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
         self.max_features = max_features
         self.compute_importances = compute_importances
         self.random_state = random_state
+        self.classes = np.asarray(classes) if classes is not None else None
 
-        self.n_features_ = None
-        self.n_outputs_ = None
-        self.classes_ = None
-        self.n_classes_ = None
+        #self.n_features_ = None
+        #self.n_outputs_ = None
         self.find_split_ = _tree.TREE_SPLIT_BEST
 
         self.tree_ = None
@@ -224,26 +224,18 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
 
         n_samples, self.n_features_ = X.shape
 
-        is_classification = isinstance(self, ClassifierMixin)
-
         y = np.atleast_1d(y)
         if y.ndim == 1:
             y = y[:, np.newaxis]
 
-        self.classes_ = []
-        self.n_classes_ = []
-        self.n_outputs_ = y.shape[1]
+        is_classification = isinstance(self, ClassifierMixin)
+
 
         if is_classification:
             y = np.copy(y)
-
-            for k in xrange(self.n_outputs_):
-                unique = np.unique(y[:, k])
-                self.classes_.append(unique)
-                self.n_classes_.append(unique.shape[0])
-                y[:, k] = np.searchsorted(unique, y[:, k])
-
+            y = self._prepare_multilabel_classes(y)
         else:
+            self.n_outputs_ = y.shape[1]
             self.classes_ = [None] * self.n_outputs_
             self.n_classes_ = [1] * self.n_outputs_
 
@@ -471,7 +463,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
                        min_density=0.1,
                        max_features=None,
                        compute_importances=False,
-                       random_state=None):
+                       random_state=None,
+                       classes=None):
         super(DecisionTreeClassifier, self).__init__(criterion,
                                                      max_depth,
                                                      min_samples_split,
@@ -479,7 +472,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
                                                      min_density,
                                                      max_features,
                                                      compute_importances,
-                                                     random_state)
+                                                     random_state,
+                                                     classes)
 
     def predict_proba(self, X):
         """Predict class probabilities of the input samples X.
@@ -663,7 +657,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
                                                     min_density,
                                                     max_features,
                                                     compute_importances,
-                                                    random_state)
+                                                    random_state,
+                                                    classes=None)
 
 
 class ExtraTreeClassifier(DecisionTreeClassifier):


### PR DESCRIPTION
I'm taking a stab at decoupling the classes in `y` from the classes that the estimators can predict. I think this cleanup would allow for easier design of an ensemble class that could use arbitrary classifiers and combine their results through voting, averaging, stacking, etc.

See https://github.com/scikit-learn/scikit-learn/issues/1183

So far I've done `naive_bayes`, `lda`, `trees`, and `forests`. I tried to do `qda` and almost got it right, but there are issues with `nan` and `inf`. `LabelBinarizer` needs some testing as well.

I've gone with the convention of class variables set in `__init__` having no trailing underscore and any other private variables using one. So `self.classes` gets set in `__init__` and then `self.classes_` gets set in `fit`. Maybe there needs to be a parameter method that resets `self.classes_` to `None` so that classifiers are not in half-working states if the user sets `classes` after the fact?

Any help with the remaining classifiers, code cleanups, or suggestions would be appreciated.
