### PR TITLE
Rename "labels" to "classes" fixes Issue #1591

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -11,7 +11,7 @@ Each clustering algorithm comes in two variants: a class, that implements
 the `fit` method to learn the clusters on train data, and a function,
 that, given train data, returns an array of integer labels corresponding
 to the different clusters. For the class, the labels over the training
-data can be found in the `labels_` attribute.
+data can be found in the `classes_` attribute.
 
 .. currentmodule:: sklearn.cluster
 
@@ -1077,7 +1077,7 @@ cluster analysis.
   >>> import numpy as np
   >>> from sklearn.cluster import KMeans
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
-  >>> labels = kmeans_model.labels_
+  >>> labels = kmeans_model.classes_
   >>> metrics.silhouette_score(X, labels, metric='euclidean')  
   ...                                                      # doctest: +ELLIPSIS
   0.55...

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -40,7 +40,7 @@ algorithms. The simplest clustering algorithm is
     >>> k_means = cluster.KMeans(n_clusters=3)
     >>> k_means.fit(X_iris) # doctest: +ELLIPSIS
     KMeans(copy_x=True, init='k-means++', ...
-    >>> print(k_means.labels_[::10])
+    >>> print(k_means.classes_[::10])
     [1 1 1 1 1 0 0 0 0 0 2 2 2 2 2]
     >>> print(y_iris[::10])
     [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2]
@@ -121,8 +121,8 @@ algorithms. The simplest clustering algorithm is
     	>>> k_means.fit(X) # doctest: +ELLIPSIS
     	KMeans(copy_x=True, init='k-means++', ...
     	>>> values = k_means.cluster_centers_.squeeze()
-    	>>> labels = k_means.labels_
-    	>>> lena_compressed = np.choose(labels, values)
+    	>>> classes = k_means.classes_
+    	>>> lena_compressed = np.choose(classes, values)
     	>>> lena_compressed.shape = lena.shape
 
     .. list-table::

--- a/examples/cluster/plot_adjusted_for_chance_measures.py
+++ b/examples/cluster/plot_adjusted_for_chance_measures.py
@@ -41,19 +41,19 @@ def uniform_labelings_scores(score_func, n_samples, n_clusters_range,
     When fixed_n_classes is not None the first labeling is considered a ground
     truth class assignement with fixed number of classes.
     """
-    random_labels = np.random.RandomState(seed).random_integers
+    random_classes = np.random.RandomState(seed).random_integers
     scores = np.zeros((len(n_clusters_range), n_runs))
 
     if fixed_n_classes is not None:
-        labels_a = random_labels(low=0, high=fixed_n_classes - 1,
+        classes_a = random_classes(low=0, high=fixed_n_classes - 1,
                                  size=n_samples)
 
     for i, k in enumerate(n_clusters_range):
         for j in range(n_runs):
             if fixed_n_classes is None:
-                labels_a = random_labels(low=0, high=k - 1, size=n_samples)
-            labels_b = random_labels(low=0, high=k - 1, size=n_samples)
-            scores[i, j] = score_func(labels_a, labels_b)
+                classes_a = random_classes(low=0, high=k - 1, size=n_samples)
+            classes_b = random_classes(low=0, high=k - 1, size=n_samples)
+            scores[i, j] = score_func(classes_a, classes_b)
     return scores
 
 score_funcs = [

--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -17,27 +17,27 @@ from sklearn.datasets.samples_generator import make_blobs
 ##############################################################################
 # Generate sample data
 centers = [[1, 1], [-1, -1], [1, -1]]
-X, labels_true = make_blobs(n_samples=300, centers=centers, cluster_std=0.5,
+X, classes_true = make_blobs(n_samples=300, centers=centers, cluster_std=0.5,
                             random_state=0)
 
 ##############################################################################
 # Compute Affinity Propagation
 af = AffinityPropagation(preference=-50).fit(X)
 cluster_centers_indices = af.cluster_centers_indices_
-labels = af.labels_
+classes = af.classes_
 
 n_clusters_ = len(cluster_centers_indices)
 
 print('Estimated number of clusters: %d' % n_clusters_)
-print("Homogeneity: %0.3f" % metrics.homogeneity_score(labels_true, labels))
-print("Completeness: %0.3f" % metrics.completeness_score(labels_true, labels))
-print("V-measure: %0.3f" % metrics.v_measure_score(labels_true, labels))
+print("Homogeneity: %0.3f" % metrics.homogeneity_score(classes_true, classes))
+print("Completeness: %0.3f" % metrics.completeness_score(classes_true, classes))
+print("V-measure: %0.3f" % metrics.v_measure_score(classes_true, classes))
 print("Adjusted Rand Index: %0.3f"
-      % metrics.adjusted_rand_score(labels_true, labels))
+      % metrics.adjusted_rand_score(classes_true, classes))
 print("Adjusted Mutual Information: %0.3f"
-      % metrics.adjusted_mutual_info_score(labels_true, labels))
+      % metrics.adjusted_mutual_info_score(classes_true, classes))
 print("Silhouette Coefficient: %0.3f"
-      % metrics.silhouette_score(X, labels, metric='sqeuclidean'))
+      % metrics.silhouette_score(X, classes, metric='sqeuclidean'))
 
 ##############################################################################
 # Plot result
@@ -50,7 +50,7 @@ pl.clf()
 
 colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
 for k, col in zip(range(n_clusters_), colors):
-    class_members = labels == k
+    class_members = classes == k
     cluster_center = X[cluster_centers_indices[k]]
     pl.plot(X[class_members, 0], X[class_members, 1], col + '.')
     pl.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -86,8 +86,8 @@ for i_dataset, dataset in enumerate([noisy_circles, noisy_moons, blobs,
         t0 = time.time()
         algorithm.fit(X)
         t1 = time.time()
-        if hasattr(algorithm, 'labels_'):
-            y_pred = algorithm.labels_.astype(np.int)
+        if hasattr(algorithm, 'classes_'):
+            y_pred = algorithm.classes_.astype(np.int)
         else:
             y_pred = algorithm.predict(X)
 

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -52,9 +52,9 @@ for name, est in estimators.iteritems():
 
     pl.cla()
     est.fit(X)
-    labels = est.labels_
+    classes = est.classes_
 
-    ax.scatter(X[:, 3], X[:, 0], X[:, 2], c=labels.astype(np.float))
+    ax.scatter(X[:, 3], X[:, 0], X[:, 2], c=classes.astype(np.float))
 
     ax.w_xaxis.set_ticklabels([])
     ax.w_yaxis.set_ticklabels([])
@@ -79,7 +79,7 @@ for name, label in [('Setosa', 0),
               X[y == label, 2].mean(), name,
               horizontalalignment='center',
               bbox=dict(alpha=.5, edgecolor='w', facecolor='w'))
-# Reorder the labels to have colors matching the cluster results
+# Reorder the classes to have colors matching the cluster results
 y = np.choose(y, [1, 2, 0]).astype(np.float)
 ax.scatter(X[:, 3], X[:, 0], X[:, 2], c=y)
 

--- a/examples/cluster/plot_color_quantization.py
+++ b/examples/cluster/plot_color_quantization.py
@@ -54,10 +54,10 @@ image_array_sample = shuffle(image_array, random_state=0)[:1000]
 kmeans = KMeans(n_clusters=n_colors, random_state=0).fit(image_array_sample)
 print("done in %0.3fs." % (time() - t0))
 
-# Get labels for all points
+# Get classes for all points
 print("Predicting color indices on the full image (k-means)")
 t0 = time()
-labels = kmeans.predict(image_array)
+classes = kmeans.predict(image_array)
 print("done in %0.3fs." % (time() - t0))
 
 
@@ -65,19 +65,19 @@ codebook_random = shuffle(image_array, random_state=0)[:n_colors + 1]
 print("Predicting color indices on the full image (random)")
 t0 = time()
 dist = euclidean_distances(codebook_random, image_array, squared=True)
-labels_random = dist.argmin(axis=0)
+classes_random = dist.argmin(axis=0)
 print("done in %0.3fs." % (time() - t0))
 
 
-def recreate_image(codebook, labels, w, h):
-    """Recreate the (compressed) image from the code book & labels"""
+def recreate_image(codebook, classes, w, h):
+    """Recreate the (compressed) image from the code book & classes"""
     d = codebook.shape[1]
     image = np.zeros((w, h, d))
-    label_idx = 0
+    class_idx = 0
     for i in range(w):
         for j in range(h):
-            image[i][j] = codebook[labels[label_idx]]
-            label_idx += 1
+            image[i][j] = codebook[classes[class_idx]]
+            class_idx += 1
     return image
 
 # Display all results, alongside original image
@@ -93,12 +93,12 @@ pl.clf()
 ax = pl.axes([0, 0, 1, 1])
 pl.axis('off')
 pl.title('Quantized image (64 colors, K-Means)')
-pl.imshow(recreate_image(kmeans.cluster_centers_, labels, w, h))
+pl.imshow(recreate_image(kmeans.cluster_centers_, classes, w, h))
 
 pl.figure(3)
 pl.clf()
 ax = pl.axes([0, 0, 1, 1])
 pl.axis('off')
 pl.title('Quantized image (64 colors, Random)')
-pl.imshow(recreate_image(codebook_random, labels_random, w, h))
+pl.imshow(recreate_image(codebook_random, classes_random, w, h))
 pl.show()

--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -19,7 +19,7 @@ from sklearn.datasets.samples_generator import make_blobs
 ##############################################################################
 # Generate sample data
 centers = [[1, 1], [-1, -1], [1, -1]]
-X, labels_true = make_blobs(n_samples=750, centers=centers, cluster_std=0.4)
+X, classes_true = make_blobs(n_samples=750, centers=centers, cluster_std=0.4)
 
 ##############################################################################
 # Compute similarities
@@ -30,21 +30,21 @@ S = 1 - (D / np.max(D))
 # Compute DBSCAN
 db = DBSCAN(eps=0.95, min_samples=10).fit(S)
 core_samples = db.core_sample_indices_
-labels = db.labels_
+classes = db.classes_
 
-# Number of clusters in labels, ignoring noise if present.
-n_clusters_ = len(set(labels)) - (1 if -1 in labels else 0)
+# Number of clusters in classes, ignoring noise if present.
+n_clusters_ = len(set(classes)) - (1 if -1 in classes else 0)
 
 print('Estimated number of clusters: %d' % n_clusters_)
-print("Homogeneity: %0.3f" % metrics.homogeneity_score(labels_true, labels))
-print("Completeness: %0.3f" % metrics.completeness_score(labels_true, labels))
-print("V-measure: %0.3f" % metrics.v_measure_score(labels_true, labels))
+print("Homogeneity: %0.3f" % metrics.homogeneity_score(classes_true, classes))
+print("Completeness: %0.3f" % metrics.completeness_score(classes_true, classes))
+print("V-measure: %0.3f" % metrics.v_measure_score(classes_true, classes))
 print("Adjusted Rand Index: %0.3f"
-      % metrics.adjusted_rand_score(labels_true, labels))
+      % metrics.adjusted_rand_score(classes_true, classes))
 print("Adjusted Mutual Information: %0.3f"
-      % metrics.adjusted_mutual_info_score(labels_true, labels))
+      % metrics.adjusted_mutual_info_score(classes_true, classes))
 print("Silhouette Coefficient: %0.3f"
-      % metrics.silhouette_score(D, labels, metric='precomputed'))
+      % metrics.silhouette_score(D, classes, metric='precomputed'))
 
 ##############################################################################
 # Plot result
@@ -57,14 +57,14 @@ pl.clf()
 
 # Black removed and is used for noise instead.
 colors = cycle('bgrcmybgrcmybgrcmybgrcmy')
-for k, col in zip(set(labels), colors):
+for k, col in zip(set(classes), colors):
     if k == -1:
         # Black used for noise.
         col = 'k'
         markersize = 6
-    class_members = [index[0] for index in np.argwhere(labels == k)]
+    class_members = [index[0] for index in np.argwhere(classes == k)]
     cluster_core_samples = [index for index in core_samples
-                            if labels[index] == k]
+                            if classes[index] == k]
     for index in class_members:
         x = X[index]
         if index in core_samples and k != -1:

--- a/examples/cluster/plot_digits_agglomeration.py
+++ b/examples/cluster/plot_digits_agglomeration.py
@@ -53,9 +53,9 @@ for i in range(4):
     pl.yticks(())
 
 pl.subplot(3, 4, 10)
-pl.imshow(np.reshape(agglo.labels_, images[0].shape),
+pl.imshow(np.reshape(agglo.classes_, images[0].shape),
           interpolation='nearest', cmap=pl.cm.spectral)
 pl.xticks(())
 pl.yticks(())
-pl.title('Labels')
+pl.title('Classes')
 pl.show()

--- a/examples/cluster/plot_kmeans_digits.py
+++ b/examples/cluster/plot_kmeans_digits.py
@@ -7,7 +7,7 @@ In this example with compare the various initialization strategies for
 K-means in terms of runtime and quality of the results.
 
 As the ground truth is known here, we also apply different cluster
-quality metrics to judge the goodness of fit of the cluster labels to the
+quality metrics to judge the goodness of fit of the cluster classes to the
 ground truth.
 
 Cluster quality metrics evaluated (see :ref:`clustering_evaluation` for
@@ -44,7 +44,7 @@ data = scale(digits.data)
 
 n_samples, n_features = data.shape
 n_digits = len(np.unique(digits.target))
-labels = digits.target
+classes = digits.target
 
 sample_size = 300
 
@@ -62,12 +62,12 @@ def bench_k_means(estimator, name, data):
     estimator.fit(data)
     print('% 9s   %.2fs    %i   %.3f   %.3f   %.3f   %.3f   %.3f    %.3f'
           % (name, (time() - t0), estimator.inertia_,
-             metrics.homogeneity_score(labels, estimator.labels_),
-             metrics.completeness_score(labels, estimator.labels_),
-             metrics.v_measure_score(labels, estimator.labels_),
-             metrics.adjusted_rand_score(labels, estimator.labels_),
-             metrics.adjusted_mutual_info_score(labels,  estimator.labels_),
-             metrics.silhouette_score(data, estimator.labels_,
+             metrics.homogeneity_score(classes, estimator.classes_),
+             metrics.completeness_score(classes, estimator.classes_),
+             metrics.v_measure_score(classes, estimator.classes_),
+             metrics.adjusted_rand_score(classes, estimator.classes_),
+             metrics.adjusted_mutual_info_score(classes,  estimator.classes_),
+             metrics.silhouette_score(data, estimator.classes_,
                                       metric='euclidean',
                                       sample_size=sample_size)))
 
@@ -100,7 +100,7 @@ x_min, x_max = reduced_data[:, 0].min() + 1, reduced_data[:, 0].max() - 1
 y_min, y_max = reduced_data[:, 1].min() + 1, reduced_data[:, 1].max() - 1
 xx, yy = np.meshgrid(np.arange(x_min, x_max, h), np.arange(y_min, y_max, h))
 
-# Obtain labels for each point in mesh. Use last trained model.
+# Obtain classes for each point in mesh. Use last trained model.
 Z = kmeans.predict(np.c_[xx.ravel(), yy.ravel()])
 
 # Put the result into a color plot

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -107,7 +107,7 @@ km = MiniBatchKMeans(n_clusters=n_clusters, init='random', n_init=1,
 
 fig = pl.figure()
 for k in range(n_clusters):
-    my_members = km.labels_ == k
+    my_members = km.classes_ == k
     color = cm.spectral(float(k) / n_clusters, 1)
     pl.plot(X[my_members, 0], X[my_members, 1], 'o', marker='.', c=color)
     cluster_center = km.cluster_centers_[k]

--- a/examples/cluster/plot_lena_compress.py
+++ b/examples/cluster/plot_lena_compress.py
@@ -36,10 +36,10 @@ X = lena.reshape((-1, 1))  # We need an (n_sample, n_feature) array
 k_means = cluster.KMeans(n_clusters=n_clusters, n_init=4)
 k_means.fit(X)
 values = k_means.cluster_centers_.squeeze()
-labels = k_means.labels_
+classes = k_means.classes_
 
-# create an array from labels and values
-lena_compressed = np.choose(labels, values)
+# create an array from classes and values
+lena_compressed = np.choose(classes, values)
 lena_compressed.shape = lena.shape
 
 vmin = lena.min()
@@ -55,9 +55,9 @@ pl.imshow(lena_compressed, cmap=pl.cm.gray, vmin=vmin, vmax=vmax)
 
 # equal bins lena
 regular_values = np.linspace(0, 256, n_clusters + 1)
-regular_labels = np.searchsorted(regular_values, lena) - 1
+regular_classes = np.searchsorted(regular_values, lena) - 1
 regular_values = .5 * (regular_values[1:] + regular_values[:-1])  # mean
-regular_lena = np.choose(regular_labels.ravel(), regular_values)
+regular_lena = np.choose(regular_classes.ravel(), regular_values)
 regular_lena.shape = lena.shape
 pl.figure(3, figsize=(3, 2.2))
 pl.imshow(regular_lena, cmap=pl.cm.gray, vmin=vmin, vmax=vmax)

--- a/examples/cluster/plot_lena_segmentation.py
+++ b/examples/cluster/plot_lena_segmentation.py
@@ -10,7 +10,7 @@ partly-homogenous regions.
 This procedure (spectral clustering on an image) is an efficient
 approximate solution for finding normalized graph cuts.
 
-There are two options to assign labels:
+There are two options to assign classes:
 
 * with 'kmeans' spectral clustering will cluster samples in the embedding space
   using a kmeans algorithm
@@ -56,16 +56,16 @@ N_REGIONS = 11
 
 for assign_labels in ('kmeans', 'discretize'):
     t0 = time.time()
-    labels = spectral_clustering(graph, n_clusters=N_REGIONS,
+    classes = spectral_clustering(graph, n_clusters=N_REGIONS,
                                  assign_labels=assign_labels,
                                  random_state=1)
     t1 = time.time()
-    labels = labels.reshape(lena.shape)
+    classes = classes.reshape(lena.shape)
 
     pl.figure(figsize=(5, 5))
     pl.imshow(lena,   cmap=pl.cm.gray)
     for l in range(N_REGIONS):
-        pl.contour(labels == l, contours=1,
+        pl.contour(classes == l, contours=1,
                    colors=[pl.cm.spectral(l / float(N_REGIONS)), ])
     pl.xticks(())
     pl.yticks(())

--- a/examples/cluster/plot_lena_ward_segmentation.py
+++ b/examples/cluster/plot_lena_ward_segmentation.py
@@ -38,17 +38,17 @@ print("Compute structured hierarchical clustering...")
 st = time.time()
 n_clusters = 15  # number of regions
 ward = Ward(n_clusters=n_clusters, connectivity=connectivity).fit(X)
-label = np.reshape(ward.labels_, lena.shape)
+class_ = np.reshape(ward.classes_, lena.shape)
 print("Elapsed time: ", time.time() - st)
-print("Number of pixels: ", label.size)
-print("Number of clusters: ", np.unique(label).size)
+print("Number of pixels: ", class_.size)
+print("Number of clusters: ", np.unique(class_).size)
 
 ###############################################################################
 # Plot the results on an image
 pl.figure(figsize=(5, 5))
 pl.imshow(lena, cmap=pl.cm.gray)
 for l in range(n_clusters):
-    pl.contour(label == l, contours=1,
+    pl.contour(class_ == l, contours=1,
                colors=[pl.cm.spectral(l / float(n_clusters)), ])
 pl.xticks(())
 pl.yticks(())

--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -29,11 +29,11 @@ bandwidth = estimate_bandwidth(X, quantile=0.2, n_samples=500)
 
 ms = MeanShift(bandwidth=bandwidth, bin_seeding=True)
 ms.fit(X)
-labels = ms.labels_
+classes = ms.classes_
 cluster_centers = ms.cluster_centers_
 
-labels_unique = np.unique(labels)
-n_clusters_ = len(labels_unique)
+classes_unique = np.unique(classes)
+n_clusters_ = len(classes_unique)
 
 print("number of estimated clusters : %d" % n_clusters_)
 
@@ -47,7 +47,7 @@ pl.clf()
 
 colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
 for k, col in zip(range(n_clusters_), colors):
-    my_members = labels == k
+    my_members = classes == k
     cluster_center = cluster_centers[k]
     pl.plot(X[my_members, 0], X[my_members, 1], col + '.')
     pl.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,

--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -30,7 +30,7 @@ np.random.seed(0)
 batch_size = 45
 centers = [[1, 1], [-1, -1], [1, -1]]
 n_clusters = len(centers)
-X, labels_true = make_blobs(n_samples=3000, centers=centers, cluster_std=0.7)
+X, classes_true = make_blobs(n_samples=3000, centers=centers, cluster_std=0.7)
 
 ##############################################################################
 # Compute clustering with Means
@@ -39,9 +39,9 @@ k_means = KMeans(init='k-means++', n_clusters=3, n_init=10)
 t0 = time.time()
 k_means.fit(X)
 t_batch = time.time() - t0
-k_means_labels = k_means.labels_
+k_means_classes = k_means.classes_
 k_means_cluster_centers = k_means.cluster_centers_
-k_means_labels_unique = np.unique(k_means_labels)
+k_means_classes_unique = np.unique(k_means_classes)
 
 ##############################################################################
 # Compute clustering with MiniBatchKMeans
@@ -51,9 +51,9 @@ mbk = MiniBatchKMeans(init='k-means++', n_clusters=3, batch_size=batch_size,
 t0 = time.time()
 mbk.fit(X)
 t_mini_batch = time.time() - t0
-mbk_means_labels = mbk.labels_
+mbk_means_classes = mbk.classes_
 mbk_means_cluster_centers = mbk.cluster_centers_
-mbk_means_labels_unique = np.unique(mbk_means_labels)
+mbk_means_classes_unique = np.unique(mbk_means_classes)
 
 ##############################################################################
 # Plot result
@@ -74,7 +74,7 @@ order = distance.argmin(axis=1)
 # KMeans
 ax = fig.add_subplot(1, 3, 1)
 for k, col in zip(range(n_clusters), colors):
-    my_members = k_means_labels == k
+    my_members = k_means_classes == k
     cluster_center = k_means_cluster_centers[k]
     ax.plot(X[my_members, 0], X[my_members, 1], 'w',
             markerfacecolor=col, marker='.')
@@ -89,7 +89,7 @@ pl.text(-3.5, 1.8,  'train time: %.2fs\ninertia: %f' % (
 # MiniBatchKMeans
 ax = fig.add_subplot(1, 3, 2)
 for k, col in zip(range(n_clusters), colors):
-    my_members = mbk_means_labels == order[k]
+    my_members = mbk_means_classes == order[k]
     cluster_center = mbk_means_cluster_centers[order[k]]
     ax.plot(X[my_members, 0], X[my_members, 1], 'w',
             markerfacecolor=col, marker='.')
@@ -102,11 +102,11 @@ pl.text(-3.5, 1.8, 'train time: %.2fs\ninertia: %f' %
         (t_mini_batch, mbk.inertia_))
 
 # Initialise the different array to all False
-different = (mbk_means_labels == 4)
+different = (mbk_means_classes == 4)
 ax = fig.add_subplot(1, 3, 3)
 
 for l in range(n_clusters):
-    different += ((k_means_labels == k) != (mbk_means_labels == order[k]))
+    different += ((k_means_classes == k) != (mbk_means_classes == order[k]))
 
 identic = np.logical_not(different)
 ax.plot(X[identic, 0], X[identic, 1], 'w',

--- a/examples/cluster/plot_segmentation_toy.py
+++ b/examples/cluster/plot_segmentation_toy.py
@@ -70,12 +70,12 @@ graph.data = np.exp(-graph.data / graph.data.std())
 
 # Force the solver to be arpack, since amg is numerically
 # unstable on this example
-labels = spectral_clustering(graph, n_clusters=4, eigen_solver='arpack')
-label_im = -np.ones(mask.shape)
-label_im[mask] = labels
+classes = spectral_clustering(graph, n_clusters=4, eigen_solver='arpack')
+class_im = -np.ones(mask.shape)
+class_im[mask] = classes
 
 pl.matshow(img)
-pl.matshow(label_im)
+pl.matshow(class_im)
 
 ###############################################################################
 # 2 circles
@@ -88,11 +88,11 @@ img += 1 + 0.2 * np.random.randn(*img.shape)
 graph = image.img_to_graph(img, mask=mask)
 graph.data = np.exp(-graph.data / graph.data.std())
 
-labels = spectral_clustering(graph, n_clusters=2, eigen_solver='arpack')
-label_im = -np.ones(mask.shape)
-label_im[mask] = labels
+classes = spectral_clustering(graph, n_clusters=2, eigen_solver='arpack')
+class_im = -np.ones(mask.shape)
+class_im[mask] = classes
 
 pl.matshow(img)
-pl.matshow(label_im)
+pl.matshow(class_im)
 
 pl.show()

--- a/examples/cluster/plot_ward_structured_vs_unstructured.py
+++ b/examples/cluster/plot_ward_structured_vs_unstructured.py
@@ -44,18 +44,18 @@ X[:, 1] *= .5
 print("Compute unstructured hierarchical clustering...")
 st = time.time()
 ward = Ward(n_clusters=6).fit(X)
-label = ward.labels_
+class_ = ward.classes_
 print("Elapsed time: ", time.time() - st)
-print("Number of points: ", label.size)
+print("Number of points: ", class_.size)
 
 ###############################################################################
 # Plot result
 fig = pl.figure()
 ax = p3.Axes3D(fig)
 ax.view_init(7, -80)
-for l in np.unique(label):
-    ax.plot3D(X[label == l, 0], X[label == l, 1], X[label == l, 2],
-              'o', color=pl.cm.jet(np.float(l) / np.max(label + 1)))
+for l in np.unique(class_):
+    ax.plot3D(X[class_ == l, 0], X[class_ == l, 1], X[class_ == l, 2],
+              'o', color=pl.cm.jet(np.float(l) / np.max(class_ + 1)))
 pl.title('Without connectivity constraints')
 
 
@@ -69,18 +69,18 @@ connectivity = kneighbors_graph(X, n_neighbors=10)
 print("Compute structured hierarchical clustering...")
 st = time.time()
 ward = Ward(n_clusters=6, connectivity=connectivity).fit(X)
-label = ward.labels_
+class_ = ward.classes_
 print("Elapsed time: ", time.time() - st)
-print("Number of points: ", label.size)
+print("Number of points: ", class_.size)
 
 ###############################################################################
 # Plot result
 fig = pl.figure()
 ax = p3.Axes3D(fig)
 ax.view_init(7, -80)
-for l in np.unique(label):
-    ax.plot3D(X[label == l, 0], X[label == l, 1], X[label == l, 2],
-              'o', color=pl.cm.jet(float(l) / np.max(label + 1)))
+for l in np.unique(class_):
+    ax.plot3D(X[class_ == l, 0], X[class_ == l, 1], X[class_ == l, 2],
+              'o', color=pl.cm.jet(float(l) / np.max(class_ + 1)))
 pl.title('With connectivity constraints')
 
 pl.show()

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -118,8 +118,8 @@ print("%d documents" % len(dataset.data))
 print("%d categories" % len(dataset.target_names))
 print()
 
-labels = dataset.target
-true_k = np.unique(labels).shape[0]
+classes = dataset.target
+true_k = np.unique(classes).shape[0]
 
 print("Extracting features from the training dataset using a sparse vectorizer")
 t0 = time()
@@ -165,12 +165,12 @@ km.fit(X)
 print("done in %0.3fs" % (time() - t0))
 print()
 
-print("Homogeneity: %0.3f" % metrics.homogeneity_score(labels, km.labels_))
-print("Completeness: %0.3f" % metrics.completeness_score(labels, km.labels_))
-print("V-measure: %0.3f" % metrics.v_measure_score(labels, km.labels_))
+print("Homogeneity: %0.3f" % metrics.homogeneity_score(classes, km.classes_))
+print("Completeness: %0.3f" % metrics.completeness_score(classes, km.classes_))
+print("V-measure: %0.3f" % metrics.v_measure_score(classes, km.classes_))
 print("Adjusted Rand-Index: %.3f"
-      % metrics.adjusted_rand_score(labels, km.labels_))
+      % metrics.adjusted_rand_score(classes, km.classes_))
 print("Silhouette Coefficient: %0.3f"
-      % metrics.silhouette_score(X, labels, sample_size=1000))
+      % metrics.silhouette_score(X, classes, sample_size=1000))
 
 print()

--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -35,12 +35,12 @@ class AgglomerationTransform(TransformerMixin):
         """
         X = array2d(X)
         nX = []
-        if len(self.labels_) != X.shape[1]:
+        if len(self.classes_) != X.shape[1]:
             raise ValueError("X has a different number of features than "
                              "during fitting.")
 
-        for l in np.unique(self.labels_):
-            nX.append(pooling_func(X[:, self.labels_ == l], axis=1))
+        for l in np.unique(self.classes_):
+            nX.append(pooling_func(X[:, self.classes_ == l], axis=1))
         return np.array(nX).T
 
     def inverse_transform(self, Xred):
@@ -61,13 +61,13 @@ class AgglomerationTransform(TransformerMixin):
             each of the cluster of samples.
         """
         if np.size((Xred.shape)) == 1:
-            X = np.zeros([self.labels_.shape[0]])
+            X = np.zeros([self.classes_.shape[0]])
         else:
-            X = np.zeros([Xred.shape[0], self.labels_.shape[0]])
-        unil = np.unique(self.labels_)
+            X = np.zeros([Xred.shape[0], self.classes_.shape[0]])
+        unil = np.unique(self.classes_)
         for i in range(len(unil)):
             if np.size((Xred.shape)) == 1:
-                X[self.labels_ == unil[i]] = Xred[i]
+                X[self.classes_ == unil[i]] = Xred[i]
             else:
-                X[:, self.labels_ == unil[i]] = array2d(Xred[:, i]).T
+                X[:, self.classes_ == unil[i]] = array2d(Xred[:, i]).T
         return X

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -244,13 +244,13 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         self.verbose = verbose
         self.preference = preference
         self.affinity = affinity
-    
+
     @property
     @deprecated("Attribute labels_ is deprecated and "
-        "will be removed in 0.15. Use 'classes_' instead")
+                "will be removed in 0.15. Use 'classes_' instead")
     def labels_(self):
         return self.classes_
-    
+
     @property
     def _pairwise(self):
         return self.affinity is "precomputed"

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -12,6 +12,7 @@ import warnings
 
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import as_float_array
+from ..utils import deprecated
 from ..metrics import euclidean_distances
 
 
@@ -57,8 +58,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
     cluster_centers_indices: array [n_clusters]
         index of clusters centers
 
-    labels : array [n_samples]
-        cluster labels for each point
+    classes : array [n_samples]
+        cluster classes for each point
 
     Notes
     -----
@@ -159,16 +160,16 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
 
         c = np.argmax(S[:, I], axis=1)
         c[I] = np.arange(K)
-        labels = I[c]
-        # Reduce labels to a sorted, gapless, list
-        cluster_centers_indices = np.unique(labels)
-        labels = np.searchsorted(cluster_centers_indices, labels)
+        classes = I[c]
+        # Reduce classes to a sorted, gapless, list
+        cluster_centers_indices = np.unique(classes)
+        classes = np.searchsorted(cluster_centers_indices, classes)
     else:
-        labels = np.empty((n_samples, 1))
+        classes = np.empty((n_samples, 1))
         cluster_centers_indices = None
-        labels.fill(np.nan)
+        classes.fill(np.nan)
 
-    return cluster_centers_indices, labels
+    return cluster_centers_indices, classes
 
 
 ###############################################################################
@@ -212,8 +213,8 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     `cluster_centers_indices_` : array, [n_clusters]
         Indices of cluster centers
 
-    `labels_` : array, [n_samples]
-        Labels of each point
+    `classes_` : array, [n_samples]
+        classes of each point
 
     `affinity_matrix_` : array-like, [n_samples, n_samples]
         Stores the affinity matrix used in ``fit``.
@@ -243,7 +244,13 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         self.verbose = verbose
         self.preference = preference
         self.affinity = affinity
-
+    
+    @property
+    @deprecated("Attribute labels_ is deprecated and "
+        "will be removed in 0.15. Use 'classes_' instead")
+    def labels_(self):
+        return self.classes_
+    
     @property
     def _pairwise(self):
         return self.affinity is "precomputed"
@@ -274,7 +281,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
                              "'euclidean'. Got %s instead"
                              % str(self.affinity))
 
-        self.cluster_centers_indices_, self.labels_ = affinity_propagation(
+        self.cluster_centers_indices_, self.classes_ = affinity_propagation(
             self.affinity_matrix_, self.preference, max_iter=self.max_iter,
             convergence_iter=self.convergence_iter, damping=self.damping,
             copy=self.copy, verbose=self.verbose)

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -14,6 +14,7 @@ from ..metrics import pairwise_distances
 from ..utils import check_random_state
 from ..utils import deprecated
 
+
 def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
            random_state=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
@@ -46,7 +47,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
         Indices of core samples.
 
     classes : array [n_samples]
-        Cluster classes for each point.  Noisy samples are given the label -1.
+        Cluster classes for each point.  Noisy samples are given the class -1.
 
     Notes
     -----
@@ -74,8 +75,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
     classes = -np.ones(n)
     # A list of all core samples found.
     core_samples = []
-    # label_num is the label given to the new cluster
-    label_num = 0
+    # class_num is the class given to the new cluster
+    class_num = 0
     # Look at all samples and determine if they are core.
     # If they are then build a new cluster from them.
     for index in index_order:
@@ -83,7 +84,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
             # This point is already classified, or not enough for a core point.
             continue
         core_samples.append(index)
-        classes[index] = label_num
+        classes[index] = class_num
         # candidates for new core samples in the cluster.
         candidates = [index]
         while len(candidates) > 0:
@@ -93,7 +94,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
             for c in candidates:
                 noise = np.where(classes[neighborhoods[c]] == -1)[0]
                 noise = neighborhoods[c][noise]
-                classes[noise] = label_num
+                classes[noise] = class_num
                 for neighbor in noise:
                     # check if its a core point as well
                     if len(neighborhoods[neighbor]) >= min_samples:
@@ -104,7 +105,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
             candidates = new_candidates
         # Current cluster finished.
         # Next core point found will start a new cluster.
-        label_num += 1
+        class_num += 1
     return core_samples, classes
 
 
@@ -143,7 +144,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
     `classes_` : array, shape = [n_samples]
         Cluster classes for each point in the dataset given to fit().
-        Noisy samples are given the label -1.
+        Noisy samples are given the class -1.
 
     Notes
     -----
@@ -163,13 +164,13 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         self.min_samples = min_samples
         self.metric = metric
         self.random_state = random_state
-    
+
     @property
     @deprecated("Attribute labels_ is deprecated and "
-        "will be removed in 0.15. Use 'classes_' instead")
+                "will be removed in 0.15. Use 'classes_' instead")
     def labels_(self):
         return self.classes_
-    
+
     def fit(self, X):
         """Perform DBSCAN clustering from vector array or distance matrix.
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -111,7 +111,8 @@ def ward_tree(X, connectivity=None, n_components=None, copy=True,
         warnings.warn("the number of connected components of the "
                       "connectivity matrix is %d > 1. Completing it to avoid "
                       "stopping the tree early." % n_components)
-        connectivity = _fix_connectivity(X, connectivity, n_components, classes)
+        connectivity = _fix_connectivity(X, connectivity,
+                                         n_components, classes)
         n_components = 1
 
     if n_clusters is None:
@@ -264,10 +265,10 @@ def _hc_cut(n_clusters, children, n_leaves):
         # Insert the 2 children and remove the largest node
         heappush(nodes, -these_children[0])
         heappushpop(nodes, -these_children[1])
-    label = np.zeros(n_leaves, dtype=np.int)
+    class_ = np.zeros(n_leaves, dtype=np.int)
     for i, node in enumerate(nodes):
-        label[_hierarchical._hc_get_descendent(-node, children, n_leaves)] = i
-    return label
+        class_[_hierarchical._hc_get_descendent(-node, children, n_leaves)] = i
+    return class_
 
 
 ###############################################################################
@@ -336,10 +337,10 @@ class Ward(BaseEstimator, ClusterMixin):
 
     @property
     @deprecated("Attribute labels_ is deprecated and "
-        "will be removed in 0.15. Use 'classes_' instead")
+                "will be removed in 0.15. Use 'classes_' instead")
     def labels_(self):
         return self.classes_
-    
+
     def fit(self, X):
         """Fit the hierarchical clustering on the data
 
@@ -388,7 +389,7 @@ class Ward(BaseEstimator, ClusterMixin):
         # Cut the tree
         if compute_full_tree:
             self.classes_ = _hc_cut(self.n_clusters, self.children_,
-                                   self.n_leaves_)
+                                    self.n_leaves_)
         else:
             classes = _hierarchical.hc_get_heads(parents, copy=False)
             # copy to avoid holding a reference on the original array

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -98,7 +98,7 @@ def _k_init(X, n_clusters, n_local_trials=None, random_state=None,
     current_pot = closest_dist_sq.sum()
 
     # Pick the remaining n_clusters-1 points
-    for c in range(1, n_clusters):
+    for c in xrange(1, n_clusters):
         # Choose center candidates by sampling with probability proportional
         # to the squared distance to the closest existing center
         rand_vals = random_state.random_sample(n_local_trials) * current_pot
@@ -112,7 +112,7 @@ def _k_init(X, n_clusters, n_local_trials=None, random_state=None,
         best_candidate = None
         best_pot = None
         best_dist_sq = None
-        for trial in range(n_local_trials):
+        for trial in xrange(n_local_trials):
             # Compute potential when including center candidate
             new_dist_sq = np.minimum(closest_dist_sq,
                                      distance_to_candidates[trial])
@@ -150,7 +150,7 @@ def _tolerance(X, tol):
 
 def k_means(X, n_clusters, init='k-means++', precompute_distances=True,
             n_init=10, max_iter=300, verbose=False,
-            tol=1e-4, random_state=None, copy_x=True, n_jobs=1):
+            tol=1e-4, random_state=None, copy_x=True, n_jobs=1, k=None):
     """K-means clustering algorithm.
 
     Parameters
@@ -229,6 +229,12 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances=True,
 
     """
     random_state = check_random_state(random_state)
+
+    if not k is None:
+        n_clusters = k
+        warnings.warn("Parameter k has been renamed to 'n_clusters'"
+                      " and will be removed in release 0.14.",
+                      DeprecationWarning, stacklevel=2)
 
     best_inertia = np.infty
     X = as_float_array(X, copy=copy_x)
@@ -363,7 +369,7 @@ def _kmeans_single(X, n_clusters, max_iter=300, init='k-means++',
     centers = _init_centroids(X, n_clusters, init, random_state=random_state,
                               x_squared_norms=x_squared_norms)
     if verbose:
-        print('Initialization complete')
+        print 'Initialization complete'
 
     # Allocate memory to store the distances for each sample to its
     # closer center for reallocation in case of ties
@@ -386,7 +392,7 @@ def _kmeans_single(X, n_clusters, max_iter=300, init='k-means++',
             centers = _k_means._centers_dense(X, labels, n_clusters, distances)
 
         if verbose:
-            print('Iteration %i, inertia %s' % (i, inertia))
+            print 'Iteration %i, inertia %s' % (i, inertia)
 
         if best_inertia is None or inertia < best_inertia:
             best_labels = labels.copy()
@@ -395,7 +401,7 @@ def _kmeans_single(X, n_clusters, max_iter=300, init='k-means++',
 
         if np.sum((centers_old - centers) ** 2) < tol:
             if verbose:
-                print('Converged to similar centers at iteration', i)
+                print 'Converged to similar centers at iteration', i
             break
     return best_labels, best_inertia, best_centers
 
@@ -699,11 +705,21 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         ----------
         X : array-like or sparse matrix, shape=(n_samples, n_features)
         """
+
+        if not self.k is None:
+            n_clusters = self.k
+            warnings.warn("Parameter k has been renamed by 'n_clusters'"
+                          " and will be removed in release 0.14.",
+                          DeprecationWarning, stacklevel=2)
+            self.n_clusters = n_clusters
+        else:
+            n_clusters = self.n_clusters
+
         random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)
 
         self.cluster_centers_, self.labels_, self.inertia_ = k_means(
-            X, n_clusters=self.n_clusters, init=self.init, n_init=self.n_init,
+            X, n_clusters=n_clusters, init=self.init, n_init=self.n_init,
             max_iter=self.max_iter, verbose=self.verbose,
             precompute_distances=self.precompute_distances,
             tol=self.tol, random_state=random_state, copy_x=self.copy_x,
@@ -846,7 +862,7 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
     # Perform label assignement to nearest centers
     nearest_center, inertia = _labels_inertia(X, x_squared_norms, centers,
                                               distances=distances)
-    if random_reassign and reassignment_ratio > 0:
+    if random_reassign:
         random_state = check_random_state(random_state)
         # Reassign clusters that have very low counts
         to_reassign = np.logical_or(
@@ -869,8 +885,6 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
             if n_reassigns:
                 print("[_mini_batch_step] Reassigning %i cluster centers."
                       % n_reassigns)
-        if sp.issparse(new_centers) and not sp.issparse(centers):
-            new_centers = new_centers.toarray()
         centers[to_reassign] = new_centers
 
     # implementation for the sparse CSR reprensation completely written in
@@ -943,14 +957,14 @@ def _mini_batch_convergence(model, iteration_idx, n_iter, tol,
             'mean batch inertia: %f, ewa inertia: %f ' % (
                 iteration_idx + 1, n_iter, batch_inertia,
                 ewa_inertia))
-        print(progress_msg)
+        print progress_msg
 
     # Early stopping based on absolute tolerance on squared change of
     # centers postion (using EWA smoothing)
     if tol > 0.0 and ewa_diff < tol:
         if verbose:
-            print('Converged (small centers change) at iteration %d/%d'
-                  % (iteration_idx + 1, n_iter))
+            print 'Converged (small centers change) at iteration %d/%d' % (
+                iteration_idx + 1, n_iter)
         return True
 
     # Early stopping heuristic due to lack of improvement on smoothed inertia
@@ -965,9 +979,9 @@ def _mini_batch_convergence(model, iteration_idx, n_iter, tol,
     if (model.max_no_improvement is not None
             and no_improvement >= model.max_no_improvement):
         if verbose:
-            print('Converged (lack of improvement in inertia)'
-                  ' at iteration %d/%d'
-                  % (iteration_idx + 1, n_iter))
+            print ('Converged (lack of improvement in inertia)'
+                   ' at iteration %d/%d' % (
+                       iteration_idx + 1, n_iter))
         return True
 
     # update the convergence context to maintain state across sucessive calls:
@@ -1096,6 +1110,11 @@ class MiniBatchKMeans(KMeans):
             Coordinates of the data points to cluster
         """
         random_state = check_random_state(self.random_state)
+        if self.k is not None:
+            warnings.warn("Parameter k has been replaced by 'n_clusters'"
+                          " and will be removed in release 0.14.",
+                          DeprecationWarning, stacklevel=2)
+            self.n_clusters = self.k
         X = check_arrays(X, sparse_format="csr", copy=False,
                          check_ccontiguous=True, dtype=np.float64)[0]
         n_samples, n_features = X.shape
@@ -1141,8 +1160,8 @@ class MiniBatchKMeans(KMeans):
         best_inertia = None
         for init_idx in range(self.n_init):
             if self.verbose:
-                print("Init %d/%d with method: %s"
-                      % (init_idx + 1, self.n_init, self.init))
+                print "Init %d/%d with method: %s" % (
+                    init_idx + 1, self.n_init, self.init)
             counts = np.zeros(self.n_clusters, dtype=np.int32)
 
             # TODO: once the `k_means` function works with sparse input we
@@ -1167,8 +1186,8 @@ class MiniBatchKMeans(KMeans):
             _, inertia = _labels_inertia(X_valid, x_squared_norms_valid,
                                          cluster_centers)
             if self.verbose:
-                print("Inertia for init %d/%d: %f"
-                      % (init_idx + 1, self.n_init, inertia))
+                print "Inertia for init %d/%d: %f" % (
+                    init_idx + 1, self.n_init, inertia)
             if best_inertia is None or inertia < best_inertia:
                 self.cluster_centers_ = cluster_centers
                 self.counts_ = counts
@@ -1179,7 +1198,8 @@ class MiniBatchKMeans(KMeans):
 
         # Perform the iterative optimization until the final convergence
         # criterion
-        for iteration_idx in range(n_iter):
+        for iteration_idx in xrange(n_iter):
+
             # Sample a minibatch from the full dataset
             minibatch_indices = random_state.random_integers(
                 0, n_samples - 1, self.batch_size)
@@ -1209,7 +1229,7 @@ class MiniBatchKMeans(KMeans):
 
         if self.compute_labels:
             if self.verbose:
-                print('Computing label assignements and total inertia')
+                print 'Computing label assignements and total inertia'
             self.labels_, self.inertia_ = _labels_inertia(
                 X, x_squared_norms, self.cluster_centers_)
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -263,13 +263,13 @@ class MeanShift(BaseEstimator, ClusterMixin):
         self.cluster_all = cluster_all
         self.cluster_centers_ = None
         self.classes_ = None
-    
+
     @property
     @deprecated("Attribute labels_ is deprecated and "
-        "will be removed in 0.15. Use 'classes_' instead")
+                "will be removed in 0.15. Use 'classes_' instead")
     def labels_(self):
         return self.classes_
-    
+
     def fit(self, X):
         """ Compute MeanShift
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ..externals import six
 from ..utils import extmath, check_random_state
+from ..utils import deprecated
 from ..base import BaseEstimator, ClusterMixin
 from ..neighbors import NearestNeighbors
 
@@ -88,8 +89,8 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     cluster_centers : array [n_clusters, n_features]
         Coordinates of cluster centers.
 
-    labels : array [n_samples]
-        Cluster labels for each point.
+    classes : array [n_samples]
+        Cluster classes for each point.
 
     Notes
     -----
@@ -144,17 +145,17 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
             unique[i] = 1  # leave the current point as unique
     cluster_centers = sorted_centers[unique]
 
-    # ASSIGN LABELS: a point belongs to the cluster that it is closest to
+    # ASSIGN CLASSES: a point belongs to the cluster that it is closest to
     nbrs = NearestNeighbors(n_neighbors=1).fit(cluster_centers)
-    labels = np.zeros(n_samples, dtype=np.int)
+    classes = np.zeros(n_samples, dtype=np.int)
     distances, idxs = nbrs.kneighbors(X)
     if cluster_all:
-        labels = idxs.flatten()
+        classes = idxs.flatten()
     else:
-        labels.fill(-1)
+        classes.fill(-1)
         bool_selector = distances.flatten() <= bandwidth
-        labels[bool_selector] = idxs.flatten()[bool_selector]
-    return cluster_centers, labels
+        classes[bool_selector] = idxs.flatten()[bool_selector]
+    return cluster_centers, classes
 
 
 def get_bin_seeds(X, bin_size, min_bin_freq=1):
@@ -226,8 +227,8 @@ class MeanShift(BaseEstimator, ClusterMixin):
     `cluster_centers_` : array, [n_clusters, n_features]
         Coordinates of cluster centers.
 
-    `labels_` :
-        Labels of each point.
+    `classes_` :
+        classes of each point.
 
     Notes
     -----
@@ -261,8 +262,14 @@ class MeanShift(BaseEstimator, ClusterMixin):
         self.bin_seeding = bin_seeding
         self.cluster_all = cluster_all
         self.cluster_centers_ = None
-        self.labels_ = None
-
+        self.classes_ = None
+    
+    @property
+    @deprecated("Attribute labels_ is deprecated and "
+        "will be removed in 0.15. Use 'classes_' instead")
+    def labels_(self):
+        return self.classes_
+    
     def fit(self, X):
         """ Compute MeanShift
 
@@ -271,7 +278,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
         X : array-like, shape=[n_samples, n_features]
             Input points.
         """
-        self.cluster_centers_, self.labels_ = \
+        self.cluster_centers_, self.classes_ = \
             mean_shift(X, bandwidth=self.bandwidth, seeds=self.seeds,
                        bin_seeding=self.bin_seeding,
                        cluster_all=self.cluster_all)

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -268,7 +268,7 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
 
     if assign_labels == 'kmeans':
         _, classes, _ = k_means(maps, n_clusters, random_state=random_state,
-                               n_init=n_init)
+                                n_init=n_init)
     else:
         classes = discretize(maps, random_state=random_state)
 
@@ -405,10 +405,10 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
 
     @property
     @deprecated("Attribute labels_ is deprecated and "
-        "will be removed in 0.15. Use 'classes_' instead")
+                "will be removed in 0.15. Use 'classes_' instead")
     def labels_(self):
         return self.classes_
-    
+
     def fit(self, X):
         """Creates an affinity matrix for X using the selected affinity,
         then applies spectral clustering to this affinity matrix.
@@ -440,12 +440,12 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
 
         random_state = check_random_state(self.random_state)
         self.classes_ = spectral_clustering(self.affinity_matrix_,
-                                           n_clusters=self.n_clusters,
-                                           eigen_solver=self.eigen_solver,
-                                           random_state=random_state,
-                                           n_init=self.n_init,
-                                           eigen_tol=self.eigen_tol,
-                                           assign_labels=self.assign_labels)
+                                            n_clusters=self.n_clusters,
+                                            eigen_solver=self.eigen_solver,
+                                            random_state=random_state,
+                                            n_init=self.n_init,
+                                            eigen_tol=self.eigen_tol,
+                                            assign_labels=self.assign_labels)
         return self
 
     @property

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -43,8 +43,8 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
 
     Returns
     -------
-    labels : array of integers, shape: n_samples
-        The labels of the clusters.
+    classes : array of integers, shape: n_samples
+        The classes of the clusters.
 
     References
     ----------
@@ -126,9 +126,9 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
 
             t_discrete = np.dot(vectors, rotation)
 
-            labels = t_discrete.argmax(axis=1)
+            classes = t_discrete.argmax(axis=1)
             vectors_discrete = csc_matrix(
-                (np.ones(len(labels)), (np.arange(0, n_samples), labels)),
+                (np.ones(len(classes)), (np.arange(0, n_samples), classes)),
                 shape=(n_samples, n_components))
 
             t_svd = vectors_discrete.T * vectors
@@ -151,7 +151,7 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
 
     if not has_converged:
         raise LinAlgError('SVD did not converge')
-    return labels
+    return classes
 
 
 def spectral_clustering(affinity, n_clusters=8, n_components=None,
@@ -217,8 +217,8 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
 
     Returns
     -------
-    labels: array of integers, shape: n_samples
-        The labels of the clusters.
+    classes: array of integers, shape: n_samples
+        The classes of the clusters.
 
     References
     ----------
@@ -267,12 +267,12 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
                               eigen_tol=eigen_tol, drop_first=False)
 
     if assign_labels == 'kmeans':
-        _, labels, _ = k_means(maps, n_clusters, random_state=random_state,
+        _, classes, _ = k_means(maps, n_clusters, random_state=random_state,
                                n_init=n_init)
     else:
-        labels = discretize(maps, random_state=random_state)
+        classes = discretize(maps, random_state=random_state)
 
-    return labels
+    return classes
 
 
 class SpectralClustering(BaseEstimator, ClusterMixin):
@@ -344,8 +344,8 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
         Affinity matrix used for clustering. Available only if after calling
         ``fit``.
 
-    `labels_` :
-        Labels of each point
+    `classes_` :
+        classes of each point
 
     Notes
     -----
@@ -403,6 +403,12 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
         self.eigen_tol = eigen_tol
         self.assign_labels = assign_labels
 
+    @property
+    @deprecated("Attribute labels_ is deprecated and "
+        "will be removed in 0.15. Use 'classes_' instead")
+    def labels_(self):
+        return self.classes_
+    
     def fit(self, X):
         """Creates an affinity matrix for X using the selected affinity,
         then applies spectral clustering to this affinity matrix.
@@ -433,7 +439,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
                              % self.affinity)
 
         random_state = check_random_state(self.random_state)
-        self.labels_ = spectral_clustering(self.affinity_matrix_,
+        self.classes_ = spectral_clustering(self.affinity_matrix_,
                                            n_clusters=self.n_clusters,
                                            eigen_solver=self.eigen_solver,
                                            random_state=random_state,

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -3,6 +3,7 @@ Tests for DBSCAN clustering algorithm
 """
 
 import pickle
+import warnings
 
 import numpy as np
 from scipy.spatial import distance
@@ -25,17 +26,27 @@ def test_dbscan_similarity():
     D = distance.squareform(distance.pdist(X))
     D /= np.max(D)
     # Compute DBSCAN
-    core_samples, labels = dbscan(D, metric="precomputed", eps=eps,
-                                  min_samples=min_samples)
+    core_samples, classes = dbscan(D, metric="precomputed", eps=eps,
+                                   min_samples=min_samples)
     # number of clusters, ignoring noise if present
-    n_clusters_1 = len(set(labels)) - (1 if -1 in labels else 0)
+    n_clusters_1 = len(set(classes)) - (1 if -1 in classes else 0)
 
     assert_equal(n_clusters_1, n_clusters)
 
     db = DBSCAN(metric="precomputed", eps=eps, min_samples=min_samples)
-    labels = db.fit(D).labels_
+    classes = db.fit(D).classes_
 
-    n_clusters_2 = len(set(labels)) - int(-1 in labels)
+    #Test for deprecations of labels_
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = db.fit(D).labels_
+        # Verify some things
+        print w
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
+    n_clusters_2 = len(set(classes)) - int(-1 in classes)
     assert_equal(n_clusters_2, n_clusters)
 
 
@@ -48,17 +59,17 @@ def test_dbscan_feature():
     metric = 'euclidean'
     # Compute DBSCAN
     # parameters chosen for task
-    core_samples, labels = dbscan(X, metric=metric, eps=eps,
-                                  min_samples=min_samples)
+    core_samples, classes = dbscan(X, metric=metric, eps=eps,
+                                   min_samples=min_samples)
 
     # number of clusters, ignoring noise if present
-    n_clusters_1 = len(set(labels)) - int(-1 in labels)
+    n_clusters_1 = len(set(classes)) - int(-1 in classes)
     assert_equal(n_clusters_1, n_clusters)
 
     db = DBSCAN(metric=metric, eps=eps, min_samples=min_samples)
-    labels = db.fit(X).labels_
+    classes = db.fit(X).classes_
 
-    n_clusters_2 = len(set(labels)) - int(-1 in labels)
+    n_clusters_2 = len(set(classes)) - int(-1 in classes)
     assert_equal(n_clusters_2, n_clusters)
 
 
@@ -72,17 +83,17 @@ def test_dbscan_callable():
     metric = distance.euclidean
     # Compute DBSCAN
     # parameters chosen for task
-    core_samples, labels = dbscan(X, metric=metric, eps=eps,
-                                  min_samples=min_samples)
+    core_samples, classes = dbscan(X, metric=metric, eps=eps,
+                                   min_samples=min_samples)
 
     # number of clusters, ignoring noise if present
-    n_clusters_1 = len(set(labels)) - int(-1 in labels)
+    n_clusters_1 = len(set(classes)) - int(-1 in classes)
     assert_equal(n_clusters_1, n_clusters)
 
     db = DBSCAN(metric=metric, eps=eps, min_samples=min_samples)
-    labels = db.fit(X).labels_
+    classes = db.fit(X).classes_
 
-    n_clusters_2 = len(set(labels)) - int(-1 in labels)
+    n_clusters_2 = len(set(classes)) - int(-1 in classes)
     assert_equal(n_clusters_2, n_clusters)
 
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -83,16 +83,25 @@ def test_ward_clustering():
     clustering = Ward(n_clusters=10, connectivity=connectivity,
                       memory=mkdtemp())
     clustering.fit(X)
-    labels = clustering.labels_
-    assert_true(np.size(np.unique(labels)) == 10)
+    #Check labels deprecation
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = clustering.labels_
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
+    classes = clustering.classes_
+    assert_true(np.size(np.unique(classes)) == 10)
     # Check that we obtain the same solution with early-stopping of the
     # tree building
     clustering.compute_full_tree = False
     clustering.fit(X)
-    np.testing.assert_array_equal(clustering.labels_, labels)
+    np.testing.assert_array_equal(clustering.classes_, classes)
     clustering.connectivity = None
     clustering.fit(X)
-    assert_true(np.size(np.unique(clustering.labels_)) == 10)
+    assert_true(np.size(np.unique(clustering.classes_)) == 10)
     # Check that we raise a TypeError on dense matrices
     clustering = Ward(n_clusters=10,
                       connectivity=connectivity.todense())
@@ -113,7 +122,15 @@ def test_ward_agglomeration():
     connectivity = grid_to_graph(*mask.shape)
     ward = WardAgglomeration(n_clusters=5, connectivity=connectivity)
     ward.fit(X)
-    assert_true(np.size(np.unique(ward.labels_)) == 5)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = ward.labels_
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
+    assert_true(np.size(np.unique(ward.classes_)) == 5)
 
     Xred = ward.transform(X)
     assert_true(Xred.shape[1] == 5)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -52,7 +52,7 @@ def test_kmeans_dtype():
     X = (X * 10).astype(np.uint8)
     km = KMeans(n_init=1).fit(X)
     with warnings.catch_warnings(record=True) as w:
-        assert_array_equal(km.labels_, km.predict(X))
+        assert_array_equal(km.classes_, km.predict(X))
         assert_equal(len(w), 1)
 
 
@@ -158,7 +158,17 @@ def _check_fitted_model(km):
     centers = km.cluster_centers_
     assert_equal(centers.shape, (n_clusters, n_features))
 
-    labels = km.labels_
+    labels = km.classes_
+
+    #Also test labels_ deprecation
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = km.labels_
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
     assert_equal(np.unique(labels).shape[0], n_clusters)
 
     # check that the labels assignements are perfect (up to a permutation)
@@ -197,7 +207,7 @@ def test_k_means_new_centers():
                 random_state=1)
     for this_X in (X, sp.coo_matrix(X)):
         km.fit(this_X)
-        this_labels = km.labels_
+        this_labels = km.classes_
         # Reorder the labels so that the first instance is in cluster 0,
         # the second in cluster 1, ...
         this_labels = unique(this_labels, return_index=True)[1][this_labels]
@@ -429,7 +439,7 @@ def test_k_means_non_collapsed():
     km.fit(my_X)
 
     # centers must not been collapsed
-    assert_equal(len(np.unique(km.labels_)), 3)
+    assert_equal(len(np.unique(km.classes_)), 3)
 
     centers = km.cluster_centers_
     assert_true(np.linalg.norm(centers[0] - centers[1]) >= 0.1)
@@ -448,11 +458,11 @@ def test_predict():
 
     # sanity check: re-predict labeling for training set samples
     pred = km.predict(X)
-    assert_array_equal(pred, km.labels_)
+    assert_array_equal(pred, km.classes_)
 
     # re-predict labels for training set using fit_predict
     pred = km.fit_predict(X)
-    assert_array_equal(pred, km.labels_)
+    assert_array_equal(pred, km.classes_)
 
 
 def test_score():
@@ -472,7 +482,15 @@ def test_predict_minibatch_dense_input():
 
     # sanity check: re-predict labeling for training set samples
     pred = mb_k_means.predict(X)
-    assert_array_equal(mb_k_means.predict(X), mb_k_means.labels_)
+    assert_array_equal(mb_k_means.predict(X), mb_k_means.classes_)
+    #Check labels- deprecation for mb_k_means
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = mb_k_means.labels_
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
 
 
 def test_predict_minibatch_kmeanspp_init_sparse_input():
@@ -480,7 +498,7 @@ def test_predict_minibatch_kmeanspp_init_sparse_input():
                                  n_init=10).fit(X_csr)
 
     # sanity check: re-predict labeling for training set samples
-    assert_array_equal(mb_k_means.predict(X_csr), mb_k_means.labels_)
+    assert_array_equal(mb_k_means.predict(X_csr), mb_k_means.classes_)
 
     # sanity check: predict centroid labels
     pred = mb_k_means.predict(mb_k_means.cluster_centers_)
@@ -488,7 +506,7 @@ def test_predict_minibatch_kmeanspp_init_sparse_input():
 
     # check that models trained on sparse input also works for dense input at
     # predict time
-    assert_array_equal(mb_k_means.predict(X), mb_k_means.labels_)
+    assert_array_equal(mb_k_means.predict(X), mb_k_means.classes_)
 
 
 def test_predict_minibatch_random_init_sparse_input():
@@ -496,7 +514,7 @@ def test_predict_minibatch_random_init_sparse_input():
                                  n_init=10).fit(X_csr)
 
     # sanity check: re-predict labeling for training set samples
-    assert_array_equal(mb_k_means.predict(X_csr), mb_k_means.labels_)
+    assert_array_equal(mb_k_means.predict(X_csr), mb_k_means.classes_)
 
     # sanity check: predict centroid labels
     pred = mb_k_means.predict(mb_k_means.cluster_centers_)
@@ -504,7 +522,7 @@ def test_predict_minibatch_random_init_sparse_input():
 
     # check that models trained on sparse input also works for dense input at
     # predict time
-    assert_array_equal(mb_k_means.predict(X), mb_k_means.labels_)
+    assert_array_equal(mb_k_means.predict(X), mb_k_means.classes_)
 
 
 def test_input_dtypes():
@@ -529,7 +547,7 @@ def test_input_dtypes():
                         init=init_int).fit(X_int_csr),
     ]
     expected_labels = [0, 1, 1, 0, 0, 1]
-    scores = np.array([v_measure_score(expected_labels, km.labels_)
+    scores = np.array([v_measure_score(expected_labels, km.classes_)
                        for km in fitted_models])
     assert_array_equal(scores, np.ones(scores.shape[0]))
 

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -2,7 +2,7 @@
 Testing for mean shift clustering methods
 
 """
-
+import warnings
 import numpy as np
 
 from sklearn.utils.testing import assert_equal
@@ -29,7 +29,16 @@ def test_mean_shift():
     assert_true(0.9 <= bandwidth_ <= 1.5)
 
     ms = MeanShift(bandwidth=bandwidth)
-    labels = ms.fit(X).labels_
+    #test labels_ deprecation
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = ms.fit(X).labels_
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
+    labels = ms.fit(X).classes_
     cluster_centers = ms.cluster_centers_
     labels_unique = np.unique(labels)
     n_clusters_ = len(labels_unique)

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -154,7 +154,7 @@ def test_pipline_spectral_clustering(seed=36):
         km.fit(se.fit_transform(S))
         assert_array_almost_equal(
             normalized_mutual_info_score(
-                km.labels_,
+                km.classes_,
                 true_labels), 1.0, 2)
 
 

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -733,8 +733,13 @@ def normalized_mutual_info_score(labels_true, labels_pred):
     return nmi
 
 
-def entropy(classes):
+def entropy(classes, labels=None):
     """Calculates the entropy for a labeling."""
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated and will be "
+                      "removed in 0.15. Please use 'classes' instead",
+                      DeprecationWarning)
+        classes = labels
     if len(classes) == 0:
         return 1.0
     class_idx = unique(classes, return_inverse=True)[1]

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -733,12 +733,12 @@ def normalized_mutual_info_score(labels_true, labels_pred):
     return nmi
 
 
-def entropy(labels):
+def entropy(classes):
     """Calculates the entropy for a labeling."""
-    if len(labels) == 0:
+    if len(classes) == 0:
         return 1.0
-    label_idx = unique(labels, return_inverse=True)[1]
-    pi = np.bincount(label_idx).astype(np.float)
+    class_idx = unique(classes, return_inverse=True)[1]
+    pi = np.bincount(class_idx).astype(np.float)
     pi = pi[pi > 0]
     pi_sum = np.sum(pi)
     # log(a / b) should be calculated as log(a) - log(b) for

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -76,7 +76,8 @@ def silhouette_score(X, classes, labels=None, metric='euclidean',
     """
     if labels is not None:
         warnings.warn("Parameter 'labels' is deprecated and will be "
-                      "removed in 0.15. Please use 'classes' instead")
+                      "removed in 0.15. Please use 'classes' instead",
+                      DeprecationWarning)
         classes = labels
 
     if sample_size is not None:
@@ -148,7 +149,8 @@ def silhouette_samples(X, classes, labels=None, metric='euclidean', **kwds):
 
     if labels is not None:
         warnings.warn("Parameter 'labels' is deprecated and will"
-                      " be removed in 0.15. Please use 'classes' instead")
+                      " be removed in 0.15. Please use 'classes' instead",
+                      DeprecationWarning)
         classes = labels
 
     distances = pairwise_distances(X, metric=metric, **kwds)
@@ -186,7 +188,8 @@ def _intra_cluster_distance(distances_row, classes, i, labels=None):
     if labels is not None:
         warnings.warn("Parameter 'labels' is deprecated"
                       " and will be removed in 0.15. "
-                      "Please use 'classes' instead")
+                      "Please use 'classes' instead",
+                      DeprecationWarning)
         classes = labels
 
     mask = classes == classes[i]

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -10,8 +10,8 @@ from ...utils import check_random_state
 from ..pairwise import pairwise_distances
 
 
-def silhouette_score(X, labels, metric='euclidean', sample_size=None,
-                     random_state=None, **kwds):
+def silhouette_score(X, classes, labels=None, metric='euclidean',
+                     sample_size=None, random_state=None, **kwds):
     """Compute the mean Silhouette Coefficient of all samples.
 
     The Silhouette Coefficient is calculated using the mean intra-cluster
@@ -33,8 +33,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
              [n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
-    labels : array, shape = [n_samples]
-             label values for each sample
+    classes : array, shape = [n_samples]
+             class values for each sample
 
     metric : string, or callable
         The metric to use when calculating distance between instances in a
@@ -74,17 +74,22 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <http://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated and will be "
+                      "removed in 0.15. Please use 'classes' instead")
+        classes = labels
+
     if sample_size is not None:
         random_state = check_random_state(random_state)
         indices = random_state.permutation(X.shape[0])[:sample_size]
         if metric == "precomputed":
-            X, labels = X[indices].T[indices].T, labels[indices]
+            X, classes = X[indices].T[indices].T, classes[indices]
         else:
-            X, labels = X[indices], labels[indices]
-    return np.mean(silhouette_samples(X, labels, metric=metric, **kwds))
+            X, classes = X[indices], classes[indices]
+    return np.mean(silhouette_samples(X, classes, metric=metric, **kwds))
 
 
-def silhouette_samples(X, labels, metric='euclidean', **kwds):
+def silhouette_samples(X, classes, labels=None, metric='euclidean', **kwds):
     """Compute the Silhouette Coefficient for each sample.
 
     The Silhoeutte Coefficient is a measure of how well samples are clustered
@@ -109,8 +114,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
              [n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
-    labels : array, shape = [n_samples]
-             label values for each sample
+    classes : array, shape = [n_samples]
+             class values for each sample
 
     metric : string, or callable
         The metric to use when calculating distance between instances in a
@@ -140,18 +145,24 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
        <http://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
+
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated and will"
+                      " be removed in 0.15. Please use 'classes' instead")
+        classes = labels
+
     distances = pairwise_distances(X, metric=metric, **kwds)
-    n = labels.shape[0]
-    A = np.array([_intra_cluster_distance(distances[i], labels, i)
+    n = classes.shape[0]
+    A = np.array([_intra_cluster_distance(distances[i], classes, i)
                   for i in range(n)])
-    B = np.array([_nearest_cluster_distance(distances[i], labels, i)
+    B = np.array([_nearest_cluster_distance(distances[i], classes, i)
                   for i in range(n)])
     sil_samples = (B - A) / np.maximum(A, B)
     # nan values are for clusters of size 1, and should be 0
     return np.nan_to_num(sil_samples)
 
 
-def _intra_cluster_distance(distances_row, labels, i):
+def _intra_cluster_distance(distances_row, classes, i, labels=None):
     """Calculate the mean intra-cluster distance for sample i.
 
     Parameters
@@ -159,25 +170,32 @@ def _intra_cluster_distance(distances_row, labels, i):
     distances_row : array, shape = [n_samples]
         Pairwise distance matrix between sample i and each sample.
 
-    labels : array, shape = [n_samples]
-        label values for each sample
+    classes : array, shape = [n_samples]
+        class values for each sample
 
     i : int
         Sample index being calculated. It is excluded from calculation and
-        used to determine the current label
+        used to determine the current class
 
     Returns
     -------
     a : float
         Mean intra-cluster distance for sample i
     """
-    mask = labels == labels[i]
+
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated"
+                      " and will be removed in 0.15. "
+                      "Please use 'classes' instead")
+        classes = labels
+
+    mask = classes == classes[i]
     mask[i] = False
     a = np.mean(distances_row[mask])
     return a
 
 
-def _nearest_cluster_distance(distances_row, labels, i):
+def _nearest_cluster_distance(distances_row, classes, i, labels=None):
     """Calculate the mean nearest-cluster distance for sample i.
 
     Parameters
@@ -185,19 +203,19 @@ def _nearest_cluster_distance(distances_row, labels, i):
     distances_row : array, shape = [n_samples]
         Pairwise distance matrix between sample i and each sample.
 
-    labels : array, shape = [n_samples]
-        label values for each sample
+    classes : array, shape = [n_samples]
+        class values for each sample
 
     i : int
         Sample index being calculated. It is used to determine the current
-        label.
+        class.
 
     Returns
     -------
     b : float
         Mean nearest-cluster distance for sample i
     """
-    label = labels[i]
-    b = np.min([np.mean(distances_row[labels == cur_label])
-               for cur_label in set(labels) if not cur_label == label])
+    class_ = classes[i]
+    b = np.min([np.mean(distances_row[classes == cur_class])
+               for cur_class in set(classes) if not cur_class == class_])
     return b

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -541,7 +541,7 @@ def roc_curve(y_true, y_score, pos_label=None):
 ###############################################################################
 # Multiclass general function
 ###############################################################################
-def confusion_matrix(y_true, y_pred, labels=None):
+def confusion_matrix(y_true, y_pred, classes=None, labels=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
@@ -556,8 +556,8 @@ def confusion_matrix(y_true, y_pred, labels=None):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array, shape = [n_classes]
-        List of all labels occuring in the dataset.
+    classes : array, shape = [n_classes]
+        List of all classes occuring in the dataset.
         If none is given, those that appear at least once
         in ``y_true`` or ``y_pred`` are used.
 
@@ -582,9 +582,17 @@ def confusion_matrix(y_true, y_pred, labels=None):
 
     """
     if labels is None:
-        labels = unique_labels(y_true, y_pred)
+        if classes is not None:
+            labels = np.asarray(classes, dtype=np.int)
+        else:
+            labels = unique_labels(y_true, y_pred)
     else:
-        labels = np.asarray(labels, dtype=np.int)
+        warnings.warn("Parameter 'labels' is deprecated"
+                      " and will be removed in 0.15. "
+                      "Please use 'classes' instead",
+                      DeprecationWarning)
+        classes = labels
+        labels = np.asarray(classes, dtype=np.int)
 
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
@@ -726,7 +734,8 @@ def accuracy_score(y_true, y_pred):
     return np.mean(y_pred == y_true)
 
 
-def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
+def f1_score(y_true, y_pred, classes=None, labels=None,
+             pos_label=1, average='weighted'):
     """Compute the F1 score, also known as balanced F-score or F-measure
 
     The F1 score can be interpreted as a weighted average of the precision and
@@ -747,8 +756,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    classes : array
+        Integer array of classes.
 
     pos_label : int
         In the binary classification case, give the label of the positive class
@@ -806,11 +815,17 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     array([ 0.8,  0. ,  0. ])
 
     """
-    return fbeta_score(y_true, y_pred, 1, labels=labels,
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated"
+                      " and will be removed in 0.15."
+                      "Please use 'classes' instead", DeprecationWarning)
+        classes = labels
+
+    return fbeta_score(y_true, y_pred, 1, classes=classes,
                        pos_label=pos_label, average=average)
 
 
-def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
+def fbeta_score(y_true, y_pred, beta, classes=None, labels=None, pos_label=1,
                 average='weighted'):
     """Compute the F-beta score
 
@@ -833,8 +848,8 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     beta: float
         Weight of precision in harmonic mean.
 
-    labels : array
-        Integer array of labels.
+    classes : array
+        Integer array of classes.
 
     pos_label : int
         In the binary classification case, give the label of the positive class
@@ -905,16 +920,23 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     array([ 0.71...,  0.        ,  0.        ])
 
     """
+
+    if labels is not None:
+        warnings.warn("Parameter 'labels' is deprecated"
+                      " and will be removed in 0.15."
+                      "Please use 'classes' instead", DeprecationWarning)
+        classes = labels
+
     _, _, f, _ = precision_recall_fscore_support(y_true, y_pred,
                                                  beta=beta,
-                                                 labels=labels,
+                                                 classes=classes,
                                                  pos_label=pos_label,
                                                  average=average)
     return f
 
 
-def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
-                                    pos_label=1, average=None):
+def precision_recall_fscore_support(y_true, y_pred, beta=1.0, classes=None,
+                                    labels=None,  pos_label=1, average=None):
     """Compute precision, recall, F-measure and support for each class
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -950,8 +972,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     beta : float, 1.0 by default
         The strength of recall versus precision in the F-score.
 
-    labels : array
-        Integer array of labels.
+    classes : array
+        Integer array of classes.
 
     pos_label : int
         In the binary classification case, give the label of the positive class
@@ -1030,9 +1052,16 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     y_true, y_pred = check_arrays(y_true, y_pred)
     if labels is None:
-        labels = unique_labels(y_true, y_pred)
+        if classes is None:
+            labels = unique_labels(y_true, y_pred)
+        else:
+            labels = np.asarray(classes, dtype=np.int)
     else:
-        labels = np.asarray(labels, dtype=np.int)
+        warnings.warn("'labels' was renamed to classes and will "
+                      "be removed in 0.15.",
+                      DeprecationWarning)
+        classes = labels
+        labels = np.asarray(classes, dtype=np.int)
 
     n_labels = labels.size
     true_pos = np.zeros(n_labels, dtype=np.double)
@@ -1101,7 +1130,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         return avg_precision, avg_recall, avg_fscore, None
 
 
-def precision_score(y_true, y_pred, labels=None, pos_label=1,
+def precision_score(y_true, y_pred, classes=None, labels=None, pos_label=1,
                     average='weighted'):
     """Compute the precision
 
@@ -1120,8 +1149,8 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    classes : array
+        Integer array of classes.
 
     pos_label : int
         In the binary classification case, give the label of the positive class
@@ -1177,14 +1206,20 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     array([ 0.66...,  0.        ,  0.        ])
 
     """
+    if labels is not None:
+        warnings.warn("'labels' was renamed to classes and will "
+                      "be removed in 0.15.",
+                      DeprecationWarning)
+        classes = labels
     p, _, _, _ = precision_recall_fscore_support(y_true, y_pred,
-                                                 labels=labels,
+                                                 classes=classes,
                                                  pos_label=pos_label,
                                                  average=average)
     return p
 
 
-def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
+def recall_score(y_true, y_pred, classes=None, labels=None,
+                 pos_label=1, average='weighted'):
     """Compute the recall
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
@@ -1201,11 +1236,11 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    classes : array
+        Integer array of classes.
 
     pos_label : int
-        In the binary classification case, give the label of the positive class
+        In the binary classification case, give the class of the positive class
         (default is 1). Everything else but ``pos_label`` is considered to
         belong to the negative class.  Set to ``None`` in the case of
         multiclass classification.
@@ -1257,6 +1292,12 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     array([ 1.,  0.,  0.])
 
     """
+    if labels is not None:
+        warnings.warn("'labels' was renamed to classes and will "
+                      "be removed in 0.15.",
+                      DeprecationWarning)
+        classes = labels
+
     _, r, _, _ = precision_recall_fscore_support(y_true, y_pred,
                                                  labels=labels,
                                                  pos_label=pos_label,
@@ -1272,10 +1313,10 @@ def zero_one_score(y_true, y_pred):
     Parameters
     ----------
     y_true : array-like, shape = n_samples
-        Ground truth (correct) labels.
+        Ground truth (correct) classes.
 
     y_pred : array-like, shape = n_samples
-        Predicted labels, as returned by a classifier.
+        Predicted classes, as returned by a classifier.
 
     Returns
     -------
@@ -1290,7 +1331,8 @@ def zero_one_score(y_true, y_pred):
 ###############################################################################
 # Multiclass utility function
 ###############################################################################
-def classification_report(y_true, y_pred, labels=None, target_names=None):
+def classification_report(y_true, y_pred, classes=None,
+                          labels=None, target_names=None):
     """Build a text report showing the main classification metrics
 
     Parameters
@@ -1301,11 +1343,11 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array, shape = [n_labels]
-        Optional list of label indices to include in the report.
+    classes : array, shape = [n_classes]
+        Optional list of classes indices to include in the report.
 
     target_names : list of strings
-        Optional display names matching the labels (same order).
+        Optional display names matching the classes (same order).
 
     Returns
     -------
@@ -1331,9 +1373,17 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     """
 
     if labels is None:
-        labels = unique_labels(y_true, y_pred)
+        if classes is not None:
+            labels = np.asarray(classes, dtype=np.int)
+        else:
+            labels = unique_labels(y_true, y_pred)
     else:
-        labels = np.asarray(labels, dtype=np.int)
+        warnings.warn("'labels' was renamed to classes and will "
+                      "be removed in 0.15.",
+                      DeprecationWarning)
+        classes = labels
+
+        labels = np.asarray(classes, dtype=np.int)
 
     last_line_heading = 'avg / total'
 
@@ -1355,7 +1405,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     report += '\n'
 
     p, r, f1, s = precision_recall_fscore_support(y_true, y_pred,
-                                                  labels=labels,
+                                                  classes=labels,
                                                   average=None)
 
     for i, label in enumerate(labels):

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -316,9 +316,22 @@ def test_precision_recall_f1_score_multiclass():
     fs = f1_score(y_true, y_pred, average='weighted')
     assert_array_almost_equal(fs, 0.55, 2)
 
-    # same prediction but with and explicit label ordering
-    p, r, f, s = precision_recall_fscore_support(
+    # test deprecation for labels parameter for
+    # precision_recall_fscore_support
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _, _, _, _ = precision_recall_fscore_support(
         y_true, y_pred, labels=[0, 2, 1], average=None)
+        # Verify some things
+        print w
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+
+    # same prediction but with and explicit label ordering
+    # Test deprecation of "labels" for confusion matrix
+
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, classes=[0, 2, 1], average=None)
     assert_array_almost_equal(p, [0.82, 0.47, 0.55], 2)
     assert_array_almost_equal(r, [0.92, 0.90, 0.17], 2)
     assert_array_almost_equal(f, [0.87, 0.62, 0.26], 2)
@@ -370,25 +383,36 @@ def test_confusion_matrix_multiclass():
                             [5, 5, 20],
                             [0, 2, 18]])
 
+    # Test deprecation of "labels" for confusion matrix
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = confusion_matrix(y_true, y_pred, labels=[0, 2, 1])
+        # Verify some things
+        print w
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
     # compute confusion matrix with explicit label ordering
-    cm = confusion_matrix(y_true, y_pred, labels=[0, 2, 1])
+
+    cm = confusion_matrix(y_true, y_pred, classes=[0, 2, 1])
     assert_array_equal(cm, [[23, 0, 2],
                             [0, 18, 2],
                             [5, 20, 5]])
 
 
 def test_confusion_matrix_multiclass_subset_labels():
-    """Test confusion matrix - multi-class case with subset of labels"""
+    """Test confusion matrix - multi-class case with subset of classes"""
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    # compute confusion matrix with only first two labels considered
-    cm = confusion_matrix(y_true, y_pred, labels=[0, 1])
+    # compute confusion matrix with only first two classes considered
+    cm = confusion_matrix(y_true, y_pred, classes=[0, 1])
     assert_array_equal(cm, [[23, 2],
                             [5, 5]])
 
-    # compute confusion matrix with explicit label ordering for only subset
+    # compute confusion matrix with explicit class ordering for only subset
     # of labels
-    cm = confusion_matrix(y_true, y_pred, labels=[2, 1])
+    cm = confusion_matrix(y_true, y_pred, classes=[2, 1])
     assert_array_equal(cm, [[18, 2],
                             [20, 5]])
 
@@ -408,8 +432,20 @@ def test_classification_report():
 
 avg / total       0.62      0.61      0.56        75
 """
-    report = classification_report(
+
+    # test deprecation for labels for classification_report
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = classification_report(
         y_true, y_pred, labels=np.arange(len(iris.target_names)),
+        target_names=iris.target_names)
+        # Verify some things
+        print w
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+
+    report = classification_report(
+        y_true, y_pred, classes=np.arange(len(iris.target_names)),
         target_names=iris.target_names)
     assert_equal(report, expected_report)
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -437,8 +437,8 @@ def test_clustering():
             # fit
             alg.fit(X)
 
-        assert_equal(alg.labels_.shape, (n_samples,))
-        pred = alg.labels_
+        assert_equal(alg.classes_.shape, (n_samples,))
+        pred = alg.classes_
         assert_greater(adjusted_rand_score(pred, y), 0.4)
         # fit another time with ``fit_predict`` and compare results
         if Alg is SpectralClustering:


### PR DESCRIPTION
Done for clusters/
except for kmeans. I need advice.
The _kmeans.py has lots of functions/attributs/variables with "label" in it. 
Should those all be deprecated?
Passes all the tests but I also I need to update the tests to make sure it is giving deprecation warnings.
fixes Issue #1591 
