### PR TITLE
Changed minus sign to plus.

### DIFF
--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -163,7 +163,7 @@ class Parallel(Logger):
             The number of jobs to use for the computation. If -1 all CPUs
             are used. If 1 is given, no parallel computing code is used
             at all, which is useful for debuging. For n_jobs below -1,
-            (n_cpus + 1 - n_jobs) are used. Thus for n_jobs = -2, all
+            (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all
             CPUs but one are used.
         verbose: int, optional
             The verbosity level: if non zero, progress messages are


### PR DESCRIPTION
Sorry this may seem confusing and like like a duplicate, but the other pull requests for the same issue did not correct the parallel.py file because it was external. But now Gael has fixed the documentation in that file on the joblib repository so now it probably makes sense to change the file here for correctness/consistency.
