### PR TITLE
MRG Nystroem kernel approxmation

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -26,10 +26,21 @@ Since there has not been much empirical work using approximate embeddings, it
 is advisable to compare results against exact kernel methods when possible.
 
 
+.. currentmodule:: sklearn.kernel_approximation
+
+Nystroem Method for Kernel Approximation
+----------------------------------------
+The Nystroem method, as implemented in :class:`Nystroem` is a general method
+for low-rank approximations of kernels. It achieves this by essentially subsampling
+the data on which the kernel is evaluated.
+By default :class:`Nystroem` uses the ``rbf`` kernel, but it can use any
+kernel function or a precomputed kernel matrix.
+The number of samples used - which is also the dimensionality of the features computed -
+is given by the parameter ``n_components``.
+
+
 Radial Basis Function Kernel
 ----------------------------
-
-.. currentmodule:: sklearn.kernel_approximation
 
 The :class:`RBFSampler` constructs an approximate mapping for the radial basis
 function kernel. This transformation can be used to explicitly model a kernel map,
@@ -65,6 +76,10 @@ similar to those produced by a kernel SVM. Note that "fitting" the feature
 function does not actually depend on the data given to the ``fit`` function.
 Only the dimensionality of the data is used.
 Details on the method can be found in [RR2007]_.
+
+For a given value of ``n_components`` :class:`RBFSampler` is often less acurate
+as :class:`Nystroem`. :class:`RBFSampler` is cheaper to compute, though, making
+use of larger feature spaces more efficient.
 
 .. figure:: ../auto_examples/images/plot_kernel_approximation_2.png
     :target: ../auto_examples/plot_kernel_approximation.html

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,6 +86,9 @@ Changelog
    - Implement `predict_proba` in :class:`multiclass.OneVsRestClassifier`, by
      Andrew Winterman.
 
+   - Added :class:`kernel_approximation.Nystrom` for approximating arbitrary
+     kernels to the :ref:`kernel_approximation` module by `Andreas Müller`_.
+
 API changes summary
 -------------------
    - Renamed all occurences of ``n_atoms`` to ``n_components`` for consistency.

--- a/examples/plot_kernel_approximation.py
+++ b/examples/plot_kernel_approximation.py
@@ -14,6 +14,9 @@ of :class:`RBFSampler`, which uses random Fourier features) and different sized
 subsets of the training set (for :class:`Nystroem)` for the approximate mapping
 are shown.
 
+Please not that the dataset here is not large enough to show the benefits
+of kernel approximation, as the exact SVM is still reasonably fast.
+
 Sampling more dimensions clearly leads to better classification results, but
 comes at a greater cost. This means there is a tradeoff between runtime and
 accuracy, given by the parameter n_components. Note that solving the Linear
@@ -78,7 +81,7 @@ linear_svm = svm.LinearSVC()
 feature_map_fourier = RBFSampler(gamma=.2, random_state=1)
 feature_map_nystroem = Nystroem(gamma=.2, random_state=1)
 fourier_approx_svm = pipeline.Pipeline([("feature_map", feature_map_fourier),
-                                               ("svm", svm.LinearSVC())])
+                                        ("svm", svm.LinearSVC())])
 
 nystroem_approx_svm = pipeline.Pipeline([("feature_map", feature_map_nystroem),
                                         ("svm", svm.LinearSVC())])
@@ -132,15 +135,15 @@ timescale.plot(sample_sizes, fourier_times, '--',
                label='Fourier approx. kernel')
 
 # horizontal lines for exact rbf and linear kernels:
-accuracy.plot([sample_sizes[0], sample_sizes[-1]], [linear_svm_score,
-    linear_svm_score], label="linear svm")
-timescale.plot([sample_sizes[0], sample_sizes[-1]], [linear_svm_time,
-        linear_svm_time], '--', label='linear svm')
+accuracy.plot([sample_sizes[0], sample_sizes[-1]],
+              [linear_svm_score, linear_svm_score], label="linear svm")
+timescale.plot([sample_sizes[0], sample_sizes[-1]],
+               [linear_svm_time, linear_svm_time], '--', label='linear svm')
 
-accuracy.plot([sample_sizes[0], sample_sizes[-1]], [kernel_svm_score,
-    kernel_svm_score], label="rbf svm")
-timescale.plot([sample_sizes[0], sample_sizes[-1]], [kernel_svm_time,
-        kernel_svm_time], '--', label='rbf svm')
+accuracy.plot([sample_sizes[0], sample_sizes[-1]],
+              [kernel_svm_score, kernel_svm_score], label="rbf svm")
+timescale.plot([sample_sizes[0], sample_sizes[-1]],
+               [kernel_svm_time, kernel_svm_time], '--', label='rbf svm')
 
 # vertical line for dataset dimensionality = 64
 accuracy.plot([64, 64], [0.7, 1], label="n_features")

