### PR TITLE
Fix for roc_curve when one class is present

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,9 @@ Changelog
      :func:`manifold.spectral_embedding`, implementing the
      "laplacian eigenmaps" for nonlinear dimensionality reduction by Wei Li.
 
+   - Fix :func:`metrics.roc_curve` fails when y_true has only one class 
+     by Wei Li.
+
 API changes summary
 -------------------
    - Renamed all occurences of ``n_atoms`` to ``n_components`` for consistency.

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -90,23 +90,23 @@ def roc_curve(y_true, y_score, pos_label=None):
     ----------
 
     y_true : array, shape = [n_samples]
-        true binary labels in range {0,1} or {-1,1}
-        if not binary label, pos_label should be explictly given
+        true binary labels in range {0, 1} or {-1, 1}.
+        If not binary label, pos_label should be explictly given.
 
     y_score : array, shape = [n_samples]
         target scores, can either be probability estimates of
         the positive class, confidence values, or binary decisions.
 
-    pos_label : integer
-        label considered as postive and others are negative
+    pos_label : int
+        label considered as postive and others are considered negative.
 
     Returns
     -------
     fpr : array, shape = [>2]
-        False Positive Rates
+        False Positive Rates.
 
     tpr : array, shape = [>2]
-        True Positive Rates
+        True Positive Rates.
 
     thresholds : array, shape = [>2]
         Thresholds on y_score used to compute fpr and tpr.
@@ -146,7 +146,7 @@ def roc_curve(y_true, y_score, pos_label=None):
         raise ValueError("ROC is defined for binary classification only or "
                          "pos_label should be explicitly given")
     elif pos_label is None:
-        pos_label = 1
+        pos_label = 1.
 
     # y_true will be transformed into a boolean vector
     y_true = (y_true == pos_label)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -91,7 +91,7 @@ def roc_curve(y_true, y_score, pos_label=None):
 
     y_true : array, shape = [n_samples]
         true binary labels in range {0, 1} or {-1, 1}.
-        If not binary label, pos_label should be explictly given.
+        If labels are not binary, pos_label should be explictly given.
 
     y_score : array, shape = [n_samples]
         target scores, can either be probability estimates of

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -98,7 +98,7 @@ def roc_curve(y_true, y_score, pos_label=None):
         the positive class, confidence values, or binary decisions.
 
     pos_label : int
-        label considered as postive and others are considered negative.
+        label considered as positive and others are considered negative.
 
     Returns
     -------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -81,7 +81,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
     return CM
 
 
-def roc_curve(y_true, y_score, pos_label = None):
+def roc_curve(y_true, y_score, pos_label=None):
     """compute Receiver operating characteristic (ROC)
 
     Note: this implementation is restricted to the binary classification task.
@@ -90,7 +90,8 @@ def roc_curve(y_true, y_score, pos_label = None):
     ----------
 
     y_true : array, shape = [n_samples]
-        true binary labels
+        true binary labels in range {0,1} or {-1,1}
+        if not binary label, pos_label should be explictly given
 
     y_score : array, shape = [n_samples]
         target scores, can either be probability estimates of
@@ -122,7 +123,7 @@ def roc_curve(y_true, y_score, pos_label = None):
     >>> from sklearn import metrics
     >>> y = np.array([1, 1, 2, 2])
     >>> scores = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores)
+    >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
 
@@ -133,14 +134,15 @@ def roc_curve(y_true, y_score, pos_label = None):
     """
     y_true = np.ravel(y_true)
     y_score = np.ravel(y_score)
-
     classes = np.unique(y_true)
 
     # ROC only for binary classification if pos_label not given
     if (pos_label is None and
-        not (np.all(classes==[0,1]) or
-             np.all(classes==[0]) or
-             np.all(classes==[1]))):
+        not (np.all(classes == [0, 1]) or
+             np.all(classes == [-1, 1]) or
+             np.all(classes == [0]) or
+             np.all(classes == [-1]) or
+             np.all(classes == [1]))):
         raise ValueError("ROC is defined for binary classification only or "
                          "pos_label should be explicitly given")
     elif pos_label is None:
@@ -150,7 +152,7 @@ def roc_curve(y_true, y_score, pos_label = None):
     y_true = (y_true == pos_label)
     n_pos = float(y_true.sum())
     n_neg = y_true.shape[0] - n_pos
