### PR TITLE
Add docs for `vocabulary_` and `stop_words_` attributes of Countvectorizer.

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -200,6 +200,16 @@ class CountVectorizer(BaseEstimator):
 
     dtype: type, optional
         Type of the matrix returned by fit_transform() or transform().
+
+    Attributes
+    ----------
+    `vocabulary_`: dict
+        A mapping of terms to frequencies.
+
+    `stop_words_`: set
+        Terms that were ignored because they occurred in either too
+        many (`max_df`) or in too few (`min_df`) documents.  This is
+        only available if no vocabulary was given.
     """
 
     _white_spaces = re.compile(ur"\s\s+")
@@ -497,7 +507,7 @@ class CountVectorizer(BaseEstimator):
 
         # store the learned stop words to make it easier to debug the value of
         # max_df
-        self.max_df_stop_words_ = stop_words
+        self.stop_words_ = stop_words
 
         # store map from term name to feature integer index: we sort the term
         # to have reproducible outcome for the vocabulary structure: otherwise
@@ -574,6 +584,13 @@ class CountVectorizer(BaseEstimator):
 
         return [t for t, i in sorted(self.vocabulary_.iteritems(),
                                      key=itemgetter(1))]
+
+    @property
+    def max_df_stop_words_(self):
+        warnings.warn(
+            "The 'stop_words_ attribute was renamed to 'max_df_stop_words'. "
+            "The old attribute will be removed in 0.15.", DeprecationWarning)
+        return self.stop_words_
 
 
 class TfidfTransformer(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
(Also rename `max_df_stop_words_ to stop_words_.)
