### PR TITLE
New Manifold Learning Example using a Sphere

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -314,7 +314,7 @@ tangent spaces to learn the embedding.  LTSA can be performed with function
    :target: ../auto_examples/manifold/plot_lle_digits.html
    :align: center
    :scale: 50
-   
+
 Complexity
 ----------
 
@@ -348,7 +348,8 @@ The overall complexity of standard LTSA is
 Multi-dimensional Scaling (MDS)
 ===============================
 
-Multidimensional scaling (:class:`MDS`) seeks a low-dimensional
+`Multidimensional scaling <http://en.wikipedia.org/wiki/Multidimensional_scaling>`_
+(:class:`MDS`) seeks a low-dimensional
 representation of the data in which the distances respect well the
 distances in the original high-dimensional space.
 

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -9,6 +9,9 @@ with various manifold learning methods.
 For a discussion and comparison of these algorithms, see the
 :ref:`manifold module page <manifold>`
 
+For a similiar example, where the methods are applied to a
+sphere dataset, see :ref:`example_manifold_plot_manifold_sphere.py`
+
 Note that the purpose of the MDS is to find a low-dimensional
 representation of the data (here 2D) in which the distances respect well
 the distances in the original high-dimensional space, unlike other

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -10,8 +10,8 @@ An application of the different :ref:`manifold` techniques
 on a spherical data-set. Here one can see the use of
 dimensionality reduction in order to gain some intuition
 regarding the Manifold learning methods. Regarding the dataset,
-The poles are cut from the sphere, as well as a thin slice down its
-side. This enables the Manifold Learning techniques to
+the poles are cut from the sphere, as well as a thin slice down its
+side. This enables the manifold learning techniques to
 'spread it open' whilst projecting it onto two dimensions.
 
 For a similiar example, where the methods are applied to the
@@ -73,7 +73,7 @@ except:
     ax = fig.add_subplot(241, projection='3d')
     pl.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
 
-sphere_data = np.array([x, y, z])
+sphere_data = np.array([x, y, z]).T
 
 # Perform Locally Linear Embedding Manifold learning
 methods = ['standard', 'ltsa', 'hessian', 'modified']
@@ -83,10 +83,9 @@ for i, method in enumerate(methods):
     t0 = time()
     trans_data = manifold.LocallyLinearEmbedding(n_neighbors, 2,
                                                 eigen_solver='auto',
-                                                method=method).fit_transform(sphere_data.T)
+                                                method=method).fit_transform(sphere_data).T
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)
-    trans_data = trans_data.T
 
     ax = fig.add_subplot(242 + i)
     pl.scatter(trans_data[0], trans_data[1], c=colors, cmap=pl.cm.rainbow)
@@ -97,10 +96,9 @@ for i, method in enumerate(methods):
 
 # Perform Isomap Manifold learning.
 t0 = time()
-trans_data = manifold.Isomap(n_neighbors, n_components=2).fit_transform(sphere_data.T)
+trans_data = manifold.Isomap(n_neighbors, n_components=2).fit_transform(sphere_data).T
 t1 = time()
 print "%s: %.2g sec" % ('ISO', t1 - t0)
-trans_data = trans_data.T
 
 ax = fig.add_subplot(246)
 pl.scatter(trans_data[0], trans_data[1],  c=colors, cmap=pl.cm.rainbow)
@@ -112,8 +110,7 @@ pl.axis('tight')
 # Perform Multi-dimensional scaling.
 t0 = time()
 mds = manifold.MDS(2, max_iter=100, n_init=1)
