### PR TITLE
[MRG] Support float values for max_features

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -709,11 +709,12 @@ class RandomForestClassifier(ForestClassifier):
         "gini" for the Gini impurity and "entropy" for the information gain.
         Note: this parameter is tree-specific.
 
-    max_features : int, string or None, optional (default="auto")
+    max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features` on regression
-            problems.
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.
@@ -853,11 +854,12 @@ class RandomForestRegressor(ForestRegressor):
         criterion is "mse" for the mean squared error.
         Note: this parameter is tree-specific.
 
-    max_features : int, string or None, optional (default="auto")
+    max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features`
-            on regression problems.
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.
@@ -987,11 +989,12 @@ class ExtraTreesClassifier(ForestClassifier):
         "gini" for the Gini impurity and "entropy" for the information gain.
         Note: this parameter is tree-specific.
 
-    max_features : int, string or None, optional (default="auto")
-        The number of features to consider when looking for the best split.
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features`
-            on regression problems.
+    max_features : int, float, string or None, optional (default="auto")
+        The number of features to consider when looking for the best split:
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.
@@ -1135,11 +1138,12 @@ class ExtraTreesRegressor(ForestRegressor):
         criterion is "mse" for the mean squared error.
         Note: this parameter is tree-specific.
 
-    max_features : int, string or None, optional (default="auto")
+    max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features`
-            on regression problems.
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -712,8 +712,9 @@ class RandomForestClassifier(ForestClassifier):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
@@ -857,8 +858,9 @@ class RandomForestRegressor(ForestRegressor):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
@@ -992,8 +994,9 @@ class ExtraTreesClassifier(ForestClassifier):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
@@ -1141,8 +1144,9 @@ class ExtraTreesRegressor(ForestRegressor):
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -740,11 +740,18 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         Choosing `subsample < 1.0` leads to a reduction of variance
         and an increase in bias.
 
-    max_features : int, None, optional (default=None)
-        The number of features to consider when looking for the best split.
-        Features are choosen randomly at each split point.
-        If None, then `max_features=n_features`. Choosing
-        `max_features < n_features` leads to a reduction of variance
+    max_features : int, float, string or None, optional (default="auto")
+        The number of features to consider when looking for the best split:
+          - If int, then consider `max_features` features at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
+          - If "auto", then `max_features=sqrt(n_features)`.
+          - If "sqrt", then `max_features=sqrt(n_features)`.
+          - If "log2", then `max_features=log2(n_features)`.
+          - If None, then `max_features=n_features`.
+
+        Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.
 
     init : BaseEstimator, None, optional (default=None)
@@ -970,11 +977,18 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         Choosing `subsample < 1.0` leads to a reduction of variance
         and an increase in bias.
 
-    max_features : int, None, optional (default=None)
-        The number of features to consider when looking for the best split.
-        Features are choosen randomly at each split point.
-        If None, then `max_features=n_features`. Choosing
-        `max_features < n_features` leads to a reduction of variance
+    max_features : int, float, string or None, optional (default=None)
+        The number of features to consider when looking for the best split:
+          - If int, then consider `max_features` features at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
+          - If "auto", then `max_features=n_features`.
+          - If "sqrt", then `max_features=sqrt(n_features)`.
+          - If "log2", then `max_features=log2(n_features)`.
+          - If None, then `max_features=n_features`.
+
+        Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.
 
     alpha : float (default=0.9)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -538,25 +538,8 @@ class BaseGradientBoosting(BaseEnsemble):
         else:
             self.loss_ = loss_class(self.n_classes_)
 
-        if self.min_samples_split <= 0:
-            raise ValueError("min_samples_split must be larger than 0")
-
-        if self.min_samples_leaf <= 0:
-            raise ValueError("min_samples_leaf must be larger than 0")
-
         if self.subsample <= 0.0 or self.subsample > 1:
             raise ValueError("subsample must be in (0,1]")
