### PR TITLE
Ridge sample weights: fixes #1489

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -13,6 +13,7 @@ Generalized Linear models.
 # License: BSD Style.
 
 from abc import ABCMeta, abstractmethod
+import numbers
 
 import numpy as np
 import scipy.sparse as sp
@@ -67,19 +68,29 @@ def sparse_center_data(X, y, fit_intercept, normalize=False):
     return X_data, y, X_mean, y_mean, X_std
 
 
-def center_data(X, y, fit_intercept, normalize=False, copy=True):
+def center_data(X, y, fit_intercept, normalize=False, copy=True,
+                sample_weight=None):
     """
     Centers data to have mean zero along axis 0. This is here because
     nearly all linear models will want their data to be centered.
+
+    If sample_weight is not None, then the weighted mean of X and y
+    is zero, and not the mean itself
     """
     X = as_float_array(X, copy)
+    no_sample_weight = (sample_weight is None
+                        or isinstance(sample_weight, numbers.Number))
 
     if fit_intercept:
         if sp.issparse(X):
             X_mean = np.zeros(X.shape[1])
             X_std = np.ones(X.shape[1])
         else:
-            X_mean = X.mean(axis=0)
+            if no_sample_weight:
+                X_mean = X.mean(axis=0)
+            else:
+                X_mean = (np.sum(X * sample_weight[:, np.newaxis], axis=0)
+                            / np.sum(sample_weight))
             X -= X_mean
             if normalize:
                 X_std = np.sqrt(np.sum(X ** 2, axis=0))
@@ -87,7 +98,16 @@ def center_data(X, y, fit_intercept, normalize=False, copy=True):
                 X /= X_std
             else:
                 X_std = np.ones(X.shape[1])
