### PR TITLE
BUG: Build random forests the same way regardless of n_jobs and add a te...

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -201,7 +201,7 @@ features::
   >>> clf = ExtraTreesClassifier(random_state=0)
   >>> X_new = clf.fit(X, y).transform(X)
   >>> clf.feature_importances_
-  array([ 0.08062796,  0.03471289,  0.42329694,  0.46136221])
+  array([ 0.12604616,  0.07234783,  0.38787583,  0.41373018])
   >>> X_new.shape
   (150, 2)
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -357,7 +357,7 @@ class BaseForest(BaseEnsemble, SelectorMixin):
         n_jobs, n_trees, _ = _partition_trees(self)
 
         # Precalculate the random states
-        seeds = [random_state.randint(MAX_INT, size=n_trees[i]) for i in xrange(len(n_trees))]
+        seeds = [random_state.randint(MAX_INT, size=i) for i in n_trees]
 
         # Parallel loop
         all_trees = Parallel(n_jobs=n_jobs, verbose=self.verbose)(

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -440,7 +440,7 @@ def test_parallel_train():
         probas.append(proba)
 
     for proba1, proba2 in zip(probas, probas[1:]):
-        assert np.allclose(proba1, proba2)
+        assert_true(np.allclose(proba1, proba2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
...st for this. Don't predict in parallel since the cost of copying memory in joblib outweighs the speedups for random forests. Fixes #1685.
