### PR TITLE
make min_density parameter for gradient boosting

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -426,14 +426,15 @@ class BaseGradientBoosting(BaseEnsemble):
 
     @abstractmethod
     def __init__(self, loss, learning_rate, n_estimators, min_samples_split,
-                 min_samples_leaf, max_depth, init, subsample, max_features,
-                 random_state, alpha=0.9, verbose=0):
+                 min_samples_leaf, min_density, max_depth, init, subsample,
+                 max_features, random_state, alpha=0.9, verbose=0):
 
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.loss = loss
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
+        self.min_density = min_density
         self.subsample = subsample
         self.max_features = max_features
         self.max_depth = max_depth
@@ -559,9 +560,6 @@ class BaseGradientBoosting(BaseEnsemble):
             raise ValueError("alpha must be in (0.0, 1.0)")
 
         random_state = check_random_state(self.random_state)
-
-        # use default min_density (0.1) only for deep trees
-        self.min_density = 0.0 if self.max_depth < 6 else 0.1
 
         # create argsorted X for fast tree induction
         X_argsorted = np.asfortranarray(
@@ -739,6 +737,17 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     min_samples_leaf : integer, optional (default=1)
         The minimum number of samples required to be at a leaf node.
 
+    min_density : float, optional (default=0.1)
+        This parameter controls a trade-off in an optimization heuristic. It
+        controls the minimum density of the `sample_mask` (i.e. the
+        fraction of samples in the mask). If the density falls below this
+        threshold the mask is recomputed and the input data is packed
+        which results in data copying.  If `min_density` equals to one,
+        the partitions are always represented as copies of the original
+        data. Otherwise, partitions are represented as bit masks (aka
+        sample masks).
+        Note: this parameter is tree-specific.
+
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
         learners. If smaller than 1.0 this results in Stochastic Gradient
@@ -813,13 +822,13 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     def __init__(self, loss='deviance', learning_rate=0.1, n_estimators=100,
                  subsample=1.0, min_samples_split=2, min_samples_leaf=1,
-                 max_depth=3, init=None, random_state=None,
+                 min_density=0.1, max_depth=3, init=None, random_state=None,
                  max_features=None, verbose=0):
 
         super(GradientBoostingClassifier, self).__init__(
             loss, learning_rate, n_estimators, min_samples_split,
-            min_samples_leaf, max_depth, init, subsample, max_features,
-            random_state, verbose=verbose)
+            min_samples_leaf, min_density, max_depth, init, subsample,
+            max_features, random_state, verbose=verbose)
 
     def fit(self, X, y):
         """Fit the gradient boosting model.
@@ -969,6 +978,17 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     min_samples_leaf : integer, optional (default=1)
         The minimum number of samples required to be at a leaf node.
 
+    min_density : float, optional (default=0.1)
+        This parameter controls a trade-off in an optimization heuristic. It
+        controls the minimum density of the `sample_mask` (i.e. the
+        fraction of samples in the mask). If the density falls below this
+        threshold the mask is recomputed and the input data is packed
+        which results in data copying.  If `min_density` equals to one,
+        the partitions are always represented as copies of the original
+        data. Otherwise, partitions are represented as bit masks (aka
+        sample masks).
+        Note: this parameter is tree-specific.
+
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
         learners. If smaller than 1.0 this results in Stochastic Gradient
@@ -1048,13 +1068,13 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     def __init__(self, loss='ls', learning_rate=0.1, n_estimators=100,
                  subsample=1.0, min_samples_split=2, min_samples_leaf=1,
-                 max_depth=3, init=None, random_state=None,
+                 min_density=0.1, max_depth=3, init=None, random_state=None,
                  max_features=None, alpha=0.9, verbose=0):
 
         super(GradientBoostingRegressor, self).__init__(
             loss, learning_rate, n_estimators, min_samples_split,
-            min_samples_leaf, max_depth, init, subsample, max_features,
-            random_state, alpha, verbose)
+            min_samples_leaf, min_density, max_depth, init, subsample,
+            max_features, random_state, alpha, verbose)
 
     def fit(self, X, y):
         """Fit the gradient boosting model.

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -477,11 +477,19 @@ def test_mem_layout():
 
 
 def test_min_density():
-    """Check if min_density is properly set when growing deep trees."""
-    clf = GradientBoostingClassifier(max_depth=6)
+    """Check if setting min_density works and default is 0.1."""
+    clf = GradientBoostingClassifier()
     clf.fit(X, y)
     assert clf.min_density == 0.1
 
-    clf = GradientBoostingClassifier(max_depth=5)
+    clf = GradientBoostingClassifier(min_density=0.5)
     clf.fit(X, y)
-    assert clf.min_density == 0.0
+    assert clf.min_density == 0.5
+
+    clf = GradientBoostingRegressor()
+    clf.fit(X, y)
+    assert clf.min_density == 0.1
+
+    clf = GradientBoostingRegressor(min_density=0.5)
+    clf.fit(X, y)
+    assert clf.min_density == 0.5


### PR DESCRIPTION
I'm not sure why min_density is handled differently for gradient boosting compared to the random forest estimators. This commit simply makes gradient boosting treat min_density the same as random forests. I ran into this in a recent Kaggle competition, I set max_depth < 6 and training slowed to a crawl. Setting min_density to 0.1 fixed that. I'm not sure if the tests are still necessary but I updated them regardless.

I don't know the history of this, but perhaps there is a good reason, @pprett?
2b56ee1ba3428f572338934db06d8b9f3e07c481
