### PR TITLE
MRG: scipy.sparse coef_ on linear models

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,9 +8,6 @@
 Changelog
 ---------
 
-   - Hyperlinks to documentation in example code on the website by
-     `Martin Luessi`_.
-
    - :class:`grid_search.GridSearchCV` and
      :func:`cross_validation.cross_val_score` now support the use of advanced
      scoring function such as area under the ROC curve and f-beta scores.
@@ -28,6 +25,14 @@ Changelog
      are now computed on the fly when accessing  the ``feature_importances_``
      attribute. Setting ``compute_importances=True`` is no longer required.
      By `Gilles Louppe`_.
+
+   - :class:`LinearSVC`, :class:`SGDClassifier` and :class:`SGDRegressor`
+     now have a ``sparsify`` method that converts their ``coef_`` into a
+     sparse matrix, meaning stored models trained using these estimators
+     can be made much more compact.
+
+   - Hyperlinks to documentation in example code on the website by
+     `Martin Luessi`_.
 
 
 .. _changes_0_13:

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -197,7 +197,8 @@ class LinearClassifierMixin(ClassifierMixin):
             raise ValueError("X has %d features per sample; expecting %d"
                              % (X.shape[1], n_features))
 
-        scores = safe_sparse_dot(X, self.coef_.T) + self.intercept_
+        scores = safe_sparse_dot(X, self.coef_.T,
+                                 dense_output=True) + self.intercept_
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -137,7 +137,8 @@ class LinearModel(BaseEstimator):
             Returns predicted values.
         """
         X = safe_asarray(X)
-        return safe_sparse_dot(X, self.coef_.T) + self.intercept_
+        return safe_sparse_dot(X, self.coef_.T,
+                               dense_output=True) + self.intercept_
 
     def predict(self, X):
         """Predict using the linear model
@@ -220,6 +221,60 @@ class LinearClassifierMixin(ClassifierMixin):
         else:
             indices = scores.argmax(axis=1)
         return self.classes_[indices]
+
+
+class SparseCoefMixin(object):
+    """Mixin for converting coef_ to and from CSR format.
+
+    L1-regularizing estimators should inherit this.
+    """
+
+    def densify(self):
+        """Convert coefficient matrix to dense array format.
+
+        Converts the ``coef_`` member (back) to a numpy.ndarray. This is the
+        default format of coef_ and is required for fitting, so calling this
+        method is only required on models that have previously been sparsified;
+        otherwise, it is a no-op.
+
+        Returns
+        -------
+        self: estimator
+        """
+        if not hasattr(self, "coef_"):
+            raise ValueError("Estimator must be fitted before densifying.")
+        if sp.issparse(self.coef_):
+            self.coef_ = self.coef_.toarray()
+        return self
+
+    def sparsify(self):
+        """Convert coefficient matrix to sparse format.
+
+        Converts the coef_ member to a scipy.sparse matrix, which for
+        L1-regularized models can be much more memory- and storage-efficient
+        than the usual numpy.ndarray representation.
+
+        The intercept_ member is not converted.
+
+        Notes
+        -----
+        For non-sparse models, i.e. when there are not many zeros in coef_,
+        this may actually *increase* memory usage, so use this method with
+        care. A rule of thumb is that the number of zero elements, which can
+        be computed with (coef_ == 0).sum(), must be more than 50% for this
+        to provide significant benefits.
+
+        After calling this method, further fitting with the partial_fit
+        method (if any) will not work until you call densify.
+
+        Returns
+        -------
+        self: estimator
+        """
+        if not hasattr(self, "coef_"):
+            raise ValueError("Estimator must be fitted before sparsifying.")
+        self.coef_ = sp.csr_matrix(self.coef_)
+        return self
 
 
 class LinearRegression(LinearModel, RegressorMixin):

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1,11 +1,12 @@
 import numpy as np
 
-from .base import LinearClassifierMixin
+from .base import LinearClassifierMixin, SparseCoefMixin
 from ..feature_selection.selector_mixin import SelectorMixin
 from ..svm.base import BaseLibLinear
 
 
