### PR TITLE
Crossvalidation __repr__ fix

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -691,13 +691,13 @@ class Bootstrap(object):
 
     def __repr__(self):
         return ('%s(%d, n_iter=%d, train_size=%d, test_size=%d, '
-                'random_state=%d)' % (
+                'random_state=%s)' % (
                     self.__class__.__name__,
                     self.n,
                     self.n_iter,
                     self.train_size,
                     self.test_size,
-                    self.random_state,
+                    self.random_state
                 ))
 
     def __len__(self):

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -203,8 +203,8 @@ def _nls_subproblem(V, W, H_init, tol, max_iter):
         raise ValueError("Negative values in H_init passed to NLS solver.")
 
     H = H_init
-    WtV = safe_sparse_dot(W.T, V, dense_output=True)
-    WtW = safe_sparse_dot(W.T, W, dense_output=True)
+    WtV = safe_sparse_dot(W.T, V, dense_output = True)
+    WtW = safe_sparse_dot(W.T, W, dense_output = True)
 
     # values justified in the paper
     alpha = 1
@@ -360,8 +360,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_components=None, init=None, sparseness=None, beta=1,
-            eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000,
-            random_state=None):
+                 eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000,
+                 random_state=None):
         self.n_components = n_components
         self.init = init
         self.tol = tol
@@ -389,17 +389,18 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
             random_state = check_random_state(init)
             init = "random"
             warnings.warn("Passing a random seed or generator as init "
-                "is deprecated and will be removed in 0.15. Use "
-                "init='random' and random_state instead.", DeprecationWarning)
+                          "is deprecated and will be removed in 0.15. Use "
+                          "init='random' and random_state instead.",
+                          DeprecationWarning)
         else:
             random_state = self.random_state
 
         if init == 'nndsvd':
             W, H = _initialize_nmf(X, self.n_components)
         elif init == 'nndsvda':
-            W, H = _initialize_nmf(X, self.n_components, variant='a')
+            W, H = _initialize_nmf(X, self.n_components, variant = 'a')
         elif init == 'nndsvdar':
-            W, H = _initialize_nmf(X, self.n_components, variant='ar')
+            W, H = _initialize_nmf(X, self.n_components, variant = 'ar')
         elif init == "random":
             rng = check_random_state(random_state)
             W = rng.randn(n_samples, self.n_components)
@@ -423,17 +424,95 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
                                               self.nls_max_iter)
         elif self.sparseness == 'data':
             W, gradW, iterW = _nls_subproblem(
-                    safe_vstack([X.T, np.zeros((1, n_samples))]),
-                    safe_vstack([H.T, np.sqrt(self.beta) * np.ones((1,
-                                 self.n_components))]),
-                    W.T, tolW, self.nls_max_iter)
+                safe_vstack([X.T, np.zeros((1, n_samples))]),
+                safe_vstack([H.T, np.sqrt(self.beta) * np.ones((1,
+                                                                self
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                .n_components))]),
+                W.T, tolW, self.nls_max_iter)
         elif self.sparseness == 'components':
             W, gradW, iterW = _nls_subproblem(
-                    safe_vstack([X.T,
-                                 np.zeros((self.n_components, n_samples))]),
-                    safe_vstack([H.T, np.sqrt(self.eta)
-                                      * np.eye(self.n_components)]),
-                    W.T, tolW, self.nls_max_iter)
+                safe_vstack([X.T,
+                             np.zeros((self.n_components, n_samples))]),
+                safe_vstack([H.T, np.sqrt(self.eta)
+                                  * np.eye(self.n_components)]),
+                W.T, tolW, self.nls_max_iter)
 
         return W, gradW, iterW
 
@@ -445,17 +524,17 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
                                               self.nls_max_iter)
         elif self.sparseness == 'data':
             H, gradH, iterH = _nls_subproblem(
-                    safe_vstack([X,
-                                 np.zeros((self.n_components, n_features))]),
-                    safe_vstack([W, np.sqrt(self.eta)
-                                    * np.eye(self.n_components)]),
-                    H, tolH, self.nls_max_iter)
+                safe_vstack([X,
+                             np.zeros((self.n_components, n_features))]),
+                safe_vstack([W, np.sqrt(self.eta)
+                                * np.eye(self.n_components)]),
+                H, tolH, self.nls_max_iter)
         elif self.sparseness == 'components':
             H, gradH, iterH = _nls_subproblem(
-                    safe_vstack([X, np.zeros((1, n_features))]),
-                    safe_vstack([W, np.sqrt(self.beta) *
-                          np.ones((1, self.n_components))]),
-                    H, tolH, self.nls_max_iter)
+                safe_vstack([X, np.zeros((1, n_features))]),
+                safe_vstack([W, np.sqrt(self.beta) *
+                                np.ones((1, self.n_components))]),
+                H, tolH, self.nls_max_iter)
 
         return H, gradH, iterH
 
@@ -486,9 +565,9 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         W, H = self._init(X)
 
         gradW = (np.dot(W, np.dot(H, H.T))
-                 - safe_sparse_dot(X, H.T, dense_output=True))
+                 - safe_sparse_dot(X, H.T, dense_output = True))
         gradH = (np.dot(np.dot(W.T, W), H)
-                 - safe_sparse_dot(W.T, X, dense_output=True))
+                 - safe_sparse_dot(W.T, X, dense_output = True))
         init_grad = norm(np.r_[gradW, gradH.T])
         tolW = max(0.001, self.tol) * init_grad  # why max?
         tolH = tolW
@@ -561,7 +640,14 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         X = atleast2d_or_csr(X)
         H = np.zeros((X.shape[0], self.n_components))
         for j in xrange(0, X.shape[0]):
-            H[j, :], _ = nnls(self.components_.T, X[j, :])
+            #nnls assumes X[j, :] is dense
+            if sp.issparse(X):
+                warnings.warn(
+                    "Data matrix is sparse, converting to dense format")
+                H[j, :], _ = nnls(self.components_.T,
+                                  X[j, :].toarray().squeeze())
+            else:
+                H[j, :], _ = nnls(self.components_.T, X[j, :])
         return H
 
 


### PR DESCRIPTION
The  `__repr__` method of `cross_validation.Bootstrap` failed if `self.random_state is None`.

Note: please ignore the a25c3a9 commit, it is a part of another pull request and was accidentally left of this branch.
