### PR TITLE
MRG added ``classes`` parameter to LabelBinarizer

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -360,7 +360,7 @@ matrix from a list of multi-class labels::
 
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(neg_label=0, pos_label=1)
+    LabelBinarizer(classes=None, multilabel=None, neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -360,8 +360,7 @@ matrix from a list of multi-class labels::
 
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(classes=None, indicator_matrix=None, multilabel=None,
-            neg_label=0, pos_label=1)
+    LabelBinarizer(classes=None, label_type='auto', neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -360,7 +360,8 @@ matrix from a list of multi-class labels::
 
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(classes=None, multilabel=None, neg_label=0, pos_label=1)
+    LabelBinarizer(classes=None, indicator_matrix=None, multilabel=None,
+            neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -247,7 +247,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     @property
     def multilabel_(self):
         """Whether this is a multilabel classifier"""
-        return self.label_binarizer_.multilabel
+        return self.label_binarizer_.multilabel_
 
     def score(self, X, y):
         if self.multilabel_:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -955,7 +955,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
     LabelBinarizer(classes=None, indicator_matrix=None, multilabel=None,
-           neg_label=0, pos_label=1)
+            neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1124,7 +1124,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             half = (self.pos_label - self.neg_label) / 2.0
             threshold = self.neg_label + half
 
-        if self.multilabel:
+        if self.multilabel_:
             Y = np.array(Y > threshold, dtype=int)
             # Return the predictions in the same format as in fit
             if self.indicator_matrix_:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -16,6 +16,7 @@ from .externals.six import string_types
 from .utils import check_arrays, array2d, atleast2d_or_csr, safe_asarray
 from .utils import warn_if_not_float
 from .utils.fixes import unique
+from .utils import deprecated
 
 from .utils.sparsefuncs import inplace_csr_row_normalize_l1
 from .utils.sparsefuncs import inplace_csr_row_normalize_l2
@@ -941,7 +942,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         Array of possible classes.
 
     label_type : string, default="auto"
-        Possible values and expected forms of y are:
+        Expected type of y.
+        Possible values are:
             - "multiclass", y is array of ints
             - "multilabel-indicator", y is indicator matrix of classes
             - "multiclass-list", y is list of lists of labels
@@ -953,12 +955,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     `classes_` : array of shape [n_class]
         Holds the label for each class.
 
-    `multilabel_` : bool
-        Whether the estimator was fitted for multi-label data.
+    `label_type_` : bool
+        The type of label used. Inferred from training data if
+        ``label_type="auto"``.
 
-    `indicator_matrix_` : bool
-        Whether the estimator was fitted with a label indicator matrix.
-        This will determine the result of ``inverse_transform``.
 
     Examples
     --------
@@ -1159,6 +1159,16 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             y = Y.argmax(axis=1)
 
         return self.classes_[y]
+
+    @property
+    @deprecated("Use ``label_type_`` instead. Will be removed in 0.15.")
+    def multilabel_(self):
+        return self.label_type in ["multilabel-list", "multilabel-indicator"]
+
+    @property
+    @deprecated("Use ``label_type_`` instead. Will be removed in 0.15.")
+    def label_indicator_(self):
+        return self.label_type == "multilabel-indicator"
 
 
 class KernelCenterer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -938,16 +938,16 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     pos_label : int (default: 1)
         Value with which positive labels must be encoded.
 
-    classes : ndarray if int or None (default)
+    classes : ndarray of int or None (default)
         Array of possible classes.
 
     label_type : string, default="auto"
         Expected type of y.
         Possible values are:
-            - "multiclass", y is array of ints
-            - "multilabel-indicator", y is indicator matrix of classes
-            - "multiclass-list", y is list of lists of labels
-            - "auto", form of y is determined during 'fit'. If 'fit' is not
+            - "multiclass", y is an array-like of ints
+            - "multilabel-indicator", y is an indicator matrix of classes
+            - "multiclass-list", y is a list of lists of labels
+            - "auto", the form of y is determined during 'fit'. If 'fit' is not
               called, multiclass is assumed.
 
     Attributes
@@ -955,9 +955,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     `classes_` : array of shape [n_class]
         Holds the label for each class.
 
-    `label_type_` : bool
+    `label_type_` : string
         The type of label used. Inferred from training data if
-        ``label_type="auto"``.
+        ``label_type="auto"``, otherwise identical to the ``label_type``
+        parameter.
 
 
     Examples
@@ -981,8 +982,6 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
     def __init__(self, neg_label=0, pos_label=1, classes=None,
                  label_type='auto'):
-        if neg_label >= pos_label:
-            raise ValueError("neg_label must be strictly less than pos_label.")
 
         self.neg_label = neg_label
         self.pos_label = pos_label
@@ -1016,6 +1015,9 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
 
         """
+        if self.neg_label >= self.pos_label:
+            raise ValueError("neg_label must be strictly less than pos_label.")
+
         label_type = _get_label_type(y)
 
         if self.label_type not in ["auto", label_type]:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -954,7 +954,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(classes=None, multilabel=None, neg_label=0, pos_label=1)
+    LabelBinarizer(classes=None, indicator_matrix=None, multilabel=None,
+           neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])
@@ -1007,7 +1008,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         """
         self.multilabel_ = _is_multilabel(y)
         if self.multilabel is not None and self.multilabel != self.multilabel_:
-            raise ValueError("Parameter multilabel was set explicity but "
+            raise ValueError("Parameter multilabel was set explicitly but "
                              "does not match the data.")
         if self.multilabel_:
             self.indicator_matrix_ = _is_label_indicator_matrix(y)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -928,6 +928,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     classes : ndarray if int or None (default)
         Array of possible classes.
 
+    multilabel : bool or None (default)
+        Whether or not data will be multilabel.
+        If None, it will be inferred during fitting.
+
     Attributes
     ----------
     `classes_` : array of shape [n_class]

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1141,7 +1141,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             half = (self.pos_label - self.neg_label) / 2.0
             threshold = self.neg_label + half
 
-        if self.label_type_ != "multiclass":
+        if self.multilabel_:
             Y = np.array(Y > threshold, dtype=int)
             # Return the predictions in the same format as in fit
             if self.label_type_ == "multilabel-indicator":
@@ -1161,14 +1161,13 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         return self.classes_[y]
 
     @property
-    @deprecated("Use ``label_type_`` instead. Will be removed in 0.15.")
     def multilabel_(self):
-        return self.label_type in ["multilabel-list", "multilabel-indicator"]
+        return self.label_type_ in ["multilabel-list", "multilabel-indicator"]
 
     @property
-    @deprecated("Use ``label_type_`` instead. Will be removed in 0.15.")
+    @deprecated("it will be removed in 0.15. Use ``label_type_`` instead.")
     def label_indicator_(self):
-        return self.label_type == "multilabel-indicator"
+        return self.label_type_ == "multilabel-indicator"
 
 
 class KernelCenterer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -965,8 +965,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> lb = preprocessing.LabelBinarizer()
     >>> lb.fit([1, 2, 6, 4, 2])
-    LabelBinarizer(classes=None, indicator_matrix=None, multilabel=None,
-            neg_label=0, pos_label=1)
+    LabelBinarizer(classes=None, label_type='auto', neg_label=0, pos_label=1)
     >>> lb.classes_
     array([1, 2, 4, 6])
     >>> lb.transform([1, 6])

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1009,7 +1009,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                 difference = set.difference(classes_set, self.classes)
                 warnings.warn("Found class(es) %s, which was not contained "
                               "in parameter ``classes`` and will be ignored."
-                              % str(difference))
+                              % str(list(difference)))
             self.classes_ = np.unique(self.classes)
         else:
             self.classes_ = classes

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -932,6 +932,11 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         Whether or not data will be multilabel.
         If None, it will be inferred during fitting.
 
+    indicator_matrix : bool or None (default)
+        Whether ``inverse_transform`` will produce an indicator
+        matrix encoding (if False it will return list of lists).
+        If None, it will be inferred during fitting.
+
     Attributes
     ----------
     `classes_` : array of shape [n_class]
@@ -939,6 +944,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
     `multilabel_` : bool
         Whether the estimator was fitted for multi-label data.
+
+    `indicator_matrix_` : bool
+        Whether the estimator was fitted with a label indicator matrix.
+        This will determine the result of ``inverse_transform``.
 
     Examples
     --------
@@ -960,7 +969,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, neg_label=0, pos_label=1, classes=None,
-                 multilabel=None):
+                 multilabel=None, indicator_matrix=None):
         if neg_label >= pos_label:
             raise ValueError("neg_label must be strictly less than pos_label.")
 
@@ -968,6 +977,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self.pos_label = pos_label
         self.classes = classes
         self.multilabel = multilabel
+        self.indicator_matrix = indicator_matrix
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
@@ -975,6 +985,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                 self.classes_ = np.unique(self.classes)
                 # default to not doing multi-label things
                 self.multilabel_ = bool(self.multilabel)
+                self.indicator_matrix_ = bool(self.indicator_matrix)
             else:
                 raise ValueError("LabelBinarizer was not fitted yet.")
 

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -676,6 +676,9 @@ def test_label_binarizer_classes():
                         indicator_matrix=True)
     assert_array_equal(lb.inverse_transform(Y), Y)
 
