### PR TITLE
[MRG] Refactor accuracy score + Fix bugs with 1d array

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -72,7 +72,7 @@ Accuracy score
 ---------------
 The :func:`accuracy_score` function computes the
 `accuracy <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_, the fraction
-of correct predictions. In multilabel classification,
+(default) or the number of correct predictions. In multilabel classification,
 the function returns the subset accuracy:
 the entire set of labels for a sample must be entirely correct
 or the sample has an accuracy of zero.
@@ -96,6 +96,8 @@ where :math:`1(x)` is the `indicator function
   >>> y_true = [0, 1, 2, 3]
   >>> accuracy_score(y_true, y_pred)
   0.5
+  >>> accuracy_score(y_true, y_pred, normalize=False)
+  2
 
   In the multilabel case with binary indicator format:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,10 @@ Changelog
    - Performance improvements in :class:`isotonic.IsotonicRegression` by
      Nelle Varoquaux.
 
+   - :func:`metrics.accuracy_score` has an option normalize to return
+     the fraction or the number of correctly classified sample
+     by `Arnaud Joly`_.
+
 
 API changes summary
 -------------------


### PR DESCRIPTION
This pull request intends to reduce the amount of redundant code between `accuracy_score` and `zero_one_loss` (see issue #1748). In order to achieve this,  a normalize option has been added to `accuracy_score`.

Furthermore,  mix representation of 1d vector are now properly handle by all the metrics that comparse `y_true` to `y_pred`.