-trans_data = mds.fit_transform(euclidean_distances(sphere_data.T))
-trans_data = trans_data.T
+trans_data = mds.fit_transform(euclidean_distances(sphere_data)).T
 t1 = time()
 print "MDS: %.2g sec" % (t1 - t0)
 

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -3,7 +3,7 @@
 
 """
 =========================================
-Manifold Learning methods on a sphere
+Manifold Learning methods on a severed sphere
 =========================================
 
 An application of the different :ref:`manifold` techniques

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -52,20 +52,20 @@ n_samples = 1000
 
 # Create our sphere.
 random_state = check_random_state(0)
-p = random_state.rand(n_samples)*(2*np.pi-0.55)
-t = random_state.rand(n_samples)*np.pi
+p = random_state.rand(n_samples) * (2 * np.pi - 0.55)
+t = random_state.rand(n_samples) * np.pi
 
 # Sever the poles from the sphere.
-indices = ((t < (np.pi-(np.pi/8))) & (t > ((np.pi/8))))
+indices = ((t < (np.pi - (np.pi / 8))) & (t > ((np.pi / 8))))
 colors = p[indices]
-x, y, z = np.sin(t[indices])*np.cos(p[indices]), \
-    np.sin(t[indices])*np.sin(p[indices]), \
+x, y, z = np.sin(t[indices]) * np.cos(p[indices]), \
+    np.sin(t[indices]) * np.sin(p[indices]), \
     np.cos(t[indices])
 
 # Plot our dataset.
 fig = pl.figure(figsize=(15, 8))
 pl.suptitle("Manifold Learning with %i points, %i neighbors"
-               % (1000, n_neighbors), fontsize=14)
+            % (1000, n_neighbors), fontsize=14)
 
 ax = fig.add_subplot(241, projection='3d')
 ax.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
@@ -83,8 +83,9 @@ labels = ['LLE', 'LTSA', 'Hessian LLE', 'Modified LLE']
 
 for i, method in enumerate(methods):
     t0 = time()
-    trans_data = manifold.LocallyLinearEmbedding(n_neighbors, 2,
-                                                method=method).fit_transform(sphere_data).T
+    trans_data = manifold\
+        .LocallyLinearEmbedding(n_neighbors, 2,
+                                method=method).fit_transform(sphere_data).T
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)
 
@@ -97,7 +98,8 @@ for i, method in enumerate(methods):
 
 # Perform Isomap Manifold learning.
 t0 = time()
-trans_data = manifold.Isomap(n_neighbors, n_components=2).fit_transform(sphere_data).T
+trans_data = manifold.Isomap(n_neighbors, n_components=2)\
+    .fit_transform(sphere_data).T
 t1 = time()
 print "%s: %.2g sec" % ('ISO', t1 - t0)
 
@@ -123,4 +125,3 @@ ax.yaxis.set_major_formatter(NullFormatter())
 pl.axis('tight')
 
 pl.show()
-

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -67,14 +67,13 @@ fig = pl.figure(figsize=(15, 8))
 pl.suptitle("Manifold Learning with %i points, %i neighbors"
                % (1000, n_neighbors), fontsize=14)
 
+ax = fig.add_subplot(241, projection='3d')
+ax.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
 try:
     # compatibility matplotlib < 1.0
-    ax = fig.add_subplot(241, projection='3d')
-    ax.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
     ax.view_init(40, -10)
 except:
-    ax = fig.add_subplot(241, projection='3d')
-    pl.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
+    pass
 
 sphere_data = np.array([x, y, z]).T
 

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -17,11 +17,12 @@ side. This enables the manifold learning techniques to
 For a similiar example, where the methods are applied to the
 S-curve dataset, see :ref:`example_manifold_plot_compare_methods.py`
 
-Note that the purpose of the MDS is to find a low-dimensional
-representation of the data (here 2D) in which the distances respect well
-the distances in the original high-dimensional space, unlike other
-manifold-learning algorithms, it does not seeks an isotropic
-representation of the data in the low-dimensional space.
+Note that the purpose of the :ref:`MDS <multidimensional_scaling>` is
+to find a low-dimensional representation of the data (here 2D) in
+which the distances respect well the distances in the original
+high-dimensional space, unlike other manifold-learning algorithms,
+it does not seeks an isotropic representation of the data in
+the low-dimensional space.
 """
 
 # Author: Jaques Grobler <jaques.grobler@inria.fr>

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+=========================================
+Manifold Learning methods on a sphere
+=========================================
+
+An application of the different :ref:`manifold` techniques
+on a spherical data-set. Here one can see the use of
+dimensionality reduction in order to gain some intuition
+regarding the Manifold learning methods. Regarding the dataset,
+The poles are cut from the sphere, as well as a thin slice down its
+side. This enables the Manifold Learning techniques to
+'spread it open' whilst projecting it onto two dimensions.
+
+For a similiar example, where the methods are applied to the
+S-curve dataset, see :ref:`example_manifold_plot_compare_methods.py`
+
+Note that the purpose of the MDS is to find a low-dimensional
+representation of the data (here 2D) in which the distances respect well
+the distances in the original high-dimensional space, unlike other
+manifold-learning algorithms, it does not seeks an isotropic
+representation of the data in the low-dimensional space.
+"""
+
+# Author: Jaques Grobler <jaques.grobler@inria.fr>
+# License: BSD
+
+print __doc__
+
+from time import time
+
+import numpy as np
+import pylab as pl
+from mpl_toolkits.mplot3d import Axes3D
+from matplotlib.ticker import NullFormatter
+
+from sklearn import manifold
+from sklearn.metrics import euclidean_distances
+from sklearn.utils import check_random_state
+
+# Next line to silence pyflakes.
+Axes3D
+
+# Variables for manifold learning.
+n_neighbors = 10
+n_samples = 1000
+
+# Create our sphere.
+random_state = check_random_state(0)
+p = random_state.rand(n_samples)*(2*np.pi-0.55)
+t = random_state.rand(n_samples)*np.pi
+
+# Sever the poles from the sphere.
+indices = ((t < (np.pi-(np.pi/8))) & (t > ((np.pi/8))))
+colors = p[indices]
+x, y, z = np.sin(t[indices])*np.cos(p[indices]), \
+    np.sin(t[indices])*np.sin(p[indices]), \
+    np.cos(t[indices])
+
+# Plot our dataset.
+fig = pl.figure(figsize=(15, 8))
+pl.suptitle("Manifold Learning with %i points, %i neighbors"
+               % (1000, n_neighbors), fontsize=14)
+
+try:
+    # compatibility matplotlib < 1.0
+    ax = fig.add_subplot(241, projection='3d')
+    ax.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
+    ax.view_init(40, -10)
+except:
+    ax = fig.add_subplot(241, projection='3d')
+    pl.scatter(x, y, z, c=p[indices], cmap=pl.cm.rainbow)
+
+sphere_data = np.array([x, y, z])
+
+# Perform Locally Linear Embedding Manifold learning
+methods = ['standard', 'ltsa', 'hessian', 'modified']
+labels = ['LLE', 'LTSA', 'Hessian LLE', 'Modified LLE']
+
+for i, method in enumerate(methods):
+    t0 = time()
+    trans_data = manifold.LocallyLinearEmbedding(n_neighbors, 2,
+                                                eigen_solver='auto',
+                                                method=method).fit_transform(sphere_data.T)
+    t1 = time()
+    print "%s: %.2g sec" % (methods[i], t1 - t0)
+    trans_data = trans_data.T
+
+    ax = fig.add_subplot(242 + i)
+    pl.scatter(trans_data[0], trans_data[1], c=colors, cmap=pl.cm.rainbow)
+    pl.title("%s (%.2g sec)" % (labels[i], t1 - t0))
+    ax.xaxis.set_major_formatter(NullFormatter())
+    ax.yaxis.set_major_formatter(NullFormatter())
+    pl.axis('tight')
+
+# Perform Isomap Manifold learning.
+t0 = time()
+trans_data = manifold.Isomap(n_neighbors, n_components=2).fit_transform(sphere_data.T)
+t1 = time()
+print "%s: %.2g sec" % ('ISO', t1 - t0)
+trans_data = trans_data.T
+
+ax = fig.add_subplot(246)
+pl.scatter(trans_data[0], trans_data[1],  c=colors, cmap=pl.cm.rainbow)
+pl.title("%s (%.2g sec)" % ('Isomap', t1 - t0))
+ax.xaxis.set_major_formatter(NullFormatter())
+ax.yaxis.set_major_formatter(NullFormatter())
+pl.axis('tight')
+
+# Perform Multi-dimensional scaling.
+t0 = time()
+mds = manifold.MDS(2, max_iter=100, n_init=1)
+trans_data = mds.fit_transform(euclidean_distances(sphere_data.T))
+trans_data = trans_data.T
+t1 = time()
+print "MDS: %.2g sec" % (t1 - t0)
+
+ax = fig.add_subplot(247)
+pl.scatter(trans_data[0], trans_data[1],  c=colors, cmap=pl.cm.rainbow)
+pl.title("MDS (%.2g sec)" % (t1 - t0))
+ax.xaxis.set_major_formatter(NullFormatter())
+ax.yaxis.set_major_formatter(NullFormatter())
+pl.axis('tight')
+
+pl.show()
+

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -22,7 +22,9 @@ to find a low-dimensional representation of the data (here 2D) in
 which the distances respect well the distances in the original
 high-dimensional space, unlike other manifold-learning algorithms,
 it does not seeks an isotropic representation of the data in
-the low-dimensional space.
+the low-dimensional space. Here the manifold problem matches fairly
+that of representing a flat map of the Earth, as with
+`map projection<http://en.wikipedia.org/wiki/Map_projection>`_
 """
 
 # Author: Jaques Grobler <jaques.grobler@inria.fr>
