### PR TITLE
[MRG] Metric documentation (mainly in classification)

### DIFF
--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -192,7 +192,7 @@ def benchmark(clf):
     t0 = time()
     pred = clf.predict(X_test)
     test_time = time() - t0
-    err = metrics.zero_one(y_test, pred) / float(pred.shape[0])
+    err = metrics.zero_one_loss(y_test, pred) / float(pred.shape[0])
     return err, train_time, test_time
 
 ######################################################################

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -683,7 +683,7 @@ Classification metrics
    metrics.recall_score
    metrics.roc_curve
    metrics.zero_one_score
-   metrics.zero_one
+   metrics.zero_one_loss
 
 Regression metrics
 ------------------

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -668,6 +668,7 @@ Classification metrics
    :toctree: generated/
    :template: function.rst
 
+   metrics.accuracy_score
    metrics.auc
    metrics.auc_score
    metrics.average_precision_score
@@ -682,7 +683,6 @@ Classification metrics
    metrics.precision_score
    metrics.recall_score
    metrics.roc_curve
-   metrics.zero_one_score
    metrics.zero_one_loss
 
 Regression metrics

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -695,6 +695,7 @@ details.
    :toctree: generated/
    :template: function.rst
 
+   metrics.explained_variance_score
    metrics.mean_absolute_error
    metrics.mean_squared_error
    metrics.r2_score

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -704,7 +704,8 @@ details.
 Clustering metrics
 ------------------
 
-See the :ref:`clustering` section of the user guide for further details.
+See the :ref:`clustering_evaluation` section of the user guide for further
+details.
 
 .. automodule:: sklearn.metrics.cluster
    :no-members:

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -676,6 +676,7 @@ Classification metrics
    metrics.f1_score
    metrics.fbeta_score
    metrics.hinge_loss
+   metrics.matthews_corrcoef
    metrics.precision_recall_curve
    metrics.precision_recall_fscore_support
    metrics.precision_score

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -56,6 +56,9 @@ Others have been extended to the multiclass case:
 
 In the following sub-sections, we will describe each of those functions.
 
+.. Precision, recall ahd F-score
+.. -----------------------------
+
 Hinge loss
 ----------
 
@@ -72,6 +75,21 @@ value and :math:`w`, the predicted decisions as output by
   L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
 
+
+Zero one loss
+--------------
+The :func:`zero_one` function computes the 0-1 classification loss over
+:math:`n_{\text{samples}}`. If :math:`\hat{y}_i` is the predicted value of
+the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
+then the 0-1 loss :math:`L_{0-1}` is given by
+
+.. math::
+
+   L_{0-1}(y_i, \hat{y}_i) = 1(\hat{y} != y)
+
+where :math:`1(x)` is the indicator function.
+
+
 .. _regression_metrics:
 
 Regression metrics
@@ -81,7 +99,7 @@ Regression metrics
 
 Mean absolute error
 -------------------
-The :func:`mean_absolute_error` function allows to compute the `mean absolute
+The :func:`mean_absolute_error` function computes the `mean absolute
 error <http://en.wikipedia.org/wiki/Mean_absolute_error>`_, which is a risk
 function corresponding to the expected value of the absolute error loss or
 :math:`l1`-norm loss.
@@ -97,7 +115,7 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 
 Mean squared error
 ------------------
-The :func:`mean_squared_error` function allows to compute the `mean square
+The :func:`mean_squared_error` function computes the `mean square
 error <http://en.wikipedia.org/wiki/Mean_squared_error>`_, which is a risk
 function corresponding to the expected value of the squared error loss or
 quadratic loss.
@@ -113,7 +131,7 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
 R² score, the coefficient of determination
 ------------------------------------------
-The :func:`r2_score` function allows to compute R², the `coefficient of
+The :func:`r2_score` function computes R², the `coefficient of
 determination <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_.
 It provides a measure of how well future samples are likely to
 be predicted by the model.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -488,7 +488,7 @@ value and :math:`w` is the predicted decisions as output by
 
   L_\text{Hinge}(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
-Here a small example demontrating the use of the :func:`hinge_loss` function
+Here a small example demonstrating the use of the :func:`hinge_loss` function
 with a svm classifier:
 
   >>> from sklearn import svm
@@ -531,7 +531,7 @@ the MCC coefficient is defined as
 
   MCC = \frac{tp \times tn - fp \times fn}{\sqrt{(tp + fp)(tp + fn)(tn + fp)(tn + fn)}}.
 
-Here a small example illlustring the usage of the :func:`matthews_corrcoef`
+Here a small example illustrating the usage of the :func:`matthews_corrcoef`
 function:
 
     >>> from sklearn.metrics import matthews_corrcoef
@@ -547,7 +547,7 @@ Receiver operating characteristic (ROC)
 
 The function :func:`roc_curve` computes the `receiver operating characteristic
 curve, or ROC curve (quoting
-wikipedia) <http://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_:
+Wikipedia) <http://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_:
 
   "A receiver operating characteristic (ROC), or simply ROC curve, is a
   graphical plot which illustrates the performance of a binary classifier
@@ -769,7 +769,8 @@ Dummy estimators
 
 When doing supervised learning, a simple sanity check consists in comparing one's
 estimator against simple rules of thumb.
-:class:`DummyClassifier` implements three such simple strategies for classification:
+:class:`DummyClassifier` implements three such simple strategies for
+classification:
 
 - `stratified` generates randomly predictions by respecting the training
   set's class distribution,
@@ -783,34 +784,43 @@ To illustrate :class:`DummyClassifier`, first let's create an imbalanced
 dataset::
 
   >>> from sklearn.datasets import load_iris
+  >>> from sklearn.cross_validation import train_test_split
   >>> iris = load_iris()
   >>> X, y = iris.data, iris.target
   >>> y[y != 1] = -1
+  >>> X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
 Next, let's compare the accuracy of `SVC` and `most_frequent`::
 
   >>> from sklearn.dummy import DummyClassifier
   >>> from sklearn.svm import SVC
-  >>> clf = SVC(kernel='linear', C=1).fit(X, y)
-  >>> clf.score(X, y)  # doctest: +ELLIPSIS
-  0.73...
-  >>> clf = DummyClassifier(strategy='most_frequent', random_state=0).fit(X, y)
-  >>> clf.score(X, y)  # doctest: +ELLIPSIS
-  0.66...
+  >>> clf = SVC(kernel='linear', C=1).fit(X_train, y_train)
+  >>> clf.score(X_test, y_test) # doctest: +ELLIPSIS
+  0.63...
+  >>> clf = DummyClassifier(strategy='most_frequent',random_state=0)
+  >>> clf.fit(X_train, y_train)
+  DummyClassifier(random_state=0, strategy='most_frequent')
+  >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
+  0.57...
 
-We see that `SVC` doesn't do much better than a dummy classifier. Now, let's change
-the kernel::
+We see that `SVC` doesn't do much better than a dummy classifier. Now, let's
+change the kernel::
 
-  >>> clf = SVC(kernel='rbf', C=1).fit(X, y)
-  >>> clf.score(X, y)  # doctest: +ELLIPSIS
-  0.99...
+  >>> clf = SVC(kernel='rbf', C=1).fit(X_train, y_train)
+  >>> clf.score(X_test, y_test)  # doctest: +ELLIPSIS
+  0.97...
 
-We see that the accuracy was boosted to almost 100%.
+We see that the accuracy was boosted to almost 100%. For a better estimate
+of the accuracy, it is recommended to use a cross validation strategy, if it
+is not too CPU costly. For more information see the :ref:`cross_validation`
+section. Moreover if you want to optimize over the parameter space, it is
+highly recommended to use an appropriate methodology see the :ref:`grid_search`
+section.
 
-More generally, when the accuracy of a classifier is too close to random classification, it
-probably means that something went wrong: features are not helpful, a
-hyper parameter is not correctly tuned, the classifier is suffering from class
-imbalance, etc...
+More generally, when the accuracy of a classifier is too close to random
+classification, it probably means that something went wrong: features are not
+helpful, a hyper parameter is not correctly tuned, the classifier is suffering
+from class imbalance, etc...
 
 :class:`DummyRegressor` implements a simple rule of thumb for regression:
 always predict the mean of the training targets.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -43,6 +43,7 @@ Others have been extended to the multiclass case:
    :template: function.rst
 
   accuraccy_sscore
+  classification_report
   confusion_matrix
   f1_score
   fbeta_score
@@ -69,6 +70,10 @@ defined as
 
 where :math:`1(x)` is the indicator function.
 
+.. topic:: Example:
+  * See :ref:`example_plot_permutation_test_for_classification.py`
+    for an example of accuraccy score usage to assess with permutations the
+    significance of a classification score.
 
 Area under the curve (AUC)
 --------------------------
@@ -101,6 +106,41 @@ By definition a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
 equal to the number of observations known to be in group :math:`i` but
 predicted to be in group :math:`j`.
 
+.. topic:: Example:
+
+  * See :ref:`example_plot_confusion_matrix.py`
+    for an example of confusion matrix usage to evaluate the quality of the
+    output of a classifier.
+
+  * See :ref:`example_plot_digits_classification.py`
+    for an example of confusion matrix usage in the classification of the
+    hand-written digits.
+
+  * See :ref:`example_document_classification_20newsgroups.py`
+    for an example of confusion matrix usage in the classification of text
+    documents.
+
+
+Clasification report
+--------------------
+The :func:`classification_report` function build a text report showing the main
+ classification metrics.
+
+.. topic:: Example:
+
+  * See :ref:`example_plot_digits_classification.py`
+    for an example of classification report usage in the classification of the
+    hand-written digits.
+
+  * See :ref:`example_document_classification_20newsgroups.py`
+    for an example of classification report usage in the classification of text
+    documents.
+
+  * See :ref:`example_grid_search_digits.py`
+    for an example of classification report usage in parameter estimation using
+    grid search with a nested cross-validation
+
+
 .. _precision_recall_f_measure_metrics:
 
 Precision, recall and F-measures
@@ -123,6 +163,17 @@ score:
     for an example of precision-Recall metric to evaluate the quality of the
     output of a classifier with :func:`precision_recall_curve`.
 
+  * See :ref:`example_document_classification_20newsgroups.py`
+    for an example of f1 score usage with classification of text
+    documents.
+
+  * See :ref:`example_grid_search_digits.py`
+    for an example of precision and recall score usage in parameter estimation
+    using grid search with a nested cross-validation
+
+  * See :ref:`example_plot_sparse_recovery.py`
+    for an example of :func:`precision_recall_curve` usage in feature selection
+    for sparse linear models
 
 Binary classification
 ^^^^^^^^^^^^^^^^^^^^^
@@ -333,6 +384,9 @@ The following figure shows an example of ROC curve.
     for an example of receiver operating characteristic (ROC) metric to
     evaluate the quality of the output of a classifier using cross-validation.
 
+  * See :ref:`example_plot_species_distribution_modeling.py`
+    for an example of receiver operating characteristic (ROC) metric usage to
+    model species distribution.
 
 Zero one loss
 --------------
@@ -347,6 +401,12 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 
 where :math:`1(x)` is the indicator function.
 
+
+.. topic:: Example:
+
+  * See :ref:`example_plot_rfe_with_cross_validation.py`
+    for an example of zero one loss usage to perform recursive feature
+    elimination with cross-validation.
 
 
 .. _regression_metrics:
@@ -393,6 +453,7 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
 
+
 Mean squared error
 ------------------
 The :func:`mean_squared_error` function computes the `mean square
@@ -407,6 +468,12 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 .. math::
 
   \text{MSE}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (y_i - \hat{y}_i)^2.
+
+.. topic:: Examples:
+
+  * See :ref:`example_plot_gradient_boosting_regression.py`
+    for an example of mean squared error usage to
+    evaluate gradient boosting regression.
 
 
 R² score, the coefficient of determination
@@ -426,6 +493,11 @@ over :math:`n_{\text{samples}}` is defined as
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
 
+.. topic:: Examples:
+
+  * See :ref:`example_plot_lasso_and_elasticnet.py`
+    for an example of R² score usage to
+    evaluate Lasso and Elastic Net on sparse signals.
 
 Clustering metrics
 ======================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -239,6 +239,38 @@ value and :math:`w`, the predicted decisions as output by
   L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
 
+Receiver operating characteristic (ROC)
+---------------------------------------
+
+The function :func:`roc_curve` computes the `receiver operating characteristic
+curve, or ROC curve (quoting
+wikipedia) <http://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_:
+
+  A receiver operating characteristic (ROC), or simply ROC curve, is a
+  graphical plot which illustrates the performance of a binary classifier
+  system as its discrimination threshold is varied. It is created by plotting
+  the fraction of true positives out of the positives (TPR = true positive
+  rate) vs. the fraction of false positives out of the negatives (FPR = false
+  positive rate), at various threshold settings. TPR is also known as
+  sensitivity, and FPR is one minus the specificity or true negative rate.
+
+The following figure shows an example of ROC curve.
+
+.. image:: ../auto_examples/images/plot_roc_1.png
+   :target: ../auto_examples/plot_roc.html
+   :scale: 75
+   :align: center
+
+.. topic:: Examples:
+
+  * See :ref:`example_plot_roc.py`
+    for an example of receiver operating characteristic (ROC) metric to
+    evaluate the quality of the output of a classifier.
+
+  * See :ref:`example_plot_roc_crossval.py`
+    for an example of receiver operating characteristic (ROC) metric to
+    evaluate the quality of the output of a classifier using cross-validation.
+
 
 Zero one loss
 --------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -75,10 +75,16 @@ defined as
 where :math:`1(x)` is the `indicator function
 <http://en.wikipedia.org/wiki/Indicator_function>`_.
 
+  >>> from sklearn.metrics import accuracy_score
+  >>> y_pred = [0, 2, 1, 3]
+  >>> y_true = [0, 1, 2, 3]
+  >>> accuracy_score(y_true, y_pred)
+  0.5
+
 .. topic:: Example:
 
   * See :ref:`example_plot_permutation_test_for_classification.py`
-    for an example of accuracy score usage to assess using permutations of
+    for an example of accuracy score usage using permutations of
     the dataset.
 
 Area under the curve (AUC)
@@ -89,6 +95,13 @@ is the area under the receiver operating characteristic (ROC) curve.
 This function requires  the true binary value and the target scores, which can
 either be probability estimates of the positive class, confidence values, or
 binary decisions.
+
+  >>> import numpy as np
+  >>> from sklearn.metrics import auc_score
+  >>> y_true = np.array([0, 0, 1, 1])
+  >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+  >>> auc_score(y_true, y_scores)
+  0.75
 
 For more information see the
 `Wikipedia article on AUC
@@ -103,10 +116,18 @@ The :func:`average_precision_score` function computes the average precision
 (AP) from prediction scores. This score corresponds to the area under the
 precision-recall curve.
 
+  >>> import numpy as np
+  >>> from sklearn.metrics import average_precision_score
+  >>> y_true = np.array([0, 0, 1, 1])
+  >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+  >>> average_precision_score(y_true, y_scores)
+  0.79166666666666663
+
 For more information see the
 `Wikipedia article on average precision
 <http://en.wikipedia.org/wiki/Information_retrieval#Average_precision>`_
 and the :ref:`precision_recall_f_measure_metrics` section.
+
 
 Confusion matrix
 ----------------
@@ -153,20 +174,21 @@ Classification report
 ---------------------
 The :func:`classification_report` function builds a text report showing the
 main classification metrics. Here a small example with custom ``target_names``
-and infered labels::
+and infered labels:
 
-  >>> from sklearn.metrics import classification_report
-  >>> y_true = [0, 1, 2, 2, 0]
-  >>> y_pred = [0, 0, 2, 2, 0]
-  >>> target_names = ['class 0', 'class 1', 'class 2']
-  >>> print(classification_report(y_true, y_pred, target_names=target_names))
-               precision    recall  f1-score   support
-
-      class 0       0.67      1.00      0.80         2
-      class 1       0.00      0.00      0.00         1
-      class 2       1.00      1.00      1.00         2
-
-  avg / total       0.67      0.80      0.72         5
+   >>> from sklearn.metrics import classification_report
+   >>> y_true = [0, 1, 2, 2, 0]
+   >>> y_pred = [0, 0, 2, 2, 0]
+   >>> target_names = ['class 0', 'class 1', 'class 2']
+   >>> print(classification_report(y_true, y_pred, target_names=target_names))
+                precision    recall  f1-score   support
+   <BLANKLINE>
+       class 0       0.67      1.00      0.80         2
+       class 1       0.00      0.00      0.00         1
+       class 2       1.00      1.00      1.00         2
+   <BLANKLINE>
+   avg / total       0.67      0.80      0.72         5
+   <BLANKLINE>
 
 .. topic:: Example:
 
@@ -214,6 +236,9 @@ score:
    precision_recall_fscore_support
    precision_score
    recall_score
+
+Note that the :func:`precision_recall_curve` function is restricted to the
+binary case.
 
 The average precision score might also interest you. See the
 :ref:`average_precision_metrics` section.
@@ -269,6 +294,40 @@ In this context, we can define the notions of precision, recall and F-measure:
 
    F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}.
 
