### PR TITLE
CountVectorizer Rewrite

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -294,9 +294,10 @@ reasonable (please see  the :ref:`reference documentation
   CountVectorizer(analyzer=u'word', binary=False, charset=u'utf-8',
           charset_error=u'strict', dtype=<type 'numpy.int64'>,
           input=u'content', lowercase=True, max_df=1.0, max_features=None,
-          min_df=1, ngram_range=(1, 1), preprocessor=None, stop_words=None,
+          min_df=1, ngram_range=(1, 1), preprocessor=None, 
+          sort_features=True, stop_words=None,
           strip_accents=None, token_pattern=u'(?u)\\b\\w\\w+\\b',
-          tokenizer=None, vocabulary=None, sort_features=True)
+          tokenizer=None, vocabulary=None)
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
 corpus of text documents::

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -294,9 +294,9 @@ reasonable (please see  the :ref:`reference documentation
   CountVectorizer(analyzer=u'word', binary=False, charset=u'utf-8',
           charset_error=u'strict', dtype=<type 'numpy.int64'>,
           input=u'content', lowercase=True, max_df=1.0, max_features=None,
-          min_df=1, ngram_range=(1, 1), preprocessor=None, 
-          sort_features=True, stop_words=None,
-          strip_accents=None, token_pattern=u'(?u)\\b\\w\\w+\\b',
+          min_df=1, ngram_range=(1, 1), preprocessor=None,
+          stop_words=None, strip_accents=None,
+          token_pattern=u'(?u)\\b\\w\\w+\\b',
           tokenizer=None, vocabulary=None)
 
 Let's use it to tokenize and count the word occurrences of a minimalistic

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -296,7 +296,7 @@ reasonable (please see  the :ref:`reference documentation
           input=u'content', lowercase=True, max_df=1.0, max_features=None,
           min_df=1, ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=u'(?u)\\b\\w\\w+\\b',
-          tokenizer=None, vocabulary=None)
+          tokenizer=None, vocabulary=None,sort_features=True)
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
 corpus of text documents::

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -311,7 +311,7 @@ corpus of text documents::
   >>> X = vectorizer.fit_transform(corpus)
   >>> X                                       # doctest: +NORMALIZE_WHITESPACE
   <4x9 sparse matrix of type '<type 'numpy.int64'>'
-      with 19 stored elements in COOrdinate format>
+      with 19 stored elements in Compressed Sparse Column format>
 
 The default configuration tokenizes the string by extracting words of
 at least 2 letters. The specific function that does this step can be
@@ -536,7 +536,7 @@ span across words::
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
   ...                                         # doctest: +NORMALIZE_WHITESPACE
   <1x4 sparse matrix of type '<type 'numpy.int64'>'
-     with 4 stored elements in COOrdinate format>
+     with 4 stored elements in Compressed Sparse Column format>
   >>> ngram_vectorizer.get_feature_names()
   [u' fox ', u' jump', u'jumpy', u'umpy ']
 
@@ -544,7 +544,7 @@ span across words::
   >>> ngram_vectorizer.fit_transform(['jumpy fox'])
   ...                                         # doctest: +NORMALIZE_WHITESPACE
   <1x5 sparse matrix of type '<type 'numpy.int64'>'
-      with 5 stored elements in COOrdinate format>
+      with 5 stored elements in Compressed Sparse Column format>
   >>> ngram_vectorizer.get_feature_names()
   [u'jumpy', u'mpy f', u'py fo', u'umpy ', u'y fox']
 

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -296,7 +296,7 @@ reasonable (please see  the :ref:`reference documentation
           input=u'content', lowercase=True, max_df=1.0, max_features=None,
           min_df=1, ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=u'(?u)\\b\\w\\w+\\b',
-          tokenizer=None, vocabulary=None,sort_features=True)
+          tokenizer=None, vocabulary=None, sort_features=True)
 
 Let's use it to tokenize and count the word occurrences of a minimalistic
 corpus of text documents::

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -515,8 +515,8 @@ def test_feature_names():
 
     feature_names = cv.get_feature_names()
     assert_equal(len(feature_names), n_features)
