### PR TITLE
MRG: Simplify the shape of (n_)classes_ for single output trees/forests

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -104,7 +104,7 @@ the class labels for the training samples::
 After being fitted, the model can then be used to predict new values::
 
     >>> clf.predict([[2., 2.]])
-    array([ 1.])
+    array([1])
 
 :class:`DecisionTreeClassifier` is capable of both binary (where the
 labels are [-1, 1]) classification and multiclass (where the labels are
@@ -151,7 +151,7 @@ a PDF file (or any other supported file type) directly in Python::
 After being fitted, the model can then be used to predict new values::
 
     >>> clf.predict(iris.data[0, :])
-    array([ 0.])
+    array([0])
 
 .. figure:: ../auto_examples/tree/images/plot_iris_1.png
    :target: ../auto_examples/tree/plot_iris.html
@@ -255,7 +255,7 @@ the lower half of those faces.
 
 .. topic:: References:
 
- * M. Dumont et al,  `Fast multi-class image annotation with random subwindows 
+ * M. Dumont et al,  `Fast multi-class image annotation with random subwindows
    and multiple output randomized trees
    <http://www.montefiore.ulg.ac.be/services/stochastic/pubs/2009/DMWG09/dumont-visapp09-shortpaper.pdf>`_, International Conference on
    Computer Vision Theory and Applications 2009

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -156,9 +156,9 @@ API changes summary
      :class:`cluster.SpectralClustering` to ``eigen_solver``.
 
     - ``classes_`` and ``n_classes_`` attributes of
-      `tree.DecisionTreeClassifier` and all derived ensemble models are now
-      flat in case single output problems and nested in cases of multi-output
-      problems.
+      :class:`tree.DecisionTreeClassifier` and all derived ensemble models are
+      now flat in case single output problems and nested in cases of
+      multi-output problems.
 
 .. _changes_0_12.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -155,6 +155,11 @@ API changes summary
    - Renamed ``mode`` in :func:`manifold.spectral_embedding` and
      :class:`cluster.SpectralClustering` to ``eigen_solver``.
 
+    - ``classes_`` and ``n_classes_`` attributes of
+      `tree.DecisionTreeClassifier` and all derived ensemble models are now
+      flat in case single output problems and nested in cases of multi-output
+      problems.
+
 .. _changes_0_12.1:
 
 0.12.1

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -377,9 +377,13 @@ class BaseForest(BaseEnsemble, SelectorMixin):
                              "This probably means too few trees were used "
                              "to compute any reliable oob estimates.")
 
-                    decision = predictions[k] / predictions[k].sum(axis=1)[:, np.newaxis]
+                    decision = (predictions[k] /
+                                predictions[k].sum(axis=1)[:, np.newaxis])
                     self.oob_decision_function_.append(decision)
-                    self.oob_score_ += np.mean(y[:, k] == classes_[k].take(np.argmax(predictions[k], axis=1), axis=0))
+                    self.oob_score_ += (np.mean(y[:, k] ==
+                                        classes_[k].take(
+                                            np.argmax(predictions[k], axis=1),
+                                            axis=0)))
 
                 if self.n_outputs_ == 1:
                     self.oob_decision_function_ = \
@@ -484,7 +488,9 @@ class ForestClassifier(BaseForest, ClassifierMixin):
             predictions = np.zeros((n_samples, self.n_outputs_))
 
             for k in xrange(self.n_outputs_):
-                predictions[:, k] = self.classes_[k].take(np.argmax(probas[k], axis=1), axis=0)
+                predictions[:, k] = self.classes_[k].take(np.argmax(probas[k],
+                                                                    axis=1),
+                                                          axis=0)
 
             return predictions
 
@@ -540,7 +546,6 @@ class ForestClassifier(BaseForest, ClassifierMixin):
                 p[k] /= self.n_estimators
 
         return p
