### PR TITLE
MRG renaming chunk_size to batch_size in MiniBatchDictionaryLearning

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -176,11 +176,14 @@ API changes summary
      now flat in case of single output problems and nested in case of
      multi-output problems.
 
+   - The ``estimators_`` attribute of
+     :class:`ensemble.gradient_boosting.GradientBoostingRegressor` and
+     :class:`ensemble.gradient_boosting.GradientBoostingClassifier` is now an
+     array of :class:'tree.DecisionTreeRegressor'.
 
-    - The ``estimators_`` attribute of
-    :class:`ensemble.gradient_boosting.GradientBoostingRegressor` and
-    :class:`ensemble.gradient_boosting.GradientBoostingClassifier` is now
-    an array of :class:'tree.DecisionTreeRegressor'.
+   - Renamed ``chunk_size`` to ``batch_size`` in
+     :class:`decomposition.MiniBatchDictionaryLearning` and
+     :class:`decomposition.MiniBatchSparsePCA` for consistency.
 
 .. _changes_0_12.1:
 

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -82,13 +82,13 @@ estimators = [
 
     ('Sparse comp. - MiniBatchSparsePCA',
      decomposition.MiniBatchSparsePCA(n_components=n_components, alpha=0.8,
-                                      n_iter=100, chunk_size=3,
+                                      n_iter=100, batch_size=3,
                                       random_state=rng),
      True),
 
     ('MiniBatchDictionaryLearning',
     decomposition.MiniBatchDictionaryLearning(n_components=15, alpha=0.1,
-                                              n_iter=50, chunk_size=3,
+                                              n_iter=50, batch_size=3,
                                               random_state=rng),
      True),
 

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -489,9 +489,10 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
 
 
 def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
-                return_code=True, dict_init=None, callback=None, chunk_size=3,
-                verbose=False, shuffle=True, n_jobs=1, method='lars',
-                iter_offset=0, random_state=None, n_atoms=None):
+                         return_code=True, dict_init=None, callback=None,
+                         batch_size=3, verbose=False, shuffle=True, n_jobs=1,
+                         method='lars', iter_offset=0, random_state=None,
+                         n_atoms=None, chunk_size=None):
     """Solves a dictionary learning matrix factorization problem online.
 
     Finds the best dictionary and the corresponding sparse code for
@@ -508,58 +509,58 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     Parameters
     ----------
     X: array of shape (n_samples, n_features)
-        data matrix
+        Data matrix.
 
-    n_components: int,
-        number of dictionary atoms to extract
+    n_components : int,
+        Number of dictionary atoms to extract.
 
-    alpha: int,
-        sparsity controlling parameter
+    alpha : int,
+        Sparsity controlling parameter.
 
-    n_iter: int,
-        number of iterations to perform
+    n_iter : int,
+        Number of iterations to perform.
 
-    return_code: boolean,
-        whether to also return the code U or just the dictionary V
+    return_code : boolean,
+        Whether to also return the code U or just the dictionary V.
 
-    dict_init: array of shape (n_components, n_features),
-        initial value for the dictionary for warm restart scenarios
+    dict_init : array of shape (n_components, n_features),
+        Initial value for the dictionary for warm restart scenarios.
 
-    callback:
-        callable that gets invoked every five iterations
+    callback :
+        Callable that gets invoked every five iterations.
 
-    chunk_size: int,
-        the number of samples to take in each batch
+    batch_size : int,
+        The number of samples to take in each batch.
 
-    verbose:
-        degree of output the procedure will print
+    verbose :
+        Degree of output the procedure will print.
 
-    shuffle: boolean,
-        whether to shuffle the data before splitting it in batches
+    shuffle : boolean,
+        Whether to shuffle the data before splitting it in batches.
 
-    n_jobs: int,
-        number of parallel jobs to run, or -1 to autodetect.
+    n_jobs : int,
+        Number of parallel jobs to run, or -1 to autodetect.
 
-    method: {'lars', 'cd'}
+    method : {'lars', 'cd'}
         lars: uses the least angle regression method to solve the lasso problem
         (linear_model.lars_path)
         cd: uses the coordinate descent method to compute the
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    iter_offset: int, default 0
-        number of previous iterations completed on the dictionary used for
-        initialization
+    iter_offset : int, default 0
+        Number of previous iterations completed on the dictionary used for
+        initialization.
 
-    random_state: int or RandomState
+    random_state : int or RandomState
         Pseudo number generator state used for random sampling.
 
     Returns
     -------
-    code: array of shape (n_samples, n_components),
+    code : array of shape (n_samples, n_components),
         the sparse code (only returned if `return_code=True`)
 
-    dictionary: array of shape (n_components, n_features),
+    dictionary : array of shape (n_components, n_features),
         the solutions to the dictionary learning problem
 
     See also
@@ -572,11 +573,17 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
 
     """
 
