### PR TITLE
[MRG]  mean absolute error and multioutput regression metrics

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -668,21 +668,21 @@ Classification metrics
    :toctree: generated/
    :template: function.rst
 
-   metrics.confusion_matrix
-   metrics.roc_curve
    metrics.auc
-   metrics.precision_score
-   metrics.recall_score
-   metrics.fbeta_score
-   metrics.f1_score
    metrics.auc_score
    metrics.average_precision_score
-   metrics.precision_recall_fscore_support
    metrics.classification_report
+   metrics.confusion_matrix
+   metrics.f1_score
+   metrics.fbeta_score
+   metrics.hinge_loss
    metrics.precision_recall_curve
+   metrics.precision_recall_fscore_support
+   metrics.precision_score
+   metrics.recall_score
+   metrics.roc_curve
    metrics.zero_one_score
    metrics.zero_one
-   metrics.hinge_loss
 
 Regression metrics
 ------------------

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -652,6 +652,9 @@ From text
 :mod:`sklearn.metrics`: Metrics
 ===============================
 
+See the :ref:`model_evaluation` section and the :ref:`metrics` section of the
+user guide for further details.
+
 .. automodule:: sklearn.metrics
    :no-members:
    :no-inherited-members:
@@ -683,6 +686,9 @@ Classification metrics
 
 Regression metrics
 ------------------
+
+See the :ref:`regression_metrics` section of the user guide for further
+details.
 
 .. autosummary::
    :toctree: generated/

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -694,8 +694,10 @@ details.
    :toctree: generated/
    :template: function.rst
 
-   metrics.r2_score
+   metrics.mean_absolute_error
    metrics.mean_squared_error
+   metrics.r2_score
+
 
 Clustering metrics
 ------------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -73,7 +73,7 @@ over :math:`n_{\text{samples}}` is given by
 
 .. math::
 
-  R^2(y) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_{\text{samples}}} (y_i - \bar{y})^2}
+  R^2(y, \hat{y}) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_{\text{samples}}} (y_i - \bar{y})^2}
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -3,12 +3,72 @@
 ===================
 Model evaluation
 ===================
+The :mod:`sklearn.metrics` implements score functions, performance metrics
+and pairwise metrics and distance computations. Those functions are usefull to
+assess the performance of an estimator under a specific criterion. Note that
+in many cases, the `score` method of the underlying estimator is sufficient
+and appropriate.
+
+In this module, functions named as
+
+  * `*_score` return a scalar value to maximize: the higher the better.
+  * `*_loss` return a scalar value to minimize: the lower the better
+
+.. _regression_metrics:
+
+Regression metrics
+==================
+
+.. currentmodule:: sklearn.metrics
+
+Mean squared error
+------------------
+The :func:`mean_squared_error` function allows to compute the mean square
+error, which is a risk function corresponding to the expected value
+of the squared error loss or quadratic loss.
+
+If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
+and :math:`y_i` is the corresponding true value, then the mean squared error
+(MSE) estimated over :math:`n_{\text{samples}}` is given by
+
+.. math::
+
+  MSE(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2.
+
+.. topic:: References:
+
+ * `Wikipedia - Mean squared error
+   <http://en.wikipedia.org/wiki/Mean_squared_error>`_
+
+
+R² score, the coefficient of determination
+------------------------------------------
+The :func:`r2_score` function allows to compute R², the coefficient of
+determination. It provides a measure of how well future samples are likely to
+be predicted by the model.
+
+If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
+and :math:`y_i` is the corresponding true value, then the score R² estimated
+over :math:`n_{\text{samples}}` is given by
+
+.. math::
+
+  R^2(y) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_{\text{samples}}} (y_i - \bar{y})^2}
+
+where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
+
+.. topic:: References:
+
+ * `Wikipedia - Coefficient of determination
+   <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_
+
 
 .. TODO
+  Classification metrics
+  ======================
 
-  Metrics
-  =======
-
+  Clustering metrics
+  ======================
 
 Dummy estimators
 =================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -21,6 +21,26 @@ Regression metrics
 
 .. currentmodule:: sklearn.metrics
 
+Mean absolute error
+-------------------
+The :func:`mean_absolute_error` function allows to compute the mean absolute
+error, which is a risk function corresponding to the expected value
+of the absolute error loss or :math:`l1`-norm loss.
+
+If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
+and :math:`y_i` is the corresponding true value, then the mean absolute error
+(MAE) estimated over :math:`n_{\text{samples}}` is given by
+
+.. math::
+
+  \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} \left| y_i - \hat{y}_i \right|.
+
+.. topic:: References:
+
+ * `Wikipedia - Mean absolute error
+   <http://en.wikipedia.org/wiki/Mean_absolute_error>`_
+
+
 Mean squared error
 ------------------
 The :func:`mean_squared_error` function allows to compute the mean square
