### PR TITLE
BF: explicitly mark train_test_split as not the one for nosetesting

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1368,3 +1368,5 @@ def train_test_split(*arrays, **options):
         splitted.append(a[train])
         splitted.append(a[test])
     return splitted
+
+train_test_split.__test__ = False  # to avoid a pb with nosetests


### PR DESCRIPTION
otherwise nose might consider running it resulting in
  File "/tmp/buildd/scikit-learn-0.13/debian/python-sklearn/usr/lib/python2.7/dist-packages/sklearn/cross_validation.py", line 1349, in train_test_split
    raise ValueError("At least one array required as input")
ValueError: At least one array required as input

as was also reported on the mailing list
Message-ID: 50F6B2D3.1010801@sina.com
