### PR TITLE
WIP chi square kernel and histogram intersection kernel

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -598,7 +598,9 @@ pairwise_kernel_functions = {
     'sigmoid': sigmoid_kernel,
     'polynomial': polynomial_kernel,
     'poly': polynomial_kernel,
-    'linear': linear_kernel
+    'linear': linear_kernel,
+    'histogram_intersection' : histogram_intersection_kernel,
+    'chi_square' : chi_square_kernel
 }
 
 
@@ -610,15 +612,17 @@ def kernel_metrics():
     each of the valid strings.
 
     The valid distance metrics, and the function they map to, are:
-      ============   ==================================
-      metric         Function
-      ============   ==================================
-      'linear'       sklearn.pairwise.linear_kernel
-      'poly'         sklearn.pairwise.polynomial_kernel
-      'polynomial'   sklearn.pairwise.polynomial_kernel
-      'rbf'          sklearn.pairwise.rbf_kernel
-      'sigmoid'      sklearn.pairwise.sigmoid_kernel
-      ============   ==================================
+      ============             ==================================
+      metric                   Function
+      ============             ==================================
+      'linear'                 sklearn.pairwise.linear_kernel
+      'poly'                   sklearn.pairwise.polynomial_kernel
+      'polynomial'             sklearn.pairwise.polynomial_kernel
+      'rbf'                    sklearn.pairwise.rbf_kernel
+      'sigmoid'                sklearn.pairwise.sigmoid_kernel
+      'histogram_intersection' sklearn.pairwise.histogram_intersection_kernel
+      'chi_square'             sklearn.pairwise.chi_square_kernel
+      ============             ==================================
     """
     return pairwise_kernel_functions
 
@@ -628,7 +632,9 @@ kernel_params = {
     "sigmoid": set(("gamma", "coef0")),
     "polynomial": set(("gamma", "degree", "coef0")),
     "poly": set(("gamma", "degree", "coef0")),
-    "linear": ()
+    "linear": (),
+    "histogram_intersection" : set(("alpha", "beta")),
+    "chi_square" : set()
 }
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -599,8 +599,8 @@ pairwise_kernel_functions = {
     'polynomial': polynomial_kernel,
     'poly': polynomial_kernel,
     'linear': linear_kernel,
-    'histogram_intersection' : histogram_intersection_kernel,
-    'chi_square' : chi_square_kernel
+    'histogram_intersection': histogram_intersection_kernel,
+    'chi_square': chi_square_kernel
 }
 
 
@@ -633,8 +633,8 @@ kernel_params = {
     "polynomial": set(("gamma", "degree", "coef0")),
     "poly": set(("gamma", "degree", "coef0")),
     "linear": (),
-    "histogram_intersection" : set(("alpha", "beta")),
-    "chi_square" : set()
+    "histogram_intersection": set(("alpha", "beta")),
+    "chi_square": set()
 }
 
 
@@ -654,7 +654,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     kernel between the arrays from both X and Y.
 
     Valid values for metric are::
-        ['rbf', 'sigmoid', 'polynomial', 'poly', 'linear']
+        ['rbf', 'sigmoid', 'polynomial', 'poly', 'linear', 'chi_square',
+        'histogram_intersection']
 
     Parameters
     ----------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -168,7 +168,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
         YY = atleast2d_or_csr(Y_norm_squared)
         if YY.shape != (1, Y.shape[0]):
             raise ValueError(
-                        "Incompatible dimensions for Y and Y_norm_squared")
+                "Incompatible dimensions for Y and Y_norm_squared")
 
     # TODO: a faster Cython implementation would do the clipping of negative
     # values in a single pass over the output matrix.
@@ -234,10 +234,11 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
            [ 1.,  1.]]...)
     """
     X, Y = check_pairwise_arrays(X, Y)
+    if issparse(X) or issparse(Y):
+        raise TypeError("manhattan distances currently does not"
+                        " support sparse matrices.")
     n_samples_X, n_features_X = X.shape
     n_samples_Y, n_features_Y = Y.shape
-    if n_features_X != n_features_Y:
-        raise Exception("X and Y should have the same number of features!")
     D = np.abs(X[:, np.newaxis, :] - Y[np.newaxis, :, :])
     if sum_over_features:
         D = np.sum(D, axis=2)