-    
+
     if n_pos == 0:
         warnings.warn("No positive samples in y_true, "
                       "true positve value should be meaningless")
@@ -305,7 +307,7 @@ def auc(x, y, reorder=False):
     >>> from sklearn import metrics
     >>> y = np.array([1, 1, 2, 2])
     >>> pred = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> fpr, tpr, thresholds = metrics.roc_curve(y, pred)
+    >>> fpr, tpr, thresholds = metrics.roc_curve(y, pred, pos_label=2)
     >>> metrics.auc(fpr, tpr)
     0.75
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -13,6 +13,7 @@ better
 # License: BSD Style.
 
 from itertools import izip
+import warnings
 import numpy as np
 from scipy.sparse import coo_matrix
 
@@ -80,7 +81,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
     return CM
 
 
-def roc_curve(y_true, y_score):
+def roc_curve(y_true, y_score, pos_label = None):
     """compute Receiver operating characteristic (ROC)
 
     Note: this implementation is restricted to the binary classification task.
@@ -94,6 +95,9 @@ def roc_curve(y_true, y_score):
     y_score : array, shape = [n_samples]
         target scores, can either be probability estimates of
         the positive class, confidence values, or binary decisions.
+
+    pos_label : integer
+        label considered as postive and others are negative
 
     Returns
     -------
@@ -128,19 +132,36 @@ def roc_curve(y_true, y_score):
 
     """
     y_true = np.ravel(y_true)
-    classes = np.unique(y_true)
-
-    # ROC only for binary classification
-    if classes.shape[0] != 2:
-        raise ValueError("ROC is defined for binary classification only")
-
     y_score = np.ravel(y_score)
 
-    n_pos = float(np.sum(y_true == classes[1]))  # nb of true positive
-    n_neg = float(np.sum(y_true == classes[0]))  # nb of true negative
+    classes = np.unique(y_true)
+
+    # ROC only for binary classification if pos_label not given
+    if (pos_label is None and
+        not (np.all(classes==[0,1]) or
+             np.all(classes==[0]) or
+             np.all(classes==[1]))):
+        raise ValueError("ROC is defined for binary classification only or "
+                         "pos_label should be explicitly given")
+    elif pos_label is None:
+        pos_label = 1
+
+    # y_true will be transformed into a boolean vector
+    y_true = (y_true == pos_label)
+    n_pos = float(y_true.sum())
+    n_neg = y_true.shape[0] - n_pos
+    
+    if n_pos == 0:
+        warnings.warn("No positive samples in y_true, "
+                      "true positve value should be meaningless")
+        n_pos = np.nan
+    if n_neg == 0:
+        warnings.warn("No negative samples in y_true, "
+                      "false positve value should be meaningless")
+        n_neg = np.nan
 
     thresholds = np.unique(y_score)
-    neg_value, pos_value = classes[0], classes[1]
+    neg_value, pos_value = False, True
 
     tpr = np.empty(thresholds.size, dtype=np.float)  # True positive rate
     fpr = np.empty(thresholds.size, dtype=np.float)  # False positive rate
@@ -178,6 +199,12 @@ def roc_curve(y_true, y_score):
     elif fpr.shape[0] == 1:
         fpr = np.array([0.0, fpr[0], 1.0])
         tpr = np.array([0.0, tpr[0], 1.0])
+
+    if n_pos is np.nan:
+        tpr[0] = np.nan
+
+    if n_neg is np.nan:
+        fpr[0] = np.nan
 
     return fpr, tpr, thresholds[::-1]
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -538,7 +538,7 @@ def test_roc_curve_one_label():
     with warnings.catch_warnings(True) as w:
         fpr, tpr, thresholds = roc_curve(y_true, y_pred)
         assert_equal(len(w), 1)
-    # all true labels, all fpr except at zero should be nan
+    # all true labels, all fpr should be nan
     assert_array_equal(fpr,
                        np.nan * np.ones(len(thresholds) + 1))
     # assert there are warnings
@@ -546,6 +546,6 @@ def test_roc_curve_one_label():
         fpr, tpr, thresholds = roc_curve([1 - x for x in y_true],
                                          y_pred)
         assert_equal(len(w), 1)
-    # all true labels, all fpr except at zero should be nan
+    # all negative labels, all tpr should be nan
     assert_array_equal(tpr,
                        np.nan * np.ones(len(thresholds) + 1))

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -219,7 +219,7 @@ def test_average_precision_score_tied_values():
     # could be swapped around, creating an imperfect sorting. This
     # imperfection should come through in the end score, making it less
     # than one.
