### PR TITLE
WIP recommend OpenBLAS for Ubuntu (and Debian?)

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -35,14 +35,23 @@ Installing from source
 
 Installing from source requires you to have installed python (>= 2.6), numpy
 (>= 1.3), scipy (>= 0.7), setuptools, python development headers and a working
-C++ compiler. Under Debian-based systems you can get all this by executing with
-root privileges::
+C++ compiler. Under Debian-based systems, which include Ubuntu,
+you can install all requirements by::
 
     sudo apt-get install python-dev python-numpy python-numpy-dev python-setuptools python-numpy-dev python-scipy libatlas-dev g++
 
+The above installs the ATLAS linear algebra library.
+On Ubuntu 11.10 and later, it is recommended to instead install OpenBLAS,
+which can provide a significant speedup, especially on multicore hardware::
+
+    # NumPy may not run when both ATLAS and OpenBLAS are installed,
+    # so remove the former.
+    sudo apt-get remove libatlas3gf-base libatlas-dev
+    sudo apt-get install libopenblas-dev
+
 .. note::
 
-    In Order to build the documentation and run the example code contains in
+    In order to build the documentation and run the example code contains in
     this documentation you will need matplotlib::
 
         sudo apt-get install python-matplotlib


### PR DESCRIPTION
I just spent way too much time optimizing matrix multiplication on an Ubuntu/AMD box and found out that installing OpenBLAS instead of ATLAS can give a major speedup to good old `np.dot` on two 2-d arrays of `dtype=np.float64`. It takes just two `apt-get` commands to replace ATLAS, so I added those to the installation instructions.

The main thing left to do for this PR is test whether the same trick works on my Debian/Intel box at work.
