### PR TITLE
StratifiedKFold: remove pointless copy of labels

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -372,10 +372,9 @@ class StratifiedKFold(object):
         self.indices = indices
 
     def __iter__(self):
-        y = self.y.copy()
         n_folds = self.n_folds
-        n = y.size
-        idx = np.argsort(y)
+        n = self.y.size
+        idx = np.argsort(self.y)
 
         for i in range(n_folds):
             test_index = np.zeros(n, dtype=np.bool)


### PR DESCRIPTION
`cross_validation.StratifiedKFold.__iter__` currently makes a copy of the `labels` attribute, then just `argsort`s it and never uses the copy. There doesn't seem to be any reason to do that; presumably this just accidentally survived a rewrite of the function.
