### PR TITLE
Speed regression in random forests for predicting > 5k rows + clarify docs for n_jobs

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -112,6 +112,48 @@ def _parallel_build_trees(n_trees, forest, X, y, sample_weight,
     return trees
 
 
+def _parallel_predict_proba(trees, X, n_classes, n_outputs):
+    """Private function used to compute a batch of predictions within a job."""
+    n_samples = X.shape[0]
+
+    if n_outputs == 1:
+        proba = np.zeros((n_samples, n_classes))
+
+        for tree in trees:
+            proba_tree = tree.predict_proba(X)
+
+            if n_classes == tree.n_classes_:
+                proba += proba_tree
+
+            else:
+                for j, c in enumerate(tree.classes_):
+                    proba[:, c] += proba_tree[:, j]
+
+    else:
+        proba = []
+
+        for k in xrange(n_outputs):
+            proba.append(np.zeros((n_samples, n_classes[k])))
+
+        for tree in trees:
+            proba_tree = tree.predict_proba(X)
+
+            for k in xrange(n_outputs):
+                if n_classes[k] == tree.n_classes_[k]:
+                    proba[k] += proba_tree[k]
+
+                else:
+                    for j, c in enumerate(tree.classes_[k]):
+                        proba[k][:, c] += proba_tree[k][:, j]
+
+    return proba
+
+
+def _parallel_predict_regression(trees, X):
+    """Private function used to compute a batch of predictions within a job."""
+    return sum(tree.predict(X) for tree in trees)
+
+
 def _partition_trees(forest):
     """Private function used to partition trees between jobs."""
     # Compute the number of jobs
@@ -524,39 +566,31 @@ class ForestClassifier(BaseForest, ClassifierMixin):
         if getattr(X, "dtype", None) != DTYPE or X.ndim != 2:
             X = array2d(X, dtype=DTYPE)
 
-        n_samples = X.shape[0]
+        # Assign chunk of trees to jobs
+        n_jobs, n_trees, starts = _partition_trees(self)
+
+        # Parallel loop
+        all_proba = Parallel(n_jobs=n_jobs, verbose=self.verbose)(
+            delayed(_parallel_predict_proba)(
+                self.estimators_[starts[i]:starts[i + 1]],
+                X,
+                self.n_classes_,
+                self.n_outputs_)
+            for i in range(n_jobs))
+
+        # Reduce
+        proba = all_proba[0]
 
         if self.n_outputs_ == 1:
-            proba = np.zeros((n_samples, self.n_classes_))
-
-            for tree in self.estimators_:
-                proba_tree = tree.predict_proba(X)
-
-                if self.n_classes_ == tree.n_classes_:
-                    proba += proba_tree
-
-                else:
-                    for j, c in enumerate(tree.classes_):
-                        proba[:, c] += proba_tree[:, j]
+            for j in xrange(1, len(all_proba)):
+                proba += all_proba[j]
 
             proba /= self.n_estimators
 
         else:
-            proba = []
-
-            for k in xrange(self.n_outputs_):
-                proba.append(np.zeros((n_samples, self.n_classes_[k])))
-
-            for tree in self.estimators_:
-                proba_tree = tree.predict_proba(X)
-
+            for j in xrange(1, len(all_proba)):
                 for k in xrange(self.n_outputs_):
-                    if self.n_classes_[k] == tree.n_classes_[k]:
-                        proba[k] += proba_tree[k]
-
-                    else:
-                        for j, c in enumerate(tree.classes_[k]):
-                            proba[k][:, c] += proba_tree[k][:, j]
+                    proba[k] += all_proba[j][k]
 
             for k in xrange(self.n_outputs_):
                 proba[k] /= self.n_estimators
@@ -643,8 +677,18 @@ class ForestRegressor(BaseForest, RegressorMixin):
         if getattr(X, "dtype", None) != DTYPE or X.ndim != 2:
             X = array2d(X, dtype=DTYPE)
 
-        y_hat = sum(tree.predict(X) for tree in self.estimators_)
-        y_hat /= self.n_estimators
+        # Assign chunk of trees to jobs
+        n_jobs, n_trees, starts = _partition_trees(self)
+
+        # Parallel loop
+        all_y_hat = Parallel(n_jobs=n_jobs, verbose=self.verbose)(
+            delayed(_parallel_predict_regression)(
+                self.estimators_[starts[i]:starts[i + 1]], X)
+            for i in range(n_jobs))
+
+        # Reduce
+        y_hat = sum(all_y_hat) / self.n_estimators
+
         return y_hat
 
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -755,8 +755,8 @@ class RandomForestClassifier(ForestClassifier):
         the generalization error.
 
     n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel. If -1, then the number of jobs
-        is set to the number of cores.
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        If -1, then the number of jobs is set to the number of cores.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -897,8 +897,8 @@ class RandomForestRegressor(ForestRegressor):
         the generalization error.
 
     n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel. If -1, then the number of jobs
-        is set to the number of cores.
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        If -1, then the number of jobs is set to the number of cores.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -1031,8 +1031,8 @@ class ExtraTreesClassifier(ForestClassifier):
         the generalization error.
 
     n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel. If -1, then the number of jobs
-        is set to the number of cores.
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        If -1, then the number of jobs is set to the number of cores.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -1178,8 +1178,8 @@ class ExtraTreesRegressor(ForestRegressor):
         the generalization error.
 
     n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel. If -1, then the number of jobs
-        is set to the number of cores.
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        If -1, then the number of jobs is set to the number of cores.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;
@@ -1290,8 +1290,8 @@ class RandomTreesEmbedding(BaseForest):
         sample masks).
 
     n_jobs : integer, optional (default=1)
-        The number of jobs to run in parallel. If -1, then the number of jobs
-        is set to the number of cores.
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        If -1, then the number of jobs is set to the number of cores.
 
     random_state : int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;


### PR DESCRIPTION
It seems that for predicting less than 5k rows most of the time is in the fork, but for more rows, most of the time is in the actual predict, highly dependent on a bunch of parameters. The slowdown for predicting millions of rows in parallel is worse than the slowdown for predicting a few rows, so parallel should be the default imho. To get the other behavior, you can just set `n_jobs=1` before calling `predict`.

I tried to run the `scikit-learn-speed` project but it relies on some version of `vbench` that I can't seem to find. Specifically, the classes `PythonBenchmark` and `LineProfilerBenchmarkMixin` are missing. I would like to add some more tests for random forests so we have tests on varying datasets and can track performance in the future.
