### PR TITLE
[MRG] add latent semantic analysis/sparse truncated SVD

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -217,6 +217,7 @@ Samples generator
    decomposition.KernelPCA
    decomposition.FactorAnalysis
    decomposition.FastICA
+   decomposition.TruncatedSVD
    decomposition.NMF
    decomposition.SparsePCA
    decomposition.MiniBatchSparsePCA

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -232,6 +232,82 @@ factorization, while larger values shrink many coefficients to zero.
      R. Jenatton, G. Obozinski, F. Bach, 2009
 
 
+.. _LSA:
+
+Truncated singular value decomposition and latent semantic analysis
+===================================================================
+
+:class:`TruncatedSVD` implements a variant of singular value decomposition
+(SVD) that only computes the :math:`k` largest singular values,
+where :math:`k` is a user-specified parameter.
+
+When truncated SVD is applied to term-document matrices
+(as returned by ``CountVectorizer`` or ``TfidfVectorizer``),
+this transformation is known as
+`latent semantic analysis <http://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
+(LSA), because it transforms such matrices
+to a "semantic" space of low dimensionality.
+In particular, LSA is known to combat the effects of synonymy and polysemy
+(both of which roughly mean there are multiple meanings per word),
+which cause term-document matrices to be overly sparse
+and exhibit poor similarity under measures such as cosine similarity.
+
+.. note::
+    LSA is also known as latent semantic indexing, LSI,
+    though strictly that refers to its use in persistent indexes
+    for information retrieval purposes.
+
+Mathematically, truncated SVD applied to training samples :math:`X`
+produces a low-rank approximation :math:`X`:
+
+.. math::
+    X \approx X_k = U_k \Sigma_k V_k^\top
+
+After this operation, :math:`U_k \Sigma_k^\top`
+is the transformed training set with :math:`k` features
+(called ``n_components`` in the API).
+
+To also transform a test set :math:`X`, we multiply it with :math:`V_k`:
+
+.. math::
+    X' = X V_k^\top
+
+.. note::
+    Most treatments of LSA in the natural language processing (NLP)
+    and information retrieval (IR) literature
+    swap the axis of the matrix :math:`X` so that it has shape
+    ``n_features`` × ``n_samples``.
+    We present LSA in a different way that matches the scikit-learn API better,
+    but the singular values found are the same.
+
+:class:`TruncatedSVD` is very similar to :class:`PCA`, but differs
+in that it works on sample matrices :math:`X` directly
+instead of their covariance matrices.
+When the columnwise (per-feature) means of :math:`X`
+are subtracted from the feature values,
+truncated SVD on the resulting matrix is equivalent to PCA.
+In practical terms, this means
+that the :class:`TruncatedSVD` transformer accepts ``scipy.sparse``
+matrices without the need to densify them,
+as densifying may fill up memory even for medium-sized document collections.
+
+While the :class:`TruncatedSVD` transformer
+works with any (sparse) feature matrix,
+using it on tf–idf matrices is recommended over raw frequency counts
+in an LSA/document processing setting.
+In particular, sublinear scaling and inverse document frequency
+should be turned on (``sublinear_tf=True, use_idf=True``)
+to bring the feature values closer to a Gaussian distribution,
+compensating for LSA's erroneous assumptions about textual data.
+
+.. topic:: References:
+
+  * Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze (2008),
+    *Introduction to Information Retrieval*, Cambridge University Press,
+    chapter 18: `Matrix decompositions & latent semantic indexing
+    <http://nlp.stanford.edu/IR-book/pdf/18lsi.pdf>`_
+
+
 .. _DictionaryLearning:
 
 Dictionary Learning

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -300,6 +300,10 @@ should be turned on (``sublinear_tf=True, use_idf=True``)
 to bring the feature values closer to a Gaussian distribution,
 compensating for LSA's erroneous assumptions about textual data.
 
+.. topic:: Examples:
+
+   * :ref:`example_document_clustering.py`
+
 .. topic:: References:
 
   * Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze (2008),

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -98,6 +98,11 @@ Changelog
    - Refactored and vectorized implementation of :func:`metrics.roc_curve`
      and :func:`metrics.precision_recall_curve`. By `Joel Nothman`_.
 
