### PR TITLE
implemented predict_proba for OneVsRestClassifier

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -181,12 +181,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         if not hasattr(self, "estimators_"):
             raise ValueError("The object hasn't been fitted yet!")
 
-    def _check_has_proba(self):
-        try:
-            self.estimator.predict_proba
-        except:
-            raise ValueError("The estimator has no predict_proba method")
-
 
     def predict(self, X):
         """Predict multi-class targets using underlying estimators.
@@ -228,8 +222,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Returns the probability of the sample for each class in the model,
             where classes are ordered as they are in self.classes_.
         """
-        self._check_has_proba()
-
         return predict_proba_ovr(self.estimators_, X,
                                  is_multilabel=self.multilabel_)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -183,6 +183,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     def _check_has_proba(self):
         try:
             self.estimator.predict_proba
+        except:
+            raise ValueError("The estimator has no predict_proba method")
 
 
     def predict(self, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -95,9 +95,10 @@ def predict_proba_ovr(estimators, X, is_multilabel):
     #in the multi-label case, these are not disjoint. In the single-label case,
     #these are disjoint
 
-    if not multilabel:
+    if not is_multilabel:
         #then probabilities should be normalized to 1.
-        Y /= np.sum(Y,axis = 1)[:,np.newaxis]
+        Y /= np.sum(Y,axis = 1)[:,np.newaxis] 
+        #could use Y.T instead of np.newaxis, but I'd lose succintness and gain little clairity.
     return Y
 
 class _ConstantPredictor(BaseEstimator):
@@ -208,8 +209,14 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         """Probability estimates.
 
         The returned estimates for all classes are ordered by label of classes.
-        Note that since this is a multilabel problem, and each sample can have
-        any number of labels, probabilities will *not* sum to unity.
+
+        Note that in the multilabel case, each sample can have any number of
+        labels. This returns the marginal probability that the given sample has
+        the label in question. For example, it is entirely consistent that two
+        labels both have a 90% probability of applying to a given sample.
+
+        In the single label multiclass case, the rows of the returned matrix
+        should sum to unity.
 
         Parameters
         ----------
@@ -221,7 +228,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Returns the probability of the sample for each class in the model,
             where classes are ordered as they are in self.classes_.
         """
-        self._check_has_proba(self)
+        self._check_has_proba()
 
         return predict_proba_ovr(self.estimators_, X,
                                  is_multilabel=self.multilabel_)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -19,7 +19,7 @@ long as such a method is implemented by the base classifier. This method
 returns probabilities of class membership in both the single label and
 multilabel case.  Note that in the multilabel case, probabilities are the
 marginal probability that a given sample falls in the given class. As such, in
-the multilable case the sum of these probabilities over all possible labels
+the multilabel case the sum of these probabilities over all possible labels
 for a given sample *will not* sum to unity, as they do in the single label
 case.  """
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -92,13 +92,14 @@ def predict_ovr(estimators, label_binarizer, X):
     thresh = 0 if hasattr(e, "decision_function") and is_classifier(e) else .5
     return label_binarizer.inverse_transform(Y.T, threshold=thresh)
 
+
 def predict_proba_ovr(estimators, X, is_multilabel):
-    """Estimate probabilities using the one-vs-the-rest strategy. 
+    """Estimate probabilities using the one-vs-the-rest strategy.
 
     If multilabel is true, returned matrix will not sum to one.  Estimators
     must have a predict_proba method."""
 
-    Y = np.array([est.predict_proba(X)[:,1] for est in  estimators]).T
+    Y = np.array([est.predict_proba(X)[:, 1] for est in estimators]).T
 
     #Y[i,j] gives the probability that sample i has the label j.
     #in the multi-label case, these are not disjoint. In the single-label case,
@@ -106,9 +107,9 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
     if not is_multilabel:
         #then probabilities should be normalized to 1.
-        Y /= np.sum(Y,axis = 1)[:,np.newaxis] 
-        #could use Y.T instead of np.newaxis, but I'd lose succintness and gain little clairity.
+        Y /= np.sum(Y, axis=1)[:, np.newaxis]
     return Y
+
 
 class _ConstantPredictor(BaseEstimator):
     def fit(self, X, y):
@@ -190,7 +191,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         if not hasattr(self, "estimators_"):
             raise ValueError("The object hasn't been fitted yet!")
 
-
     def predict(self, X):
         """Predict multi-class targets using underlying estimators.
 
@@ -233,7 +233,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         """
         return predict_proba_ovr(self.estimators_, X,
                                  is_multilabel=self.multilabel_)
-
 
     @property
     def multilabel_(self):
@@ -283,7 +282,7 @@ def fit_ovo(estimator, X, y):
     classes = np.unique(y)
     n_classes = classes.shape[0]
     estimators = [_fit_ovo_binary(estimator, X, y, classes[i], classes[j])
-                    for i in range(n_classes) for j in range(i + 1, n_classes)]
+                  for i in range(n_classes) for j in range(i + 1, n_classes)]
 
     return estimators, classes
 
