### PR TITLE
MRG adding SomeScore objects for better (?!) grid search interface.

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -668,7 +668,7 @@ Model Selection Interface
    :toctree: generated/
    :template: class_with_call.rst
 
-   metrics.AsScorer
+   metrics.Scorer
 
 .. autosummary::
    :toctree: generated/

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -662,6 +662,14 @@ user guide for further details.
 
 .. currentmodule:: sklearn
 
+Grid Search Interface
+---------------------
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   metrics.AsScorer
+
 Classification metrics
 ----------------------
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -666,7 +666,7 @@ Grid Search Interface
 ---------------------
 .. autosummary::
    :toctree: generated/
-   :template: class.rst
+   :template: class_with_call.rst
 
    metrics.AsScorer
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -662,13 +662,19 @@ user guide for further details.
 
 .. currentmodule:: sklearn
 
-Grid Search Interface
----------------------
+Model Selection Interface
+-------------------------
 .. autosummary::
    :toctree: generated/
    :template: class_with_call.rst
 
    metrics.AsScorer
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+    metrics.score_objects
 
 Classification metrics
 ----------------------

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -670,12 +670,6 @@ Model Selection Interface
 
    metrics.Scorer
 
-.. autosummary::
-   :toctree: generated/
-   :template: function.rst
-
-   metrics.score_objects
-
 Classification metrics
 ----------------------
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -674,7 +674,7 @@ Model Selection Interface
    :toctree: generated/
    :template: function.rst
 
-    metrics.score_objects
+   metrics.score_objects
 
 Classification metrics
 ----------------------

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -83,14 +83,15 @@ by::
 
 By default, the score computed at each CV iteration is the ``score``
 method of the estimator. It is possible to change this by passing a custom
-scoring function, e.g. from the metrics module::
+scoring function::
 
   >>> from sklearn import metrics
   >>> cross_validation.cross_val_score(clf, iris.data, iris.target, cv=5,
-  ...     score_func=metrics.f1_score)
+  ...     scoring='f1')
   ...                                                     # doctest: +ELLIPSIS
   array([ 1.  ...,  0.96...,  0.89...,  0.96...,  1.        ])
 
+See :ref:`scoring_functions` for details.
 In the case of the Iris dataset, the samples are balanced across target
 classes hence the accuracy and the F1-score are almost equal.
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -91,7 +91,7 @@ scoring function::
   ...                                                     # doctest: +ELLIPSIS
   array([ 1.  ...,  0.96...,  0.89...,  0.96...,  1.        ])
 
-See :ref:`scoring_functions` for details.
+See :ref:`score_func_objects` for details.
 In the case of the Iris dataset, the samples are balanced across target
 classes hence the accuracy and the F1-score are almost equal.
 

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -49,7 +49,7 @@ combinations is retained.
   This can be done by using the :func:`cross_validation.train_test_split`
   utility function.
 
-.. _scoring_functions:
+.. _gridsearch_scoring:
 
 .. currentmodule:: sklearn.grid_search
 
@@ -73,7 +73,7 @@ that can be selected by giving a string argument:
 - ``recall``, corresponding to :func:`sklearn.metrics.recall_score`.
 
 Custom scoring functions can be specified by passing any callable that can be called by :class:`GridSearchCV` as
-``scoring(estimator, X, y)``. An easy way to create such a callable is via :class:`sklearn.metrics.AsScorer`.
+``scoring(estimator, X, y)``. See :ref:`score_func_objects` for more details.
 
 Examples
 ========

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -60,7 +60,7 @@ to evaluate a parameter setting. These are the :func:`sklearn.metrics.accuracy_s
 and :func:`sklearn.metrics.r2_score` for regression.
 For some applications, other scoring function are better suited (for example in
 unbalanced classification, the accuracy score is often non-informative). An alternative scoring function
-can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several build-in scores available,
+can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several built-in scores available,
 that can be selected by giving a string argument:
 
 ===================     =========================================

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -59,31 +59,10 @@ By default, :class:`GridSearchCV` uses the ``score`` function of the estimator
 to evaluate a parameter setting. These are the :func:`sklearn.metrics.accuracy_score` for classification
 and :func:`sklearn.metrics.r2_score` for regression.
 For some applications, other scoring function are better suited (for example in
-unbalanced classification, the accuracy score is often non-informative). An alternative scoring function
-can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several built-in scores available,
-that can be selected by giving a string argument:
-
-===================     ===============================================
-Scoring                 Function
-===================     ===============================================
-**Classification**
-'accuracy'              :func:`sklearn.metrics.accuracy_score`
-'average_precision'     :func:`sklearn.metrics.average_precision_score`
-'f1'                    :func:`sklearn.metrics.f1_score`
-'precision'             :func:`sklearn.metrics.precision_score`
-'recall'                :func:`sklearn.metrics.recall_score`
-'roc_auc'               :func:`sklearn.metrics.auc_score`
-
-**Clustering**
-'ari'`                  :func:`sklearn.metrics.adjusted_rand_score`
-
-**Regression**
-'mse'                   :func:`sklearn.metrics.mean_squared_error`
-'r2'                    :func:`sklearn.metrics.r2_score`
-===================     ===============================================
-
-Custom scoring functions can be specified by passing any callable that can be called by :class:`GridSearchCV` as
-``scoring(estimator, X, y)``. See :ref:`score_func_objects` for more details.
+unbalanced classification, the accuracy score is often non-informative). An
+alternative scoring function can be specified via the ``scoring`` parameter to
+:class:`GridSearchCV`. 
+See :ref:`score_func_objects` for more details.
 
 Examples
 ========

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -49,9 +49,9 @@ combinations is retained.
   This can be done by using the :func:`cross_validation.train_test_split`
   utility function.
 
-.. _gridsearch_scoring:
-
 .. currentmodule:: sklearn.grid_search
+
+.. _gridsearch_scoring:
 
 Scoring functions for GridSearchCV
 ----------------------------------

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -51,27 +51,29 @@ combinations is retained.
 
 .. _scoring_functions:
 
+.. currentmodule:: sklearn.grid_search
+
 Scoring functions for GridSearchCV
 ----------------------------------
-By default, :class:`grid_search.GridSearchCV` uses the ``score`` function of the estimator
-to evaluate a parameter setting. These are the :func:``sklearn.metrics.zero_one_score`` for classification
-and ``sklearn.metrics.r2_score`` for regression.
+By default, :class:`GridSearchCV` uses the ``score`` function of the estimator
+to evaluate a parameter setting. These are the :func:`sklearn.metrics.zero_one_score` for classification
+and :func:`sklearn.metrics.r2_score` for regression.
 For some applications, other scoring function are better suited (for example in
 unbalanced classification, the zero-one score is often non-informative). An alternative scoring function
-can be specified via the ``scoring`` parameter to GridSearchCV. There are several build-in scores available,
+can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several build-in scores available,
 that can be selected by giving a string argument:
 
-- ``r2``, corresponding to ``sklearn.metrics.r2_score``.
-- ``mse``, corresponding to ``sklearn.metrics.mean_squared_error``.
-- ``zero_one``, corresponding to ``sklearn.metrics.zero_one_score``.
-- ``f1``, corresponding to ``sklearn.metrics.f1_score``.
-- ``roc_auc``, corresponding to ``sklearn.metrics.auc_score``, the area under the ROC curve.
-- ``average_precision``, corresponding to ``sklearn.metrics.average_precision_score``, the area under the Precision-Recall curve.
-- ``precision``, corresponding to ``sklearn.metrics.precision_score``.
-- ``recall``, corresponding to ``sklearn.metrics.recall_score``.
+- ``r2``, corresponding to :func:`sklearn.metrics.r2_score`.
+- ``mse``, corresponding to :func:`sklearn.metrics.mean_squared_error`.
+- ``zero_one``, corresponding to :func:`sklearn.metrics.zero_one_score`.
+- ``f1``, corresponding to :func:`sklearn.metrics.f1_score`.
+- ``roc_auc``, corresponding to :func:`sklearn.metrics.auc_score`, the area under the ROC curve.
+- ``average_precision``, corresponding to :func:`sklearn.metrics.average_precision_score`, the area under the Precision-Recall curve.
+- ``precision``, corresponding to :func:`sklearn.metrics.precision_score`.
+- ``recall``, corresponding to :func:`sklearn.metrics.recall_score`.
 
-Custom scoring functions can be specified by passing any callable that can be called by :class:`grid_search.GridSearchCV`` as
-``scoring(estimator, X, y)``. An easy way to create such a callable is via :class:``sklearn.metrics.AsScorer``.
+Custom scoring functions can be specified by passing any callable that can be called by :class:`GridSearchCV` as
+``scoring(estimator, X, y)``. An easy way to create such a callable is via :class:`sklearn.metrics.AsScorer`.
 
 Examples
 ========

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -63,24 +63,24 @@ unbalanced classification, the accuracy score is often non-informative). An alte
 can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several built-in scores available,
 that can be selected by giving a string argument:
 
-===================     =========================================
+===================     ===============================================
 Scoring                 Function
-===================     =========================================
+===================     ===============================================
 **Classification**
-'accuracy'              sklearn.metrics.accuracy_score
-'average_precision'     sklearn.metrics.average_precision_score
-'f1'                    sklearn.metrics.f1_score
-'precision'             sklearn.metrics.precision_score
-'recall'                sklearn.metrics.recall_score
-'roc_auc'               sklearn.merrics.auc_score
+'accuracy'              :func:`sklearn.metrics.accuracy_score`
+'average_precision'     :func:`sklearn.metrics.average_precision_score`
+'f1'                    :func:`sklearn.metrics.f1_score`
+'precision'             :func:`sklearn.metrics.precision_score`
+'recall'                :func:`sklearn.metrics.recall_score`
+'roc_auc'               :func:`sklearn.metrics.auc_score`
 
 **Clustering**
-'ari'`                  sklearn.metrics.adjusted_rand_score
+'ari'`                  :func:`sklearn.metrics.adjusted_rand_score`
 
 **Regression**
-'mse'                   sklearn.metrics.mean_squared_error
-'r2'                    sklearn.metrics.r2_score
-===================     =========================================
+'mse'                   :func:`sklearn.metrics.mean_squared_error`
+'r2'                    :func:`sklearn.metrics.r2_score`
+===================     ===============================================
 
 Custom scoring functions can be specified by passing any callable that can be called by :class:`GridSearchCV` as
 ``scoring(estimator, X, y)``. See :ref:`score_func_objects` for more details.

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -63,14 +63,24 @@ unbalanced classification, the accuracy score is often non-informative). An alte
 can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several build-in scores available,
 that can be selected by giving a string argument:
 
-- ``r2``, corresponding to :func:`sklearn.metrics.r2_score`.
-- ``mse``, corresponding to :func:`sklearn.metrics.mean_squared_error`.
-- ``zero_one``, corresponding to :func:`sklearn.metrics.accuracy_score`.
-- ``f1``, corresponding to :func:`sklearn.metrics.f1_score`.
-- ``roc_auc``, corresponding to :func:`sklearn.metrics.auc_score`, the area under the ROC curve.
-- ``average_precision``, corresponding to :func:`sklearn.metrics.average_precision_score`, the area under the Precision-Recall curve.
-- ``precision``, corresponding to :func:`sklearn.metrics.precision_score`.
-- ``recall``, corresponding to :func:`sklearn.metrics.recall_score`.
+===================     =========================================
+Scoring                 Function
+===================     =========================================
+**Classification**
+'accuracy'              sklearn.metrics.accuracy_score
+'average_precision'     sklearn.metrics.average_precision_score
+'f1'                    sklearn.metrics.f1_score
+'precision'             sklearn.metrics.precision_score
+'recall'                sklearn.metrics.recall_score
+'roc_auc'               sklearn.merrics.auc_score
+
+**Clustering**
+'ari'`                  sklearn.metrics.adjusted_rand_score
+
+**Regression**
+'mse'                   sklearn.metrics.mean_squared_error
+'r2'                    sklearn.metrics.r2_score
+===================     =========================================
 
 Custom scoring functions can be specified by passing any callable that can be called by :class:`GridSearchCV` as
 ``scoring(estimator, X, y)``. See :ref:`score_func_objects` for more details.

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -49,6 +49,29 @@ combinations is retained.
   This can be done by using the :func:`cross_validation.train_test_split`
   utility function.
 
