### PR TITLE
MRG Dimensionality reduction using LSA/LSI

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -217,7 +217,7 @@ Samples generator
    decomposition.KernelPCA
    decomposition.FactorAnalysis
    decomposition.FastICA
-   decomposition.LSA
+   decomposition.LatentSemanticAnalysis
    decomposition.NMF
    decomposition.SparsePCA
    decomposition.MiniBatchSparsePCA

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -217,6 +217,7 @@ Samples generator
    decomposition.KernelPCA
    decomposition.FactorAnalysis
    decomposition.FastICA
+   decomposition.LSA
    decomposition.NMF
    decomposition.SparsePCA
    decomposition.MiniBatchSparsePCA

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -237,7 +237,7 @@ factorization, while larger values shrink many coefficients to zero.
 Latent semantic analysis
 ========================
 
-:class:`LatentSemanticAnalysis` implements LSA
+:class:`LatentSemanticAnalysis` implements LSA,
 a transformation of term-document matrices
 (as returned by ``CountVectorizer`` or ``TfidfVectorizer``)
 to a "semantic" space of low dimensionality.
@@ -251,29 +251,50 @@ Mathematically, LSA amounts to a truncated singular value decomposition (SVD)
 on the training samples :math:`X`:
 
 .. math::
-    X_k = U_k \Sigma_k V_k^\top
+    X \approx X_k = U_k \Sigma_k V_k^\top
 
 After this operation, :math:`U_k \Sigma_k^\top`
-is the transformed training set with :math:`k` features.
+is the transformed training set with :math:`k` features
+(called ``n_components`` in the API).
+
 To also transform a test set :math:`X`, we multiply it with :math:`V_k`:
 
 .. math::
     X' = X V_k^\top
 
+.. note::
+    Most treatments of LSA in the natural language processing (NLP)
+    and information retrieval (IR) literature
+    swap the axis of the matrix :math:`X` so that it has shape
+    ``n_features`` × ``n_samples``.
+    We present LSA in a different way that matches the scikit-learn API better,
+    but the singular values found are the same.
+
 LSA is very similar to PCA, but differs
 in that it works on sample matrices :math:`X` directly
 instead of their covariance matrices.
-In practical terms, this means :class:`LatentSemanticAnalysis`'s methods
-accept ``scipy.sparse`` matrices without the need to densify them;
-densifying may fill up memory even for medium-sized document collections.
+When the columnwise (per-feature) means of :math:`X`
+are subtracted from the feature values,
+LSA on the resulting matrix is equivalent to PCA.
+In practical terms, this means
+that the :class:`LatentSemanticAnalysis` transformer
+accepts ``scipy.sparse`` matrices without the need to densify them,
+as densifying may fill up memory even for medium-sized document collections.
 
 While the :class:`LatentSemanticAnalysis` transformer
 works with any (sparse) feature matrix,
-using it on tf-idf matrices is recommended.
+using it on tf–idf matrices is recommended over raw frequency counts.
 In particular, sublinear scaling and inverse document frequency
 should be turned on (``sublinear_tf=True, use_idf=True``)
-to bring the tf-idf values closer to a Gaussian distribution,
+to bring the feature values closer to a Gaussian distribution,
 compensating for LSA's erroneous assumptions about textual data.
