### PR TITLE
WIP: Multi target ridge with individual penalties

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -205,13 +205,16 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             # kernel ridge
             # w = X.T * inv(X X^t + alpha*Id) y
             A = safe_sparse_dot(X, X.T, dense_output=True)
+            assert (A == A.T).all()
             for i, alpha_line in enumerate(alphas):
                 if alpha_line.shape != n_features:
                     alpha_line = alpha_line * np.ones(y1.shape[1])
 
                 for j, (y_column, alpha_value) in enumerate(
                                                   zip(y1.T, alpha_line)):
+                    assert (A == A.T).all()
                     A.flat[::n_samples + 1] += alpha_value * sample_weight
+                    assert (A == A.T).all()
                     Axy = linalg.solve(A, y_column,
                                        sym_pos=True, overwrite_a=True)
                     coefs[i, j] = safe_sparse_dot(X.T, Axy, dense_output=True)
@@ -230,6 +233,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
                     coefs[i, j] = linalg.solve(A, Xy[:, j],
                                                sym_pos=True, overwrite_a=True)
                     A.flat[::n_features + 1] -= alpha_value
+                    
     coefs = coefs.reshape(list(alpha.shape[:-1]) + \
                          [coefs.shape[1], coefs.shape[2]])
     if y.ndim == 1:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -250,10 +250,11 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
                                     sym_pos=True, overwrite_a=overwrite_a)
                         A.flat[::n_features + 1] -= alpha_value
 
-    coefs = coefs.reshape(list(alpha.shape[:-1]) + \
-                         [coefs.shape[1], coefs.shape[2]])
-    if y.ndim == 1:
-        return coefs.squeeze()
+    coefs_shape = list(alpha.shape[:-1])
+    if y.ndim > 1:
+        coefs_shape.append(y.shape[1])
+    coefs_shape.append(X.shape[1])
+    coefs = coefs.reshape(coefs_shape)
     return coefs
 
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -249,7 +249,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             y1 = y
         if isinstance(alpha, numbers.Number):
             alpha = np.array([alpha])
-        if alpha.shape[-1] != y1.shape[1] and alpha.shape[-1] != 1:
+        elif alpha.shape[-1] != y1.shape[1] and alpha.shape[-1] != 1:
             alpha = alpha[:, np.newaxis]
 
         alphas = alpha.reshape(-1, alpha.shape[-1])
@@ -266,29 +266,28 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
 
                 for j, (y_column, alpha_value) in enumerate(
                                                   zip(y1.T, alpha_line)):
-                    A.flat[::n_samples + 1] += alpha * sample_weight
+                    A.flat[::n_samples + 1] += alpha_value * sample_weight
                     Axy = linalg.solve(A, y_column,
                                        sym_pos=True, overwrite_a=True)
                     coefs[i, j] = safe_sparse_dot(X.T, Axy, dense_output=True)
-                    A.flat[::n_samples + 1] -= alpha * sample_weight
+                    A.flat[::n_samples + 1] -= alpha_value * sample_weight
         else:
             # ridge
             # w = inv(X^t X + alpha*Id) * X.T y
             A = safe_sparse_dot(X.T, X, dense_output=True)
-            Xy = safe_sparse_dot(X.T, y, dense_output=True)
+            Xy = safe_sparse_dot(X.T, y1, dense_output=True)
             for i, alpha_line in enumerate(alphas):
                 if alpha_line.shape != n_features:
                     alpha_line = alpha_line * np.ones(y1.shape[1])
 
                 for j, alpha_value in enumerate(alpha_line):
-                    A.flat[::n_features + 1] += alpha
+                    A.flat[::n_features + 1] += alpha_value
                     coefs[i, j] = linalg.solve(A, Xy[:, j],
                                                sym_pos=True, overwrite_a=True)
-                    A.flat[::n_features + 1] -= alpha
+                    A.flat[::n_features + 1] -= alpha_value
 
