### PR TITLE
MRG undo renaming of class_prior to class_weight in naive bayes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -257,6 +257,9 @@ API changes summary
 
    - :func:`datasets.make_circles` now has the same number of inner and outer points.
 
+   - In the Naive Bayes classifiers, the ``class_prior`` parmeter was moved
+     from ``fit`` to ``__init__``.
+
 
 .. _changes_0_12.1:
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -211,10 +211,6 @@ class BaseDiscreteNB(BaseNB):
         sample_weight : array-like, shape = [n_samples], optional
             Weights applied to individual samples (1. for unweighted).
 
-        class_prior : array, shape [n_classes]
-            Custom prior probability per class.
-            Overrides the fit_prior parameter.
-
         Returns
         -------
         self : object
@@ -240,11 +236,11 @@ class BaseDiscreteNB(BaseNB):
             Y *= array2d(sample_weight).T
 
         if class_prior is not None:
-            warnings.warn('class_prior is deprecated in fit function and will '
-                          'be removed in version 0.15. Use the `__init__` '
-                          'parameter  class_weight instead.')
+            warnings.warn('class_prior has been made an ``__init__`` parameter'
+                          ' and will be removed from fit in version 0.15.',
+                          DeprecationWarning)
         else:
-            class_prior = self.class_weight
+            class_prior = self.class_prior
 
         if class_prior:
             if len(class_prior) != n_classes:
@@ -299,7 +295,7 @@ class MultinomialNB(BaseDiscreteNB):
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
 
-    class_weight : array-like, size=[n_classes,]
+    class_prior : array-like, size=[n_classes,]
         Prior probabilities of the classes. If specified the priors are not
         adjusted according to the data.
 
@@ -324,7 +320,7 @@ class MultinomialNB(BaseDiscreteNB):
     >>> from sklearn.naive_bayes import MultinomialNB
     >>> clf = MultinomialNB()
     >>> clf.fit(X, Y)
-    MultinomialNB(alpha=1.0, class_weight=None, fit_prior=True)
+    MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)
     >>> print(clf.predict(X[2]))
     [3]
 
@@ -335,10 +331,10 @@ class MultinomialNB(BaseDiscreteNB):
     Tackling the poor assumptions of naive Bayes text classifiers, ICML.
     """
 
-    def __init__(self, alpha=1.0, fit_prior=True, class_weight=None):
+    def __init__(self, alpha=1.0, fit_prior=True, class_prior=None):
         self.alpha = alpha
         self.fit_prior = fit_prior
-        self.class_weight = class_weight
+        self.class_prior = class_prior
 
     def _count(self, X, Y):
         """Count and smooth feature occurrences."""
@@ -377,7 +373,7 @@ class BernoulliNB(BaseDiscreteNB):
         Whether to learn class prior probabilities or not.
         If false, a uniform prior will be used.
 
-    class_weight : array-like, size=[n_classes,]
+    class_prior : array-like, size=[n_classes,]
         Prior probabilities of the classes. If specified the priors are not
         adjusted according to the data.
 
@@ -397,7 +393,7 @@ class BernoulliNB(BaseDiscreteNB):
     >>> from sklearn.naive_bayes import BernoulliNB
     >>> clf = BernoulliNB()
     >>> clf.fit(X, Y)
-    BernoulliNB(alpha=1.0, binarize=0.0, class_weight=None, fit_prior=True)
+    BernoulliNB(alpha=1.0, binarize=0.0, class_prior=None, fit_prior=True)
     >>> print(clf.predict(X[2]))
     [3]
 
@@ -416,11 +412,11 @@ class BernoulliNB(BaseDiscreteNB):
     """
 
     def __init__(self, alpha=1.0, binarize=.0, fit_prior=True,
-                 class_weight=None):
+                 class_prior=None):
         self.alpha = alpha
         self.binarize = binarize
         self.fit_prior = fit_prior
-        self.class_weight = class_weight
+        self.class_prior = class_prior
 
     def _count(self, X, Y):
         """Count and smooth feature occurrences."""

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -152,7 +152,7 @@ def test_discretenb_provide_prior():
     """Test whether discrete NB classes use provided prior"""
 
     for cls in [BernoulliNB, MultinomialNB]:
-        clf = cls(class_weight=[0.5, 0.5])
+        clf = cls(class_prior=[0.5, 0.5])
         clf.fit([[0], [0], [1]], [0, 0, 1])
         prior = np.exp(clf.class_log_prior_)
         assert_array_equal(prior, np.array([.5, .5]))


### PR DESCRIPTION
This is my current thoughts on #1511.
I am not sure that the rename was a good idea, so I'd like to stay with the old name for the release.
