### PR TITLE
MRG add matplotlib version requirement, rephrase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,11 @@ Dependencies
 
 The required dependencies to build the software are Python >= 2.6,
 setuptools, Numpy >= 1.3, SciPy >= 0.7 and a working C/C++ compiler.
-This configuration matches the Ubuntu 10.04 LTS release from April 2010.
 
-To run the tests you will also need nose >= 0.10.
+For running the examples Matplotlib >= 0.99.1 is required and for running the
+tests you need nose >= 0.10.
+
+This configuration matches the Ubuntu 10.04 LTS release from April 2010.
 
 
 Install


### PR DESCRIPTION
As per discussion in #1439.

The nose version we require is actually even [lower](http://packages.ubuntu.com/search?keywords=nose&searchon=names&suite=lucid&section=all) than Lucid, but I think the phrasing basically says "above lucid is fine" and I wanted to keep it simple.
