### PR TITLE
Fix staged_predict_proba() in gradient_boosting.

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -874,7 +874,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
             The predicted value of the input samples.
         """
         for score in self.staged_decision_function(X):
-            yield self._score_to_proba(X)
+            yield self._score_to_proba(score)
 
     def predict(self, X):
         """Predict class for X.


### PR DESCRIPTION
This function must be broken because of illegal calling of `_score_to_proba()`:

In `predict_proba` we have line:

```
return self._score_to_proba(score)
```

But in `staged_predict_proba` there is:

```
yield self._score_to_proba(X)
```

So last line throws exception somewhere saying that two sizes are incompatible (yes, one of them is X[1,:] times bigger than another).
