### PR TITLE
Standard scaler sparse matrix with_std default changed to auto

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -73,7 +73,7 @@ This class is hence suitable for use in the early steps of a
 
   >>> scaler = preprocessing.StandardScaler().fit(X)
   >>> scaler
-  StandardScaler(copy=True, with_mean=True, with_std=True)
+  StandardScaler(copy=True, with_mean=True, with_std='auto')
 
   >>> scaler.mean_                                      # doctest: +ELLIPSIS
   array([ 1. ...,  0. ...,  0.33...])

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -306,7 +306,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         X = check_arrays(X, copy=self.copy, sparse_format="csr")[0]
         if sp.issparse(X):
-            if self.with_std == True:
+            if self.with_std is True:
                 raise TypeError(
                     "Cannot scale sparse matrices: pass `with_std=False` ")
             else:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -262,9 +262,11 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     with_mean : boolean, True by default
         If True, center the data before scaling.
 
-    with_std : boolean, True by default
+    with_std : boolean, 'auto' by default
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
+        Set to false by default if input is a CSR matrix.
+        Otherwise set to True by default.
 
     copy : boolean, optional, default is True
         Set to False to perform inplace row normalization and avoid a
@@ -307,6 +309,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             if self.with_std == True:
                 raise TypeError(
                     "Cannot scale sparse matrices: pass `with_std=False` ")
+            else:
+                self.with_std_ = False
 
             if self.with_mean:
                 raise ValueError(

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -320,10 +320,12 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             return self
         else:
             if self.with_std == "auto":
-                self.with_std = True
+                self.with_std_ = True
+            else:
+                self.with_std_ = self.with_std
             warn_if_not_float(X, estimator=self)
             self.mean_, self.std_ = _mean_and_std(
-                X, axis=0, with_mean=self.with_mean, with_std=self.with_std)
+                X, axis=0, with_mean=self.with_mean, with_std=self.with_std_)
             return self
 
     def transform(self, X, y=None, copy=None):

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -304,8 +304,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         X = check_arrays(X, copy=self.copy, sparse_format="csr")[0]
         if sp.issparse(X):
-            if with_std == "auto":
-                with_std = False
+            if self.with_std == True:
+                raise TypeError(
+                    "Cannot scale sparse matrices: pass `with_std=False` ")
+
             if self.with_mean:
                 raise ValueError(
                     "Cannot center sparse matrices: pass `with_mean=False` "
@@ -317,6 +319,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             self.std_[var == 0.0] = 1.0
             return self
         else:
+            if self.with_std == "auto":
+                self.with_std = True
             warn_if_not_float(X, estimator=self)
             self.mean_, self.std_ = _mean_and_std(
                 X, axis=0, with_mean=self.with_mean, with_std=self.with_std)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -288,7 +288,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     to further remove the linear correlation across features.
     """
 
-    def __init__(self, copy=True, with_mean=True, with_std=True):
+    def __init__(self, copy=True, with_mean=True, with_std='auto'):
         self.with_mean = with_mean
         self.with_std = with_std
         self.copy = copy
@@ -304,6 +304,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         X = check_arrays(X, copy=self.copy, sparse_format="csr")[0]
         if sp.issparse(X):
+            if with_std == "auto":
+                with_std = False
             if self.with_mean:
                 raise ValueError(
                     "Cannot center sparse matrices: pass `with_mean=False` "

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -63,6 +63,16 @@ def test_scaler_1d():
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
 
+    #Test value of self.with_std_
+    scaler = StandardScaler()
+    X_scaled = scaler.fit(X)
+    assert_true(scaler.with_std_)
+
+    scaler = StandardScaler(with_mean=False)
+    X_csr=sp.csr_matrix(X)
+    X_scaled = scaler.fit(X_csr)
+    assert_false(scaler.with_std_)
+
 
 def test_scaler_2d_arrays():
     """Test scaling of 2d array along first axis"""

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -69,7 +69,7 @@ def test_scaler_1d():
     assert_true(scaler.with_std_)
 
     scaler = StandardScaler(with_mean=False)
-    X_csr=sp.csr_matrix(X)
+    X_csr = sp.csr_matrix(X)
     X_scaled = scaler.fit(X_csr)
     assert_false(scaler.with_std_)
 


### PR DESCRIPTION
Solves   Issue #1724

Although I am having following fail in test. How should I deal with it?

```
======================================================================
FAIL: sklearn.tests.test_common.test_estimators_overwrite_params
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/home/hrishi/scikit-learn/sparse3/sklearn/tests/test_common.py", line 951, in test_estimators_overwrite_params
    % (name, k, v, new_params[k]))
AssertionError: Estimator StandardScaler changes its parameter with_std from auto to True during fit.
    'Estimator StandardScaler changes its parameter with_std from auto to True during fit.' = self._formatMessage('Estimator StandardScaler changes its parameter with_std from auto to True during fit.', "%s is not false" % safe_repr(True))
>>  raise self.failureException('Estimator StandardScaler changes its parameter with_std from auto to True during fit.')


----------------------------------------------------------------------
Ran 1831 tests in 185.116s

FAILED (SKIP=14, failures=1)

```