-    assert_array_equal(['beer', 'burger', 'celeri', 'coke', 'pizza',
-                        'salad', 'sparkling', 'tomato', 'water'],
+    assert_array_equal(['pizza', 'beer', 'burger', 'coke', 'salad',
+                        'celeri', 'sparkling', 'water', 'tomato'],
                        feature_names)
 
     for idx, name in enumerate(feature_names):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -809,7 +809,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                         csc_m, feature_to_position, stop_words_, max_features)
             self.stop_words_ = stop_words_
             self.vocabulary_ = feature_to_position
-        return csc_m.tocoo()
+        return csc_m
 
     def transform(self, raw_documents):
         """Extract token counts out of raw text documents using the vocabulary

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -772,7 +772,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                     j_indices.append(feature_to_position[feature])
                     values.append(1)
             # assert j == len(feature_to_count)
-            del feature_to_count
+            del feature_to_count  # free memory
             n_doc = i + 1
             max_doc_count = (max_df if isinstance(max_df, numbers.Integral)
                                          else int(round(max_df * n_doc)))
@@ -788,6 +788,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         csc_m = self._term_counts_to_matrix(
                                 n_doc, i_indices,
                                 j_indices, values, n_features).tocsc()
+        del i_indices, j_indices, values  # free memory
         if binary:
             csc_m.data.fill(1)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -557,12 +557,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
 
-    sort_features : boolean, True by default.
-        If True, the output matrix has the feature columns in order
-        corresponding to sorted vocabulary.  If False, order of the
-        columns is determined by features first encountered.
-        Computation is faster without sorting.
-
     Attributes
     ----------
     `vocabulary_` : dict
@@ -585,8 +579,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), analyzer='word',
                  max_df=1.0, min_df=1, max_features=None,
-                 vocabulary=None, binary=False, dtype=np.int64,
-                 sort_features=True):
+                 vocabulary=None, binary=False, dtype=np.int64):
         self.input = input
         self.charset = charset
         self.charset_error = charset_error
@@ -620,7 +613,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             self.fixed_vocabulary = False
         self.binary = binary
         self.dtype = dtype
-        self.sort_features = sort_features
 
     def _term_counts_to_matrix(self, n_doc, i_indices,
                                j_indices, values, n_features):
@@ -644,16 +636,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         #     print "self.binary", self.binary
         #     print spmatrix.todense()
         return spmatrix
-
-    def _sort_features_and_matrix(self, cscmatrix, feature_to_position):
-        '''sort dict by keys and assign values to the sorted key index'''
-        sorted_by_name_dict = {}
-        sorted_features = sorted(feature_to_position)
-        new_positions = []
-        for i, k in enumerate(sorted_features):
-            sorted_by_name_dict[k] = i
-            new_positions.append(feature_to_position[k])
-        return cscmatrix[:, new_positions], sorted_by_name_dict
 
     def _remove_highandlow(self, cscmatrix,
                            feature_to_position, high, low):
@@ -814,7 +796,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         max_df = self.max_df
         min_df = self.min_df
         max_features = self.max_features
-        sort_features = self.sort_features
         binary = self.binary
         i_indices = _make_int_array()
         j_indices = _make_int_array()
@@ -855,9 +836,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if binary:
             csc_m.data.fill(1)
         if not fixed_vocab:
-            if sort_features:
-                csc_m, feature_to_position = self.\
-                    _sort_features_and_matrix(csc_m, feature_to_position)
             stop_words_ = set()
             # get rid of features between max_df and min_df
             if max_doc_count < n_doc or min_doc_count > 1:
@@ -1211,12 +1189,6 @@ class TfidfVectorizer(CountVectorizer):
     sublinear_tf : boolean, optional
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
-    sort_features : boolean, True by default.
-        If True, the output matrix has the feature columns in order
-        corresponding to sorted vocabulary.  If False, order of the
-        columns is determined by features first encountered.
-        Computation is faster without sorting.
-
     See also
     --------
     CountVectorizer
@@ -1236,7 +1208,7 @@ class TfidfVectorizer(CountVectorizer):
                  ngram_range=(1, 1), max_df=1.0, min_df=1,
                  max_features=None, vocabulary=None, binary=False,
                  dtype=np.int64, norm='l2', use_idf=True, smooth_idf=True,
-                 sublinear_tf=False, sort_features=True):
+                 sublinear_tf=False):
 
         super(TfidfVectorizer, self).__init__(
             input=input, charset=charset, charset_error=charset_error,
@@ -1245,7 +1217,7 @@ class TfidfVectorizer(CountVectorizer):
             stop_words=stop_words, token_pattern=token_pattern,
             ngram_range=ngram_range, max_df=max_df, min_df=min_df,
             max_features=max_features, vocabulary=vocabulary, binary=False,
-            dtype=dtype, sort_features=sort_features)
+            dtype=dtype)
 
         self._tfidf = TfidfTransformer(norm=norm, use_idf=use_idf,
                                        smooth_idf=smooth_idf,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -94,7 +94,7 @@ def _check_stop_list(stop):
 class VectorizerMixin(object):
     """Provides common code for text vectorizers (tokenization logic)."""
 
-    _white_spaces = re.compile(ur"\s\s+")
+    _white_spaces = re.compile(r"\s\s+")
 
     def decode(self, doc):
         """Decode the input into a string of unicode symbols