+.. _scoring_functions:
+
+Scoring functions for GridSearchCV
+----------------------------------
+By default, :class:`grid_search.GridSearchCV` uses the ``score`` function of the estimator
+to evaluate a parameter setting. These are the :func:``sklearn.metrics.zero_one_score`` for classification
+and ``sklearn.metrics.r2_score`` for regression.
+For some applications, other scoring function are better suited (for example in
+unbalanced classification, the zero-one score is often non-informative). An alternative scoring function
+can be specified via the ``scoring`` parameter to GridSearchCV. There are several build-in scores available,
+that can be selected by giving a string argument:
+
+- ``r2``, corresponding to ``sklearn.metrics.r2_score``.
+- ``mse``, corresponding to ``sklearn.metrics.mean_squared_error``.
+- ``zero_one``, corresponding to ``sklearn.metrics.zero_one_score``.
+- ``f1``, corresponding to ``sklearn.metrics.f1_score``.
+- ``roc_auc``, corresponding to ``sklearn.metrics.auc_score``, the area under the ROC curve.
+- ``average_precision``, corresponding to ``sklearn.metrics.average_precision_score``, the area under the Precision-Recall curve.
+- ``precision``, corresponding to ``sklearn.metrics.precision_score``.
+- ``recall``, corresponding to ``sklearn.metrics.recall_score``.
+
+Custom scoring functions can be specified by passing any callable that can be called by :class:`grid_search.GridSearchCV`` as
+``scoring(estimator, X, y)``. An easy way to create such a callable is via :class:``sklearn.metrics.AsScorer``.
 
 Examples
 ========

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -56,16 +56,16 @@ combinations is retained.
 Scoring functions for GridSearchCV
 ----------------------------------
 By default, :class:`GridSearchCV` uses the ``score`` function of the estimator
-to evaluate a parameter setting. These are the :func:`sklearn.metrics.zero_one_score` for classification
+to evaluate a parameter setting. These are the :func:`sklearn.metrics.accuracy_score` for classification
 and :func:`sklearn.metrics.r2_score` for regression.
 For some applications, other scoring function are better suited (for example in
-unbalanced classification, the zero-one score is often non-informative). An alternative scoring function
+unbalanced classification, the accuracy score is often non-informative). An alternative scoring function
 can be specified via the ``scoring`` parameter to :class:`GridSearchCV`. There are several build-in scores available,
 that can be selected by giving a string argument:
 
 - ``r2``, corresponding to :func:`sklearn.metrics.r2_score`.
 - ``mse``, corresponding to :func:`sklearn.metrics.mean_squared_error`.
-- ``zero_one``, corresponding to :func:`sklearn.metrics.zero_one_score`.
+- ``zero_one``, corresponding to :func:`sklearn.metrics.accuracy_score`.
 - ``f1``, corresponding to :func:`sklearn.metrics.f1_score`.
 - ``roc_auc``, corresponding to :func:`sklearn.metrics.auc_score`, the area under the ROC curve.
 - ``average_precision``, corresponding to :func:`sklearn.metrics.average_precision_score`, the area under the Precision-Recall curve.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -827,6 +827,15 @@ with non default value for its parameters such as the beta parameter for the
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=ftwo_scorer)
 
+The second use case is to help build a completely new and custom scorer object from a simple python function::
+
+    >>> def my_custom_loss_func(ground_truth, predictions):
+    ...     diff = np.abs(ground_truth - predictions).max()
+    ...     return np.log(1 + diff)
+    ...
+    >>> my_custom_scorer = AsScorer(my_custom_loss_func, greater_is_better=False)
+    >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=my_custom_scorer)
+
 :class:`AsScorer` takes as parameters the function you want to use,
 whether it is a score (``greater_is_better=True``) or a loss
 (``greater_is_better=False``), whether the function you provided takes

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -772,8 +772,8 @@ function for more information see the :ref:`clustering_evaluation` section.
 
 .. currentmodule:: sklearn
 
-Flexible Scoring Objects
-========================
+`Scoring` objects: defining your scoring rules
+===============================================
 While the above functions provide a simple interface for most use-cases, they
 can not directly be used for model selection and evaluation using
 :class:`grid_search.GridSearchCV` and
@@ -790,28 +790,28 @@ them), you can simply provide a string as the ``scoring`` parameter. Possible
 values are:
 
 
-===================     =========================================
+===================     ===============================================
 Scoring                 Function
-===================     =========================================
+===================     ===============================================
 **Classification**
-'accuracy'              sklearn.metrics.accuracy_score
-'average_precision'     sklearn.metrics.average_precision_score
-'f1'                    sklearn.metrics.f1_score
-'precision'             sklearn.metrics.precision_score
-'recall'                sklearn.metrics.recall_score
-'roc_auc'               sklearn.merrics.auc_score
+'accuracy'              :func:`sklearn.metrics.accuracy_score`
+'average_precision'     :func:`sklearn.metrics.average_precision_score`
+'f1'                    :func:`sklearn.metrics.f1_score`
+'precision'             :func:`sklearn.metrics.precision_score`
+'recall'                :func:`sklearn.metrics.recall_score`
+'roc_auc'               :func:`sklearn.metrics.auc_score`
 
 **Clustering**
-'ari'`                  sklearn.metrics.adjusted_rand_score
+'ari'`                  :func:`sklearn.metrics.adjusted_rand_score`
 
 **Regression**
-'mse'                   sklearn.metrics.mean_squared_error
-'r2'                    sklearn.metrics.r2_score
-===================     =========================================
+'mse'                   :func:`sklearn.metrics.mean_squared_error`
+'r2'                    :func:`sklearn.metrics.r2_score`
+===================     ===============================================
 
 .. currentmodule:: sklearn.metrics
 
-Creating Scoring Objects From Score Functions
+Creating scoring objects from score functions
 ---------------------------------------------
 If you want to use a scoring function that takes additional parameters, such as
 :func:`fbeta_score`, you need to generate an appropriate scoring object.  The
@@ -819,6 +819,7 @@ simplest way to generate a callable object for scoring is by using
 :class:`Scorer`.
 :class:`Scorer` converts score functions as above into callables
 that can be used for model evaluation.
+
 One typical use case is to wrap an existing scoring function from the library
 with non default value for its parameters such as the beta parameter for the
 :func:fbeta_score function::
@@ -846,7 +847,7 @@ predictions as input (``needs_threshold=False``) or needs confidence scores
 in the example above.
 
 
-Implementing Your Own Scoring Object
+Implementing your own scoring object
 ------------------------------------
 You can generate even more flexible model scores by constructing your own
 scoring object from scratch, without using the :class:`Scorer` helper class.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -814,15 +814,15 @@ Creating Scoring Objects From Score Functions
 If you want to use a scoring function that takes additional parameters, such as
 :func:`fbeta_score`, you need to generate an appropriate scoring object.  The
 simplest way to generate a callable object for scoring is by using
-:class:`AsScorer`.
-:class:`AsScorer` converts score functions as above into callables
+:class:`Scorer`.
+:class:`Scorer` converts score functions as above into callables
 that can be used for model evaluation.
 One typical use case is to wrap an existing scoring function from the library
 with non default value for its parameters such as the beta parameter for the
 :func:fbeta_score function::
 
-    >>> from sklearn.metrics import fbeta_score, AsScorer
-    >>> ftwo_scorer = AsScorer(fbeta_score, beta=2)
+    >>> from sklearn.metrics import fbeta_score, Scorer
+    >>> ftwo_scorer = Scorer(fbeta_score, beta=2)
     >>> from sklearn.grid_search import GridSearchCV
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=ftwo_scorer)
@@ -833,10 +833,10 @@ The second use case is to help build a completely new and custom scorer object f
     ...     diff = np.abs(ground_truth - predictions).max()
     ...     return np.log(1 + diff)
     ...
-    >>> my_custom_scorer = AsScorer(my_custom_loss_func, greater_is_better=False)
+    >>> my_custom_scorer = Scorer(my_custom_loss_func, greater_is_better=False)
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=my_custom_scorer)
 
-:class:`AsScorer` takes as parameters the function you want to use,
+:class:`Scorer` takes as parameters the function you want to use,
 whether it is a score (``greater_is_better=True``) or a loss
 (``greater_is_better=False``), whether the function you provided takes
 predictions as input (``needs_threshold=False``) or needs confidence scores
@@ -847,7 +847,7 @@ in the example above.
 Implementing Your Own Scoring Object
 ------------------------------------
 You can generate even more flexible model scores by constructing your own
-scoring object from scratch, without using the :class:`AsScorer` helper class.
+scoring object from scratch, without using the :class:`Scorer` helper class.
 The requirements that a callable can be used for model selection are as
 follows:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -768,18 +768,18 @@ function for more information see the :ref:`clustering_evaluation` section.
 
 .. _score_func_objects:
 
-.. currentmodule:: sklearn.cross_validation
+.. currentmodule:: sklearn
 
 Flexible Scoring Objects
 ========================
 While the above functions provide a simple interface for most use-cases, they
 can not directly be used for model selection and evaluation using
-:class:`GridSearchCV` and
-:func:`cross_val_score`, as scoring functions have different
+:class:`grid_search.GridSearchCV` and
+:func:`cross_validation.cross_val_score`, as scoring functions have different
 signatures and might require additional parameters.
 
-Instead, :class:`GridSearchCV` and
-:func:`cross_val_score` both take callables that implement
+Instead, :class:`grid_search.GridSearchCV` and
+:func:`cross_validation.cross_val_score` both take callables that implement
 estimator dependent functions. That allows for very flexible evaluation of
 models, for example taking complexity of the model into account.
 
@@ -792,7 +792,6 @@ values are:
 Scoring                 Function
 ===================     =========================================
 **Classification**
--------------------     -----------------------------------------
 'accuracy'              sklearn.metrics.accuracy_score
 'average_precision'     sklearn.metrics.average_precision_score
 'f1'                    sklearn.metrics.f1_score
@@ -801,11 +800,9 @@ Scoring                 Function
 'roc_auc'               sklearn.merrics.auc_score
 
 **Clustering**
--------------------     -----------------------------------------
 'ari'`                  sklearn.metrics.adjusted_rand_score
 
 **Regression**
--------------------     -----------------------------------------
 'mse'                   sklearn.metrics.mean_squared_error
 'r2'                    sklearn.metrics.r2_score
 ===================     =========================================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -297,7 +297,7 @@ In this context, we can define the notions of precision, recall and F-measure:
 
    F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}.
 
-Here some small examples in binary classification:
+Here some small examples in binary classification::
 
   >>> from sklearn import metrics
   >>> y_pred = [0, 1, 0, 0]
@@ -411,7 +411,7 @@ their support
 
   \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{\beta^2 |\hat{y}_i| + |y_i|}.
 
-Here an example where ``average`` is set to ``average`` to ``macro``:
+Here an example where ``average`` is set to ``average`` to ``macro``::
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -427,7 +427,7 @@ Here an example where ``average`` is set to ``average`` to ``macro``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
   (0.22..., 0.33..., 0.26..., None)
 
-Here an example where ``average`` is set to to ``micro``:
+Here an example where ``average`` is set to to ``micro``::
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -443,7 +443,7 @@ Here an example where ``average`` is set to to ``micro``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
   (0.33..., 0.33..., 0.33..., None)
 
-Here an example where ``average`` is set to to ``weighted``:
+Here an example where ``average`` is set to to ``weighted``::
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -459,7 +459,7 @@ Here an example where ``average`` is set to to ``weighted``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
   (0.22..., 0.33..., 0.26..., None)
 