+   - The new estimator :class:`sklearn.decomposition.TruncatedSVD`
+     performs dimensionality reduction using SVD on sparse matrices,
+     and can be used for latent semantic analysis (LSA).
+     By `Lars Buitinck`_.
+
 
 API changes summary
 -------------------
@@ -116,6 +121,9 @@ API changes summary
 
    - ``gcv_mode="auto"`` no longer tries to perform SVD on a densified
      sparse matrix in :class:`sklearn.linear_model.RidgeCV`.
+
+   - Sparse matrix support in :class:`sklearn.decomposition.RandomizedPCA`
+     is now deprecated in favor of the new ``TruncatedSVD``.
 
 
 .. _changes_0_13_1:

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -58,6 +58,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import Normalizer
 from sklearn import metrics
 
 from sklearn.cluster import KMeans, MiniBatchKMeans
@@ -157,8 +158,9 @@ print()
 if opts.n_components:
     print("Performing dimensionality reduction using LSA")
     t0 = time()
-    lsa = LatentSemanticAnalysis(opts.n_components)
+    lsa = TruncatedSVD(opts.n_components)
     X = lsa.fit_transform(X)
+    X = Normalizer(copy=False).fit_transform(X)
 
     print("done in %fs" % (time() - t0))
     print()

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -160,6 +160,9 @@ if opts.n_components:
     t0 = time()
     lsa = TruncatedSVD(opts.n_components)
     X = lsa.fit_transform(X)
+    # Vectorizer results are normalized, which makes KMeans behave as
+    # spherical k-means for better results. Since LSA/SVD results are
+    # not normalized, we have to redo the normalization.
     X = Normalizer(copy=False).fit_transform(X)
 
     print("done in %fs" % (time() - t0))

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -53,6 +53,7 @@ necessary to get a good convergence.
 from __future__ import print_function
 
 from sklearn.datasets import fetch_20newsgroups
+from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer
@@ -75,6 +76,9 @@ logging.basicConfig(level=logging.INFO,
 
 # parse commandline arguments
 op = OptionParser()
+op.add_option("--lsa",
+              dest="n_components", type="int",
+              help="Preprocess documents with latent semantic analysis.")
 op.add_option("--no-minibatch",
               action="store_false", dest="minibatch", default=True,
               help="Use ordinary k-means algorithm (in batch mode).")
@@ -87,6 +91,9 @@ op.add_option("--use-hashing",
 op.add_option("--n-features", type=int, default=10000,
               help="Maximum number of features (dimensions)"
                    "to extract from text.")
+op.add_option("--verbose",
+              action="store_true", dest="verbose", default=False,
+              help="Print progress reports inside k-means algorithm.")
 
 print(__doc__)
 op.print_help()
@@ -147,17 +154,25 @@ print("done in %fs" % (time() - t0))
 print("n_samples: %d, n_features: %d" % X.shape)
 print()
 
+if opts.n_components:
+    print("Performing dimensionality reduction using LSA")
+    t0 = time()
+    lsa = LatentSemanticAnalysis(opts.n_components)
+    X = lsa.fit_transform(X)
+
+    print("done in %fs" % (time() - t0))
+    print()
+
 
 ###############################################################################
 # Do the actual clustering
 
 if opts.minibatch:
     km = MiniBatchKMeans(n_clusters=true_k, init='k-means++', n_init=1,
-                         init_size=1000,
-                         batch_size=1000, verbose=1)
+                         init_size=1000, batch_size=1000, verbose=opts.verbose)
 else:
     km = KMeans(n_clusters=true_k, init='k-means++', max_iter=100, n_init=1,
-                verbose=1)
+                verbose=opts.verbose)
 
 print("Clustering sparse data with %s" % km)
 t0 = time()

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -8,6 +8,7 @@ from .nmf import NMF, ProjectedGradientNMF
 from .pca import PCA, RandomizedPCA, ProbabilisticPCA
 from .kernel_pca import KernelPCA
 from .sparse_pca import SparsePCA, MiniBatchSparsePCA