@@ -127,14 +127,14 @@ class VectorizerMixin(object):
             for n in xrange(min_n,
                             min(max_n + 1, n_original_tokens + 1)):
                 for i in xrange(n_original_tokens - n + 1):
-                    tokens.append(u" ".join(original_tokens[i: i + n]))
+                    tokens.append(" ".join(original_tokens[i: i + n]))
 
         return tokens
 
     def _char_ngrams(self, text_document):
         """Tokenize text_document into a sequence of character n-grams"""
         # normalize white spaces
-        text_document = self._white_spaces.sub(u" ", text_document)
+        text_document = self._white_spaces.sub(" ", text_document)
 
         text_len = len(text_document)
         ngrams = []
@@ -155,7 +155,7 @@ class VectorizerMixin(object):
         min_n, max_n = self.ngram_range
         ngrams = []
         for w in text_document.split():
-            w = u' ' + w + u' '
+            w = ' ' + w + ' '
             w_len = len(w)
             for n in xrange(min_n, max_n + 1):
                 offset = 0
@@ -371,7 +371,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
     def __init__(self, input='content', charset='utf-8',
                  charset_error='strict', strip_accents=None,
                  lowercase=True, preprocessor=None, tokenizer=None,
-                 stop_words=None, token_pattern=ur"(?u)\b\w\w+\b",
+                 stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), analyzer='word', n_features=(2 ** 20),
                  binary=False, norm='l2', non_negative=False,
                  dtype=np.float64):
@@ -450,8 +450,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     If you do not provide an a-priori dictionary and you do not use an analyzer
     that does some kind of feature selection then the number of features will
-    be equal to the vocabulary size found by analysing the data. The default
-    analyzer does simple stop word filtering for English.
+    be equal to the vocabulary size found by analysing the data. 
 
     Parameters
     ----------
@@ -587,7 +586,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), analyzer='word',
                  max_df=1.0, min_df=1, max_features=None,
-                 vocabulary=None, binary=False, dtype=long, sort_features=True):
+                 vocabulary=None, binary=False, dtype=np.int64, sort_features=True):
         self.input = input
         self.charset = charset
         self.charset_error = charset_error
@@ -1150,8 +1149,9 @@ class TfidfVectorizer(CountVectorizer):
                  preprocessor=None, tokenizer=None, analyzer='word',
                  stop_words=None, token_pattern=r"(?u)\b\w\w+\b",
                  ngram_range=(1, 1), max_df=1.0, min_df=1,
-                 max_features=None, vocabulary=None, binary=False, dtype=long,
-                 norm='l2', use_idf=True, smooth_idf=True, sublinear_tf=False):
+                 max_features=None, vocabulary=None, binary=False, 
+                 dtype=np.int64, norm='l2', use_idf=True, smooth_idf=True, 
+                 sublinear_tf=False):
 
         super(TfidfVectorizer, self).__init__(
             input=input, charset=charset, charset_error=charset_error,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -4,6 +4,7 @@
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
 #          Robert Layton <robertlayton@gmail.com>
 #          Jochen Wersdörfer <jochen@wersdoerfer.de>
+#          Roman Sinayev <roman.sinayev@gmail.com>
 #
 # License: BSD Style.
 """


### PR DESCRIPTION
Rewrote CountVectorizer fit transform.  I did some tests and it performs about 40% faster.  For example, here's the plot on my dataset of 50000 English documents of 150-1000 words in length.  It passes all the tests in the sklearn/feature_extraction/tests/test_text.py
![countvect_1](https://f.cloud.github.com/assets/786402/259497/40bfd536-8cbf-11e2-89c6-99099cd87f50.png)