+Here some small examples in binary classification:
+
+  >>> from sklearn import metrics
+  >>> y_pred = [0, 1, 0, 0]
+  >>> y_true = [0, 1, 0, 1]
+  >>> metrics.precision_score(y_true, y_pred)
+  1.0
+  >>> metrics.recall_score(y_true, y_pred)
+  0.5
+  >>> metrics.f1_score(y_true, y_pred)
+  0.66666666666666663
+  >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)
+  0.83333333333333337
+  >>> metrics.fbeta_score(y_true, y_pred, beta=1)
+  0.66666666666666663
+  >>> metrics.fbeta_score(y_true, y_pred, beta=2)
+  0.55555555555555558
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
+  (array([ 0.66666667,  1.        ]), array([ 1. ,  0.5]), array([ 0.71428571,  0.83333333]), array([2, 2], dtype=int64))
+
+
+  >>> import numpy as np
+  >>> from sklearn.metrics import precision_recall_curve
+  >>> y_true = np.array([0, 0, 1, 1])
+  >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+  >>> precision, recall, threshold = precision_recall_curve(y_true, y_scores)
+  >>> precision
+  array([ 0.66666667,  0.5       ,  1.        ,  1.        ])
+  >>> recall
+  array([ 1. ,  0.5,  0.5,  0. ])
+  >>> threshold
+  array([ 0.35,  0.4 ,  0.8 ])
+
+
 Multiclass and multilabels classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In multiclass and multilabels classification task, the notions of precision,
@@ -319,7 +378,6 @@ The macro precision, recall and :math:`F_\beta` are averaged over all labels
 
   \texttt{macro\_{}F\_{}beta} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} {F_\beta}_j.
 
-
 The micro precision, recall and :math:`F_\beta` are averaged over all instances
 
 .. math::
@@ -350,6 +408,72 @@ their support
 
   \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{\beta^2 |\hat{y}_i| + |y_i|}.
 
+Let's show several example on how you can use those functions.
+Here an example when you set ``average`` to ``macro``:
+
+  >>> from sklearn import metrics
+  >>> y_true = [0, 1, 2, 0, 1, 2]
+  >>> y_pred = [0, 2, 1, 0, 0, 1]
+  >>> metrics.precision_score(y_true, y_pred, average='macro')
+  0.22222222222222221
+  >>> metrics.recall_score(y_true, y_pred, average='macro')
+  0.33333333333333331
+  >>> metrics.fbeta_score(y_true, y_pred, average='macro', beta=0.5)
+  0.23809523809523805
+  >>> metrics.f1_score(y_true, y_pred, average='macro')
+  0.26666666666666666
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='macro')
+  (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+
+Here an example when you set ``average`` to ``micro``:
+
+  >>> from sklearn import metrics
+  >>> y_true = [0, 1, 2, 0, 1, 2]
+  >>> y_pred = [0, 2, 1, 0, 0, 1]
+  >>> metrics.precision_score(y_true, y_pred, average='micro')
+  0.33333333333333331
+  >>> metrics.recall_score(y_true, y_pred, average='micro')
+  0.33333333333333331
+  >>> metrics.f1_score(y_true, y_pred, average='micro')
+  0.33333333333333331
+  >>> metrics.fbeta_score(y_true, y_pred, average='micro', beta=0.5)
+  0.33333333333333337
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='micro')
+  (0.33333333333333331, 0.33333333333333331, 0.33333333333333331, None)
+
+Here an example when you set ``average`` to ``weighted``:
+
+  >>> from sklearn import metrics
+  >>> y_true = [0, 1, 2, 0, 1, 2]
+  >>> y_pred = [0, 2, 1, 0, 0, 1]
+  >>> metrics.precision_score(y_true, y_pred, average='weighted')
+  0.22222222222222221
+  >>> metrics.recall_score(y_true, y_pred, average='weighted')
+  0.33333333333333331
+  >>> metrics.fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
+  0.23809523809523805
+  >>> metrics.f1_score(y_true, y_pred, average='weighted')
+  0.26666666666666666
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='weighted')
+  (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+
+Here an example
+when you set ``average`` to ``None``:
+
+  >>> from sklearn import metrics
+  >>> y_true = [0, 1, 2, 0, 1, 2]
+  >>> y_pred = [0, 2, 1, 0, 0, 1]
+  >>> metrics.precision_score(y_true, y_pred, average=None)
+  array([ 0.66666667,  0.        ,  0.        ])
+  >>> metrics.recall_score(y_true, y_pred, average=None)
+  array([ 1.,  0.,  0.])
+  >>> metrics.f1_score(y_true, y_pred, average=None)
+  array([ 0.8,  0. ,  0. ])
+  >>> metrics.fbeta_score(y_true, y_pred, average=None, beta=0.5)
+  array([ 0.71428571,  0.        ,  0.        ])
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
+  (array([ 0.66666667,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71428571,  0.        ,  0.        ]), array([2, 2, 2], dtype=int64))
+
 
 Hinge loss
 ----------
@@ -365,6 +489,24 @@ value and :math:`w` is the predicted decisions as output by
 .. math::
 
   L_\text{Hinge}(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
+
+Here a small example demontrating the use of the :func:`hinge_loss` function
+with a svm classifier:
+
+  >>> from sklearn import svm
+  >>> from sklearn.metrics import hinge_loss
+  >>> X = [[0], [1]]
+  >>> y = [-1, 1]
+  >>> est = svm.LinearSVC(random_state=0)
+  >>> est.fit(X, y)
+  LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
+       intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
+       random_state=0, tol=0.0001, verbose=0)
+  >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
+  >>> pred_decision
+  array([-2.18177944,  2.36355888,  0.09088972])
+  >>> hinge_loss([-1, 1, 1], pred_decision)
+  0.30303676038544258
 
 
 Matthews correlation coefficient
@@ -390,6 +532,15 @@ the MCC coefficient is defined as
 .. math::
 
   MCC = \frac{tp \times tn - fp \times fn}{\sqrt{(tp + fp)(tp + fn)(tn + fp)(tn + fn)}}.
+
+Here a small example illlustring the usage of the :func:`matthews_corrcoef`
+function:
+
+    >>> from sklearn.metrics import matthews_corrcoef
+    >>> y_true = [+1, +1, +1, -1]
+    >>> y_pred = [+1, -1, +1, +1]
+    >>> matthews_corrcoef(y_true, y_pred)
+    -0.33333333333333331
 
 .. _roc_metrics:
 
@@ -442,8 +593,10 @@ The following figure shows an example of such ROC curve.
 
 Zero one loss
 --------------
-The :func:`zero_one_loss` function computes the 0-1 classification loss over
-:math:`n_{\text{samples}}`. This function isn't normalized over the samples.
+The :func:`zero_one_loss` function computes the sum or the average of the 0-1
+classification loss (:math:`L_{0-1}`) over :math:`n_{\text{samples}}`. By
+defaults, the function normalizes over the sample. To get the sum of the
+:math:`L_{0-1}`, set ``normalize``  to ``False``.
 
 If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
@@ -456,7 +609,13 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 where :math:`1(x)` is the `indicator function
 <http://en.wikipedia.org/wiki/Indicator_function>`_.
 
-
+  >>> from sklearn.metrics import zero_one_loss
+  >>> y_pred = [1, 2, 3, 4]
+  >>> y_true = [2, 2, 3, 4]
+  >>> zero_one_loss(y_true, y_pred)
+  0.25
+  >>> zero_one_loss(y_true, y_pred, normalize=False)
+  1
 
 .. topic:: Example:
 
@@ -493,6 +652,13 @@ variance is  estimated  as follow:
 
 The best possible score is 1.0, lower values are worse.
 
+Here a small example of usage of the :func:`explained_variance_scoreé` function:
+
+    >>> from sklearn.metrics import explained_variance_score
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> explained_variance_score(y_true, y_pred)
+    0.95717344753747324
 
 Mean absolute error
 -------------------
@@ -508,6 +674,19 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 .. math::
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
+
+Here a small example of usage of the :func:`mean_absolute_error` function:
+
+  >>> from sklearn.metrics import mean_absolute_error
+  >>> y_true = [3, -0.5, 2, 7]
+  >>> y_pred = [2.5, 0.0, 2, 8]
+  >>> mean_absolute_error(y_true, y_pred)
+  0.5
+  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> mean_absolute_error(y_true, y_pred)
+  0.75
+
 
 
 Mean squared error
@@ -525,12 +704,23 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
   \text{MSE}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (y_i - \hat{y}_i)^2.
 
+Here a small example of usage of the :func:`mean_squared_error` function:
+
+  >>> from sklearn.metrics import mean_squared_error
+  >>> y_true = [3, -0.5, 2, 7]
+  >>> y_pred = [2.5, 0.0, 2, 8]
+  >>> mean_squared_error(y_true, y_pred)
+  0.375
+  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> mean_squared_error(y_true, y_pred)
+  0.70833333333333337
+
 .. topic:: Examples:
 
   * See :ref:`example_ensemble_plot_gradient_boosting_regression.py`
     for an example of mean squared error usage to
     evaluate gradient boosting regression.
-
 
 R² score, the coefficient of determination
 ------------------------------------------
@@ -548,6 +738,19 @@ over :math:`n_{\text{samples}}` is defined as
   R^2(y, \hat{y}) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}} - 1} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_\text{samples} - 1} (y_i - \bar{y})^2}
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}} - 1} y_i`.
+
+Here a small example of usage of the :func:`r2_score` function:
+
+  >>> from sklearn.metrics import r2_score
+  >>> y_true = [3, -0.5, 2, 7]
+  >>> y_pred = [2.5, 0.0, 2, 8]
+  >>> r2_score(y_true, y_pred)
+  0.94860813704496794
+  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> r2_score(y_true, y_pred)
+  0.93825665859564167
+
 
 .. topic:: Example:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -14,6 +14,49 @@ In this module, functions named as
   * `*_score` return a scalar value to maximize: the higher the better.
   * `*_loss` return a scalar value to minimize: the lower the better
 
+.. TODO
+   Missing from ref and doc
+   matthews_corrcoef
+   explained_variance_score
+
+
+.. _classification_metrics:
+
+Classification metrics
+======================
+
+.. currentmodule:: sklearn.metrics
+
+The :mod:`sklearn.metrics` implements several losses, scores and utility
+function to measure classification perfomance. Some of these are restricted to
+the binary classification case:
+
+.. autosummary::
+   :template: function.rst
+
+   auc_score
+   average_precision_score
+   hinge_loss
+   precision_recall_curve
+   roc_curve
+
+
+Others have been extended to the multiclass case:
+
+.. autosummary::
+   :template: function.rst
+
+  confusion_matrix
+  f1_score
+  fbeta_score
+  precision_recall_fscore_support
+  precision_score
+  zero_one_score
+  zero_one
+
+In the following sub-sections, we will describe each of those functions.
+
+
 .. _regression_metrics:
 
 Regression metrics

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -63,7 +63,6 @@ The :func:`hinge_loss` function allows to compute the average
 `hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge loss
 is used in maximal margin classification as support vector machines.
 
-
 If the labels are encoded with +1 and -1,  :math:`y`: the true
 value and :math:`w`, the predicted decisions as output by
 `decision_function`, then the hinge loss is given by:
@@ -82,9 +81,10 @@ Regression metrics
 
 Mean absolute error
 -------------------
-The :func:`mean_absolute_error` function allows to compute the mean absolute
-error, which is a risk function corresponding to the expected value
-of the absolute error loss or :math:`l1`-norm loss.
+The :func:`mean_absolute_error` function allows to compute the `mean absolute
+error <http://en.wikipedia.org/wiki/Mean_absolute_error>`_, which is a risk
+function corresponding to the expected value of the absolute error loss or
+:math:`l1`-norm loss.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the mean absolute error
@@ -94,17 +94,13 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} \left| y_i - \hat{y}_i \right|.
 
-.. topic:: References:
-
- * `Wikipedia - Mean absolute error
-   <http://en.wikipedia.org/wiki/Mean_absolute_error>`_
-
 
 Mean squared error
 ------------------
-The :func:`mean_squared_error` function allows to compute the mean square
-error, which is a risk function corresponding to the expected value
-of the squared error loss or quadratic loss.
+The :func:`mean_squared_error` function allows to compute the `mean square
+error <http://en.wikipedia.org/wiki/Mean_squared_error>`_, which is a risk
+function corresponding to the expected value of the squared error loss or
+quadratic loss.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the mean squared error
@@ -114,16 +110,12 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
   \text{MSE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2.
 
-.. topic:: References:
-
- * `Wikipedia - Mean squared error
-   <http://en.wikipedia.org/wiki/Mean_squared_error>`_
-
 
 R² score, the coefficient of determination
 ------------------------------------------
-The :func:`r2_score` function allows to compute R², the coefficient of
-determination. It provides a measure of how well future samples are likely to
+The :func:`r2_score` function allows to compute R², the `coefficient of
+determination <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_.
+It provides a measure of how well future samples are likely to
 be predicted by the model.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
@@ -138,13 +130,8 @@ where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{sample
 
 .. topic:: References:
 
- * `Wikipedia - Coefficient of determination
-   <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_
-
 
 .. TODO
-  Classification metrics
-  ======================
 
   Clustering metrics
   ======================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -56,6 +56,22 @@ Others have been extended to the multiclass case:
 
 In the following sub-sections, we will describe each of those functions.
 
+Hinge loss
+----------
+
+The :func:`hinge_loss` function allows to compute the average
+`hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge loss
+is used in maximal margin classification as support vector machines.
+
+
+If the labels are encoded with +1 and -1,  :math:`y`: the true
+value and :math:`w`, the predicted decisions as output by
+`decision_function`, then the hinge loss is given by:
+
+.. math::
+
+  L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
+
 
 .. _regression_metrics:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -42,15 +42,33 @@ Others have been extended to the multiclass case:
 .. autosummary::
    :template: function.rst
 
+  accuraccy_sscore
   confusion_matrix
   f1_score
   fbeta_score
   precision_recall_fscore_support
   precision_score
-  zero_one_score
   zero_one_loss
 
 In the following sub-sections, we will describe each of those functions.
+
+Accuraccy score
+---------------
+The :func:`  accuraccy_sscore` function computes the
+`accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
+of correct`predictions.
+
+If :math:`\hat{y}_i` is the predicted value of
+the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
+then the fraction of correct predictions over :math:`n_\text{samples}` is
+defined as
+
+.. math::
+
+   \texttt{accuraccy}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} 1(\hat{y} = y)
+
+where :math:`1(x)` is the indicator function.
+
 
 Area under the curve (AUC)
 --------------------------
@@ -326,23 +344,6 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 .. math::
 
    L_{0-1}(y_i, \hat{y}_i) = 1(\hat{y} \not= y)
-
-where :math:`1(x)` is the indicator function.
-
-Zero one score, the accuraccy
------------------------------
-The :func:`zero_one_score` function computes the
-`accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
-of correct`predictions.
-
-If :math:`\hat{y}_i` is the predicted value of
-the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
-then the fraction of correct predictions over :math:`n_\text{samples}` is
-defined as
-
-.. math::
-
-   \texttt{zero\_{}one}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} 1(\hat{y} = y)
 
 where :math:`1(x)` is the indicator function.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -425,10 +425,12 @@ over :math:`n_{\text{samples}}` is defined as
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
 
-.. TODO
 
-  Clustering metrics
-  ======================
+Clustering metrics
+======================
+The :mod:`sklearn.metrics` implements several losses, scores and utility
+for more information see the :ref:`clustering_evaluation` section.
+
 
 Dummy estimators
 =================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -56,6 +56,27 @@ Others have been extended to the multiclass case:
 
 In the following sub-sections, we will describe each of those functions.
 
+Area under the curve (AUC)
+--------------------------
+The :func:`auc_score` function computes the AUC which is
+the area under the receiver operating characteristic (ROC) curve.
+
+For more information see
+`wipedia article on AUC
+<http://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_curve>`_
+and the :ref:`roc_metrics` section.
+
+Average precision score
+-----------------------
+The :func:`average_precision_score` function computes the verage precision (AP)
+from prediction scores. This score corresponds to the area under the
+precision-recall curve.
+
+For more information see
+`wipedia article on average precision
+<http://en.wikipedia.org/wiki/Information_retrieval#Average_precision>`_
+and the :ref:`precision_recall_f_measure_metrics` section.
+
 Confusion matrix
 ----------------
 The :func:`confusion_matrix` function computes the `confusion matrix
@@ -65,6 +86,8 @@ the accuracy on a classification problem.
 By definition a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
 equal to the number of observations known to be in group :math:`i` but
 predicted to be in group :math:`j`.
+
+.. _precision_recall_f_measure_metrics:
 
 Precision, recall and F-measures
 --------------------------------
@@ -85,7 +108,6 @@ score:
   * See :ref:`example_plot_precision_recall.py`
     for an example of precision-Recall metric to evaluate the quality of the
     output of a classifier with :func:`precision_recall_curve`.
-
 
 
 Binary classification
@@ -137,9 +159,9 @@ With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
 
 .. topic:: References:
 
-   * `Precision and recall
+   * `Wikipedia article on precision and recall
      <http://en.wikipedia.org/wiki/Precision_and_recall>`_
-   * `F-measure <http://en.wikipedia.org/wiki/F1_score>`_
+   * `Wikipedia article on F-measure <http://en.wikipedia.org/wiki/F1_score>`_
 
 Multiclass and multilabels classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,6 +260,8 @@ value and :math:`w`, the predicted decisions as output by
 
   L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
+
+.. _roc_metrics:
 
 Receiver operating characteristic (ROC)
 ---------------------------------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -12,12 +12,8 @@ and appropriate.
 In this module, functions named as
 
   * `*_score` return a scalar value to maximize: the higher the better.
-  * `*_loss` return a scalar value to minimize: the lower the better
-
-.. TODO
-   Missing from ref and doc
-   explained_variance_score
-
+  * `*_error` or `*_loss` return a scalar value to minimize: the lower the
+    better
 
 .. _classification_metrics:
 
@@ -333,9 +329,6 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 
 where :math:`1(x)` is the indicator function.
 
-
-.. _regression_metrics:
-
 Zero one score, the accuraccy
 -----------------------------
 The :func:`zero_one` function computes the
@@ -353,11 +346,19 @@ defined as
 
 where :math:`1(x)` is the indicator function.
 
+
+
+.. _regression_metrics:
+
 Regression metrics
 ==================
 
 .. currentmodule:: sklearn.metrics
 
+The :mod:`sklearn.metrics` implements several losses, scores and utility
+functions to measure regressiion perfomance. Some of those have enhanced
+to treat the multioutput case: :func:`mean_absolute_error`,
+:func:`mean_absolute_error` and :func:`mean_squared_error`.
 
 
 Explained variance score

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -48,7 +48,7 @@ Others have been extended to the multiclass case:
   precision_recall_fscore_support
   precision_score
   zero_one_score
-  zero_one
+  zero_one_loss
 
 In the following sub-sections, we will describe each of those functions.
 
@@ -318,7 +318,7 @@ The following figure shows an example of ROC curve.
 
 Zero one loss
 --------------
-The :func:`zero_one` function computes the 0-1 classification loss over
+The :func:`zero_one_loss` function computes the 0-1 classification loss over
 :math:`n_{\text{samples}}`. If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
 then the 0-1 loss :math:`L_{0-1}` is defined as:
@@ -331,7 +331,7 @@ where :math:`1(x)` is the indicator function.
 
 Zero one score, the accuraccy
 -----------------------------
-The :func:`zero_one` function computes the
+The :func:`zero_one_score` function computes the
 `accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
 of correct`predictions.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -408,8 +408,7 @@ their support
 
   \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{\beta^2 |\hat{y}_i| + |y_i|}.
 
-Let's show several example on how you can use those functions.
-Here an example when you set ``average`` to ``macro``:
+Here an example where ``average`` is set to ``average`` to ``macro``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -425,7 +424,7 @@ Here an example when you set ``average`` to ``macro``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='macro')
   (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
 
-Here an example when you set ``average`` to ``micro``:
+Here an example where ``average`` is set to to ``micro``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -441,7 +440,7 @@ Here an example when you set ``average`` to ``micro``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='micro')
   (0.33333333333333331, 0.33333333333333331, 0.33333333333333331, None)
 