+from .truncated_svd import TruncatedSVD
 from .fastica_ import FastICA, fastica
 from .dict_learning import (dict_learning, dict_learning_online, sparse_encode,
                             DictionaryLearning, MiniBatchDictionaryLearning,

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -173,6 +173,7 @@ class PCA(BaseEstimator, TransformerMixin):
     RandomizedPCA
     KernelPCA
     SparsePCA
+    TruncatedSVD
     """
     def __init__(self, n_components=None, copy=True, whiten=False):
         self.n_components = n_components

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from scipy.sparse import csr_matrix
 
@@ -176,7 +178,12 @@ def test_sparse_randomized_pca_check_projection():
     Xt = 0.1 * rng.randn(1, p) + np.array([3, 4, 5])
     Xt = csr_matrix(Xt)
 
-    Yt = RandomizedPCA(n_components=2, random_state=0).fit(X).transform(Xt)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always', DeprecationWarning)
+        Yt = RandomizedPCA(n_components=2, random_state=0).fit(X).transform(Xt)
+        assert_equal(len(w), 1)
+        assert_equal(w[0].category, DeprecationWarning)
+
     Yt /= np.sqrt((Yt ** 2).sum())
 
     np.testing.assert_almost_equal(np.abs(Yt[0][0]), 1., 1)
@@ -194,14 +201,25 @@ def test_sparse_randomized_pca_inverse():
 
     # same check that we can find the original data from the transformed signal
     # (since the data is almost of rank n_components)
-    pca = RandomizedPCA(n_components=2, random_state=0).fit(X)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always', DeprecationWarning)
+        pca = RandomizedPCA(n_components=2, random_state=0).fit(X)
+        assert_equal(len(w), 1)
+        assert_equal(w[0].category, DeprecationWarning)
+
     Y = pca.transform(X)
+
     Y_inverse = pca.inverse_transform(Y)
     assert_almost_equal(X.todense(), Y_inverse, decimal=2)
 
     # same as above with whitening (approximate reconstruction)
-    pca = RandomizedPCA(n_components=2, whiten=True,
-                        random_state=0).fit(X)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always', DeprecationWarning)
+        pca = RandomizedPCA(n_components=2, whiten=True,
+                            random_state=0).fit(X)
+        assert_equal(len(w), 1)
+        assert_equal(w[0].category, DeprecationWarning)
+
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
     relative_max_delta = (np.abs(X.todense() - Y_inverse)

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -40,9 +40,10 @@ def test_attributes():
 
 
 def test_too_many_components():
-    for n_components in (n_features, n_features+1):
-        tsvd = TruncatedSVD(n_components=n_components)
-        assert_raises(ValueError, tsvd.fit, X)
+    for algorithm in ["arpack", "randomized"]:
+        for n_components in (n_features, n_features+1):
+            tsvd = TruncatedSVD(n_components=n_components, algorithm="algorithm")
+            assert_raises(ValueError, tsvd.fit, X)
 
 
 def test_sparse_formats():

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -21,15 +21,18 @@ Xdense = X.A
 
 
 def test_algorithms():
-    atsvd = TruncatedSVD(30, algorithm="arpack")
-    rtsvd = TruncatedSVD(30, algorithm="randomized", random_state=42)
+    svd_a = TruncatedSVD(30, algorithm="arpack")
+    svd_r = TruncatedSVD(30, algorithm="randomized", random_state=42)
 
-    # Test only the main components; for the rest, the algorithms don't give
-    # nearly the same results.
-    Xa = atsvd.fit_transform(X)[:, :6]
-    Xr = rtsvd.fit_transform(X)[:, :6]
+    Xa = svd_a.fit_transform(X)[:, :6]
+    Xr = svd_r.fit_transform(X)[:, :6]
     assert_array_almost_equal(Xa, Xr)
-    assert_array_almost_equal(atsvd.components_[:6], rtsvd.components_[:6])
+
+    comp_a = np.abs(svd_a.components_)
+    comp_r = np.abs(svd_r.components_)
+    # All elements are equal, but some elements are more equal than others.
+    assert_array_almost_equal(comp_a[:9], comp_r[:9])
+    assert_array_almost_equal(comp_a[9:], comp_r[9:], decimal=3)
 
 
 def test_attributes():
@@ -42,7 +45,7 @@ def test_attributes():
 def test_too_many_components():
     for algorithm in ["arpack", "randomized"]:
         for n_components in (n_features, n_features+1):
-            tsvd = TruncatedSVD(n_components=n_components, algorithm="algorithm")
+            tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
             assert_raises(ValueError, tsvd.fit, X)
 
 

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -1,0 +1,72 @@
+"""Test truncated SVD transformer."""
+
+import numpy as np
+import scipy.sparse as sp
+
+from sklearn.decomposition import TruncatedSVD
+from sklearn.utils import check_random_state
+from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
+                                   assert_raises)
+
+
+# Make an X that looks somewhat like a small tf-idf matrix.
+# XXX newer versions of SciPy have scipy.sparse.rand for this.
+shape = 60, 55
+n_samples, n_features = shape
+rng = check_random_state(42)
+X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
+X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
+X.data[:] = 1 + np.log(X.data)
+Xdense = X.A
+
+
+def test_algorithms():
+    atsvd = TruncatedSVD(30, algorithm="arpack")
+    rtsvd = TruncatedSVD(30, algorithm="randomized", random_state=42)
+
+    # Test only the main components; for the rest, the algorithms don't give
+    # nearly the same results.
+    Xa = atsvd.fit_transform(X)[:, :6]
+    Xr = rtsvd.fit_transform(X)[:, :6]
+    assert_array_almost_equal(Xa, Xr)
+    assert_array_almost_equal(atsvd.components_[:6], rtsvd.components_[:6])
+
+
+def test_attributes():
+    for n_components in (10, 25, 41):
+        tsvd = TruncatedSVD(n_components).fit(X)
+        assert_equal(tsvd.n_components, n_components)
+        assert_equal(tsvd.components_.shape, (n_components, n_features))
+
+
+def test_too_many_components():
+    for n_components in (n_features, n_features+1):
+        tsvd = TruncatedSVD(n_components=n_components)
+        assert_raises(ValueError, tsvd.fit, X)
+
+
+def test_sparse_formats():
+    for fmt in ("array", "csr", "csc", "coo", "lil"):
+        Xfmt = Xdense if fmt == "dense" else getattr(X, "to" + fmt)()
+        tsvd = TruncatedSVD(n_components=11)
+        Xtrans = tsvd.fit_transform(Xfmt)
+        assert_equal(Xtrans.shape, (n_samples, 11))
+        Xtrans = tsvd.transform(Xfmt)
+        assert_equal(Xtrans.shape, (n_samples, 11))
+
+
+def test_inverse_transform():
+    for algo in ("arpack", "randomized"):
+        # We need a lot of components for the reconstruction to be "almost
+        # equal" in all positions. XXX Test means or sums instead?
+        tsvd = TruncatedSVD(n_components=52, random_state=42)
+        Xt = tsvd.fit_transform(X)
+        Xinv = tsvd.inverse_transform(Xt)
+        assert_array_almost_equal(Xinv, Xdense, decimal=1)
+
+
+def test_integers():
+    Xint = X.astype(np.int64)
+    tsvd = TruncatedSVD(n_components=6)
+    Xtrans = tsvd.fit_transform(Xint)
+    assert_equal(Xtrans.shape, (n_samples, tsvd.n_components))

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -131,6 +131,11 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
             U, VT = svd_flip(U[:, ::-1], VT[::-1])
 
         elif self.algorithm == "randomized":
+            k = self.n_components
+            n_features = X.shape[1]
+            if k >= n_features:
+                raise ValueError("n_components must be < n_features;"
+                                 " got %d >= %d" % (k, n_features))
             U, Sigma, VT = randomized_svd(X, self.n_components,
                                           n_iter=self.n_iterations,
                                           random_state=random_state)

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+"""Truncated SVD for sparse matrices, aka latent semantic analysis (LSA).
+"""
+
+# Author: Lars Buitinck <L.J.Buitinck@uva.nl>
+# License: 3-clause BSD.
+
+import numpy as np
+
+try:
+    from scipy.sparse.linalg import svds
+except ImportError:
+    from ..utils.arpack import svds
+
+from ..base import BaseEstimator, TransformerMixin
+from ..utils import (array2d, as_float_array, atleast2d_or_csr,
+                     check_random_state)
+from ..utils.extmath import randomized_svd, safe_sparse_dot, svd_flip
+
+__all__ = ["TruncatedSVD"]
+
+
+class TruncatedSVD(BaseEstimator, TransformerMixin):
+    """Dimensionality reduction using truncated SVD (aka LSA).
+
+    This transformer performs linear dimensionality reduction by means of
+    truncated singular value decomposition (SVD). It is very similar to PCA,
+    but operates on sample vectors directly, instead of on a covariance matrix.
+    This means it can work with scipy.sparse matrices efficiently.
+
+    In particular, truncated SVD works on term count/tf–idf matrices as
+    returned by the vectorizers in sklearn.feature_extraction.text. In that
+    context, it is known as latent semantic analysis (LSA).
+
+    Parameters
+    ----------
+    n_components : int, default = 2
+        Desired dimensionality of output data.
+        Must be strictly less than the number of features.
+        The default value is useful for visualisation. For LSA, a value of
+        100 is recommended.
+    algorithm : string, optional
+        SVD solver to use. Either "arpack" for the ARPACK wrapper in SciPy
+        (scipy.sparse.linalg.svds), or "randomized" for the randomized
+        algorithm due to Halko (2009).
+    n_iterations : int, optional
+        Number of iterations for randomized SVD solver. Not used by ARPACK.
+    random_state : int or RandomState, optional
+        (Seed for) pseudo-random number generator. If not given, the
+        numpy.random singleton is used.
+    tol : float, optional
+        Tolerance for ARPACK. 0 means machine precision. Ignored by randomized
+        SVD solver.
+
+    Attributes
+    ----------
+    components_ : array, shape (n_components, n_features)
+
+    See also
+    --------
+    PCA
+    RandomizedPCA
+
+    References
+    ----------
+    Finding structure with randomness: Stochastic algorithms for constructing
+    approximate matrix decompositions
+    Halko, et al., 2009 (arXiv:909) http://arxiv.org/pdf/0909.4061
+
+    Notes
+    -----
+    SVD suffers from a problem called "sign indeterminancy", which means the
+    sign of the ``components_`` and the output from transform depend on the
+    algorithm and random state. To work around this, fit instances of this
+    class to data once, then keep the instance around to do transformations.
+
+    """
+    def __init__(self, n_components=2, algorithm="arpack", n_iterations=5,
+                 random_state=None, tol=0.):
+        self.algorithm = algorithm
+        self.n_components = n_components
+        self.n_iterations = n_iterations
+        self.random_state = random_state
+        self.tol = tol
+
+    def fit(self, X, y=None):
+        """Fit LSI model on training data X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            Training data.
+
+        Returns
+        -------
+        self : object
+            Returns the transformer object.
+        """
+        self._fit(X)
+        return self
+
+    def fit_transform(self, X, y=None):
+        """Fit LSI model to X and perform dimensionality reduction on X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            Training data.
+
+        Returns
+        -------
+        X_new : array, shape (n_samples, n_components)
+            Reduced version of X. This will always be a dense array.
+        """
+        U, Sigma, VT = self._fit(X)
+        Sigma = np.diag(Sigma)
+
+        # or (X * VT.T).T, whichever takes fewer operations...
+        return np.dot(U, Sigma.T)
+
+    def _fit(self, X):
+        X = as_float_array(X)
+        random_state = check_random_state(self.random_state)
+
+        if self.algorithm == "arpack":
+            U, Sigma, VT = svds(X, k=self.n_components, tol=self.tol)
+            # svds doesn't abide by scipy.linalg.svd/randomized_svd
+            # conventions, so reverse its outputs.
+            U, Sigma, VT = svd_flip(U[:, ::-1], Sigma[::-1], VT[::-1])
+
+        elif self.algorithm == "randomized":
+            U, Sigma, VT = randomized_svd(X, self.n_components,
+                                          n_iter=self.n_iterations,
+                                          random_state=random_state)
+        else:
+            raise ValueError("unknown algorithm %r" % self.algorithm)
+
+        self.components_ = VT
+        return U, Sigma, VT
+
+    def transform(self, X):
+        """Perform dimensionality reduction on X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            New data.
+
+        Returns
+        -------
+        X_new : array, shape (n_samples, n_components)
+            Reduced version of X. This will always be a dense array.
+        """
+        X = atleast2d_or_csr(X)
+        return safe_sparse_dot(X, self.components_.T)
+
+    def inverse_transform(self, X):
+        """Transform X back to its original space.
+
+        Returns an array X_original whose transform would be X.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_components)
+            New data.
+
+        Returns
+        -------
+        X_original : array, shape (n_samples, n_features)
+            Note that this is always a dense array.
+        """
+        X = array2d(X)
+        return np.dot(X, self.components_)

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -127,7 +127,8 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
             U, Sigma, VT = svds(X, k=self.n_components, tol=self.tol)
             # svds doesn't abide by scipy.linalg.svd/randomized_svd
             # conventions, so reverse its outputs.
-            U, Sigma, VT = svd_flip(U[:, ::-1], Sigma[::-1], VT[::-1])
+            Sigma = Sigma[::-1]
+            U, VT = svd_flip(U[:, ::-1], VT[::-1])
 
         elif self.algorithm == "randomized":
             U, Sigma, VT = randomized_svd(X, self.n_components,

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -40,7 +40,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         Must be strictly less than the number of features.
         The default value is useful for visualisation. For LSA, a value of
         100 is recommended.
-    algorithm : string, optional
+    algorithm : string, default = "randomized"
         SVD solver to use. Either "arpack" for the ARPACK wrapper in SciPy
         (scipy.sparse.linalg.svds), or "randomized" for the randomized
         algorithm due to Halko (2009).
@@ -76,8 +76,8 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     class to data once, then keep the instance around to do transformations.
 
     """
