### PR TITLE
[MRG] FIX new doctest examples aren't crossplatform

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -120,8 +120,8 @@ precision-recall curve.
   >>> from sklearn.metrics import average_precision_score
   >>> y_true = np.array([0, 0, 1, 1])
   >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-  >>> average_precision_score(y_true, y_scores)
-  0.79166666666666663
+  >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
+  0.79...
 
 For more information see the
 `Wikipedia article on average precision
@@ -303,16 +303,16 @@ Here some small examples in binary classification:
   1.0
   >>> metrics.recall_score(y_true, y_pred)
   0.5
-  >>> metrics.f1_score(y_true, y_pred)
-  0.66666666666666663
-  >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)
-  0.83333333333333337
-  >>> metrics.fbeta_score(y_true, y_pred, beta=1)
-  0.66666666666666663
-  >>> metrics.fbeta_score(y_true, y_pred, beta=2)
-  0.55555555555555558
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
-  (array([ 0.66666667,  1.        ]), array([ 1. ,  0.5]), array([ 0.71428571,  0.83333333]), array([2, 2], dtype=int64))
+  >>> metrics.f1_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  0.66...
+  >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+  0.83...
+  >>> metrics.fbeta_score(y_true, y_pred, beta=1)  # doctest: +ELLIPSIS
+  0.66...
+  >>> metrics.fbeta_score(y_true, y_pred, beta=2) # doctest: +ELLIPSIS
+  0.55...
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+  (array([ 0.66...,  1.        ]), array([ 1. ,  0.5]), array([ 0.71...,  0.83...]), array([2, 2], dtype=int64))
 
 
   >>> import numpy as np
@@ -320,8 +320,8 @@ Here some small examples in binary classification:
   >>> y_true = np.array([0, 0, 1, 1])
   >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
   >>> precision, recall, threshold = precision_recall_curve(y_true, y_scores)
-  >>> precision
-  array([ 0.66666667,  0.5       ,  1.        ,  1.        ])
+  >>> precision  # doctest: +ELLIPSIS
+  array([ 0.66...,  0.5       ,  1.        ,  1.        ])
   >>> recall
   array([ 1. ,  0.5,  0.5,  0. ])
   >>> threshold
@@ -413,64 +413,64 @@ Here an example where ``average`` is set to ``average`` to ``macro``:
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
   >>> y_pred = [0, 2, 1, 0, 0, 1]
-  >>> metrics.precision_score(y_true, y_pred, average='macro')
-  0.22222222222222221
-  >>> metrics.recall_score(y_true, y_pred, average='macro')
-  0.33333333333333331
-  >>> metrics.fbeta_score(y_true, y_pred, average='macro', beta=0.5)
-  0.23809523809523805
-  >>> metrics.f1_score(y_true, y_pred, average='macro')
-  0.26666666666666666
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='macro')
-  (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+  >>> metrics.precision_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  0.22...
+  >>> metrics.recall_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.fbeta_score(y_true, y_pred, average='macro', beta=0.5)  # doctest: +ELLIPSIS
+  0.23...
+  >>> metrics.f1_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  0.26...
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+  (0.22..., 0.33..., 0.26..., None)
 
 Here an example where ``average`` is set to to ``micro``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
   >>> y_pred = [0, 2, 1, 0, 0, 1]
-  >>> metrics.precision_score(y_true, y_pred, average='micro')
-  0.33333333333333331
-  >>> metrics.recall_score(y_true, y_pred, average='micro')
-  0.33333333333333331
-  >>> metrics.f1_score(y_true, y_pred, average='micro')
-  0.33333333333333331
-  >>> metrics.fbeta_score(y_true, y_pred, average='micro', beta=0.5)
-  0.33333333333333337
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='micro')
-  (0.33333333333333331, 0.33333333333333331, 0.33333333333333331, None)
+  >>> metrics.precision_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.recall_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.f1_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.fbeta_score(y_true, y_pred, average='micro', beta=0.5)  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+  (0.33..., 0.33..., 0.33..., None)
 
 Here an example where ``average`` is set to to ``weighted``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
   >>> y_pred = [0, 2, 1, 0, 0, 1]
-  >>> metrics.precision_score(y_true, y_pred, average='weighted')
-  0.22222222222222221
-  >>> metrics.recall_score(y_true, y_pred, average='weighted')
-  0.33333333333333331
-  >>> metrics.fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
-  0.23809523809523805
-  >>> metrics.f1_score(y_true, y_pred, average='weighted')
-  0.26666666666666666
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='weighted')
-  (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+  >>> metrics.precision_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+  0.22...
+  >>> metrics.recall_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+  0.33...
+  >>> metrics.fbeta_score(y_true, y_pred, average='weighted', beta=0.5)  # doctest: +ELLIPSIS
+  0.23...
+  >>> metrics.f1_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+  0.26...
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+  (0.22..., 0.33..., 0.26..., None)
 
 Here an example where ``average`` is set to ``None``:
 
   >>> from sklearn import metrics
   >>> y_true = [0, 1, 2, 0, 1, 2]
   >>> y_pred = [0, 2, 1, 0, 0, 1]
-  >>> metrics.precision_score(y_true, y_pred, average=None)
-  array([ 0.66666667,  0.        ,  0.        ])
+  >>> metrics.precision_score(y_true, y_pred, average=None)  # doctest: +ELLIPSIS
+  array([ 0.66...,  0.        ,  0.        ])
   >>> metrics.recall_score(y_true, y_pred, average=None)
   array([ 1.,  0.,  0.])
-  >>> metrics.f1_score(y_true, y_pred, average=None)
+  >>> metrics.f1_score(y_true, y_pred, average=None)  # doctest: +ELLIPSIS
   array([ 0.8,  0. ,  0. ])
-  >>> metrics.fbeta_score(y_true, y_pred, average=None, beta=0.5)
-  array([ 0.71428571,  0.        ,  0.        ])
-  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
-  (array([ 0.66666667,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71428571,  0.        ,  0.        ]), array([2, 2, 2], dtype=int64))
+  >>> metrics.fbeta_score(y_true, y_pred, average=None, beta=0.5)  # doctest: +ELLIPSIS
+  array([ 0.71...,  0.        ,  0.        ])
+  >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+  (array([ 0.66...,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71...,  0.        ,  0.        ]), array([2, 2, 2], dtype=int64))
 
 
 Hinge loss
@@ -501,10 +501,10 @@ with a svm classifier:
        intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
        random_state=0, tol=0.0001, verbose=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
-  >>> pred_decision
-  array([-2.18177944,  2.36355888,  0.09088972])
-  >>> hinge_loss([-1, 1, 1], pred_decision)
-  0.30303676038544258
+  >>> pred_decision  # doctest: +ELLIPSIS
+  array([-2.18...,  2.36...,  0.09...])
+  >>> hinge_loss([-1, 1, 1], pred_decision)  # doctest: +ELLIPSIS
+  0.30...
 
 
 Matthews correlation coefficient
@@ -537,8 +537,8 @@ function:
     >>> from sklearn.metrics import matthews_corrcoef
     >>> y_true = [+1, +1, +1, -1]
     >>> y_pred = [+1, -1, +1, +1]
-    >>> matthews_corrcoef(y_true, y_pred)
-    -0.33333333333333331
+    >>> matthews_corrcoef(y_true, y_pred)  # doctest: +ELLIPSIS
+    -0.33...
 
 .. _roc_metrics:
 
@@ -655,8 +655,8 @@ Here a small example of usage of the :func:`explained_variance_scoreé` function
     >>> from sklearn.metrics import explained_variance_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> explained_variance_score(y_true, y_pred)
-    0.95717344753747324
+    >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.957...
 
 Mean absolute error
 -------------------
@@ -711,8 +711,8 @@ Here a small example of usage of the :func:`mean_squared_error` function:
   0.375
   >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
   >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
-  >>> mean_squared_error(y_true, y_pred)
-  0.70833333333333337
+  >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
+  0.7083...
 
 .. topic:: Examples:
 
@@ -742,12 +742,12 @@ Here a small example of usage of the :func:`r2_score` function:
   >>> from sklearn.metrics import r2_score
   >>> y_true = [3, -0.5, 2, 7]
   >>> y_pred = [2.5, 0.0, 2, 8]
-  >>> r2_score(y_true, y_pred)
-  0.94860813704496794
+  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  0.948...
   >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
   >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
-  >>> r2_score(y_true, y_pred)
-  0.93825665859564167
+  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  0.938...
 
 
 .. topic:: Example:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -312,7 +312,7 @@ Here some small examples in binary classification:
   >>> metrics.fbeta_score(y_true, y_pred, beta=2) # doctest: +ELLIPSIS
   0.55...
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
-  (array([ 0.66...,  1.        ]), array([ 1. ,  0.5]), array([ 0.71...,  0.83...]), array([2, 2], dtype=int64))
+  (array([ 0.66...,  1.        ]), array([ 1. ,  0.5]), array([ 0.71...,  0.83...]), array([2, 2]...))
 
 
   >>> import numpy as np
@@ -470,7 +470,7 @@ Here an example where ``average`` is set to ``None``:
   >>> metrics.fbeta_score(y_true, y_pred, average=None, beta=0.5)  # doctest: +ELLIPSIS
   array([ 0.71...,  0.        ,  0.        ])
   >>> metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
-  (array([ 0.66...,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71...,  0.        ,  0.        ]), array([2, 2, 2], dtype=int64))
+  (array([ 0.66...,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71...,  0.        ,  0.        ]), array([2, 2, 2]...))
 
 
 Hinge loss
@@ -680,8 +680,8 @@ Here a small example of usage of the :func:`mean_absolute_error` function:
   >>> y_pred = [2.5, 0.0, 2, 8]
   >>> mean_absolute_error(y_true, y_pred)
   0.5
-  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
-  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+  >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> mean_absolute_error(y_true, y_pred)
   0.75
 
@@ -709,8 +709,8 @@ Here a small example of usage of the :func:`mean_squared_error` function:
   >>> y_pred = [2.5, 0.0, 2, 8]
   >>> mean_squared_error(y_true, y_pred)
   0.375
-  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
-  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+  >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
   0.7083...
 
@@ -744,8 +744,8 @@ Here a small example of usage of the :func:`r2_score` function:
   >>> y_pred = [2.5, 0.0, 2, 8]
   >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
   0.948...
-  >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
-  >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+  >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+  >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
   0.938...
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -977,8 +977,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     array([ 1. ,  0.5])
     >>> f  # doctest: +ELLIPSIS
     array([ 0.71...,  0.83...])
-    >>> s
-    array([2, 2], dtype=int64)
+    >>> s  # doctest: +ELLIPSIS
+    array([2, 2]...)
 
     Here an example in the multiclass case:
     >>> from sklearn.metrics import precision_recall_fscore_support
@@ -1365,8 +1365,8 @@ def mean_absolute_error(y_true, y_pred):
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> mean_absolute_error(y_true, y_pred)
     0.5
-    >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
-    >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+    >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+    >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> mean_absolute_error(y_true, y_pred)
     0.75
 
@@ -1488,8 +1488,8 @@ def r2_score(y_true, y_pred):
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
     0.948...
-    >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
-    >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
+    >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+    >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
     0.938...
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -130,10 +130,10 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
          intercept_scaling=1, loss='l2', multi_class='ovr', penalty='l2',
          random_state=0, tol=0.0001, verbose=0)
     >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
-    >>> pred_decision
-    array([-2.18177944,  2.36355888,  0.09088972])
-    >>> hinge_loss([-1, 1, 1], pred_decision)
-    0.30303676038544258
+    >>> pred_decision  # doctest: +ELLIPSIS
+    array([-2.18...,  2.36...,  0.09...])
+    >>> hinge_loss([-1, 1, 1], pred_decision)  # doctest: +ELLIPSIS
+    0.30...
 
     """
     # TODO: multi-class hinge-loss
@@ -189,8 +189,8 @@ def average_precision_score(y_true, y_score):
     >>> from sklearn.metrics import average_precision_score
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> average_precision_score(y_true, y_scores)
-    0.79166666666666663
+    >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
+    0.79...
 
     """
     precision, recall, thresholds = precision_recall_curve(y_true, y_score)
@@ -280,8 +280,8 @@ def matthews_corrcoef(y_true, y_pred):
     >>> from sklearn.metrics import matthews_corrcoef
     >>> y_true = [+1, +1, +1, -1]
     >>> y_pred = [+1, -1, +1, +1]
-    >>> matthews_corrcoef(y_true, y_pred)
-    -0.33333333333333331
+    >>> matthews_corrcoef(y_true, y_pred)  # doctest: +ELLIPSIS
+    -0.33...
 
     """
     mcc = np.corrcoef(y_true, y_pred)[0, 1]
@@ -335,8 +335,8 @@ def precision_recall_curve(y_true, probas_pred):
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> precision, recall, threshold = precision_recall_curve(y_true, y_scores)
-    >>> precision
-    array([ 0.66666667,  0.5       ,  1.        ,  1.        ])
+    >>> precision  # doctest: +ELLIPSIS
+    array([ 0.66...,  0.5       ,  1.        ,  1.        ])
     >>> recall
     array([ 1. ,  0.5,  0.5,  0. ])
     >>> threshold
@@ -774,19 +774,19 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     >>> from sklearn.metrics import f1_score
     >>> y_pred = [0, 1, 0, 0]
     >>> y_true = [0, 1, 0, 1]
-    >>> f1_score(y_true, y_pred)
-    0.66666666666666663
+    >>> f1_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.666...
 
     Here an example in the multiclass case:
     >>> from sklearn.metrics import f1_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> f1_score(y_true, y_pred, average='macro')
-    0.26666666666666666
-    >>> f1_score(y_true, y_pred, average='micro')
-    0.33333333333333331
-    >>> f1_score(y_true, y_pred, average='weighted')
-    0.26666666666666666
+    >>> f1_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    0.26...
+    >>> f1_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    0.33...
+    >>> f1_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+    0.26...
     >>> f1_score(y_true, y_pred, average=None)
     array([ 0.8,  0. ,  0. ])
 
@@ -859,25 +859,29 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     >>> from sklearn.metrics import fbeta_score
     >>> y_pred = [0, 1, 0, 0]
     >>> y_true = [0, 1, 0, 1]
-    >>> fbeta_score(y_true, y_pred, beta=0.5)
-    0.83333333333333337
-    >>> fbeta_score(y_true, y_pred, beta=1)
-    0.66666666666666663
-    >>> fbeta_score(y_true, y_pred, beta=2)
-    0.55555555555555558
+    >>> fbeta_score(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS
+    0.83...
+    >>> fbeta_score(y_true, y_pred, beta=1)  # doctest: +ELLIPSIS
+    0.66...
+    >>> fbeta_score(y_true, y_pred, beta=2)  # doctest: +ELLIPSIS
+    0.55...
 
     Here an example in the multiclass case:
     >>> from sklearn.metrics import fbeta_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
-    0.23809523809523805
-    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
-    0.33333333333333337
-    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
-    0.23809523809523805
-    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
-    array([ 0.71428571,  0.        ,  0.        ])
+    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)\
+        # doctest: +ELLIPSIS
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)\
+        # doctest: +ELLIPSIS
+    0.33...
+    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)\
+        # doctest: +ELLIPSIS
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)\
+        # doctest: +ELLIPSIS
+    array([ 0.71...,  0.        ,  0.        ])
 
     """
     _, _, f, _ = precision_recall_fscore_support(y_true, y_pred,
@@ -967,12 +971,12 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     >>> y_pred = [0, 1, 0, 0]
     >>> y_true = [0, 1, 0, 1]
     >>> p, r, f, s = precision_recall_fscore_support(y_true, y_pred, beta=0.5)
-    >>> p
-    array([ 0.66666667,  1.        ])
+    >>> p  # doctest: +ELLIPSIS
+    array([ 0.66...,  1.        ])
     >>> r
     array([ 1. ,  0.5])
-    >>> f
-    array([ 0.71428571,  0.83333333])
+    >>> f  # doctest: +ELLIPSIS
+    array([ 0.71...,  0.83...])
     >>> s
     array([2, 2], dtype=int64)
 
@@ -980,12 +984,15 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     >>> from sklearn.metrics import precision_recall_fscore_support
     >>> y_true = np.array([0, 1, 2, 0, 1, 2])
     >>> y_pred = np.array([0, 2, 1, 0, 0, 1])
-    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
-    (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
-    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
-    (0.33333333333333331, 0.33333333333333331, 0.33333333333333331, None)
-    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
-    (0.22222222222222221, 0.33333333333333331, 0.26666666666666666, None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')\
+        # doctest: +ELLIPSIS
+    (0.22..., 0.33..., 0.26..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')\
+        # doctest: +ELLIPSIS
+    (0.33..., 0.33..., 0.33..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')\
+        # doctest: +ELLIPSIS
+    (0.22..., 0.33..., 0.26..., None)
 
     """
     if beta <= 0:
@@ -1125,14 +1132,15 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     >>> from sklearn.metrics import precision_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> precision_score(y_true, y_pred, average='macro')
-    0.22222222222222221
-    >>> precision_score(y_true, y_pred, average='micro')
-    0.33333333333333331
-    >>> precision_score(y_true, y_pred, average='weighted')
-    0.22222222222222221
-    >>> precision_score(y_true, y_pred, average=None)
-    array([ 0.66666667,  0.        ,  0.        ])
+    >>> precision_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    0.22...
+    >>> precision_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    0.33...
+    >>> precision_score(y_true, y_pred, average='weighted')\
+        # doctest: +ELLIPSIS
+    0.22...
+    >>> precision_score(y_true, y_pred, average=None)  # doctest: +ELLIPSIS
+    array([ 0.66...,  0.        ,  0.        ])
 
     """
     p, _, _, _ = precision_recall_fscore_support(y_true, y_pred,
@@ -1200,12 +1208,12 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     >>> from sklearn.metrics import recall_score
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> recall_score(y_true, y_pred, average='macro')
-    0.33333333333333331
-    >>> recall_score(y_true, y_pred, average='micro')
-    0.33333333333333331
-    >>> recall_score(y_true, y_pred, average='weighted')
-    0.33333333333333331
+    >>> recall_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
+    0.33...
+    >>> recall_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    0.33...
+    >>> recall_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+    0.33...
     >>> recall_score(y_true, y_pred, average=None)
     array([ 1.,  0.,  0.])
 
@@ -1392,8 +1400,8 @@ def mean_squared_error(y_true, y_pred):
     0.375
     >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
     >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
-    >>> mean_squared_error(y_true, y_pred)
-    0.70833333333333337
+    >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.708...
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
@@ -1430,8 +1438,8 @@ def explained_variance_score(y_true, y_pred):
     >>> from sklearn.metrics import explained_variance_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> explained_variance_score(y_true, y_pred)
-    0.95717344753747324
+    >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.957...
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)
@@ -1478,12 +1486,12 @@ def r2_score(y_true, y_pred):
     >>> from sklearn.metrics import r2_score
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
-    >>> r2_score(y_true, y_pred)
-    0.94860813704496794
+    >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.948...
     >>> y_true = [[0.5, 1],[-1, 1],[7, -6]]
     >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
-    >>> r2_score(y_true, y_pred)
-    0.93825665859564167
+    >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.938...
 
     """
     y_true, y_pred = check_arrays(y_true, y_pred)


### PR DESCRIPTION
I try to solve ``Build failed in Jenkins: python-2.7-numpy-1.6.2-scipy-0.10.1 #1692`.

