### PR TITLE
Add fit_transform to FeatureUnion

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -210,6 +210,15 @@ def _transform_one(transformer, name, X, transformer_weights):
     return transformer.transform(X)
 
 
+def _fit_transform_one(transformer, name, X, y, transformer_weights,
+                       **fit_params):
+    if transformer_weights is not None and name in transformer_weights:
+        # if we have a weight for this transformer, muliply output
+        return transformer.fit_transform(X, y, **fit_params) \
+                * transformer_weights[name]
+    return transformer.fit_transform(X, y, **fit_params)
+
+
 class FeatureUnion(BaseEstimator, TransformerMixin):
     """Concatenates results of multiple transformer objects.
 
@@ -263,6 +272,31 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
         Parallel(n_jobs=self.n_jobs)(delayed(_fit_one_transformer)(trans, X, y)
                 for name, trans in self.transformer_list)
         return self
+
+    def fit_transform(self, X, y=None, **fit_params):
+        """Fit all tranformers using X, transform the data and concatenate
+        results. Valid only if all transformers implement fit_transform.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            Input data to be transformed.
+
+        Returns
+        -------
+        X_t : array-like or sparse matrix, shape (n_samples, sum_n_components)
+            hstack of results of transformers. sum_n_components is the
+            sum of n_components (output dimension) over transformers.
+        """
+        Xs = Parallel(n_jobs=self.n_jobs)(
+            delayed(_fit_transform_one)(trans, name, X, y,
+                                        self.transformer_weights, **fit_params)
+            for name, trans in self.transformer_list)
+        if any(sparse.issparse(f) for f in Xs):
+            Xs = sparse.hstack(Xs).tocsr()
+        else:
+            Xs = np.hstack(Xs)
+        return Xs
 
     def transform(self, X):
         """Transform X separately by each transformer, concatenate results.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -214,8 +214,8 @@ def _fit_transform_one(transformer, name, X, y, transformer_weights,
                        **fit_params):
     if transformer_weights is not None and name in transformer_weights:
         # if we have a weight for this transformer, muliply output
-        return transformer.fit_transform(X, y, **fit_params) \
-                * transformer_weights[name]
+        return (transformer.fit_transform(X, y, **fit_params)
+                * transformer_weights[name])
     return transformer.fit_transform(X, y, **fit_params)
 
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -214,9 +214,16 @@ def _fit_transform_one(transformer, name, X, y, transformer_weights,
                        **fit_params):
     if transformer_weights is not None and name in transformer_weights:
         # if we have a weight for this transformer, muliply output
-        return (transformer.fit_transform(X, y, **fit_params)
-                * transformer_weights[name])
-    return transformer.fit_transform(X, y, **fit_params)
+        if hasattr(transformer, 'fit_transform'):
+            return (transformer.fit_transform(X, y, **fit_params)
+                    * transformer_weights[name])
+        else:
+            return (transformer.fit(X, y, **fit_params).transform(X)
+                    * transformer_weights[name])
+    if hasattr(transformer, 'fit_transform'):
+        return transformer.fit_transform(X, y, **fit_params)
+    else:
+        return transformer.fit(X, y, **fit_params).transform(X)
 
 
 class FeatureUnion(BaseEstimator, TransformerMixin):
@@ -275,7 +282,7 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
 
     def fit_transform(self, X, y=None, **fit_params):
         """Fit all tranformers using X, transform the data and concatenate
-        results. Valid only if all transformers implement fit_transform.
+        results.
 
         Parameters
         ----------

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -212,6 +212,11 @@ def test_feature_union():
     fs.set_params(select__k=2)
     assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))
 
+    # test it works with transformers missing fit_transform
+    fs = FeatureUnion([("mock", TransfT()), ("pca", pca), ("select", select)])
+    X_transformed = fs.fit_transform(X, y)
+    assert_equal(X_transformed.shape, (X.shape[0], 8))
+
 
 def test_pipeline_transform():
     # Test whether pipeline works with a transformer at the end.
@@ -249,6 +254,10 @@ def test_feature_union_weights():
     fs = FeatureUnion([("pca", pca), ("select", select)],
             transformer_weights={"pca": 10})
     X_fit_transformed = fs.fit_transform(X, y)
+    # test it works with transformers missing fit_transform
+    fs = FeatureUnion([("mock", TransfT()), ("pca", pca), ("select", select)],
+            transformer_weights={"mock": 10})
+    X_fit_transformed_wo_method = fs.fit_transform(X, y)
     # check against expected result
 
     # We use a different pca object to control the random_state stream
@@ -260,6 +269,7 @@ def test_feature_union_weights():
                     10 * pca.fit_transform(X))
     assert_array_equal(X_fit_transformed[:, -1],
             select.fit_transform(X, y).ravel())
+    assert_equal(X_fit_transformed_wo_method.shape, (X.shape[0], 7))
 
 
 def test_feature_union_feature_names():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -240,16 +240,25 @@ def test_feature_union_weights():
     y = iris.target
     pca = RandomizedPCA(n_components=2, random_state=0)
     select = SelectKBest(k=1)
+    # test using fit followed by transform
     fs = FeatureUnion([("pca", pca), ("select", select)],
             transformer_weights={"pca": 10})
     fs.fit(X, y)
     X_transformed = fs.transform(X)
+    # test using fit_transform
+    fs = FeatureUnion([("pca", pca), ("select", select)],
+            transformer_weights={"pca": 10})
+    X_fit_transformed = fs.fit_transform(X, y)
     # check against expected result
 
     # We use a different pca object to control the random_state stream
     assert_array_almost_equal(X_transformed[:, :-1],
                     10 * pca.fit_transform(X))
     assert_array_equal(X_transformed[:, -1],
+            select.fit_transform(X, y).ravel())
+    assert_array_almost_equal(X_fit_transformed[:, :-1],
+                    10 * pca.fit_transform(X))
+    assert_array_equal(X_fit_transformed[:, -1],
             select.fit_transform(X, y).ravel())
 
 


### PR DESCRIPTION
Implements #1426.

The current implementation requires that all transformers implement `fit_transform`. I believe all transformers in the scikit implement it, either directly or through the `TransformerMixin`. Is it ok to require its presence or should we check for its existence and call `fit` followed by `transform` if it's not present?

`FeatureUnion.transform` and `FeatureUnion.fit_transform`, and also `_transform_one` and `_fit_transform_one` share similar logic, which led to some code duplication.

Let me know if you prefer to factor out common parts at the expense of extra function calls.

I believe this addition is already covered by the test `test_pipeline#test_feature_union`. If you think additional test cases are needed, tell me which.