-    y_true = [0,  1,  1]
+    y_true = [0, 1, 1]
     y_score = [.5, .5, .6]
     assert_not_equal(average_precision_score(y_true, y_score), 1.)
 
@@ -357,15 +357,15 @@ def test_confusion_matrix_multiclass():
 
     # compute confusion matrix with default labels introspection
     cm = confusion_matrix(y_true, y_pred)
-    assert_array_equal(cm, [[23, 2,  0],
-                            [5,  5, 20],
-                            [0,  2, 18]])
+    assert_array_equal(cm, [[23, 2, 0],
+                            [5, 5, 20],
+                            [0, 2, 18]])
 
     # compute confusion matrix with explicit label ordering
     cm = confusion_matrix(y_true, y_pred, labels=[0, 2, 1])
-    assert_array_equal(cm, [[23, 0,  2],
-                            [0, 18,  2],
-                            [5, 20,  5]])
+    assert_array_equal(cm, [[23, 0, 2],
+                            [0, 18, 2],
+                            [5, 20, 5]])
 
 
 def test_confusion_matrix_multiclass_subset_labels():
@@ -375,13 +375,13 @@ def test_confusion_matrix_multiclass_subset_labels():
     # compute confusion matrix with only first two labels considered
     cm = confusion_matrix(y_true, y_pred, labels=[0, 1])
     assert_array_equal(cm, [[23, 2],
-                            [5,  5]])
+                            [5, 5]])
 
     # compute confusion matrix with explicit label ordering for only subset
     # of labels
     cm = confusion_matrix(y_true, y_pred, labels=[2, 1])
-    assert_array_equal(cm, [[18,  2],
-                            [20,  5]])
+    assert_array_equal(cm, [[18, 2],
+                            [20, 5]])
 
 
 def test_classification_report():
@@ -537,15 +537,15 @@ def test_roc_curve_one_label():
     # assert there are warnings
     with warnings.catch_warnings(True) as w:
         fpr, tpr, thresholds = roc_curve(y_true, y_pred)
-        assert_equal(len(w),1)
+        assert_equal(len(w), 1)
     # all true labels, all fpr except at zero should be nan
     assert_array_equal(fpr,
-                       np.nan * np.ones(len(thresholds)+1))
+                       np.nan * np.ones(len(thresholds) + 1))
     # assert there are warnings
     with warnings.catch_warnings(True) as w:
-        fpr, tpr, thresholds = roc_curve([1-x for x in y_true],
+        fpr, tpr, thresholds = roc_curve([1 - x for x in y_true],
                                          y_pred)
-        assert_equal(len(w),1)
+        assert_equal(len(w), 1)
     # all true labels, all fpr except at zero should be nan
     assert_array_equal(tpr,
-                       np.nan * np.ones(len(thresholds)+1))
+                       np.nan * np.ones(len(thresholds) + 1))

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -529,3 +529,23 @@ def test_hinge_loss_binary():
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])
     assert_equal(1.2 / 4,
                  hinge_loss(y_true, pred_decision, pos_label=2, neg_label=0))
+
+
+def test_roc_curve_one_label():
+    y_true = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    y_pred = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    # assert there are warnings
+    with warnings.catch_warnings(True) as w:
+        fpr, tpr, thresholds = roc_curve(y_true, y_pred)
+        assert_equal(len(w),1)
+    # all true labels, all fpr except at zero should be nan
+    assert_array_equal(fpr,
+                       np.nan * np.ones(len(thresholds)+1))
+    # assert there are warnings
+    with warnings.catch_warnings(True) as w:
+        fpr, tpr, thresholds = roc_curve([1-x for x in y_true],
+                                         y_pred)
+        assert_equal(len(w),1)
+    # all true labels, all fpr except at zero should be nan
+    assert_array_equal(tpr,
+                       np.nan * np.ones(len(thresholds)+1))


### PR DESCRIPTION
Minor fix for issue #1257 when only one class is in `y_true`:

When one classes detected, a warning is issued
1. no postive classes, true positive rate (`TPR=TP/(TP+FN)`) is meaningless
2. no negative classes, false positive rate (`FPR=FP/(FP+TN)`) is meaningless
