### PR TITLE
ENH isotonic regression is now slighty more robust to noise

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -227,9 +227,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         X, y, weight = check_arrays(X, y, weight, sparse_format='dense')
         y = as_float_array(y)
         self._check_fit_data(X, y, weight)
-        order = np.argsort(X)
-        order_inv = np.zeros(len(y), dtype=np.int)
-        order_inv[order] = np.arange(len(y))
+        order = np.lexsort((y, X))
+        order_inv = np.argsort(order)
         self.X_ = as_float_array(X[order], copy=False)
         self.y_ = isotonic_regression(y[order], weight, self.y_min, self.y_max)
         return self.y_[order_inv]

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -24,6 +24,10 @@ def test_isotonic_regression():
                        ir.fit_transform(x, y)[perm])
     assert_array_equal(ir.transform(x[perm]), ir.transform(x)[perm])
 
+    # check it doesn't change y when all x are equal:
+    ir = IsotonicRegression()
+    assert_array_equal(ir.fit_transform(np.ones(len(x)), y), y)
+
 
 def test_assert_raises_exceptions():
     ir = IsotonicRegression()


### PR DESCRIPTION
By using sorting the similarities using lexsort on the pair similarities, distance, the isotonic regression is now slightly more robust to noise.

Cheers,
N