--- a/examples/plot_kernel_approximation.py
+++ b/examples/plot_kernel_approximation.py
@@ -5,21 +5,24 @@ Explicit feature map approximation for RBF kernels
 
 .. currentmodule:: sklearn.kernel_approximation
 
-An example shows how to use :class:`RBFSampler` to appoximate the feature map
-of an RBF kernel for classification with an SVM on the digits dataset.  Results
-using a linear SVM in the original space, a linear SVM using the approximate
-mapping and using a kernelized SVM are compared.  Timings and accuracy for
-varying amounts of Monte Carlo samplings for the approximate mapping are shown.
+An example shows how to use :class:`RBFSampler` and :class:`Nystrom` to
+appoximate the feature map of an RBF kernel for classification with an SVM on
+the digits dataset. Results using a linear SVM in the original space, a linear
+SVM using the approximate mappings and using a kernelized SVM are compared.
+Timings and accuracy for varying amounts of Monte Carlo samplings (in the case
+of :class:`RBFSampler`, which uses random Fourier features) and different sized
+subsets of the training set (for :class:`Nystroem)` for the approximate mapping
+are shown.
 
 Sampling more dimensions clearly leads to better classification results, but
 comes at a greater cost. This means there is a tradeoff between runtime and
-accuracy, given by the parameter n_components.  Note that solving the Linear
+accuracy, given by the parameter n_components. Note that solving the Linear
 SVM and also the approximate kernel SVM could be greatly accelerated by using
 stochastic gradient descent via :class:`sklearn.linear_model.SGDClassifier`.
 This is not easily possible for the case of the kernelized SVM.
 
 The second plot visualized the decision surfaces of the RBF kernel SVM and
-the linear SVM with approximate kernel map.
+the linear SVM with approximate kernel maps.
 The plot shows decision surfaces of the classifiers projected onto
 the first two principal components of the data. This visualization should
 be taken with a grain of salt since it is just an interesting slice through
@@ -28,14 +31,14 @@ a datapoint (represented as a dot) does not necessarily be classified
 into the region it is lying in, since it will not lie on the plane
 that the first two principal components span.
 
-The usage of :class:`RBFSampler` is described in detail in
-:ref:`kernel_approximation`.
+The usage of :class:`RBFSampler` and :class:`Nystroem` is described in detail
+in :ref:`kernel_approximation`.
 
 """
 print __doc__
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-#         modified Andreas Mueller
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: Simplified BSD
 
 # Standard scientific Python imports
@@ -46,7 +49,7 @@ from time import time
 # Import datasets, classifiers and performance metrics
 from sklearn import datasets, svm, pipeline
 from sklearn.kernel_approximation import (RBFSampler,
-                                          NystroemKernelApproximation)
+                                          Nystroem)
 from sklearn.decomposition import PCA
 
 # The digits dataset
@@ -73,7 +76,7 @@ linear_svm = svm.LinearSVC()
 # create pipeline from kernel approximation
 # and linear svm
 feature_map_fourier = RBFSampler(gamma=.2, random_state=1)
-feature_map_nystroem = NystroemKernelApproximation(gamma=.2, random_state=1)
+feature_map_nystroem = Nystroem(gamma=.2, random_state=1)
 fourier_approx_svm = pipeline.Pipeline([("feature_map", feature_map_fourier),
                                                ("svm", svm.LinearSVC())])
 
@@ -120,9 +123,9 @@ accuracy = pl.subplot(211)
 # second y axis for timeings
 timescale = pl.subplot(212)
 
-accuracy.plot(sample_sizes, nystroem_scores, label="Nystrom approx. kernel")
+accuracy.plot(sample_sizes, nystroem_scores, label="Nystroem approx. kernel")
 timescale.plot(sample_sizes, nystroem_times, '--',
-               label='Nystrom approx. kernel')
+               label='Nystroem approx. kernel')
 
 accuracy.plot(sample_sizes, fourier_scores, label="Fourier approx. kernel")
 timescale.plot(sample_sizes, fourier_times, '--',
@@ -174,7 +177,7 @@ flat_grid = grid.reshape(-1, data.shape[1])
 titles = ['SVC with rbf kernel',
           'SVC (linear kernel)\n with Fourier rbf feature map\n'
           'n_components=100',
-          'SVC (linear kernel)\n with Nystrom rbf feature map\n'
+          'SVC (linear kernel)\n with Nystroem rbf feature map\n'
           'n_components=100']
 
 pl.tight_layout()

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -8,6 +8,8 @@ approximate kernel feature maps base on Fourier transforms.
 #
 # License: BSD Style.
 
+import warnings
+
 import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import svd
@@ -368,6 +370,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         Normalization matrix needed for embedding.
         Square root of the kernel matrix on ``components_``.
 
+
     References
     ----------
     * Williams, C.K.I. and Seeger, M.
@@ -412,8 +415,18 @@ class Nystroem(BaseEstimator, TransformerMixin):
         n_samples = X.shape[0]
 
         # get basis vectors
+        if self.n_components > n_samples:
+            # XXX should we just bail?
+            n_components = n_samples
+            warnings.warn("n_components > n_samples. This is not possible.\n"
+                          "n_components was set to n_samples, which results"
+                          " in inefficient evaluation of the full kernel.")
+
+        else:
+            n_components = self.n_components
+        n_components = min(n_samples, n_components)
         inds = rnd.permutation(n_samples)
-        basis_inds = inds[:self.n_components]
+        basis_inds = inds[:n_components]
         basis = X[basis_inds]
 
         if callable(self.kernel):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -68,10 +68,13 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         self.random_state = check_random_state(self.random_state)
         n_features = X.shape[1]
 
-        self.random_weights_ = (np.sqrt(self.gamma) *
-                self.random_state.normal(size=(n_features, self.n_components)))
+        self.random_weights_ = (np.sqrt(self.gamma)
+                                * self.random_state.normal(size=(n_features,
+                                                           self.n_components)))
+
         self.random_offset_ = self.random_state.uniform(0,
-                2 * np.pi, size=self.n_components)
+                                                        2 * np.pi,
+                                                        size=self.n_components)
         return self
 
     def transform(self, X, y=None):
@@ -149,12 +152,13 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         self.random_state = check_random_state(self.random_state)
         n_features = X.shape[1]
         uniform = self.random_state.uniform(size=(n_features,
-            self.n_components))
+                                                  self.n_components))
         # transform by inverse CDF of sech
         self.random_weights_ = (1. / np.pi
-                * np.log(np.tan(np.pi / 2. * uniform)))
+                                * np.log(np.tan(np.pi / 2. * uniform)))
         self.random_offset_ = self.random_state.uniform(0,
-                2 * np.pi, size=self.n_components)
+                                                        2 * np.pi,
+                                                        size=self.n_components)
         return self
 
     def transform(self, X, y=None):
@@ -175,7 +179,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
             raise ValueError("X may not contain entries smaller than zero.")
 
         projection = safe_sparse_dot(np.log(X + self.skewedness),
-                self.random_weights_)
+                                     self.random_weights_)
 
         return (np.sqrt(2.) / np.sqrt(self.n_components)
                 * np.cos(projection + self.random_offset_))
@@ -233,7 +237,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
     def fit(self, X, y=None):
         """Set parameters."""
         X = atleast2d_or_csr(X)
-        if self.sample_interval == None:
+        if self.sample_interval is None:
             # See reference, figure 2 c)
             if self.sample_steps == 1:
                 self.sample_interval = 0.8
@@ -243,7 +247,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
                 self.sample_interval = 0.4
             else:
                 raise ValueError("If sample_steps is not in [1, 2, 3],"
-                    " you need to provide sample_interval")
+                                 " you need to provide sample_interval")
         return self
 
     def transform(self, X, y=None):
@@ -288,7 +292,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
 
         for j in xrange(1, self.sample_steps):
             factor_nz = np.sqrt(step_nz /
-                             np.cosh(np.pi * j * self.sample_interval))
+                                np.cosh(np.pi * j * self.sample_interval))
 
             X_step = np.zeros_like(X)
             X_step[non_zero] = factor_nz * np.cos(j * log_step_nz)
@@ -314,7 +318,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
 
         for j in xrange(1, self.sample_steps):
             factor_nz = np.sqrt(step_nz /
-                             np.cosh(np.pi * j * self.sample_interval))
+                                np.cosh(np.pi * j * self.sample_interval))
 
             data_step = factor_nz * np.cos(j * log_step_nz)
             X_step = sp.csr_matrix((data_step, indices, indptr),
@@ -332,7 +336,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
 class Nystroem(BaseEstimator, TransformerMixin):
     """Approximate a kernel map using a subset of the training data.
 
-    Constructes an approximate feature map for an arbitrary kernel
+    Constructs an approximate feature map for an arbitrary kernel
     using a subset of the data as basis.
 
     Parameters
@@ -344,7 +348,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         Number of features to construct.
         How many data points will be used to construct the mapping.
 
-    gamma : float, default=1.
+    gamma : float, default=1/n_features.
         Parameter for the RBF kernel.
 
     random_state : {int, RandomState}, optional
@@ -354,15 +358,15 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `basis_` : array, shape (n_components, n_features)
+    `components_` : array, shape (n_components, n_features)
         Subset of training points used to construct the feature map.
 
-    `basis_inds_` : array, shape (n_components)
-        Indices of ``basis_`` in the training set.
+    `component_indices_` : array, shape (n_components)
+        Indices of ``components_`` in the training set.
 
     `normalization_` : array, shape (n_components, n_components)
         Normalization matrix needed for embedding.
-        Square root of the kernel matrix on ``basis_``.
+        Square root of the kernel matrix on ``components_``.
 
     References
     ----------
@@ -383,10 +387,12 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     sklearn.metric.pairwise.kernel_metrics : List of build-in kernels.
     """
-    def __init__(self, kernel="rbf", gamma=1., n_components=100,
-                 random_state=None):
+    def __init__(self, kernel="rbf", gamma=None, coef0=1, degree=3,
+                 n_components=100, random_state=None):
         self.kernel = kernel
         self.gamma = gamma
+        self.coef0 = coef0
+        self.degree = degree
         self.n_components = n_components
         self.random_state = random_state
 
@@ -413,14 +419,17 @@ class Nystroem(BaseEstimator, TransformerMixin):
         if callable(self.kernel):
             basis_kernel = self.kernel(basis, basis)
         else:
+            params = {"gamma": self.gamma,
+                      "degree": self.degree,
+                      "coef0": self.coef0}
             basis_kernel = pairwise_kernels(basis, metric=self.kernel,
-                                            gamma=self.gamma)
+                                            filter_params=True, **params)
 
         # sqrt of kernel matrix on basis vectors
         U, S, V = svd(basis_kernel)
         self.normalization_ = np.dot(U * 1. / np.sqrt(S), V)
-        self.basis_ = basis
-        self.basis_inds_ = inds
+        self.components_ = basis
+        self.component_indices_ = inds
         return self
 
     def transform(self, X):
@@ -441,8 +450,9 @@ class Nystroem(BaseEstimator, TransformerMixin):
         """
 
         if callable(self.kernel):
-            embedded = self.kernel(X, self.basis_)
+            embedded = self.kernel(X, self.components_)
         else:
-            embedded = pairwise_kernels(X, self.basis_, metric=self.kernel,
+            embedded = pairwise_kernels(X, self.components_,
+                                        metric=self.kernel,
                                         gamma=self.gamma)
         return np.dot(embedded, self.normalization_.T)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -329,7 +329,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
         return sp.hstack(X_new)
 
 
-class NystroemKernelApproximation(BaseEstimator, TransformerMixin):
+class Nystroem(BaseEstimator, TransformerMixin):
     def __init__(self, kernel="rbf", gamma=1., n_components=100,
                  random_state=None):
         self.kernel = kernel

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -268,7 +268,7 @@ def linear_kernel(X, Y=None):
     return safe_sparse_dot(X, Y.T, dense_output=True)
 
 
-def polynomial_kernel(X, Y=None, degree=3, gamma=0, coef0=1):
+def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
     """
     Compute the polynomial kernel between X and Y::
 
@@ -287,7 +287,7 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=0, coef0=1):
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
     X, Y = check_pairwise_arrays(X, Y)
-    if gamma == 0:
+    if gamma is None:
         gamma = 1.0 / X.shape[1]
 
     K = linear_kernel(X, Y)
@@ -297,7 +297,7 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=0, coef0=1):
     return K
 
 
-def sigmoid_kernel(X, Y=None, gamma=0, coef0=1):
+def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
     """
     Compute the sigmoid kernel between X and Y::
 
@@ -316,7 +316,7 @@ def sigmoid_kernel(X, Y=None, gamma=0, coef0=1):
     Gram matrix: array of shape (n_samples_1, n_samples_2)
     """
     X, Y = check_pairwise_arrays(X, Y)
-    if gamma == 0:
+    if gamma is None:
         gamma = 1.0 / X.shape[1]
 
     K = linear_kernel(X, Y)
@@ -766,7 +766,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         return X
     elif metric in pairwise_kernel_functions:
         if filter_params:
-            kwds = dict((k, kwds[k]) for k in kwds \
+            kwds = dict((k, kwds[k]) for k in kwds
                                         if k in kernel_params[metric])
         func = pairwise_kernel_functions[metric]
         if n_jobs == 1:


### PR DESCRIPTION
Implements the Nystroem method for kernel approximation.
This method is pretty simple and basically works for all kernels.
I wanted to do this for some time now. There is a new NIPS paper that shows why this method is awesome.

Missing: Docs, tests.

Also, documentation in the example.
Here is the plot:
![nystrom method comparison](http://i.imgur.com/8TnwO.png)
