### PR TITLE
MRG+1: Add resample to preprocessing.

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -682,17 +682,17 @@ for growing or shrinking the dataset to any size.
 
 While the effectiveness of changing the label distribution of the training set
 is still an open question, such experiments are easy to conduct. Please note
-that this function will not generate any samples that are not in the original
-dataset, but it is possible to perturb the dataset after resampling to
-synthesize a similar but not identical dataset.
+that :func:`resample_lablels` will not generate any samples that are not in the
+original dataset, but it is possible to add noise to the dataset after resampling
+to get entirely new samples that look like the original.
 
-As an example, assume there is an unbalanced dataset with three labels ``[0, 1,
-2]`` and ``[100, 125, 150]`` samples. There are three options for the ``method``
-keyword when balancing the class distribution with the :func:`resample_labels`.
-By setting the ``method='undersample'`` parameter, the number of samples in the
-least common class determines the count of the samples for each class, which
-results in a dataset of 300 points total, with 100 points drawn from each of
-the three classes::
+As an example of resampling, assume there is an unbalanced dataset with three
+labels ``[0, 1, 2]`` and sample counts ``[100, 125, 150]``. There are three
+options if using the ``method`` keyword with :func:`resample_labels`. By setting
+the ``method='undersample'`` parameter, the number of samples in the least common
+class determines the count of the samples for each class, which in this case
+results in a dataset of 300 points total, with 100 points drawn from each of the
+three classes::
 
   >>> import numpy as np
   >>> from sklearn.preprocessing.resample import resample_labels
@@ -701,8 +701,8 @@ the three classes::
   >>> print(np.bincount(y[indices]))
   [100 100 100]
 
-With ``method='oversample'``, each class draws 150 samples and the length of the
-output is 450::
+With ``method='oversample'``, each class draws the maximum class's 150 samples
+for an output length of 450::
   >>> indices = resample_labels(y, method='oversample')
   >>> print(np.bincount(y[indices]))
   [150 150 150]
@@ -715,19 +715,19 @@ the count of each class by undersampling or oversampling as needed::
   >>> print(np.bincount(y[indices]))
   [125 125 125]
 
-Keep in mind that if your dataset changes or has rare labels that vary from
-run to run, you may end up with very few samples in your output dataset if one
-class is underrepresented or missing. One way to mitigate this problem is to use
-the ``scale`` parameter described later, but there is no substitute for being
-careful.
+Keep in mind that if your dataset starts with very few samples of a class and
+you undersample, you will get a new dataset with the number of samples from the
+smallest class times the number of labels, which will be a very small dataset.
+Using the scale keyword as described below can ensure the dataset remains large,
+but with many repeated samples. Make sure that this is what you want.
 
 
 Custom label distribution
 -------------------------
-The three built-in sampling options above produce a balanced dataset, but
-unbalancing the data by passing a ``method=dict`` is also supported. For
-instance, in the previous example, passing ``method={0: .5, 1: .25, 2: .25}``
-gives a dataset where a 0 sample is twice as likely as a 1 or 2.
+The three sampling options for the ``method`` keyword provide balanced class
+distribution, but unbalancing the classes by passing a ``method=dict`` is also
+supported. For instance, in the previous example, passing ``method={0: .5, 1: .25, 2: .25}``
+gives a dataset where a 0 class label is twice as likely as a 1 or 2.
 
 Skew the distribution with a dict::
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -675,24 +675,19 @@ Resampling of labels
 
 Balancing labels
 ----------------
-Datasets, unless carefully designed, typically do not have an equal number
-of samples from each class. Resampling the dataset with :func:`resample_labels`
-allows for balancing or changing the label distribution, if desired, and also
-for growing or shrinking the dataset to any size.
-
-While the effectiveness of changing the label distribution of the training set
-is still an open question, such experiments are easy to conduct. Please note
-that :func:`resample_lablels` will not generate any samples that are not in the
-original dataset, but it is possible to add noise to the dataset after resampling
-to get entirely new samples that look like the original.
+Datasets, unless carefully designed, will not contain an equal number of samples
+from each class. Resampling a dataset with :func:`resample_labels` allows the user
+to change the label distribution and simultaneously grow or shrink the dataset by
+drawing from samples from the original dataset. Noise may then be added to obtain
+a better training set to get more accuracy or generalization from a machine
+learning algorithm, or to test the running time as the dataset scales.
 
 As an example of resampling, assume there is an unbalanced dataset with three
