### PR TITLE
MRG FIX for iid weighting in grid-search

### DIFF
--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -145,8 +145,8 @@ estimator during the construction and exposes an estimator API::
     ...                    n_jobs=-1)
     >>> clf.fit(X_digits[:1000], y_digits[:1000]) # doctest: +ELLIPSIS
     GridSearchCV(cv=None,...
-    >>> clf.best_score_
-    0.98899999999999999
+    >>> clf.best_score_   # doctest: +ELLIPSIS
+    0.9889...
     >>> clf.best_estimator_.gamma
     9.9999999999999995e-07
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -432,20 +432,22 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
 
         scores = list()
         cv_scores = list()
-        for start in range(0, n_fits, n_folds):
+        for grid_start in range(0, n_fits, n_folds):
             n_test_samples = 0
-            mean_validation_score = 0
+            score = 0
             these_points = list()
             for this_score, clf_params, this_n_test_samples in \
-                    out[start:start + n_folds]:
+                    out[grid_start:grid_start + n_folds]:
                 these_points.append(this_score)
                 if self.iid:
                     this_score *= this_n_test_samples
-                mean_validation_score += this_score
-                n_test_samples += this_n_test_samples
+                    n_test_samples += this_n_test_samples
+                score += this_score
             if self.iid:
-                mean_validation_score /= float(n_test_samples)
-            scores.append((mean_validation_score, clf_params))
+                score /= float(n_test_samples)
+            else:
+                score /= float(n_folds)
+            scores.append((score, clf_params))
             cv_scores.append(these_points)
 
         cv_scores = np.asarray(cv_scores)


### PR DESCRIPTION
This is a fix for the iid weighting in GridSearchCV. It could be that I screwed this up before, but didn't notice as there was no test.
