### PR TITLE
DOC: add google analytics theme option

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,7 +126,8 @@ html_theme = 'scikit-learn'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {'oldversion':False, 'collapsiblesidebar': True}
+html_theme_options = {'oldversion':False, 'collapsiblesidebar': True,
+                      'google_analytics':True}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['themes']

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -19,6 +19,8 @@
 {% endif %}
 
 {% block extrahead %}
+
+{% if theme_google_analytics|tobool %}
 <script type="text/javascript">
 
   var _gaq = _gaq || [];
@@ -32,6 +34,8 @@
   })();
 
 </script>
+{% endif %}
+
 {% endblock %}
 
 {%- if pagename == 'index' %}

--- a/doc/themes/scikit-learn/theme.conf
+++ b/doc/themes/scikit-learn/theme.conf
@@ -6,3 +6,4 @@ pygments_style = tango
 [options]
 oldversion = False
 collapsiblesidebar = True
+google_analytics = True


### PR DESCRIPTION
This adds an option in `conf.py` to turn off Google Analytics in the generated html - addresses Issue #1205.  By default, this changes nothing, but by setting the `'google_analytics'` option to False, the documentation can be generated without the GA javascript.
