### PR TITLE
MRG Make MDS compute proximity from input

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -30,7 +30,6 @@ from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.ticker import NullFormatter
 
 from sklearn import manifold, datasets
-from sklearn.metrics import euclidean_distances
 
 # Next line to silence pyflakes. This import is needed.
 Axes3D
@@ -85,7 +84,7 @@ pl.axis('tight')
 
 t0 = time()
 mds = manifold.MDS(n_components, max_iter=100, n_init=1)
-Y = mds.fit_transform(euclidean_distances(X))
+Y = mds.fit_transform(X)
 t1 = time()
 print "MDS: %.2g sec" % (t1 - t0)
 ax = fig.add_subplot(247)

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -180,7 +180,7 @@ plot_embedding(X_ltsa,
 print "Computing MDS embedding"
 clf = manifold.MDS(n_components=2, n_init=1, max_iter=100)
 t0 = time()
-X_mds = clf.fit_transform(euclidean_distances(X))
+X_mds = clf.fit_transform(X)
 print "Done. Stress: %f" % clf.stress_
 plot_embedding(X_mds,
                "MDS embedding of the digits (time %.2fs)" %

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -113,7 +113,7 @@ pl.axis('tight')
 # Perform Multi-dimensional scaling.
 t0 = time()
 mds = manifold.MDS(2, max_iter=100, n_init=1)
-trans_data = mds.fit_transform(euclidean_distances(sphere_data)).T
+trans_data = mds.fit_transform(sphere_data).T
 t1 = time()
 print "MDS: %.2g sec" % (t1 - t0)
 

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -39,7 +39,7 @@ similarities += noise
 
 mds = manifold.MDS(n_components=2, max_iter=3000,
                    eps=1e-9, random_state=seed,
-                   n_jobs=1)
+                   proximity="precomputed", n_jobs=1)
 pos = mds.fit(similarities).embedding_
 
 nmds = manifold.MDS(n_components=2, metric=False,

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -39,7 +39,7 @@ similarities += noise
 
 mds = manifold.MDS(n_components=2, max_iter=3000,
                    eps=1e-9, random_state=seed,
-                   proximity="precomputed", n_jobs=1)
+                   dissimilarity="precomputed", n_jobs=1)
 pos = mds.fit(similarities).embedding_
 
 nmds = manifold.MDS(n_components=2, metric=False,

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -302,6 +302,10 @@ class MDS(BaseEstimator):
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
+    proximity : string
+        Which proximity measure to use.
+        Supported are 'euclidean' and 'precomputed'.
+
 
     Attributes
     ----------
@@ -372,18 +376,18 @@ class MDS(BaseEstimator):
             if ndarray, initialize the SMACOF algorithm with this array.
 
         """
-        if X.shape[0] == X.shape[1] and self.affinity != "precomputed":
+        if X.shape[0] == X.shape[1] and self.proximity != "precomputed":
             warnings.warn("The MDS API has changed. ``fit`` now constructs an"
                           "proximity matrix from data. To use a custom "
-                          "affinity matrix, set ``proximity=precomputed``.")
+                          "proximity matrix, set ``proximity=precomputed``.")
 
         if self.proximity is "precomputed":
             self.proximity_matrix_ = X
         elif self.proximity is "euclidean":
             self.proximity_matrix_ = euclidean_distances(X)
         else:
-            raise ValueError("Affinity must be 'precomputed' or 'euclidean'."
-                             " Got %s instead" % str(self.affinity))
+            raise ValueError("Proximity must be 'precomputed' or 'euclidean'."
+                             " Got %s instead" % str(self.proximity))
 
         self.embedding_, self.stress_ = smacof(
             X, metric=self.metric, n_components=self.n_components, init=init,

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -261,8 +261,7 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
 
 
 class MDS(BaseEstimator):
-    """
-    Multidimensional scaling
+    """Multidimensional scaling
 
     Parameters
     ----------
@@ -314,8 +313,8 @@ class MDS(BaseEstimator):
         disparities and the distances for all constrained points)
 
 
-    Notes
-    -----
+    References
+    ----------
     "Modern Multidimensional Scaling - Theory and Applications" Borg, I.;
     Groenen P. Springer Series in Statistics (1997)
 
@@ -328,8 +327,9 @@ class MDS(BaseEstimator):
     """
     def __init__(self, n_components=2, metric=True, n_init=4,
                  max_iter=300, verbose=0, eps=1e-3, n_jobs=1,
-                 random_state=None):
+                 random_state=None, proximity="euclidean"):
         self.n_components = n_components
+        self.proximity = proximity
         self.metric = metric
         self.n_init = n_init
         self.max_iter = max_iter
@@ -338,18 +338,22 @@ class MDS(BaseEstimator):
         self.n_jobs = n_jobs
         self.random_state = None
 
+    @property
+    def _pairwise(self):
+        return self.kernel == "precomputed"
+
     def fit(self, X, init=None, y=None):
         """
         Computes the position of the points in the embedding space
 
         Parameters
         ----------
-        X: array, shape=[n_samples, n_samples], symetric
-            Proximity matrice
+        X : array, shape=[n_samples, n_features]
+            Input data.
 
-        init: {None or ndarray, shape (n_samples,)}, optional
-            if None, randomly chooses the initial configuration
-            if ndarray, initialize the SMACOF algorithm with this array
+        init : {None or ndarray, shape (n_samples,)}, optional
+            If None, randomly chooses the initial configuration
+            if ndarray, initialize the SMACOF algorithm with this array.
         """
         self.fit_transform(X, init=init)
         return self
@@ -360,14 +364,27 @@ class MDS(BaseEstimator):
 
         Parameters
         ----------
-        X: array, shape=[n_samples, n_samples], symetric
-            Proximity matrice
+        X : array, shape=[n_samples, n_features]
+            Input data.
 
-        init: {None or ndarray, shape (n_samples,)}, optional
-            if None, randomly chooses the initial configuration
-            if ndarray, initialize the SMACOF algorithm with this array
+        init : {None or ndarray, shape (n_samples,)}, optional
+            If None, randomly chooses the initial configuration
+            if ndarray, initialize the SMACOF algorithm with this array.
 
         """
+        if X.shape[0] == X.shape[1] and self.affinity != "precomputed":
+            warnings.warn("The MDS API has changed. ``fit`` now constructs an"
+                          "proximity matrix from data. To use a custom "
+                          "affinity matrix, set ``proximity=precomputed``.")
+
+        if self.proximity is "precomputed":
+            self.proximity_matrix_ = X
+        elif self.proximity is "euclidean":
+            self.proximity_matrix_ = euclidean_distances(X)
+        else:
+            raise ValueError("Affinity must be 'precomputed' or 'euclidean'."
+                             " Got %s instead" % str(self.affinity))
+
         self.embedding_, self.stress_ = smacof(
             X, metric=self.metric, n_components=self.n_components, init=init,
             n_init=self.n_init, n_jobs=self.n_jobs, max_iter=self.max_iter,

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -302,8 +302,8 @@ class MDS(BaseEstimator):
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
-    proximity : string
-        Which proximity measure to use.
+    dissimilarity : string
+        Which dissimilarity measure to use.
         Supported are 'euclidean' and 'precomputed'.
 
 
@@ -331,9 +331,9 @@ class MDS(BaseEstimator):
     """
     def __init__(self, n_components=2, metric=True, n_init=4,
                  max_iter=300, verbose=0, eps=1e-3, n_jobs=1,
-                 random_state=None, proximity="euclidean"):
+                 random_state=None, dissimilarity="euclidean"):
         self.n_components = n_components
