### PR TITLE
ENH annotate metrics to simplify populating SCORERS

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -39,9 +39,11 @@ def needs_threshold(metric):
     metric.needs_threshold = True
     return metric
 
+
 def greater_is_better(metric):
     metric.greater_is_better = True
     return metric
+
 
 def lesser_is_better(metric):
     metric.greater_is_better = False
@@ -724,7 +726,7 @@ def zero_one_loss(y_true, y_pred, normalize=True):
     """
     y_true, y_pred = check_arrays(y_true, y_pred, allow_lists=True)
 
-    if is_multilabel(y_true):    
+    if is_multilabel(y_true):
         # Handle mix representation
         if type(y_true) != type(y_pred):
             labels = unique_labels(y_true, y_pred)
@@ -739,7 +741,7 @@ def zero_one_loss(y_true, y_pred, normalize=True):
             # numpy 1.3 : it is required to perform a unique before setxor1d
             #             to get unique label in numpy 1.3.
             #             This is needed in order to handle redundant labels.
-            # FIXME : check if this can be simplified when 1.3 is removed        
+            # FIXME : check if this can be simplified when 1.3 is removed
             loss = np.array([np.size(np.setxor1d(np.unique(pred),
                                                  np.unique(true))) > 0
                              for pred, true in zip(y_pred, y_true)])

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -31,6 +31,24 @@ from ..utils.multiclass import unique_labels
 
 
 ###############################################################################
+# Annotations
+###############################################################################
+
+# TODO: is there a better name for this, or its opposite, "categorical"?
+def needs_threshold(metric):
+    metric.needs_threshold = True
+    return metric
+
+def greater_is_better(metric):
+    metric.greater_is_better = True
+    return metric
+
+def lesser_is_better(metric):
+    metric.greater_is_better = False
+    return metric
+
+
+###############################################################################
 # General utilities
 ###############################################################################
 def auc(x, y, reorder=False):
@@ -96,6 +114,7 @@ def auc(x, y, reorder=False):
 ###############################################################################
 # Binary classification loss
 ###############################################################################
+@lesser_is_better
 def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
     """Average hinge loss (non-regularized)
 
@@ -159,6 +178,8 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
 ###############################################################################
 # Binary classification scores
 ###############################################################################
+@needs_threshold
+@greater_is_better
 def average_precision_score(y_true, y_score):
     """Compute average precision (AP) from prediction scores
 
@@ -205,6 +226,8 @@ def average_precision_score(y_true, y_score):
     return auc(recall, precision)
 
 
+@needs_threshold
+@greater_is_better
 def auc_score(y_true, y_score):
     """Compute Area Under the Curve (AUC) from prediction scores
 
@@ -251,6 +274,7 @@ def auc_score(y_true, y_score):
     return auc(fpr, tpr, reorder=True)
 
 
+@greater_is_better
 def matthews_corrcoef(y_true, y_pred):
     """Compute the Matthews correlation coefficient (MCC) for binary classes
 
@@ -306,6 +330,7 @@ def matthews_corrcoef(y_true, y_pred):
         return mcc
 
 
+@needs_threshold
 def precision_recall_curve(y_true, probas_pred):
     """Compute precision-recall pairs for different probability thresholds
 
@@ -418,6 +443,7 @@ def precision_recall_curve(y_true, probas_pred):
     return precision, recall, thresholds
 
 
+@needs_threshold
 def roc_curve(y_true, y_score, pos_label=None):
     """Compute Receiver operating characteristic (ROC)
 
@@ -640,6 +666,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
 ###############################################################################
 # Multiclass loss function
 ###############################################################################
+@lesser_is_better
 def zero_one_loss(y_true, y_pred, normalize=True):
     """Zero-one classification loss.
 
@@ -730,6 +757,7 @@ def zero_one_loss(y_true, y_pred, normalize=True):
             "'zero_one_loss' and will be removed in release 0.15."
             "Default behavior is changed from 'normalize=False' to "
             "'normalize=True'")
+@lesser_is_better
 def zero_one(y_true, y_pred, normalize=False):
     """Zero-One classification loss
 
@@ -771,6 +799,7 @@ def zero_one(y_true, y_pred, normalize=False):
 ###############################################################################
 # Multiclass score functions
 ###############################################################################
+@greater_is_better
 def accuracy_score(y_true, y_pred):
     """Accuracy classification score.
 
@@ -846,6 +875,7 @@ def accuracy_score(y_true, y_pred):
     return np.mean(score)
 
 
+@greater_is_better
 def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     """Compute the F1 score, also known as balanced F-score or F-measure
 
@@ -931,6 +961,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
                        pos_label=pos_label, average=average)
 
 
+@greater_is_better
 def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
                 average='weighted'):
     """Compute the F-beta score
