### PR TITLE
MRG: Add dummy feature utility function

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -878,9 +878,10 @@ Pairwise metrics
    :toctree: generated/
    :template: function.rst
 
-   preprocessing.scale
-   preprocessing.normalize
+   preprocessing.add_dummy_feature
    preprocessing.binarize
+   preprocessing.normalize
+   preprocessing.scale
 
 
 :mod:`sklearn.qda`: Quadratic Discriminant Analysis

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -11,7 +11,7 @@ import numbers
 import numpy as np
 import scipy.sparse as sp
 
-from .utils import check_arrays, array2d, atleast2d_or_csr
+from .utils import check_arrays, array2d, atleast2d_or_csr, safe_asarray
 from .utils import warn_if_not_float
 from .utils.fixes import unique
 from .base import BaseEstimator, TransformerMixin
@@ -1129,3 +1129,47 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         K += self.K_fit_all_
 
         return K
+
+
+def add_dummy_feature(X, value=1.0):
+    """Augment dataset with an additional dummy feature.
+
+    This is useful for fitting an intercept term with implementations which
+    cannot otherwise fit it directly.
+
+    Parameters
+    ----------
+    X : array or scipy.sparse matrix with shape [n_samples, n_features]
+        Data.
+
+    value : float
+        Value to use for the dummy feature.
+
+    Returns
+    -------
+
+    X : array or scipy.sparse matrix with shape [n_samples, n_features + 1]
+        Same data with dummy feature added as firt column.
+    """
+    X = safe_asarray(X)
+    n_samples, n_features = X.shape
+    shape = (n_samples, n_features + 1)
+    if sp.issparse(X):
+        if sp.isspmatrix_coo(X):
+            col = X.col + 1
+            col = np.concatenate((np.zeros(n_samples), col))
+            row = np.concatenate((np.arange(n_samples), X.row))
+            data = np.concatenate((np.ones(n_samples) * value, X.data))
+            return sp.coo_matrix((data, (row, col)), shape)
+        elif sp.isspmatrix_csc(X):
+            indptr = X.indptr + n_samples
+            indptr = np.concatenate((np.array([0]), indptr))
+            indices = np.concatenate((np.arange(n_samples), X.indices))
+            data = np.concatenate((np.ones(n_samples) * value, X.data))
+            return sp.csc_matrix((data, indices, indptr), shape)
+        else:
+            klass = X.__class__
+            X = klass(add_dummy_feature(X.tocoo(), value))
+            return klass(X)
+    else:
+        return np.hstack((np.ones((n_samples, 1)) * value, X))

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1149,7 +1149,15 @@ def add_dummy_feature(X, value=1.0):
     -------
 
     X : array or scipy.sparse matrix with shape [n_samples, n_features + 1]
-        Same data with dummy feature added as firt column.
+        Same data with dummy feature added as first column.
+
+    Example
+    --------
+
+    >>> from sklearn.preprocessing import add_dummy_feature
+    >>> add_dummy_feature([[0, 1], [1, 0]])
+    array([[ 1.,  0.,  1.],
+           [ 1.,  1.,  0.]])
     """
     X = safe_asarray(X)
     n_samples, n_features = X.shape

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1156,15 +1156,23 @@ def add_dummy_feature(X, value=1.0):
     shape = (n_samples, n_features + 1)
     if sp.issparse(X):
         if sp.isspmatrix_coo(X):
+            # Shift columns to the right.
             col = X.col + 1
+            # Column indices of dummy feature are 0 everywhere.
             col = np.concatenate((np.zeros(n_samples), col))
+            # Row indices of dummy feature are 0, ..., n_samples-1.
             row = np.concatenate((np.arange(n_samples), X.row))
+            # Prepend the dummy feature n_samples times.
             data = np.concatenate((np.ones(n_samples) * value, X.data))
             return sp.coo_matrix((data, (row, col)), shape)
         elif sp.isspmatrix_csc(X):
+            # Shift index pointers since we need to add n_samples elements.
             indptr = X.indptr + n_samples
+            # indptr[0] must be 0.
             indptr = np.concatenate((np.array([0]), indptr))
+            # Row indices of dummy feature are 0, ..., n_samples-1.
             indices = np.concatenate((np.arange(n_samples), X.indices))
+            # Prepend the dummy feature n_samples times.
             data = np.concatenate((np.ones(n_samples) * value, X.data))
             return sp.csc_matrix((data, indices, indptr), shape)
         else:

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -612,12 +612,14 @@ def test_add_dummy_feature():
 def test_add_dummy_feature_coo():
     X = sp.coo_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
+    assert_true(sp.isspmatrix_coo(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
 def test_add_dummy_feature_csc():
     X = sp.csc_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
+    assert_true(sp.isspmatrix_csc(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -21,6 +21,7 @@ from sklearn.preprocessing import normalize
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import scale
 from sklearn.preprocessing import MinMaxScaler
+from sklearn.preprocessing import add_dummy_feature
 
 from sklearn import datasets
 from sklearn.linear_model.stochastic_gradient import SGDClassifier
@@ -600,3 +601,28 @@ def test_fit_transform():
         X_transformed = obj.fit(X).transform(X)
         X_transformed2 = obj.fit_transform(X)
         assert_array_equal(X_transformed, X_transformed2)
+
+
+def test_add_dummy_feature():
+    X = [[1, 0], [0, 1], [0, 1]]
+    X = add_dummy_feature(X)
+    assert_array_equal(X, [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
+
+
+def test_add_dummy_feature_coo():
+    X = sp.coo_matrix([[1, 0], [0, 1], [0, 1]])
+    X = add_dummy_feature(X)
+    assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
+
+
+def test_add_dummy_feature_csc():
+    X = sp.csc_matrix([[1, 0], [0, 1], [0, 1]])
+    X = add_dummy_feature(X)
+    assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
+
+
+def test_add_dummy_feature_csr():
+    X = sp.csr_matrix([[1, 0], [0, 1], [0, 1]])
+    X = add_dummy_feature(X)
+    assert_true(sp.isspmatrix_csr(X), X)
+    assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])


### PR DESCRIPTION
This PR adds a simple utility function to the preprocessing module that adds a dummy feature (a column with all 1) to a dataset. It supports ndarrays, COO matrices and CSC matrices efficiently. For CSR matrices, it converts to COO first.

It's not used in the scikit yet but since it's not trivial to implement in the sparse case, it think it is nice to have a well-tested function for this purpose in the scikit.