+    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=False)
+    assert_raise_message(ValueError, "multilabel was set explicitly",
+                         lb.fit, y)
     lb = LabelBinarizer(classes=np.arange(1, 3))
     assert_raise_message(ValueError, "not fitted with multilabel",
                          lb.transform, y)

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -673,6 +673,18 @@ def test_label_binarizer_classes():
 
     # check that labels present at fit time that are not in 'classes'
     # will be ignored but a warning will be shown
+    lb = LabelBinarizer(classes=[1, 2])
+    with warnings.catch_warnings(record=True) as w:
+        transformed = lb.fit_transform([0, 1, 2])
+
+    # warning was raised:
+    assert_equal(len(w), 1)
+    assert_true("not contained in parameter ``classes`` and will be ignored."
+                in str(w[0]))
+
+    # result is as for binary case
+    assert_equal(transformed.shape, (3, 1))
+    assert_array_equal(transformed.ravel(), [0, 0, 1])
 
 
 def test_label_binarizer_multilabel_unlabeled():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -8,6 +8,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 
@@ -638,6 +639,40 @@ def test_label_binarizer_iris():
     y_pred2 = SGDClassifier().fit(iris.data, iris.target).predict(iris.data)
     accuracy2 = np.mean(iris.target == y_pred2)
     assert_almost_equal(accuracy, accuracy2)
