### PR TITLE
Faster patch extraction

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -192,26 +192,30 @@ def extract_patches(arr, patch_shape=8, extraction_step=1):
 
     Parameters
     ----------
-    arr: ndarray, n-dimensional array of which patches are to be extracted
+    arr: ndarray
+        n-dimensional array of which patches are to be extracted
 
-    patch_shape: integer or tuple, indicates the shape of the patches to be
-        extracted. If an integer is given, the shape will be a hypercube of
+    patch_shape: integer or tuple of length arr.ndim
+        Indicates the shape of the patches to be extracted. If an
+        integer is given, the shape will be a hypercube of
         sidelength given by its value.
 
-    extraction_step: integer or tuple, indicates step size at which extraction
-        shall be performed. If integer is given, then the step is uniform in
-        all dimensions.
+    extraction_step: integer or tuple of length arr.ndim
+        Indicates step size at which extraction shall be performed.
+        If integer is given, then the step is uniform in all dimensions.
 
 
     Returns
     -------
 
-    patches: strided ndarray, 2n-dimensional array indexing patches on first
-        n dimensions and containing patches on the last n dimensions. These
-        dimensions are fake, but this way no data is copied. A simple reshape
-        invokes a copying operation to obtain a list of patches:
-        result.reshape([-1] + list(patch_shape))"""
-    
+    patches: strided ndarray
+        2n-dimensional array indexing patches on first n dimensions and
+        containing patches on the last n dimensions. These dimensions
+        are fake, but this way no data is copied. A simple reshape invokes
+        a copying operation to obtain a list of patches:
+        result.reshape([-1] + list(patch_shape))
+    """
+
     arr_ndim = arr.ndim
 
     if isinstance(patch_shape, numbers.Number):
@@ -224,8 +228,8 @@ def extract_patches(arr, patch_shape=8, extraction_step=1):
     slices = [slice(None, None, st) for st in extraction_step]
     indexing_strides = arr[slices].strides
 
-    patch_indices_shape = (np.array(arr.shape) - np.array(patch_shape)) /\
-        np.array(extraction_step) + 1
+    patch_indices_shape = ((np.array(arr.shape) - np.array(patch_shape)) /
+        np.array(extraction_step)) + 1
 
     shape = tuple(list(patch_indices_shape) + list(patch_shape))
     strides = tuple(list(indexing_strides) + list(patch_strides))

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -13,6 +13,7 @@ from itertools import product
 import numbers
 import numpy as np
 from scipy import sparse
+from numpy.lib.stride_tricks import as_strided
 
 from ..utils.fixes import in1d
 from ..utils import array2d, check_random_state
@@ -180,6 +181,58 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
 ###############################################################################
 # From an image to a set of small image patches
 
