### PR TITLE
Fix pipeline fails if final estimator doesn't implement fit_transform

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -129,10 +129,12 @@ class Pipeline(BaseEstimator):
     def fit_transform(self, X, y=None, **fit_params):
         """Fit all the transforms one after the other and transform the
         data, then use fit_transform on transformed data using the final
-        estimator. Valid only if the final estimator implements
-        fit_transform."""
+        estimator."""
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
-        return self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
+        if hasattr(self.steps[-1][-1], 'fit_transform'):
+            return self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
+        else:
+            return self.steps[-1][-1].fit(Xt, y, **fit_params).transform(Xt)
 
     def predict(self, X):
         """Applies transforms to the data, and the predict method of the

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -238,6 +238,20 @@ def test_pipeline_transform():
     assert_array_almost_equal(X_back, X_back2)
 
 
+def test_pipeline_fit_transform():
+    # Test whether pipeline works with a transformer missing fit_transform
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    transft = TransfT()
+    pipeline = Pipeline([('mock', transft)])
+
+    # test fit_transform:
+    X_trans = pipeline.fit_transform(X, y)
+    X_trans2 = transft.fit(X, y).transform(X)
+    assert_array_almost_equal(X_trans, X_trans2)
+
+
 def test_feature_union_weights():
     # test feature union with transformer weights
     iris = load_iris()


### PR DESCRIPTION
Added test case and fallback to using `fit` followed by `transform` if final estimator does not implement `fit_transform`.
