### PR TITLE
BernoulliNB: Fix the denominator of P(feature | label)

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -254,7 +254,7 @@ class BaseDiscreteNB(BaseNB):
 
         self.feature_log_prob_ = (np.log(N_c_i + self.alpha)
                                 - np.log(N_c.reshape(-1, 1)
-                                       + self.alpha * X.shape[1]))
+                                       + self.alpha * N_c.size))
 
         return self
 
@@ -409,7 +409,9 @@ class BernoulliNB(BaseDiscreteNB):
     def _count(self, X, Y):
         if self.binarize is not None:
             X = binarize(X, threshold=self.binarize)
-        return super(BernoulliNB, self)._count(X, Y)
+        N_c, N_c_i = super(BernoulliNB, self)._count(X, Y)
+        N_c = Y.sum(axis=0)
+        return N_c, N_c_i
 
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""


### PR DESCRIPTION
For the Bernoulli Naïve Bayes when calculating feature_log_prob_, I believe the denominator is incorrect. N_c should be the number of data of class c. The probability P(feature | label) should be the number of times that feature is seen in data with that label, divided by the number of data with that label.

Cheers,
Shaun