-labels ``[0, 1, 2]`` and sample counts ``[100, 125, 150]``. There are three
-options if using the ``method`` keyword with :func:`resample_labels`. By setting
-the ``method='undersample'`` parameter, the number of samples in the least common
-class determines the count of the samples for each class, which in this case
-results in a dataset of 300 points total, with 100 points drawn from each of the
-three classes::
+class labels ``[0, 1, 2]`` and sample counts ``[100, 125, 150]``. The ``method``
+keyword of :func:`resample_labels` supports three string options or instead take a
+``dict``.  By setting ``method='undersample'``, the number of samples in the least
+common class determines the count of the samples for each class, in this case 300
+total samples, 100 from each class::
 
   >>> import numpy as np
   >>> from sklearn.preprocessing.resample import resample_labels
@@ -709,17 +704,17 @@ for an output length of 450::
 
 
 Using ``method='balance'`` keeps the length of the dataset at 375 but equalizes
-the count of each class by undersampling or oversampling as needed::
+the count of each class by undersampling or oversampling classes as needed::
 
   >>> indices = resample_labels(y, method='balance')
   >>> print(np.bincount(y[indices]))
   [125 125 125]
 
 Keep in mind that if your dataset starts with very few samples of a class and
-you undersample, you will get a new dataset with the number of samples from the
-smallest class times the number of labels, which will be a very small dataset.
-Using the scale keyword as described below can ensure the dataset remains large,
-but with many repeated samples. Make sure that this is what you want.
+you choose the ``undersample`` option, the output dataset will be very small.
+Using the ``scale`` keyword as described below can ensure the dataset remains
+large, but with many repeated samples. You may then add noise or reconsider your
+approach.
 
 
 Custom label distribution
@@ -779,7 +774,7 @@ run out of samples, instead the sample pool starts over with the original
 dataset. Thus, if you set ``scale=10.0`` and sample without replacement,
 the dataset will have each sample repeated ten times. In effect, only
 the last repetition of the dataset might vary when sampling without
-replacement.
+replacement, and only if the full dataset is not repeated.
 
 Shuffling the data can take considerable CPU time and is turned off by
 default, but is possible by setting the keyword argument ``shuffle=True``.
@@ -794,10 +789,11 @@ testing datasets completely separate because estimators do very well
 on samples they have been trained on and testing results will be overly
 optimistic. When resampling, since you are duplicating samples exactly,
 there is now the possiblity that a sample could find its way into both
-sets.
+the training and testing sets.
 
 Even ruling out coding errors, techniques such as scaling a dataset
 and then running cross-validation on it would potentially place some
 samples in both datasets. The danger is that your results are not as
-good as the metrics report. Therefore, use extreme care when resampling
-so that you do not confuse the training and testing datasets.
+good as the metrics report or that model generalization is worse.
+Therefore, use extreme care when resampling so that you do not confuse
+the training and testing datasets.

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -1,6 +1,6 @@
 """
 The :mod:`sklearn.preprocessing` module includes scaling, centering,
-normalization, binarization and imputation methods.
+normalization, binarization, imputation and resampling methods.
 """
 
 from ._function_transformer import FunctionTransformer
@@ -34,6 +34,7 @@ from .label import MultiLabelBinarizer
 
 from .imputation import Imputer
 