@@ -374,10 +375,10 @@ def chi_square_kernel(X, Y=None):
     n_samples_2, _ = Y.shape
     print n_samples_1, n_samples_2, n_features
     if issparse(X) or issparse(Y):
-        raise TypeError("chi square kernel currently do not"
+        raise TypeError("chi square kernel currently does not"
                         " support sparse matrices.")
     XY = X[:, np.newaxis, :] + Y[np.newaxis, :, :]
-    K = XY - 4. * X[:, np.newaxis, :] * Y[np.newaxis, :, :]/XY
+    K = XY - 4. * X[:, np.newaxis, :] * Y[np.newaxis, :, :] / XY
     K = K.sum(axis=2) * 2
     K = 1 - K
     return K
@@ -385,7 +386,7 @@ def chi_square_kernel(X, Y=None):
 
 def histogram_intersection_kernel(X, Y=None, alpha=None, beta=None):
     """
-    Compute the histogram intersection kernel (min kernel) 
+    Compute the histogram intersection kernel (min kernel)
     between X and Y::
 
         K(x, y) = \sum_i^n min(|x_i|^\alpha, |y_i|^\beta)
@@ -412,10 +413,10 @@ def histogram_intersection_kernel(X, Y=None, alpha=None, beta=None):
     n_samples_1, n_features = X.shape
     n_samples_2, _ = Y.shape
     if issparse(X) or issparse(Y):
-        raise TypeError("histogram intersection kernel currently do not"
+        raise TypeError("histogram intersection kernel currently does not"
                         " support sparse matrices.")
     else:
-        K = np.minimum(X[:, np.newaxis, :], 
+        K = np.minimum(X[:, np.newaxis, :],
                        Y[np.newaxis, :, :]).sum(axis=2)
     return K
 
@@ -429,7 +430,7 @@ pairwise_distance_functions = {
     'l1': manhattan_distances,
     'manhattan': manhattan_distances,
     'cityblock': manhattan_distances,
-    }
+}
 
 
 def distance_metrics():
@@ -598,7 +599,7 @@ pairwise_kernel_functions = {
     'polynomial': polynomial_kernel,
     'poly': polynomial_kernel,
     'linear': linear_kernel
-    }
+}
 
 
 def kernel_metrics():
@@ -701,8 +702,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         return X
     elif metric in pairwise_kernel_functions:
         if filter_params:
-            kwds = dict((k, kwds[k]) for k in kwds \
-                                        if k in kernel_params[metric])
+            kwds = dict((k, kwds[k]) for k in kwds
+                        if k in kernel_params[metric])
         func = pairwise_kernel_functions[metric]
         if n_jobs == 1:
             return func(X, Y, **kwds)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -396,7 +396,7 @@ def histogram_intersection_kernel(X, Y=None, alpha=None, beta=None):
     Y : array of shape (n_samples_2, n_features)
 
     alpha : float
-    
+
     beta : float
 
     Returns
@@ -466,8 +466,8 @@ def _parallel_pairwise(X, Y, func, n_jobs, **kwds):
         Y = X
 
     ret = Parallel(n_jobs=n_jobs, verbose=0)(
-            delayed(func)(X, Y[s], **kwds)
-            for s in gen_even_slices(Y.shape[0], n_jobs))
+        delayed(func)(X, Y[s], **kwds)
+        for s in gen_even_slices(Y.shape[0], n_jobs))
 
     return np.hstack(ret)
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -364,8 +364,6 @@ def chi_square_kernel(X, Y=None):
 
     Y : array of shape (n_samples_2, n_features)
 
-    gamma : float
-
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
@@ -397,7 +395,9 @@ def histogram_intersection_kernel(X, Y=None, alpha=None, beta=None):
 
     Y : array of shape (n_samples_2, n_features)
 
-    gamma : float
+    alpha : float
+    
+    beta : float
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy import linalg
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_equal
+from numpy.testing import assert_almost_equal
 from nose.tools import assert_raises
 from nose.tools import assert_true
 from scipy.sparse import csr_matrix
@@ -16,6 +17,8 @@ from .. import pairwise_distances, pairwise_kernels
 from ..pairwise import pairwise_kernel_functions
 from ..pairwise import check_pairwise_arrays
 from ..pairwise import _parallel_pairwise
+from ..pairwise import chi_square_kernel
+from ..pairwise import histogram_intersection_kernel
 
 
 def test_pairwise_distances():
@@ -192,6 +195,32 @@ def test_rbf_kernel():
     K = rbf_kernel(X, X)
     # the diagonal elements of a rbf kernel are 1
     assert_array_almost_equal(K.flat[::6], np.ones(5))
+
+
+def test_chi_square_kernel():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    Y = rng.random_sample((10, 4))
+    K = chi_square_kernel(X, Y)
+    for i, x in enumerate(X):
+        for j, y in enumerate(Y):
+            assert_almost_equal(K[i,j], 1 - 2 * np.sum((x - y)**2/(x+y)), decimal=10)
+    
+
+def test_histogram_intersection_kernel():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    Y = rng.random_sample((10, 4))
+    K = histogram_intersection_kernel(X, Y)
+    for i, x in enumerate(X):
+        for j, y in enumerate(Y):
+            assert_almost_equal(K[i,j], np.minimum(x,y).sum(), decimal=10)
+    alpha = 0.9
+    beta  = 0.8
+    K = histogram_intersection_kernel(X, Y, alpha, beta)
+    for i, x in enumerate(X):
+        for j, y in enumerate(Y):
+            assert_almost_equal(K[i,j], np.minimum(np.abs(x)**alpha,np.abs(y)**beta).sum(), decimal=10)
 
 
 def test_check_dense_matrices():

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -99,7 +99,8 @@ def test_pairwise_kernels():
     X = rng.random_sample((5, 4))
     Y = rng.random_sample((2, 4))
     # Test with all metrics that should be in pairwise_kernel_functions.
-    test_metrics = ["rbf", "sigmoid", "polynomial", "linear"]
+    test_metrics = ["rbf", "sigmoid", "polynomial", "linear",
+                    "histogram_intersection", "chi_square"]
     for metric in test_metrics:
         function = pairwise_kernel_functions[metric]
         # Test with Y=None
@@ -118,8 +119,11 @@ def test_pairwise_kernels():
         # Test with sparse X and Y
         X_sparse = csr_matrix(X)
         Y_sparse = csr_matrix(Y)
-        K1 = pairwise_kernels(X_sparse, Y=Y_sparse, metric=metric)
-        assert_array_almost_equal(K1, K2)
+        try:
+            K1 = pairwise_kernels(X_sparse, Y=Y_sparse, metric=metric)
+            assert_array_almost_equal(K1, K2)
+        except TypeError:
+            pass
     # Test with a callable function, with given keywords.
     metric = callable_rbf_kernel
     kwds = {}

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -204,8 +204,9 @@ def test_chi_square_kernel():
     K = chi_square_kernel(X, Y)
     for i, x in enumerate(X):
         for j, y in enumerate(Y):
-            assert_almost_equal(K[i,j], 1 - 2 * np.sum((x - y)**2/(x+y)), decimal=10)
-    
+            assert_almost_equal(
+                K[i, j], 1 - 2 * np.sum((x - y) ** 2 / (x + y)), decimal=10)
+
 
 def test_histogram_intersection_kernel():
     rng = np.random.RandomState(0)
@@ -214,13 +215,14 @@ def test_histogram_intersection_kernel():
     K = histogram_intersection_kernel(X, Y)
     for i, x in enumerate(X):
         for j, y in enumerate(Y):
-            assert_almost_equal(K[i,j], np.minimum(x,y).sum(), decimal=10)
+            assert_almost_equal(K[i, j], np.minimum(x, y).sum(), decimal=10)
     alpha = 0.9
-    beta  = 0.8
+    beta = 0.8
     K = histogram_intersection_kernel(X, Y, alpha, beta)
     for i, x in enumerate(X):
         for j, y in enumerate(Y):
-            assert_almost_equal(K[i,j], np.minimum(np.abs(x)**alpha,np.abs(y)**beta).sum(), decimal=10)
+            assert_almost_equal(K[i, j], np.minimum(
+                np.abs(x) ** alpha, np.abs(y) ** beta).sum(), decimal=10)
 
 
 def test_check_dense_matrices():


### PR DESCRIPTION
This adds the chi square kernel and histogram intersection kernels (issue #1172) and raise an `TypeError` for Manhattan distances for sparse inputs (issue #1384)

Currently they both supports dense matrix only. Not sure how to make it effectively support dense/sparse input and sparse/sparse inputs.

Some discussion for adapting @jakevdp https://github.com/jakevdp/pyDistances/ for possible solutions for sparse inputs can be found in (issue #1384).