-        self.proximity = proximity
+        self.dissimilarity = dissimilarity
         self.metric = metric
         self.n_init = n_init
         self.max_iter = max_iter
@@ -376,21 +376,22 @@ class MDS(BaseEstimator):
             if ndarray, initialize the SMACOF algorithm with this array.
 
         """
-        if X.shape[0] == X.shape[1] and self.proximity != "precomputed":
+        if X.shape[0] == X.shape[1] and self.dissimilarity != "precomputed":
             warnings.warn("The MDS API has changed. ``fit`` now constructs an"
-                          "proximity matrix from data. To use a custom "
-                          "proximity matrix, set ``proximity=precomputed``.")
+                          "dissimilarity matrix from data. To use a custom "
+                          "dissimilarity matrix, set "
+                          "``dissimilarity=precomputed``.")
 
-        if self.proximity is "precomputed":
-            self.proximity_matrix_ = X
-        elif self.proximity is "euclidean":
-            self.proximity_matrix_ = euclidean_distances(X)
+        if self.dissimilarity is "precomputed":
+            self.dissimilarity_matrix_ = X
+        elif self.dissimilarity is "euclidean":
+            self.dissimilarity_matrix_ = euclidean_distances(X)
         else:
             raise ValueError("Proximity must be 'precomputed' or 'euclidean'."
-                             " Got %s instead" % str(self.proximity))
+                             " Got %s instead" % str(self.dissimilarity))
 
         self.embedding_, self.stress_ = smacof(
-            self.proximity_matrix_, metric=self.metric,
+            self.dissimilarity_matrix_, metric=self.metric,
             n_components=self.n_components, init=init, n_init=self.n_init,
             n_jobs=self.n_jobs, max_iter=self.max_iter, verbose=self.verbose,
             eps=self.eps, random_state=self.random_state)

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -390,8 +390,9 @@ class MDS(BaseEstimator):
                              " Got %s instead" % str(self.proximity))
 
         self.embedding_, self.stress_ = smacof(
-            X, metric=self.metric, n_components=self.n_components, init=init,
-            n_init=self.n_init, n_jobs=self.n_jobs, max_iter=self.max_iter,
-            verbose=self.verbose, eps=self.eps, random_state=self.random_state)
+            self.proximity_matrix_, metric=self.metric,
+            n_components=self.n_components, init=init, n_init=self.n_init,
+            n_jobs=self.n_jobs, max_iter=self.max_iter, verbose=self.verbose,
+            eps=self.eps, random_state=self.random_state)
 
         return self.embedding_

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -57,5 +57,5 @@ def test_MDS():
                     [5, 0, 2, 2],
                     [3, 2, 0, 1],
                     [4, 2, 1, 0]])
-    mds_clf = mds.MDS(metric=False, n_jobs=3)
+    mds_clf = mds.MDS(metric=False, n_jobs=3, proximity="precomputed")
     mds_clf.fit(sim)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -57,5 +57,5 @@ def test_MDS():
                     [5, 0, 2, 2],
                     [3, 2, 0, 1],
                     [4, 2, 1, 0]])
-    mds_clf = mds.MDS(metric=False, n_jobs=3, proximity="precomputed")
+    mds_clf = mds.MDS(metric=False, n_jobs=3, dissimilarity="precomputed")
     mds_clf.fit(sim)


### PR DESCRIPTION
This introduces a new parameter to MDS and changes the default behaviour, as I did it before in the "precomputed" PR.
What are other proximities that can be used? I only saw examples with euclidean distances.

I used the name `proximity` as it was used in the docstring before.
I don't like the name proximity for two reasons:
1) It's not used anywhere else
2) it is misleading imho. A distance is passed, so a high value means "far apart".  A high proximity means close together, right?

Should I rename it into "distance?" do we have any other algorithms that take dissimilarties?

@NelleV could you please have a look and voice your opinion? Thanks.
I didn't adjust the tests yet as I first wanted to get some feedback.

Closes #1390.