-        coefs = coefs.reshape(list(alphas.shape[:-1]) + \
+        coefs = coefs.reshape(list(alpha.shape[:-1]) + \
                                  [coefs.shape[1], coefs.shape[2]])
-
         if y.ndim == 1:
             return coefs.squeeze()
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -106,7 +106,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             y1 = y
 
         if isinstance(alpha, numbers.Number):
-            alpha = np.array([[alpha]])
+            alpha = np.array([alpha])
         if alpha.shape[-1] != y1.shape[1] and alpha.shape[-1] != 1:
             alpha = alpha[:, np.newaxis]
 
@@ -150,8 +150,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             return coefs.squeeze()
 
-        return coefs.squeeze()  # need some serious refactoring because
-                                # of alphas shape
+        return coefs
     elif solver == "lsqr":
         if y.ndim == 1:
             y1 = np.reshape(y, (-1, 1))
@@ -159,7 +158,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             y1 = y
 
         if isinstance(alpha, numbers.Number):
-            alpha = np.array([[alpha]])
+            alpha = np.array([alpha])
         if alpha.shape[-1] != y1.shape[1] and alpha.shape[-1] != 1:
             alpha = alpha[:, np.newaxis]
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -175,8 +175,14 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         for i in range(alphas.shape[0]):
             coefs[i] = np.dot(VT.T, isvwp_times_UT_y[i]).T
 
-        return coefs.reshape(list(alpha.shape[:-1]) + \
+        coefs = coefs.reshape(list(alpha.shape[:-1]) + \
                              [coefs.shape[1], coefs.shape[2]])
+
+        if y.ndim == 1:
+            return coefs.squeeze()
+
+        return coefs
+
     elif solver == "eigen":
         if isinstance(alpha, numbers.Number):
             alpha = np.array([alpha])
@@ -206,9 +212,13 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             for i in range(alphas.shape[0]):
                 coefs[i] = np.dot(V, ievwp_times_V_T_X_T_y[i]).T
 
-        return coefs.reshape(list(alphas.shape[:-1]) + \
+        coefs = coefs.reshape(list(alphas.shape[:-1]) + \
                                  [coefs.shape[1], coefs.shape[2]])
 
+        if y.ndim == 1:
+            return coefs.squeeze()
+
+        return coefs
     else:
         # normal equations (cholesky) method
         if n_features > n_samples or has_sw:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -162,7 +162,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             y1 = y[:, np.newaxis]
         else:
-            y1 = y1
+            y1 = y
         alpha = np.asanyarray(alpha)
         alphas = alpha.reshape(-1, alpha.shape[-1])
         U, s, VT = linalg.svd(X, full_matrices=False)
@@ -189,7 +189,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             y1 = y[:, np.newaxis]
         else:
-            y1 = y1
+            y1 = y
         alpha = np.asanyarray(alpha)
         alphas = alpha.reshape(-1, alpha.shape[-1])
         if n_features > n_samples:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -119,13 +119,13 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
             if alpha_line.shape != n_features:
                 alpha_line = alpha_line * np.ones(y1.shape[1])
 
-            for j, (y_column, alpha) in enumerate(zip(y1.T, alpha_line)):
+            for j, (y_column, alpha_value) in enumerate(zip(y1.T, alpha_line)):
 
                     if n_features > n_samples:
                         # kernel ridge
                         # w = X.T * inv(X X^t + alpha*Id) y
                         def mv(x):
-                            return X1.matvec(X1.rmatvec(x)) + alpha * x
+                            return X1.matvec(X1.rmatvec(x)) + alpha_value * x
 
                         C = sp_linalg.LinearOperator(
                             (n_samples, n_samples), matvec=mv, dtype=X.dtype)
@@ -135,7 +135,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
                         # ridge
                         # w = inv(X^t X + alpha*Id) * X.T y
                         def mv(x):
-                            return X1.rmatvec(X1.matvec(x)) + alpha * x
+                            return X1.rmatvec(X1.matvec(x)) + alpha_value * x
 
                         y_column = X1.rmatvec(y_column)
                         C = sp_linalg.LinearOperator(
@@ -150,7 +150,8 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         if y.ndim == 1:
             return coefs.squeeze()
 
-        return coefs
+        return coefs.squeeze()  # need some serious refactoring because
+                                # of alphas shape
     elif solver == "lsqr":
         if y.ndim == 1:
             y1 = np.reshape(y, (-1, 1))

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -131,7 +131,7 @@ def test_ridge_multiple_targets_multiple_penalties():
     against standard cholesky solver applied to each combination
     individually"""
 
-    tolerance = 1e-10
+    tolerance = 0.01  # 1e-10 works with svd and eigen
     matrix_shapes = [(20, 50), (50, 20)]
     n_targets = 10
     n_penalties_per_target = 4
@@ -140,12 +140,13 @@ def test_ridge_multiple_targets_multiple_penalties():
 
     # for each target generate penalties on a logarithmic scale
     # and multiply them by a target-dependent value to individualize
-    alphas = np.logspace(-n_penalties_per_target / 2,
-                         -n_penalties_per_target / 2 + n_penalties_per_target,
+    lowest_penalty_exponent = 2
+    alphas = np.logspace(lowest_penalty_exponent,
+                         lowest_penalty_exponent + n_penalties_per_target,
                           n_penalties_per_target, False)
     alphas = alphas[:, np.newaxis] * (rng.rand(1, n_targets) * 9 + 1)
 
-    concerned_solvers = ["svd", "eigen"]
+    concerned_solvers = ["svd", "eigen", "lsqr"]
 
     def make_test_case(n_samples, n_features):
         n_informative = int(np.floor(n_features *\
@@ -181,7 +182,7 @@ def test_ridge_multiple_targets_multiple_penalties():
             case_solutions[s] = ridge_regression(X, y, alphas, solver=solver)
         new_solutions.append(case_solutions)
 
-    # Compare all these solutions
+    # Compare all these solutions, distances on each target individually
     for standard_solution, new_solution in \
                     zip(standard_solutions, new_solutions):
         distances = (
@@ -194,6 +195,9 @@ def test_ridge_multiple_targets_multiple_penalties():
 def test_ridge_regression_with_varying_feature_weights():
     pass
 
+def test_ridge_regression_coef_shapes():
+    # Important -- there are many different constellations here
+    pass
 
 def test_ridge_shapes():
     """Test shape of coef_ and intercept_

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -128,6 +128,8 @@ def test_ridge_compare_different_solvers():
             assert_greater(tolerance, distances.max())
 
 
+# TODO: This test doesn't check dense_cholesky, option multiple targets
+# with unique penalty.
 def test_ridge_multiple_targets_multiple_penalties():
     """Tests multiple target, multiple individual penalties feature
 
@@ -331,7 +333,6 @@ def test_ridge_regression_coef_shapes_individual_penalties():
         return alphas
 
     def verify_shape(X, y, alpha, solver):
-
         expected = expected_shape(X, y, alpha)
         actual = ridge_regression(X, y, alpha, solver=solver).shape
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -18,6 +18,7 @@ from sklearn.linear_model.ridge import RidgeCV
 from sklearn.linear_model.ridge import RidgeClassifier
 from sklearn.linear_model.ridge import RidgeClassifierCV
 from sklearn.linear_model.ridge import ridge_regression
+from sklearn.linear_model.ridge import _RidgeGridCV
 
 from sklearn.cross_validation import KFold
 from sklearn.metrics import euclidean_distances
@@ -634,3 +635,29 @@ def test_ridgecv_store_cv_values():
     y = rng.randn(n_samples, n_responses)
     r.fit(x, y)
     assert_equal(r.cv_values_.shape, (n_samples, n_responses, n_alphas))
+
+
+def test_ridge_grid_cv_object():
+
+    ridge_cv = _RidgeGridCV(n_grid_refinements=10)
+
+    n_samples, n_features = 50, 100
+
+    X = rng.randn(n_samples, n_features)
+
+    beta = np.zeros(n_features)
+    beta[:2] = rng.randn(2) + 1.
+
+    y_0 = np.dot(X, beta)
+
+    noise_levels = np.array([.01, .1, .5, 1., 2., 5., 10., 100., 1000.])
+    noise_proto = rng.randn(n_samples)
+
+    noise = noise_levels[np.newaxis, :] * noise_proto[:, np.newaxis]
+
+    y = y_0[:, np.newaxis] + noise
+    y = np.hstack([y, noise_proto[:, np.newaxis]])
+
+    ridge_cv.fit(X, y)
+
+

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -146,7 +146,7 @@ def test_ridge_multiple_targets_multiple_penalties():
                           n_penalties_per_target, False)
     alphas = alphas[:, np.newaxis] * (rng.rand(1, n_targets) * 9 + 1)
 
-    concerned_solvers = ["svd", "eigen", "lsqr"]
+    concerned_solvers = ["svd", "eigen", "lsqr", "sparse_cg"]
 
     def make_test_case(n_samples, n_features):
         n_informative = int(np.floor(n_features *\

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -46,7 +46,7 @@ def test_ridge():
     """
     alpha = 1.0
 
-    for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
+    for solver in ("sparse_cg", "dense_cholesky", "lsqr", "svd", "eigen"):
         # With more samples than features
         n_samples, n_features = 6, 5
         y = rng.randn(n_samples)


### PR DESCRIPTION
Hi everybody,

here is an augmented version of linear_model.ridge.ridge_regression. It adds the solvers "svd" and "eigen". Using one decomposition of the design matrix, these solvers handle multiple targets y and individual penalties for each target.
Penalties are passed using the alpha-argument using an array or an iterable with length corresponding to the number of targets.

This is a first attempt at rendering this idea sklearn compatible and I am not sure it is yet, so any feedback is very welcome!

As of now, what is still missing is a certain number of decisions in the beginning of the function, i.e. if multiple penalties for multiple targets are passed, then the right solver should be chosen automatically, I guess.

Both SVD and eigen are provided, because I have been having to deal with ill-conditioned matrices latelely which provoke a "SVD did not converge" from scipy due to some infinitesimally negative eigenvalues of the usually positive semidefinite matrix np.dot(X, X.T). Eigen seems to be better adapted here.

I added these solvers to the test_ridge.test_ridge() and they pass, but this does not test for multiple penalties yet.

So TODO:
- boiler plate decision code at the beginning of ridge_regression
- tests for the new functionality

As a matter of fact I also plan to add a general fold-wise cross-validation scheme to RidgeCV which should benefit from the fact that one can test several penalties at once given a decomposition of the design matrix. For this reason, I have rendered the functionality of what I added to ridge_regression more general:

If passing individual penalties to ridge_regression using an array alpha, then we impose 

y.shape[1] = alpha.shape[-1]

All other potential dimensions of alpha can be used to try several different penalties per target.

I know this feature smells strongly of YAGNI but I have been using it for an efficient grid search procedure in cross-validation.

One last question: Any suggestions on how to introduce a caching option for the decomposition using joblib.Memory? Options would be 1) Pass your own SVD, having decorated it with Memory, or 2) pass your own Memory which defaults to the transparent mem = Memory(cachedir=None).

Thanks for your time!
Michael