-Here an example where ``average`` is set to ``None``:
+Here an example where ``average`` is set to ``None``::
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -492,7 +492,7 @@ value and :math:`w` is the predicted decisions as output by
   L_\text{Hinge}(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
 Here a small example demonstrating the use of the :func:`hinge_loss` function
-with a svm classifier:
+with a svm classifier::
 
   >>> from sklearn import svm
   >>> from sklearn.metrics import hinge_loss
@@ -822,7 +822,7 @@ that can be used for model evaluation.
 
 One typical use case is to wrap an existing scoring function from the library
 with non default value for its parameters such as the beta parameter for the
-:func:fbeta_score function::
+:func:`fbeta_score` function::
 
     >>> from sklearn.metrics import fbeta_score, Scorer
     >>> ftwo_scorer = Scorer(fbeta_score, beta=2)

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -653,7 +653,7 @@ variance is  estimated  as follow:
 
 The best possible score is 1.0, lower values are worse.
 
-Here a small example of usage of the :func:`explained_variance_scoreé`
+Here a small example of usage of the :func:`explained_variance_score`
 function::
 
     >>> from sklearn.metrics import explained_variance_score

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -809,6 +809,9 @@ Scoring                 Function
 'r2'                    :func:`sklearn.metrics.r2_score`
 ===================     ===============================================
 
+The corresponding scorer objects are stored in the dictionary
+``sklearn.metrics.SCORERS``.
+
 .. currentmodule:: sklearn.metrics
 
 Creating scoring objects from score functions

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -849,14 +849,27 @@ For scoring functions that take no additional parameters (which are most of
 them), you can simply provide a string as the ``scoring`` parameter. Possible
 values are:
 
-- ``r2``, corresponding to :func:`sklearn.metrics.r2_score`.
-- ``mse``, corresponding to :func:`sklearn.metrics.mean_squared_error`.
-- ``zero_one``, corresponding to :func:`sklearn.metrics.accuracy_score`.
-- ``f1``, corresponding to :func:`sklearn.metrics.f1_score`.
-- ``roc_auc``, corresponding to :func:`sklearn.metrics.auc_score`, the area under the ROC curve.
-- ``average_precision``, corresponding to :func:`sklearn.metrics.average_precision_score`, the area under the Precision-Recall curve.
-- ``precision``, corresponding to :func:`sklearn.metrics.precision_score`.
-- ``recall``, corresponding to :func:`sklearn.metrics.recall_score`.
+===============     ====================================
+scoring             Function
+===============     ====================================
+Classification
+--------------      ------------------------------------
+'accuracy'          sklearn.metrics.accuracy_score
+'average_precision' sklearn.metrics.average_precision_score
+'f1'                sklearn.metrics.f1_score
+'precision'         sklearn.metrics.precision_score
+'recall'            sklearn.metrics.recall_score
+'roc_auc'           sklearn.merrics.auc_score
+
+Clustering
+--------------      ------------------------------------
+'ari'`              sklearn.metrics.adjusted_rand_score
+
+Regression
+--------------      ------------------------------------
+'mse'               sklearn.metrics.mean_squared_error
+'r2'                sklearn.metrics.r2_score
+===============     ====================================
 
 Creating Scoring Objects From Score Functions
 ---------------------------------------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -816,7 +816,10 @@ If you want to use a scoring function that takes additional parameters, such as
 simplest way to generate a callable object for scoring is by using
 :class:`AsScorer`.
 :class:`AsScorer` converts score functions as above into callables
-that can be used for model evaluation::
+that can be used for model evaluation.
+One typical use case is to wrap an existing scoring function from the library
+with non default value for its parameters such as the beta parameter for the
+:func:fbeta_score function::
 
     >>> from sklearn.metrics import fbeta_score, AsScorer
     >>> ftwo_scorer = AsScorer(fbeta_score, beta=2)
@@ -835,8 +838,9 @@ in the example above.
 Implementing Your Own Scoring Object
 ------------------------------------
 You can generate even more flexible model scores by constructing your own
-scoring object. The requirements that a callable can be used for model
-selection are as follows:
+scoring object from scratch, without using the :class:`AsScorer` helper class.
+The requirements that a callable can be used for model selection are as
+follows:
 
 - It can be called with parameters ``(estimator, X, y)``, where ``estimator``
   it the model that should be evaluated, ``X`` is validation data and ``y``

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -653,7 +653,8 @@ variance is  estimated  as follow:
 
 The best possible score is 1.0, lower values are worse.
 
-Here a small example of usage of the :func:`explained_variance_scoreé` function:
+Here a small example of usage of the :func:`explained_variance_scoreé`
+function::
 
     >>> from sklearn.metrics import explained_variance_score
     >>> y_true = [3, -0.5, 2, 7]
@@ -676,7 +677,7 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
 
-Here a small example of usage of the :func:`mean_absolute_error` function:
+Here a small example of usage of the :func:`mean_absolute_error` function::
 
   >>> from sklearn.metrics import mean_absolute_error
   >>> y_true = [3, -0.5, 2, 7]
@@ -705,7 +706,8 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
   \text{MSE}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (y_i - \hat{y}_i)^2.
 
-Here a small example of usage of the :func:`mean_squared_error` function:
+Here a small example of usage of the :func:`mean_squared_error`
+function::
 
   >>> from sklearn.metrics import mean_squared_error
   >>> y_true = [3, -0.5, 2, 7]
@@ -740,7 +742,7 @@ over :math:`n_{\text{samples}}` is defined as
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}} - 1} y_i`.
 
-Here a small example of usage of the :func:`r2_score` function:
+Here a small example of usage of the :func:`r2_score` function::
 
   >>> from sklearn.metrics import r2_score
   >>> y_true = [3, -0.5, 2, 7]

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -864,6 +864,9 @@ follows:
 - The callable has a boolean attribute ``greater_is_better`` which indicates whether
   high or low values correspond to a better estimator.
 
+Objects that meet those conditions as said to implement the sklearn Scorer
+protocol.
+
 
 .. _dummy_estimators:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -817,8 +817,8 @@ If you want to use a scoring function that takes additional parameters, such as
 :func:`fbeta_score`, you need to generate an appropriate scoring object.  The
 simplest way to generate a callable object for scoring is by using
 :class:`Scorer`.
-:class:`Scorer` converts score functions as above into callables
-that can be used for model evaluation.
+:class:`Scorer` converts score functions as above into callables that can be
+used for model evaluation.
 
 One typical use case is to wrap an existing scoring function from the library
 with non default value for its parameters such as the beta parameter for the
@@ -830,7 +830,8 @@ with non default value for its parameters such as the beta parameter for the
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=ftwo_scorer)
 
-The second use case is to help build a completely new and custom scorer object from a simple python function::
+The second use case is to help build a completely new and custom scorer object
+from a simple python function::
 
     >>> def my_custom_loss_func(ground_truth, predictions):
     ...     diff = np.abs(ground_truth - predictions).max()
@@ -839,12 +840,12 @@ The second use case is to help build a completely new and custom scorer object f
     >>> my_custom_scorer = Scorer(my_custom_loss_func, greater_is_better=False)
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]}, scoring=my_custom_scorer)
 
-:class:`Scorer` takes as parameters the function you want to use,
-whether it is a score (``greater_is_better=True``) or a loss
-(``greater_is_better=False``), whether the function you provided takes
-predictions as input (``needs_threshold=False``) or needs confidence scores
-(``needs_threshold=True``) and any additional parameters, such as ``beta``
-in the example above.
+:class:`Scorer` takes as parameters the function you want to use, whether it is
+a score (``greater_is_better=True``) or a loss (``greater_is_better=False``),
+whether the function you provided takes predictions as input
+(``needs_threshold=False``) or needs confidence scores
+(``needs_threshold=True``) and any additional parameters, such as ``beta`` in
+the example above.
 
 
 Implementing your own scoring object
@@ -855,9 +856,9 @@ The requirements that a callable can be used for model selection are as
 follows:
 
 - It can be called with parameters ``(estimator, X, y)``, where ``estimator``
-  it the model that should be evaluated, ``X`` is validation data and ``y``
-  is the ground truth target for ``X`` (in the supervised case) or ``None``
-  in the unsupervised case.
+  it the model that should be evaluated, ``X`` is validation data and ``y`` is
+  the ground truth target for ``X`` (in the supervised case) or ``None`` in the
+  unsupervised case.
 
 - The call returns a number indicating the quality of estimator.
 
@@ -875,10 +876,9 @@ Dummy estimators
 
 .. currentmodule:: sklearn.dummy
 
-When doing supervised learning, a simple sanity check consists in comparing one's
-estimator against simple rules of thumb.
-:class:`DummyClassifier` implements three such simple strategies for
-classification:
+When doing supervised learning, a simple sanity check consists in comparing
+one's estimator against simple rules of thumb. :class:`DummyClassifier`
+implements three such simple strategies for classification:
 
 - `stratified` generates randomly predictions by respecting the training
   set's class distribution,

--- a/doc/templates/class_with_call.rst
+++ b/doc/templates/class_with_call.rst
@@ -1,0 +1,13 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+   .. automethod:: __call__
+   {% endblock %}
+
+

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,11 +12,11 @@ Changelog
      `Martin Luessi`_.
 
    - :class:`grid_search.GridSearchCV` and
-     :func:`cross_validation.cross_Val_score` now support the use of advanced
+     :func:`cross_validation.cross_val_score` now support the use of advanced
      scoring function such as area under the ROC curve and f-beta scores.
-     See :ref:`scoring_functions` for details.
+     See :ref:`score_func_objects` for details. By `Andreas Müller`_.
      Passing a function from :mod:`sklearn.metrics` as ``score_func`` is
-     deprecated.
+     deprecated. 
 
 
 .. _changes_0_13:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,8 @@ Changelog
      :func:`cross_validation.cross_Val_score` now support the use of advanced
      scoring function such as area under the ROC curve and f-beta scores.
      See :ref:`scoring_functions` for details.
+     Passing a function from :mod:`sklearn.metrics` as ``score_func`` is
+     deprecated.
 
 
 .. _changes_0_13:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ Changelog
    - Hyperlinks to documentation in example code on the website by
      `Martin Luessi`_.
 
+   - :class:`grid_search.GridSearchCV` and
+     :func:`cross_validation.cross_Val_score` now support the use of advanced
+     scoring function such as area under the ROC curve and f-beta scores.
+     See :ref:`scoring_functions` for details.
+
 
 .. _changes_0_13:
 

--- a/examples/grid_search_digits.py
+++ b/examples/grid_search_digits.py
@@ -22,8 +22,6 @@ from sklearn import datasets
 from sklearn.cross_validation import train_test_split
 from sklearn.grid_search import GridSearchCV
 from sklearn.metrics import classification_report
-from sklearn.metrics import precision_score
-from sklearn.metrics import recall_score
 from sklearn.svm import SVC
 
 print(__doc__)
@@ -46,16 +44,13 @@ tuned_parameters = [{'kernel': ['rbf'], 'gamma': [1e-3, 1e-4],
                      'C': [1, 10, 100, 1000]},
                     {'kernel': ['linear'], 'C': [1, 10, 100, 1000]}]
 
-scores = [
-    ('precision', precision_score),
-    ('recall', recall_score),
-]
+scores = ['precision', 'recall']
 
-for score_name, score_func in scores:
-    print("# Tuning hyper-parameters for %s" % score_name)
+for score in scores:
+    print("# Tuning hyper-parameters for %s" % score)
     print()
 
-    clf = GridSearchCV(SVC(C=1), tuned_parameters, score_func=score_func)
+    clf = GridSearchCV(SVC(C=1), tuned_parameters, scoring=score)
     clf.fit(X_train, y_train, cv=5)
 
     print("Best parameters set found on development set:")

--- a/examples/plot_permutation_test_for_classification.py
+++ b/examples/plot_permutation_test_for_classification.py
@@ -22,7 +22,6 @@ import pylab as pl
 from sklearn.svm import SVC
 from sklearn.cross_validation import StratifiedKFold, permutation_test_score
 from sklearn import datasets
-from sklearn.metrics import accuracy_score
 
 
 ##############################################################################
@@ -43,7 +42,7 @@ svm = SVC(kernel='linear')
 cv = StratifiedKFold(y, 2)
 
 score, permutation_scores, pvalue = permutation_test_score(
-    svm, X, y, accuracy_score, cv=cv, n_permutations=100, n_jobs=1)
+    svm, X, y, scoring="accuracy", cv=cv, n_permutations=100, n_jobs=1)
 
 print("Classification score %s (pvalue : %s)" % (score, pvalue))
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -22,7 +22,7 @@ from .base import is_classifier, clone
 from .utils import check_arrays, check_random_state, safe_mask
 from .utils.fixes import unique
 from .externals.joblib import Parallel, delayed
