### PR TITLE
MRG : fix kfold balance due to int rounding

### DIFF
--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -198,7 +198,7 @@ automatically by cross-validation::
         tol=0.0001, verbose=False)
     >>> # The estimator chose automatically its lambda:
     >>> lasso.alpha_ # doctest: +ELLIPSIS
-    0.01318...
+    0.01229...
 
 These estimators are called similarly to their counterparts, with 'CV'
 appended to their name.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,9 @@ Changelog
    - Fixed bug in :class:`MinMaxScaler` causing incorrect scaling of the
      features for non-default ``feature_range`` settings. By `Andreas Müller`_.
 
+   - Fixed bug in :class:`KFold` causing imperfect class balance in some
+     cases. By `Alexandre Gramfort`_ and Tadej Janež.
+
 
 .. _changes_0_13_1:
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -247,8 +247,8 @@ class KFold(object):
 
     Notes
     -----
-    All the folds have size trunc(n_samples / n_folds), the last one has the
-    complementary.
+    The first n % n_folds folds have size n // n_folds + 1, other folds have
+    size n // n_folds.
 
     See also
     --------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -286,10 +286,7 @@ class KFold(object):
         for i, fold_size in enumerate(fold_sizes):
             test_index = np.zeros(n, dtype=np.bool)
             start, stop = current, current + fold_size
-            if i < n_folds - 1:
-                test_index[self.idxs[start:stop]] = True
-            else:
-                test_index[self.idxs[start:]] = True
+            test_index[self.idxs[start:stop]] = True
             train_index = np.logical_not(test_index)
             if self.indices:
                 train_index = self.idxs[train_index]

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -280,7 +280,7 @@ class KFold(object):
     def __iter__(self):
         n = self.n
         n_folds = self.n_folds
-        fold_size = n // n_folds
+        fold_size = int(round(n / float(n_folds)))
 
         for i in range(n_folds):
             test_index = np.zeros(n, dtype=np.bool)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -280,18 +280,21 @@ class KFold(object):
     def __iter__(self):
         n = self.n
         n_folds = self.n_folds
-        fold_size = int(round(n / float(n_folds)))
-
-        for i in range(n_folds):
+        fold_sizes = (n // n_folds) * np.ones(n_folds, dtype=np.int)
+        fold_sizes[:n % n_folds] += 1
+        current = 0
+        for i, fold_size in enumerate(fold_sizes):
             test_index = np.zeros(n, dtype=np.bool)
+            start, stop = current, current + fold_size
             if i < n_folds - 1:
-                test_index[self.idxs[i * fold_size:(i + 1) * fold_size]] = True
+                test_index[self.idxs[start:stop]] = True
             else:
-                test_index[self.idxs[i * fold_size:]] = True
+                test_index[self.idxs[start:]] = True
             train_index = np.logical_not(test_index)
             if self.indices:
                 train_index = self.idxs[train_index]
                 test_index = self.idxs[test_index]
+            current = stop
             yield train_index, test_index
 
     def __repr__(self):

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -153,11 +153,11 @@ def test_lasso_path():
     X, y, X_test, y_test = build_dataset()
     max_iter = 150
     clf = LassoCV(n_alphas=10, eps=1e-3, max_iter=max_iter).fit(X, y)
-    assert_almost_equal(clf.alpha_, 0.026, 2)
+    assert_almost_equal(clf.alpha_, 0.056, 2)
 
     clf = LassoCV(n_alphas=10, eps=1e-3, max_iter=max_iter, precompute=True)
     clf.fit(X, y)
-    assert_almost_equal(clf.alpha_, 0.026, 2)
+    assert_almost_equal(clf.alpha_, 0.056, 2)
 
     # Check that the lars and the coordinate descent implementation
     # select a similar alpha

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -132,12 +132,12 @@ def test_kfold_indices():
 
 def test_kfold_balance():
     # Check that KFold returns folds with balanced sizes
-    for kf in [cval.KFold(i, 5) for i in range(11, 15)]:
+    for kf in [cval.KFold(i, 5) for i in range(11, 17)]:
         sizes = []
         for _, test in kf:
             sizes.append(len(test))
 
-        assert_equal(np.min(sizes) + 1, np.max(sizes))
+        assert_true((np.max(sizes) - np.min(sizes)) <= 1)
         assert_equal(np.sum(sizes), kf.n)
 
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -130,6 +130,16 @@ def test_kfold_indices():
     assert_array_equal(all_folds, np.arange(300))
 
 
+def test_kfold_round():
+    # Check KFold rounding of fold size
+    kf = cval.KFold(14, 5)
+    sizes = []
+    for _, test in kf:
+        sizes.append(len(test))
+
+    assert_equal(np.min(sizes) + 1, np.max(sizes))
+
+
 def test_shuffle_kfold():
     # Check the indices are shuffled properly, and that all indices are
     # returned in the different test folds

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -132,12 +132,12 @@ def test_kfold_indices():
 
 def test_kfold_round():
     # Check KFold rounding of fold size
-    kf = cval.KFold(14, 5)
-    sizes = []
-    for _, test in kf:
-        sizes.append(len(test))
+    for kf in [cval.KFold(12, 5), cval.KFold(14, 5)]:
+        sizes = []
+        for _, test in kf:
+            sizes.append(len(test))
 
-    assert_equal(np.min(sizes) + 1, np.max(sizes))
+        assert_equal(np.min(sizes) + 1, np.max(sizes))
 
 
 def test_shuffle_kfold():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -130,9 +130,9 @@ def test_kfold_indices():
     assert_array_equal(all_folds, np.arange(300))
 
 
-def test_kfold_round():
-    # Check KFold rounding of fold size
-    for kf in [cval.KFold(12, 5), cval.KFold(14, 5)]:
+def test_kfold_balance():
+    # Check that KFold returns folds with balanced sizes
+    for kf in [cval.KFold(i, 5) for i in range(11, 15)]:
         sizes = []
         for _, test in kf:
             sizes.append(len(test))

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -138,6 +138,7 @@ def test_kfold_balance():
             sizes.append(len(test))
 
         assert_equal(np.min(sizes) + 1, np.max(sizes))
+        assert_equal(np.sum(sizes), kf.n)
 
 
 def test_shuffle_kfold():


### PR DESCRIPTION
to avoid this:

```
>>> from sklearn import cross_validation
>>> list(cross_validation.KFold(14, 5, indices=True, shuffle=True,
random_state=32))
[(array([13,  2, 12,  9,  1, 10,  4,  3,  8,  6,  5, 11]), array([0,
7])), (array([ 0, 13, 12,  9,  1, 10,  4,  3,  8,  6,  5,  7]),
array([ 2, 11])), (array([ 0,  2, 12,  9,  1, 10,  4,  3,  6,  5, 11,
7]), array([13,  8])), (array([ 0, 13,  2, 12,  1, 10,  4,  3,  8,  5,
11,  7]), array([9, 6])), (array([ 0, 13,  2,  9,  8,  6, 11,  7]),
array([12,  1, 10,  4,  3,  5]))]
```
