### PR TITLE
Fixed bug with transform() method of ProjectedGradientNMF

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -360,8 +360,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_components=None, init=None, sparseness=None, beta=1,
-            eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000,
-            random_state=None):
+                 eta=0.1, tol=1e-4, max_iter=200, nls_max_iter=2000,
+                 random_state=None):
         self.n_components = n_components
         self.init = init
         self.tol = tol
@@ -389,8 +389,9 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
             random_state = check_random_state(init)
             init = "random"
             warnings.warn("Passing a random seed or generator as init "
-                "is deprecated and will be removed in 0.15. Use "
-                "init='random' and random_state instead.", DeprecationWarning)
+                          "is deprecated and will be removed in 0.15. Use "
+                          "init='random' and random_state instead.",
+                DeprecationWarning)
         else:
             random_state = self.random_state
 
@@ -420,20 +421,20 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
         if self.sparseness == None:
             W, gradW, iterW = _nls_subproblem(X.T, H.T, W.T, tolW,
-                                              self.nls_max_iter)
+                self.nls_max_iter)
         elif self.sparseness == 'data':
             W, gradW, iterW = _nls_subproblem(
-                    safe_vstack([X.T, np.zeros((1, n_samples))]),
-                    safe_vstack([H.T, np.sqrt(self.beta) * np.ones((1,
-                                 self.n_components))]),
-                    W.T, tolW, self.nls_max_iter)
+                safe_vstack([X.T, np.zeros((1, n_samples))]),
+                safe_vstack([H.T, np.sqrt(self.beta) *
+                                  np.ones((1, self.n_components))]),
+                W.T, tolW, self.nls_max_iter)
         elif self.sparseness == 'components':
             W, gradW, iterW = _nls_subproblem(
-                    safe_vstack([X.T,
-                                 np.zeros((self.n_components, n_samples))]),
-                    safe_vstack([H.T, np.sqrt(self.eta)
-                                      * np.eye(self.n_components)]),
-                    W.T, tolW, self.nls_max_iter)
+                safe_vstack([X.T,
+                             np.zeros((self.n_components, n_samples))]),
+                safe_vstack([H.T, np.sqrt(self.eta)
+                                  * np.eye(self.n_components)]),
+                W.T, tolW, self.nls_max_iter)
 
         return W, gradW, iterW
 
@@ -442,20 +443,20 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
         if self.sparseness == None:
             H, gradH, iterH = _nls_subproblem(X, W, H, tolH,
-                                              self.nls_max_iter)
+                self.nls_max_iter)
         elif self.sparseness == 'data':
             H, gradH, iterH = _nls_subproblem(
-                    safe_vstack([X,
-                                 np.zeros((self.n_components, n_features))]),
-                    safe_vstack([W, np.sqrt(self.eta)
-                                    * np.eye(self.n_components)]),
-                    H, tolH, self.nls_max_iter)
+                safe_vstack([X,
+                             np.zeros((self.n_components, n_features))]),
+                safe_vstack([W, np.sqrt(self.eta)
+                                * np.eye(self.n_components)]),
+                H, tolH, self.nls_max_iter)
         elif self.sparseness == 'components':
             H, gradH, iterH = _nls_subproblem(
-                    safe_vstack([X, np.zeros((1, n_features))]),
-                    safe_vstack([W, np.sqrt(self.beta) *
-                          np.ones((1, self.n_components))]),
-                    H, tolH, self.nls_max_iter)
+                safe_vstack([X, np.zeros((1, n_features))]),
+                safe_vstack([W, np.sqrt(self.beta) *
+                                np.ones((1, self.n_components))]),
+                H, tolH, self.nls_max_iter)
 
         return H, gradH, iterH
 
@@ -563,8 +564,10 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         for j in xrange(0, X.shape[0]):
             #nnls assumes X[j, :] is dense
             if sp.issparse(X):
-                warnings.warn("Data matrix is sparse, converting to dense format")
-                H[j, :], _ = nnls(self.components_.T, X[j, :].toarray().squeeze())
+                warnings.warn(
+                    "Data matrix is sparse, converting to dense format")
+                H[j, :], _ = nnls(self.components_.T,
+                    X[j, :].toarray().ravel())
             else:
                 H[j, :], _ = nnls(self.components_.T, X[j, :])
         return H

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -562,6 +562,12 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         H = np.zeros((X.shape[0], self.n_components))
         for j in xrange(0, X.shape[0]):
             H[j, :], _ = nnls(self.components_.T, X[j, :])
+            #nnls assumes X[j, :] is dense
+            if sp.issparse(X):
+                warnings.warn("Data matrix is sparse, converting to dense format")
+                H[j, :], _ = nnls(self.components_.T, X[j, :].toarray().squeeze())
+            else:
+                H[j, :], _ = nnls(self.components_.T, X[j, :])
         return H
 
 

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -561,7 +561,6 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         X = atleast2d_or_csr(X)
         H = np.zeros((X.shape[0], self.n_components))
         for j in xrange(0, X.shape[0]):
-            H[j, :], _ = nnls(self.components_.T, X[j, :])
             #nnls assumes X[j, :] is dense
             if sp.issparse(X):
                 warnings.warn("Data matrix is sparse, converting to dense format")

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -148,8 +148,11 @@ def test_sparse_input():
                                   random_state=999).fit_transform(A_sparse)
     assert_array_almost_equal(T1, T2)
 
-    # same with sparseness
+    # throws ValueError without changes from 00021cb80870b7b
+    T2 = nmf.ProjectedGradientNMF(n_components=5, init='random',random_state=999)\
+        .fit(A_sparse).transform(A_sparse)
 
+    # same with sparseness
     T2 = nmf.ProjectedGradientNMF(n_components=5, init='random',
             sparseness='data', random_state=999).fit_transform(A_sparse)
     T1 = nmf.ProjectedGradientNMF(n_components=5, init='random',


### PR DESCRIPTION
The slice `X[j, :]` is converted to an array (in `scipy.optimize.nnls`), which results in an empty tuple for the size of the slice when X is sparse. `scipy.optimize.nnls` then raises a `ValueError` claiming a vector is required. The problem only occurs when one invokes `fit` followed by a `transform`, which is what happens when `ProjectedGradientNMF` is used in a `Pipeline` which is passed on to `cross_validation.cross_val_score`.

I've added a statement  demonstrating the problem to the unit test. Without the fix I am submitting, the unit test fails.
