### PR TITLE
train_test_split: test_size default is None

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -191,6 +191,9 @@ API changes summary
      :class:`decomposition.MiniBatchDictionaryLearning` and
      :class:`decomposition.MiniBatchSparsePCA` for consistency.
 
+   - Changed default test_size in :func:`cross_validation.train_test_split`
+     to None. 
+
 .. _changes_0_12.1:
 
 0.12.1

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -721,16 +721,17 @@ class ShuffleSplit(object):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float (default 0.1) or int
+    test_size : float (default 0.1), int, or None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples.
+        int, represents the absolute number of test samples. If None,
+        the value is automatically set to the complement of the train size.
 
     train_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the train split. If
         int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test fraction.
+        the value is automatically set to the complement of the test size.
 
     indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
@@ -821,6 +822,10 @@ class ShuffleSplit(object):
 
 
 def _validate_shuffle_split(n, test_size, train_size):
+    if test_size is None and train_size is None:
+        raise ValueError(
+            'test_size and train_size can not both be None')
+
     if test_size is not None:
         if np.asarray(test_size).dtype.kind == 'f':
             if test_size >= 1.:
@@ -924,16 +929,17 @@ class StratifiedShuffleSplit(object):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float (default 0.1) or int
+    test_size : float (default 0.1), int, or None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples.
+        int, represents the absolute number of test samples. If None,
+        the value is automatically set to the complement of the train size.
 
     train_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the train split. If
         int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test fraction.
+        the value is automatically set to the complement of the test size.
 
     indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -319,6 +319,9 @@ def test_train_test_split():
     assert_array_equal(X_test, X_s_test.toarray())
     assert_array_equal(X_train[:, 0], y_train * 10)
     assert_array_equal(X_test[:, 0], y_test * 10)
+    split = cval.train_test_split(X, y, test_size=None, train_size=.5)
+    X_train, X_test, y_train, y_test = split
+    assert_equal(len(y_test), len(y_train))
 
 
 def test_cross_val_score_with_score_func_classification():
@@ -465,6 +468,8 @@ def test_shufflesplit_errors():
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=10)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=8, train_size=3)
     assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=1j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=None,
+                train_size=None)
 
 
 def test_shufflesplit_reproducible():


### PR DESCRIPTION
If test_size is None and train_size is not None, test_size
is the complement of train_size. If test_size and train_size
are None, test_size = 0.25.
Docstring is updated.
Existing tests didn't seem to cover much of existing behaviour
and no updates were added. New behaviour was tested.