-Here an example when you set ``average`` to ``weighted``:
+Here an example where ``average`` is set to to ``weighted``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
@@ -457,8 +456,7 @@ Here an example when you set ``average`` to ``weighted``:
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='weighted')
   (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
 
-Here an example
-when you set ``average`` to ``None``:
+Here an example where ``average`` is set to ``None``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -62,7 +62,7 @@ In the following sub-sections, we will describe each of those functions.
 Hinge loss
 ----------
 
-The :func:`hinge_loss` function allows to compute the average
+The :func:`hinge_loss` function computes the average
 `hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge loss
 is used in maximal margin classification as support vector machines.
 
@@ -91,6 +91,22 @@ where :math:`1(x)` is the indicator function.
 
 
 .. _regression_metrics:
+
+Zero one score, the accuraccy
+-----------------------------
+The :func:`zero_one` function computes the
+`accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
+of correct`predictions.
+
+If :math:`\hat{y}_i` is the predicted value of
+the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
+then the fraction of correct predictions over :math:`n_\text{samples}` is given by
+
+.. math::
+
+   \texttt{zero\_{}one}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}} 1(\hat{y} = y)
+
+where :math:`1(x)` is the indicator function.
 
 Regression metrics
 ==================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -135,7 +135,7 @@ The :func:`confusion_matrix` function computes the `confusion matrix
 <http://en.wikipedia.org/wiki/Confusion_matrix>`_ to evaluate
 the accuracy on a classification problem.
 
-By definition, a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
+By definition, a confusion matrix :math:`C` is such that :math:`C_{i, j}` is
 equal to the number of observations known to be in group :math:`i` but
 predicted to be in group :math:`j`. Here an example of such confusion matrix::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -23,8 +23,9 @@ Classification metrics
 .. currentmodule:: sklearn.metrics
 
 The :mod:`sklearn.metrics` implements several losses, scores and utility
-functions to measure classification performance. Some of these are restricted to
-the binary classification case:
+functions to measure classification performance.
+
+Some of these are restricted to the binary classification case:
 
 .. autosummary::
    :template: function.rst
@@ -37,7 +38,7 @@ the binary classification case:
    roc_curve
 
 
-Others have been extended to the multiclass case:
+Others also work in the multiclass case:
 
 .. autosummary::
    :template: function.rst
@@ -50,6 +51,9 @@ Others have been extended to the multiclass case:
   precision_recall_fscore_support
   precision_score
   zero_one_loss
+
+Some metrics might require probability estimates of the positive class,
+confidence values or binary decisions value.
 
 In the following sub-sections, we will describe each of those functions.
 
@@ -74,18 +78,24 @@ where :math:`1(x)` is the `indicator function
 .. topic:: Example:
 
   * See :ref:`example_plot_permutation_test_for_classification.py`
-    for an example of accuracy score usage to assess with permutations the
-    significance of a classification score.
+    for an example of accuracy score usage to assess using permutations of
+    the dataset.
 
 Area under the curve (AUC)
 --------------------------
-The :func:`auc_score` function computes the AUC which is
-the area under the receiver operating characteristic (ROC) curve.
+The :func:`auc_score` function computes the 'area under the curve' (AUC) which
+is the area under the receiver operating characteristic (ROC) curve.
+
+This function requires  the true binary value and the target scores, which can
+either be probability estimates of the positive class, confidence values, or
+binary decisions.
 
 For more information see the
 `Wikipedia article on AUC
 <http://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_curve>`_
 and the :ref:`roc_metrics` section.
+
+.. _average_precision_metrics:
 
 Average precision score
 -----------------------
@@ -106,7 +116,23 @@ the accuracy on a classification problem.
 
 By definition, a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
 equal to the number of observations known to be in group :math:`i` but
-predicted to be in group :math:`j`.
+predicted to be in group :math:`j`. Here an example of such confusion matrix::
+
+  >>> from sklearn.metrics import confusion_matrix
+  >>> y_true = [2, 0, 2, 2, 0, 1]
+  >>> y_pred = [0, 0, 2, 2, 0, 2]
+  >>> confusion_matrix(y_true, y_pred)
+  array([[2, 0, 0],
+         [0, 0, 1],
+         [1, 0, 2]])
+
+Here a visual representation of such confusion matrix (this figure comes
+from the :ref:`example_plot_confusion_matrix.py` example):
+
+.. image:: ../auto_examples/images/plot_confusion_matrix_1.png
+   :target: ../auto_examples/plot_confusion_matrix.html
+   :scale: 75
+   :align: center
 
 .. topic:: Example:
 
@@ -126,7 +152,21 @@ predicted to be in group :math:`j`.
 Classification report
 ---------------------
 The :func:`classification_report` function builds a text report showing the
-main classification metrics.
+main classification metrics. Here a small example with custom ``target_names``
+and infered labels::
+
+  >>> from sklearn.metrics import classification_report
+  >>> y_true = [0, 1, 2, 2, 0]
+  >>> y_pred = [0, 0, 2, 2, 0]
+  >>> target_names = ['class 0', 'class 1', 'class 2']
+  >>> print(classification_report(y_true, y_pred, target_names=target_names))
+               precision    recall  f1-score   support
+
+      class 0       0.67      1.00      0.80         2
+      class 1       0.00      0.00      0.00         1
+      class 2       1.00      1.00      1.00         2
+
+  avg / total       0.67      0.80      0.72         5
 
 .. topic:: Example:
 
@@ -147,6 +187,21 @@ main classification metrics.
 
 Precision, recall and F-measures
 --------------------------------
+
+The `precision <http://en.wikipedia.org/wiki/Precision_and_recall#Precision>`_
+is intuitively the ability of the classifier not to label as
+positive a sample that is negative.
+
+The `recall <http://en.wikipedia.org/wiki/Precision_and_recall#Recall>`_ is
+intuitively the ability of the classifier to find all the positive samples.
+
+The  `F-measure <http://en.wikipedia.org/wiki/F1_score>`_
+(:math:`F_\beta` and :math:`F_1` measures) can be interpreted as a weighted
+harmonic mean of the precision and recall. A
+:math:`F_\beta` measure reaches its best value at 1 and worst score at 0.
+With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
+:math:`F_1` measure, wheres the recall and the precsion are equally important.
+
 Several functions allow you to analyze the precision, recall and F-measures
 score:
 
@@ -160,7 +215,10 @@ score:
    precision_score
    recall_score
 
-.. topic:: Example:
+The average precision score might also interest you. See the
+:ref:`average_precision_metrics` section.
+
+.. topic:: Examples:
 
   * See :ref:`example_document_classification_20newsgroups.py`
     for an example of :func:`f1_score` usage with classification of text
@@ -197,39 +255,19 @@ following table:
 |                   | Missing result      | Correct absence of result|
 +-------------------+---------------------+--------------------------+
 
-In this context, we can define the notions of precision, recall and F-measure.
-
-The precision is intuitively the ability of the classifier not to label as
-positive a sample that is negative and is defined as
+In this context, we can define the notions of precision, recall and F-measure:
 
 .. math::
 
-   \text{precision} = \frac{tp}{tp + fp}.
-
-The recall is intuitively the ability of the classifier to find all the
-positive samples and is defined as
+   \text{precision} = \frac{tp}{tp + fp},
 
 .. math::
 
-   \text{recall} = \frac{tp}{tp + fn}.
-
-
-The :math:`F_\beta` measure can be interpreted as a weighted harmonic mean of
-the precision and recall
+   \text{recall} = \frac{tp}{tp + fn},
 
 .. math::
 
-   F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\text{precision} + \text{recall}}
-
-A :math:`F_\beta` measure reaches its best value at 1 and worst score at 0.
-With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
-:math:`F_1` measure, wheres the recall and the precsion are equally important.
-
-.. topic:: References:
-
-   * `Wikipedia article on precision and recall
-     <http://en.wikipedia.org/wiki/Precision_and_recall>`_
-   * `Wikipedia article on F-measure <http://en.wikipedia.org/wiki/F1_score>`_
+   F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}.
 
 Multiclass and multilabels classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,7 +288,7 @@ Moreover, these notions can be further extended. The functions
 .. warning::
 
   Currently those functions support only the multiclass case. However the
-  following definitions will be general and will remain valid in the multilabel
+  following definitions are general and remain valid in the multilabel
   case.
 
 Let's define some notations:
@@ -294,7 +332,7 @@ The micro precision, recall and :math:`F_\beta` are averaged over all instances
 
 .. math::
 
-  \texttt{micro\_{}F\_{}beta} = (1 + \beta^2) \frac{\texttt{micro\_{}precision} \times  \texttt{micro\_{}recall}}{\texttt{micro\_{}precision} +  \texttt{micro\_{}recall}}.
+  \texttt{micro\_{}F\_{}beta} = (1 + \beta^2) \frac{\texttt{micro\_{}precision} \times  \texttt{micro\_{}recall}}{\beta^2 \texttt{micro\_{}precision} +  \texttt{micro\_{}recall}}.
 
 
 The weighted precision, recall and :math:`F_\beta` are averaged weighted by
@@ -310,7 +348,7 @@ their support
 
 .. math::
 
-  \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{|y_i| + |\hat{y}_i|}.
+  \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{\beta^2 |\hat{y}_i| + |y_i|}.
 
 
 Hinge loss
@@ -370,6 +408,17 @@ wikipedia) <http://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_:
   positive rate), at various threshold settings. TPR is also known as
   sensitivity, and FPR is one minus the specificity or true negative rate."
 
+Here a small example of how to use the :func:`roc_curve` function::
+
+    >>> import numpy as np
+    >>> from sklearn import metrics
+    >>> y = np.array([1, 1, 2, 2])
+    >>> scores = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
+    >>> fpr
+    array([ 0. ,  0.5,  0.5,  1. ])
+
+
 The following figure shows an example of such ROC curve.
 
 .. image:: ../auto_examples/images/plot_roc_1.png
@@ -394,7 +443,9 @@ The following figure shows an example of such ROC curve.
 Zero one loss
 --------------
 The :func:`zero_one_loss` function computes the 0-1 classification loss over
-:math:`n_{\text{samples}}`. If :math:`\hat{y}_i` is the predicted value of
+:math:`n_{\text{samples}}`. This function isn't normalized over the samples.
+
+If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
 then the 0-1 loss :math:`L_{0-1}` is defined as:
 
@@ -404,6 +455,7 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 
 where :math:`1(x)` is the `indicator function
 <http://en.wikipedia.org/wiki/Indicator_function>`_.
+
 
 
 .. topic:: Example:
@@ -497,7 +549,7 @@ over :math:`n_{\text{samples}}` is defined as
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}} - 1} y_i`.
 
-.. topic:: Examples:
+.. topic:: Example:
 
   * See :ref:`example_linear_model_plot_lasso_and_elasticnet.py`
     for an example of R² score usage to
@@ -506,7 +558,7 @@ where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{sample
 Clustering metrics
 ======================
 The :mod:`sklearn.metrics` implements several losses, scores and utility
-for more information see the :ref:`clustering_evaluation` section.
+function for more information see the :ref:`clustering_evaluation` section.
 
 
 Dummy estimators

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -16,7 +16,6 @@ In this module, functions named as
 
 .. TODO
    Missing from ref and doc
-   matthews_corrcoef
    explained_variance_score
 
 
@@ -37,6 +36,7 @@ the binary classification case:
    auc_score
    average_precision_score
    hinge_loss
+   matthews_corrcoef
    precision_recall_curve
    roc_curve
 
@@ -193,7 +193,8 @@ Let's define some notations:
      :math:`\texttt{F\_beta}_j` are respectively the precision, the recall and
      :math:`F_\beta` measure for the :math:`j`-th label;
    * :math:`tp_j`, :math:`fp_j` and :math:`fn_j` respectively the number of
-     true positive, false positive, false negative for the :math:`j`-th label;
+     true positives, false positives, false negatives for the :math:`j`-th
+     label;
    * :math:`y_i` is the set of true label and
      :math:`\hat{y}_i` is the set of predicted for the
      :math:`i`-th sample;
@@ -244,7 +245,6 @@ their support
   \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{|y_i| + |\hat{y}_i|}
 
 
-
 Hinge loss
 ----------
 
@@ -260,6 +260,30 @@ value and :math:`w`, the predicted decisions as output by
 
   L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
+
+Matthews correlation coefficient
+--------------------------------
+The :func:`matthews_corrcoef` function computes the matthew's correlation
+coefficient (MCC) for binary classes (quoting the `wikipedia article on the
+matthew's correlation coefficient
+<http://en.wikipedia.org/wiki/Matthews_correlation_coefficient>`_)
+
+    The Matthews correlation coefficient is used in machine learning as a
+    measure of the quality of binary (two-class) classifications. It takes
+    into account true and false positives and negatives and is generally
+    regarded as a balanced measure which can be used even if the classes are
+    of very different sizes. The MCC is in essence a correlation coefficient
+    value between -1 and +1. A coefficient of +1 represents a perfect
+    prediction, 0 an average random prediction and -1 an inverse prediction.
+    The statistic is also known as the phi coefficient. [source: Wikipedia]
+
+If :math:`tp`, :math:`tn`, :math:`fp` and :math:`fn` are respectively the
+number of true positives, true negatives, false positives ans false negatives,
+the MCC coefficient is defined as
+
+.. math::
+
+  MCC = \frac{tp \times tn - fp \times fn}{\sqrt{(tp + fp)(tp + fn)(tn + fp)(tn + fn)}}
 
 .. _roc_metrics:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -6,7 +6,7 @@ Model evaluation
 The :mod:`sklearn.metrics` implements score functions, performance metrics
 and pairwise metrics and distance computations. Those functions are usefull to
 assess the performance of an estimator under a specific criterion. Note that
