### PR TITLE
 FIX KFold should return the same result when indices=True and when indices=False.

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -289,8 +289,9 @@ class KFold(object):
             test_index[self.idxs[start:stop]] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                train_index = self.idxs[train_index]
-                test_index = self.idxs[test_index]
+                ind = np.arange(n)
+                train_index = ind[train_index]
+                test_index = ind[test_index]
             current = stop
             yield train_index, test_index
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -283,13 +283,14 @@ class KFold(object):
         fold_sizes = (n // n_folds) * np.ones(n_folds, dtype=np.int)
         fold_sizes[:n % n_folds] += 1
         current = 0
+        if self.indices:
+            ind = np.arange(n)
         for i, fold_size in enumerate(fold_sizes):
             test_index = np.zeros(n, dtype=np.bool)
             start, stop = current, current + fold_size
             test_index[self.idxs[start:stop]] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(n)
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             current = stop

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -474,6 +474,32 @@ def test_cross_val_generator_with_indices():
             X_train, X_test = X[train], X[test]
             y_train, y_test = y[train], y[test]
 
+def test_cross_val_generator_mask_indices_same():
+    # Test that the cross validation generators return the same results when
+    # indices=True and when indices=False
+    y = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2])
+    labels = np.array([1, 1, 2, 3, 3, 3, 4])
+    
+    loo_mask = cval.LeaveOneOut(5, indices=False)
+    loo_ind = cval.LeaveOneOut(5, indices=True)
+    lpo_mask = cval.LeavePOut(10, 2, indices=False)
+    lpo_ind = cval.LeavePOut(10, 2, indices=True)
+    kf_mask = cval.KFold(10, 5, indices=False, shuffle=True, random_state=1)
+    kf_ind = cval.KFold(10, 5, indices=True, shuffle=True, random_state=1)
+    skf_mask = cval.StratifiedKFold(y, 3, indices=False)
+    skf_ind = cval.StratifiedKFold(y, 3, indices=True)
+    lolo_mask = cval.LeaveOneLabelOut(labels, indices=False)
+    lolo_ind = cval.LeaveOneLabelOut(labels, indices=True)
+    lopo_mask = cval.LeavePLabelOut(labels, 2, indices=False)
+    lopo_ind = cval.LeavePLabelOut(labels, 2, indices=True)
+    
+    for cv_mask, cv_ind in [(loo_mask, loo_ind), (lpo_mask, lpo_ind),
+            (kf_mask, kf_ind), (skf_mask, skf_ind), (lolo_mask, lolo_ind),
+            (lopo_mask, lopo_ind)]:
+        for (train_mask, test_mask), (train_ind, test_ind) in \
+                zip(cv_mask, cv_ind):
+            assert_array_equal(np.where(train_mask == True)[0], train_ind)
+            assert_array_equal(np.where(test_mask == True)[0], test_ind)
 
 def test_bootstrap_errors():
     assert_raises(ValueError, cval.Bootstrap, 10, train_size=100)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -474,6 +474,7 @@ def test_cross_val_generator_with_indices():
             X_train, X_test = X[train], X[test]
             y_train, y_test = y[train], y[test]
 
+
 def test_cross_val_generator_mask_indices_same():
     # Test that the cross validation generators return the same results when
     # indices=True and when indices=False
@@ -500,6 +501,7 @@ def test_cross_val_generator_mask_indices_same():
                 zip(cv_mask, cv_ind):
             assert_array_equal(np.where(train_mask == True)[0], train_ind)
             assert_array_equal(np.where(test_mask == True)[0], test_ind)
+
 
 def test_bootstrap_errors():
     assert_raises(ValueError, cval.Bootstrap, 10, train_size=100)


### PR DESCRIPTION
Here is an example of the problem:

``` python
import numpy as np
from sklearn.cross_validation import KFold

kf_mask = KFold(10, 5, indices=False, shuffle=True, random_state=1)
kf_ind = KFold(10, 5, indices=True, shuffle=True, random_state=1)
for (train_mask, test_mask), (train_ind, test_ind) in zip(kf_mask, kf_ind):
    print np.where(train_mask == True)[0]
    print train_ind
    print np.where(test_mask == True)[0]
    print test_ind
```

The output is:

``` python
[0 1 3 4 5 6 7 8]
[2 9 4 0 3 1 7 8]
[2 9]
[6 5]
[0 1 2 3 5 7 8 9]
[2 9 6 4 3 7 8 5]
[4 6]
[0 1]
[1 2 4 5 6 7 8 9]
[9 6 0 3 1 7 8 5]
[0 3]
[2 4]
[0 2 3 4 5 6 8 9]
[2 6 4 0 3 1 8 5]
[1 7]
[9 7]
[0 1 2 3 4 6 7 9]
[2 9 6 4 0 1 7 5]
[5 8]
[3 8]
```

The output with the fix applied is the following:

``` python
[0 1 3 4 5 6 7 8]
[0 1 3 4 5 6 7 8]
[2 9]
[2 9]
[0 1 2 3 5 7 8 9]
[0 1 2 3 5 7 8 9]
[4 6]
[4 6]
[1 2 4 5 6 7 8 9]
[1 2 4 5 6 7 8 9]
[0 3]
[0 3]
[0 2 3 4 5 6 8 9]
[0 2 3 4 5 6 8 9]
[1 7]
[1 7]
[0 1 2 3 4 6 7 9]
[0 1 2 3 4 6 7 9]
[5 8]
[5 8]

```
