### PR TITLE
fixed the __repr__ method of cross_validation.Bootstrap

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -691,7 +691,7 @@ class Bootstrap(object):
 
     def __repr__(self):
         return ('%s(%d, n_iter=%d, train_size=%d, test_size=%d, '
-                'random_state=%d)' % (
+                'random_state=%s)' % (
                     self.__class__.__name__,
                     self.n,
                     self.n_iter,


### PR DESCRIPTION
which failed if `self.random_state is None` with the following error:

`File "./scikit-learn/sklearn/cross_validation.py", line 700, in __repr__
    self.random_state,
TypeError: %d format: a number is required, not NoneType
``