+
+.. topic:: References:
+
+  * Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze (2008),
+    *Introduction to Information Retrieval*, Cambridge University Press,
+    chapter 18: `Matrix decompositions & latent semantic indexing
+    <http://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
 
 
 .. _DictionaryLearning:

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -237,7 +237,7 @@ factorization, while larger values shrink many coefficients to zero.
 Latent semantic analysis
 ========================
 
-:class:`LSA` implements latent semantic analysis,
+:class:`LatentSemanticAnalysis` implements LSA
 a transformation of term-document matrices
 (as returned by ``CountVectorizer`` or ``TfidfVectorizer``)
 to a "semantic" space of low dimensionality.
@@ -263,11 +263,12 @@ To also transform a test set :math:`X`, we multiply it with :math:`V_k`:
 LSA is very similar to PCA, but differs
 in that it works on sample matrices :math:`X` directly
 instead of their covariance matrices.
-In practical terms, this means :class:`LSA`'s methods
+In practical terms, this means :class:`LatentSemanticAnalysis`'s methods
 accept ``scipy.sparse`` matrices without the need to densify them;
 densifying may fill up memory even for medium-sized document collections.
 
-While the :class:`LSA` transformer works with any (sparse) feature matrix,
+While the :class:`LatentSemanticAnalysis` transformer
+works with any (sparse) feature matrix,
 using it on tf-idf matrices is recommended.
 In particular, sublinear scaling and inverse document frequency
 should be turned on (``sublinear_tf=True, use_idf=True``)

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -232,6 +232,49 @@ factorization, while larger values shrink many coefficients to zero.
      R. Jenatton, G. Obozinski, F. Bach, 2009
 
 
+.. _LSA:
+
+Latent semantic analysis
+========================
+
+:class:`LSA` implements latent semantic analysis,
+a transformation of term-document matrices
+(as returned by ``CountVectorizer`` or ``TfidfVectorizer``)
+to a "semantic" space of low dimensionality.
+
+.. note::
+    LSA is also known as latent semantic indexing, LSI,
+    though strictly that refers to its use in persistent indexes
+    for information retrieval purposes.
+
+Mathematically, LSA amounts to a truncated singular value decomposition (SVD)
+on the training samples :math:`X`:
+
+.. math::
+    X_k = U_k \Sigma_k V_k^\top
+
+After this operation, :math:`U_k \Sigma_k^\top`
+is the transformed training set with :math:`k` features.
+To also transform a test set :math:`X`, we multiply it with :math:`V_k`:
+
+.. math::
+    X' = X V_k^\top
+
+LSA is very similar to PCA, but differs
+in that it works on sample matrices :math:`X` directly
+instead of their covariance matrices.
+In practical terms, this means :class:`LSA`'s methods
+accept ``scipy.sparse`` matrices without the need to densify them;
+densifying may fill up memory even for medium-sized document collections.
+
+While the :class:`LSA` transformer works with any (sparse) feature matrix,
+using it on tf-idf matrices is recommended.
+In particular, sublinear scaling and inverse document frequency
+should be turned on (``sublinear_tf=True, use_idf=True``)
+to bring the tf-idf values closer to a Gaussian distribution,
+compensating for LSA's erroneous assumptions about textual data.
+
+
 .. _DictionaryLearning:
 
 Dictionary Learning

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -17,7 +17,7 @@ k-means.
 # License: Simplified BSD
 
 from sklearn.datasets import fetch_20newsgroups
-from sklearn.decomposition import LSA
+from sklearn.decomposition import LatentSemanticAnalysis
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn import metrics
 
@@ -92,7 +92,7 @@ print
 if opts.n_components:
     print "Performing dimensionality reduction using LSA"
     t0 = time()
-    lsa = LSA(opts.n_components)
+    lsa = LatentSemanticAnalysis(opts.n_components)
     X = lsa.fit_transform(X)
 
     print "done in %fs" % (time() - t0)

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -17,6 +17,7 @@ k-means.
 # License: Simplified BSD
 
 from sklearn.datasets import fetch_20newsgroups
+from sklearn.decomposition import LSA
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn import metrics
 
@@ -36,9 +37,15 @@ logging.basicConfig(level=logging.INFO,
 
 # parse commandline arguments
 op = OptionParser()
+op.add_option("--lsa",
+              dest="n_components", type="int",
+              help="Preprocess documents with latent semantic analysis.")
 op.add_option("--no-minibatch",
               action="store_false", dest="minibatch", default=True,
               help="Use ordinary k-means algorithm.")
+op.add_option("--verbose",
+              action="store_true", dest="verbose", default=False,
+              help="Print progress reports inside k-means algorithm.")
 
 print __doc__
 op.print_help()
@@ -80,6 +87,17 @@ vectorizer = TfidfVectorizer(max_df=0.5, max_features=10000,
 X = vectorizer.fit_transform(dataset.data)
 
 print "done in %fs" % (time() - t0)
+print
+
+if opts.n_components:
+    print "Performing dimensionality reduction using LSA"
+    t0 = time()
+    lsa = LSA(opts.n_components)
+    X = lsa.fit_transform(X)
+
+    print "done in %fs" % (time() - t0)
+    print
+
 print "n_samples: %d, n_features: %d" % X.shape
 print
 
@@ -89,13 +107,12 @@ print
 
 if opts.minibatch:
     km = MiniBatchKMeans(n_clusters=true_k, init='k-means++', n_init=1,
-                         init_size=1000,
-                         batch_size=1000, verbose=1)
+                         init_size=1000, batch_size=1000, verbose=opts.verbose)
 else:
     km = KMeans(n_clusters=true_k, init='random', max_iter=100, n_init=1,
-                verbose=1)
+                verbose=opts.verbose)
 
-print "Clustering sparse data with %s" % km
+print "Clustering sparse data with\n    %r" % km
 t0 = time()
 km.fit(X)
 print "done in %0.3fs" % (time() - t0)

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -4,7 +4,7 @@ algorithms, including among others PCA, NMF or ICA. Most of the algorithms of
 this module can be regarded as dimensionality reduction techniques.
 """
 
-from .lsa import LSA
+from .lsa import LatentSemanticAnalysis
 from .nmf import NMF, ProjectedGradientNMF
 from .pca import PCA, RandomizedPCA, ProbabilisticPCA
 from .kernel_pca import KernelPCA

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -4,6 +4,7 @@ algorithms, including among others PCA, NMF or ICA. Most of the algorithms of
 this module can be regarded as dimensionality reduction techniques.
 """
 
+from .lsa import LSA
 from .nmf import NMF, ProjectedGradientNMF
 from .pca import PCA, RandomizedPCA, ProbabilisticPCA
 from .kernel_pca import KernelPCA

--- a/sklearn/decomposition/lsa.py
+++ b/sklearn/decomposition/lsa.py
@@ -11,10 +11,10 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import as_float_array, atleast2d_or_csr
 from ..utils.extmath import safe_sparse_dot
 
-__all__ = ["LSA"]
+__all__ = ["LatentSemanticAnalysis"]
 
 
-class LSA(BaseEstimator, TransformerMixin):
+class LatentSemanticAnalysis(BaseEstimator, TransformerMixin):
     """Dimensionality reduction using latent semantic analysis (LSA, aka LSI).
 
     LSA performs linear dimensionality reduction by means of truncated

--- a/sklearn/decomposition/lsa.py
+++ b/sklearn/decomposition/lsa.py
@@ -1,0 +1,106 @@
+"""Latent semantic analysis.
+"""
+
+# Author: Lars Buitinck <L.J.Buitinck@uva.nl>
+# License: 3-clause BSD.
+
+import numpy as np
+from scipy.sparse.linalg import svds
+
+from ..base import BaseEstimator, TransformerMixin
+from ..utils import as_float_array, atleast2d_or_csr
+from ..utils.extmath import safe_sparse_dot
+
+__all__ = ["LSA"]
+
+
+class LSA(BaseEstimator, TransformerMixin):
+    """Dimensionality reduction using latent semantic analysis (LSA, aka LSI).
+
+    LSA performs linear dimensionality reduction by means of truncated
+    singular value decomposition (SVD). It is very similar to PCA, but operates
+    on sample vectors directly, instead of on a covariance matrix. This means
+    it can work with scipy.sparse matrices efficiently, in particular term
+    count/tfidf matrices as returned by the vectorizers in
+    sklearn.feature_extraction.text.
+
+    This implementation uses the scipy.sparse.linalg.svds implementation of
+    truncated SVD.
+
+    Parameters
+    ----------
+    n_components : int, optional
+        Desired dimensionality of output data.
+        Must be strictly less than the number of features.
+    tol : float, optional
+        Tolerance for underlying eigensolver. 0 means machine precision.
+
+    Attributes
+    ----------
+    components_ : array, shape (n_components, n_features)
+
+    See also
+    --------
+    PCA
+    RandomizedPCA
+    """
+    def __init__(self, n_components=100, tol=0.):
+        self.n_components = n_components
+        self.tol = tol
+
+    def fit(self, X, y=None):
+        """Fit LSI model on training data X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            Training data.
+
+        Returns
+        -------
+        self : object
+            Returns the transformer object.
+        """
+        self._fit(X)
+        return self
+
+    def fit_transform(self, X, y=None):
+        """Fit LSI model to X and perform dimensionality reduction on X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            Training data.
+
+        Returns
+        -------
+        X_new : array, shape (n_samples, n_components)
+            Reduced version of X. This will always be a dense array.
+        """
+        U, Sigma, VT = self._fit(X)
+        Sigma = np.diag(Sigma)
+
+        # or (X * VT.T).T, whichever takes fewer operations...
+        return np.dot(U, Sigma.T)
+
+    def _fit(self, X):
+        X = as_float_array(X)
+        U, Sigma, VT = svds(X, k=self.n_components, tol=self.tol)
+        self.components_ = VT
+        return U, Sigma, VT
+
+    def transform(self, X):
+        """Perform dimensionality reduction on X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            New data.
+
+        Returns
+        -------
+        X_new : array, shape (n_samples, n_components)
+            Reduced version of X. This will always be a dense array.
+        """
+        X = atleast2d_or_csr(X)
+        return safe_sparse_dot(X, self.components_.T)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -173,6 +173,7 @@ class PCA(BaseEstimator, TransformerMixin):
     ProbabilisticPCA
     RandomizedPCA
     KernelPCA
+    LSA
     SparsePCA
     """
     def __init__(self, n_components=None, copy=True, whiten=False):

--- a/sklearn/decomposition/tests/test_lsa.py
+++ b/sklearn/decomposition/tests/test_lsa.py
@@ -1,0 +1,48 @@
+"""Test latent semantic analysis."""
+
+import numpy as np
+import scipy.sparse as sp
+
+from sklearn.decomposition import LSA
+from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_equal, assert_raises
+
+
+# Make an X that looks somewhat like a small tf-idf matrix.
+# XXX newer versions of SciPy have scipy.sparse.rand for this.
+shape = 60, 55
+n_samples, n_features = shape
+rng = check_random_state(42)
+X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
+X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
+X.data[:] = 1 + np.log(X.data)
+
+
+def test_attributes():
+    for n_components in (10, 25, 41):
+        lsa = LSA(n_components).fit(X)
+        assert_equal(lsa.n_components, n_components)
+        assert_equal(lsa.components_.shape, (n_components, n_features))
+
+
+def test_too_many_components():
+    for n_components in (n_features, n_features+1):
+        lsa = LSA(n_components=n_components)
+        assert_raises(ValueError, lsa.fit, X)
+
+
+def test_sparse_formats():
+    for fmt in ("array", "csr", "csc", "coo", "lil"):
+        Xfmt = getattr(X, "to" + fmt)()
+        lsa = LSA(n_components=11)
+        Xtrans = lsa.fit_transform(Xfmt)
+        assert_equal(Xtrans.shape, (n_samples, 11))
+        Xtrans = lsa.transform(Xfmt)
+        assert_equal(Xtrans.shape, (n_samples, 11))
+
+
+def test_integers():
+    Xint = X.astype(np.int64)
+    lsa = LSA(n_components=6)
+    Xtrans = lsa.fit_transform(Xint)
+    assert_equal(Xtrans.shape, (n_samples, lsa.n_components))

--- a/sklearn/decomposition/tests/test_lsa.py
+++ b/sklearn/decomposition/tests/test_lsa.py
@@ -5,7 +5,8 @@ import scipy.sparse as sp
 
 from sklearn.decomposition import LatentSemanticAnalysis
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_equal, assert_raises
+from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
+                                   assert_raises)
 
 
 # Make an X that looks somewhat like a small tf-idf matrix.
@@ -16,6 +17,19 @@ rng = check_random_state(42)
 X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
 X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
 X.data[:] = 1 + np.log(X.data)
+Xdense = X.A
+
+
+def test_algorithms():
+    alsa = LatentSemanticAnalysis(30, algorithm="arpack")
+    rlsa = LatentSemanticAnalysis(30, algorithm="randomized", random_state=42)
+
+    # Test only the main components; for the rest, the algorithms don't give
+    # nearly the same results.
+    Xa = alsa.fit_transform(X)[:, :6]
+    Xr = rlsa.fit_transform(X)[:, :6]
+    assert_array_almost_equal(Xa, Xr)
+    assert_array_almost_equal(alsa.components_[:6], rlsa.components_[:6])
 
 
 def test_attributes():
@@ -33,12 +47,22 @@ def test_too_many_components():
 
 def test_sparse_formats():
     for fmt in ("array", "csr", "csc", "coo", "lil"):
-        Xfmt = getattr(X, "to" + fmt)()
+        Xfmt = Xdense if fmt == "dense" else getattr(X, "to" + fmt)()
         lsa = LatentSemanticAnalysis(n_components=11)
         Xtrans = lsa.fit_transform(Xfmt)
         assert_equal(Xtrans.shape, (n_samples, 11))
         Xtrans = lsa.transform(Xfmt)
         assert_equal(Xtrans.shape, (n_samples, 11))
+
+
+def test_inverse_transform():
+    for algo in ("arpack", "randomized"):
+        # We need a lot of components for the reconstruction to be "almost
+        # equal" in all positions. XXX Test means or sums instead?
+        lsa = LatentSemanticAnalysis(n_components=52, random_state=42)
+        Xt = lsa.fit_transform(X)
+        Xinv = lsa.inverse_transform(Xt)
+        assert_array_almost_equal(Xinv, Xdense, decimal=1)
 
 
 def test_integers():

--- a/sklearn/decomposition/tests/test_lsa.py
+++ b/sklearn/decomposition/tests/test_lsa.py
@@ -3,7 +3,7 @@
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.decomposition import LSA
+from sklearn.decomposition import LatentSemanticAnalysis
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_equal, assert_raises
 
@@ -20,21 +20,21 @@ X.data[:] = 1 + np.log(X.data)
 
 def test_attributes():
     for n_components in (10, 25, 41):
-        lsa = LSA(n_components).fit(X)
+        lsa = LatentSemanticAnalysis(n_components).fit(X)
         assert_equal(lsa.n_components, n_components)
         assert_equal(lsa.components_.shape, (n_components, n_features))
 
 
 def test_too_many_components():
     for n_components in (n_features, n_features+1):
-        lsa = LSA(n_components=n_components)
+        lsa = LatentSemanticAnalysis(n_components=n_components)
         assert_raises(ValueError, lsa.fit, X)
 
 
 def test_sparse_formats():
     for fmt in ("array", "csr", "csc", "coo", "lil"):
         Xfmt = getattr(X, "to" + fmt)()
-        lsa = LSA(n_components=11)
+        lsa = LatentSemanticAnalysis(n_components=11)
         Xtrans = lsa.fit_transform(Xfmt)
         assert_equal(Xtrans.shape, (n_samples, 11))
         Xtrans = lsa.transform(Xfmt)
@@ -43,6 +43,6 @@ def test_sparse_formats():
 
 def test_integers():
     Xint = X.astype(np.int64)
-    lsa = LSA(n_components=6)
+    lsa = LatentSemanticAnalysis(n_components=6)
     Xtrans = lsa.fit_transform(Xint)
     assert_equal(Xtrans.shape, (n_samples, lsa.n_components))


### PR DESCRIPTION
Following the recent discussion on the ML, I decided to implement latent semantic analysis (LSA) for dimensionality reduction. The implementation is slightly different from what I described in my email because I figured it could be done simpler. The code works (try the clustering example with `--lsa=100`), the tests pass and there's documentation, but...
- the docs need some more love, and especially some reference
- there's no doctest
- there's a potential opportunity for optimization in `fit_transform`, see the comment
- maybe this should have a more general name, like <del>`ReducedSVD`</del> `TruncatedSVD`; it's only LSI when applied to term count matrices

Let me know what you think!
