### PR TITLE
Fix automatic setup of class weights.

### DIFF
--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -318,3 +318,12 @@ def test_ecoc_gridsearch():
     cv.fit(iris.data, iris.target)
     best_C = cv.best_estimator_.estimators_[0].C
     assert_true(best_C in Cs)
+
+def test_shifted_class_labels():
+    m1 = svm.SVC(kernel='linear')
+    m1.fit(iris.data, iris.target)
+    pred1 = m1.predict(iris.data)
+    m2 = svm.SVC(kernel='linear', class_weight='auto')
+    m2.fit(iris.data, iris.target + 1)
+    pred2 = m2.predict(iris.data)
+    assert_array_equal(pred1, pred2 - 1)

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -35,7 +35,7 @@ def compute_class_weight(class_weight, classes, y):
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'auto':
         # anti-proportional to the number of samples in the class
-        weight = np.array([1.0 / np.sum(y == i) for i in classes],
+        weight = np.array([1.0 / np.sum(y == i) for i in range(len(classes))],
                           dtype=np.float64, order='C')
         weight *= classes.shape[0] / np.sum(weight)
     else:


### PR DESCRIPTION
Automatic setup of class weights works only when the classes are numbered by {0, 1, .., n-1}. For this case the mapping done on sklearn/svm/base.py#141 by a call to unique(y, return_inverse=True) is identity.

For classes numbered differently (eg. just shifting the target), the class weights setup causes division by zero and subsequent mediocre performance of the classifier (prediction of a single class).