Three errors are given

```

======================================================================
FAIL: Doctest: model_evaluation.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sp/lib/python/cpython-2.7.2/lib/python2.7/doctest.py", line 2166, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for model_evaluation.rst
  File "<https://jenkins.shiningpanda-ci.com/scikit-learn/job/python-2.7-numpy-1.6.2-scipy-0.10.1/ws/doc/modules/model_evaluation.rst",> line 0

----------------------------------------------------------------------
File "<https://jenkins.shiningpanda-ci.com/scikit-learn/job/python-2.7-numpy-1.6.2-scipy-0.10.1/ws/doc/modules/model_evaluation.rst",> line 314, in model_evaluation.rst
Failed example:
    metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
Expected:
    (array([ 0.66666667,  1.        ]), array([ 1. ,  0.5]), array([ 0.71428571,  0.83333333]), array([2, 2], dtype=int64))
Got:
    (array([ 0.66666667,  1.        ]), array([ 1. ,  0.5]), array([ 0.71428571,  0.83333333]), array([2, 2]))
----------------------------------------------------------------------
File "<https://jenkins.shiningpanda-ci.com/scikit-learn/job/python-2.7-numpy-1.6.2-scipy-0.10.1/ws/doc/modules/model_evaluation.rst",> line 472, in model_evaluation.rst
Failed example:
    metrics.precision_recall_fscore_support(y_true, y_pred, beta=0.5)
Expected:
    (array([ 0.66666667,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71428571,  0.        ,  0.        ]), array([2, 2, 2], dtype=int64))
Got:
    (array([ 0.66666667,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71428571,  0.        ,  0.        ]), array([2, 2, 2]))
----------------------------------------------------------------------
File "<https://jenkins.shiningpanda-ci.com/scikit-learn/job/python-2.7-numpy-1.6.2-scipy-0.10.1/ws/doc/modules/model_evaluation.rst",> line 506, in model_evaluation.rst
Failed example:
    hinge_loss([-1, 1, 1], pred_decision)
Expected:
    0.30303676038544258
Got:
    0.30303676038544253

>>  raise self.failureException(self.format_failure(<StringIO.StringIO instance at 0x41c9320>.getvalue()))
```

I've solved the  floating precision with `# doctest: +ELLIPSIS`. 
However, I haven't succeeded to solve the `dtype=int64` error properly. Any advices is appreciated.  
