### PR TITLE
[MRG] MinMaxScaler on zero variance features

### DIFF
--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -190,7 +190,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
                              " than maximum. Got %s." % str(feature_range))
         min_ = np.min(X, axis=0)
         scale_ = np.max(X, axis=0) - min_
-        # Do not scale feature with zero variance
+        # Do not scale constant features
         scale_[scale_ == 0.0] = 1.0
         self.scale_ = (feature_range[1] - feature_range[0]) / scale_
         self.min_ = feature_range[0] - min_ / scale_

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -190,6 +190,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
                              " than maximum. Got %s." % str(feature_range))
         min_ = np.min(X, axis=0)
         scale_ = np.max(X, axis=0) - min_
+        # Do not scale feature with zero variance
+        scale_[scale_ == 0.0] = 1.0
         self.scale_ = (feature_range[1] - feature_range[0]) / scale_
         self.min_ = feature_range[0] - min_ / scale_
         return self

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -137,13 +137,23 @@ def test_min_max_scaler_zero_variance_features():
          [ 0.,  1., -0.1],
          [ 0.,  1.,  1.1]]
 
-    scaler = MinMaxScaler()
+    X_new = [[ 0.,  2.,  0.5],
+             [-1.,  1.,  0. ],
+             [ 0.,  1.,  1.5]]
+
     # default params
+    scaler = MinMaxScaler()
     X_trans = scaler.fit_transform(X)
     X_expected_0_1 = [[ 0.,  0.,  0.5],
                       [ 0.,  0.,  0.0],
                       [ 0.,  0.,  1.0]]
     assert_array_almost_equal(X_trans, X_expected_0_1)
+
+    X_trans_new = scaler.transform(X_new)
+    X_expected_0_1_new = [[ 0.,  1.,  0.5  ],
+                          [-1.,  0.,  0.083],
+                          [ 0.,  0.,  1.333]]
+    assert_array_almost_equal(X_trans_new, X_expected_0_1_new, decimal=2)
 
     # not default params
     scaler = MinMaxScaler(feature_range=(1, 2))

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -111,7 +111,7 @@ def test_scaler_2d_arrays():
     assert_true(X_scaled is not X)
 
 
-def test_min_max_scaler():
+def test_min_max_scaler_iris():
     X = iris.data
     scaler = MinMaxScaler()
     # default params
@@ -129,6 +129,29 @@ def test_min_max_scaler():
     # raises on invalid range
     scaler = MinMaxScaler(feature_range=(2, 1))
     assert_raises(ValueError, scaler.fit, X)
+
+
+def test_min_max_scaler_zero_variance_features():
+    """Check min max scaler on toy data with zero variance features"""
+    X = [[ 0.,  1.,  0.5],
+         [ 0.,  1., -0.1],
+         [ 0.,  1.,  1.1]]
+
+    scaler = MinMaxScaler()
+    # default params
+    X_trans = scaler.fit_transform(X)
+    X_expected_0_1 = [[ 0.,  0.,  0.5],
+                      [ 0.,  0.,  0.0],
+                      [ 0.,  0.,  1.0]]
+    assert_array_almost_equal(X_trans, X_expected_0_1)
+
+    # not default params
+    scaler = MinMaxScaler(feature_range=(1, 2))
+    X_trans = scaler.fit_transform(X)
+    X_expected_1_2 = [[ 1.,  1.,  1.5],
+                      [ 1.,  1.,  1.0],
+                      [ 1.,  1.,  2.0]]
+    assert_array_almost_equal(X_trans, X_expected_1_2)
 
 
 def test_scaler_without_centering():


### PR DESCRIPTION
A simple bugfix + non-regression test.

There is no what's new entry, so I did not document the bugfix. When was that class introduced? Is it new in 0.13?
