### PR TITLE
Update coordinate_descent.py

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -217,7 +217,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         # precompute if n_samples > n_features
         if hasattr(precompute, '__array__'):
             Gram = precompute
-        elif precompute or (precompute == 'auto' and n_samples > n_features):
+        elif precompute == True or (precompute == 'auto' and n_samples > n_features):
             Gram = np.dot(X.T, X)
         else:
             Gram = None


### PR DESCRIPTION
Reverting _dense_fit to explicitly check precompute == True rather than just looking at its truthiness (was problem because default value is 'auto' which is meant to have a special meaning).

Should prevent unwanted precomputing, see https://github.com/scikit-learn/scikit-learn/issues/1734