-in many cases, the `score` method of the underlying estimator is sufficient
+in many cases, the ``score`` method of the underlying estimator is sufficient
 and appropriate.
 
 In this module, functions named as
@@ -56,19 +56,183 @@ Others have been extended to the multiclass case:
 
 In the following sub-sections, we will describe each of those functions.
 
-.. Precision, recall ahd F-score
-.. -----------------------------
+Confusion matrix
+----------------
+The :func:`confusion_matrix` function computes the `confusion matrix
+<http://en.wikipedia.org/wiki/Confusion_matrix>`_ to evaluate
+the accuracy on a classification problem.
+
+By definition a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
+equal to the number of observations known to be in group :math:`i` but
+predicted to be in group :math:`j`.
+
+Precision, recall and F-measures
+--------------------------------
+Several functions allow you to analyse the precision, recall and F-measures
+score:
+
+.. autosummary::
+   :template: function.rst
+
+   f1_score
+   fbeta_score
+   precision_recall_curve
+   precision_recall_fscore_support
+   precision_score
+
+.. topic:: Example:
+
+  * See :ref:`example_plot_precision_recall.py`
+    for an example of precision-Recall metric to evaluate the quality of the
+    output of a classifier with :func:`precision_recall_curve`.
+
+
+
+Binary classification
+^^^^^^^^^^^^^^^^^^^^^
+
+In a binary classification task, the terms ''positive'' and ''negative'' refer
+to the classifier's prediction and the terms ''true'' and ''false'' refer to
+whether that prediction corresponds to the external judgment (sometimes known
+as the ''observation''). Given these definitions, we can formulate the
+following table:
+
++-------------------+------------------------------------------------+
+|                   |    Actual class (observation)                  |
++-------------------+---------------------+--------------------------+
+|   Predicted class | tp (true positive)  | fp (false positive)      |
+|   (expectation)   | Correct result      | Unexpected result        |
+|                   +---------------------+--------------------------+
+|                   | fn (false negative) | tn (true negative)       |
+|                   | Missing result      | Correct absence of result|
++-------------------+---------------------+--------------------------+
+
+In this context, we can define the notions of precision, recall and F-measure.
+
+The precision is intuitively the ability of the classifier not to label as
+positive a sample that is negative
+
+.. math::
+
+   \text{precision} = \frac{tp}{tp + fp}.
+
+The recall is intuitively the ability of the classifier to find all the
+positive samples
+
+.. math::
+
+   \text{recall} = \frac{tp}{tp + fn}.
+
+
+The :math:`F_\beta` measure can be interpreted as a weighted harmonic mean of
+the precision and recall, where a :math:`F_\beta` measure reaches
+its best value at 1 and worst score at 0.
+
+.. math::
+
+   F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\text{precision} + \text{recall}}
+
+With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
+:math:`F_1` measure, wheres the recall and he precsion are equally important.
+
+.. topic:: References:
+
+   * `Precision and recall
+     <http://en.wikipedia.org/wiki/Precision_and_recall>`_
+   * `F-measure <http://en.wikipedia.org/wiki/F1_score>`_
+
+Multiclass and multilabels classification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In multiclass and multilabels classification task, the notions of precision,
+recall and F-measures can be applied to each label independantly.
+
+Nevertheless, these notions can be further extended:
+
+The functions :func:`f1_score`, :func:`fbeta_score`,
+:func:`precision_recall_fscore_support` and `precision_score` support an
+argument ``average`` which define the type of averaging that is performed:
+
+ * ``"macro"``: average over classes (does not take imbalance into account).
+ * ``"micro"``: average over instances (takes imbalance into account).
+ * ``"weighted"``: average weighted by support (takes imbalance into account).
+   It can result in f1 score that is not between precision and recall.
+ * ``None``: no averaging is performed.
+
+.. warning::
+
+  Currently those functions support only the multiclass case. But the following
+  definitions will be general and will treat the multilabel case.
+
+Let's define some notations:
+
+   * :math:`n_\text{labels}` and :math:`n_\text{samples}` denotes respectively the
+     number of labels and the number of samples.
+   * :math:`\texttt{precision}_j`, :math:`\texttt{recall}_j` and
+     :math:`\texttt{F\_beta}_j` are respectively the precision, the recall and
+     :math:`F_\beta` measure for the :math:`j`-th label;
+   * :math:`tp_j`, :math:`fp_j` and :math:`fn_j` respectively the number of
+     true positive, false positive, false negative for the :math:`j`-th label;
+   * :math:`y_i` is the set of true label and
+     :math:`\hat{y}_i` is the set of predicted for the
+     :math:`i`-th sample;
+
+The macro precision, recall and :math:`F_\beta` are averaged over all labels
+
+.. math::
+
+  \texttt{macro\_{}precision} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{precision}_j
+
+.. math::
+
+  \texttt{macro\_{}recall} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{recall}_j
+
+.. math::
+
+  \texttt{macro\_{}F\_{}beta} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{F\_beta}_j
+
+
+The micro precision, recall and :math:`F_\beta` are averaged over all instance
+
+.. math::
+
+  \texttt{micro\_{}precision} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fp_j}
+
+.. math::
+
+  \texttt{micro\_{}recall} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fn_j}
+
+.. math::
+
+  \texttt{micro\_{}F\_{}beta} = (1 + \beta^2) \frac{\texttt{micro\_{}precision} \times  \texttt{micro\_{}recall}}{\texttt{micro\_{}precision} +  \texttt{micro\_{}recall}}
+
+
+The weighted precision, recall and :math:`F_\beta` are averaged weighted by
+their support
+
+.. math::
+
+  \texttt{weighted\_{}precision}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|y_i \cup \hat{y}_i|}
+
+.. math::
+
+  \texttt{weighted\_{}recall}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|\hat{y}_i|}
+
+.. math::
+
+  \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{|y_i| + |\hat{y}_i|}
+
+
 
 Hinge loss
 ----------
 
 The :func:`hinge_loss` function computes the average
-`hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge loss
-is used in maximal margin classification as support vector machines.
+`hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge
+loss is used in maximal margin classification as support vector machines.
 
 If the labels are encoded with +1 and -1,  :math:`y`: the true
 value and :math:`w`, the predicted decisions as output by
-`decision_function`, then the hinge loss is given by:
+``decision_function``, then the hinge loss is defined as:
 
 .. math::
 
@@ -81,11 +245,11 @@ Zero one loss
 The :func:`zero_one` function computes the 0-1 classification loss over
 :math:`n_{\text{samples}}`. If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
-then the 0-1 loss :math:`L_{0-1}` is given by
+then the 0-1 loss :math:`L_{0-1}` is defined as:
 
 .. math::
 
-   L_{0-1}(y_i, \hat{y}_i) = 1(\hat{y} != y)
+   L_{0-1}(y_i, \hat{y}_i) = 1(\hat{y} \not= y)
 
 where :math:`1(x)` is the indicator function.
 
@@ -100,11 +264,12 @@ of correct`predictions.
 
 If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
-then the fraction of correct predictions over :math:`n_\text{samples}` is given by
+then the fraction of correct predictions over :math:`n_\text{samples}` is
+defined as
 
 .. math::
 
-   \texttt{zero\_{}one}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}} 1(\hat{y} = y)
+   \texttt{zero\_{}one}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} 1(\hat{y} = y)
 
 where :math:`1(x)` is the indicator function.
 
@@ -122,11 +287,11 @@ function corresponding to the expected value of the absolute error loss or
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the mean absolute error
-(MAE) estimated over :math:`n_{\text{samples}}` is given by
+(MAE) estimated over :math:`n_{\text{samples}}` is defined as
 
 .. math::
 
-  \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} \left| y_i - \hat{y}_i \right|.
+  \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
 
 
 Mean squared error
@@ -138,11 +303,11 @@ quadratic loss.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the mean squared error
-(MSE) estimated over :math:`n_{\text{samples}}` is given by
+(MSE) estimated over :math:`n_{\text{samples}}` is defined as
 
 .. math::
 
-  \text{MSE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2.
+  \text{MSE}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (y_i - \hat{y}_i)^2.
 
 
 R² score, the coefficient of determination
@@ -154,16 +319,13 @@ be predicted by the model.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the score R² estimated
-over :math:`n_{\text{samples}}` is given by
+over :math:`n_{\text{samples}}` is defined as
 
 .. math::
 
-  R^2(y, \hat{y}) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}}} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_{\text{samples}}} (y_i - \bar{y})^2}
+  R^2(y, \hat{y}) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}} - 1} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_\text{samples} - 1} (y_i - \bar{y})^2}
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
-
-.. topic:: References:
-
 
 .. TODO
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -3,17 +3,17 @@
 ===================
 Model evaluation
 ===================
-The :mod:`sklearn.metrics` implements score functions, performance metrics
-and pairwise metrics and distance computations. Those functions are usefull to
+The :mod:`sklearn.metrics` implements score functions, performance metrics,
+pairwise metrics and distance computations. Those functions are usefull to
 assess the performance of an estimator under a specific criterion. Note that
 in many cases, the ``score`` method of the underlying estimator is sufficient
 and appropriate.
 
 In this module, functions named as
 
-  * `*_score` return a scalar value to maximize: the higher the better.
-  * `*_error` or `*_loss` return a scalar value to minimize: the lower the
-    better
+  * ``*_score`` return a scalar value to maximize: the higher the better;
+  * ``*_error`` or ``*_loss`` return a scalar value to minimize: the lower the
+    better.
 
 .. _classification_metrics:
 
@@ -23,7 +23,7 @@ Classification metrics
 .. currentmodule:: sklearn.metrics
 
 The :mod:`sklearn.metrics` implements several losses, scores and utility
-functions to measure classification perfomance. Some of these are restricted to
+functions to measure classification performance. Some of these are restricted to
 the binary classification case:
 
 .. autosummary::
@@ -42,7 +42,7 @@ Others have been extended to the multiclass case:
 .. autosummary::
    :template: function.rst
 
-  accuraccy_sscore
+  accuracy_score
   classification_report
   confusion_matrix
   f1_score
@@ -53,11 +53,11 @@ Others have been extended to the multiclass case:
 
 In the following sub-sections, we will describe each of those functions.
 
-Accuraccy score
+Accuracy score
 ---------------
-The :func:`  accuraccy_sscore` function computes the
+The :func:`accuracy_score` function computes the
 `accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
-of correct`predictions.
+of correct predictions.
 
 If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
@@ -66,13 +66,15 @@ defined as
 
 .. math::
 
-   \texttt{accuraccy}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} 1(\hat{y} = y)
+   \texttt{accuracy}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} 1(\hat{y} = y)
 
-where :math:`1(x)` is the indicator function.
+where :math:`1(x)` is the `indicator function
+<http://en.wikipedia.org/wiki/Indicator_function>`_.
 
 .. topic:: Example:
+
   * See :ref:`example_plot_permutation_test_for_classification.py`
-    for an example of accuraccy score usage to assess with permutations the
+    for an example of accuracy score usage to assess with permutations the
     significance of a classification score.
 
 Area under the curve (AUC)
@@ -80,19 +82,19 @@ Area under the curve (AUC)
 The :func:`auc_score` function computes the AUC which is
 the area under the receiver operating characteristic (ROC) curve.
 
-For more information see
-`wipedia article on AUC
+For more information see the
+`Wikipedia article on AUC
 <http://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_curve>`_
 and the :ref:`roc_metrics` section.
 
 Average precision score
 -----------------------
-The :func:`average_precision_score` function computes the verage precision (AP)
-from prediction scores. This score corresponds to the area under the
+The :func:`average_precision_score` function computes the average precision
+(AP) from prediction scores. This score corresponds to the area under the
 precision-recall curve.
 
-For more information see
-`wipedia article on average precision
+For more information see the
+`Wikipedia article on average precision
 <http://en.wikipedia.org/wiki/Information_retrieval#Average_precision>`_
 and the :ref:`precision_recall_f_measure_metrics` section.
 
@@ -102,7 +104,7 @@ The :func:`confusion_matrix` function computes the `confusion matrix
 <http://en.wikipedia.org/wiki/Confusion_matrix>`_ to evaluate
 the accuracy on a classification problem.
 
-By definition a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
+By definition, a confusion matrix :math:`cm` is such that :math:`cm[i, j]` is
 equal to the number of observations known to be in group :math:`i` but
 predicted to be in group :math:`j`.
 
@@ -113,7 +115,7 @@ predicted to be in group :math:`j`.
     output of a classifier.
 
   * See :ref:`example_plot_digits_classification.py`
-    for an example of confusion matrix usage in the classification of the
+    for an example of confusion matrix usage in the classification of
     hand-written digits.
 
   * See :ref:`example_document_classification_20newsgroups.py`
@@ -121,10 +123,10 @@ predicted to be in group :math:`j`.
     documents.
 
 
-Clasification report
---------------------
-The :func:`classification_report` function build a text report showing the main
- classification metrics.
+Classification report
+---------------------
+The :func:`classification_report` function builds a text report showing the
+main classification metrics.
 
 .. topic:: Example:
 
@@ -138,14 +140,14 @@ The :func:`classification_report` function build a text report showing the main
 
   * See :ref:`example_grid_search_digits.py`
     for an example of classification report usage in parameter estimation using
-    grid search with a nested cross-validation
+    grid search with a nested cross-validation.
 
 
 .. _precision_recall_f_measure_metrics:
 
 Precision, recall and F-measures
 --------------------------------
-Several functions allow you to analyse the precision, recall and F-measures
+Several functions allow you to analyze the precision, recall and F-measures
 score:
 
 .. autosummary::
@@ -156,24 +158,25 @@ score:
    precision_recall_curve
    precision_recall_fscore_support
    precision_score
+   recall_score
 
 .. topic:: Example:
+
+  * See :ref:`example_document_classification_20newsgroups.py`
+    for an example of :func:`f1_score` usage with classification of text
+    documents.
+
+  * See :ref:`example_grid_search_digits.py`
+    for an example of :func:`precision_score` and :func:`recall_score` usage
+    in parameter estimation using grid search with a nested cross-validation.
 
   * See :ref:`example_plot_precision_recall.py`
     for an example of precision-Recall metric to evaluate the quality of the
     output of a classifier with :func:`precision_recall_curve`.
 
-  * See :ref:`example_document_classification_20newsgroups.py`
-    for an example of f1 score usage with classification of text
-    documents.
-
-  * See :ref:`example_grid_search_digits.py`
-    for an example of precision and recall score usage in parameter estimation
-    using grid search with a nested cross-validation
-
-  * See :ref:`example_plot_sparse_recovery.py`
+  * See :ref:`example_linear_model_plot_sparse_recovery.py`
     for an example of :func:`precision_recall_curve` usage in feature selection
-    for sparse linear models
+    for sparse linear models.
 
 Binary classification
 ^^^^^^^^^^^^^^^^^^^^^
@@ -197,14 +200,14 @@ following table:
 In this context, we can define the notions of precision, recall and F-measure.
 
 The precision is intuitively the ability of the classifier not to label as
-positive a sample that is negative
+positive a sample that is negative and is defined as
 
 .. math::
 
    \text{precision} = \frac{tp}{tp + fp}.
 
 The recall is intuitively the ability of the classifier to find all the
-positive samples
+positive samples and is defined as
 
 .. math::
 
@@ -212,15 +215,15 @@ positive samples
 
 
 The :math:`F_\beta` measure can be interpreted as a weighted harmonic mean of
-the precision and recall, where a :math:`F_\beta` measure reaches
-its best value at 1 and worst score at 0.
+the precision and recall
 
 .. math::
 
    F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\text{precision} + \text{recall}}
 
+A :math:`F_\beta` measure reaches its best value at 1 and worst score at 0.
 With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
-:math:`F_1` measure, wheres the recall and he precsion are equally important.
+:math:`F_1` measure, wheres the recall and the precsion are equally important.
 
 .. topic:: References:
 
@@ -231,34 +234,34 @@ With :math:`\beta = 1`, the :math:`F_\beta` measure leads to the
 Multiclass and multilabels classification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In multiclass and multilabels classification task, the notions of precision,
-recall and F-measures can be applied to each label independantly.
+recall and F-measures can be applied to each label independently.
 
