### PR TITLE
[MRG + 2] ENH enable setting pipeline components as parameters

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -89,7 +89,7 @@ This is particularly important for doing grid searches::
 
     >>> from sklearn.model_selection import GridSearchCV
     >>> params = dict(reduce_dim__n_components=[2, 5, 10],
-    ...               clf__C=[0.1, 10, 100])
+    ...               svm__C=[0.1, 10, 100])
     >>> grid_search = GridSearchCV(clf, param_grid=params)
 
 Individual steps may also be replaced as parameters, and non-final steps may be

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -37,12 +37,12 @@ is an estimator object::
     >>> from sklearn.pipeline import Pipeline
     >>> from sklearn.svm import SVC
     >>> from sklearn.decomposition import PCA
-    >>> estimators = [('reduce_dim', PCA()), ('svm', SVC())]
-    >>> clf = Pipeline(estimators)
-    >>> clf # doctest: +NORMALIZE_WHITESPACE
+    >>> estimators = [('reduce_dim', PCA()), ('clf', SVC())]
+    >>> pipe = Pipeline(estimators)
+    >>> pipe # doctest: +NORMALIZE_WHITESPACE
     Pipeline(steps=[('reduce_dim', PCA(copy=True, iterated_power=4,
     n_components=None, random_state=None, svd_solver='auto', tol=0.0,
-    whiten=False)), ('svm', SVC(C=1.0, cache_size=200, class_weight=None,
+    whiten=False)), ('clf', SVC(C=1.0, cache_size=200, class_weight=None,
     coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
     kernel='rbf', max_iter=-1, probability=False, random_state=None,
     shrinking=True, tol=0.001, verbose=False))])
@@ -63,23 +63,23 @@ filling in the names automatically::
 
 The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 
-    >>> clf.steps[0]
+    >>> pipe.steps[0]
     ('reduce_dim', PCA(copy=True, iterated_power=4, n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False))
 
 and as a ``dict`` in ``named_steps``::
 
-    >>> clf.named_steps['reduce_dim']
+    >>> pipe.named_steps['reduce_dim']
     PCA(copy=True, iterated_power=4, n_components=None, random_state=None,
       svd_solver='auto', tol=0.0, whiten=False)
 
 Parameters of the estimators in the pipeline can be accessed using the
 ``<estimator>__<parameter>`` syntax::
 
-    >>> clf.set_params(svm__C=10) # doctest: +NORMALIZE_WHITESPACE
+    >>> pipe.set_params(clf__C=10) # doctest: +NORMALIZE_WHITESPACE
     Pipeline(steps=[('reduce_dim', PCA(copy=True, iterated_power=4,
         n_components=None, random_state=None, svd_solver='auto', tol=0.0,
-        whiten=False)), ('svm', SVC(C=10, cache_size=200, class_weight=None,
+        whiten=False)), ('clf', SVC(C=10, cache_size=200, class_weight=None,
         coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
         kernel='rbf', max_iter=-1, probability=False, random_state=None,
         shrinking=True, tol=0.001, verbose=False))])
@@ -89,8 +89,8 @@ This is particularly important for doing grid searches::
 
     >>> from sklearn.model_selection import GridSearchCV
     >>> params = dict(reduce_dim__n_components=[2, 5, 10],
-    ...               svm__C=[0.1, 10, 100])
-    >>> grid_search = GridSearchCV(clf, param_grid=params)
+    ...               clf__C=[0.1, 10, 100])
+    >>> grid_search = GridSearchCV(pipe, param_grid=params)
 
 Individual steps may also be replaced as parameters, and non-final steps may be
 ignored by setting them to ``None``::
@@ -99,7 +99,7 @@ ignored by setting them to ``None``::
     >>> params = dict(reduce_dim=[None, PCA(5), PCA(10)],
     ...               clf=[SVC(), LogisticRegression()],
     ...               clf__C=[0.1, 10, 100])
-    >>> grid_search = GridSearchCV(clf, param_grid=params)
+    >>> grid_search = GridSearchCV(pipe, param_grid=params)
 
 .. topic:: Examples:
 

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -47,7 +47,6 @@ is an estimator object::
     kernel='rbf', max_iter=-1, probability=False, random_state=None,
     shrinking=True, tol=0.001, verbose=False))])
 
-
 The utility function :func:`make_pipeline` is a shorthand
 for constructing pipelines;
 it takes a variable number of estimators and returns a pipeline,