-from .metrics import scorers, AsScorer
+from .metrics import scorers, Scorer
 
 __all__ = ['Bootstrap',
            'KFold',
@@ -1122,7 +1122,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         warnings.warn("Passing function as ``score_func`` is "
                       "deprecated and will be removed in 0.15. "
                       "Either use strings or score objects.", stacklevel=2)
-        scorer = AsScorer(score_func)
+        scorer = Scorer(score_func)
     elif isinstance(scoring, basestring):
         scorer = scorers[scoring]
     else:
@@ -1276,7 +1276,7 @@ def permutation_test_score(estimator, X, y, scoring=None, cv=None,
         warnings.warn("Passing function as ``score_func`` is "
                       "deprecated and will be removed in 0.15. "
                       "Either use strings or score objects.")
-        scorer = AsScorer(score_func)
+        scorer = Scorer(score_func)
     elif isinstance(scoring, basestring):
         scorer = scorers[scoring]
     else:

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1093,8 +1093,9 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
 
     scoring : string or callable, optional
         Either one of either a string ("zero_one", "f1", "roc_auc", ... for
-        classification, "mse", "r2",... for regression) or a callable.
-        See the user guide for details.
+        classification, "mse", "r2", ... for regression) or a callable.
+        See 'Scoring objects' in the model evaluation section of the user guide
+        for details.
 
     cv : cross-validation generator, optional
         A cross-validation generator. If None, a 3-fold cross
@@ -1221,9 +1222,10 @@ def permutation_test_score(estimator, X, y, scoring=None, cv=None,
         supervised learning.
 
     scoring : string or object, optional
-        Either one of ["zero_one", "f1", "auc"] for classification,
-        ["mse", "r2"] for regression or an object providing a
-        scoring method.
+        Either one of either a string ("zero_one", "f1", "roc_auc", ... for
+        classification, "mse", "r2", ... for regression) or a callable.
+        See 'Scoring objects' in the model evaluation section of the user guide
+        for details.
 
     cv : integer or crossvalidation generator, optional
         If an integer is passed, it is the number of fold (default 3).

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1036,8 +1036,7 @@ def _cross_val_score(estimator, X, y, score_func, train, test, verbose,
     """Inner loop for cross validation"""
     n_samples = X.shape[0] if sp.issparse(X) else len(X)
     fit_params = dict([(k, np.asarray(v)[train]
-                        if hasattr(v, '__len__')
-                        and len(v) == n_samples else v)
+                       if hasattr(v, '__len__') and len(v) == n_samples else v)
                        for k, v in fit_params.items()])
     if not hasattr(X, "shape"):
         if getattr(estimator, "_pairwise", False):

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -22,7 +22,7 @@ from .base import is_classifier, clone
 from .utils import check_arrays, check_random_state, safe_mask
 from .utils.fixes import unique
 from .externals.joblib import Parallel, delayed
-from .metrics import scorers, Scorer
+from .metrics import SCORERS, Scorer
 
 __all__ = ['Bootstrap',
            'KFold',
@@ -1124,7 +1124,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
                       "Either use strings or score objects.", stacklevel=2)
         scorer = Scorer(score_func)
     elif isinstance(scoring, basestring):
-        scorer = scorers[scoring]
+        scorer = SCORERS[scoring]
     else:
         scorer = scoring
     if scorer is None and not hasattr(estimator, 'score'):
@@ -1278,7 +1278,7 @@ def permutation_test_score(estimator, X, y, scoring=None, cv=None,
                       "Either use strings or score objects.")
         scorer = Scorer(score_func)
     elif isinstance(scoring, basestring):
-        scorer = scorers[scoring]
+        scorer = SCORERS[scoring]
     else:
         scorer = scoring
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1088,10 +1088,10 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         The target variable to try to predict in the case of
         supervised learning.
 
-    scoring : string or object, optional
-        Either one of ["zero_one", "f1", "auc"] for classification,
-        ["mse", "r2"] for regression or an object providing a
-        scoreing method.
+    scoring : string or callable, optional
+        Either one of either a string ("zero_one", "f1", "roc_auc", ... for
+        classification, "mse", "r2",... for regression) or a callable.
+        See the user guide for details.
 
     cv : cross-validation generator, optional
         A cross-validation generator. If None, a 3-fold cross

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1067,6 +1067,9 @@ def _cross_val_score(estimator, X, y, scorer, train, test, verbose,
         score = estimator.score(X_test, y_test)
     else:
         score = scorer(estimator, X_test, y_test)
+        if not isinstance(score, numbers.Number):
+            raise ValueError("scoring must return a number, got %s (%s)"
+                             " instead." % (str(score), type(score)))
     if verbose > 1:
         print("score: %f" % score)
     return score

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -183,10 +183,10 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
         dictionaries, in which case the grids spanned by each dictionary
         in the list are explored.
 
-    scoring : string or object, optional
-        Either one of ["zero_one", "f1", "auc"] for classification,
-        ["mse", "r2"] for regression or an object providing a
-        scoring method.
+    scoring : string or callable, optional
+        Either one of either a string ("zero_one", "f1", "roc_auc", ... for
+        classification, "mse", "r2",... for regression) or a callable.
+        See the user guide for details.
 
     fit_params : dict, optional
         parameters to pass to the fit method

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -10,6 +10,7 @@ of an estimator.
 from itertools import product
 import time
 import warnings
+import numbers
 
 import numpy as np
 
@@ -122,6 +123,10 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, scorer,
             this_score = scorer(clf, X_test)
         else:
             this_score = clf.score(X_test)
+
+    if not isinstance(this_score, numbers.Number):
+        raise ValueError("scoring must return a number, got %s (%s)"
+                         " instead." % (str(this_score), type(this_score)))
 
     if verbose > 2:
         msg += ", score=%f" % this_score

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -186,7 +186,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
     scoring : string or object, optional
         Either one of ["zero_one", "f1", "auc"] for classification,
         ["mse", "r2"] for regression or an object providing a
-        scoreing method.
+        scoring method.
 
     fit_params : dict, optional
         parameters to pass to the fit method

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -191,7 +191,8 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
     scoring : string or callable, optional
         Either one of either a string ("zero_one", "f1", "roc_auc", ... for
         classification, "mse", "r2",... for regression) or a callable.
-        See the user guide for details.
+        See 'Scoring objects' in the model evaluation section of the user guide
+        for details.
 
     fit_params : dict, optional
         parameters to pass to the fit method

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -180,7 +180,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
         in the list are explored.
 
     score : string or object, optional
-        Either one of ["zero-one", "f1", "auc"] for classification,
+        Either one of ["zero_one", "f1", "auc"] for classification,
         ["mse", "r2"] for regression or an object providing a
         scoreing method.
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -20,7 +20,7 @@ from .cross_validation import check_cv
 from .externals.joblib import Parallel, delayed, logger
 from .utils.validation import _num_samples
 from .utils import check_arrays, safe_mask
-from .metrics import scorers, AsScorer
+from .metrics import scorers, Scorer
 
 __all__ = ['GridSearchCV', 'IterGrid', 'fit_grid_point']
 
@@ -368,12 +368,12 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
             warnings.warn("Passing a loss function is "
                           "deprecated and will be removed in 0.15. "
                           "Either use strings or score objects.")
-            scorer = AsScorer(self.loss_func, greater_is_better=False)
+            scorer = Scorer(self.loss_func, greater_is_better=False)
         elif self.score_func is not None:
             warnings.warn("Passing function as ``score_func`` is "
                           "deprecated and will be removed in 0.15. "
                           "Either use strings or score objects.")
-            scorer = AsScorer(self.score_func)
+            scorer = Scorer(self.score_func)
         elif isinstance(self.scoring, basestring):
             scorer = scorers[self.scoring]
         else:

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -283,12 +283,13 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
 
     """
 
-    def __init__(self, estimator, param_grid, score=None, loss_func=None,
+    def __init__(self, estimator, param_grid, scoring=None, loss_func=None,
                  score_func=None, fit_params=None, n_jobs=1, iid=True,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs'):
         if (not hasattr(estimator, 'score') and
             (not hasattr(estimator, 'predict')
-             or (score is None and loss_func is None and score_func is None))):
+             or (scoring is None and loss_func is None
+                 and score_func is None))):
             raise TypeError("The provided estimator %s does not implement a "
                             "score function. In this case, it needs to "
                             "implement a predict fuction and you have to "
@@ -301,7 +302,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
         self.param_grid = param_grid
         self.loss_func = loss_func
         self.score_func = score_func
-        self.score = score
+        self.scoring = scoring
         self.n_jobs = n_jobs
         self.fit_params = fit_params if fit_params is not None else {}
         self.iid = iid
@@ -364,10 +365,10 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
                           "deprecated and will be removed in 0.15. "
                           "Either use strings or score objects.")
             scorer = AsScorer(self.score_func)
-        if isinstance(self.score, str):  # FIXME BaseString
-            scorer = scorers[self.score]
+        elif isinstance(self.scoring, str):  # FIXME BaseString
+            scorer = scorers[self.scoring]
         else:
-            scorer = self.score
+            scorer = self.scoring
 
         self.scorer_ = scorer
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -20,7 +20,7 @@ from .cross_validation import check_cv
 from .externals.joblib import Parallel, delayed, logger
 from .utils.validation import _num_samples
 from .utils import check_arrays, safe_mask
-from .metrics import scorers, Scorer
+from .metrics import SCORERS, Scorer
 
 __all__ = ['GridSearchCV', 'IterGrid', 'fit_grid_point']
 
@@ -375,7 +375,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
                           "Either use strings or score objects.")
             scorer = Scorer(self.score_func)
         elif isinstance(self.scoring, basestring):
-            scorer = scorers[self.scoring]
+            scorer = SCORERS[self.scoring]
         else:
             scorer = self.scoring
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -179,7 +179,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
         dictionaries, in which case the grids spanned by each dictionary
         in the list are explored.
 
-    score : string or object, optional
+    scoring : string or object, optional
         Either one of ["zero_one", "f1", "auc"] for classification,
         ["mse", "r2"] for regression or an object providing a
         scoreing method.
@@ -365,7 +365,7 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
                           "deprecated and will be removed in 0.15. "
                           "Either use strings or score objects.")
             scorer = AsScorer(self.score_func)
-        elif isinstance(self.scoring, str):  # FIXME BaseString
+        elif isinstance(self.scoring, basestring):
             scorer = scorers[self.scoring]
         else:
             scorer = self.scoring
@@ -375,10 +375,11 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
         pre_dispatch = self.pre_dispatch
         out = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                        pre_dispatch=pre_dispatch)(
-                           delayed(fit_grid_point)(
-                               X, y, base_clf, clf_params, train, test,
-                               scorer, self.verbose, **self.fit_params)
-                           for clf_params in grid for train, test in cv)
+                           delayed(fit_grid_point)(X, y, base_clf, clf_params,
+                                                   train, test, scorer,
+                                                   self.verbose,
+                                                   **self.fit_params) for
+                           clf_params in grid for train, test in cv)
 
         # Out is a list of triplet: score, estimator, n_test_samples
         n_grid_points = len(list(grid))

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -118,7 +118,11 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, scorer,
             this_score = clf.score(X_test, y_test)
     else:
         clf.fit(X_train, **fit_params)
-        this_score = clf.score(X_test)
+        if scorer is not None:
+            this_score = scorer(clf, X_test)
+        else:
+            this_score = clf.score(X_test)
+
     if verbose > 2:
         msg += ", score=%f" % this_score
     if verbose > 1:

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -407,9 +407,11 @@ class GridSearchCV(BaseEstimator, MetaEstimatorMixin):
 
         # Note: we do not use max(out) to make ties deterministic even if
         # comparison on estimator instances is not deterministic
-        greater_is_better = True
         if scorer is not None:
             greater_is_better = scorer.greater_is_better
+        else:
+            greater_is_better = True
+
         if greater_is_better:
             best_score = -np.inf
         else:

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -388,7 +388,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
     RBFSampler : An approximation to the RBF kernel using random Fourier
                  features.
 
-    sklearn.metric.pairwise.kernel_metrics : List of build-in kernels.
+    sklearn.metric.pairwise.kernel_metrics : List of built-in kernels.
     """
     def __init__(self, kernel="rbf", gamma=None, coef0=1, degree=3,
                  n_components=100, random_state=None):

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,7 +28,7 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
-from .score_objects import AsScorer, scorers, score_objects
+from .score_objects import Scorer, scorers, score_objects
 
 from . import cluster
 from .cluster import (adjusted_rand_score,
@@ -81,6 +81,6 @@ __all__ = ['accuracy_score',
            'silhouette_samples',
            'v_measure_score',
            'zero_one_loss',
-           'AsScorer',
+           'Scorer',
            'scorers',
            'score_objects']

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,7 +28,7 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
-from .score_objects import AsScorer, scorers
+from .score_objects import AsScorer, scorers, score_objects
 
 from . import cluster
 from .cluster import (adjusted_rand_score,
@@ -82,4 +82,5 @@ __all__ = ['accuracy_score',
            'v_measure_score',
            'zero_one_loss',
            'AsScorer',
-           'scorers']
+           'scorers',
+           'score_objects']

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,7 +28,7 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
-from .score_objects import Scorer, scorers, score_objects
+from .scorer import Scorer, scorers, score_objects
 
 from . import cluster
 from .cluster import (adjusted_rand_score,

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,6 +28,8 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
+from .score_objects import _score_obj_from_string, _score_obj_from_func
+
 from . import cluster
 from .cluster import (adjusted_rand_score,
                       adjusted_mutual_info_score,

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,7 +28,7 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
-from .score_objects import _score_obj_from_string, _score_obj_from_func
+from .score_objects import AsScorer, scorers
 
 from . import cluster
 from .cluster import (adjusted_rand_score,
@@ -80,4 +80,6 @@ __all__ = ['accuracy_score',
            'silhouette_score',
            'silhouette_samples',
            'v_measure_score',
-           'zero_one_loss']
+           'zero_one_loss',
+           'AsScorer',
+           'scorers']

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -28,7 +28,7 @@ from .metrics import (accuracy_score,
 from .metrics import zero_one
 from .metrics import zero_one_score
 
-from .scorer import Scorer, scorers, score_objects
+from .scorer import Scorer, SCORERS
 
 from . import cluster
 from .cluster import (adjusted_rand_score,
@@ -82,5 +82,4 @@ __all__ = ['accuracy_score',
            'v_measure_score',
            'zero_one_loss',
            'Scorer',
-           'scorers',
-           'score_objects']
+           'SCORERS']

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -526,10 +526,10 @@ pairwise_distance_functions = {
 
 
 def distance_metrics():
-    """ Valid metrics for pairwise_distances
+    """Valid metrics for pairwise_distances.
 
     This function simply returns the valid pairwise distance metrics.
-    It exists, however, to allow for a verbose description of the mapping for
+    It exists to allow for a description of the mapping for
     each of the valid strings.
 
     The valid distance metrics, and the function they map to, are:
@@ -537,11 +537,11 @@ def distance_metrics():
     ============     ====================================
     metric           Function
     ============     ====================================
-    'cityblock'      sklearn.pairwise.manhattan_distances
-    'euclidean'      sklearn.pairwise.euclidean_distances
-    'l1'             sklearn.pairwise.manhattan_distances
-    'l2'             sklearn.pairwise.euclidean_distances
-    'manhattan'      sklearn.pairwise.manhattan_distances
+    'cityblock'      metrics.pairwise.manhattan_distances
+    'euclidean'      metrics.pairwise.euclidean_distances
+    'l1'             metrics.pairwise.manhattan_distances
+    'l2'             metrics.pairwise.euclidean_distances
+    'manhattan'      metrics.pairwise.manhattan_distances
     ============     ====================================
 
     """

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
+                      auc_score, average_precision_score)
+
+
+def _score_obj_from_func(score_func, greater_is_better_=True,
+                         needs_threshold=False):
+    # construct a scoring object from a simple scoring function
+    if needs_threshold:
+        class ScoreObj(object):
+            greater_is_better = greater_is_better_
+
+            def __call__(self, estimator, X, y):
+                if len(np.unique(y)) > 2:
+                    raise ValueError("This classification score only "
+                                     "supports binary classification.")
+                try:
+                    y_pred = estimator.decision_function(X).ravel()
+                except (NotImplementedError, AttributeError):
+                    y_pred = estimator.predict_proba(X)[:, 1]
+                return score_func(y, y_pred)
+    else:
+        class ScoreObj(object):
+            greater_is_better = greater_is_better_
+
+            def __call__(self, estimator, X, y):
+                y_pred = estimator.predict(X)
+                return score_func(y, y_pred)
+    return ScoreObj
+
+
+def _score_obj_from_string(score_func):
+    # construct scoring object from string
+    # TODO
+    pass
+
+# Standard regression scores
+R2Score = _score_obj_from_func(r2_score, True)
+MSEScore = _score_obj_from_func(mean_squared_error, False)
+
+# Standard Classification Scores
+ZeroOneScore = _score_obj_from_func(zero_one_score, False)
+F1Score = _score_obj_from_func(f1_score, False)
+
+# Score functions that need decision values
+AUCScore = _score_obj_from_func(auc_score, True, True)
+AveragePrecisionScore = _score_obj_from_func(average_precision_score, True,
+                                             True)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -31,8 +31,8 @@ class AsScorer(object):
         can not be computed using predictions alone, but need the output of
         ``decision_function`` or ``predict_proba``.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sklearn.metrics import fbeta_score, AsScorer
     >>> ftwo_scorer = AsScorer(fbeta_score, beta=2)
     >>> from sklearn.grid_search import GridSearchCV

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -11,7 +11,7 @@ class AsScorer(object):
     """Flexible scores for any estimator.
 
     This class wraps estimator scoring functions for the use in GridSearchCV
-    and cross_val_score. It takes a score function, such as ``zero_one_score``,
+    and cross_val_score. It takes a score function, such as ``accuracy_score``,
     ``mean_squared_error``, ``adjusted_rand_index`` or ``average_precision``
     and provides a call method.
 

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -7,7 +7,7 @@ from . import (r2_score, mean_squared_error, accuracy_score, f1_score,
 from .cluster import adjusted_rand_score
 
 
-class AsScorer(object):
+class Scorer(object):
     """Flexible scores for any estimator.
 
     This class wraps estimator scoring functions for the use in GridSearchCV
@@ -33,8 +33,8 @@ class AsScorer(object):
 
     Examples
     --------
-    >>> from sklearn.metrics import fbeta_score, AsScorer
-    >>> ftwo_scorer = AsScorer(fbeta_score, beta=2)
+    >>> from sklearn.metrics import fbeta_score, Scorer
+    >>> ftwo_scorer = Scorer(fbeta_score, beta=2)
     >>> from sklearn.grid_search import GridSearchCV
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
@@ -84,22 +84,22 @@ class AsScorer(object):
 
 
 # Standard regression scores
-r2_scorer = AsScorer(r2_score)
-mse_scorer = AsScorer(mean_squared_error, greater_is_better=False)
+r2_scorer = Scorer(r2_score)
+mse_scorer = Scorer(mean_squared_error, greater_is_better=False)
 
 # Standard Classification Scores
-accuracy_scorer = AsScorer(accuracy_score)
-f1_scorer = AsScorer(f1_score)
+accuracy_scorer = Scorer(accuracy_score)
+f1_scorer = Scorer(f1_score)
 
 # Score functions that need decision values
-auc_scorer = AsScorer(auc_score, greater_is_better=True, needs_threshold=True)
-average_precision_scorer = AsScorer(average_precision_score,
-                                    needs_threshold=True)
-precision_scorer = AsScorer(precision_score)
-recall_scorer = AsScorer(recall_score)
+auc_scorer = Scorer(auc_score, greater_is_better=True, needs_threshold=True)
+average_precision_scorer = Scorer(average_precision_score,
+                                  needs_threshold=True)
+precision_scorer = Scorer(precision_score)
+recall_scorer = Scorer(recall_score)
 
 # Clustering scores
-ari_scorer = AsScorer(adjusted_rand_score)
+ari_scorer = Scorer(adjusted_rand_score)
 
 scorers = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
                f1=f1_scorer, roc_auc=auc_scorer,

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,25 +1,20 @@
-import warnings
 import numpy as np
 
-from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
-                      auc_score, average_precision_score, precision_score)
+from . import (r2_score, mean_squared_error, zero_one_score, f1_score,
+               auc_score, average_precision_score, precision_score)
+
+from .cluster import adjusted_rand_score
 
 
 class AsScorer(object):
     def __init__(self, score_func, greater_is_better=True,
-                 needs_threshold=False, is_unsupervised=False, **kwargs):
+                 needs_threshold=False, **kwargs):
         self.score_func = score_func
         self.greater_is_better = greater_is_better
         self.needs_threshold = needs_threshold
-        self.is_unsupervised = is_unsupervised
         self.kwargs = kwargs
 
-    def __call__(self, estimator, X, y=None):
-        if y is None and not self.is_unsupervised:
-            # this is a warning for backward compatibility.
-            # should it be a deprecation warning?
-            warnings.warn("Score function %s is supervised, but no y was "
-                          "passed." % type(self.score_func))
+    def __call__(self, estimator, X, y):
         if self.needs_threshold:
             if len(np.unique(y)) > 2:
                 raise ValueError("This classification score only "
@@ -48,6 +43,9 @@ AveragePrecisionScorer = AsScorer(average_precision_score,
                                   needs_threshold=True)
 PrecisionScorer = AsScorer(precision_score)
 
+# Clustering scores
+ARIScorer = AsScorer(adjusted_rand_score)
+
 scorers = dict(r2=R2Scorer, mse=MSEScorer, zero_one=ZeroOneScorer, f1=F1Scorer,
                auc=AUCScorer, ap=AveragePrecisionScorer,
-               precision=PrecisionScorer)
+               precision=PrecisionScorer, ari=ARIScorer)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from . import (r2_score, mean_squared_error, zero_one_score, f1_score,
-               auc_score, average_precision_score, precision_score)
+               auc_score, average_precision_score, precision_score,
+               recall_score)
 
 from .cluster import adjusted_rand_score
 
@@ -95,10 +96,11 @@ AUCScorer = AsScorer(auc_score, True, True)
 AveragePrecisionScorer = AsScorer(average_precision_score,
                                   needs_threshold=True)
 PrecisionScorer = AsScorer(precision_score)
+RecallScorer = AsScorer(recall_score)
 
 # Clustering scores
 ARIScorer = AsScorer(adjusted_rand_score)
 
 scorers = dict(r2=R2Scorer, mse=MSEScorer, zero_one=ZeroOneScorer, f1=F1Scorer,
-               auc=AUCScorer, ap=AveragePrecisionScorer,
-               precision=PrecisionScorer, ari=ARIScorer)
+               roc_auc=AUCScorer, average_precision=AveragePrecisionScorer,
+               precision=PrecisionScorer, recall=RecallScorer, ari=ARIScorer)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -84,24 +84,27 @@ class AsScorer(object):
 
 
 # Standard regression scores
-R2Scorer = AsScorer(r2_score)
-MSEScorer = AsScorer(mean_squared_error, greater_is_better=False)
+r2_scorer = AsScorer(r2_score)
+mse_scorer = AsScorer(mean_squared_error, greater_is_better=False)
 
 # Standard Classification Scores
-AccuracyScorer = AsScorer(accuracy_score)
-F1Scorer = AsScorer(f1_score)
+accuracy_scorer = AsScorer(accuracy_score)
+f1_scorer = AsScorer(f1_score)
 
 # Score functions that need decision values
-AUCScorer = AsScorer(auc_score, True, True)
-AveragePrecisionScorer = AsScorer(average_precision_score,
-                                  needs_threshold=True)
-PrecisionScorer = AsScorer(precision_score)
-RecallScorer = AsScorer(recall_score)
+auc_scorer = AsScorer(auc_score, True, True)
+average_precision_scorer = AsScorer(average_precision_score,
+                                    needs_threshold=True)
+precision_scorer = AsScorer(precision_score)
+recall_scorer = AsScorer(recall_score)
 
 # Clustering scores
-ARIScorer = AsScorer(adjusted_rand_score)
+ari_scorer = AsScorer(adjusted_rand_score)
 
-scorers = dict(r2=R2Scorer, mse=MSEScorer, accuracy=AccuracyScorer,
-               f1=F1Scorer, roc_auc=AUCScorer,
-               average_precision=AveragePrecisionScorer,
-               precision=PrecisionScorer, recall=RecallScorer, ari=ARIScorer)
+scorers = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
+               f1=f1_scorer, roc_auc=auc_scorer,
+               average_precision=average_precision_scorer,
+               precision=precision_scorer, recall=recall_scorer,
+               ari=ari_scorer)
+
+

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -32,8 +32,8 @@ R2Scorer = AsScorer(r2_score, True)
 MSEScorer = AsScorer(mean_squared_error, False)
 
 # Standard Classification Scores
-ZeroOneScorer = AsScorer(zero_one_score, False)
-F1Scorer = AsScorer(f1_score, False)
+ZeroOneScorer = AsScorer(zero_one_score, True)
+F1Scorer = AsScorer(f1_score, True)
 
 # Score functions that need decision values
 AUCScorer = AsScorer(auc_score, True, True)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -114,27 +114,27 @@ def score_objects():
     This function simply returns the valid score function callables. It exists
     to allow for a description of the mapping for each of the valid strings.
 
-    ===============     ====================================
-    scoring             Function
-    ===============     ====================================
+    ===================     =========================================
+    Scoring                 Function
+    ===================     =========================================
     Classification
-    --------------      ------------------------------------
-    'accuracy'          sklearn.metrics.accuracy_score
-    'average_precision' sklearn.metrics.average_precision_score
-    'f1'                sklearn.metrics.f1_score
-    'precision'         sklearn.metrics.precision_score
-    'recall'            sklearn.metrics.recall_score
-    'roc_auc'           sklearn.merrics.auc_score
+    -------------------     -----------------------------------------
+    'accuracy'              sklearn.metrics.accuracy_score
+    'average_precision'     sklearn.metrics.average_precision_score
+    'f1'                    sklearn.metrics.f1_score
+    'precision'             sklearn.metrics.precision_score
+    'recall'                sklearn.metrics.recall_score
+    'roc_auc'               sklearn.merrics.auc_score
 
     Clustering
-    --------------      ------------------------------------
-    'ari'`              sklearn.metrics.adjusted_rand_score
+    -------------------     -----------------------------------------
+    'ari'`                  sklearn.metrics.adjusted_rand_score
 
     Regression
-    --------------      ------------------------------------
-    'mse'               sklearn.metrics.mean_squared_error
-    'r2'                sklearn.metrics.r2_score
-    ===============     ====================================
+    -------------------     -----------------------------------------
+    'mse'                   sklearn.metrics.mean_squared_error
+    'r2'                    sklearn.metrics.r2_score
+    ===================     =========================================
 
     """
     return scorers

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -4,46 +4,40 @@ from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
                       auc_score, average_precision_score)
 
 
-def _score_obj_from_func(score_func, greater_is_better_=True,
-                         needs_threshold=False):
-    # construct a scoring object from a simple scoring function
-    if needs_threshold:
-        class ScoreObj(object):
-            greater_is_better = greater_is_better_
+class AsScorer(object):
+    def __init__(self, score_func, greater_is_better=True,
+                 needs_threshold=False, **kwargs):
+        self.score_func = score_func
+        self.greater_is_better = greater_is_better
+        self.needs_threshold = needs_threshold
+        self.kwargs = kwargs
 
-            def __call__(self, estimator, X, y):
-                if len(np.unique(y)) > 2:
-                    raise ValueError("This classification score only "
-                                     "supports binary classification.")
-                try:
-                    y_pred = estimator.decision_function(X).ravel()
-                except (NotImplementedError, AttributeError):
-                    y_pred = estimator.predict_proba(X)[:, 1]
-                return score_func(y, y_pred)
-    else:
-        class ScoreObj(object):
-            greater_is_better = greater_is_better_
+    def __call__(self, estimator, X, y):
+        if self.needs_threshold:
+            if len(np.unique(y)) > 2:
+                raise ValueError("This classification score only "
+                                 "supports binary classification.")
+            try:
+                y_pred = estimator.decision_function(X).ravel()
+            except (NotImplementedError, AttributeError):
+                y_pred = estimator.predict_proba(X)[:, 1]
+            return self.score_func(y, y_pred)
+        else:
+            y_pred = estimator.predict(X)
+            return self.score_func(y, y_pred)
 
-            def __call__(self, estimator, X, y):
-                y_pred = estimator.predict(X)
-                return score_func(y, y_pred)
-    return ScoreObj
-
-
-def _score_obj_from_string(score_func):
-    # construct scoring object from string
-    # TODO
-    pass
 
 # Standard regression scores
-R2Score = _score_obj_from_func(r2_score, True)
-MSEScore = _score_obj_from_func(mean_squared_error, False)
+R2Scorer = AsScorer(r2_score, True)
+MSEScorer = AsScorer(mean_squared_error, False)
 
 # Standard Classification Scores
-ZeroOneScore = _score_obj_from_func(zero_one_score, False)
-F1Score = _score_obj_from_func(f1_score, False)
+ZeroOneScorer = AsScorer(zero_one_score, False)
+F1Scorer = AsScorer(f1_score, False)
 
 # Score functions that need decision values
-AUCScore = _score_obj_from_func(auc_score, True, True)
-AveragePrecisionScore = _score_obj_from_func(average_precision_score, True,
-                                             True)
+AUCScorer = AsScorer(auc_score, True, True)
+AveragePrecisionScorer = AsScorer(average_precision_score, True, True)
+
+scorers = dict(r2=R2Scorer, mse=MSEScorer, zero_one=ZeroOneScorer, f1=F1Scorer,
+               auc=AUCScorer, ap=AveragePrecisionScorer)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
@@ -6,13 +7,19 @@ from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
 
 class AsScorer(object):
     def __init__(self, score_func, greater_is_better=True,
-                 needs_threshold=False, **kwargs):
+                 needs_threshold=False, is_unsupervised=False, **kwargs):
         self.score_func = score_func
         self.greater_is_better = greater_is_better
         self.needs_threshold = needs_threshold
+        self.is_unsupervised = is_unsupervised
         self.kwargs = kwargs
 
-    def __call__(self, estimator, X, y):
+    def __call__(self, estimator, X, y=None):
+        if y is None and not self.is_unsupervised:
+            # this is a warning for backward compatibility.
+            # should it be a deprecation warning?
+            warnings.warn("Score function %s is supervised, but no y was "
+                          "passed." % type(self.score_func))
         if self.needs_threshold:
             if len(np.unique(y)) > 2:
                 raise ValueError("This classification score only "

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -7,6 +7,38 @@ from .cluster import adjusted_rand_score
 
 
 class AsScorer(object):
+    """Flexible scores for any estimator.
+
+    This class wraps estimator scoring functions for the use in GridSearchCV
+    and cross_val_score. It takes a score function, such as ``zero_one_score``,
+    ``mean_squared_error``, ``adjusted_rand_index`` or ``average_precision``
+    and provides a call method.
+
+    Parameters
+    ----------
+    score_func : callable,
+        Score function (or loss function) with signature
+        ``score_func(y, y_pred, **kwargs)``.
+
+    greater_is_better : boolean, default=True
+        Whether score_func is a score function (default), meaning high is good,
+        or a loss function, meaning low is good.
+
+    needs_threshold : bool, default=False
+        Whether score_func takes a continuous decision certainty.
+        For example ``average_precision`` or the area under the roc curve
+        can not be computed using predictions alone, but need the output of
+        ``decision_function`` or ``predict_proba``.
+
+    Example
+    -------
+    >>> from sklearn.metrics import fbeta_score, AsScorer
+    >>> ftwo_scorer = AsScorer(fbeta_score, beta=2)
+    >>> from sklearn.grid_search import GridSearchCV
+    >>> from sklearn.svm import LinearSVC
+    >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
+    ...                     scoring=ftwo_scorer)
+    """
     def __init__(self, score_func, greater_is_better=True,
                  needs_threshold=False, **kwargs):
         self.score_func = score_func
@@ -15,6 +47,27 @@ class AsScorer(object):
         self.kwargs = kwargs
 
     def __call__(self, estimator, X, y):
+        """Score X and y using the provided estimator.
+
+        Parameters
+        ----------
+        estimator : object
+            Trained estimator to use for scoring.
+            If ``needs_threshold`` is True, estimator needs
+            to provide ``decision_function`` or ``predict_proba``.
+            Otherwise, estimator needs to provide ``predict``.
+
+        X : array-like or sparse matrix
+            Test data that will be scored by the estimator.
+
+        y : array-like
+            True prediction for X.
+
+        Returns
+        -------
+        score : float
+            Score function applied to prediction of estimator on X.
+        """
         if self.needs_threshold:
             if len(np.unique(y)) > 2:
                 raise ValueError("This classification score only "

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .metrics import (r2_score, mean_squared_error, zero_one_score, f1_score,
-                      auc_score, average_precision_score)
+                      auc_score, average_precision_score, precision_score)
 
 
 class AsScorer(object):
@@ -28,16 +28,19 @@ class AsScorer(object):
 
 
 # Standard regression scores
-R2Scorer = AsScorer(r2_score, True)
-MSEScorer = AsScorer(mean_squared_error, False)
+R2Scorer = AsScorer(r2_score)
+MSEScorer = AsScorer(mean_squared_error, greater_is_better=False)
 
 # Standard Classification Scores
-ZeroOneScorer = AsScorer(zero_one_score, True)
-F1Scorer = AsScorer(f1_score, True)
+ZeroOneScorer = AsScorer(zero_one_score)
+F1Scorer = AsScorer(f1_score)
 
 # Score functions that need decision values
 AUCScorer = AsScorer(auc_score, True, True)
-AveragePrecisionScorer = AsScorer(average_precision_score, True, True)
+AveragePrecisionScorer = AsScorer(average_precision_score,
+                                  needs_threshold=True)
+PrecisionScorer = AsScorer(precision_score)
 
 scorers = dict(r2=R2Scorer, mse=MSEScorer, zero_one=ZeroOneScorer, f1=F1Scorer,
-               auc=AUCScorer, ap=AveragePrecisionScorer)
+               auc=AUCScorer, ap=AveragePrecisionScorer,
+               precision=PrecisionScorer)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -92,7 +92,7 @@ accuracy_scorer = AsScorer(accuracy_score)
 f1_scorer = AsScorer(f1_score)
 
 # Score functions that need decision values
-auc_scorer = AsScorer(auc_score, True, True)
+auc_scorer = AsScorer(auc_score, greater_is_better=True, needs_threshold=True)
 average_precision_scorer = AsScorer(average_precision_score,
                                     needs_threshold=True)
 precision_scorer = AsScorer(precision_score)

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -108,3 +108,33 @@ scorers = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
                ari=ari_scorer)
 
 
+def score_objects():
+    """Valid score functions for GridSearchCV and cross_val_score.
+
+    This function simply returns the valid score function callables. It exists
+    to allow for a description of the mapping for each of the valid strings.
+
+    ===============     ====================================
+    scoring             Function
+    ===============     ====================================
+    Classification
+    --------------      ------------------------------------
+    'accuracy'          sklearn.metrics.accuracy_score
+    'average_precision' sklearn.metrics.average_precision_score
+    'f1'                sklearn.metrics.f1_score
+    'precision'         sklearn.metrics.precision_score
+    'recall'            sklearn.metrics.recall_score
+    'roc_auc'           sklearn.merrics.auc_score
+
+    Clustering
+    --------------      ------------------------------------
+    'ari'`              sklearn.metrics.adjusted_rand_score
+
+    Regression
+    --------------      ------------------------------------
+    'mse'               sklearn.metrics.mean_squared_error
+    'r2'                sklearn.metrics.r2_score
+    ===============     ====================================
+
+    """
+    return scorers

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -23,10 +23,10 @@ class AsScorer(object):
                 y_pred = estimator.decision_function(X).ravel()
             except (NotImplementedError, AttributeError):
                 y_pred = estimator.predict_proba(X)[:, 1]
-            return self.score_func(y, y_pred)
+            return self.score_func(y, y_pred, **self.kwargs)
         else:
             y_pred = estimator.predict(X)
-            return self.score_func(y, y_pred)
+            return self.score_func(y, y_pred, **self.kwargs)
 
 
 # Standard regression scores

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -117,8 +117,7 @@ def score_objects():
     ===================     =========================================
     Scoring                 Function
     ===================     =========================================
-    Classification
-    -------------------     -----------------------------------------
+    **Classification**
     'accuracy'              sklearn.metrics.accuracy_score
     'average_precision'     sklearn.metrics.average_precision_score
     'f1'                    sklearn.metrics.f1_score
@@ -126,12 +125,10 @@ def score_objects():
     'recall'                sklearn.metrics.recall_score
     'roc_auc'               sklearn.merrics.auc_score
 
-    Clustering
-    -------------------     -----------------------------------------
+    **Clustering**
     'ari'`                  sklearn.metrics.adjusted_rand_score
 
-    Regression
-    -------------------     -----------------------------------------
+    **Regression**
     'mse'                   sklearn.metrics.mean_squared_error
     'r2'                    sklearn.metrics.r2_score
     ===================     =========================================

--- a/sklearn/metrics/score_objects.py
+++ b/sklearn/metrics/score_objects.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import (r2_score, mean_squared_error, zero_one_score, f1_score,
+from . import (r2_score, mean_squared_error, accuracy_score, f1_score,
                auc_score, average_precision_score, precision_score,
                recall_score)
 
@@ -88,7 +88,7 @@ R2Scorer = AsScorer(r2_score)
 MSEScorer = AsScorer(mean_squared_error, greater_is_better=False)
 
 # Standard Classification Scores
-ZeroOneScorer = AsScorer(zero_one_score)
+AccuracyScorer = AsScorer(accuracy_score)
 F1Scorer = AsScorer(f1_score)
 
 # Score functions that need decision values
@@ -101,6 +101,7 @@ RecallScorer = AsScorer(recall_score)
 # Clustering scores
 ARIScorer = AsScorer(adjusted_rand_score)
 
-scorers = dict(r2=R2Scorer, mse=MSEScorer, zero_one=ZeroOneScorer, f1=F1Scorer,
-               roc_auc=AUCScorer, average_precision=AveragePrecisionScorer,
+scorers = dict(r2=R2Scorer, mse=MSEScorer, accuracy=AccuracyScorer,
+               f1=F1Scorer, roc_auc=AUCScorer,
+               average_precision=AveragePrecisionScorer,
                precision=PrecisionScorer, recall=RecallScorer, ari=ARIScorer)

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -1,3 +1,21 @@
+"""
+The :mod:`sklearn.metrics.scorer` submodule implements a flexible
+interface for model selection and evaluation using
+arbitrary score functions.
+
+A Scorer object is a callable that can be passed to
+:class:`sklearn.grid_search.GridSearchCV` or
+:func:`sklearn.cross_validation.cross_val_score` as the ``scoring`` parameter,
+to specify how a model should be evaluated.
+
+The signature of the call is ``(estimator, X, y)`` where ``estimator``
+is the model to be evaluated, ``X`` is the test data and ``y`` is the
+ground truth labeling (or ``None`` in the case of unsupervised models).
+"""
+
+# Authors: Andreas Mueller <amueller@ais.uni-bonn.de>
+# Liscence: Simplified BSD
+
 import numpy as np
 
 from . import (r2_score, mean_squared_error, accuracy_score, f1_score,

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -129,37 +129,8 @@ recall_scorer = Scorer(recall_score)
 # Clustering scores
 ari_scorer = Scorer(adjusted_rand_score)
 
-scorers = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
+SCORERS = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
                f1=f1_scorer, roc_auc=auc_scorer,
                average_precision=average_precision_scorer,
                precision=precision_scorer, recall=recall_scorer,
                ari=ari_scorer)
-
-
-def score_objects():
-    """Valid score functions for GridSearchCV and cross_val_score.
-
-    This function simply returns the valid score function callables. It exists
-    to allow for a description of the mapping for each of the valid strings.
-
-    ===================     =========================================
-    Scoring                 Function
-    ===================     =========================================
-    **Classification**
-    'accuracy'              sklearn.metrics.accuracy_score
-    'average_precision'     sklearn.metrics.average_precision_score
-    'f1'                    sklearn.metrics.f1_score
-    'precision'             sklearn.metrics.precision_score
-    'recall'                sklearn.metrics.recall_score
-    'roc_auc'               sklearn.merrics.auc_score
-
-    **Clustering**
-    'ari'`                  sklearn.metrics.adjusted_rand_score
-
-    **Regression**
-    'mse'                   sklearn.metrics.mean_squared_error
-    'r2'                    sklearn.metrics.r2_score
-    ===================     =========================================
-
-    """
-    return scorers

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -68,6 +68,13 @@ class Scorer(object):
         self.needs_threshold = needs_threshold
         self.kwargs = kwargs
 
+    def __repr__(self):
+        kwargs_string = "".join([", %s=%s" % (str(k), str(v))
+                                 for k, v in self.kwargs.items()])
+        return ("Scorer(score_func=%s, greater_is_better=%s, needs_thresholds="
+                "%s%s)" % (self.score_func.__name__, self.greater_is_better,
+                           self.needs_threshold, kwargs_string))
+
     def __call__(self, estimator, X, y):
         """Score X and y using the provided estimator.
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -49,6 +49,9 @@ class Scorer(object):
         can not be computed using predictions alone, but need the output of
         ``decision_function`` or ``predict_proba``.
 
+    **kwargs : additional arguments
+        Additional parameters to be passed to score_func.
+
     Examples
     --------
     >>> from sklearn.metrics import fbeta_score, Scorer

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -5,7 +5,7 @@ from sklearn.utils.testing import assert_raises
 
 from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
 from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.score_objects import scorers, AsScorer
+from sklearn.metrics.score_objects import scorers, Scorer
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression
@@ -25,7 +25,7 @@ def test_classification_scores():
     assert_almost_equal(score1, score2)
 
     # test fbeta score that takes an argument
-    scorer = AsScorer(fbeta_score, beta=2)
+    scorer = Scorer(fbeta_score, beta=2)
     score1 = scorer(clf, X_test, y_test)
     score2 = fbeta_score(y_test, clf.predict(X_test), beta=2)
     assert_almost_equal(score1, score2)
@@ -87,7 +87,7 @@ def test_unsupervised_scores():
 def test_raises_on_score_list():
     # test that when a list of scores is returned, we raise proper errors.
     X, y = make_blobs(random_state=0)
-    f1_scorer_no_average = AsScorer(f1_score, average=None)
+    f1_scorer_no_average = Scorer(f1_score, average=None)
     clf = DecisionTreeClassifier()
     assert_raises(ValueError, cross_val_score, clf, X, y,
                   scoring=f1_scorer_no_average)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -50,7 +50,7 @@ def test_thresholded_scores():
     assert_almost_equal(score1, score2)
     assert_almost_equal(score1, score3)
 
-    #same for an estimator without decision_function
+    # same for an estimator without decision_function
     clf = DecisionTreeClassifier()
     clf.fit(X_train, y_train)
     score1 = scorers['roc_auc'](clf, X_test, y_test)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -5,7 +5,7 @@ from sklearn.utils.testing import assert_raises
 
 from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
 from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.score_objects import SCORERS, Scorer
+from sklearn.metrics import SCORERS, Scorer
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -35,6 +35,9 @@ def test_classification_scores():
     score3 = unpickled_scorer(clf, X_test, y_test)
     assert_almost_equal(score1, score3)
 
+    # smoke test the repr:
+    repr(fbeta_score)
+
 
 def test_regression_scores():
     diabetes = load_diabetes()

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,0 +1,76 @@
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_raises
+
+from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
+from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.metrics.score_objects import scorers, AsScorer
+from sklearn.svm import LinearSVC
+from sklearn.cluster import KMeans
+from sklearn.linear_model import Ridge, LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.datasets import make_blobs, load_diabetes
+from sklearn.cross_validation import train_test_split
+
+
+def test_classification_scores():
+    X, y = make_blobs(random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = LinearSVC(random_state=0)
+    clf.fit(X_train, y_train)
+    score1 = scorers['f1'](clf, X_test, y_test)
+    score2 = f1_score(y_test, clf.predict(X_test))
+    assert_almost_equal(score1, score2)
+
+    # test fbeta score that takes an argument
+    scorer = AsScorer(fbeta_score, beta=2)
+    score1 = scorer(clf, X_test, y_test)
+    score2 = fbeta_score(y_test, clf.predict(X_test), beta=2)
+    assert_almost_equal(score1, score2)
+
+
+def test_regression_scores():
+    diabetes = load_diabetes()
+    X, y = diabetes.data, diabetes.target
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = Ridge()
+    clf.fit(X_train, y_train)
+    score1 = scorers['r2'](clf, X_test, y_test)
+    score2 = r2_score(y_test, clf.predict(X_test))
+    assert_almost_equal(score1, score2)
+
+
+def test_thresholded_scores():
+    X, y = make_blobs(random_state=0, centers=2)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = LogisticRegression(random_state=0)
+    clf.fit(X_train, y_train)
+    score1 = scorers['auc'](clf, X_test, y_test)
+    score2 = auc_score(y_test, clf.decision_function(X_test))
+    score3 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
+    assert_almost_equal(score1, score2)
+    assert_almost_equal(score1, score3)
+
+    #same for an estimator without decision_function
+    clf = DecisionTreeClassifier()
+    clf.fit(X_train, y_train)
+    score1 = scorers['auc'](clf, X_test, y_test)
+    score2 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
+    assert_almost_equal(score1, score2)
+
+    # Test that an exception is raised on more than two classes
+    X, y = make_blobs(random_state=0, centers=3)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf.fit(X_train, y_train)
+    assert_raises(ValueError, scorers['auc'], clf, X_test, y_test)
+
+
+def test_unsupervised_scores():
+    # test clustering where there is some true y.
+    # We don't have any real unsupervised scorers yet
+    X, y = make_blobs(random_state=0, centers=2)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    km = KMeans(n_clusters=3)
+    km.fit(X_train)
+    score1 = scorers['ari'](km, X_test, y_test)
+    score2 = adjusted_rand_score(y_test, km.predict(X_test))
+    assert_almost_equal(score1, score2)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,3 +1,5 @@
+import pickle
+
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 
@@ -27,6 +29,11 @@ def test_classification_scores():
     score1 = scorer(clf, X_test, y_test)
     score2 = fbeta_score(y_test, clf.predict(X_test), beta=2)
     assert_almost_equal(score1, score2)
+
+    # test that custom scorer can be pickled
+    unpickled_scorer = pickle.loads(pickle.dumps(scorer))
+    score3 = unpickled_scorer(clf, X_test, y_test)
+    assert_almost_equal(score1, score3)
 
 
 def test_regression_scores():

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -9,7 +9,8 @@ from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.datasets import make_blobs, load_diabetes
-from sklearn.cross_validation import train_test_split
+from sklearn.cross_validation import train_test_split, cross_val_score
+from sklearn.grid_search import GridSearchCV
 
 
 def test_classification_scores():
@@ -74,3 +75,15 @@ def test_unsupervised_scores():
     score1 = scorers['ari'](km, X_test, y_test)
     score2 = adjusted_rand_score(y_test, km.predict(X_test))
     assert_almost_equal(score1, score2)
+
+
+def test_raises_on_score_list():
+    # test that when a list of scores is returned, we raise proper errors.
+    X, y = make_blobs(random_state=0)
+    f1_scorer_no_average = AsScorer(f1_score, average=None)
+    clf = DecisionTreeClassifier()
+    assert_raises(ValueError, cross_val_score, clf, X, y,
+                  scoring=f1_scorer_no_average)
+    grid_search = GridSearchCV(clf, scoring=f1_scorer_no_average,
+                               param_grid={'max_depth': [1, 2]})
+    assert_raises(ValueError, grid_search.fit, X, y)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -5,7 +5,7 @@ from sklearn.utils.testing import assert_raises
 
 from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
 from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.score_objects import scorers, Scorer
+from sklearn.metrics.score_objects import SCORERS, Scorer
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression
@@ -20,7 +20,7 @@ def test_classification_scores():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = LinearSVC(random_state=0)
     clf.fit(X_train, y_train)
-    score1 = scorers['f1'](clf, X_test, y_test)
+    score1 = SCORERS['f1'](clf, X_test, y_test)
     score2 = f1_score(y_test, clf.predict(X_test))
     assert_almost_equal(score1, score2)
 
@@ -42,7 +42,7 @@ def test_regression_scores():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = Ridge()
     clf.fit(X_train, y_train)
-    score1 = scorers['r2'](clf, X_test, y_test)
+    score1 = SCORERS['r2'](clf, X_test, y_test)
     score2 = r2_score(y_test, clf.predict(X_test))
     assert_almost_equal(score1, score2)
 
@@ -52,7 +52,7 @@ def test_thresholded_scores():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = LogisticRegression(random_state=0)
     clf.fit(X_train, y_train)
-    score1 = scorers['roc_auc'](clf, X_test, y_test)
+    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
     score2 = auc_score(y_test, clf.decision_function(X_test))
     score3 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
@@ -61,7 +61,7 @@ def test_thresholded_scores():
     # same for an estimator without decision_function
     clf = DecisionTreeClassifier()
     clf.fit(X_train, y_train)
-    score1 = scorers['roc_auc'](clf, X_test, y_test)
+    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
     score2 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
 
@@ -69,17 +69,17 @@ def test_thresholded_scores():
     X, y = make_blobs(random_state=0, centers=3)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf.fit(X_train, y_train)
-    assert_raises(ValueError, scorers['roc_auc'], clf, X_test, y_test)
+    assert_raises(ValueError, SCORERS['roc_auc'], clf, X_test, y_test)
 
 
 def test_unsupervised_scores():
     # test clustering where there is some true y.
-    # We don't have any real unsupervised scorers yet
+    # We don't have any real unsupervised SCORERS yet
     X, y = make_blobs(random_state=0, centers=2)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     km = KMeans(n_clusters=3)
     km.fit(X_train)
-    score1 = scorers['ari'](km, X_test, y_test)
+    score1 = SCORERS['ari'](km, X_test, y_test)
     score2 = adjusted_rand_score(y_test, km.predict(X_test))
     assert_almost_equal(score1, score2)
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -44,7 +44,7 @@ def test_thresholded_scores():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = LogisticRegression(random_state=0)
     clf.fit(X_train, y_train)
-    score1 = scorers['auc'](clf, X_test, y_test)
+    score1 = scorers['roc_auc'](clf, X_test, y_test)
     score2 = auc_score(y_test, clf.decision_function(X_test))
     score3 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
@@ -53,7 +53,7 @@ def test_thresholded_scores():
     #same for an estimator without decision_function
     clf = DecisionTreeClassifier()
     clf.fit(X_train, y_train)
-    score1 = scorers['auc'](clf, X_test, y_test)
+    score1 = scorers['roc_auc'](clf, X_test, y_test)
     score2 = auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
 
@@ -61,7 +61,7 @@ def test_thresholded_scores():
     X, y = make_blobs(random_state=0, centers=3)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf.fit(X_train, y_train)
-    assert_raises(ValueError, scorers['auc'], clf, X_test, y_test)
+    assert_raises(ValueError, scorers['roc_auc'], clf, X_test, y_test)
 
 
 def test_unsupervised_scores():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1,7 +1,8 @@
 """Test the cross_validation module"""
 
-import numpy as np
 import warnings
+
+import numpy as np
 from scipy.sparse import coo_matrix
 
 from sklearn.utils.testing import assert_true
@@ -266,20 +267,20 @@ def test_cross_val_score_fit_params():
 
 def test_cross_val_score_score_func():
     clf = MockClassifier()
-    _score_func1_args = []
+    #_score_func1_args = []
     _score_func2_args = []
 
-    def score_func1(data):
-        _score_func1_args.append(data)
-        return 1.0
+    #def score_func1(data):
+        #_score_func1_args.append(data)
+        #return 1.0
 
     def score_func2(y_test, y_predict):
         _score_func2_args.append((y_test, y_predict))
         return 1.0
 
-    score1 = cval.cross_val_score(clf, X, score_func=score_func1)
-    assert_array_equal(score1, [1.0, 1.0, 1.0])
-    assert len(_score_func1_args) == 3
+    #score1 = cval.cross_val_score(clf, X, score_func=score_func1)
+    #assert_array_equal(score1, [1.0, 1.0, 1.0])
+    #assert len(_score_func1_args) == 3
 
     score2 = cval.cross_val_score(clf, X, y, score_func=score_func2)
     assert_array_equal(score2, [1.0, 1.0, 1.0])
@@ -335,13 +336,18 @@ def test_cross_val_score_with_score_func_classification():
     # Correct classification score (aka. zero / one score) - should be the
     # same as the default estimator score
     zo_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                     score_func=accuracy_score, cv=5)
+                                     scoring="accuracy", cv=5)
     assert_array_almost_equal(zo_scores, [1., 0.97, 0.90, 0.97, 1.], 2)
 
     # F1 score (class are balanced so f1_score should be equal to zero/one
     # score
     f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                     score_func=f1_score, cv=5)
+                                     scoring="f1", cv=5)
+    assert_array_almost_equal(f1_scores, [1., 0.97, 0.90, 0.97, 1.], 2)
+    # also test deprecated old way
+    with warnings.catch_warnings(record=True):
+        f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
+                                         score_func=f1_score, cv=5)
     assert_array_almost_equal(f1_scores, [1., 0.97, 0.90, 0.97, 1.], 2)
 
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -7,6 +7,7 @@ from scipy.sparse import coo_matrix
 
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
@@ -22,6 +23,9 @@ from sklearn.datasets import load_iris
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import f1_score
 from sklearn.metrics import explained_variance_score
+from sklearn.metrics import fbeta_score
+from sklearn.metrics import AsScorer
+
 from sklearn.svm import SVC
 from sklearn.linear_model import Ridge
 
@@ -378,13 +382,20 @@ def test_permutation_score():
     score, scores, pvalue = cval.permutation_test_score(
         svm, X, y, "accuracy", cv)
     assert_greater(score, 0.9)
-    np.testing.assert_almost_equal(pvalue, 0.0, 1)
+    assert_almost_equal(pvalue, 0.0, 1)
 
     score_label, _, pvalue_label = cval.permutation_test_score(
         svm, X, y, "accuracy", cv, labels=np.ones(y.size), random_state=0)
-
     assert_true(score_label == score)
     assert_true(pvalue_label == pvalue)
+
+    # test with custom scoring object
+    scorer = AsScorer(fbeta_score, beta=2)
+    score_label, _, pvalue_label = cval.permutation_test_score(
+        svm, X, y, scoring=scorer, cv=cv, labels=np.ones(y.size),
+        random_state=0)
+    assert_almost_equal(score_label, .95, 2)
+    assert_almost_equal(pvalue_label, 0.01, 3)
 
     # check that we obtain the same results with a sparse representation
     svm_sparse = SVC(kernel='linear')

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -24,7 +24,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.metrics import f1_score
 from sklearn.metrics import explained_variance_score
 from sklearn.metrics import fbeta_score
-from sklearn.metrics import AsScorer
+from sklearn.metrics import Scorer
 
 from sklearn.svm import SVC
 from sklearn.linear_model import Ridge
@@ -395,7 +395,7 @@ def test_permutation_score():
     assert_true(pvalue_label == pvalue)
 
     # test with custom scoring object
-    scorer = AsScorer(fbeta_score, beta=2)
+    scorer = Scorer(fbeta_score, beta=2)
     score_label, _, pvalue_label = cval.permutation_test_score(
         svm, X, y, scoring=scorer, cv=cv, labels=np.ones(y.size),
         random_state=0)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -257,6 +257,11 @@ def test_cross_val_score_precomputed():
     svm = SVC(kernel="precomputed")
     assert_raises(ValueError, cval.cross_val_score, svm, X, y)
 
+    # test error is raised when the precomputed kernel is not array-like
+    # or sparse
+    assert_raises(ValueError, cval.cross_val_score, svm,
+                  linear_kernel.tolist(), y)
+
 
 def test_cross_val_score_fit_params():
     clf = MockClassifier()

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -22,8 +22,7 @@ from sklearn.datasets.samples_generator import make_classification, make_blobs
 from sklearn.svm import LinearSVC, SVC
 from sklearn.cluster import KMeans, MeanShift
 from sklearn.metrics import f1_score
-from sklearn.metrics.score_objects import AsScorer
-from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.metrics.score_objects import AsScorer, ARIScorer
 from sklearn.cross_validation import KFold, StratifiedKFold
 
 
@@ -318,18 +317,21 @@ def test_unsupervised_grid_search():
     # test grid-search with unsupervised estimator
     X, y = make_blobs(random_state=0)
     km = KMeans(random_state=0)
-    ARIScorer = AsScorer(adjusted_rand_score)
     grid_search = GridSearchCV(km, param_grid=dict(n_clusters=[2, 3, 4]),
                                scoring=ARIScorer)
+    grid_search.fit(X, y)
+    # ARI can find the right number :)
+    assert_equal(grid_search.best_params_["n_clusters"], 3)
+
+    # Now without a score, and without y
+    grid_search = GridSearchCV(km, param_grid=dict(n_clusters=[2, 3, 4]))
     grid_search.fit(X)
-    # most number of clusters should be best
     assert_equal(grid_search.best_params_["n_clusters"], 4)
 
 
 def test_bad_estimator():
     # test grid-search with unsupervised estimator
     ms = MeanShift()
-    ARIScorer = AsScorer(adjusted_rand_score)
     assert_raises(TypeError, GridSearchCV, ms,
                   param_grid=dict(gamma=[.1, 1, 10]),
                   scoring=ARIScorer)

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -22,7 +22,7 @@ from sklearn.datasets.samples_generator import make_classification, make_blobs
 from sklearn.svm import LinearSVC, SVC
 from sklearn.cluster import KMeans, MeanShift
 from sklearn.metrics import f1_score
-from sklearn.metrics.score_objects import Scorer
+from sklearn.metrics import Scorer
 from sklearn.cross_validation import KFold, StratifiedKFold
 
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -300,11 +300,11 @@ def test_bad_estimator():
 def test_score_func_string():
     # test that correct scores are used
     from sklearn.metrics import auc_score
-    clf = LinearSVC()
+    clf = LinearSVC(random_state=0)
     X, y = make_blobs(random_state=0, centers=2)
     Cs = [.1, 1, 10]
     for score in ['f1', 'auc']:
-        grid_search = GridSearchCV(clf, {'C': Cs}, score=score)
+        grid_search = GridSearchCV(clf, {'C': Cs}, scoring=score)
         grid_search.fit(X, y)
         cv = StratifiedKFold(n_folds=3, y=y)
         for C, scores in zip(Cs, grid_search.grid_scores_):

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -20,7 +20,7 @@ from sklearn.grid_search import GridSearchCV
 from sklearn.datasets.samples_generator import make_classification, make_blobs
 from sklearn.svm import LinearSVC, SVC
 from sklearn.cluster import KMeans, MeanShift
-from sklearn.metrics import f1_score, precision_score
+from sklearn.metrics import f1_score
 from sklearn.metrics.score_objects import AsScorer
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.cross_validation import KFold, StratifiedKFold
@@ -158,7 +158,7 @@ def test_grid_search_sparse():
     assert_equal(C, C2)
 
 
-def test_grid_search_sparse_score_func():
+def test_grid_search_sparse_scoring():
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
     clf = LinearSVC()
@@ -173,7 +173,6 @@ def test_grid_search_sparse_score_func():
     cv.fit(X_[:180], y_[:180])
     y_pred2 = cv.predict(X_[180:])
     C2 = cv.best_estimator_.C
-    print(cv.grid_scores_)
 
     assert_array_equal(y_pred, y_pred2)
     assert_equal(C, C2)
@@ -189,7 +188,6 @@ def test_grid_search_sparse_score_func():
     cv.fit(X_[:180], y_[:180])
     y_pred3 = cv.predict(X_[180:])
     C3 = cv.best_estimator_.C
-    print(cv.grid_scores_)
 
     assert_equal(C, C3)
     assert_array_equal(y_pred, y_pred3)
@@ -266,7 +264,7 @@ def test_refit():
     y = np.array([0] * 5 + [1] * 5)
 
     clf = GridSearchCV(BrokenClassifier(), [{'parameter': [0, 1]}],
-                       score_func=precision_score, refit=True)
+                       scoring="precision", refit=True)
     clf.fit(X, y)
 
 
@@ -286,8 +284,9 @@ def test_unsupervised_grid_search():
     # test grid-search with unsupervised estimator
     X, y = make_blobs(random_state=0)
     km = KMeans(random_state=0)
+    ARIScorer = AsScorer(adjusted_rand_score)
     grid_search = GridSearchCV(km, param_grid=dict(n_clusters=[2, 3, 4]),
-                               score_func=adjusted_rand_score)
+                               scoring=ARIScorer)
     grid_search.fit(X)
     # most number of clusters should be best
     assert_equal(grid_search.best_params_["n_clusters"], 4)