-
 
     def predict_log_proba(self, X):
         """Predict class log-probabilities for X.

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -375,6 +375,26 @@ def test_multioutput():
     np.seterr(**olderr)
 
 
+def test_classes_shape():
+    """Test that n_classes_ and classes_ have proper shape."""
+    # Classification, single output
+    clf = RandomForestClassifier()
+    clf.fit(X, y)
+
+    assert_equal(clf.n_classes_, 2)
+    assert_equal(clf.classes_, [-1, 1])
+
+    # Classification, multi-output
+    _y = np.vstack((y, np.array(y) * 2)).T
+    clf = RandomForestClassifier()
+    clf.fit(X, _y)
+
+    assert_equal(len(clf.n_classes_), 2)
+    assert_equal(len(clf.classes_), 2)
+    assert_equal(clf.n_classes_, [2, 2])
+    assert_equal(clf.classes_, [[-1, 1], [-2, 2]])
+
+
 def test_random_hasher():
     # test random forest hashing on circles dataset
     # make sure that it is linearly separable.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -494,16 +494,9 @@ def test_classifiers_train():
                     pass
 
             if hasattr(clf, "classes_"):
-                if hasattr(clf, "n_outputs_"):
-                    assert_equal(clf.n_outputs_, 1)
-                    assert_array_equal(
-                        clf.classes_, [classes],
-                        "Unexpected classes_ attribute for %r" % clf)
-                else:
-                    # flat classes array: XXX inconsistent
-                    assert_array_equal(
-                        clf.classes_, classes,
-                        "Unexpected classes_ attribute for %r" % clf)
+                assert_array_equal(
+                    clf.classes_, classes,
+                    "Unexpected classes_ attribute for %r" % clf)
 
 
 def test_classifiers_classes():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -477,6 +477,26 @@ def test_X_argsorted():
     assert_array_equal(clf.predict(T), true_result)
 
 
+def test_classes_shape():
+    """Test that n_classes_ and classes_ have proper shape."""
+    # Classification, single output
+    clf = tree.DecisionTreeClassifier()
+    clf.fit(X, y)
+
+    assert_equal(clf.n_classes_, 2)
+    assert_equal(clf.classes_, [-1, 1])
+
+    # Classification, multi-output
+    _y = np.vstack((y, np.array(y) * 2)).T
+    clf = tree.DecisionTreeClassifier()
+    clf.fit(X, _y)
+
+    assert_equal(len(clf.n_classes_), 2)
+    assert_equal(len(clf.classes_), 2)
+    assert_equal(clf.n_classes_, [2, 2])
+    assert_equal(clf.classes_, [[-1, 1], [-2, 2]])
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -363,8 +363,9 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
         # Classification
         if isinstance(self, ClassifierMixin):
             if self.n_outputs_ == 1:
-                return self.classes_.take(np.argmax(proba[:, 0], axis=1),
-                                          axis=0)
+                return np.array(self.classes_.take(
+                            np.argmax(proba[:, 0], axis=1),
+                            axis=0))
 
             else:
                 predictions = np.zeros((n_samples, self.n_outputs_))

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -297,8 +297,8 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
 
             if sample_mask.shape[0] != n_samples:
                 raise ValueError("Length of sample_mask=%d does not match "
-                                 "number of samples=%d" % (sample_mask.shape[0],
-                                                           n_samples))
+                                 "number of samples=%d"
+                                 % (sample_mask.shape[0], n_samples))
 
         if X_argsorted is not None:
             X_argsorted = np.asarray(X_argsorted, dtype=np.int32,
@@ -369,8 +369,9 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
                 P = np.zeros((n_samples, self.n_outputs_))
 
                 for k in xrange(self.n_outputs_):
-                    P[:, k] = self.classes_[k].take(np.argmax(P_[:, k], axis=1),
-                                                              axis=0)
+                    P[:, k] = self.classes_[k].take(np.argmax(P_[:, k],
+                                                              axis=1),
+                                                    axis=0)
 
                 return P
 


### PR DESCRIPTION
This is a early pull request. 

The goal is to simplify the shape of the `n_classes_` and `classes_` attributes in trees and forests when considering  single output problems.

For single output problems, 
- `n_classes_` should be a scalar corresponding to the number of classes;
-  `classes_` should be the list of class labels. 

For multi output problems, 
- `n_classes_` should be a list of scalars, such that `n_classes_[i]` is the number of classes in the i-th output, 
- `classes_` should be a list of lists of class labels, such that `classes_[i]` is the list of class labels for the i-th output.

TODO:
- ~~Update tree.py~~
- ~~Add a regression test~~
- ~~Update forest.py~~
- ~~PEP8~~ 
