### PR TITLE
Fix link to plot_lda_qda example.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -89,7 +89,7 @@
 
     .. |banner14| image:: auto_examples/images/plot_lda_qda_1.png
        :height: 139
-       :target: auto_examples/plot_lda_vs_qda.html
+       :target: auto_examples/plot_lda_qda.html
 
     .. |banner15| image:: auto_examples/cluster/images/plot_cluster_comparison_1.png
        :height: 139


### PR DESCRIPTION
This PR fix the following issue:

When clicking in the `plot_lda_vs_qda` link http://scikit-learn.org/stable/auto_examples/plot_lda_vs_qda.html (one of the examples at the top of scikit-learn), I get a 404 error.
