### PR TITLE
FIX make_classification now outputs integer labels

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -144,7 +144,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     # Intialize X and y
     X = np.zeros((n_samples, n_features))
-    y = np.zeros(n_samples)
+    y = np.zeros(n_samples, dtype=np.int)
 
     # Build the polytope
     C = np.array(list(product([-class_sep, class_sep], repeat=n_informative)))


### PR DESCRIPTION
Due to a recent very small change (https://github.com/scikit-learn/scikit-learn/commit/ffad26a299a1ce4738926bac11a4cf93dc), the tests now fail with the following error (at least with a very recent numpy version).

My patch fixes the test but do not fix the backward incompatibility we now have. Should we tackle that too (or instead of this patch)?
# 
## ERROR: sklearn.tests.test_common.test_class_weight_auto_classifies

Traceback (most recent call last):
  File "/bioinfo/users/nvaroqua/.work/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/bioinfo/users/nvaroqua/Projects/scikit-learn/sklearn/tests/test_common.py", line 904, in test_class_weight_auto_classifies
    classifier.fit(X_train, y_train)
  File "/bioinfo/users/nvaroqua/Projects/scikit-learn/sklearn/linear_model/stochastic_gradient.py", line 520, in fit
    sample_weight=sample_weight)
  File "/bioinfo/users/nvaroqua/Projects/scikit-learn/sklearn/linear_model/stochastic_gradient.py", line 419, in _fit
    classes, sample_weight, coef_init, intercept_init)
  File "/bioinfo/users/nvaroqua/Projects/scikit-learn/sklearn/linear_model/stochastic_gradient.py", line 360, in _partial_fit
    self.classes_, y)
  File "/bioinfo/users/nvaroqua/Projects/scikit-learn/sklearn/utils/class_weight.py", line 40, in compute_class_weight
    counts = bincount(y_ind, minlength=len(classes))
TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'

---

Ran 1831 tests in 260.294s