@@ -296,9 +295,10 @@ def test_unsupervised_grid_search():
 def test_bad_estimator():
     # test grid-search with unsupervised estimator
     ms = MeanShift()
+    ARIScorer = AsScorer(adjusted_rand_score)
     assert_raises(TypeError, GridSearchCV, ms,
                   param_grid=dict(gamma=[.1, 1, 10]),
-                  score_func=adjusted_rand_score)
+                  scoring=ARIScorer)
 
 
 def test_score_func_string():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -194,6 +194,8 @@ def test_grid_search_sparse_scoring():
 
 
 def test_deprecated_score_func():
+    # test that old deprecated way of passing a score / loss function is still
+    # supported
     X, y = make_classification(n_samples=200, n_features=100, random_state=0)
     clf = LinearSVC(random_state=0)
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1")
@@ -204,6 +206,7 @@ def test_deprecated_score_func():
     clf = LinearSVC(random_state=0)
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
     with warnings.catch_warnings(record=True):
+        # catch deprecation warning
         cv.fit(X[:180], y[:180])
     y_pred_func = cv.predict(X[180:])
     C_func = cv.best_estimator_.C
@@ -218,6 +221,7 @@ def test_deprecated_score_func():
     clf = LinearSVC(random_state=0)
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, loss_func=f1_loss)
     with warnings.catch_warnings(record=True):