-
-        if self.max_features is None:
-            max_features = n_features
-        else:
-            max_features = self.max_features
-
-        if not (0 < max_features <= n_features):
-            raise ValueError("max_features must be in (0, n_features]")
-
-        if self.max_depth <= 0:
-            raise ValueError("max_depth must be larger than 0")
 
         if self.init is not None:
             if (not hasattr(self.init, 'fit')

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -299,6 +299,49 @@ def test_importances():
     assert 0 < X_new.shape[1] < X.shape[1]
 
 
+def test_max_features():
+    """Check max_features."""
+    clf = tree.DecisionTreeClassifier(max_features="auto").fit(iris.data, iris.target)
+    assert_equal(clf.tree_.max_features, 2)
+
+    clf = tree.DecisionTreeRegressor(max_features="auto").fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, boston.data.shape[1])
+
+    clf = tree.DecisionTreeRegressor(max_features="sqrt").fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, int(np.sqrt(boston.data.shape[1])))
+
+    clf = tree.DecisionTreeRegressor(max_features="log2").fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, int(np.log2(boston.data.shape[1])))
+
+    clf = tree.DecisionTreeRegressor(max_features=1).fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, 1)
+
+    clf = tree.DecisionTreeRegressor(max_features=7).fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, 7)
+
+    clf = tree.DecisionTreeRegressor(max_features=0.5).fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, int(0.5 * boston.data.shape[1]))
+
+    clf = tree.DecisionTreeRegressor(max_features=1.0).fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, boston.data.shape[1])
+
+    clf = tree.DecisionTreeRegressor(max_features=None).fit(boston.data, boston.target)
+    assert_equal(clf.tree_.max_features, boston.data.shape[1])
+
+    # use values of max_features that are invalid
+    clf = tree.DecisionTreeClassifier(max_features=10)
+    assert_raises(ValueError, clf.fit, X, y)
+
+    clf = tree.DecisionTreeClassifier(max_features=-1)
+    assert_raises(ValueError, clf.fit, X, y)
+
+    clf = tree.DecisionTreeClassifier(max_features=0.0)
+    assert_raises(ValueError, clf.fit, X, y)
+
+    clf = tree.DecisionTreeClassifier(max_features="foobar")
+    assert_raises(ValueError, clf.fit, X, y)
+
+
 def test_error():
     """Test that it gives proper exception on deficient input."""
     # Invalid values for parameters
@@ -341,21 +384,6 @@ def test_error():
     clf.fit(X, y)
     t = np.asarray(T)
     assert_raises(ValueError, clf.predict, t[:, 1:])
-
-   # use values of max_features that are invalid
-    clf = tree.DecisionTreeClassifier(max_features=10)
-    assert_raises(ValueError, clf.fit, X, y)
-
-    clf = tree.DecisionTreeClassifier(max_features=-1)
-    assert_raises(ValueError, clf.fit, X, y)
-
-    clf = tree.DecisionTreeClassifier(max_features="foobar")
-    assert_raises(ValueError, clf.fit, X, y)
-
-    tree.DecisionTreeClassifier(max_features="auto").fit(X, y)
-    tree.DecisionTreeClassifier(max_features="sqrt").fit(X, y)
-    tree.DecisionTreeClassifier(max_features="log2").fit(X, y)
-    tree.DecisionTreeClassifier(max_features=None).fit(X, y)
 
     # predict before fit
     clf = tree.DecisionTreeClassifier()

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -301,31 +301,40 @@ def test_importances():
 
 def test_max_features():
     """Check max_features."""
-    clf = tree.DecisionTreeClassifier(max_features="auto").fit(iris.data, iris.target)
+    clf = tree.DecisionTreeClassifier(max_features="auto")
+    clf.fit(iris.data, iris.target)
     assert_equal(clf.tree_.max_features, 2)
 
-    clf = tree.DecisionTreeRegressor(max_features="auto").fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features="auto")
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, boston.data.shape[1])
 
-    clf = tree.DecisionTreeRegressor(max_features="sqrt").fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features="sqrt")
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, int(np.sqrt(boston.data.shape[1])))
 
-    clf = tree.DecisionTreeRegressor(max_features="log2").fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features="log2")
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, int(np.log2(boston.data.shape[1])))
 
-    clf = tree.DecisionTreeRegressor(max_features=1).fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features=1)
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, 1)
 
-    clf = tree.DecisionTreeRegressor(max_features=7).fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features=7)
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, 7)
 