-class LogisticRegression(BaseLibLinear, LinearClassifierMixin, SelectorMixin):
+class LogisticRegression(BaseLibLinear, LinearClassifierMixin, SelectorMixin,
+                         SparseCoefMixin):
     """Logistic Regression (aka logit, MaxEnt) classifier.
 
     In the multiclass case, the training algorithm uses a one-vs.-all (OvA)

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -12,7 +12,7 @@ import warnings
 
 from ..externals.joblib import Parallel, delayed
 
-from .base import LinearClassifierMixin
+from .base import LinearClassifierMixin, SparseCoefMixin
 from ..base import BaseEstimator, RegressorMixin
 from ..feature_selection.selector_mixin import SelectorMixin
 from ..utils import array2d, atleast2d_or_csr, check_arrays, deprecated
@@ -44,7 +44,7 @@ DEFAULT_EPSILON = 0.1
 """Default value of ``epsilon`` parameter. """
 
 
-class BaseSGD(BaseEstimator):
+class BaseSGD(BaseEstimator, SparseCoefMixin):
     """Base class for SGD classification and regression."""
 
     __metaclass__ = ABCMeta

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -4,9 +4,10 @@ import scipy.sparse as sp
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import raises
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import raises
 
 from sklearn.linear_model import logistic
 from sklearn import datasets
@@ -64,7 +65,7 @@ def test_predict_3_classes():
 
 
 def test_predict_iris():
-    """Test logisic regression with the iris dataset"""
+    """Test logistic regression with the iris dataset"""
     n_samples, n_features = iris.data.shape
 
     target = iris.target_names[iris.target]
@@ -79,6 +80,29 @@ def test_predict_iris():
 
     pred = iris.target_names[probabilities.argmax(axis=1)]
     assert_greater(np.mean(pred == target), .95)
+
+
+def test_sparsify():
+    """Test sparsify and densify members."""
+    n_samples, n_features = iris.data.shape
+    target = iris.target_names[iris.target]
+    clf = logistic.LogisticRegression().fit(iris.data, target)
+
+    pred_d_d = clf.decision_function(iris.data)
+
+    clf.sparsify()
+    assert_true(sp.issparse(clf.coef_))
+    pred_s_d = clf.decision_function(iris.data)
+
+    sp_data = sp.coo_matrix(iris.data)
+    pred_s_s = clf.decision_function(sp_data)
+
+    clf.densify()
+    pred_d_s = clf.decision_function(sp_data)
+
+    assert_array_equal(pred_d_d, pred_s_d)
+    assert_array_equal(pred_d_d, pred_s_s)
+    assert_array_equal(pred_d_d, pred_d_s)
 
 
 def test_inconsistent_input():

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy as np
@@ -226,7 +227,7 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         self.factory(shuffle="false")
 
     @raises(TypeError)
-    def test_arument_coef(self):
+    def test_argument_coef(self):
         """Checks coef_init not allowed as model argument (only fit)"""
         # Provided coef_ does not match dataset.
         self.factory(coef_init=np.zeros((3,))).fit(X, Y)
@@ -340,6 +341,18 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
                            n_iter=2000)
         clf.fit(X, Y)
         assert_array_equal(clf.coef_[0, 1:-1], np.zeros((4,)))
+        pred = clf.predict(X)
+        assert_array_equal(pred, Y)
+
+        # test sparsify with dense inputs
+        clf.sparsify()
+        assert_true(sp.issparse(clf.coef_))
+        pred = clf.predict(X)
+        assert_array_equal(pred, Y)
+
+        # pickle and unpickle with sparse coef_
+        clf = pickle.loads(pickle.dumps(clf))
+        assert_true(sp.issparse(clf.coef_))
         pred = clf.predict(X)
         assert_array_equal(pred, Y)
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1,10 +1,11 @@
 from .base import BaseLibLinear, BaseSVC, BaseLibSVM
 from ..base import RegressorMixin
-from ..linear_model.base import LinearClassifierMixin
+from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin
 from ..feature_selection.selector_mixin import SelectorMixin
 
 
-class LinearSVC(BaseLibLinear, LinearClassifierMixin, SelectorMixin):
+class LinearSVC(BaseLibLinear, LinearClassifierMixin, SelectorMixin,
+                SparseCoefMixin):
     """Linear Support Vector Classification.
 
     Similar to SVC with parameter kernel='linear', but implemented in terms of

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -178,6 +178,13 @@ def test_linearsvc_iris():
     pred = np.argmax(sp_clf.decision_function(iris.data), 1)
     assert_array_almost_equal(pred, clf.predict(iris.data.todense()))
 
+    # sparsify the coefficients on both models and check that they still
+    # produce the same results
+    clf.sparsify()
+    assert_array_equal(pred, clf.predict(iris.data))
+    sp_clf.sparsify()
+    assert_array_equal(pred, sp_clf.predict(iris.data))
+
 
 def test_weight():
     """


### PR DESCRIPTION
This PR adds `sparsify` and `densify` methods on linear models that support L1 regularization.

Before merge, we should:
- agree on the names of these methods (`sparsify_coef` is more explicit and maybe less ambiguous, but also longer)
- do the same trick on other estimators, as appropriate (can someone tell me which ones?)

Subsumes #1702.