-    def __init__(self, n_components=2, algorithm="arpack", n_iterations=5,
-                 random_state=None, tol=0.):
+    def __init__(self, n_components=2, algorithm="randomized",
+                 n_iterations=5, random_state=None, tol=0.):
         self.algorithm = algorithm
         self.n_components = n_components
         self.n_iterations = n_iterations
@@ -120,7 +120,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         return np.dot(U, Sigma.T)
 
     def _fit(self, X):
-        X = as_float_array(X)
+        X = as_float_array(X, copy=False)
         random_state = check_random_state(self.random_state)
 
         if self.algorithm == "arpack":

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -46,7 +46,7 @@ dont_test = ['SparseCoder', 'EllipticEnvelope', 'EllipticEnvelop',
              'DictVectorizer', 'LabelBinarizer', 'LabelEncoder',
              'TfidfTransformer', 'IsotonicRegression', 'OneHotEncoder',
              'RandomTreesEmbedding', 'FeatureHasher', 'DummyClassifier',
-             'DummyRegressor']
+             'DummyRegressor', 'TruncatedSVD']
 
 
 def test_all_estimators():

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -212,7 +212,7 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=0,
     U = np.dot(Q, Uhat)
 
     if flip_sign:
-        U, s, V = svd_flip(U, s, V)
+        U, V = svd_flip(U, V)
 
     if transpose:
         # transpose back the results according to the input convention
@@ -433,7 +433,7 @@ def cartesian(arrays, out=None):
     return out
 
 
-def svd_flip(u, s, v):
+def svd_flip(u, v):
     """Sign correction to ensure deterministic output from SVD
 
     Adjusts the columns of u and the rows of v such that the loadings in the
@@ -441,7 +441,7 @@ def svd_flip(u, s, v):
 
     Parameters
     ----------
-    u, s, v: arrays,
+    u, v: arrays
         The output of `linalg.svd` or `sklearn.utils.extmath.randomized_svd`,
         with matching inner dimensions so one can compute `np.dot(u * s, v)`.
 
@@ -454,4 +454,4 @@ def svd_flip(u, s, v):
     signs = np.sign(u[max_abs_cols, xrange(u.shape[1])])
     u *= signs
     v *= signs[:, np.newaxis]
-    return u, s, v
+    return u, v


### PR DESCRIPTION
Reissue of #1519 with `LatentSemanticAnalysis` renamed `TruncatedSVD`. I didn't touch `RandomizedPCA` and I don't intend to in this PR.

Docs and 20news clustering example make it very clear that this is LSA, for NLP/IR folks looking for that transformation.
