### PR TITLE
MRG document attributes in QDA and LDA, rename to adhere to sklearn scheme

### DIFF
--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -34,7 +34,6 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     Parameters
     ----------
-
     n_components: int
         Number of components (< n_classes - 1) for dimensionality reduction
 
@@ -43,14 +42,24 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     Attributes
     ----------
-    `means_` : array-like, shape = [n_classes, n_features]
-        Class means
-    `xbar_` : float, shape = [n_features]
-        Over all mean
-    `priors_` : array-like, shape = [n_classes]
-        Class priors (sum to 1)
+    `coef_` : array-like, shape = [n_features,]
+        Coefficients of the features in the linear decision function.
+
     `covariance_` : array-like, shape = [n_features, n_features]
-        Covariance matrix (shared by all classes)
+        Covariance matrix (shared by all classes).
+
+    `means_` : array-like, shape = [n_classes, n_features]
+        Class means.
+
+    `priors_` : array-like, shape = [n_classes]
+        Class priors (sum to 1).
+
+    `scalings_` : array-like, shape = [feature_rank, n_classes - 1]
+        Scaling of the features in the space spanned by the class
+        centroids.
+
+    `xbar_` : float, shape = [n_features]
+        Overall mean.
 
     Examples
     --------
@@ -90,8 +99,10 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         X : array-like, shape = [n_samples, n_features]
             Training vector, where n_samples in the number of samples and
             n_features is the number of features.
+
         y : array, shape = [n_samples]
             Target values (integers)
+
         store_covariance : boolean
             If True the covariance matrix (shared by all classes) is computed
             and stored in `self.covariance_` attribute.
@@ -145,7 +156,7 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         if rank < n_features:
             warnings.warn("Variables are collinear")
         # Scaling of within covariance is: V' 1/S
-        scaling = (V[:rank] / std).T / S[:rank]
+        scalings = (V[:rank] / std).T / S[:rank]
 
         ## ----------------------------
         ## 3) Between variance scaling
@@ -153,7 +164,7 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         xbar = np.dot(self.priors_, self.means_)
         # Scale weighted centers
         X = np.dot(((np.sqrt((n_samples * self.priors_) * fac)) *
-                    (means - xbar).T).T, scaling)
+                    (means - xbar).T).T, scalings)
         # Centers are living in a space with n_classes-1 dim (maximum)
         # Use svd to find projection in the space spanned by the
         # (n_classes) centers
@@ -161,10 +172,10 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         rank = np.sum(S > tol * S[0])
         # compose the scalings
-        self.scaling = np.dot(scaling, V.T[:, :rank])
+        self.scalings_ = np.dot(scalings, V.T[:, :rank])
         self.xbar_ = xbar
         # weight vectors / centroids
-        self.coef_ = np.dot(self.means_ - self.xbar_, self.scaling)
+        self.coef_ = np.dot(self.means_ - self.xbar_, self.scalings_)
         self.intercept_ = (-0.5 * np.sum(self.coef_ ** 2, axis=1) +
                            np.log(self.priors_))
         return self
@@ -176,10 +187,17 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
                       stacklevel=2)
         return self.classes_
 
+    @property
+    def scaling(self):  # pragma: no cover
+        warnings.warn("LDA.scaling is deprecated and will be removed in 0.15."
+                      " Use LDA.scalings_ instead.", DeprecationWarning,
+                      stacklevel=2)
+        return self.scalings_
+
     def _decision_function(self, X):
         X = array2d(X)
         # center and scale data
-        X = np.dot(X - self.xbar_, self.scaling)
+        X = np.dot(X - self.xbar_, self.scalings_)
         return np.dot(X, self.coef_.T) + self.intercept_
 
     def decision_function(self, X):