@@ -90,9 +89,17 @@ This is particularly important for doing grid searches::
 
     >>> from sklearn.model_selection import GridSearchCV
     >>> params = dict(reduce_dim__n_components=[2, 5, 10],
-    ...               svm__C=[0.1, 10, 100])
+    ...               clf__C=[0.1, 10, 100])
     >>> grid_search = GridSearchCV(clf, param_grid=params)
 
+Individual steps may also be replaced as parameters, and non-final steps may be
+ignored by setting them to ``None``::
+
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> params = dict(reduce_dim=[None, PCA(5), PCA(10)],
+    ...               clf=[SVC(), LogisticRegression()],
+    ...               clf__C=[0.1, 10, 100])
+    >>> grid_search = GridSearchCV(clf, param_grid=params)
 
 .. topic:: Examples:
 
@@ -171,6 +178,15 @@ and ``value`` is an estimator object::
 Like pipelines, feature unions have a shorthand constructor called
 :func:`make_union` that does not require explicit naming of the components.
 
+
+Like ``Pipeline``, individual steps may be replaced using ``set_params``,
+and ignored by setting to ``None``::
+
+    >>> combined.set_params(kernel_pca=None) # doctest: +NORMALIZE_WHITESPACE
+    FeatureUnion(n_jobs=1, transformer_list=[('linear_pca', PCA(copy=True,
+          iterated_power=4, n_components=None, random_state=None,
+          svd_solver='auto', tol=0.0, whiten=False)), ('kernel_pca', None)],
+        transformer_weights=None)
 
 .. topic:: Examples:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -233,6 +233,12 @@ Enhancements
    - Added new return type ``(data, target)`` : tuple option to :func:`load_iris` dataset. (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) 
      By `Manvendra Singh`_ and `Nelson Liu`_.   
 
+   - Added support for substituting or disabling :class:`pipeline.Pipeline`
+     and :class:`pipeline.FeatureUnion` components using the ``set_params``
+     interface that powers :mod:`sklearn.grid_search`.
+     See :ref:`example_plot_compare_reduction.py`. By `Joel Nothman`_ and
+     `Robert McGibbon`_.
+
 Bug fixes
 .........
 
@@ -4300,6 +4306,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Ori Ziv: https://github.com/zivori
 
 .. _Sears Merritt: https://github.com/merritts
+<<<<<<< 738698ac93085287844605cacdc62357c026622f
 
 .. _Wenhua Yang: https://github.com/geekoala
 
@@ -4308,7 +4315,12 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Sebastian Säger: https://github.com/ssaeger
 
 .. _YenChen Lin: https://github.com/yenchenlin
+<<<<<<< 8bd5658eff6dc3578a38edf65650c4806d1bd51b
 
 .. _Nelson Liu: https://github.com/nelson-liu
 
 .. _Manvendra Singh: https://github.com/manu-chroma
+=======
+=======
+>>>>>>> DOC add what's new entry
+>>>>>>> DOC add what's new entry

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4306,7 +4306,6 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Ori Ziv: https://github.com/zivori
 
 .. _Sears Merritt: https://github.com/merritts
-<<<<<<< 738698ac93085287844605cacdc62357c026622f
 
 .. _Wenhua Yang: https://github.com/geekoala
 
@@ -4315,12 +4314,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Sebastian Säger: https://github.com/ssaeger
 
 .. _YenChen Lin: https://github.com/yenchenlin
-<<<<<<< 8bd5658eff6dc3578a38edf65650c4806d1bd51b
 
 .. _Nelson Liu: https://github.com/nelson-liu
 
 .. _Manvendra Singh: https://github.com/manu-chroma