@@ -33,7 +53,7 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
 .. math::
 
-  MSE(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2.
+  \text{MSE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2.
 
 .. topic:: References:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,8 +107,10 @@ Changelog
     Gaussian and sparse random projection matrix
     by `Olivier Grisel`_ and `Arnaud Joly`_.
 
-   - The :fun:`metrics.mean_squared_error` and :fun:`metrics.r2_score` metrics
-     support multioutput by `Arnaud Joly`_.
+   - Add the :fun:`metrics.mean_absolute_error` function which computes the
+     mean absolute error. The :fun:`metrics.mean_squared_error`,
+     :fun:`metrics.mean_absolute_error` and
+     :fun:`metrics.r2_score` metrics support multioutput by `Arnaud Joly`_.
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -107,6 +107,8 @@ Changelog
     Gaussian and sparse random projection matrix
     by `Olivier Grisel`_ and `Arnaud Joly`_.
 
+   - The :fun:`metrics.mean_squared_error` and :fun:`metrics.r2_score` metrics
+     support multioutput by `Arnaud Joly`_.
 
 API changes summary
 -------------------

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -8,7 +8,8 @@ from .metrics import (confusion_matrix, roc_curve, auc, precision_score,
                       precision_recall_fscore_support, classification_report,
                       precision_recall_curve, explained_variance_score,
                       r2_score, zero_one, hinge_loss, matthews_corrcoef,
-                      mean_squared_error, average_precision_score, auc_score)
+                      mean_squared_error, mean_absolute_error,
+                      average_precision_score, auc_score)
 
 from . import cluster
 from .cluster import adjusted_rand_score
@@ -39,8 +40,8 @@ __all__ = ['adjusted_mutual_info_score',
            'homogeneity_completeness_v_measure',
            'homogeneity_score',
            'matthews_corrcoef',
-           'mean_square_error',
            'mean_squared_error',
+           'mean_absolute_error',
            'mutual_info_score',
            'normalized_mutual_info_score',
            'pairwise_distances',

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1078,9 +1078,32 @@ def mean_squared_error(y_true, y_pred):
     Returns
     -------
     loss : float
+
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean((y_pred - y_true) ** 2)
+
+
+def mean_absolute_error(y_true, y_pred):
+    """Mean absolute error regression loss
+
+    Return a a positive floating point value (the best value is 0.0).
+
+    Parameters
+    ----------
+    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+        Ground truth (correct) target values.
+
+    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+        Estimated target values.
+
+    Returns
+    -------
+    loss : float
+
+    """
+    y_true, y_pred = check_arrays(y_true, y_pred)
+    return np.mean(np.abs(y_pred - y_true))
 
 
 def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -10,6 +10,7 @@ better
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
+#          Arnaud Joly <a.joly@ulg.ac.be>
 # License: BSD Style.
 
 from itertools import izip
@@ -973,10 +974,10 @@ def r2_score(y_true, y_pred):
 
     Parameters
     ----------
-    y_true : array-like
+    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
         Ground truth (correct) target values.
 
-    y_pred : array-like
+    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
         Estimated target values.
 
     Returns
@@ -997,7 +998,8 @@ def r2_score(y_true, y_pred):
         raise ValueError("r2_score can only be computed given more than one"
                          " sample.")
     numerator = ((y_true - y_pred) ** 2).sum()
-    denominator = ((y_true - y_true.mean()) ** 2).sum()
+    denominator = ((y_true - y_true.mean(axis=0)) ** 2).sum()
+
     if denominator == 0.0:
         if numerator == 0.0:
             return 1.0
@@ -1005,6 +1007,7 @@ def r2_score(y_true, y_pred):
             # arbitary set to zero to avoid -inf scores, having a constant
             # y_true is not interesting for scoring a regression anyway
             return 0.0
+
     return 1 - numerator / denominator
 
 
@@ -1066,9 +1069,11 @@ def mean_squared_error(y_true, y_pred):
 
     Parameters
     ----------
-    y_true : array-like
+    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+        Ground truth (correct) target values.
 
-    y_pred : array-like
+    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+        Estimated target values.
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -18,6 +18,7 @@ from sklearn.metrics import r2_score
 from sklearn.metrics import f1_score
 from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import mean_squared_error
+from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics import precision_score
@@ -481,6 +482,11 @@ def test_losses():
     assert_almost_equal(mean_squared_error(y_true, y_pred), 12.999 / n, 2)
     assert_almost_equal(mean_squared_error(y_true, y_true), 0.00, 2)
 
+    # mean_absolute_error and mean_squared_error are equal because of
+    # it is a binary problem.
+    assert_almost_equal(mean_absolute_error(y_true, y_pred), 12.999 / n, 2)
+    assert_almost_equal(mean_absolute_error(y_true, y_true), 0.00, 2)
+
     assert_almost_equal(explained_variance_score(y_true, y_pred), -0.04, 2)
     assert_almost_equal(explained_variance_score(y_true, y_true), 1.00, 2)
     assert_equal(explained_variance_score([0, 0, 0], [0, 1, 1]), 0.0)
@@ -494,6 +500,7 @@ def test_losses():
 def test_losses_at_limits():
     # test limit cases
     assert_almost_equal(mean_squared_error([0.], [0.]), 0.00, 2)
+    assert_almost_equal(mean_absolute_error([0.], [0.]), 0.00, 2)
     assert_almost_equal(explained_variance_score([0.], [0.]), 1.00, 2)
     assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
 
@@ -512,6 +519,10 @@ def test_symmetry():
                  zero_one(y_pred, y_true))
     assert_almost_equal(mean_squared_error(y_true, y_pred),
                         mean_squared_error(y_pred, y_true))
+
+    assert_almost_equal(mean_absolute_error(y_true, y_pred),
+                        mean_absolute_error(y_pred, y_true))
+
     # not symmetric
     assert_true(explained_variance_score(y_true, y_pred) !=
                 explained_variance_score(y_pred, y_true))
@@ -565,6 +576,9 @@ def test_multioutput_regression():
     error = mean_squared_error(y_true, y_pred)
     assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
 
+    error = mean_absolute_error(y_true, y_pred)
+    assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
+
     error = r2_score(y_true, y_pred)
     assert_almost_equal(error, 1 - 5. / 2)
 
@@ -581,6 +595,7 @@ def test_multioutput_number_of_output_differ():
                        ])
 
     assert_raises(ValueError, mean_squared_error, y_true, y_pred)