@@ -218,7 +236,7 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         """
         X = array2d(X)
         # center and scale data
-        X = np.dot(X - self.xbar_, self.scaling)
+        X = np.dot(X - self.xbar_, self.scalings_)
         n_comp = X.shape[1] if self.n_components is None else self.n_components
         return np.dot(X, self.coef_[:n_comp].T)
 

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -34,12 +34,23 @@ class QDA(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    `means_` : array-like, shape = [n_classes, n_features]
-        Class means
-    `priors_` : array-like, shape = [n_classes]
-        Class priors (sum to 1)
     `covariances_` : list of array-like, shape = [n_features, n_features]
-        Covariance matrices of each class
+        Covariance matrices of each class.
+
+    `means_` : array-like, shape = [n_classes, n_features]
+        Class means.
+
+    `priors_` : array-like, shape = [n_classes]
+        Class priors (sum to 1).
+
+    `rotations_` : list of arrays
+        For each class an array of shape [n_samples, n_samples], the rotation
+        of the Gaussian distribution, i.e.  its principal axis.
+
+    `scalings_` : array-like, shape = [n_classes, n_features]
+        For each class contains the scaling of the Gaussian distribution along
+        its principal axes, i.e.  the variances in the rotated coordinate
+        system.
 
     Examples
     --------
@@ -70,8 +81,10 @@ class QDA(BaseEstimator, ClassifierMixin):
         X : array-like, shape = [n_samples, n_features]
             Training vector, where n_samples in the number of samples and
             n_features is the number of features.
+
         y : array, shape = [n_samples]
             Target values (integers)
+
         store_covariances : boolean
             If True the covariance matrices are computed and stored in the
             `self.covariances_` attribute.
@@ -112,8 +125,8 @@ class QDA(BaseEstimator, ClassifierMixin):
         if store_covariances:
             self.covariances_ = cov
         self.means_ = np.asarray(means)
-        self.scalings = np.asarray(scalings)
-        self.rotations = rotations
+        self.scalings_ = np.asarray(scalings)
+        self.rotations_ = rotations
         return self
 
     @property
@@ -123,17 +136,31 @@ class QDA(BaseEstimator, ClassifierMixin):
                       stacklevel=2)
         return self.classes_
 
+    @property
+    def scalings(self):  # pragma: no cover
+        warnings.warn("QDA.scalings is deprecated and will be removed in 0.15."
+                      " Use QDA.scalings_ instead.", DeprecationWarning,
+                      stacklevel=2)
+        return self.scalings_
+
+    @property
+    def rotations(self):  # pragma: no cover
+        warnings.warn("QDA.rotations is deprecated and will be removed in "
+                      "0.15. Use QDA.rotations_ instead.", DeprecationWarning,
+                      stacklevel=2)
+        return self.rotations_
+
     def _decision_function(self, X):
         X = array2d(X)
         norm2 = []
         for i in range(len(self.classes_)):
-            R = self.rotations[i]
-            S = self.scalings[i]
+            R = self.rotations_[i]
+            S = self.scalings_[i]
             Xm = X - self.means_[i]
             X2 = np.dot(Xm, R * (S ** (-0.5)))
             norm2.append(np.sum(X2 ** 2, 1))
         norm2 = np.array(norm2).T   # shape = [len(X), n_classes]
-        return (-0.5 * (norm2 + np.sum(np.log(self.scalings), 1))
+        return (-0.5 * (norm2 + np.sum(np.log(self.scalings_), 1))
                 + np.log(self.priors_))
 
     def decision_function(self, X):


### PR DESCRIPTION
Some cleanups in LDA and QDA.
The additional `s` in `scalings` in `LDA` is on purpose to be consistent with `QDA`.

I feel LDA and QDA are still not up to speed.

There is a `tol` parameter to `fit` in both that seems a bit weird. First, it should be a `__init__` parameter. Then, it doesn't seem to do anything in QDA but raise a warning. That seems a bit odd to me.
In LDA it seems to implement some robustness to colinear features but it is also not very clear to me.

Also, from my understanding of LDA the implementation is suboptimal. As the decision function is linear it should be possible to just store the linear decision function for `predict` and not do so many computations there.

Maybe I should open an issue for that ...

This PR closes #1480.