-    if not n_atoms is None:
+    if n_atoms is not None:
         n_components = n_atoms
-        warnings.warn("Parameter n_atoms has been renamed to"
-            'n_components'" and will be removed in release 0.14.",
-            DeprecationWarning, stacklevel=2)
+        warnings.warn("Parameter n_atoms has been renamed to "
+                      "'n_components' and will be removed in release 0.14.",
+                      DeprecationWarning, stacklevel=2)
+
+    if chunk_size is not None:
+        chunk_size = batch_size
+        warnings.warn("Parameter chunk_size has been renamed to "
+                      "'batch_size' and will be removed in release 0.14.",
+                      DeprecationWarning, stacklevel=2)
 
     if method not in ('lars', 'cd'):
         raise ValueError('Coding method not supported as a fit algorithm.')
@@ -608,7 +615,7 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     if verbose == 1:
         print '[dict_learning]',
 
-    n_batches = floor(float(len(X)) / chunk_size)
+    n_batches = floor(float(len(X)) / batch_size)
     if shuffle:
         X_train = X.copy()
         random_state.shuffle(X_train)
@@ -637,11 +644,11 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
                                   alpha=alpha).T
 
         # Update the auxiliary variables
-        if ii < chunk_size - 1:
-            theta = float((ii + 1) * chunk_size)
+        if ii < batch_size - 1:
+            theta = float((ii + 1) * batch_size)
         else:
-            theta = float(chunk_size ** 2 + ii + 1 - chunk_size)
-        beta = (theta + 1 - chunk_size) / (theta + 1)
+            theta = float(batch_size ** 2 + ii + 1 - batch_size)
+        beta = (theta + 1 - batch_size) / (theta + 1)
 
         A *= beta
         A += np.dot(this_code, this_code.T)
@@ -916,7 +923,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
                  n_jobs=1, code_init=None, dict_init=None, verbose=False,
                  split_sign=False, random_state=None, n_atoms=None):
 
-        if not n_atoms is None:
+        if n_atoms is not None:
             n_components = n_atoms
             warnings.warn("Parameter n_atoms has been renamed to"
                         'n_components'" and will be removed in release 0.14.",
@@ -1038,7 +1045,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
     verbose :
         degree of verbosity of the printed output
 
-    chunk_size : int,
+    batch_size : int,
         number of samples in each mini-batch
 
     shuffle : bool,
@@ -1068,17 +1075,23 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
 
     """
     def __init__(self, n_components=None, alpha=1, n_iter=1000,
-                 fit_algorithm='lars', n_jobs=1, chunk_size=3,
+                 fit_algorithm='lars', n_jobs=1, batch_size=3,
                  shuffle=True, dict_init=None, transform_algorithm='omp',
                  transform_n_nonzero_coefs=None, transform_alpha=None,
                  verbose=False, split_sign=False, random_state=None,
-                 n_atoms=None):
+                 n_atoms=None, chunk_size=None):
 
-        if not n_atoms is None:
+        if n_atoms is not None:
             n_components = n_atoms
             warnings.warn("Parameter n_atoms has been renamed to"
-                        'n_components'" and will be removed in release 0.14.",
-                         DeprecationWarning, stacklevel=2)
+                          "'n_components' and will be removed in release"
+                          " 0.14.", DeprecationWarning, stacklevel=2)
+
+        if chunk_size is not None:
+            chunk_size = batch_size
+            warnings.warn("Parameter chunk_size has been renamed to"
+                          "'batch_size' and will be removed in release"
+                          " 0.14.", DeprecationWarning, stacklevel=2)
 
         self._set_sparse_coding_params(n_components, transform_algorithm,
                                        transform_n_nonzero_coefs,
@@ -1089,7 +1102,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         self.dict_init = dict_init
         self.verbose = verbose
         self.shuffle = shuffle
-        self.chunk_size = chunk_size
+        self.batch_size = batch_size
         self.split_sign = split_sign
         self.random_state = random_state
 
@@ -1119,7 +1132,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
                                  method=self.fit_algorithm,
                                  n_jobs=self.n_jobs,
                                  dict_init=self.dict_init,
-                                 chunk_size=self.chunk_size,
+                                 batch_size=self.batch_size,
                                  shuffle=self.shuffle, verbose=self.verbose,
                                  random_state=self.random_state)
         self.components_ = U
@@ -1149,7 +1162,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
                                  n_iter=self.n_iter,
                                  method=self.fit_algorithm,
                                  n_jobs=self.n_jobs, dict_init=dict_init,
-                                 chunk_size=len(X), shuffle=False,
+                                 batch_size=len(X), shuffle=False,
                                  verbose=self.verbose, return_code=False,
                                  iter_offset=iter_offset,
                                  random_state=self.random_state)

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -2,6 +2,8 @@
 # Author: Vlad Niculae, Gael Varoquaux, Alexandre Gramfort
 # License: BSD
 
+import warnings
+
 import numpy as np
 
 from ..utils import check_random_state, array2d
@@ -73,8 +75,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     DictionaryLearning
     """
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
-            max_iter=1000, tol=1e-8, method='lars', n_jobs=1, U_init=None,
-            V_init=None, verbose=False, random_state=None):
+                 max_iter=1000, tol=1e-8, method='lars', n_jobs=1, U_init=None,
+                 V_init=None, verbose=False, random_state=None):
         self.n_components = n_components
         self.alpha = alpha
         self.ridge_alpha = ridge_alpha