@@ -83,7 +85,6 @@ labels = ['LLE', 'LTSA', 'Hessian LLE', 'Modified LLE']
 for i, method in enumerate(methods):
     t0 = time()
     trans_data = manifold.LocallyLinearEmbedding(n_neighbors, 2,
-                                                eigen_solver='auto',
                                                 method=method).fit_transform(sphere_data).T
     t1 = time()
     print "%s: %.2g sec" % (methods[i], t1 - t0)


### PR DESCRIPTION
Hi all,

This is another manifold learning comparison example, this time using a spherical dataset.
I sort of merged @jakevdp 's [S-curve](http://scikit-learn.org/stable/auto_examples/manifold/plot_compare_methods.html) example into mine when I added LLE and MDS.
Here is the plot the example generates:

![Spherical Dataset Manifold Learning](http://i46.tinypic.com/1076xvr.png)

The end idea with this, which would be pretty cool to have in the example gallery, is to use something like the [Basemap Matplotlib](http://matplotlib.org/basemap/users/examples.html) toolkit to have an actual Earth Globe. 

Something like (without the contours of course):

![Basemap globe](http://matplotlib.org/basemap/_images/contour1.png)

and then cut it open as with the example and apply the manifold learning techniques to it.
It could be a very useful tool for developing intuition when it comes to manifold-learning.