@@ -421,7 +420,7 @@ def fit_ecoc(estimator, X, y, code_size=1.5, random_state=None):
     cls_idx = dict((c, i) for i, c in enumerate(classes))
 
     Y = np.array([code_book[cls_idx[y[i]]] for i in xrange(X.shape[0])],
-            dtype=np.int)
+                 dtype=np.int)
 
     estimators = [_fit_binary(estimator, X, Y[:, i])
                   for i in range(Y.shape[1])]

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -12,8 +12,16 @@ estimator to be provided in their constructor. For example, it is possible to
 use these estimators to turn a binary classifier or a regressor into a
 multiclass classifier. It is also possible to use these estimators with
 multiclass estimators in the hope that their accuracy or runtime performance
-improves. It is also possible to do multilabel classification.
-"""
+improves.
+
+The one-vs-the-rest meta-classifier also implements a `predic_proba` method, so
+long as such a method is implemented by the base classifier. This method
+returns probabilities of class membership in both the single label and
+multilabel case.  Note that in the multilabel case, probabilities are the
+marginal probability that a given sample falls in the given class. As such, in
+the multilable case the sum of these probabilities over all possible labels
+for a given sample *will not* sum to unity, as they do in the single label
+case.  """
 
 # Author: Mathieu Blondel <mathieu@mblondel.org>
 #
@@ -85,9 +93,10 @@ def predict_ovr(estimators, label_binarizer, X):
     return label_binarizer.inverse_transform(Y.T, threshold=thresh)
 
 def predict_proba_ovr(estimators, X, is_multilabel):
-    """Estimate probabilities using the one-vs-the-rest strategy. If multilabel
-    is true, returned matrix will not sum to one. Estimators must have a
-    predict_proba method."""
+    """Estimate probabilities using the one-vs-the-rest strategy. 
+
+    If multilabel is true, returned matrix will not sum to one.  Estimators
+    must have a predict_proba method."""
 
     Y = np.array([est.predict_proba(X)[:,1] for est in  estimators]).T
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -97,7 +97,7 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
     if not multilabel:
         #then probabilities should be normalized to 1.
-        Y /= np.sum(Y,1)[:,np.newaxis].repeat(Y.shape[1],1 )
+        Y /= np.sum(Y,axis = 1)[:,np.newaxis]
     return Y
 
 class _ConstantPredictor(BaseEstimator):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -229,7 +229,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         -------
         T : array-like, shape = [n_samples, n_classes]
             Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in self.classes_.