+def extract_patches(arr, patch_shape=8, extraction_step=1):
+    """Extracts patches of any n-dimensional array in place using strides.
+
+    Given an n-dimensional array it will return a 2n-dimensional array with
+    the first n dimensions indexing patch position and the last n indexing
+    the patch content. This operation is immediate (O(1)). A reshape
+    performed on the first n dimensions will cause numpy to copy data, leading
+    to a list of extracted patches.
+
+    Parameters
+    ----------
+    arr: ndarray, n-dimensional array of which patches are to be extracted
+
+    patch_shape: integer or tuple, indicates the shape of the patches to be
+        extracted. If an integer is given, the shape will be a hypercube of
+        sidelength given by its value.
+
+    extraction_step: integer or tuple, indicates step size at which extraction
+        shall be performed. If integer is given, then the step is uniform in
+        all dimensions.
+
+
+    Returns
+    -------
+
+    patches: strided ndarray, 2n-dimensional array indexing patches on first
+        n dimensions and containing patches on the last n dimensions. These
+        dimensions are fake, but this way no data is copied. A simple reshape
+        invokes a copying operation to obtain a list of patches:
+        result.reshape([-1] + list(patch_shape))"""
+    
+    arr_ndim = arr.ndim
+
+    if isinstance(patch_shape, numbers.Number):
+        patch_shape = tuple([patch_shape] * arr_ndim)
+    if isinstance(extraction_step, numbers.Number):
+        extraction_step = tuple([extraction_step] * arr_ndim)
+
+    patch_strides = arr.strides
+
+    slices = [slice(None, None, st) for st in extraction_step]
+    indexing_strides = arr[slices].strides
+
+    patch_indices_shape = (np.array(arr.shape) - np.array(patch_shape)) /\
+        np.array(extraction_step) + 1
+
+    shape = tuple(list(patch_indices_shape) + list(patch_shape))
+    strides = tuple(list(indexing_strides) + list(patch_strides))
+
+    patches = as_strided(arr, shape=shape, strides=strides)
+    return patches
+
 
 def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     """Reshape a 2D image into a collection of patches
@@ -270,6 +323,9 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
         patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
         for p, (i, j) in zip(patches, product(xrange(n_h), xrange(n_w))):
             p[:] = image[i:i + p_h, j:j + p_w, :]
+        # patches = extract_patches(image, patch_shape=(p_h, p_w, n_colors),
+        #                           extraction_step=1)
+        # patches = patches.reshape(-1, p_h, p_w, n_colors)
 
     # remove the color dimension if useless
     if patches.shape[-1] == 1:

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -302,6 +302,9 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     n_w = i_w - p_w + 1
     all_patches = n_h * n_w
 
+    extracted_patches = extract_patches(image,
+                        patch_shape=(p_h, p_w, n_colors),
+                        extraction_step=1)
     if max_patches:
         if (isinstance(max_patches, (numbers.Integral))
                 and max_patches < all_patches):
@@ -317,15 +320,14 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
         i_s = rng.randint(n_h, size=n_patches)
         j_s = rng.randint(n_w, size=n_patches)
         for p, i, j in zip(patches, i_s, j_s):
-            p[:] = image[i:i + p_h, j:j + p_w, :]
+            p[:] = extracted_patches[i, j, 0]
+            # p[:] = image[i:i + p_h, j:j + p_w, :]
     else:
         n_patches = all_patches
-        patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
-        for p, (i, j) in zip(patches, product(xrange(n_h), xrange(n_w))):
-            p[:] = image[i:i + p_h, j:j + p_w, :]
-        # patches = extract_patches(image, patch_shape=(p_h, p_w, n_colors),
-        #                           extraction_step=1)
-        # patches = patches.reshape(-1, p_h, p_w, n_colors)
+        # patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
+        # for p, (i, j) in zip(patches, product(xrange(n_h), xrange(n_w))):
+        #     p[:] = image[i:i + p_h, j:j + p_w, :]
+        patches = extracted_patches.reshape(-1, p_h, p_w, n_colors)
 
     # remove the color dimension if useless
     if patches.shape[-1] == 1:

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -316,19 +316,21 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
             raise ValueError("Invalid value for max_patches: %r" % max_patches)
 
         rng = check_random_state(random_state)
-        patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
+        # patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
         i_s = rng.randint(n_h, size=n_patches)
         j_s = rng.randint(n_w, size=n_patches)
-        for p, i, j in zip(patches, i_s, j_s):
-            p[:] = extracted_patches[i, j, 0]
-            # p[:] = image[i:i + p_h, j:j + p_w, :]
+        # for p, i, j in zip(patches, i_s, j_s):
+        #     p[:] = extracted_patches[i, j, 0]
+        #     # p[:] = image[i:i + p_h, j:j + p_w, :]
+        patches = extracted_patches[i_s, j_s, 0]
     else:
         n_patches = all_patches
         # patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
         # for p, (i, j) in zip(patches, product(xrange(n_h), xrange(n_w))):
         #     p[:] = image[i:i + p_h, j:j + p_w, :]
-        patches = extracted_patches.reshape(-1, p_h, p_w, n_colors)
+        patches = extracted_patches
 
+    patches = patches.reshape(-1, p_h, p_w, n_colors)
     # remove the color dimension if useless
     if patches.shape[-1] == 1:
         return patches.reshape((n_patches, p_h, p_w))

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -316,18 +316,11 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
             raise ValueError("Invalid value for max_patches: %r" % max_patches)
 
         rng = check_random_state(random_state)
-        # patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
         i_s = rng.randint(n_h, size=n_patches)
         j_s = rng.randint(n_w, size=n_patches)
-        # for p, i, j in zip(patches, i_s, j_s):
-        #     p[:] = extracted_patches[i, j, 0]
-        #     # p[:] = image[i:i + p_h, j:j + p_w, :]
         patches = extracted_patches[i_s, j_s, 0]
     else:
         n_patches = all_patches
-        # patches = np.empty((n_patches, p_h, p_w, n_colors), dtype=image.dtype)
-        # for p, (i, j) in zip(patches, product(xrange(n_h), xrange(n_w))):
-        #     p[:] = image[i:i + p_h, j:j + p_w, :]
         patches = extracted_patches
 
     patches = patches.reshape(-1, p_h, p_w, n_colors)

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_raises
 
 from ..image import img_to_graph, grid_to_graph
 from ..image import extract_patches_2d, reconstruct_from_patches_2d, \
-                    PatchExtractor
+                    PatchExtractor, extract_patches
 from ...utils.graph import cs_graph_components
 
 
@@ -213,6 +213,53 @@ def test_patch_extractor_color():
     extr = PatchExtractor(patch_size=(p_h, p_w), random_state=0)
     patches = extr.transform(lenas)
     assert_true(patches.shape == (expected_n_patches, p_h, p_w, 3))
+
+
+def test_extract_patches_strided():
+
+    image_shapes_1D = [(10,), (10,), (11,), (10,)]
+    patch_sizes_1D = [(1,), (2,), (3,), (8,)]
+    patch_steps_1D = [(1,), (1,), (4,), (2,)]
+
+    expected_views_1D = [(10,), (9,), (3,), (2,)]
+    last_patch_1D = [(10,), (8,), (8,), (2,)]
+
+    image_shapes_2D = [(10, 20), (10, 20), (10, 20), (11, 20)]
+    patch_sizes_2D = [(2, 2), (10, 10), (10, 11), (6, 6)]
+    patch_steps_2D = [(5, 5), (3, 10), (3, 4), (4, 2)]
+
+    expected_views_2D = [(2, 4), (1, 2), (1, 3), (2, 8)]
+    last_patch_2D = [(5, 15), (0, 10), (0, 8), (4, 14)]
+
+    image_shapes_3D = [(5, 4, 3), (3, 3, 3), (7, 8, 9), (7, 8, 9)]
+    patch_sizes_3D = [(2, 2, 3), (2, 2, 2), (1, 7, 3), (1, 3, 3)]
+    patch_steps_3D = [(1, 2, 10), (1, 1, 1), (2, 1, 3), (3, 3, 4)]
+
+    expected_views_3D = [(4, 2, 1), (2, 2, 2), (4, 2, 3), (3, 2, 2)]
+    last_patch_3D = [(3, 2, 0), (1, 1, 1), (6, 1, 6), (6, 3, 4)]
+
+    image_shapes = image_shapes_1D + image_shapes_2D + image_shapes_3D
+    patch_sizes = patch_sizes_1D + patch_sizes_2D + patch_sizes_3D
+    patch_steps = patch_steps_1D + patch_steps_2D + patch_steps_3D
+    expected_views = expected_views_1D + expected_views_2D + expected_views_3D
+    last_patches = last_patch_1D + last_patch_2D + last_patch_3D
+
+    for (image_shape, patch_size, patch_step,
+         expected_view, last_patch) in zip(
+             image_shapes, patch_sizes, patch_steps,
+               expected_views, last_patches):
+        image = np.arange(np.prod(image_shape)).reshape(image_shape)
+        patches = extract_patches(image, patch_shape=patch_size,
+                                  extraction_step=patch_step)
+
+        ndim = len(image_shape)
+
+        assert patches.shape[:ndim] == expected_view
+        last_patch_slices = [slice(i, i + j, None) for i, j in
+                             zip(last_patch, patch_size)]
+        assert (patches[[slice(-1, None, None)] * ndim] ==
+                image[last_patch_slices].squeeze()).all()
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This is a very small contribution to the patch extraction method implemented in sklearn.feature_extraction.image:

Using stride tricks, a numpy array of dimension n is augmented to a "patch indexer" array of dimension 2n, where the first n indices indicate the location of the patch and the last n dimensions index the patch itself.

Up until there nothing changes in memory (except for shape and strides).

If one then calls a reshape on this array, ravelling the first n dimensions into 1 dimension, numpy proceeds to copy the data, effectively extracting patches and placing them in a list. Since this happens inside numpy, it is a lot faster than extraction using a for loop.

A benchmark on the patch extraction for the MiniBatchDictionaryLearning example shows a speed up of factor 16-17:

100x extract_patches_2d (old) ~ 20 seconds
100x extract_patches_2d (new) ~ 1.3 seconds

My only concern/question is: Will numpy always handle reshaping of strided arrays by copying? If not, this whole thing may be slightly unstable.

Otherwise, the extractor extends to any dimension, permits easy views on arrays and seems to me to have a rather general use, actually.

Thanks in advance for your time!