+from .resample import resample_labels
 
 __all__ = [
     'Binarizer',
@@ -63,4 +64,5 @@ __all__ = [
     'label_binarize',
     'quantile_transform',
     'power_transform',
+    'resample_labels',
 ]

--- a/sklearn/preprocessing/resample.py
+++ b/sklearn/preprocessing/resample.py
@@ -1,0 +1,263 @@
+# Author: Doug Coleman <doug.coleman@gmail.com>
+# License: BSD 3 clause
+
+from collections import defaultdict
+import warnings
+import numbers
+
+import numpy as np
+from ..utils.validation import check_random_state
+from ..utils.random import sample_without_replacement
+
+__all__ = ['resample_labels']
+
+
+def _collect_indices(y):
+    """Collects a list of indices for each element.
+    Returns labels and indices where those labels appear in y.
+    >>> _collect_indices(np.array([1, 2, 2, 3, 3, 3, 4, 4, 4, 4]))
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    ((1, 2, 3, 4), ([0], [1, 2], [3, 4, 5], [6, 7, 8, 9]))
+    """
+    d = defaultdict(list)
+    for k, v in enumerate(y):
+        d[v].append(k)
+    labels, indices = zip(*sorted(d.items()))
+    return labels, indices
+
+
+def _circular_sample(initial_n_samples, target_n_samples, random_state=None):
+    """Sample without replacement from array in a loop.
+    Take each sample once per loop except for the last loop, which takes
+    (n % len(array)) samples at random. Results are returned unshuffled.
+    >>> _circular_sample(3, 8, random_state=46)
+    array([0, 0, 1, 1, 2, 2, 1, 0])
+    """
+    random_state = check_random_state(random_state)
+    n_full_sets = int(target_n_samples // initial_n_samples)
+    n_remainder = target_n_samples % initial_n_samples
+    sample_indices = np.empty(target_n_samples, dtype=int)
+    last_loop_index = n_full_sets * initial_n_samples
+    sample_indices[:last_loop_index] =\
+        np.repeat(np.arange(initial_n_samples), n_full_sets)
+    if n_remainder > 0:
+        sample_indices[last_loop_index:] = \
+            sample_without_replacement(initial_n_samples, n_remainder,
+                                       random_state=random_state)
+    return sample_indices
+
+
+def _fair_array_counts(n_samples, n_classes, random_state=None):
+    """Tries to fairly partition n_samples between n_classes.
+    If this cannot be done fairly, +1 is added `remainder` times
+    to the counts for random arrays until a total of `n_samples` is
+    reached.
+
+    >>> _fair_array_counts(5, 3, random_state=43)
+    array([2, 1, 2])
+    """
+    if n_classes > n_samples:
+        raise ValueError("The number of classes is greater"
+                         " than the number of samples requested")
+    sample_size = n_samples // n_classes
+    sample_size_rem = n_samples % n_classes
+    counts = np.repeat(sample_size, n_classes)
+    if sample_size_rem > 0:
+        counts[:sample_size_rem] += 1
+        # Shuffle so the class inbalance varies between runs
+        random_state = check_random_state(random_state)
+        random_state.shuffle(counts)
+    return counts
+
+
+def _scale_n_samples(scaling, n):
+    """Helper function to scale the number of samples."""
+    if scaling is None:
+        return n
+    else:
+        if isinstance(scaling, numbers.Number) and scaling < 0:
+            raise ValueError("Scaling must be nonnegative: %s" % scaling)
+        elif isinstance(scaling, float):
+            return scaling * n
+        elif isinstance(scaling, (numbers.Integral, np.integer)):
+            return scaling
+        else:
+            raise ValueError("Invalid value for scaling, must be "
+                             "float, int, or None: %s" % scaling)
+
+
+def _weighted_sample(probas, n_samples, random_state=None):
+    """Select indices from n_samples with a weighted probability.
+
+    Parameters
+    ---------
+    probas : array-like
+        Array of probabilities summing to 1.
+    n_samples : integer
+        The number of samples to draw from at random.
+    random_state : int, or RandomState instance (optional)
+        Control the sampling for reproducible behavior.
+    """
+    random_state = check_random_state(random_state)
+    if abs(np.sum(probas) - 1.0) > .011:
+        raise ValueError("Label distribution probabilites must sum to 1")
+    cum_probas = np.cumsum(probas)
+    cum_probas[-1] = 1  # ensure that the probabilities sum to 1
+    space = np.linspace(0, 1, 10000)
+    weighted_indices = np.searchsorted(cum_probas, space)
+    rs = random_state.randint(0, high=len(space), size=n_samples)
+    return weighted_indices[rs]
+
+
+def resample_labels(y, method=None, scaling=None, replace=False,
+                    shuffle=False, random_state=None):
+    """Resamples a classes array `y` and returns an array of indices
+
+    The default behavior is to output the same ``y``. The additional
+    parameters control the desired class distribution of the indices and the
+    number of samples in the output.
+
+    Parameters
+    ----------
+    y : array-like, shape (n_samples,)
+        Target classes. Pass in the entire classes array so that this
+        function can work on the class distribution.
+    method : "balance", "oversample", "undersample", dict (optional)
+        None outputs samples with the same class distribution as `y`.
+        "balance" rebalances the classes to be equally distributed,
+            over/undersampling for `len(y)` samples by default.
+        "oversample" grows all classes to the count of the largest class.
+        "undersample" shrinks all classes to the count of the smallest class.
+        dict with pairs of class, probability with values summing to 1
+    scaling : integer, float (optional)
+        Number of samples to return.
+        None outputs the same number of samples.
+        `integer` is an absolute number of samples.
+        `float` is a scale factor.
+    replace : boolean (False by default)
+        Sample with replacement when True.
+    shuffle : boolean (False by default)
+        Shuffle the indices before returning them. This option can add
+        significant overhead, so it is disabled by default.
+    random_state : int, or RandomState instance (optional)
+        Control the sampling for reproducible behavior.
+
+    Returns
+    -------
+    indices : array-like, shape (n_samples,)
+        Indices sampled from the dataset respecting a class distribution
+        controlled by this function's parameters.
+
+    Examples
+    --------
+    Sample without replacement to reduce the size of a dataset by half
+    and keep the same class distribution. Note how to apply the indices to X.
+
+    >>> from sklearn.preprocessing import resample_labels
+    >>> import numpy as np
+    >>> X = np.array([[100], [120], [130], [110], [130], [110]])
+    >>> y = np.array([10, 12, 13, 11, 13, 11])
+    >>> indices = resample_labels(y, scaling=.5, random_state=333)
+    >>> indices, X[indices], y[indices]
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    (array([4, 5, 3]), array([[130], [110], [110]]), array([13, 11, 11]))
+
+    Sample with replacement the dataset to 1.5 times its size and balance
+    the class counts.
+
+    >>> y = np.array([30, 30, 30, 10, 20, 30])
+    >>> indices = resample_labels(y, method="balance", scaling=1.5,
+    ...                           replace=True, random_state=335)
+    >>> indices, y[indices]
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    (array([3, 3, 3, 4, 4, 4, 2, 0, 1]),
+     array([10, 10, 10, 20, 20, 20, 30, 30, 30]))
+
+    Oversample all classes to the max class count of three samples each.
+
+    >>> y = np.array([1, 2, 2, 3, 3, 3])
+    >>> indices = resample_labels(y, method="oversample", random_state=333)
+    >>> indices, y[indices]
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    (array([0, 0, 0, 1, 2, 1, 3, 4, 5]),
+     array([1, 1, 1, 2, 2, 2, 3, 3, 3]))
+
+    Undersample all classes to the min class count of one sample each and also
+    scale the number of samples by two.
+
+    >>> y = np.array([1, 2, 2, 3, 3, 3])
+    >>> indices = resample_labels(y, method="undersample", scaling=2.0,
+    ...                           random_state=333)
+    >>> indices, y[indices]
+    (array([0, 0, 1, 2, 3, 4]), array([1, 1, 2, 2, 3, 3]))
+
+    Sample twelve times with a probability dict.
+
+    >>> y = np.array([1, 2, 3])
+    >>> indices = resample_labels(y, method={1: .1, 2: .1, 3: .8},
+    ...     scaling=12, random_state=337, shuffle=True)
+    >>> indices, y[indices]
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    (array([2, 1, 2, 0, 0, 2, 1, 2, 2, 2, 2, 2]),
+     array([3, 2, 3, 1, 1, 3, 2, 3, 3, 3, 3, 3]))
+    """
+    random_state = check_random_state(random_state)
+
+    if method is None:
+        n_samples = int(_scale_n_samples(scaling, len(y)))
+        if replace:
+            # already shuffled after this call
+            sample_indices = random_state.randint(0, len(y), n_samples)
+        else:
+            sample_indices = _circular_sample(len(y), n_samples, random_state)
+            if shuffle:
+                random_state.shuffle(sample_indices)
+        return sample_indices
+
+    labels, indices = _collect_indices(y)
+
+    if method in ('balance', 'oversample', 'undersample'):
+        if method == 'balance':
+            n_samples = _scale_n_samples(scaling, len(y))
+        else:
+            if method == 'oversample':
+                count = max(len(a) for a in indices)
+            else:
+                count = min(len(a) for a in indices)
+            n_samples = _scale_n_samples(scaling, count * len(labels))
+        counts = _fair_array_counts(n_samples, len(labels), random_state)
+
+    elif isinstance(method, dict):
+        n_samples = int(_scale_n_samples(scaling, len(y)))
+        proba = dict((k, v) for k, v in list(method.items()) if v > 0)
+        desired_classes = np.asarray(list(proba.keys()))
+        desired_probs = np.asarray(list(proba.values()))
+        diff = set(desired_classes) - set(labels)
+        if len(diff) > 0:
+            raise ValueError("Can't make desired distribution: "
+                             "some classes in `proba` dict are not in `y`: %s"
+                             % list(diff))
+        bincounts = np.bincount(_weighted_sample(desired_probs,
+                                                n_samples,
+                                                random_state))
+        indices = [indices[k] for k, v in enumerate(bincounts) if v > 0]
+        counts = bincounts[bincounts > 0]
+
+    else:
+        raise ValueError("Invalid value for method: %s" % method)
+
+    if replace:
+        sample_indices = \
+            [[array[i] for i in
+                random_state.randint(0, len(array), int(count))]
+                for array, count in zip(indices, counts)]
+    else:
+        sample_indices = \
+            [[array[i] for i in
+                _circular_sample(len(array), int(count), random_state)]
+                for array, count in zip(indices, counts)]
+    sample_indices = np.concatenate(sample_indices)
+
+    if shuffle:
+        random_state.shuffle(sample_indices)
+    return sample_indices

--- a/sklearn/preprocessing/resample.py
+++ b/sklearn/preprocessing/resample.py
@@ -149,8 +149,8 @@ def resample_labels(y, method=None, scaling=None, replace=False,
 
     Examples
     --------
-    Sample without replacement to reduce the size of a dataset by half
-    and keep the same class distribution. Note how to apply the indices to X.
+    Sample without replacement to scale the dataset to half the number of
+    samples and keep original class distribution.
 
     >>> from sklearn.preprocessing import resample_labels
     >>> import numpy as np
@@ -161,8 +161,8 @@ def resample_labels(y, method=None, scaling=None, replace=False,
     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     (array([4, 5, 3]), array([[130], [110], [110]]), array([13, 11, 11]))
 
-    Sample with replacement the dataset to 1.5 times its size and balance
-    the class counts.
+    Sample with replacement to 1.5 times the dataset size and balance the
+    class counts.
 
     >>> y = np.array([30, 30, 30, 10, 20, 30])
     >>> indices = resample_labels(y, method="balance", scaling=1.5,
@@ -172,7 +172,8 @@ def resample_labels(y, method=None, scaling=None, replace=False,
     (array([3, 3, 3, 4, 4, 4, 2, 0, 1]),
      array([10, 10, 10, 20, 20, 20, 30, 30, 30]))
 
-    Take twelve samples without replacement with a probability dict.
+    Take twelve samples without replacement with a probability dict whose
+    values sum to 1.0.
 
     >>> y = np.array([1, 2, 3])
     >>> indices = resample_labels(y, method={1: .1, 2: .1, 3: .8},

--- a/sklearn/preprocessing/resample.py
+++ b/sklearn/preprocessing/resample.py
@@ -30,7 +30,7 @@ def _circular_sample(initial_n_samples, target_n_samples, random_state=None):
     Take each sample once per loop except for the last loop, which takes
     (n % len(array)) samples at random. Results are returned unshuffled.
     >>> _circular_sample(3, 8, random_state=46)
-    array([0, 0, 1, 1, 2, 2, 1, 0])
+    array([0, 0, 1, 1, 2, 2, 0, 2])
     """
     random_state = check_random_state(random_state)
     n_full_sets = int(target_n_samples // initial_n_samples)
@@ -159,7 +159,7 @@ def resample_labels(y, method=None, scaling=None, replace=False,
     >>> indices = resample_labels(y, scaling=.5, random_state=333)
     >>> indices, X[indices], y[indices]
     ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
-    (array([4, 5, 3]), array([[130], [110], [110]]), array([13, 11, 11]))
+    (array([3, 0, 2]), array([[110], [100], [130]]), array([11, 10, 13]))
 
     Sample with replacement to 1.5 times the dataset size and balance the
     class counts.

--- a/sklearn/preprocessing/tests/test_resample.py
+++ b/sklearn/preprocessing/tests/test_resample.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 
 from sklearn.utils.testing import assert_almost_equal

--- a/sklearn/preprocessing/tests/test_resample.py
+++ b/sklearn/preprocessing/tests/test_resample.py
@@ -1,0 +1,317 @@
+import warnings
+import numpy as np
+
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.preprocessing.resample import _collect_indices
+from sklearn.preprocessing.resample import _fair_array_counts
+from sklearn.preprocessing.resample import resample_labels
+
+y = np.array([1, 2, 2, 3, 3, 3, 4, 4, 4, 4])
+
+
+def test_collect_indices():
+    labels, indices = _collect_indices(y)
+
+    expected_labels = [1, 2, 3, 4]
+    expected_indices = [[0], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
+    assert_array_equal(labels, expected_labels)
+    assert_array_equal(indices, expected_indices)
+
+
+def test_resample_labels_same_distribution():
+    indices = resample_labels(y)
+    assert_equal(len(indices), 10)
+    assert_array_equal(y, y[np.sort(indices)])
+
+    indices = resample_labels(y, replace=False)
+    assert_equal(len(indices), 10)
+    assert_array_equal(y, y[np.sort(indices)])
+
+    indices = resample_labels(y, replace=True)
+    assert_equal(len(indices), 10)
+
+    indices = resample_labels(y, scaling=2.0, replace=False)
+    assert_array_equal(y[np.sort(indices)], np.repeat(y, 2))
+
+    indices = resample_labels(y, scaling=20, replace=False)
+    assert_array_equal(y[np.sort(indices)], np.repeat(y, 2))
+
+    indices = resample_labels(y, scaling=2.0, replace=False, shuffle=True)
+    assert_array_equal(y[np.sort(indices)], np.sort(np.repeat(y, 2)))
+
+    indices = resample_labels(y, scaling=20, replace=False, shuffle=True)
+    assert_array_equal(y[np.sort(indices)], np.sort(np.repeat(y, 2)))
+
+    indices = resample_labels(y, scaling=2.0, replace=True)
+    assert_equal(len(indices), 20)
+
+    indices = resample_labels(y, scaling=20, replace=True)
+    assert_equal(len(indices), 20)
+
+
+def test_resample_balanced():
+    indices = resample_labels(y, scaling=2.0, method="balance",
+                              replace=False)
+    assert_equal(len(indices), 2 * len(y))
+
+    indices = resample_labels(y, scaling=20, method="balance",
+                              replace=False)
+    assert_equal(len(indices), 2 * len(y))
+
+    indices = resample_labels(y, scaling=2.0, method="balance",
+                              replace=True)
+    assert_equal(len(indices), 2 * len(y))
+
+    indices = resample_labels(y, scaling=20, method="balance",
+                              replace=True)
+    assert_equal(len(indices), 2 * len(y))
+
+    # [0,0,0,0, 1,1,1,1, 2,2,2,2, ...]
+    z = np.concatenate([[i] * (4) for i in range(101)])
+    check_mean_std(z, 50.0, 29.1547)
+
+    # Should be equal because we sample everything and don't replace
+    indices = resample_labels(z, method=None, replace=False,
+                              random_state=42)
+    assert_array_equal(z, z[indices])
+
+    # Sample with replacement, should get nearly same mean/std as y
+    assert_almost_equal(np.mean(z), 50.0, 3)
+    indices = resample_labels(z, method=None, replace=True,
+                              random_state=42)
+    assert_almost_equal(np.mean(z[indices]), 51.2425, 3)
+    assert_almost_equal(np.std(z[indices]), 28.5119, 3)
+
+    indices = resample_labels(z, method=None, scaling=20000,
+                              replace=True, random_state=42)
+    assert_almost_equal(np.mean(z[indices]), 50.0067, 3)
+    assert_almost_equal(np.std(z[indices]), 29.2240, 3)
+
+
+def test_resample_labels_oversample():
+    indices = resample_labels(y, method="oversample", replace=False)
+    assert_equal(len(indices), 16)
+
+    indices = resample_labels(y, method="oversample", replace=True)
+    assert_equal(len(indices), 16)
+
+
+def test_resample_labels_undersample():
+    indices = resample_labels(y, method="undersample", replace=False)
+    assert_equal(len(indices), 4)
+
+    indices = resample_labels(y, method="undersample", replace=True)
+    assert_equal(len(indices), 4)
+
+
+def test_resample_labels_dict():
+    indices = resample_labels(y, scaling=2.0,
+                              method={1: .3, 2: .1, 3: .5, 4: .1},
+                              random_state=43)
+    assert_equal(len(indices), 2 * len(y))
+    assert_array_equal(np.bincount(y[indices]), [0, 5, 1, 9, 5])
+
+    indices = resample_labels(y, scaling=100,
+                              method={1: .3, 2: .1, 3: .5, 4: .1},
+                              random_state=42)
+    assert_equal(len(indices), 100)
+    assert_array_equal(np.bincount(y[indices]), [0, 28,  9, 54,  9])
+
+    indices = resample_labels(y, scaling=100,
+                              method={1: .3, 2: .7, 999: 0},
+                              random_state=42)
+    assert_equal(len(indices), 100)
+    assert_array_equal(np.bincount(y[indices]), [0, 28, 72])
+
+    indices = resample_labels(y, scaling=2.0,
+                              method={1: .3, 2: .1, 3: .5, 4: .1},
+                              replace=True, random_state=43)
+    assert_equal(len(indices), 2 * len(y))
+    assert_array_equal(np.bincount(y[indices]), [0, 5, 1, 9, 5])
+
+    indices = resample_labels(y, scaling=100,
+                              method={1: .3, 2: .1, 3: .5, 4: .1},
+                              replace=True, random_state=42)
+    assert_equal(len(indices), 100)
+    assert_array_equal(np.bincount(y[indices]), [0, 28, 9, 54, 9])
+
+    indices = resample_labels(y, scaling=100,
+                              method={1: .3, 2: .7, 999: 0},
+                              replace=True, random_state=42)
+    assert_equal(len(indices), 100)
+    assert_array_equal(np.bincount(y[indices]), [0, 28, 72])
+
+    indices = resample_labels(y, scaling=100000,
+                              method={1: .3, 2: .7, 999: 0},
+                              replace=True,
+                              random_state=42)
+    assert_equal(len(indices), 100000)
+    assert_array_equal(np.bincount(y[indices]), [0, 29972, 70028])
+
+
+def test_resample_labels_invalid_parameters():
+    assert_raises(ValueError, resample_labels, y, scaling=2.0,
+                  method="badstring")
+    assert_raises(ValueError, resample_labels, y, scaling=-2.0)
+    assert_raises(ValueError, resample_labels, y, scaling=-2)
+    assert_raises(ValueError, resample_labels, y, method="badstring")
+    assert_raises(ValueError, resample_labels, y, method={1: .5})
+    assert_raises(ValueError, resample_labels, y, method={})
+    assert_raises(ValueError, resample_labels, y, method=555)
+    assert_raises(ValueError, _fair_array_counts, 2, 5)
+    assert_raises(ValueError, resample_labels, y, scaling="failme")
+    assert_raises(ValueError, resample_labels,
+                  y, method={1: .1, 2: .1, 30000: .8},
+                  scaling=12, random_state=337, shuffle=True)
+
+
+def check_mean_std(y, expected_mean, expected_std):
+    indices = resample_labels(y, method="balance", replace=False,
+                              random_state=42)
+    assert_almost_equal(np.mean(y[indices]), expected_mean, 3)
+    assert_almost_equal(np.std(y[indices]), expected_std, 3)
+
+    indices = resample_labels(y, method="balance", replace=True,
+                              random_state=42)
+    assert_almost_equal(np.mean(y[indices]), expected_mean, 3)
+    assert_almost_equal(np.std(y[indices]), expected_std, 3)
+
+    # Scale the dataset and check the invariant
+    indices = resample_labels(y, method="balance",
+                              scaling=4.0, replace=False, random_state=42)
+    assert_almost_equal(np.mean(y[indices]), expected_mean, 3)
+    assert_almost_equal(np.std(y[indices]), expected_std, 3)
+
+    indices = resample_labels(y, method="balance", scaling=4.0,
+                              replace=True, random_state=42)
+    assert_almost_equal(np.mean(y[indices]), expected_mean, 3)
+    assert_almost_equal(np.std(y[indices]), expected_std, 3)
+
+
+def test_resample_labels_linearly_unbalanced():
+    # [0, 1,1, 2,2,2, ...]
+    y = np.concatenate([[i] * (i + 1) for i in range(101)])
+    check_mean_std(y, 50.0, 29.1547)
+
+    # Should be equal because we sample everything and don't replace
+    indices = resample_labels(y, method=None, replace=False,
+                              random_state=42)
+    assert_array_equal(y, y[indices])
+
+    # Sample with replacement, should get nearly same mean/std as y
+    assert_almost_equal(np.mean(y), 66.6666, 3)
+    indices = resample_labels(y, method=None, replace=True,
+                              random_state=42)
+    assert_almost_equal(np.mean(y[indices]), 67.1574, 3)
+    assert_almost_equal(np.std(y[indices]), 23.5837, 3)
+
+    indices = resample_labels(y, method=None, scaling=10000,
+                              replace=True, random_state=42)
+    assert_almost_equal(np.mean(y[indices]), 67.0377, 3)
+    assert_almost_equal(np.std(y[indices]), 23.6514, 3)
+
+
+def test_resample_labels_quadratically_unbalanced():
+    # [0, 1,1, 2,2,2,2, ...]
+    y = np.concatenate([[i] * 2 ** i for i in range(11)])
+    # Multiple of 11 for exact mean
+    y = y[:2002]
+    check_mean_std(y, 5.0, 3.1622)
+
+    # Should be equal because we sample everything and don't replace
+    indices = resample_labels(y, method=None, replace=False,
+                              random_state=42)
+    assert_array_equal(y, y[indices])
+
+    # Sample with replacement, should get nearly same mean/std as y
+    assert_almost_equal(np.mean(y), 8.9830, 3)
+    indices = resample_labels(y, method=None, replace=True,
+                              random_state=42)
+    assert_almost_equal(np.mean(y[indices]), 8.9755, 3)
+    assert_almost_equal(np.std(y[indices]), 1.4740, 3)
+
+    indices = resample_labels(y, scaling=4004, method=None, replace=True,
+                              random_state=42)
+    assert_almost_equal(np.mean(y[indices]), 8.9822, 3)
+    assert_almost_equal(np.std(y[indices]), 1.4315, 3)
+
+
+def test_resample_labels_shuffled():
+    assert_array_equal(
+        resample_labels(y, replace=False, shuffle=False, random_state=42),
+        np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+
+    assert_array_equal(
+        resample_labels(y, replace=False, shuffle=True, random_state=42),
+        np.array([8, 1, 5, 0, 7, 2, 9, 4, 3, 6]))
+
+    assert_array_equal(
+        resample_labels(y, replace=True, shuffle=False, random_state=42),
+        np.array([6, 3, 7, 4, 6, 9, 2, 6, 7, 4]))
+
+    assert_array_equal(
+        resample_labels(y, replace=True, shuffle=True, random_state=42),
+        np.array([6, 3, 7, 4, 6, 9, 2, 6, 7, 4]))
+
+
+def test_resample_labels_distribution_shuffled():
+    assert_array_equal(
+        resample_labels(y, method="balance", replace=False,
+                        shuffle=False,
+                        random_state=42),
+        np.array([0, 0, 0, 1, 2, 3, 4, 5, 7, 9])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method="balance", replace=True,
+                        shuffle=False,
+                        random_state=42),
+        np.array([0, 0, 0, 1, 2, 3, 3, 5, 7, 8])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method="balance", replace=False,
+                        shuffle=True,
+                        random_state=42),
+        np.array([0, 0, 3, 1, 2, 5, 7, 9, 0, 4])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method="balance", replace=True,
+                        shuffle=True,
+                        random_state=42),
+        np.array([0, 3, 8, 0, 7, 0, 1, 2, 5, 3])
+    )
+
+
+def test_resample_labels_dict_shuffled():
+    assert_array_equal(
+        resample_labels(y, method={1: .5, 2: .5},
+                        replace=False, shuffle=False,
+                        random_state=42),
+        np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 1])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method={1: .5, 2: .5},
+                        replace=False, shuffle=True,
+                        random_state=42),
+        np.array([1, 0, 0, 2, 2, 1, 1, 2, 0, 1])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method={1: .5, 2: .5},
+                        replace=True, shuffle=False,
+                        random_state=42),
+        np.array([0, 0, 0, 2, 1, 2, 2, 2, 2, 2])
+    )
+
+    assert_array_equal(
+        resample_labels(y, method={1: .5, 2: .5},
+                        replace=True, shuffle=True,
+                        random_state=42),
+        np.array([2, 0, 2, 2, 2, 2, 2, 0, 1, 0])
+    )


### PR DESCRIPTION
There have been several requests lately for class rebalancing using under/oversampling. This utility function addresses most of the use cases I can think of for sampling with replacement from a dataset.

One thing it does not do is to sample without replacement before sampling with replacement because it changes the code substantially and there is no efficient version of `random.sample` as per https://github.com/scikit-learn/scikit-learn/pull/1438#issuecomment-11162893. I could add that feature eventually.
