### PR TITLE
Python 3.x fix for sklearn.utils

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -11,7 +11,7 @@ from .validation import (as_float_array, check_arrays, safe_asarray,
                          assert_all_finite, array2d, atleast2d_or_csc,
                          atleast2d_or_csr, warn_if_not_float,
                          check_random_state)
-from class_weight import compute_class_weight
+from .class_weight import compute_class_weight
 
 __all__ = ["murmurhash3_32", "as_float_array", "check_arrays", "safe_asarray",
            "assert_all_finite", "array2d", "atleast2d_or_csc",


### PR DESCRIPTION
(it breaks e.g. "import sklearn.metrics" under Python 3.3)