-Nevertheless, these notions can be further extended:
-
-The functions :func:`f1_score`, :func:`fbeta_score`,
-:func:`precision_recall_fscore_support` and `precision_score` support an
-argument ``average`` which define the type of averaging that is performed:
+Moreover, these notions can be further extended. The functions
+:func:`f1_score`, :func:`fbeta_score`, :func:`precision_recall_fscore_support`,
+:func:`precision_score`  and :func:`recall_score` support an argument called
+``average`` which defines the type of averaging:
 
  * ``"macro"``: average over classes (does not take imbalance into account).
  * ``"micro"``: average over instances (takes imbalance into account).
  * ``"weighted"``: average weighted by support (takes imbalance into account).
-   It can result in f1 score that is not between precision and recall.
+   It can result in F1 score that is not between precision and recall.
  * ``None``: no averaging is performed.
 
 .. warning::
 
-  Currently those functions support only the multiclass case. But the following
-  definitions will be general and will treat the multilabel case.
+  Currently those functions support only the multiclass case. However the
+  following definitions will be general and will remain valid in the multilabel
+  case.
 
 Let's define some notations:
 
    * :math:`n_\text{labels}` and :math:`n_\text{samples}` denotes respectively the
      number of labels and the number of samples.
    * :math:`\texttt{precision}_j`, :math:`\texttt{recall}_j` and
-     :math:`\texttt{F\_beta}_j` are respectively the precision, the recall and
+     :math:`{F_\beta}_j` are respectively the precision, the recall and
      :math:`F_\beta` measure for the :math:`j`-th label;
    * :math:`tp_j`, :math:`fp_j` and :math:`fn_j` respectively the number of
-     true positives, false positives, false negatives for the :math:`j`-th
+     true positives, false positives and false negatives for the :math:`j`-th
      label;
    * :math:`y_i` is the set of true label and
      :math:`\hat{y}_i` is the set of predicted for the
@@ -268,30 +271,30 @@ The macro precision, recall and :math:`F_\beta` are averaged over all labels
 
 .. math::
 
-  \texttt{macro\_{}precision} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{precision}_j
+  \texttt{macro\_{}precision} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{precision}_j,
 
 .. math::
 
-  \texttt{macro\_{}recall} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{recall}_j
+  \texttt{macro\_{}recall} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{recall}_j,
 
 .. math::
 
-  \texttt{macro\_{}F\_{}beta} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} \texttt{F\_beta}_j
+  \texttt{macro\_{}F\_{}beta} = \frac{1}{n_\text{labels}} \sum_{j=0}^{n_\text{labels} - 1} {F_\beta}_j.
 
 
-The micro precision, recall and :math:`F_\beta` are averaged over all instance
-
-.. math::
-
-  \texttt{micro\_{}precision} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fp_j}
+The micro precision, recall and :math:`F_\beta` are averaged over all instances
 
 .. math::
 
-  \texttt{micro\_{}recall} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fn_j}
+  \texttt{micro\_{}precision} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fp_j},
 
 .. math::
 
-  \texttt{micro\_{}F\_{}beta} = (1 + \beta^2) \frac{\texttt{micro\_{}precision} \times  \texttt{micro\_{}recall}}{\texttt{micro\_{}precision} +  \texttt{micro\_{}recall}}
+  \texttt{micro\_{}recall} = \frac{\sum_{j=0}^{n_\text{labels} - 1} tp_j}{\sum_{j=0}^{n_\text{labels} - 1} tp_j + \sum_{j=0}^{n_\text{labels} - 1} fn_j},
+
+.. math::
+
+  \texttt{micro\_{}F\_{}beta} = (1 + \beta^2) \frac{\texttt{micro\_{}precision} \times  \texttt{micro\_{}recall}}{\texttt{micro\_{}precision} +  \texttt{micro\_{}recall}}.
 
 
 The weighted precision, recall and :math:`F_\beta` are averaged weighted by
@@ -299,15 +302,15 @@ their support
 
 .. math::
 
-  \texttt{weighted\_{}precision}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|y_i \cup \hat{y}_i|}
+  \texttt{weighted\_{}precision}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|y_i|},
 
 .. math::
 
-  \texttt{weighted\_{}recall}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|\hat{y}_i|}
+  \texttt{weighted\_{}recall}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} \frac{|y_i \cap \hat{y}_i|}{|\hat{y}_i|},
 
 .. math::
 
-  \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{|y_i| + |\hat{y}_i|}
+  \texttt{weighted\_{}F\_{}beta}(y,\hat{y}) &= \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples} - 1} (1 + \beta^2)\frac{|y_i \cap \hat{y}_i|}{|y_i| + |\hat{y}_i|}.
 
 
 Hinge loss
@@ -317,30 +320,30 @@ The :func:`hinge_loss` function computes the average
 `hinge loss function <http://en.wikipedia.org/wiki/Hinge_loss>`_. The hinge
 loss is used in maximal margin classification as support vector machines.
 
-If the labels are encoded with +1 and -1,  :math:`y`: the true
-value and :math:`w`, the predicted decisions as output by
+If the labels are encoded with +1 and -1,  :math:`y`: is the true
+value and :math:`w` is the predicted decisions as output by
 ``decision_function``, then the hinge loss is defined as:
 
 .. math::
 
-  L(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
+  L_\text{Hinge}(y, w) = \max\left\{1 - wy, 0\right\} = \left|1 - wy\right|_+
 
 
 Matthews correlation coefficient
 --------------------------------
-The :func:`matthews_corrcoef` function computes the matthew's correlation
-coefficient (MCC) for binary classes (quoting the `wikipedia article on the
-matthew's correlation coefficient
-<http://en.wikipedia.org/wiki/Matthews_correlation_coefficient>`_)
+The :func:`matthews_corrcoef` function computes the Matthew's correlation
+coefficient (MCC) for binary classes (quoting the `Wikipedia article on the
+Matthew's correlation coefficient
+<http://en.wikipedia.org/wiki/Matthews_correlation_coefficient>`_):
 
-    The Matthews correlation coefficient is used in machine learning as a
+    "The Matthews correlation coefficient is used in machine learning as a
     measure of the quality of binary (two-class) classifications. It takes
     into account true and false positives and negatives and is generally
     regarded as a balanced measure which can be used even if the classes are
     of very different sizes. The MCC is in essence a correlation coefficient
     value between -1 and +1. A coefficient of +1 represents a perfect
     prediction, 0 an average random prediction and -1 an inverse prediction.
-    The statistic is also known as the phi coefficient. [source: Wikipedia]
+    The statistic is also known as the phi coefficient."
 
 If :math:`tp`, :math:`tn`, :math:`fp` and :math:`fn` are respectively the
 number of true positives, true negatives, false positives ans false negatives,
@@ -348,7 +351,7 @@ the MCC coefficient is defined as
 
 .. math::
 
-  MCC = \frac{tp \times tn - fp \times fn}{\sqrt{(tp + fp)(tp + fn)(tn + fp)(tn + fn)}}
+  MCC = \frac{tp \times tn - fp \times fn}{\sqrt{(tp + fp)(tp + fn)(tn + fp)(tn + fn)}}.
 
 .. _roc_metrics:
 
@@ -359,15 +362,15 @@ The function :func:`roc_curve` computes the `receiver operating characteristic
 curve, or ROC curve (quoting
 wikipedia) <http://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_:
 
-  A receiver operating characteristic (ROC), or simply ROC curve, is a
+  "A receiver operating characteristic (ROC), or simply ROC curve, is a
   graphical plot which illustrates the performance of a binary classifier
   system as its discrimination threshold is varied. It is created by plotting
   the fraction of true positives out of the positives (TPR = true positive
   rate) vs. the fraction of false positives out of the negatives (FPR = false
   positive rate), at various threshold settings. TPR is also known as
-  sensitivity, and FPR is one minus the specificity or true negative rate.
+  sensitivity, and FPR is one minus the specificity or true negative rate."
 
-The following figure shows an example of ROC curve.
+The following figure shows an example of such ROC curve.
 
 .. image:: ../auto_examples/images/plot_roc_1.png
    :target: ../auto_examples/plot_roc.html
@@ -384,8 +387,8 @@ The following figure shows an example of ROC curve.
     for an example of receiver operating characteristic (ROC) metric to
     evaluate the quality of the output of a classifier using cross-validation.
 
-  * See :ref:`example_plot_species_distribution_modeling.py`
-    for an example of receiver operating characteristic (ROC) metric usage to
+  * See :ref:`example_applications_plot_species_distribution_modeling.py`
+    for an example of receiver operating characteristic (ROC) metric to
     model species distribution.
 
 Zero one loss
@@ -399,13 +402,14 @@ then the 0-1 loss :math:`L_{0-1}` is defined as:
 
    L_{0-1}(y_i, \hat{y}_i) = 1(\hat{y} \not= y)
 
-where :math:`1(x)` is the indicator function.
+where :math:`1(x)` is the `indicator function
+<http://en.wikipedia.org/wiki/Indicator_function>`_.
 
 
 .. topic:: Example:
 
   * See :ref:`example_plot_rfe_with_cross_validation.py`
-    for an example of zero one loss usage to perform recursive feature
+    for an example of the zero one loss usage to perform recursive feature
     elimination with cross-validation.
 
 
@@ -417,9 +421,9 @@ Regression metrics
 .. currentmodule:: sklearn.metrics
 
 The :mod:`sklearn.metrics` implements several losses, scores and utility
-functions to measure regressiion perfomance. Some of those have enhanced
-to treat the multioutput case: :func:`mean_absolute_error`,
-:func:`mean_absolute_error` and :func:`mean_squared_error`.
+functions to measure regression performance. Some of those have been enhanced
+to handle the multioutput case: :func:`mean_absolute_error`,
+:func:`mean_absolute_error` and :func:`r2_score`.
 
 
 Explained variance score
@@ -433,7 +437,7 @@ variance is  estimated  as follow:
 
 .. math::
 
-  \texttt{explained\_{}variance\_{}score} = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
+  \texttt{explained\_{}variance}(y, \hat{y}) = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
 
 The best possible score is 1.0, lower values are worse.
 
@@ -471,7 +475,7 @@ and :math:`y_i` is the corresponding true value, then the mean squared error
 
 .. topic:: Examples:
 
-  * See :ref:`example_plot_gradient_boosting_regression.py`
+  * See :ref:`example_ensemble_plot_gradient_boosting_regression.py`
     for an example of mean squared error usage to
     evaluate gradient boosting regression.
 
@@ -491,11 +495,11 @@ over :math:`n_{\text{samples}}` is defined as
 
   R^2(y, \hat{y}) = 1 - \frac{\sum_{i=0}^{n_{\text{samples}} - 1} (y_i - \hat{y}_i)^2}{\sum_{i=0}^{n_\text{samples} - 1} (y_i - \bar{y})^2}
 
-where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}} y_i`.
+where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}} - 1} y_i`.
 
 .. topic:: Examples:
 
-  * See :ref:`example_plot_lasso_and_elasticnet.py`
+  * See :ref:`example_linear_model_plot_lasso_and_elasticnet.py`
     for an example of R² score usage to
     evaluate Lasso and Elastic Net on sparse signals.
 
@@ -552,7 +556,7 @@ We see that the accuracy was boosted to almost 100%.
 
 More generally, when the accuracy of a classifier is too close to random classification, it
 probably means that something went wrong: features are not helpful, a
-hyparameter is not correctly tuned, the classifier is suffering from class
+hyper parameter is not correctly tuned, the classifier is suffering from class
 imbalance, etc...
 
 :class:`DummyRegressor` implements a simple rule of thumb for regression:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -27,7 +27,7 @@ Classification metrics
 .. currentmodule:: sklearn.metrics
 
 The :mod:`sklearn.metrics` implements several losses, scores and utility
-function to measure classification perfomance. Some of these are restricted to
+functions to measure classification perfomance. Some of these are restricted to
 the binary classification case:
 
 .. autosummary::
@@ -358,6 +358,24 @@ Regression metrics
 
 .. currentmodule:: sklearn.metrics
 
