### PR TITLE
ENH Various ehancements to the cross_validation module

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -377,7 +377,7 @@ class StratifiedKFold(object):
 
     def __iter__(self):
         n_folds = self.n_folds
-        n = self.y.size
+        n = len(self.y)
         idx = np.argsort(self.y)
         if self.indices:
             ind = np.arange(n)
@@ -453,7 +453,7 @@ class LeaveOneLabelOut(object):
     def __init__(self, labels, indices=True):
         self.labels = labels
         self.unique_labels = unique(self.labels)
-        self.n_unique_labels = self.unique_labels.size
+        self.n_unique_labels = len(self.unique_labels)
         self.indices = indices
 
     def __iter__(self):
@@ -540,7 +540,7 @@ class LeavePLabelOut(object):
     def __init__(self, labels, p, indices=True):
         self.labels = labels
         self.unique_labels = unique(self.labels)
-        self.n_unique_labels = self.unique_labels.size
+        self.n_unique_labels = len(self.unique_labels)
         self.p = p
         self.indices = indices
 
@@ -549,9 +549,9 @@ class LeavePLabelOut(object):
         labels = np.array(self.labels, copy=True)
         comb = combinations(range(self.n_unique_labels), self.p)
         if self.indices:
-            ind = np.arange(labels.size)
+            ind = np.arange(len(labels))
         for idx in comb:
-            test_index = np.zeros(labels.size, dtype=np.bool)
+            test_index = np.zeros(len(labels), dtype=np.bool)
             idx = np.array(idx)
             for l in self.unique_labels[idx]:
                 test_index[labels == l] = True
@@ -899,7 +899,7 @@ def _validate_stratified_shuffle_split(y, test_size, train_size):
                          " number of labels for any class cannot"
                          " be less than 2.")
 
-    n_train, n_test = _validate_shuffle_split(y.size, test_size, train_size)
+    n_train, n_test = _validate_shuffle_split(len(y), test_size, train_size)
 
     if n_train < n_cls:
         raise ValueError('The train_size = %d should be greater or '
@@ -974,7 +974,7 @@ class StratifiedShuffleSplit(object):
                  indices=True, random_state=None, n_iterations=None):
 
         self.y = np.array(y)
-        self.n = self.y.size
+        self.n = len(self.y)
         self.n_iter = n_iter
         if n_iterations is not None:  # pragma: no cover
             warnings.warn("n_iterations was renamed to n_iter for consistency"
@@ -1159,9 +1159,9 @@ def _permutation_test_score(estimator, X, y, cv, scorer):
 def _shuffle(y, labels, random_state):
     """Return a shuffled copy of y eventually shuffle among same labels."""
     if labels is None:
-        ind = random_state.permutation(y.size)
+        ind = random_state.permutation(len(y))
     else:
-        ind = np.arange(labels.size)
+        ind = np.arange(len(labels))
         for label in unique(labels):
             this_mask = (labels == label)
             ind[this_mask] = random_state.permutation(ind[this_mask])

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -450,13 +450,14 @@ class LeaveOneLabelOut(object):
 
     def __init__(self, labels, indices=True):
         self.labels = labels
-        self.n_unique_labels = unique(labels).size
+        self.unique_labels = unique(self.labels)
+        self.n_unique_labels = self.unique_labels.size
         self.indices = indices
 
     def __iter__(self):
         # We make a copy here to avoid side-effects during iteration
         labels = np.array(self.labels, copy=True)
-        for i in unique(labels):
+        for i in self.unique_labels:
             test_index = np.zeros(len(labels), dtype=np.bool)
             test_index[labels == i] = True
             train_index = np.logical_not(test_index)
@@ -543,13 +544,12 @@ class LeavePLabelOut(object):
     def __iter__(self):
         # We make a copy here to avoid side-effects during iteration
         labels = np.array(self.labels, copy=True)
-        unique_labels = unique(labels)
         comb = combinations(range(self.n_unique_labels), self.p)
 
         for idx in comb:
             test_index = np.zeros(labels.size, dtype=np.bool)
             idx = np.array(idx)
-            for l in unique_labels[idx]:
+            for l in self.unique_labels[idx]:
                 test_index[labels == l] = True
             train_index = np.logical_not(test_index)
             if self.indices:

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -93,12 +93,13 @@ class LeaveOneOut(object):
 
     def __iter__(self):
         n = self.n
+        if self.indices:
+            ind = np.arange(n)
         for i in range(n):
             test_index = np.zeros(n, dtype=np.bool)
             test_index[i] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(n)
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             yield train_index, test_index
@@ -169,12 +170,13 @@ class LeavePOut(object):
         n = self.n
         p = self.p
         comb = combinations(range(n), p)
+        if self.indices:
+            ind = np.arange(n)
         for idx in comb:
             test_index = np.zeros(n, dtype=np.bool)
             test_index[np.array(idx)] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(n)
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             yield train_index, test_index
@@ -377,13 +379,13 @@ class StratifiedKFold(object):
         n_folds = self.n_folds
         n = self.y.size
         idx = np.argsort(self.y)
-
+        if self.indices:
+            ind = np.arange(n)
         for i in range(n_folds):
             test_index = np.zeros(n, dtype=np.bool)
             test_index[idx[i::n_folds]] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(n)
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             yield train_index, test_index
@@ -457,12 +459,13 @@ class LeaveOneLabelOut(object):
     def __iter__(self):
         # We make a copy here to avoid side-effects during iteration
         labels = np.array(self.labels, copy=True)
+        if self.indices:
+            ind = np.arange(len(labels))
         for i in self.unique_labels:
             test_index = np.zeros(len(labels), dtype=np.bool)
             test_index[labels == i] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(len(labels))
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             yield train_index, test_index
@@ -545,7 +548,8 @@ class LeavePLabelOut(object):
         # We make a copy here to avoid side-effects during iteration
         labels = np.array(self.labels, copy=True)
         comb = combinations(range(self.n_unique_labels), self.p)
-
+        if self.indices:
+            ind = np.arange(labels.size)
         for idx in comb:
             test_index = np.zeros(labels.size, dtype=np.bool)
             idx = np.array(idx)
@@ -553,7 +557,6 @@ class LeavePLabelOut(object):
                 test_index[labels == l] = True
             train_index = np.logical_not(test_index)
             if self.indices:
-                ind = np.arange(labels.size)
                 train_index = ind[train_index]
                 test_index = ind[test_index]
             yield train_index, test_index


### PR DESCRIPTION
One additional explanation. I discovered that in some places `array.size` was used and in some places `len(array)`.
So I used IPython's `%timeit` to compare the two and I discovered that `len(array)` is a bit faster:

``` python
In [1]: import numpy as np

In [2]: a = np.ones(100)

In [3]: b = np.ones(1000000)

In [4]: c = np.ones((10000, 10000))

In [5]: %timeit a.size
10000000 loops, best of 3: 71.9 ns per loop

In [6]: %timeit len(a)
10000000 loops, best of 3: 58.6 ns per loop

In [7]: %timeit b.size
10000000 loops, best of 3: 75.4 ns per loop

In [8]: %timeit len(b)
10000000 loops, best of 3: 61.2 ns per loop

In [9]: %timeit c.size
10000000 loops, best of 3: 75.8 ns per loop

In [10]: %timeit len(c)
10000000 loops, best of 3: 60.9 ns per loop

In [11]:
```