-=======
-=======
->>>>>>> DOC add what's new entry
->>>>>>> DOC add what's new entry

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -37,7 +37,7 @@ N_FEATURES_OPTIONS = [2, 4, 8]
 C_OPTIONS = [1, 10, 100, 1000]
 param_grid = [
     {
-        'reduce_dim': [PCA(), NMF()],
+        'reduce_dim': [PCA(iterated_power=7), NMF()],
         'reduce_dim__n_components': N_FEATURES_OPTIONS,
         'classify__C': C_OPTIONS
     },

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -1,0 +1,78 @@
+
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+=================================================================
+Selecting dimensionality reduction with Pipeline and GridSearchCV
+=================================================================
+
+This example constructs a pipeline that does dimensionality
+reduction followed by prediction with a support vector
+classifier. It demonstrates the use of GridSearchCV and
+Pipeline to optimize over different classes of estimators in a
+single CV run -- unsupervised PCA and NMF dimensionality
+reductions are compared to univariate feature selection during
+the grid search.
+"""
+# Authors: Robert McGibbon, Joel Nothman
+
+from __future__ import print_function, division
+print(__doc__)
+
+from operator import attrgetter
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_digits
+from sklearn.grid_search import GridSearchCV
+from sklearn.pipeline import Pipeline
+from sklearn.svm import LinearSVC
+from sklearn.decomposition import PCA, NMF
+from sklearn.feature_selection import SelectKBest, chi2
+
+pipe = Pipeline([
+    ('reduce_dim', PCA()),
+    ('classify', LinearSVC())
+])
+
+N_FEATURES_OPTIONS = [2, 4, 8]
+C_OPTIONS = [1, 10, 100, 1000]
+param_grid = [
+    {
+        'reduce_dim': [PCA(), NMF()],
+        'reduce_dim__n_components': N_FEATURES_OPTIONS,
+        'classify__C': C_OPTIONS
+    },
+    {
+        'reduce_dim': [SelectKBest(chi2)],
+        'reduce_dim__k': N_FEATURES_OPTIONS,
+        'classify__C': C_OPTIONS
+    },
+]
+reducer_labels = ['PCA', 'NMF', 'KBest(chi2)']
+
+grid = GridSearchCV(pipe, cv=3, n_jobs=-2, param_grid=param_grid)
+digits = load_digits()
+grid.fit(digits.data, digits.target)
+
+mean_scores = np.array([entry.mean_validation_score
+                        for entry in grid.grid_scores_])
+# scores are in the order of param_grid iteration, which is alphabetical
+mean_scores = mean_scores.reshape(len(C_OPTIONS), -1, len(N_FEATURES_OPTIONS))
+# select score for best C
+mean_scores = mean_scores.max(axis=0)
+bar_offsets = (np.arange(len(N_FEATURES_OPTIONS)) *
+               (len(reducer_labels) + 1) + .5)
+
+plt.figure()
+COLORS = 'bgrcmyk'
+for i, (label, reducer_scores) in enumerate(zip(reducer_labels, mean_scores)):
+    plt.bar(bar_offsets + i, reducer_scores, label=label, color=COLORS[i])
+
+plt.title("Comparing feature reduction techniques")
+plt.xlabel('Reduced number of features')
+plt.xticks(bar_offsets + len(reducer_labels) / 2, N_FEATURES_OPTIONS)
+plt.ylabel('Digit classification accuracy')
+plt.ylim((0, 1))
+plt.legend(loc='upper left')
+plt.show()

--- a/examples/plot_compare_reduction.py
+++ b/examples/plot_compare_reduction.py
@@ -16,18 +16,17 @@ the grid search.
 # Authors: Robert McGibbon, Joel Nothman
 
 from __future__ import print_function, division
-print(__doc__)
-
-from operator import attrgetter
 
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.datasets import load_digits
-from sklearn.grid_search import GridSearchCV
+from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
 from sklearn.decomposition import PCA, NMF
 from sklearn.feature_selection import SelectKBest, chi2
+
+print(__doc__)
 
 pipe = Pipeline([
     ('reduce_dim', PCA()),
@@ -50,12 +49,11 @@ param_grid = [
 ]
 reducer_labels = ['PCA', 'NMF', 'KBest(chi2)']
 
-grid = GridSearchCV(pipe, cv=3, n_jobs=-2, param_grid=param_grid)
+grid = GridSearchCV(pipe, cv=3, n_jobs=2, param_grid=param_grid)
 digits = load_digits()
 grid.fit(digits.data, digits.target)
 
-mean_scores = np.array([entry.mean_validation_score
-                        for entry in grid.grid_scores_])
+mean_scores = np.array(grid.results_['test_mean_score'])
 # scores are in the order of param_grid iteration, which is alphabetical
 mean_scores = mean_scores.reshape(len(C_OPTIONS), -1, len(N_FEATURES_OPTIONS))
 # select score for best C

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -306,9 +306,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data samples, where ``n_sampless`` is the number of samples and
-            ``n_features`` is the number of features.
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
 
         Returns
         -------
@@ -359,9 +359,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data samples, where ``n_samples`` is the number of samples and
-            ``n_features`` is the number of features.
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
 
         Returns
         -------
@@ -399,9 +399,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data samples, where ``n_samples`` is the number of samples and
-            ``n_features`` is the number of features.
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
 
         Returns
         -------
@@ -419,9 +419,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data samples, where ``n_samples`` is the number of samples and
-            ``n_features`` is the number of features.
+        X : iterable
+            Data to transform. Must fulfill input requirements of first step
+            of the pipeline.
 
         Returns
         -------
@@ -441,7 +441,9 @@ class Pipeline(_BasePipeline):
         ----------
         Xt : array-like, shape = [n_samples, n_transformed_features]
             Data samples, where ``n_samples`` is the number of samples and
-            ``n_features`` is the number of features.
+            ``n_features`` is the number of features. Must fulfill
+            input requirements of last step of pipeline's
+            ``inverse_transform`` method.
 
         Returns
         -------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -171,7 +171,7 @@ class Pipeline(_BasePipeline):
     def set_params(self, **kwargs):
         """Set the parameters of this estimator.
 
-        Valid parameter keys can be listed with ``get_params``.
+        Valid parameter keys can be listed with ``get_params()``.
 
         Returns
         -------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -99,7 +99,7 @@ class Pipeline(_BasePipeline):
     cross-validated together while setting different parameters.
     For this, it enables setting parameters of the various steps using their
     names and the parameter name separated by a '__', as in the example below.
-    A step's estimator may be replaced in entirety by setting the parameter
+    A step's estimator may be replaced entirely by setting the parameter
     with its name.
 
     Read more in the :ref:`User Guide <pipeline>`.
@@ -300,8 +300,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_sampless`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -349,8 +349,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -368,8 +368,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -388,8 +388,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -408,8 +408,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -428,8 +428,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         Xt : array-like, shape = [n_samples, n_transformed_features]
-            Data samples, where n_samples in the number of samples and
-            n_features is the number of features.
+            Data samples, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -452,8 +452,8 @@ class Pipeline(_BasePipeline):
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
-            Evaluation data, where n_samples in the number of samples and
-            n_features is the number of features.
+            Evaluation data, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------
@@ -551,7 +551,7 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
     several feature extraction mechanisms into a single transformer.
 
     Parameters of the transformers may be set using its name and the parameter
-    name separated by a '__'. A transformer may be replaced in entirety by
+    name separated by a '__'. A transformer may be replaced entirely by
     setting the parameter with its name.
 
     Read more in the :ref:`User Guide <feature_union>`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -379,9 +379,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data samples, where ``n_samples`` is the number of samples and
-            ``n_features`` is the number of features.
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
 
         Returns
         -------
@@ -465,9 +465,9 @@ class Pipeline(_BasePipeline):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Data to score. Must fulfill input requirements of first step of the
-            pipeline.
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
 
         y : iterable, default=None
             Targets used for scoring. Must fulfill label requirements for all

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -25,10 +25,9 @@ from .utils.metaestimators import if_delegate_has_method
 __all__ = ['Pipeline', 'FeatureUnion']
 
 
-class _BasePipeline(BaseEstimator):
-    """Handles parameter management for classifiers composed of named steps."""
-
-    __metaclass__ = ABCMeta
+class _BasePipeline(six.with_metaclass(ABCMeta, BaseEstimator)):
+    """Handles parameter management for classifiers composed of named steps.
+    """
 
     @abstractmethod
     def __init__(self):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -68,9 +68,7 @@ class _BasePipeline(six.with_metaclass(ABCMeta, BaseEstimator)):
             if '__' not in name and name in step_names:
                 self._replace_step(steps_attr, name, params.pop(name))
         # 3. Step parameters and other initilisation arguments
-        print('here', getattr(self, steps_attr))
         super(_BasePipeline, self).set_params(**params)
-        print('there', getattr(self, steps_attr))
         return self
 
     def _validate_names(self, names):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -655,6 +655,8 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
         feature_names : list of strings
             Names of the features produced by transform.
         """
+        # Implemented as a proprerty so hasattr(feat_union, get_feature_names)
+        # returns False if any transformer lacks get_feature_names
         getters = [(name, trans.get_feature_names)
                    for name, trans, weight in self._iter()]
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -648,7 +648,6 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
                 for name, trans in self.transformer_list
                 if trans is not None)
 
-    @property
     def get_feature_names(self):
         """Get feature names from all transformers.
 
@@ -657,18 +656,14 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
         feature_names : list of strings
             Names of the features produced by transform.
         """
-        # Implemented as a proprerty so hasattr(feat_union, get_feature_names)
-        # returns False if any transformer lacks get_feature_names
-        getters = [(name, trans.get_feature_names)
-                   for name, trans, weight in self._iter()]
-
-        def fn():
-            feature_names = []
-            for name, getter in getters:
-                feature_names.extend([name + "__" + f for f in
-                                      getter()])
-            return feature_names
-        return fn
+        feature_names = []
+        for name, trans, weight in self._iter():
+            if not hasattr(trans, 'get_feature_names'):
+                raise AttributeError("Transformer %s does not provide"
+                                     " get_feature_names." % str(name))
+            feature_names.extend([name + "__" + f for f in
+                                  trans.get_feature_names()])
+        return feature_names
 
     def fit(self, X, y=None):
         """Fit all transformers using X.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -242,7 +242,7 @@ class Pipeline(_BasePipeline):
 
     def fit(self, X, y=None, **fit_params):
         """Fit the model
-        
+
         Fit all the transforms one after the other and transform the
         data, then fit the transformed data using the final estimator.
 
@@ -681,8 +681,6 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
             delayed(_fit_transform_one)(trans, name, weight, X, y,
                                         **fit_params)
             for name, trans, weight in self._iter())
-        print(len(result))
-        print('!!!', result[0])
 
         Xs, transformers = zip(*result)
         self._update_transformer_list(transformers)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -643,6 +643,8 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
                                 (t, type(t)))
 
     def _iter(self):
+        """Generate (name, est, weight) tuples excluding None transformers
+        """
         get_weight = (self.transformer_weights or {}).get
         return ((name, trans, get_weight(name))
                 for name, trans in self.transformer_list

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -97,7 +97,8 @@ class Pipeline(_BasePipeline):
     For this, it enables setting parameters of the various steps using their
     names and the parameter name separated by a '__', as in the example below.
     A step's estimator may be replaced entirely by setting the parameter
-    with its name.
+    with its name to another estimator, or a transformer removed by setting
+    to None.
 
     Read more in the :ref:`User Guide <pipeline>`.
 
@@ -571,7 +572,8 @@ class FeatureUnion(_BasePipeline, TransformerMixin):
 
     Parameters of the transformers may be set using its name and the parameter
     name separated by a '__'. A transformer may be replaced entirely by
-    setting the parameter with its name.
+    setting the parameter with its name to another transformer,
+    or removed by setting to None.
 
     Read more in the :ref:`User Guide <feature_union>`.
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -72,15 +72,15 @@ class _BasePipeline(six.with_metaclass(ABCMeta, BaseEstimator)):
     def _validate_names(self, names):
         if len(set(names)) != len(names):
             raise ValueError('Names provided are not unique: '
-                             '{!r}'.format(list(names)))
+                             '{0!r}'.format(list(names)))
         invalid_names = set(names).intersection(self.get_params(deep=False))
         if invalid_names:
             raise ValueError('Step names conflict with constructor arguments: '
-                             '{!r}'.format(sorted(invalid_names)))
+                             '{0!r}'.format(sorted(invalid_names)))
         invalid_names = [name for name in names if '__' in name]
         if invalid_names:
             raise ValueError('Step names must not contain __: got '
-                             '{!r}'.format(invalid_names))
+                             '{0!r}'.format(invalid_names))
 
 
 class Pipeline(_BasePipeline):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -224,8 +224,8 @@ class Pipeline(_BasePipeline):
     # Estimator interface
 
     def _fit(self, X, y=None, **fit_params):
-        fit_params_steps = {name: {} for name, step in self.steps
-                            if step is not None}
+        fit_params_steps = dict((name, {}) for name, step in self.steps
+                                if step is not None)
         for pname, pval in six.iteritems(fit_params):
             step, param = pname.split('__', 1)
             fit_params_steps[step][param] = pval

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -461,7 +461,8 @@ class Pipeline(_BasePipeline):
         """
         Xt = X
         for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
+            if transform is not None:
+                Xt = transform.transform(Xt)
         return self.steps[-1][-1].score(Xt, y)
 
     @property

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -358,7 +358,8 @@ class Pipeline(_BasePipeline):
         """
         Xt = X
         for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
+            if transform is not None:
+                Xt = transform.transform(Xt)
         return self.steps[-1][-1].predict_proba(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
@@ -435,7 +436,7 @@ class Pipeline(_BasePipeline):
         -------
         Xt : array-like, shape = [n_samples, n_features]
         """
-        if X.ndim == 1:
+        if hasattr(X, 'ndim') and X.ndim == 1:
             warn("From version 0.19, a 1d X will not be reshaped in"
                  " pipeline.inverse_transform any more.", FutureWarning)
             X = X[None, :]

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -41,7 +41,6 @@ class _BasePipeline(six.with_metaclass(ABCMeta, BaseEstimator)):
                 new_steps[i] = (name, new_val)
                 break
         setattr(self, steps_attr, new_steps)
-        print(name, i, new_steps)
 
     def _get_params(self, steps_attr, deep=True):
         out = super(_BasePipeline, self).get_params(deep=False)
@@ -63,7 +62,6 @@ class _BasePipeline(six.with_metaclass(ABCMeta, BaseEstimator)):
             setattr(self, steps_attr, params.pop(steps_attr))
         # 2. Step replacement
         step_names, _ = zip(*getattr(self, steps_attr))
-        print(step_names, params.keys())
         for name in list(six.iterkeys(params)):
             if '__' not in name and name in step_names:
                 self._replace_step(steps_attr, name, params.pop(name))

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -389,7 +389,7 @@ def test_set_pipeline_steps():
 
 
 def test_set_pipeline_step_none():
-    """Test setting Pipeline steps to None"""
+    # Test setting Pipeline steps to None
     X = np.array([[1]])
     y = np.array([1])
     mult2 = MultT(mult=2)
@@ -397,7 +397,7 @@ def test_set_pipeline_step_none():
     mult5 = MultT(mult=5)
 
     def make():
-        return Pipeline([('m2', mult2), ('m3', mult3), ('est', mult5)])
+        return Pipeline([('m2', mult2), ('m3', mult3), ('last', mult5)])
 
     pipeline = make()
 
@@ -432,7 +432,7 @@ def test_set_pipeline_step_none():
 
     pipeline = make()
     assert_raises_regex(TypeError, r'Last step of Pipeline .*\bfit\b.*',
-                        pipeline.set_params, est=None)
+                        pipeline.set_params, last=None)
 
 
 def test_make_pipeline():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -431,7 +431,8 @@ def test_set_pipeline_step_none():
     assert_array_equal(X, pipeline.inverse_transform([[exp]]))
 
     pipeline = make()
-    assert_raises(TypeError, pipeline.set_params, est=None)
+    assert_raises_regex(TypeError, r'Last step of Pipeline .*\bfit\b.*',
+                        pipeline.set_params, est=None)
 
 
 def test_make_pipeline():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -429,7 +429,6 @@ def test_set_pipeline_step_none():
     assert_array_equal([[exp]], pipeline.fit_transform(X, y))
     assert_array_equal([exp], pipeline.predict(X))
     assert_array_equal(X, pipeline.inverse_transform([[exp]]))
-    print(pipeline.get_params(deep=True))
     assert_dict_equal(pipeline.get_params(deep=True),
                       {'steps': pipeline.steps,
                        'm2': mult2,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1529,6 +1529,9 @@ def check_get_params_invariance(name, estimator):
         def fit(self, X, y):
             return self
 
+        def transform(self, X):
+            return X
+
     if name in ('FeatureUnion', 'Pipeline'):
         e = estimator([('clf', T())])
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -48,6 +48,7 @@ from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
 
 # Conveniently import all assertions in one place.
+from nose.tools import assert_dict_equal
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_true

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -48,13 +48,17 @@ from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
 
 # Conveniently import all assertions in one place.
-from nose.tools import assert_dict_equal
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_true
 from nose.tools import assert_false
 from nose.tools import assert_raises
 from nose.tools import raises
+try:
+    from nose.tools import assert_dict_equal
+except ImportError:
+    # Not in old versions of nose, but is only for formatting anyway
+    assert_dict_equal = assert_equal
 from nose import SkipTest
 from nose import with_setup
 


### PR DESCRIPTION
Until now, `get_params()` would return the steps of a pipeline by name, but setting them would fail silently (by setting an unused attribute); fixes bug #1800.

This allows users to grid search over alternative estimators for some step, as illustrated in the included example, or even to delete a step in a search by setting it to `None`.
But it may also be more directly practical: while a user may currently use `get_params` to extract an estimator from a nested pipeline using the double-underscore naming convention, e.g. [for selective serialisation](http://stackoverflow.com/questions/36259967/how-to-pickle-individual-steps-in-sklearns-pipeline/36273792#36273792), they cannot use the reciprocal `set_params` which this PR enables.

This changeset also prohibits step names that equal initialisation parameters of the pipeline; otherwise `FeatureUnion.set_params(transformer_weights=foo)` would be ambiguous.