+    assert_raises(ValueError, mean_absolute_error, y_true, y_pred)
     assert_raises(ValueError, r2_score, y_true, y_pred)
 
 
@@ -591,7 +606,7 @@ def test_multioutput_regression_invariance_to_dimension_shuffling():
     y_true = np.reshape(y_true, (-1, n_dims))
     y_pred = np.reshape(y_pred, (-1, n_dims))
 
-    for metric in [r2_score, mean_squared_error]:
+    for metric in [r2_score, mean_squared_error, mean_absolute_error]:
         error = metric(y_true, y_pred)
 
         for _ in xrange(3):

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -549,3 +549,37 @@ def test_roc_curve_one_label():
     # all negative labels, all tpr should be nan
     assert_array_equal(tpr,
                        np.nan * np.ones(len(thresholds) + 1))
+
+
+def test_multioutput_regression():
+    y_true = np.array([[1, 0, 0, 1],
+                       [0, 1, 1, 1],
+                       [1, 1, 0, 1],
+                       ])
+
+    y_pred = np.array([[0, 0, 0, 1],
+                       [1, 0, 1, 1],
+                       [0, 0, 0, 1],
+                       ])
+
+    error = mean_squared_error(y_true, y_pred)
+    assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
+
+    error = r2_score(y_true, y_pred)
+    assert_almost_equal(error, 1 - 5. / 2)
+
+
+def test_multioutput_regression_invariance_to_dimension_shuffling():
+    # test invariance to dimension shuffling
+    y_true, y_pred, _ = make_prediction()
+    n_dims = 3
+    y_true = np.reshape(y_true, (-1, n_dims))
+    y_pred = np.reshape(y_pred, (-1, n_dims))
+
+    for metric in [r2_score, mean_squared_error]:
+        error = metric(y_true, y_pred)
+
+        for _ in xrange(3):
+            perm = np.random.permutation(n_dims)
+            assert_almost_equal(error,
+                                metric(y_true[:, perm], y_pred[:, perm]))

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -569,6 +569,21 @@ def test_multioutput_regression():
     assert_almost_equal(error, 1 - 5. / 2)
 
 
+def test_multioutput_number_of_output_differ():
+    y_true = np.array([[1, 0, 0, 1],
+                       [0, 1, 1, 1],
+                       [1, 1, 0, 1],
+                       ])
+
+    y_pred = np.array([[0, 0],
+                       [1, 0],
+                       [0, 0],
+                       ])
+
+    assert_raises(ValueError, mean_squared_error, y_true, y_pred)
+    assert_raises(ValueError, r2_score, y_true, y_pred)
+
+
 def test_multioutput_regression_invariance_to_dimension_shuffling():
     # test invariance to dimension shuffling
     y_true, y_pred, _ = make_prediction()


### PR DESCRIPTION
This pull request implement two new features :
- add the metrics `mean_absolute_error`;
- add multioutput support for `r2_score`,  `mean_absolute_error` and `mean_square_error`.

I have been unable to find a narrative documentation corresponding to those regression metrics. So I wrote it. 

Reviews and comments are welcome. :-)