+        # catch deprecation warning
         cv.fit(X[:180], y[:180])
     y_pred_loss = cv.predict(X[180:])
     C_loss = cv.best_estimator_.C

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -22,7 +22,7 @@ from sklearn.datasets.samples_generator import make_classification, make_blobs
 from sklearn.svm import LinearSVC, SVC
 from sklearn.cluster import KMeans, MeanShift
 from sklearn.metrics import f1_score
-from sklearn.metrics.score_objects import AsScorer
+from sklearn.metrics.score_objects import Scorer
 from sklearn.cross_validation import KFold, StratifiedKFold
 
 
@@ -183,7 +183,7 @@ def test_grid_search_sparse_scoring():
     # test loss where greater is worse
     def f1_loss(y_true_, y_pred_):
         return -f1_score(y_true_, y_pred_)
-    F1Loss = AsScorer(f1_loss, greater_is_better=False)
+    F1Loss = Scorer(f1_loss, greater_is_better=False)
     cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring=F1Loss)
     cv.fit(X_[:180], y_[:180])
     y_pred3 = cv.predict(X_[180:])

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -341,7 +341,7 @@ def test_bad_estimator():
                   scoring='ari')
 
 
-def test_score_func_string():
+def test_grid_search_score_consistency():
     # test that correct scores are used
     from sklearn.metrics import auc_score
     clf = LinearSVC(random_state=0)

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -343,7 +343,7 @@ def test_score_func_string():
     clf = LinearSVC(random_state=0)
     X, y = make_blobs(random_state=0, centers=2)
     Cs = [.1, 1, 10]