+            where classes are ordered as they are in `self.classes_`.
         """
         return predict_proba_ovr(self.estimators_, X,
                                  is_multilabel=self.multilabel_)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -146,13 +146,11 @@ def test_ovr_multilabel_dataset():
 def test_ovr_multilabel_predict_proba():
     #shamelessly coppied from test_ovr_multilable_dataset.
     base_clf = MultinomialNB(alpha=1)
-    n_samples = 100
-    n_classes = 5
     for au in (False, True):
         X, Y = datasets.make_multilabel_classification(n_samples=100,
                                                 n_features=20,
                                                 n_classes=5,
-                                                n_labels=3 
+                                                n_labels=3 ,
                                                 length=50,
                                                 allow_unlabeled=au,
                                                 random_state=0)
@@ -182,7 +180,6 @@ def test_ovr_single_label_predict_proba():
     base_clf = MultinomialNB(alpha=1)
     n_samples = 100
     n_classes = 5
-    multilabel=False
     X,Y = iris.data, iris.target
     X_train, Y_train = X[:80], Y[:80]
     X_test, Y_test = X[80:], Y[80:]
@@ -198,8 +195,8 @@ def test_ovr_single_label_predict_proba():
     assert_almost_equal(Y_proba.sum(axis=1), 1.0)
     #predict assigns a label if the probability that the
     #sample has the label is greater than than 0.5.
-    pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
-    assert_equal(pred, Y_pred)
+    pred = np.array([l.argmax() for l in Y_proba])
+    assert_true(not (pred-Y_pred).any())
 
 def test_ovr_gridsearch():
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -5,6 +5,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
 
 from sklearn.utils.testing import assert_greater
@@ -143,51 +144,44 @@ def test_ovr_multilabel_dataset():
         assert_almost_equal(multilabel_recall(Y_test, Y_pred), recall,
                             decimal=2)
 
+
 def test_ovr_multilabel_predict_proba():
-    #shamelessly coppied from test_ovr_multilable_dataset.
     base_clf = MultinomialNB(alpha=1)
     for au in (False, True):
         X, Y = datasets.make_multilabel_classification(n_samples=100,
-                                                n_features=20,
-                                                n_classes=5,
-                                                n_labels=3 ,
-                                                length=50,
-                                                allow_unlabeled=au,
-                                                random_state=0)
+                                                       n_features=20,
+                                                       n_classes=5,
+                                                       n_labels=3,
+                                                       length=50,
+                                                       allow_unlabeled=au,
+                                                       random_state=0)
         X_train, Y_train = X[:80], Y[:80]
         X_test, Y_test = X[80:], Y[80:]
         clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
         #decision function only estimator. Fails in current implementation.
-        decision_only_base = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-        assert_raises(AttributeError, decision_only_base.predict_proba, X_test)
+        decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
+        assert_raises(AttributeError, decision_only.predict_proba, X_test)
 
         Y_pred = clf.predict(X_test)
         Y_proba = clf.predict_proba(X_test)
-
 
         #predict assigns a label if the probability that the
         #sample has the label is greater than than 0.5.
         pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
         assert_equal(pred, Y_pred)
 
-        #I'm also supposed to check for malformed input but it seems like
-        #that should happen in the base estimator to me 
-
 
 def test_ovr_single_label_predict_proba():
-    #shamelessly coppied from test_ovr_multilable_dataset.
     base_clf = MultinomialNB(alpha=1)
-    n_samples = 100
-    n_classes = 5
-    X,Y = iris.data, iris.target
+    X, Y = iris.data, iris.target
     X_train, Y_train = X[:80], Y[:80]
     X_test, Y_test = X[80:], Y[80:]
     clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
     #decision function only estimator. Fails in current implementation.
-    decision_only_base = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-    assert_raises(AttributeError, decision_only_base.predict_proba, X_test)
+    decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
+    assert_raises(AttributeError, decision_only.predict_proba, X_test)
 
     Y_pred = clf.predict(X_test)
     Y_proba = clf.predict_proba(X_test)
@@ -196,7 +190,8 @@ def test_ovr_single_label_predict_proba():
     #predict assigns a label if the probability that the
     #sample has the label is greater than than 0.5.
     pred = np.array([l.argmax() for l in Y_proba])
-    assert_true(not (pred-Y_pred).any())
+    assert_false((pred - Y_pred).any())
+
 
 def test_ovr_gridsearch():
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -143,44 +143,63 @@ def test_ovr_multilabel_dataset():
         assert_almost_equal(multilabel_recall(Y_test, Y_pred), recall,
                             decimal=2)
 
-def test_ovr_predict_proba():
+def test_ovr_multilabel_predict_proba():
     #shamelessly coppied from test_ovr_multilable_dataset.
     base_clf = MultinomialNB(alpha=1)
     n_samples = 100
     n_classes = 5
-    for multilabel in (False, True):
-        for au in (False, True):
-            if multilabel:
-                X, Y = datasets.make_multilabel_classification(n_samples=100,
-                                                    n_features=20,
-                                                    n_classes=5,
-                                                    n_labels=3 
-                                                    length=50,
-                                                    allow_unlabeled=au,
-                                                    random_state=0)
-            else:
-                X,Y = iris.data, iris.target
-            X_train, Y_train = X[:80], Y[:80]
-            X_test, Y_test = X[80:], Y[80:]
-            clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
+    for au in (False, True):
+        X, Y = datasets.make_multilabel_classification(n_samples=100,
+                                                n_features=20,
+                                                n_classes=5,
+                                                n_labels=3 
+                                                length=50,
+                                                allow_unlabeled=au,
+                                                random_state=0)
+        X_train, Y_train = X[:80], Y[:80]
+        X_test, Y_test = X[80:], Y[80:]
+        clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
-            #decision function only estimator. Fails in current implementation.
-            decision_only_base = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-            assert_raises(ValueError, decision_only_base.predict_proba, X_test)
+        #decision function only estimator. Fails in current implementation.
+        decision_only_base = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
+        assert_raises(AttributeError, decision_only_base.predict_proba, X_test)
 
-            Y_pred = clf.predict(X_test)
-            Y_proba = clf.predict_proba(X_test)
+        Y_pred = clf.predict(X_test)
+        Y_proba = clf.predict_proba(X_test)
 
-            if not multilabel: 
-                assert_almost_equal(Y_proba.sum(axis=1), 1.0)
 
-            #predict assigns a label if the probability that the
-            #sample has the label is greater than than 0.5.
-            pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
-            assert_equal(pred, Y_pred)
+        #predict assigns a label if the probability that the
+        #sample has the label is greater than than 0.5.
+        pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
+        assert_equal(pred, Y_pred)
 
-            #I'm also supposed to check for malformed input but it seems like
-            #that should happen in the base estimator to me 
+        #I'm also supposed to check for malformed input but it seems like
+        #that should happen in the base estimator to me 
+
+
+def test_ovr_single_label_predict_proba():
+    #shamelessly coppied from test_ovr_multilable_dataset.
+    base_clf = MultinomialNB(alpha=1)
+    n_samples = 100
+    n_classes = 5
+    multilabel=False
+    X,Y = iris.data, iris.target
+    X_train, Y_train = X[:80], Y[:80]
+    X_test, Y_test = X[80:], Y[80:]
+    clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
+
+    #decision function only estimator. Fails in current implementation.
+    decision_only_base = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
+    assert_raises(AttributeError, decision_only_base.predict_proba, X_test)
+
+    Y_pred = clf.predict(X_test)
+    Y_proba = clf.predict_proba(X_test)
+
+    assert_almost_equal(Y_proba.sum(axis=1), 1.0)
+    #predict assigns a label if the probability that the
+    #sample has the label is greater than than 0.5.
+    pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
+    assert_equal(pred, Y_pred)
 
 def test_ovr_gridsearch():
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))


### PR DESCRIPTION
This also involved writing function `predict_proba_ovr` to mimic the
methodology of existing code.

Note that in the multilabel case, the marginal probability of the sample having the given label is returned. These probabilities do not sum to unity, since the set of such probabilities over all labels do not partition the sample space.
