### PR TITLE
ENH allow SelectKBest to select all features in a parameter search

### DIFF
--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -189,6 +189,21 @@ def test_select_kbest_classif():
     assert_array_equal(support, gtruth)
 
 
+def test_select_kbest_all():
+    """
+    Test whether k="all" correctly returns all features.
+    """
+    X, y = make_classification(n_samples=200, n_features=20,
+                               n_informative=3, n_redundant=2,
+                               n_repeated=0, n_classes=8,
+                               n_clusters_per_class=1, flip_y=0.0,
+                               class_sep=10, shuffle=False, random_state=0)
+
+    univariate_filter = SelectKBest(f_classif, k='all')
+    X_r = univariate_filter.fit(X, y).transform(X)
+    assert_array_almost_equal(X, X_r)
+
+
 def test_select_fpr_classif():
     """
     Test whether the relative univariate feature selection

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -429,7 +429,8 @@ class SelectKBest(_ScoreFilter):
         if k == 'all':
             return np.ones(self.scores_.shape, dtype=bool)
         if k > len(self.scores_):
-            raise ValueError("cannot select %d features among %d"
+            raise ValueError("Cannot select %d features among %d. "
+                             "Use k='all' to return all features."
                              % (k, len(self.scores_)))
 
         scores = _clean_nans(self.scores_)

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -401,8 +401,9 @@ class SelectKBest(_ScoreFilter):
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues).
 
-    k : int, optional, default=10
+    k : int or SelectKBest.SELECT_ALL, optional, default=10
         Number of top features to select.
+        The SELECT_ALL option bypasses selection, for use in a parameter search.
 
     Attributes
     ----------
@@ -418,6 +419,7 @@ class SelectKBest(_ScoreFilter):
     way.
 
     """
+    SELECT_ALL = None
 
     def __init__(self, score_func=f_classif, k=10):
         self.k = k
@@ -425,6 +427,8 @@ class SelectKBest(_ScoreFilter):
 
     def _get_support_mask(self):
         k = self.k
+        if k is self.SELECT_ALL:
+            return np.ones(self.scores_.shape, dtype=bool)
         if k > len(self.scores_):
             raise ValueError("cannot select %d features among %d"
                              % (k, len(self.scores_)))

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -401,9 +401,9 @@ class SelectKBest(_ScoreFilter):
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues).
 
-    k : int or SelectKBest.SELECT_ALL, optional, default=10
+    k : int or "all", optional, default=10
         Number of top features to select.
-        The SELECT_ALL option bypasses selection, for use in a parameter search.
+        The "all" option bypasses selection, for use in a parameter search.
 
     Attributes
     ----------
@@ -419,7 +419,6 @@ class SelectKBest(_ScoreFilter):
     way.
 
     """
-    SELECT_ALL = None
 
     def __init__(self, score_func=f_classif, k=10):
         self.k = k
@@ -427,7 +426,7 @@ class SelectKBest(_ScoreFilter):
 
     def _get_support_mask(self):
         k = self.k
-        if k is self.SELECT_ALL:
+        if k == 'all':
             return np.ones(self.scores_.shape, dtype=bool)
         if k > len(self.scores_):
             raise ValueError("cannot select %d features among %d"


### PR DESCRIPTION
Currently it is difficult to perform a grid-search over k for `SelectKBest` feature selection such that one parameter option is to ignore `SelectKBest` altogether (i.e. `k` == infty). If `k > X.shape[1]`, it throws an error, and `X.shape` is not always known when the parameter grid is constructed. This patch allows one to use a parameter grid such as `{'k': [5, 10, 20, 40, 80, SelectKBest.SELECT_ALL]}` to include bypassing the selector as an option.

An alternative to this is to harness #1769 (together with `param_grid` being a list of dicts) to simply switch off the `SelectKBest` component. Perhaps neither solution is intuitive!
