### PR TITLE
FIX Python 3 compatibility

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -25,7 +25,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils.fixes import lsqr
 from ..utils.sparsefuncs import (csc_mean_variance_axis0,
                                  inplace_csc_column_scale)
-from cd_fast import sparse_std
+from .cd_fast import sparse_std
 
 
 ###

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -185,7 +185,7 @@ class GMMTester():
         g.weights_ = self.weights
 
         samples = g.sample(n)
-        self.assertEquals(samples.shape, (n, self.n_features))
+        self.assertEqual(samples.shape, (n, self.n_features))
 
     def test_train(self, params='wmc'):
         g = mixture.GMM(n_components=self.n_components,

--- a/sklearn/tests/test_hmm.py
+++ b/sklearn/tests/test_hmm.py
@@ -173,7 +173,7 @@ class TestBaseHMM(TestCase):
 
         h = self.StubHMM(n_components)
 
-        self.assertEquals(h.n_components, n_components)
+        self.assertEqual(h.n_components, n_components)
 
         h.startprob_ = startprob
         assert_array_almost_equal(h.startprob_, startprob)
@@ -270,7 +270,7 @@ class GaussianHMMBaseTester(object):
         h.startprob_ = self.startprob
 
         samples = h.sample(n)[0]
-        self.assertEquals(samples.shape, (n, self.n_features))
+        self.assertEqual(samples.shape, (n, self.n_features))
 
     def test_fit(self, params='stmc', n_iter=5, verbose=False, **kwargs):
         h = hmm.GaussianHMM(self.n_components, self.covariance_type)
@@ -456,7 +456,7 @@ class MultinomialHMMTestCase(TestCase):
     def test_attributes(self):
         h = hmm.MultinomialHMM(self.n_components)
 
-        self.assertEquals(h.n_components, self.n_components)
+        self.assertEqual(h.n_components, self.n_components)
 
         h.startprob_ = self.startprob
         assert_array_almost_equal(h.startprob_, self.startprob)
@@ -479,7 +479,7 @@ class MultinomialHMMTestCase(TestCase):
         self.assertRaises(ValueError, h.__setattr__, 'emissionprob_', [])
         self.assertRaises(ValueError, h.__setattr__, 'emissionprob_',
                           np.zeros((self.n_components - 2, self.n_symbols)))
-        self.assertEquals(h.n_symbols, self.n_symbols)
+        self.assertEqual(h.n_symbols, self.n_symbols)
 
     def test_eval(self):
         idx = np.repeat(range(self.n_components), 10)
@@ -493,8 +493,8 @@ class MultinomialHMMTestCase(TestCase):
 
     def test_sample(self, n=1000):
         samples = self.h.sample(n)[0]
-        self.assertEquals(len(samples), n)
-        self.assertEquals(len(np.unique(samples)), self.n_symbols)
+        self.assertEqual(len(samples), n)
+        self.assertEqual(len(np.unique(samples)), self.n_symbols)
 
     def test_fit(self, params='ste', n_iter=5, verbose=False, **kwargs):
         h = self.h
@@ -586,7 +586,7 @@ class GMMHMMBaseTester(object):
     def test_attributes(self):
         h = hmm.GMMHMM(self.n_components, covariance_type=self.covariance_type)
 
-        self.assertEquals(h.n_components, self.n_components)
+        self.assertEqual(h.n_components, self.n_components)
 
         h.startprob_ = self.startprob
         assert_array_almost_equal(h.startprob_, self.startprob)
@@ -628,7 +628,7 @@ class GMMHMMBaseTester(object):
                        startprob=self.startprob, transmat=self.transmat,
                        gmms=self.gmms)
         samples = h.sample(n)[0]
-        self.assertEquals(samples.shape, (n, self.n_features))
+        self.assertEqual(samples.shape, (n, self.n_features))
 
     def test_fit(self, params='stmwc', n_iter=5, verbose=False, **kwargs):
         h = hmm.GMMHMM(self.n_components, covars_prior=1.0)

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -92,15 +92,11 @@ def test_discretenb_pickle():
         clf = cls().fit(X2, y2)
         y_pred = clf.predict(X2)
 
-        store = StringIO()
+        store = BytesIO()
         pickle.dump(clf, store)
-        clf = pickle.load(StringIO(store.getvalue()))
+        clf = pickle.load(BytesIO(store.getvalue()))
 
         assert_array_equal(y_pred, clf.predict(X2))
-
-    store = BytesIO()
-    pickle.dump(clf, store)
-    clf = pickle.load(BytesIO(store.getvalue()))
 
 
 def test_input_check():

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -107,6 +107,7 @@ for x in np.__version__.split('.'):
     except ValueError:
         # x may be of the form dev-1ea1592
         np_version.append(x)
+np_version = tuple(np_version)
 
 if np_version[:2] < (1, 5):
     unique = _unique


### PR DESCRIPTION
Fixed old-style imports, a bug that prevented scikit-learn from importing in python 3.2 and some failing tests.