-    for score in ['f1', 'auc']:
+    for score in ['f1', 'roc_auc']:
         grid_search = GridSearchCV(clf, {'C': Cs}, scoring=score)
         grid_search.fit(X, y)
         cv = StratifiedKFold(n_folds=3, y=y)
@@ -355,7 +355,7 @@ def test_score_func_string():
                 clf.fit(X[train], y[train])
                 if score == "f1":
                     correct_score = f1_score(y[test], clf.predict(X[test]))
-                elif score == "auc":
+                elif score == "roc_auc":
                     correct_score = auc_score(y[test],
                                               clf.decision_function(X[test]))
                 assert_almost_equal(correct_score, scores[i])

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -22,7 +22,7 @@ from sklearn.datasets.samples_generator import make_classification, make_blobs
 from sklearn.svm import LinearSVC, SVC
 from sklearn.cluster import KMeans, MeanShift
 from sklearn.metrics import f1_score
-from sklearn.metrics.score_objects import AsScorer, ARIScorer
+from sklearn.metrics.score_objects import AsScorer
 from sklearn.cross_validation import KFold, StratifiedKFold
 
 
@@ -322,7 +322,7 @@ def test_unsupervised_grid_search():
     X, y = make_blobs(random_state=0)
     km = KMeans(random_state=0)
     grid_search = GridSearchCV(km, param_grid=dict(n_clusters=[2, 3, 4]),
-                               scoring=ARIScorer)
+                               scoring='ari')
     grid_search.fit(X, y)
     # ARI can find the right number :)
     assert_equal(grid_search.best_params_["n_clusters"], 3)
@@ -338,7 +338,7 @@ def test_bad_estimator():
     ms = MeanShift()
     assert_raises(TypeError, GridSearchCV, ms,
                   param_grid=dict(gamma=[.1, 1, 10]),
-                  scoring=ARIScorer)
+                  scoring='ari')
 
 
 def test_score_func_string():


### PR DESCRIPTION
This is hopefully my last shot at adding more advanced score functions, as discussed in the other PRs and the ML.

Compare to #1198 and #1014.

This is sort of a draft (again) and it would be great if I could get some feedback before going further.

This PR basically implements a new interface in GridSearchCV using callable score objects with an `(estimator, X, y)`
signature. To create these objects I introduced an internal factory-style function.
The idea would be to either pass a string or a callable object to GridSearchCV.

~~At the moment, I complicated things a bit by keeping `score_func` as the parameter name in `GridSearchCV`. I think it might be better to deprecate it and add a new `score` parameter.~~

~~I am not sure if I am entirely happy with this. The factory seems a bit overly complicated, but maybe that is a matter of taste. Alternative suggestions welcome. It feels a bit as if decorators would be a more natural.~~

I am happy now.