-    clf = tree.DecisionTreeRegressor(max_features=0.5).fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features=0.5)
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, int(0.5 * boston.data.shape[1]))
 
-    clf = tree.DecisionTreeRegressor(max_features=1.0).fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features=1.0)
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, boston.data.shape[1])
 
-    clf = tree.DecisionTreeRegressor(max_features=None).fit(boston.data, boston.target)
+    clf = tree.DecisionTreeRegressor(max_features=None)
+    clf.fit(boston.data, boston.target)
     assert_equal(clf.tree_.max_features, boston.data.shape[1])
 
     # use values of max_features that are invalid

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -338,6 +338,9 @@ def test_max_features():
     clf = tree.DecisionTreeClassifier(max_features=0.0)
     assert_raises(ValueError, clf.fit, X, y)
 
+    clf = tree.DecisionTreeClassifier(max_features=1.5)
+    assert_raises(ValueError, clf.fit, X, y)
+
     clf = tree.DecisionTreeClassifier(max_features="foobar")
     assert_raises(ValueError, clf.fit, X, y)
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -464,8 +464,9 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
@@ -659,8 +660,9 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
           - If int, then consider `max_features` features at each split.
-          - If float, then consider `int(max_features * n_features) features
-            at each split.
+          - If float, then `max_features` is a percentage and
+            `int(max_features * n_features)` features are considered at each
+            split.
           - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -307,7 +307,7 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
                     'values are "auto", "sqrt" or "log2".')
         elif self.max_features is None:
             max_features = self.n_features_
-        elif isinstance(self.max_features, numbers.Integral):
+        elif isinstance(self.max_features, (numbers.Integral, np.integer)):
             max_features = self.max_features
         else: # float
             max_features = int(self.max_features * self.n_features_)

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -13,6 +13,7 @@ randomized trees. Single and multi-output problems are both handled.
 
 from __future__ import division
 
+import numbers
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from warnings import warn
@@ -306,10 +307,10 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
                     'values are "auto", "sqrt" or "log2".')
         elif self.max_features is None:
             max_features = self.n_features_
-        elif isinstance(self.max_features, float):
-            max_features = int(self.max_features * self.n_features_)
-        else:
+        elif isinstance(self.max_features, numbers.Integral):
             max_features = self.max_features
+        else: # float
+            max_features = int(self.max_features * self.n_features_)
 
         if len(y) != n_samples:
             raise ValueError("Number of labels=%d does not match "

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -306,6 +306,8 @@ class BaseDecisionTree(BaseEstimator, SelectorMixin):
                     'values are "auto", "sqrt" or "log2".')
         elif self.max_features is None:
             max_features = self.n_features_
+        elif isinstance(self.max_features, float):
+            max_features = int(self.max_features * self.n_features_)
         else:
             max_features = self.max_features
 
@@ -459,11 +461,12 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         The function to measure the quality of a split. Supported criteria are
         "gini" for the Gini impurity and "entropy" for the information gain.
 
-    max_features : int, string or None, optional (default=None)
+    max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features`
-            on regression problems.
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=sqrt(n_features)`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.
@@ -653,11 +656,12 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         The function to measure the quality of a split. The only supported
         criterion is "mse" for the mean squared error.
 
-    max_features : int, string or None, optional (default=None)
+    max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
-          - If "auto", then `max_features=sqrt(n_features)` on
-            classification tasks and `max_features=n_features`
-            on regression problems.
+          - If int, then consider `max_features` features at each split.
+          - If float, then consider `int(max_features * n_features) features
+            at each split.
+          - If "auto", then `max_features=n_features`.
           - If "sqrt", then `max_features=sqrt(n_features)`.
           - If "log2", then `max_features=log2(n_features)`.
           - If None, then `max_features=n_features`.


### PR DESCRIPTION
This PR implements float values support for `max_features` in decision trees and ensembles. 

For example, one can now instantiate a random forest with `max_features=0.5*n_features` with `clf = RandomForestClassifier(max_features=0.5)`. The goal is to alleviate the need to know the exact number of features in the dataset, which can be cumbersome when one deals with feature engineering and the dimension of `X` varies.
