### PR TITLE
Update AUTHORS file.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,7 +87,3 @@ People
   * `Wei Li <http://kuantkid.github.com>`_
 
   * `Arnaud Joly <http://www.ajoly.org>`_
-
-
-If we forgot anyone, do not hesitate to send me an email to
-amueller@ais.uni-bonn.de and I'll include you in the list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,25 +24,9 @@ People
 
   * David Cournapeau
 
-  * Fred Mailhot
-
-  * David Cooke
-
-  * David Huard
-
-  * Dave Morrill
-
-  * Ed Schofield
-
-  * Eric Jones
-
   * Jarrod Millman
 
   * `Matthieu Brucher <http://matt.eifelle.com/>`_
-
-  * Travis Oliphant
-
-  * Pearu Peterson
 
   * `Fabian Pedregosa <http://fseoane.net/blog/>`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1587,6 +1587,11 @@ of commits):
     *  1  Chris Filo Gorgolewski
 
 
+Earlier versions
+================
+
+Earlier versions included contributions by Fred Mailhot, David Cooke,
+David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Olivier Grisel: http://twitter.com/ogrisel
 


### PR DESCRIPTION
Following a private discussion among the project owners, we have decided to update the AUTHORS.rst file so that it reflects better the core contributors of the project (or past core contributors).

Since this is a sensitive subject, instead of completely deleting names, I've moved them to a new "earlier versions" section in the "what's new file". The contributors that I moved were confirmed by David Cournapeau to not have made substantial contributions.

Any suggestion / comment welcome.