-        y_mean = y.mean(axis=0)
+        if no_sample_weight:
+            y_mean = y.mean(axis=0)
+        else:
+            if y.ndim <= 1:
+                y_mean = (np.sum(y * sample_weight, axis=0)
+                            / np.sum(sample_weight))
+            else:
+                # cater for multi-output problems
+                y_mean = (np.sum(y * sample_weight[:, np.newaxis], axis=0)
+                            / np.sum(sample_weight))
         y = y - y_mean
     else:
         X_mean = np.zeros(X.shape[1])

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -578,7 +578,8 @@ class _RidgeGCV(LinearModel):
         n_samples, n_features = X.shape
 
         X, y, X_mean, y_mean, X_std = LinearModel._center_data(
-            X, y, self.fit_intercept, self.normalize, self.copy_X)
+            X, y, self.fit_intercept, self.normalize, self.copy_X,
+            sample_weight=sample_weight)
 
         gcv_mode = self.gcv_mode
         with_sw = len(np.shape(sample_weight))

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -210,7 +210,8 @@ class _BaseRidge(LinearModel):
         y = np.asarray(y, dtype=np.float)
 
         X, y, X_mean, y_mean, X_std = self._center_data(
-            X, y, self.fit_intercept, self.normalize, self.copy_X)
+            X, y, self.fit_intercept, self.normalize, self.copy_X,
+            sample_weight=sample_weight)
 
         self.coef_ = ridge_regression(X, y,
                                       alpha=self.alpha,

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -21,10 +21,10 @@ from sklearn.linear_model.ridge import RidgeClassifierCV
 
 from sklearn.cross_validation import KFold
 
-rng = np.random.RandomState(0)
 diabetes = datasets.load_diabetes()
 X_diabetes, y_diabetes = diabetes.data, diabetes.target
 ind = np.arange(X_diabetes.shape[0])
+rng = np.random.RandomState(0)
 rng.shuffle(ind)
 ind = ind[:200]
 X_diabetes, y_diabetes = X_diabetes[ind], y_diabetes[ind]
@@ -44,6 +44,7 @@ def test_ridge():
     TODO: for this test to be robust, we should use a dataset instead
     of np.random.
     """
+    rng = np.random.RandomState(0)
     alpha = 1.0
 
     for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
@@ -72,9 +73,11 @@ def test_ridge():
         assert_greater(ridge.score(X, y), 0.9)
 
 
+
 def test_ridge_shapes():
     """Test shape of coef_ and intercept_
     """
+    rng = np.random.RandomState(0)
     n_samples, n_features = 5, 10
     X = rng.randn(n_samples, n_features)
     y = rng.randn(n_samples)
@@ -99,6 +102,7 @@ def test_ridge_shapes():
 def test_ridge_intercept():
     """Test intercept with multiple targets GH issue #708
     """
+    rng = np.random.RandomState(0)
     n_samples, n_features = 5, 10
     X = rng.randn(n_samples, n_features)
     y = rng.randn(n_samples)
@@ -141,6 +145,7 @@ def test_toy_ridge_object():
 def test_ridge_vs_lstsq():
     """On alpha=0., Ridge and OLS yield the same solution."""
 
+    rng = np.random.RandomState(0)
     # we need more samples than features
     n_samples, n_features = 5, 4
     y = rng.randn(n_samples)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -90,7 +90,7 @@ def test_ridge_sample_weights():
             # for the square loss
             coefs2 = ridge_regression(
                             X * np.sqrt(sample_weight)[:, np.newaxis],
-                            y * np.sqrt(sample_weight)[:, np.newaxis],
+                            y * np.sqrt(sample_weight),
                             alpha, solver=solver)
             assert_array_almost_equal(coefs, coefs2)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -12,6 +12,7 @@ from sklearn import datasets
 from sklearn.metrics import mean_squared_error
 
 from sklearn.linear_model.base import LinearRegression
+from sklearn.linear_model.ridge import ridge_regression
 from sklearn.linear_model.ridge import Ridge
 from sklearn.linear_model.ridge import _RidgeGCV
 from sklearn.linear_model.ridge import RidgeCV
@@ -72,6 +73,25 @@ def test_ridge():
         ridge.fit(X, y, sample_weight=np.ones(n_samples))
         assert_greater(ridge.score(X, y), 0.9)
 
+
+def test_ridge_sample_weights():
+    rng = np.random.RandomState(0)
+    alpha = 1.0
+
+    for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
+        for n_samples, n_features in ((6, 5), (5, 10)):
+            n_samples, n_features = 6, 5
+            y = rng.randn(n_samples)
+            X = rng.randn(n_samples, n_features)
+            sample_weight = 1 + rng.rand(n_samples)
+
+            coefs = ridge_regression(X, y, alpha, sample_weight,
+                                     solver=solver)
+            coefs2 = ridge_regression(
+                            X * np.sqrt(sample_weight)[:, np.newaxis],
+                            y * np.sqrt(sample_weight)[:, np.newaxis],
+                            alpha, solver=solver)
+            assert_array_almost_equal(coefs, coefs2)
 
 
 def test_ridge_shapes():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -80,13 +80,14 @@ def test_ridge_sample_weights():
 
     for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
         for n_samples, n_features in ((6, 5), (5, 10)):
-            n_samples, n_features = 6, 5
             y = rng.randn(n_samples)
             X = rng.randn(n_samples, n_features)
             sample_weight = 1 + rng.rand(n_samples)
 
             coefs = ridge_regression(X, y, alpha, sample_weight,
                                      solver=solver)
+            # Sample weight can be implemented via a simple rescaling
+            # for the square loss
             coefs2 = ridge_regression(
                             X * np.sqrt(sample_weight)[:, np.newaxis],
                             y * np.sqrt(sample_weight)[:, np.newaxis],

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -676,10 +676,6 @@ def test_class_weight_classifiers():
             if name == "NuSVC":
                 # the sparse version has a parameter that doesn't do anything
                 continue
-            if name.startswith("RidgeClassifier"):
-                # RidgeClassifier shows unexpected behavior
-                # FIXME!
-                continue
             if name.endswith("NB"):
                 # NaiveBayes classifiers have a somewhat different interface.
                 # FIXME SOON!


### PR DESCRIPTION
This fixes #1489 (wrong behavior in ridge for sample weights) by fixing the formulas of the ridge when sample weights are passed, and by shifting the intercept.