@@ -1228,6 +1259,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         return avg_precision, avg_recall, avg_fscore, None
 
 
+@greater_is_better
 def precision_score(y_true, y_pred, labels=None, pos_label=1,
                     average='weighted'):
     """Compute the precision
@@ -1311,6 +1343,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     return p
 
 
+@greater_is_better
 def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     """Compute the recall
 
@@ -1393,6 +1426,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
 
 @deprecated("Function zero_one_score has been renamed to "
             'accuracy_score'" and will be removed in release 0.15.")
+@greater_is_better
 def zero_one_score(y_true, y_pred):
     """Zero-one classification score (accuracy)
 
@@ -1508,6 +1542,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
 ###############################################################################
 # Multilabel loss function
 ###############################################################################
+@lesser_is_better
 def hamming_loss(y_true, y_pred, classes=None):
     """Compute the average Hamming loss.
 
@@ -1611,6 +1646,7 @@ def hamming_loss(y_true, y_pred, classes=None):
 ###############################################################################
 # Regression loss functions
 ###############################################################################
+@lesser_is_better
 def mean_absolute_error(y_true, y_pred):
     """Mean absolute error regression loss
 
@@ -1644,6 +1680,7 @@ def mean_absolute_error(y_true, y_pred):
     return np.mean(np.abs(y_pred - y_true))
 
 
+@lesser_is_better
 def mean_squared_error(y_true, y_pred):
     """Mean squared error regression loss
 
@@ -1680,6 +1717,7 @@ def mean_squared_error(y_true, y_pred):
 ###############################################################################
 # Regression score functions
 ###############################################################################
+@greater_is_better
 def explained_variance_score(y_true, y_pred):
     """Explained variance regression score function
 
@@ -1724,6 +1762,7 @@ def explained_variance_score(y_true, y_pred):
     return 1 - numerator / denominator
 
 
+@greater_is_better
 def r2_score(y_true, y_pred):
     """R² (coefficient of determination) regression score function.
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -67,13 +67,13 @@ class Scorer(object):
         self.kwargs = kwargs
 
         if greater_is_better is None:
-            greater_is_better = self._get_annotation(score_func,
-                    'greater_is_better', True)
+            greater_is_better = self._get_annotation(
+                score_func, 'greater_is_better', True)
         self.greater_is_better = greater_is_better
 
         if needs_threshold is None:
-            needs_threshold = self._get_annotation(score_func,
-                    'needs_threshold', False)
+            needs_threshold = self._get_annotation(
+                score_func, 'needs_threshold', False)
         self.needs_threshold = needs_threshold
 
     @staticmethod
@@ -81,7 +81,7 @@ class Scorer(object):
         if hasattr(func, attr):
             return getattr(func, attr)
         while hasattr(func, 'func'):
-            func = getattr(func, 'func') # unwrap functools.partial
+            func = getattr(func, 'func')  # unwrap functools.partial
             if hasattr(func, attr):
                 return getattr(func, attr)
         return default
@@ -129,8 +129,9 @@ class Scorer(object):
             return self.score_func(y, y_pred, **self.kwargs)
 
 
-SCORERS = {name: Scorer(metric)
-        for name, metric in [
+SCORERS = {
+    name: Scorer(metric)
+    for name, metric in [
         # Regression
         ('r2', r2_score),
         ('mse', mean_squared_error),
@@ -144,4 +145,5 @@ SCORERS = {name: Scorer(metric)
         ('average_precision', average_precision_score),
         # Clustering
         ('ari', adjusted_rand_score),
-]}
+    ]
+}

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -7,7 +7,7 @@ from sklearn.utils.testing import assert_raises
 
 from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
 from sklearn.metrics.metrics import (needs_threshold, greater_is_better,
-        lesser_is_better)
+                                     lesser_is_better)
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.metrics import SCORERS, Scorer
 from sklearn.svm import LinearSVC
@@ -48,7 +48,7 @@ def test_scorer_annotated_params():
 def test_scorer_wrapped_annotated_params():
     """Test to ensure metric annotations are found within functools.partial"""
     metric = functools.partial(
-            lesser_is_better(lambda test, pred, param=5: 1.), param=1)
+        lesser_is_better(lambda test, pred, param=5: 1.), param=1)
     scorer = Scorer(metric)
     assert_equal(scorer.greater_is_better, False)
     assert_equal(scorer.needs_threshold, False)


### PR DESCRIPTION
This patch makes `needs_threshold` and `greater_is_better` an attribute of each metric, rather than providing them when a `Scorer` constructed from them. I am not sure these are the most appropriate names, but their use means information isn't duplicated in `scorer.py`. (It also would allow for composite `Scorer`s to be easily constructed assuming their support in #1768 is granted.)

Perhaps there should be other machine-readable annotations on our library of metrics:
- lower and upper bound
- `is_symmetric`
- `multiclass`/`binary`/`regression`

but their application is not clear to me.