@@ -180,7 +182,7 @@ class MiniBatchSparsePCA(SparsePCA):
     callback : callable,
         callable that gets invoked every five iterations
 
-    chunk_size : int,
+    batch_size : int,
         the number of features to take in each mini batch
 
     verbose :
@@ -217,14 +219,21 @@ class MiniBatchSparsePCA(SparsePCA):
     DictionaryLearning
     """
     def __init__(self, n_components=None, alpha=1, ridge_alpha=0.01,
-            n_iter=100, callback=None, chunk_size=3, verbose=False,
-            shuffle=True, n_jobs=1, method='lars', random_state=None):
+                 n_iter=100, callback=None, batch_size=3, verbose=False,
+                 shuffle=True, n_jobs=1, method='lars', random_state=None,
+                 chunk_size=None):
+
+        if chunk_size is not None:
+            chunk_size = batch_size
+            warnings.warn("Parameter chunk_size has been renamed to "
+                          "'batch_size' and will be removed in release 0.14.",
+                          DeprecationWarning, stacklevel=2)
         self.n_components = n_components
         self.alpha = alpha
         self.ridge_alpha = ridge_alpha
         self.n_iter = n_iter
         self.callback = callback
-        self.chunk_size = chunk_size
+        self.batch_size = batch_size
         self.verbose = verbose
         self.shuffle = shuffle
         self.n_jobs = n_jobs
@@ -255,7 +264,7 @@ class MiniBatchSparsePCA(SparsePCA):
                                      n_iter=self.n_iter, return_code=True,
                                      dict_init=None, verbose=self.verbose,
                                      callback=self.callback,
-                                     chunk_size=self.chunk_size,
+                                     batch_size=self.batch_size,
                                      shuffle=self.shuffle,
                                      n_jobs=self.n_jobs, method=self.method,
                                      random_state=self.random_state)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -134,7 +134,7 @@ def test_dict_learning_online_partial_fit():
     V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     rng1 = np.random.RandomState(0)
     rng2 = np.random.RandomState(0)
-    dico1 = MiniBatchDictionaryLearning(n_components, n_iter=10, chunk_size=1,
+    dico1 = MiniBatchDictionaryLearning(n_components, n_iter=10, batch_size=1,
                                         shuffle=False, dict_init=V,
                                         random_state=rng1).fit(X)
     dico2 = MiniBatchDictionaryLearning(n_components, n_iter=1, dict_init=V,


### PR DESCRIPTION
This is the remainder of the inconsistent parameter renaming as far as I can tell.
I'd like to merge before the release if possible, so that all the deprecations happen at the same time.

Closes #1217.