+
+
+Explained variance score
+------------------------
+The :func:`explained_variance_score` computes the `explained variance
+regression score <http://en.wikipedia.org/wiki/Explained_variation>`_.
+
+If :math:`\hat{y}` is the estimated target output
+and :math:`y` is the corresponding (correct) target output, then the explained
+variance is  estimated  as follow:
+
+.. math::
+
+  \texttt{explained\_{}variance\_{}score} = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
+
+The best possible score is 1.0, lower values are worse.
+
+
 Mean absolute error
 -------------------
 The :func:`mean_absolute_error` function computes the `mean absolute
@@ -372,7 +390,6 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 .. math::
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
-
 
 Mean squared error
 ------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -127,6 +127,8 @@ Changelog
      of ``class_weight`` was reversed as erroneously higher weight meant less
      positives of a given class in earlier releases.
 
+   - Improve narrative documentation for :mod:`sklearn.metrics`: regression
+     and classification metrics by `Arnaud Joly`_.
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -127,14 +127,9 @@ Changelog
      of ``class_weight`` was reversed as erroneously higher weight meant less
      positives of a given class in earlier releases.
 
-<<<<<<< HEAD
-   - Improve narrative documentation for :mod:`sklearn.metrics`: regression
-     and classification metrics by `Arnaud Joly`_.
-=======
    - Improve narrative documentation and consistency in
      :mod:`sklearn.metrics` for regression and classification metrics
      by `Arnaud Joly`_.
->>>>>>> ENH rename zero_loss_score to accuracy_score
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -117,18 +117,24 @@ Changelog
      Gaussian and sparse random projection matrix
      by `Olivier Grisel`_ and `Arnaud Joly`_.
 
-   - Add the :fun:`metrics.mean_absolute_error` function which computes the
-     mean absolute error. The :fun:`metrics.mean_squared_error`,
-     :fun:`metrics.mean_absolute_error` and
-     :fun:`metrics.r2_score` metrics support multioutput by `Arnaud Joly`_.
+   - Add the :func:`metrics.mean_absolute_error` function which computes the
+     mean absolute error. The :func:`metrics.mean_squared_error`,
+     :func:`metrics.mean_absolute_error` and
+     :func:`metrics.r2_score` metrics support multioutput by `Arnaud Joly`_.
 
    - Fixed ``class_weight`` support in :class:`svm.LinearSVC` and
      :class:`linear_model.LogisticRegression` by `Andreas Müller`_. The meaning
      of ``class_weight`` was reversed as erroneously higher weight meant less
      positives of a given class in earlier releases.
 
+<<<<<<< HEAD
    - Improve narrative documentation for :mod:`sklearn.metrics`: regression
      and classification metrics by `Arnaud Joly`_.
+=======
+   - Improve narrative documentation and consistency in
+     :mod:`sklearn.metrics` for regression and classification metrics
+     by `Arnaud Joly`_.
+>>>>>>> ENH rename zero_loss_score to accuracy_score
 
 API changes summary
 -------------------
@@ -225,6 +231,9 @@ API changes summary
 
    - Renamed function :func:`sklearn.metrics.zero_one` to
      :func:`sklearn.metrics.zero_one_loss`.
+
+   - Renamed function :func:`sklearn.metrics.zero_one_score` to
+     :func:`sklearn.metrics.accuracy_score`.
 
 .. _changes_0_12.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -225,8 +225,10 @@ API changes summary
      :class:`cross_validation.StratifiedShuffleSplit`.
 
    - Renamed function :func:`sklearn.metrics.zero_one` to
-     :func:`sklearn.metrics.zero_one_loss`. The default behavior
-     ``normalize=False`` is changed to ``normalize=True``.
+     :func:`sklearn.metrics.zero_one_loss`. Be aware that the default behavior
+     in :func:`sklearn.metrics.zero_one_loss` is different from
+     :func:`sklearn.metrics.zero_one`: ``normalize=False`` is changed to
+     ``normalize=True``.
 
    - Renamed function :func:`sklearn.metrics.zero_one_score` to
      :func:`sklearn.metrics.accuracy_score`.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -223,6 +223,9 @@ API changes summary
      :class:`cross_validation.ShuffleSplit` and
      :class:`cross_validation.StratifiedShuffleSplit`.
 
+   - Renamed function :func:`sklearn.metrics.zero_one` to
+     :func:`sklearn.metrics.zero_one_loss`.
+
 .. _changes_0_12.1:
 
 0.12.1

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -225,7 +225,8 @@ API changes summary
      :class:`cross_validation.StratifiedShuffleSplit`.
 
    - Renamed function :func:`sklearn.metrics.zero_one` to
-     :func:`sklearn.metrics.zero_one_loss`.
+     :func:`sklearn.metrics.zero_one_loss`. The default behavior
+     ``normalize=False`` is changed to ``normalize=True``.
 
    - Renamed function :func:`sklearn.metrics.zero_one_score` to
      :func:`sklearn.metrics.accuracy_score`.

--- a/examples/plot_permutation_test_for_classification.py
+++ b/examples/plot_permutation_test_for_classification.py
@@ -22,7 +22,7 @@ import pylab as pl
 from sklearn.svm import SVC
 from sklearn.cross_validation import StratifiedKFold, permutation_test_score
 from sklearn import datasets
-from sklearn.metrics import zero_one_score
+from sklearn.metrics import accuracy_score
 
 
 ##############################################################################
@@ -43,7 +43,7 @@ svm = SVC(kernel='linear')
 cv = StratifiedKFold(y, 2)
 
 score, permutation_scores, pvalue = permutation_test_score(
-    svm, X, y, zero_one_score, cv=cv, n_permutations=100, n_jobs=1)
+    svm, X, y, accuracy_score, cv=cv, n_permutations=100, n_jobs=1)
 
 print "Classification score %s (pvalue : %s)" % (score, pvalue)
 

--- a/examples/plot_rfe_with_cross_validation.py
+++ b/examples/plot_rfe_with_cross_validation.py
@@ -12,7 +12,7 @@ from sklearn.svm import SVC
 from sklearn.cross_validation import StratifiedKFold
 from sklearn.feature_selection import RFECV
 from sklearn.datasets import make_classification
-from sklearn.metrics import zero_one
+from sklearn.metrics import zero_one_loss
 
 # Build a classification task using 3 informative features
 X, y = make_classification(n_samples=1000, n_features=25, n_informative=3,
@@ -22,7 +22,7 @@ X, y = make_classification(n_samples=1000, n_features=25, n_informative=3,
 # Create the RFE object and compute a cross-validated score.
 svc = SVC(kernel="linear")
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(y, 2),
-              loss_func=zero_one)
+              loss_func=zero_one_loss)
 rfecv.fit(X, y)
 
 print "Optimal number of features : %d" % rfecv.n_features_

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -7,7 +7,6 @@ import inspect
 import numpy as np
 from scipy import sparse
 
-
 ###############################################################################
 def clone(estimator, safe=True):
     """Constructs a new estimator with the same parameters.
@@ -267,7 +266,8 @@ class ClassifierMixin(object):
         z : float
 
         """
-        return np.mean(self.predict(X) == y)
+        from .metrics import accuracy_score
+        return accuracy_score(y, self.predict(X))
 
 
 ###############################################################################

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1246,8 +1246,8 @@ def permutation_test_score(estimator, X, y, score_func, cv=None,
 
     pvalue : float
         The returned value equals p-value if `score_func` returns bigger
-        numbers for better scores (e.g., zero_one). If `score_func` is rather a
-        loss function (i.e. when lower is better such as with
+        numbers for better scores (e.g., accuracy_score). If `score_func` is
+        rather a loss function (i.e. when lower is better such as with
         `mean_squared_error`) then this is actually the complement of the
         p-value:  1 - p-value.
 

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -9,7 +9,7 @@ from scipy import sparse
 
 from sklearn.feature_selection.rfe import RFE, RFECV
 from sklearn.datasets import load_iris
-from sklearn.metrics import zero_one
+from sklearn.metrics import zero_one_loss
 from sklearn.svm import SVC
 from sklearn.utils import check_random_state
 
@@ -86,7 +86,7 @@ def test_rfecv():
 
     # Test using a customized loss function
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, cv=3,
-                  loss_func=zero_one)
+                  loss_func=zero_one_loss)
     rfecv.fit(X, y)
     X_r = rfecv.transform(X)
 

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -7,9 +7,12 @@ from .metrics import (confusion_matrix, roc_curve, auc, precision_score,
                       recall_score, fbeta_score, f1_score, zero_one_score,
                       precision_recall_fscore_support, classification_report,
                       precision_recall_curve, explained_variance_score,
-                      r2_score, zero_one, hinge_loss, matthews_corrcoef,
+                      r2_score, zero_one_loss, hinge_loss, matthews_corrcoef,
                       mean_squared_error, mean_absolute_error,
                       average_precision_score, auc_score)
+
+# Will be removed in 0.15
+from .metrics import zero_one
 
 from . import cluster
 from .cluster import adjusted_rand_score
@@ -54,5 +57,5 @@ __all__ = ['adjusted_mutual_info_score',
            'roc_curve',
            'silhouette_score',
            'v_measure_score',
-           'zero_one',
+           'zero_one_loss',
            'zero_one_score']

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -3,30 +3,49 @@ The :mod:`sklearn.metrics` module includes score functions, performance metrics
 and pairwise metrics and distance computations.
 """
 
-from .metrics import (confusion_matrix, roc_curve, auc, precision_score,
-                      recall_score, fbeta_score, f1_score, zero_one_score,
-                      precision_recall_fscore_support, classification_report,
-                      precision_recall_curve, explained_variance_score,
-                      r2_score, zero_one_loss, hinge_loss, matthews_corrcoef,
-                      mean_squared_error, mean_absolute_error,
-                      average_precision_score, auc_score)
+from .metrics import (accuracy_score,
+                      average_precision_score,
+                      auc,
+                      auc_score,
+                      classification_report,
+                      confusion_matrix,
+                      explained_variance_score,
+                      f1_score,
+                      fbeta_score,
+                      hinge_loss,
+                      matthews_corrcoef,
+                      mean_squared_error,
+                      mean_absolute_error,
+                      precision_recall_curve,
+                      precision_recall_fscore_support,
+                      precision_score,
+                      recall_score,
+                      r2_score,
+                      roc_curve,
+                      zero_one_loss)
 
 # Will be removed in 0.15
 from .metrics import zero_one
+from .metrics import zero_one_score
 
 from . import cluster
-from .cluster import adjusted_rand_score
-from .cluster import homogeneity_completeness_v_measure
-from .cluster import homogeneity_score
-from .cluster import completeness_score
-from .cluster import v_measure_score
-from .cluster import silhouette_score
-from .cluster import mutual_info_score
-from .cluster import adjusted_mutual_info_score
-from .cluster import normalized_mutual_info_score
-from .pairwise import euclidean_distances, pairwise_distances, pairwise_kernels
+from .cluster import (adjusted_rand_score,
+                      adjusted_mutual_info_score,
+                      completeness_score,
+                      homogeneity_completeness_v_measure,
+                      homogeneity_score,
+                      mutual_info_score,
+                      normalized_mutual_info_score,
+                      silhouette_score,
+                      v_measure_score)
 
-__all__ = ['adjusted_mutual_info_score',
+
+from .pairwise import (euclidean_distances,
+                       pairwise_distances,
+                       pairwise_kernels)
+
+__all__ = ['accuracy_score',
+           'adjusted_mutual_info_score',
            'adjusted_rand_score',
            'auc',
            'auc_score',
@@ -57,5 +76,4 @@ __all__ = ['adjusted_mutual_info_score',
            'roc_curve',
            'silhouette_score',
            'v_measure_score',
-           'zero_one_loss',
-           'zero_one_score']
+           'zero_one_loss']

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -350,7 +350,7 @@ def precision_recall_curve(y_true, probas_pred):
 
 
 def roc_curve(y_true, y_score, pos_label=None):
-    """compute Receiver operating characteristic (ROC)
+    """Compute Receiver operating characteristic (ROC)
 
     Note: this implementation is restricted to the binary classification task.
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -94,13 +94,12 @@ def unique_labels(*lists_of_labels):
 # Binary classification loss
 ###############################################################################
 def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
-    """
-    Cumulated hinge loss (non-regularized).
+    """Average hinge loss (non-regularized).
 
     Assuming labels in y_true are encoded with +1 and -1,
     when a prediction mistake is made, margin = y_true * pred_decision
     is always negative (since the signs disagree), therefore 1 - margin
-    is always greater than 1. The cumulated hinge loss therefore
+    is always greater than 1. The cumulated hinge loss is therefore
     upperbounds the number of mistakes made by the classifier.
 
     Parameters
@@ -110,6 +109,14 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
 
     pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
         Predicted decisions, as output by decision_function (floats)
+
+    Returns
+    -------
+    loss : float
+
+    References
+    ----------
+    http://en.wikipedia.org/wiki/Hinge_loss
 
     """
     # TODO: multi-class hinge-loss

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -998,6 +998,34 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     return r
 
 
+def accuracy_score(y_true, y_pred):
+    """Accuracy classification score
+
+    Positive integer (number of good classifications).
+    The best performance is 1.
+
+    Return the fraction of correct predictions in y_pred.
+
+    Parameters
+    ----------
+    y_true : array-like, shape = n_samples
+        Ground truth (correct) labels.
+
+    y_pred : array-like, shape = n_samples
+        Predicted labels, as returned by a classifier.
+
+    Returns
+    -------
+    score : float
+
+    See also
+    --------
+    zero_one_loss Zero-One classification loss
+    """
+    y_true, y_pred = check_arrays(y_true, y_pred)
+    return np.mean(y_pred == y_true)
+
+
 def zero_one_score(y_true, y_pred):
     """Zero-one classification score (accuracy)
 
@@ -1019,8 +1047,11 @@ def zero_one_score(y_true, y_pred):
     score : float
 
     """
-    y_true, y_pred = check_arrays(y_true, y_pred)
-    return np.mean(y_pred == y_true)
+    warnings.warn(
+        "Function zero_one_score has been renamed to "
+        'accuracy_score'" and will be removed in release 0.15.",
+        DeprecationWarning, stacklevel=2)
+    return accuracy_score(y_true, y_pred)
 
 
 ###############################################################################

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -536,14 +536,11 @@ def confusion_matrix(y_true, y_pred, labels=None):
 ###############################################################################
 # Multiclass loss function
 ###############################################################################
-def zero_one(y_true, y_pred, normalize=False):
+def zero_one_loss(y_true, y_pred, normalize=True):
     """Zero-One classification loss
 
-    Positive integer (number of misclassifications) or float (fraction of
-    misclassifications, only when normalize != False).
     The best performance is 0.
 
-    Return the number of errors
 
     Parameters
     ----------
@@ -554,6 +551,44 @@ def zero_one(y_true, y_pred, normalize=False):
     normalize : bool, optional
         If False (default), return the number of misclassifications.
         Otherwise, return the fraction of misclassifications.
+
+    Returns
+    -------
+    loss : float or int,
+        If normalize is True, return the fraction of misclassifications
+        (float), else it returns the number of misclassifications (int).
+
+    Examples
+    --------
+    >>> from sklearn.metrics import zero_one
+    >>> y_pred = [2, 1, 3, 4]
+    >>> y_true = [1, 2, 3, 4]
+    >>> zero_one_loss(y_true, y_pred)
+    0.5
+    >>> zero_one_loss(y_true, y_pred, normalize=False)
+    2
+
+    """
+    y_true, y_pred = check_arrays(y_true, y_pred)
+    if not normalize:
+        return np.sum(y_pred != y_true)
+    else:
+        return np.mean(y_pred != y_true)
+
+
+def zero_one(y_true, y_pred, normalize=False):
+    """Zero-One classification loss
+
+    Positive integer (number of misclassifications). The best performance
+    is 0.
+
+    Return the number of errors
+
+    Parameters
+    ----------
+    y_true : array-like
+
+    y_pred : array-like
 
     Returns
     -------
@@ -570,11 +605,12 @@ def zero_one(y_true, y_pred, normalize=False):
     0.5
 
     """
-    y_true, y_pred = check_arrays(y_true, y_pred)
-    if not normalize:
-        return np.sum(y_pred != y_true)
-    else:
-        return np.mean(y_pred != y_true)
+    warnings.warn(
+        "Function zero_one has been renamed to "
+        'zero_one_loss'" and will be removed in release 0.15."
+        "Default behavior change from normalize=False to normalize=True",
+        DeprecationWarning, stacklevel=2)
+    return zero_one_loss(y_true, y_pred, normalize)
 
 
 ###############################################################################

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -18,7 +18,7 @@ import warnings
 import numpy as np
 from scipy.sparse import coo_matrix
 
-from ..utils import check_arrays
+from ..utils import check_arrays, deprecated
 
 
 ###############################################################################
@@ -639,6 +639,10 @@ def zero_one_loss(y_true, y_pred, normalize=True):
         return np.mean(y_pred != y_true)
 
 
+@deprecated("Function 'zero_one' has been renamed to "
+            "'zero_one_loss' and will be removed in release 0.15."
+            "Default behavior is changed from 'normalize=False' to "
+            "'normalize=True'")
 def zero_one(y_true, y_pred, normalize=False):
     """Zero-One classification loss
 
@@ -669,11 +673,6 @@ def zero_one(y_true, y_pred, normalize=False):
     0.25
 
     """
-    warnings.warn(
-        "Function zero_one has been renamed to "
-        'zero_one_loss'" and will be removed in release 0.15."
-        "Default behavior change from normalize=False to normalize=True",
-        DeprecationWarning, stacklevel=2)
     return zero_one_loss(y_true, y_pred, normalize)
 
 
@@ -1218,6 +1217,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     return r
 
 
+@deprecated("Function zero_one_score has been renamed to "
+            'accuracy_score'" and will be removed in release 0.15.")
 def zero_one_score(y_true, y_pred):
     """Zero-one classification score (accuracy)
 
@@ -1236,10 +1237,6 @@ def zero_one_score(y_true, y_pred):
         The best performance is 1.
 
     """
-    warnings.warn(
-        "Function zero_one_score has been renamed to "
-        'accuracy_score'" and will be removed in release 0.15.",
-        DeprecationWarning, stacklevel=2)
     return accuracy_score(y_true, y_pred)
 
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -237,6 +237,7 @@ def matthews_corrcoef(y_true, y_pred):
     References
     ----------
     http://en.wikipedia.org/wiki/Matthews_correlation_coefficient
+
     http://dx.doi.org/10.1093/bioinformatics/16.5.412
 
     """

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -118,6 +118,23 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
     ----------
     http://en.wikipedia.org/wiki/Hinge_loss
 
+    Examples
+    --------
+    >>> from sklearn import svm
+    >>> from sklearn.metrics import hinge_loss
+    >>> X = [[0], [1]]
+    >>> y = [-1, 1]
+    >>> est = svm.LinearSVC(random_state=0)
+    >>> est.fit(X, y)
+    LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
+         intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
+         random_state=0, tol=0.0001, verbose=0)
+    >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
+    >>> pred_decision
+    array([-2.18177944,  2.36355888,  0.09088972])
+    >>> hinge_loss([-1, 1, 1], pred_decision)
+    0.30303676038544258
+
     """
     # TODO: multi-class hinge-loss
 
@@ -147,7 +164,6 @@ def average_precision_score(y_true, y_score):
 
     Parameters
     ----------
-
     y_true : array, shape = [n_samples]
         True binary labels.
 
@@ -163,10 +179,19 @@ def average_precision_score(y_true, y_score):
     ----------
     http://en.wikipedia.org/wiki/Information_retrieval#Average_precision
 
-
     See also
     --------
     auc_score: Area under the ROC curve
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import average_precision_score
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> average_precision_score(y_true, y_scores)
+    0.79166666666666663
+
     """
     precision, recall, thresholds = precision_recall_curve(y_true, y_score)
     return auc(recall, precision)
@@ -199,6 +224,16 @@ def auc_score(y_true, y_score):
     See also
     --------
     average_precision_score: Area under the precision-recall curve
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import auc_score
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> auc_score(y_true, y_scores)
+    0.75
+
     """
 
     fpr, tpr, tresholds = roc_curve(y_true, y_score)
@@ -239,6 +274,14 @@ def matthews_corrcoef(y_true, y_pred):
     http://en.wikipedia.org/wiki/Matthews_correlation_coefficient
 
     http://dx.doi.org/10.1093/bioinformatics/16.5.412
+
+    Examples
+    --------
+    >>> from sklearn.metrics import matthews_corrcoef
+    >>> y_true = [+1, +1, +1, -1]
+    >>> y_pred = [+1, -1, +1, +1]
+    >>> matthews_corrcoef(y_true, y_pred)
+    -0.33333333333333331
 
     """
     mcc = np.corrcoef(y_true, y_pred)[0, 1]
@@ -287,6 +330,20 @@ def precision_recall_curve(y_true, probas_pred):
 
     thresholds : array, shape = [n]
         Thresholds on y_score used to compute precision and recall.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import precision_recall_curve
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> precision, recall, threshold = precision_recall_curve(y_true, y_scores)
+    >>> precision
+    array([ 0.66666667,  0.5       ,  1.        ,  1.        ])
+    >>> recall
+    array([ 1. ,  0.5,  0.5,  0. ])
+    >>> threshold
+    array([ 0.35,  0.4 ,  0.8 ])
 
     """
     y_true = np.ravel(y_true)
@@ -384,6 +441,9 @@ def roc_curve(y_true, y_score, pos_label=None):
         correspond to both fpr and tpr, which are sorted in reversed order
         during their calculation.
 
+    References
+    ----------
+    http://en.wikipedia.org/wiki/Receiver_operating_characteristic
 
     Examples
     --------
@@ -394,10 +454,6 @@ def roc_curve(y_true, y_score, pos_label=None):
     >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
-
-    References
-    ----------
-    http://en.wikipedia.org/wiki/Receiver_operating_characteristic
 
     """
     y_true = np.ravel(y_true)
@@ -570,13 +626,13 @@ def zero_one_loss(y_true, y_pred, normalize=True):
 
     Examples
     --------
-    >>> from sklearn.metrics import zero_one
-    >>> y_pred = [2, 1, 3, 4]
-    >>> y_true = [1, 2, 3, 4]
+    >>> from sklearn.metrics import zero_one_loss
+    >>> y_pred = [1, 2, 3, 4]
+    >>> y_true = [2, 2, 3, 4]
     >>> zero_one_loss(y_true, y_pred)
-    0.5
+    0.25
     >>> zero_one_loss(y_true, y_pred, normalize=False)
-    2
+    1
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
@@ -604,15 +660,17 @@ def zero_one(y_true, y_pred, normalize=False):
         If normalize is True, return the fraction of misclassifications
         (float), else it returns the number of misclassifications (int).
 
+
     Examples
     --------
     >>> from sklearn.metrics import zero_one
-    >>> y_pred = [2, 1, 3, 4]
-    >>> y_true = [1, 2, 3, 4]
+    >>> y_pred = [1, 2, 3, 4]
+    >>> y_true = [2, 2, 3, 4]
     >>> zero_one(y_true, y_pred)
-    2
+    1
     >>> zero_one(y_true, y_pred, normalize=True)
-    0.5
+    0.25
+
     """
     warnings.warn(
         "Function zero_one has been renamed to "
@@ -626,7 +684,7 @@ def zero_one(y_true, y_pred, normalize=False):
 # Multiclass score function
 ###############################################################################
 def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
-    """Compute the f1 score of a prediction.
+    """Compute the f1 score
 
     The F1 score can be interpreted as a weighted average of the precision
     and recall, where an F1 score reaches its best value at 1 and worst
@@ -680,6 +738,28 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     ----------
     http://en.wikipedia.org/wiki/F1_score
 
+    Examples
+    --------
+    Here an example in the binary case:
+    >>> from sklearn.metrics import f1_score
+    >>> y_pred = [0, 1, 0, 0]
+    >>> y_true = [0, 1, 0, 1]
+    >>> f1_score(y_true, y_pred)
+    0.66666666666666663
+
+    Here an example in the multiclass case:
+    >>> from sklearn.metrics import f1_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> f1_score(y_true, y_pred, average='macro')
+    0.26666666666666666
+    >>> f1_score(y_true, y_pred, average='micro')
+    0.33333333333333331
+    >>> f1_score(y_true, y_pred, average='weighted')
+    0.26666666666666666
+    >>> f1_score(y_true, y_pred, average=None)
+    array([ 0.8,  0. ,  0. ])
+
     """
     return fbeta_score(y_true, y_pred, 1, labels=labels,
                        pos_label=pos_label, average=average)
@@ -687,7 +767,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
 
 def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
                 average='weighted'):
-    """Compute fbeta score
+    """Compute the fbeta score
 
     The F_beta score is the weighted harmonic mean of precision and recall,
     reaching its optimal value at 1 and its worst value at 0.
@@ -742,6 +822,32 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     Addison Wesley, pp. 327-328.
 
     http://en.wikipedia.org/wiki/F1_score
+
+    Examples
+    --------
+    Here an example in the binary case:
+    >>> from sklearn.metrics import fbeta_score
+    >>> y_pred = [0, 1, 0, 0]
+    >>> y_true = [0, 1, 0, 1]
+    >>> fbeta_score(y_true, y_pred, beta=0.5)
+    0.83333333333333337
+    >>> fbeta_score(y_true, y_pred, beta=1)
+    0.66666666666666663
+    >>> fbeta_score(y_true, y_pred, beta=2)
+    0.55555555555555558
+
+    Here an example in the multiclass case:
+    >>> from sklearn.metrics import fbeta_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
+    0.23809523809523805
+    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
+    0.33333333333333337
+    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
+    0.23809523809523805
+    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
+    array([ 0.71428571,  0.        ,  0.        ])
 
     """
     _, _, f, _ = precision_recall_fscore_support(y_true, y_pred,
@@ -823,6 +929,33 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     References
     ----------
     http://en.wikipedia.org/wiki/Precision_and_recall
+
+    Examples
+    --------
+    Here an example in the binary case:
+    >>> from sklearn.metrics import precision_recall_fscore_support
+    >>> y_pred = [0, 1, 0, 0]
+    >>> y_true = [0, 1, 0, 1]
+    >>> p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=0.5)
+    >>> p
+    array([ 0.66666667,  1.        ])
+    >>> r
+    array([ 1. ,  0.5])
+    >>> f
+    array([ 0.71428571,  0.83333333])
+    >>> s
+    array([2, 2], dtype=int64)
+
+    Here an example in the multiclass case:
+    >>> from sklearn.metrics import precision_recall_fscore_support
+    >>> y_true = np.array([0, 1, 2, 0, 1, 2])
+    >>> y_pred = np.array([0, 2, 1, 0, 0, 1])
+    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
+    (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
+    (0.33333333333333331, 0.33333333333333331, 0.33333333333333331, None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
+    (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
 
     """
     if beta <= 0:
@@ -949,6 +1082,28 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
         weighted average of the precision of each class for the
         multiclass task.
 
+    Examples
+    --------
+    Here an example in the binary case:
+    >>> from sklearn.metrics import precision_score
+    >>> y_pred = [0, 1, 0, 0]
+    >>> y_true = [0, 1, 0, 1]
+    >>> precision_score(y_true, y_pred)
+    1.0
+
+    Here an example in the multiclass case:
+    >>> from sklearn.metrics import precision_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> precision_score(y_true, y_pred, average='macro')
+    0.22222222222222221
+    >>> precision_score(y_true, y_pred, average='micro')
+    0.33333333333333331
+    >>> precision_score(y_true, y_pred, average='weighted')
+    0.22222222222222221
+    >>> precision_score(y_true, y_pred, average=None)
+    array([ 0.66666667,  0.        ,  0.        ])
+
     """
     p, _, _, _ = precision_recall_fscore_support(y_true, y_pred,
                                                  labels=labels,
@@ -1002,6 +1157,28 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
         Recall of the positive class in binary classification or weighted
         average of the recall of each class for the multiclass task.
 
+    Examples
+    --------
+    Here an example in the binary case:
+    >>> from sklearn.metrics import recall_score
+    >>> y_pred = [0, 1, 0, 0]
+    >>> y_true = [0, 1, 0, 1]
+    >>> recall_score(y_true, y_pred)
+    0.5
+
+    Here an example in the multiclass case:
+    >>> from sklearn.metrics import recall_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> recall_score(y_true, y_pred, average='macro')
+    0.33333333333333331
+    >>> recall_score(y_true, y_pred, average='micro')
+    0.33333333333333331
+    >>> recall_score(y_true, y_pred, average='weighted')
+    0.33333333333333331
+    >>> recall_score(y_true, y_pred, average=None)
+    array([ 1.,  0.,  0.])
+
     """
     _, r, _, _ = precision_recall_fscore_support(y_true, y_pred,
                                                  labels=labels,
@@ -1030,6 +1207,15 @@ def accuracy_score(y_true, y_pred):
     See also
     --------
     zero_one_loss Zero-One classification loss
+
+    Examples
+    --------
+    >>> from sklearn.metrics import accuracy_score
+    >>> y_pred = [0, 2, 1, 3]
+    >>> y_true = [0, 1, 2, 3]
+    >>> accuracy_score(y_true, y_pred)
+    0.5
+
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean(y_pred == y_true)
@@ -1093,12 +1279,13 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     >>> target_names = ['class 0', 'class 1', 'class 2']
     >>> print(classification_report(y_true, y_pred, target_names=target_names))
                  precision    recall  f1-score   support
-
+    <BLANKLINE>
         class 0       0.67      1.00      0.80         2
         class 1       0.00      0.00      0.00         1
         class 2       1.00      1.00      1.00         2
-
+    <BLANKLINE>
     avg / total       0.67      0.80      0.72         5
+    <BLANKLINE>
 
     """
 
@@ -1168,6 +1355,19 @@ def mean_absolute_error(y_true, y_pred):
     -------
     loss : float
         A positive floating point value (the best value is 0.0).
+
+    Examples
+    --------
+    >>> from sklearn.metrics import mean_absolute_error
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> mean_absolute_error(y_true, y_pred)
+    0.5
+    >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+    >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+    >>> mean_absolute_error(y_true, y_pred)
+    0.75
+
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean(np.abs(y_pred - y_true))
@@ -1188,6 +1388,19 @@ def mean_squared_error(y_true, y_pred):
     -------
     loss : float
         A positive floating point value (the best value is 0.0).
+
+    Examples
+    --------
+    >>> from sklearn.metrics import mean_squared_error
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> mean_squared_error(y_true, y_pred)
+    0.375
+    >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+    >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+    >>> mean_squared_error(y_true, y_pred)
+    0.70833333333333337
+
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean((y_pred - y_true) ** 2)
@@ -1217,6 +1430,14 @@ def explained_variance_score(y_true, y_pred):
     Notes
     -----
     This is not a symmetric function.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import explained_variance_score
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> explained_variance_score(y_true, y_pred)
+    0.95717344753747324
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
@@ -1257,6 +1478,19 @@ def r2_score(y_true, y_pred):
     References
     ----------
     http://en.wikipedia.org/wiki/Coefficient_of_determination
+
+    Examples
+    --------
+    >>> from sklearn.metrics import r2_score
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> r2_score(y_true, y_pred)
+    0.94860813704496794
+    >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
+    >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+    >>> r2_score(y_true, y_pred)
+    0.93825665859564167
+
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     if len(y_true) == 1:

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -22,7 +22,7 @@ from ..utils import check_arrays
 
 
 ###############################################################################
-# General Utilities
+# General utilities
 ###############################################################################
 def auc(x, y, reorder=False):
     """Compute Area Under the Curve (AUC) using the trapezoidal rule
@@ -153,7 +153,7 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
 
 
 ###############################################################################
-# Binary classification score
+# Binary classification scores
 ###############################################################################
 def average_precision_score(y_true, y_score):
     """Compute average precision (AP) from prediction scores.
@@ -291,9 +291,6 @@ def matthews_corrcoef(y_true, y_pred):
         return mcc
 
 
-###############################################################################
-# Binary classification score
-###############################################################################
 def precision_recall_curve(y_true, probas_pred):
     """Compute precision-recall pairs for different probability thresholds.
 
@@ -681,8 +678,42 @@ def zero_one(y_true, y_pred, normalize=False):
 
 
 ###############################################################################
-# Multiclass score function
+# Multiclass score functions
 ###############################################################################
+def accuracy_score(y_true, y_pred):
+    """Accuracy classification score
+
+    Parameters
+    ----------
+    y_true : array-like, shape = n_samples
+        Ground truth (correct) labels.
+
+    y_pred : array-like, shape = n_samples
+        Predicted labels, as returned by a classifier.
+
+    Returns
+    -------
+    score : float
+        The fraction of correct predictions in y_pred.
+        The best performance is 1.
+
+    See also
+    --------
+    zero_one_loss Zero-One classification loss
+
+    Examples
+    --------
+    >>> from sklearn.metrics import accuracy_score
+    >>> y_pred = [0, 2, 1, 3]
+    >>> y_true = [0, 1, 2, 3]
+    >>> accuracy_score(y_true, y_pred)
+    0.5
+
+    """
+    y_true, y_pred = check_arrays(y_true, y_pred)
+    return np.mean(y_pred == y_true)
+
+
 def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     """Compute the f1 score
 
@@ -1187,40 +1218,6 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     return r
 
 
-def accuracy_score(y_true, y_pred):
-    """Accuracy classification score
-
-    Parameters
-    ----------
-    y_true : array-like, shape = n_samples
-        Ground truth (correct) labels.
-
-    y_pred : array-like, shape = n_samples
-        Predicted labels, as returned by a classifier.
-
-    Returns
-    -------
-    score : float
-        The fraction of correct predictions in y_pred.
-        The best performance is 1.
-
-    See also
-    --------
-    zero_one_loss Zero-One classification loss
-
-    Examples
-    --------
-    >>> from sklearn.metrics import accuracy_score
-    >>> y_pred = [0, 2, 1, 3]
-    >>> y_true = [0, 1, 2, 3]
-    >>> accuracy_score(y_true, y_pred)
-    0.5
-
-    """
-    y_true, y_pred = check_arrays(y_true, y_pred)
-    return np.mean(y_pred == y_true)
-
-
 def zero_one_score(y_true, y_pred):
     """Zero-one classification score (accuracy)
 
@@ -1338,7 +1335,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
 
 
 ###############################################################################
-# Regresssion loss function
+# Regression loss functions
 ###############################################################################
 def mean_absolute_error(y_true, y_pred):
     """Mean absolute error regression loss
@@ -1407,7 +1404,7 @@ def mean_squared_error(y_true, y_pred):
 
 
 ###############################################################################
-# Regrsssion score function
+# Regression score functions
 ###############################################################################
 def explained_variance_score(y_true, y_pred):
     """Explained variance regression score function

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -33,15 +33,15 @@ def auc(x, y, reorder=False):
     Parameters
     ----------
     x : array, shape = [n]
-        x coordinates
+        x coordinates.
 
     y : array, shape = [n]
-        y coordinates
+        y coordinates.
 
     reorder : boolean, optional
         If True, assume that the curve is ascending in the case of ties,
         as for an ROC curve. With descending curve, you will get false
-        results
+        results.
 
     Returns
     -------
@@ -105,10 +105,10 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
     Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target (integers)
+        True target (integers).
 
     pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
-        Predicted decisions, as output by decision_function (floats)
+        Predicted decisions, as output by decision_function (floats).
 
     Returns
     -------
@@ -510,6 +510,17 @@ def confusion_matrix(y_true, y_pred, labels=None):
     References
     ----------
     http://en.wikipedia.org/wiki/Confusion_matrix
+
+    Examples
+    --------
+    >>> from sklearn.metrics import confusion_matrix
+    >>> y_true = [2, 0, 2, 2, 0, 1]
+    >>> y_pred = [0, 0, 2, 2, 0, 2]
+    >>> confusion_matrix(y_true, y_pred)
+    array([[2, 0, 0],
+           [0, 0, 1],
+           [1, 0, 2]])
+
     """
     if labels is None:
         labels = unique_labels(y_true, y_pred)
@@ -581,8 +592,6 @@ def zero_one(y_true, y_pred, normalize=False):
     Positive integer (number of misclassifications). The best performance
     is 0.
 
-    Return the number of errors
-
     Parameters
     ----------
     y_true : array-like
@@ -592,6 +601,8 @@ def zero_one(y_true, y_pred, normalize=False):
     Returns
     -------
     loss : float
+        If normalize is True, return the fraction of misclassifications
+        (float), else it returns the number of misclassifications (int).
 
     Examples
     --------
@@ -602,7 +613,6 @@ def zero_one(y_true, y_pred, normalize=False):
     2
     >>> zero_one(y_true, y_pred, normalize=True)
     0.5
-
     """
     warnings.warn(
         "Function zero_one has been renamed to "
@@ -639,7 +649,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
         Estimated targets as returned by a classifier.
 
     labels : array
-        Integer array of labels
+        Integer array of labels.
 
     pos_label : int
         In the binary classification case, give the label of the positive
@@ -655,7 +665,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
             Average over classes (does not take imbalance into account).
         micro:
             Average over instances (takes imbalance into account).
-            This implies that ``precision == recall == f1``
+            This implies that ``precision == recall == f1``.
         weighted:
             Average weighted by support (takes imbalance into account).
             Can result in f1 score that is not between precision and recall.
@@ -664,7 +674,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     -------
     f1_score : float
         f1_score of the positive class in binary classification or weighted
-        average of the f1_scores of each class for the multiclass task
+        average of the f1_scores of each class for the multiclass task.
 
     References
     ----------
@@ -715,7 +725,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
             Average over classes (does not take imbalance into account).
         micro:
             Average over instances (takes imbalance into account).
-            This implies that ``precision == recall == f1``
+            This implies that ``precision == recall == f1``.
         weighted:
             Average weighted by support (takes imbalance into account).
             Can result in f1 score that is not between precision and recall.
@@ -779,7 +789,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         The strength of recall versus precision in the f-score.
 
     labels : array
-        Integer array of labels
+        Integer array of labels.
 
     pos_label : int
         In the binary classification case, give the label of the positive
@@ -795,7 +805,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
             Average over classes (does not take imbalance into account).
         micro:
             Average over instances (takes imbalance into account).
-            This implies that ``precision == recall == f1``
+            This implies that ``precision == recall == f1``.
         weighted:
             Average weighted by support (takes imbalance into account).
             Can result in f1 score that is not between precision and recall.
@@ -803,8 +813,11 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     Returns
     -------
     precision: array, shape = [n_unique_labels], dtype = np.double
+
     recall: array, shape = [n_unique_labels], dtype = np.double
+
     f1_score: array, shape = [n_unique_labels], dtype = np.double
+
     support: array, shape = [n_unique_labels], dtype = np.long
 
     References
@@ -924,7 +937,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
             Average over classes (does not take imbalance into account).
         micro:
             Average over instances (takes imbalance into account).
-            This implies that ``precision == recall == f1``
+            This implies that ``precision == recall == f1``.
         weighted:
             Average weighted by support (takes imbalance into account).
             Can result in f1 score that is not between precision and recall.
@@ -934,7 +947,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     precision : float
         Precision of the positive class in binary classification or
         weighted average of the precision of each class for the
-        multiclass task
+        multiclass task.
 
     """
     p, _, _, _ = precision_recall_fscore_support(y_true, y_pred,
@@ -978,7 +991,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
             Average over classes (does not take imbalance into account).
         micro:
             Average over instances (takes imbalance into account).
-            This implies that ``precision == recall == f1``
+            This implies that ``precision == recall == f1``.
         weighted:
             Average weighted by support (takes imbalance into account).
             Can result in f1 score that is not between precision and recall.
@@ -1000,11 +1013,6 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
 def accuracy_score(y_true, y_pred):
     """Accuracy classification score
 
-    Positive integer (number of good classifications).
-    The best performance is 1.
-
-    Return the fraction of correct predictions in y_pred.
-
     Parameters
     ----------
     y_true : array-like, shape = n_samples
@@ -1016,6 +1024,8 @@ def accuracy_score(y_true, y_pred):
     Returns
     -------
     score : float
+        The fraction of correct predictions in y_pred.
+        The best performance is 1.
 
     See also
     --------
@@ -1028,11 +1038,6 @@ def accuracy_score(y_true, y_pred):
 def zero_one_score(y_true, y_pred):
     """Zero-one classification score (accuracy)
 
-    Positive integer (number of good classifications).
-    The best performance is 1.
-
-    Return the fraction of correct predictions in y_pred.
-
     Parameters
     ----------
     y_true : array-like, shape = n_samples
@@ -1044,6 +1049,8 @@ def zero_one_score(y_true, y_pred):
     Returns
     -------
     score : float
+        fraction of correct predictions in y_pred.
+        The best performance is 1.
 
     """
     warnings.warn(
@@ -1076,7 +1083,22 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     Returns
     -------
     report : string
-        Text summary of the precision, recall, f1-score for each class
+        Text summary of the precision, recall, f1-score for each class.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import classification_report
+    >>> y_true = [0, 1, 2, 2, 0]
+    >>> y_pred = [0, 0, 2, 2, 0]
+    >>> target_names = ['class 0', 'class 1', 'class 2']
+    >>> print(classification_report(y_true, y_pred, target_names=target_names))
+                 precision    recall  f1-score   support
+
+        class 0       0.67      1.00      0.80         2
+        class 1       0.00      0.00      0.00         1
+        class 2       1.00      1.00      1.00         2
+
+    avg / total       0.67      0.80      0.72         5
 
     """
 
@@ -1134,8 +1156,6 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
 def mean_absolute_error(y_true, y_pred):
     """Mean absolute error regression loss
 
-    Return a a positive floating point value (the best value is 0.0).
-
     Parameters
     ----------
     y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
@@ -1147,7 +1167,7 @@ def mean_absolute_error(y_true, y_pred):
     Returns
     -------
     loss : float
-
+        A positive floating point value (the best value is 0.0).
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean(np.abs(y_pred - y_true))
@@ -1156,8 +1176,6 @@ def mean_absolute_error(y_true, y_pred):
 def mean_squared_error(y_true, y_pred):
     """Mean squared error regression loss
 
-    Return a a positive floating point value (the best value is 0.0).
-
     Parameters
     ----------
     y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
@@ -1169,7 +1187,7 @@ def mean_squared_error(y_true, y_pred):
     Returns
     -------
     loss : float
-
+        A positive floating point value (the best value is 0.0).
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
     return np.mean((y_pred - y_true) ** 2)
@@ -1183,8 +1201,6 @@ def explained_variance_score(y_true, y_pred):
 
     Best possible score is 1.0, lower values are worse.
 
-    Note: the explained variance is not a symmetric function.
-
     Parameters
     ----------
     y_true : array-like
@@ -1196,8 +1212,11 @@ def explained_variance_score(y_true, y_pred):
     Returns
     -------
     score : float
-        explained variance
+        The explained variance.
 
+    Notes
+    -----
+    This is not a symmetric function.
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1,10 +1,10 @@
 """Utilities to evaluate the predictive performance of models
 
-Functions named as *_score return a scalar value to maximize: the higher the
-better
+Functions named as ``*_score`` return a scalar value to maximize: the higher
+the better
 
-Function named as *_loss return a scalar value to minimize: the lower the
-better
+Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
+the lower the better
 """
 
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
@@ -540,7 +540,6 @@ def zero_one_loss(y_true, y_pred, normalize=True):
     """Zero-One classification loss
 
     The best performance is 0.
-
 
     Parameters
     ----------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -484,9 +484,9 @@ def roc_curve(y_true, y_score, pos_label=None):
 def confusion_matrix(y_true, y_pred, labels=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
-    By definition a confusion matrix cm is such that cm[i, j] is equal
-    to the number of observations known to be in group i but predicted
-    to be in group j.
+    By definition a confusion matrix :math:`cm` is such that :math:`cm[i, j]`
+    is equal to the number of observations known to be in group :math:`i` but
+    predicted to be in group :math:`j`..
 
     Parameters
     ----------

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -27,6 +27,7 @@ from sklearn.metrics import roc_curve
 from sklearn.metrics import auc_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import zero_one
+from sklearn.metrics import zero_one_loss
 from sklearn.metrics import hinge_loss
 
 
@@ -481,10 +482,19 @@ def test_losses():
     assert_equal(zero_one(y_true, y_pred), 13)
     assert_almost_equal(zero_one(y_true, y_pred, normalize=True),
                         13 / float(n), 2)
+
+    assert_equal(zero_one_loss(y_true, y_pred, normalize=False), 13)
+    assert_almost_equal(zero_one_loss(y_true, y_pred, normalize=True),
+                        13 / float(n), 2)
+    assert_almost_equal(zero_one_loss(y_true, y_true),
+                        0.0, 2)
+    assert_almost_equal(zero_one_loss(y_true, y_true, normalize=False),
+                        0, 2)
+
     assert_almost_equal(mean_squared_error(y_true, y_pred), 12.999 / n, 2)
     assert_almost_equal(mean_squared_error(y_true, y_true), 0.00, 2)
 
-    # mean_absolute_error and mean_squared_error are equal because of
+    # mean_absolute_error and mean_squared_error are equal because
     # it is a binary problem.
     assert_almost_equal(mean_absolute_error(y_true, y_pred), 12.999 / n, 2)
     assert_almost_equal(mean_absolute_error(y_true, y_true), 0.00, 2)
@@ -521,7 +531,16 @@ def test_symmetry():
                  zero_one(y_pred, y_true))
 
     assert_almost_equal(zero_one(y_true, y_pred, normalize=True),
-                 zero_one(y_pred, y_true, normalize=True), 2)
+                        zero_one(y_pred, y_true, normalize=True), 2)
+
+    assert_almost_equal(zero_one(y_true, y_pred, normalize=False),
+                        zero_one(y_pred, y_true, normalize=False), 2)
+
+    assert_equal(zero_one_loss(y_true, y_pred),
+                 zero_one_loss(y_pred, y_true))
+
+    assert_equal(zero_one_loss(y_true, y_pred, normalize=False),
+                 zero_one_loss(y_pred, y_true, normalize=False))
 
     assert_almost_equal(mean_squared_error(y_true, y_pred),
                         mean_squared_error(y_pred, y_true))
@@ -582,6 +601,8 @@ def test_multioutput_regression():
     error = mean_squared_error(y_true, y_pred)
     assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
 
+    # mean_absolute_error and mean_squared_error are equal because
+    # it is a binary problem.
     error = mean_absolute_error(y_true, y_pred)
     assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -488,24 +488,30 @@ def test_losses():
     y_true, y_pred, _ = make_prediction(binary=True)
     n_samples = y_true.shape[0]
 
-    assert_equal(zero_one(y_true, y_pred), 13)
-    assert_almost_equal(zero_one(y_true, y_pred, normalize=True),
-                        13 / float(n_samples), 2)
+    # Classification
+    # --------------
+    with warnings.catch_warnings(True):
+    # Throw deprecated warning
+        assert_equal(zero_one(y_true, y_pred), 13)
+        assert_almost_equal(zero_one(y_true, y_pred, normalize=True),
+                            13 / float(n_samples), 2)
 
-    assert_equal(zero_one_loss(y_true, y_pred, normalize=False), 13)
-    assert_almost_equal(zero_one_loss(y_true, y_pred, normalize=True),
+    assert_almost_equal(zero_one_loss(y_true, y_pred),
                         13 / float(n_samples), 2)
-    assert_almost_equal(zero_one_loss(y_true, y_true),
-                        0.0, 2)
-    assert_almost_equal(zero_one_loss(y_true, y_true, normalize=False),
-                        0, 2)
+    assert_equal(zero_one_loss(y_true, y_pred, normalize=False), 13)
+    assert_almost_equal(zero_one_loss(y_true, y_true), 0.0, 2)
+    assert_almost_equal(zero_one_loss(y_true, y_true, normalize=False), 0, 2)
 
     assert_equal(accuracy_score(y_true, y_pred),
                  1 - zero_one_loss(y_true, y_pred))
 
-    assert_equal(zero_one_score(y_true, y_pred),
-                 1 - zero_one_loss(y_true, y_pred))
+    with warnings.catch_warnings(True):
+    # Throw deprecated warning
+        assert_equal(zero_one_score(y_true, y_pred),
+                     1 - zero_one_loss(y_true, y_pred))
 
+    # Regression
+    # ----------
     assert_almost_equal(mean_squared_error(y_true, y_pred),
                         12.999 / n_samples, 2)
     assert_almost_equal(mean_squared_error(y_true, y_true),
@@ -548,14 +554,13 @@ def test_symmetry():
     assert_equal(accuracy_score(y_true, y_pred),
                  accuracy_score(y_pred, y_true))
 
-    assert_equal(zero_one(y_true, y_pred),
-                 zero_one(y_pred, y_true))
+    with warnings.catch_warnings(True):
+        # Throw deprecated warning
+        assert_equal(zero_one(y_true, y_pred),
+                     zero_one(y_pred, y_true))
 
-    assert_almost_equal(zero_one(y_true, y_pred, normalize=True),
-                        zero_one(y_pred, y_true, normalize=True), 2)
-
-    assert_almost_equal(zero_one(y_true, y_pred, normalize=False),
-                        zero_one(y_pred, y_true, normalize=False), 2)
+        assert_almost_equal(zero_one(y_true, y_pred, normalize=False),
+                            zero_one(y_pred, y_true, normalize=False), 2)
 
     assert_equal(zero_one_loss(y_true, y_pred),
                  zero_one_loss(y_pred, y_true))
@@ -563,8 +568,10 @@ def test_symmetry():
     assert_equal(zero_one_loss(y_true, y_pred, normalize=False),
                  zero_one_loss(y_pred, y_true, normalize=False))
 
-    assert_equal(zero_one_score(y_true, y_pred),
-                 zero_one_score(y_pred, y_true))
+    with warnings.catch_warnings(True):
+    # Throw deprecated warning
+        assert_equal(zero_one_score(y_true, y_pred),
+                     zero_one_score(y_pred, y_true))
 
     assert_almost_equal(mean_squared_error(y_true, y_pred),
                         mean_squared_error(y_pred, y_true))

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -31,7 +31,8 @@ from sklearn.utils import shuffle
 from sklearn.preprocessing import StandardScaler, Scaler
 from sklearn.datasets import (load_iris, load_boston, make_blobs,
                               make_classification)
-from sklearn.metrics import zero_one_score, adjusted_rand_score
+from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
+
 from sklearn.lda import LDA
 from sklearn.svm.base import BaseLibSVM
 
@@ -53,7 +54,6 @@ from sklearn.cluster import (WardAgglomeration, AffinityPropagation,
 from sklearn.isotonic import IsotonicRegression
 from sklearn.random_projection import (GaussianRandomProjection,
                                        SparseRandomProjection)
-from sklearn.metrics import f1_score
 
 from sklearn.cross_validation import train_test_split
 
@@ -482,7 +482,7 @@ def test_classifiers_train():
             y_pred = clf.predict(X)
             assert_equal(y_pred.shape, (n_samples,))
             # training set performance
-            assert_greater(zero_one_score(y, y_pred), 0.85)
+            assert_greater(accuracy_score(y, y_pred), 0.85)
 
             # raises error on malformed input for predict
             assert_raises(ValueError, clf.predict, X.T)
@@ -547,7 +547,7 @@ def test_classifiers_classes():
         y_pred = clf.predict(X)
         # training set performance
         assert_array_equal(np.unique(y), np.unique(y_pred))
-        assert_greater(zero_one_score(y, y_pred), 0.78,
+        assert_greater(accuracy_score(y, y_pred), 0.78,
                        "accuracy of %s not greater than 0.78" % str(Clf))
         assert_array_equal(
             clf.classes_, classes,

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -9,22 +9,22 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal
+
 from sklearn.utils.fixes import unique
 
 from sklearn import cross_validation as cval
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_regression
 from sklearn.datasets import load_iris
-from sklearn.metrics import zero_one_score
+from sklearn.metrics import accuracy_score
 from sklearn.metrics import f1_score
 from sklearn.metrics import mean_squared_error
 from sklearn.metrics import r2_score
 from sklearn.metrics import explained_variance_score
 from sklearn.svm import SVC
 from sklearn.linear_model import Ridge
-
-from numpy.testing import assert_array_almost_equal
-from numpy.testing import assert_array_equal
 
 
 class MockListClassifier(BaseEstimator):
@@ -335,7 +335,7 @@ def test_cross_val_score_with_score_func_classification():
     # Correct classification score (aka. zero / one score) - should be the
     # same as the default estimator score
     zo_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                     score_func=zero_one_score, cv=5)
+                                     score_func=accuracy_score, cv=5)
     assert_array_almost_equal(zo_scores, [1., 0.97, 0.90, 0.97, 1.], 2)
 
     # F1 score (class are balanced so f1_score should be equal to zero/one
@@ -380,13 +380,13 @@ def test_permutation_score():
     cv = cval.StratifiedKFold(y, 2)
 
     score, scores, pvalue = cval.permutation_test_score(
-        svm, X, y, zero_one_score, cv)
+        svm, X, y, accuracy_score, cv)
 
     assert_greater(score, 0.9)
     np.testing.assert_almost_equal(pvalue, 0.0, 1)
 
     score_label, _, pvalue_label = cval.permutation_test_score(
-        svm, X, y, zero_one_score, cv, labels=np.ones(y.size), random_state=0)
+        svm, X, y, accuracy_score, cv, labels=np.ones(y.size), random_state=0)
 
     assert_true(score_label == score)
     assert_true(pvalue_label == pvalue)
@@ -395,7 +395,7 @@ def test_permutation_score():
     svm_sparse = SVC(kernel='linear')
     cv_sparse = cval.StratifiedKFold(y, 2, indices=True)
     score_label, _, pvalue_label = cval.permutation_test_score(
-        svm_sparse, X_sparse, y, zero_one_score, cv_sparse,
+        svm_sparse, X_sparse, y, accuracy_score, cv_sparse,
         labels=np.ones(y.size), random_state=0)
 
     assert_true(score_label == score)
@@ -405,7 +405,7 @@ def test_permutation_score():
     y = np.mod(np.arange(len(y)), 3)
 
     score, scores, pvalue = cval.permutation_test_score(svm, X, y,
-                                                        zero_one_score, cv)
+                                                        accuracy_score, cv)
 
     assert_less(score, 0.5)
     assert_greater(pvalue, 0.4)


### PR DESCRIPTION
I would like to partly tackle the issue in #1508. 
In this pr, I intend to add definitions to classification metrics and remaining regression metrics.

Before going into the MRG state, I still have read two or three times the added documentation to find mistakes. 

Furthermore, I am not sure about the documentation on `explained_variance_score`. It is new to me.

Questions:
1. After this pr, I would like to add some multilabels metrics, some thoughts about this?
2. Why is there a `zero_one` and `zero_one_score` instead of  `zero_one_loss` and `accuracy_score`?
3. Why `ClassifierMixin` uses a "homebrew" accuracy metrics in the score member?
