### PR TITLE
Fix AttributeError caused by an unlearned idf vector

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -389,6 +389,10 @@ def test_vectorizer():
     t2 = TfidfTransformer(norm='l1', use_idf=False)
     tf = t2.fit(counts_train).transform(counts_train).toarray()
     assert_equal(t2.idf_, None)
+    
+    # test idf transform with unlearned idf vector
+    t3 = TfidfTransformer(use_idf=True)
+    assert_raises(ValueError, t3.transform, counts_train)
 
     # L1-normalized term frequencies sum to one
     assert_array_almost_equal(np.sum(tf, axis=1), [1.0] * n_train)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -915,6 +915,8 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
             X.data += 1
 
         if self.use_idf:
+            if not hasattr(self, "_idf_diag"):
+                raise ValueError("idf vector not fitted")  
             expected_n_features = self._idf_diag.shape[0]
             if n_features != expected_n_features:
                 raise ValueError("Input has n_features=%d while the model"


### PR DESCRIPTION
Just a quick fix for a silly use case. If you call `transform` on a TfidfTransformer (with use_idf=True), and have not computed an idf_vector with `fit`, you get this rather unhelpful error:

```
Traceback (most recent call last):
  File "htcls.py", line 30, in <module>
    X = t.transform(X)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/sklearn/feature_extraction/text.py", line 918, in transform
    expected_n_features = self._idf_diag.shape[0]
AttributeError: 'TfidfTransformer' object has no attribute '_idf_diag'
```

This PR raises a more descriptive ValueError describing the error.