+
+
+def test_label_binarizer_classes():
+    # check that explictly giving classes works
+    lb = LabelBinarizer(classes=np.arange(3))
+    y = np.ones(10)
+    # if classes is specified, we don't need to fit
+    assert_equal(lb.transform(y).shape, (10, 3))
+    assert_array_equal(y, np.argmax(lb.transform(y), axis=1))
+
+    # check that fitting doesn't change the shape
+    assert_equal(lb.fit_transform(y).shape, (10, 3))
+
+    # also works with weird classes:
+    lb = LabelBinarizer(classes=['a', 'b', 'see'])
+    transformed = lb.transform(['see', 'see'])
+    assert_equal(transformed.shape, (2, 3))
+    assert_array_equal(np.argmax(transformed, axis=1), [2, 2])
+
+    # also works with multilabel data if we say so:
+    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=True)
+    y = [[1, 2], [1], []]
+    Y = np.array([[1, 1],
+                  [1, 0],
+                  [0, 0]])
+    assert_array_equal(lb.transform(y), Y)
+    assert_array_equal(lb.fit_transform(y), Y)
+
+    lb = LabelBinarizer(classes=np.arange(1, 3))
+    assert_raise_message(ValueError, "not fitted with multilabel",
+                         lb.transform, y)
+
+    # check that labels present at fit time that are not in 'classes'
+    # will be ignored but a warning will be shown
 
 
 def test_label_binarizer_multilabel_unlabeled():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -661,7 +661,8 @@ def test_label_binarizer_classes():
     assert_array_equal(['see', 'see'], lb.inverse_transform(transformed))
 
     # also works with multilabel data if we say so:
-    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=True)
+    lb = LabelBinarizer(classes=np.arange(1, 3),
+                        label_type="multilabel-list")
     y = [(1, 2), (1,), ()]
     Y = np.array([[1, 1],
                   [1, 0],
@@ -672,15 +673,17 @@ def test_label_binarizer_classes():
     assert_array_equal(lb.inverse_transform(Y), y)
 
     # inverse transform  with indicator_matrix=True
-    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=True,
-                        indicator_matrix=True)
+    lb = LabelBinarizer(classes=np.arange(1, 3),
+                        label_type="multilabel-indicator")
     assert_array_equal(lb.inverse_transform(Y), Y)
 
-    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=False)
-    assert_raise_message(ValueError, "multilabel was set explicitly",
+    lb = LabelBinarizer(classes=np.arange(1, 3), label_type="multiclass")
+    assert_raise_message(ValueError, "label_type was set to multiclass, "
+                         "but got y of type multilabel-list.",
                          lb.fit, y)
     lb = LabelBinarizer(classes=np.arange(1, 3))
-    assert_raise_message(ValueError, "not fitted with multilabel",
+    assert_raise_message(ValueError, "label_type was set to multiclass,"
+                         " but got y of type multilabel-list.",
                          lb.transform, y)
 
     # check that labels present at fit time that are not in 'classes'

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -657,15 +657,24 @@ def test_label_binarizer_classes():
     transformed = lb.transform(['see', 'see'])
     assert_equal(transformed.shape, (2, 3))
     assert_array_equal(np.argmax(transformed, axis=1), [2, 2])
+    # test inverse transform
+    assert_array_equal(['see', 'see'], lb.inverse_transform(transformed))
 
     # also works with multilabel data if we say so:
     lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=True)
-    y = [[1, 2], [1], []]
+    y = [(1, 2), (1,), ()]
     Y = np.array([[1, 1],
                   [1, 0],
                   [0, 0]])
     assert_array_equal(lb.transform(y), Y)
     assert_array_equal(lb.fit_transform(y), Y)
+    # inverse transform of label indicator matrix to label
+    assert_array_equal(lb.inverse_transform(Y), y)
+
+    # inverse transform  with indicator_matrix=True
+    lb = LabelBinarizer(classes=np.arange(1, 3), multilabel=True,
+                        indicator_matrix=True)
+    assert_array_equal(lb.inverse_transform(Y), Y)
 
     lb = LabelBinarizer(classes=np.arange(1, 3))
     assert_raise_message(ValueError, "not fitted with multilabel",


### PR DESCRIPTION
Adds a `classes` parameter to `LabelBinarizer`. I wanted that to add `partial_fit` to the naive Bayes models.
If `classes` is specified, there is no need to call `fit`.
This PR still needs tests.
