### PR TITLE
MRG set min_df in fe.text back to 1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,13 @@ Changelog
      :class:`feature_extraction.text.TfidfVectorizer`,
      by Jochen Wersdörfer.
 
+   - The ``min_df`` parameter in
+     :class:`feature_extraction.text.CountVectorizer` and
+     :class:`feature_extraction.text.TfidfVectorizer`, which used to be 2,
+     has been reset to 1 to avoid unpleasant surprises (empty vocabularies)
+     for novice users who try it out on tiny document collections.
+     A value of at least 2 is still recommended for practical use.
+
    - Feature importances in :class:`tree.DecisionTreeClassifier`,
      :class:`tree.DecisionTreeRegressor` and all derived ensemble estimators
      are now computed on the fly when accessing  the ``feature_importances_``

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -268,7 +268,7 @@ def test_countvectorizer_empty_vocabulary():
         assert_in("empty vocabulary", str(e).lower())
 
     try:
-        v = CountVectorizer(min_df=1, max_df=1.0, stop_words="english")
+        v = CountVectorizer(max_df=1.0, stop_words="english")
         # fit on stopwords only
         v.fit(["to be or not to be", "and me too", "and so do you"])
         assert False, "we shouldn't get here"
@@ -356,7 +356,7 @@ def test_vectorizer():
     n_train = len(ALL_FOOD_DOCS) - 1
 
     # test without vocabulary
-    v1 = CountVectorizer(max_df=0.5, min_df=1)
+    v1 = CountVectorizer(max_df=0.5)
     counts_train = v1.fit_transform(train_data)
     if hasattr(counts_train, 'tocsr'):
         counts_train = counts_train.tocsr()
@@ -424,7 +424,7 @@ def test_vectorizer():
     # test the direct tfidf vectorizer
     # (equivalent to term count vectorizer + tfidf transformer)
     train_data = iter(ALL_FOOD_DOCS[:-1])
-    tv = TfidfVectorizer(norm='l1', min_df=1)
+    tv = TfidfVectorizer(norm='l1')
     assert_false(tv.fixed_vocabulary)
 
     tv.max_df = v1.max_df
@@ -504,7 +504,7 @@ def test_hashing_vectorizer():
 
 
 def test_feature_names():
-    cv = CountVectorizer(max_df=0.5, min_df=1)
+    cv = CountVectorizer(max_df=0.5)
 
     # test for Value error on unfitted/empty vocabulary
     assert_raises(ValueError, cv.get_feature_names)
@@ -540,7 +540,7 @@ def test_vectorizer_max_features():
 
 def test_vectorizer_max_df():
     test_data = ['abc', 'dea']  # the letter a occurs in both strings
-    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     vect.fit(test_data)
     assert_true(u'a' in vect.vocabulary_.keys())
     assert_equal(len(vect.vocabulary_.keys()), 5)
@@ -578,7 +578,7 @@ def test_vectorizer_min_df():
 def test_count_binary_occurrences():
     # by default multiple occurrences are counted as longs
     test_data = ['aaabc', 'abbde']
-    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal(['a', 'b', 'c', 'd', 'e'], vect.get_feature_names())
     assert_array_equal([[3, 1, 1, 0, 0],
@@ -586,8 +586,7 @@ def test_count_binary_occurrences():
 
     # using boolean features, we can fetch the binary occurrence info
     # instead.
-    vect = CountVectorizer(analyzer='char', max_df=1.0,
-                           binary=True, min_df=1)
+    vect = CountVectorizer(analyzer='char', max_df=1.0, binary=True)
     X = vect.fit_transform(test_data).toarray()
     assert_array_equal([[1, 1, 1, 0, 0],
                         [1, 1, 0, 1, 1]], X)
@@ -627,7 +626,7 @@ def test_hashed_binary_occurrences():
 def test_vectorizer_inverse_transform():
     # raw documents
     data = ALL_FOOD_DOCS
-    for vectorizer in (TfidfVectorizer(min_df=1), CountVectorizer(min_df=1)):
+    for vectorizer in (TfidfVectorizer(), CountVectorizer()):
         transformed_data = vectorizer.fit_transform(data)
         inversed_data = vectorizer.inverse_transform(transformed_data)
         analyze = vectorizer.build_analyzer()
@@ -656,7 +655,7 @@ def test_count_vectorizer_pipeline_grid_selection():
     y_train = y[1:-1]
     y_test = np.array([y[0], y[-1]])
 
-    pipeline = Pipeline([('vect', CountVectorizer(min_df=1)),
+    pipeline = Pipeline([('vect', CountVectorizer()),
                          ('svc', LinearSVC())])
 
     parameters = {
@@ -694,7 +693,7 @@ def test_vectorizer_pipeline_grid_selection():
     y_train = y[1:-1]
     y_test = np.array([y[0], y[-1]])
 
-    pipeline = Pipeline([('vect', TfidfVectorizer(min_df=1)),
+    pipeline = Pipeline([('vect', TfidfVectorizer()),
                          ('svc', LinearSVC())])
 
     parameters = {
@@ -741,7 +740,7 @@ def test_vectorizer_unicode():
         u"\xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb0\xd1\x82\xd1\x8c\xd1\x81\xd1"
         u"\x8f.")
 
-    vect = CountVectorizer(min_df=1)
+    vect = CountVectorizer()
     X_counted = vect.fit_transform([document])
     assert_equal(X_counted.shape, (1, 15))
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -531,7 +531,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    min_df : float in range [0.0, 1.0] or int, optional, 2 by default
+    min_df : float in range [0.0, 1.0] or int, optional, 1 by default
         When building the vocabulary ignore terms that have a term frequency
         strictly lower than the given threshold. This value is also called
         cut-off in the literature.
@@ -579,7 +579,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                  lowercase=True, preprocessor=None, tokenizer=None,
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), analyzer='word',
-                 max_df=1.0, min_df=2, max_features=None,
+                 max_df=1.0, min_df=1, max_features=None,
                  vocabulary=None, binary=False, dtype=long):
         self.input = input
         self.charset = charset
@@ -1088,7 +1088,7 @@ class TfidfVectorizer(CountVectorizer):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    min_df : float in range [0.0, 1.0] or int, optional, 2 by default
+    min_df : float in range [0.0, 1.0] or int, optional, 1 by default
         When building the vocabulary ignore terms that have a term frequency
         strictly lower than the given threshold.
         This value is also called cut-off in the literature.
@@ -1145,7 +1145,7 @@ class TfidfVectorizer(CountVectorizer):
                  charset_error='strict', strip_accents=None, lowercase=True,
                  preprocessor=None, tokenizer=None, analyzer='word',
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
-                 ngram_range=(1, 1), max_df=1.0, min_df=2,
+                 ngram_range=(1, 1), max_df=1.0, min_df=1,
                  max_features=None, vocabulary=None, binary=False, dtype=long,
                  norm='l2', use_idf=True, smooth_idf=True, sublinear_tf=False):
 


### PR DESCRIPTION
`min_df=2` is simply too confusing for users, since it causes trivial examples with fewer than three documents (and often with a few more) to fail. Many scikit-learn questions on [StackOverflow](http://stackoverflow.com/q/15220961/166749) pertain to this, and the fact that I've been recommending `TfidfVectorizer` for general-purpose document comparison (rather than learning) makes it worse.

As @ogrisel remarked somewhere, expert users will know how and when to set this parameter.

Not sure if there was already an issue about this on the tracker?
