### PR TITLE
MRG : add reconstruction_err_ for NMF with sparse input

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -517,7 +517,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
             if not sp.issparse(X):
                 self.reconstruction_err_ = norm(X - np.dot(W, H))
             else:
-                norm2X = np.sum(X.data ** 2)  # XXX: must be a cleaner way
+                norm2X = np.sum(X.data ** 2)  # Ok because X is CSR
                 normWHT = np.trace(np.dot(np.dot(H.T, np.dot(W.T, W)), H))
                 cross_prod = np.trace(np.dot((X * H.T).T, W))
                 self.reconstruction_err_ = sqrt(norm2X + normWHT

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -10,6 +10,7 @@
 
 from __future__ import division
 
+from math import sqrt
 import warnings
 import numbers
 
@@ -301,8 +302,6 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         Frobenius norm of the matrix difference between the
         training data and the reconstructed data from the
         fit produced by the model. ``|| X - WH ||_2``
-        Not computed for sparse input matrices because it is
-        too expensive in terms of memory.
 
     Examples
     --------
@@ -517,6 +516,12 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
             if not sp.issparse(X):
                 self.reconstruction_err_ = norm(X - np.dot(W, H))
+            else:
+                norm2X = np.sum(X.data ** 2)  # XXX: must be a cleaner way
+                normWHT = np.trace(np.dot(np.dot(H.T, np.dot(W.T, W)), H))
+                cross_prod = np.trace(np.dot((X * H.T).T, W))
+                self.reconstruction_err_ = sqrt(norm2X + normWHT
+                                                - 2. * cross_prod)
 
             self.components_ = H
 

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -123,7 +123,6 @@ def test_projgrad_nmf_sparseness():
     Test that sparsity contraints actually increase sparseness in the
     part where they are applied.
     """
-
     A = np.abs(random_state.randn(10, 10))
     m = nmf.ProjectedGradientNMF(n_components=5).fit(A)
     data_sp = nmf.ProjectedGradientNMF(
@@ -144,8 +143,11 @@ def test_sparse_input():
                                   random_state=999).fit_transform(A)
 
     A_sparse = csr_matrix(A)
-    T2 = nmf.ProjectedGradientNMF(n_components=5, init='random',
-                                  random_state=999).fit_transform(A_sparse)
+    pg_nmf = nmf.ProjectedGradientNMF(n_components=5, init='random',
+                                      random_state=999)
+    T2 = pg_nmf.fit_transform(A_sparse)
+    assert_array_almost_equal(pg_nmf.reconstruction_err_,
+                  np.linalg.norm(A - np.dot(T2, pg_nmf.components_), 'fro'))
     assert_array_almost_equal(T1, T2)
 
     # same with sparseness

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy import linalg
 from sklearn.decomposition import nmf
 
 from sklearn.utils.testing import assert_true
@@ -33,8 +34,8 @@ def test_initialize_close():
     """
     A = np.abs(random_state.randn(10, 10))
     W, H = nmf._initialize_nmf(A, 10)
-    error = np.linalg.norm(np.dot(W, H) - A)
-    sdev = np.linalg.norm(A - A.mean())
+    error = linalg.norm(np.dot(W, H) - A)
+    sdev = linalg.norm(A - A.mean())
     assert_true(error <= sdev)
 
 
@@ -147,7 +148,7 @@ def test_sparse_input():
                                       random_state=999)
     T2 = pg_nmf.fit_transform(A_sparse)
     assert_array_almost_equal(pg_nmf.reconstruction_err_,
-                  np.linalg.norm(A - np.dot(T2, pg_nmf.components_), 'fro'))
+                  linalg.norm(A - np.dot(T2, pg_nmf.components_), 'fro'))
     assert_array_almost_equal(T1, T2)
 
     # same with sparseness


### PR DESCRIPTION
I hacked something to get the frobenius norm of a sparse matrix. Let me know if there is a cleaner way.
