### PR TITLE
update banner for version 12 as older version

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,7 +126,7 @@ html_theme = 'scikit-learn'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {'oldversion':False, 'collapsiblesidebar': True}
+html_theme_options = {'oldversion':True, 'collapsiblesidebar': True}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['themes']


### PR DESCRIPTION
Activate old-version banner for 0.12 documentation..
The main reason for the PR is just to get the go-ahead for pushing
the rebuilt-with-banner version onto the version 12 doc on sourcefource..
Let me know if there's any reason to wait first :)
