### PR TITLE
ENH extensible parameter search results

### DIFF
--- a/examples/grid_search_digits.py
+++ b/examples/grid_search_digits.py
@@ -59,9 +59,10 @@ for score in scores:
     print()
     print("Grid scores on development set:")
     print()
-    means = clf.grid_results_['test_score']
+    candidates = clf.search_results_['parameters']
+    means = clf.search_results_['test_score']
     stds = clf.fold_results_['test_score'].std(axis=1)
-    for params, mean, std in zip(clf.grid_results_['parameters'], means, stds):
+    for params, mean, std in zip(candidates, means, stds):
         print("%0.3f (+/-%0.03f) for %r"
               % (mean, std / 2, params))
     print()

--- a/examples/grid_search_digits.py
+++ b/examples/grid_search_digits.py
@@ -59,9 +59,11 @@ for score in scores:
     print()
     print("Grid scores on development set:")
     print()
-    for params, mean_score, scores in clf.cv_scores_:
+    means = clf.grid_results_['test_score']
+    stds = clf.fold_results_['test_score'].std(axis=1)
+    for params, mean, std in zip(clf.grid_results_['parameters'], means, stds):
         print("%0.3f (+/-%0.03f) for %r"
-              % (mean_score, scores.std() / 2, params))
+              % (mean, std / 2, params))
     print()
 
     print("Detailed classification report:")

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -105,12 +105,8 @@ for (k, (C, gamma, clf)) in enumerate(classifiers):
     pl.axis('tight')
 
 # plot the scores of the grid
-# cv_scores_ contains parameter settings and scores
-score_dict = grid.cv_scores_
-
-# We extract just the scores
-scores = [x[1] for x in score_dict]
-scores = np.array(scores).reshape(len(C_range), len(gamma_range))
+scores = grid.grid_results_['test_score']
+scores = scores.reshape(len(C_range), len(gamma_range))
 
 # draw heatmap of accuracy as a function of gamma and C
 pl.figure(figsize=(8, 6))

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -105,7 +105,7 @@ for (k, (C, gamma, clf)) in enumerate(classifiers):
     pl.axis('tight')
 
 # plot the scores of the grid
-scores = grid.grid_results_['test_score']
+scores = grid.search_results_['test_score']
 scores = scores.reshape(len(C_range), len(gamma_range))
 
 # draw heatmap of accuracy as a function of gamma and C

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -131,7 +131,7 @@ for fignum, (clf, cs, X, y) in enumerate(clf_sets):
                             cv=ShuffleSplit(n=n_samples, train_size=train_size,
                                             n_iter=250, random_state=1))
         grid.fit(X, y)
-        scores = [x[1] for x in grid.cv_scores_]
+        scores = grid.grid_results_['test_score']
 
         scales = [(1, 'No scaling'),
                   ((n_samples * train_size), '1/n_samples'),

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -131,7 +131,7 @@ for fignum, (clf, cs, X, y) in enumerate(clf_sets):
                             cv=ShuffleSplit(n=n_samples, train_size=train_size,
                                             n_iter=250, random_state=1))
         grid.fit(X, y)
-        scores = grid.grid_results_['test_score']
+        scores = grid.search_results_['test_score']
 
         scales = [(1, 'No scaling'),
                   ((n_samples * train_size), '1/n_samples'),

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1093,7 +1093,7 @@ def fit_fold(estimator, X, y, train, test, scorer,
         else:
             msg = '%s' % (', '.join('%s=%s' % (k, v)
                           for k, v in est_params.items()))
-        print("[CVEvaluator]%s %s" % (msg, (64 - len(msg)) * '.'))
+        print("[fit_fold]%s %s" % (msg, (64 - len(msg)) * '.'))
 
     n_samples = _num_samples(X)
 
@@ -1157,7 +1157,7 @@ def fit_fold(estimator, X, y, train, test, scorer,
         end_msg = "%s -%s" % (msg,
                               logger.short_format_time(time.time() -
                                                        start_time))
-        print("[CVEvaluator]%s %s" % ((64 - len(end_msg)) * '.', end_msg))
+        print("[fit_fold]%s %s" % ((64 - len(end_msg)) * '.', end_msg))
     return {
         'test_score': test_score,
         'test_n_samples': _num_samples(X_test),

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1070,7 +1070,7 @@ def fit_fold(estimator, X, y, train, test, scorer,
         Verbosity level.
 
     est_params : dict
-        Parameters to be set on estimator for this grid point.
+        Parameters to be set on estimator for this fold.
 
     **fit_params : kwargs
         Additional parameter passed to the fit function of the estimator.

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1042,7 +1042,7 @@ class StratifiedShuffleSplit(object):
 ##############################################################################
 
 def fit_fold(estimator, X, y, train, test, scorer,
-                   verbose, est_params=None, fit_params=None):
+             verbose, est_params=None, fit_params=None):
     """Run fit on one set of parameters.
 
     Parameters
@@ -1159,8 +1159,8 @@ def fit_fold(estimator, X, y, train, test, scorer,
                                                        start_time))
         print("[CVEvaluator]%s %s" % ((64 - len(end_msg)) * '.', end_msg))
     return {
-            'test_score': test_score,
-            'test_n_samples': _num_samples(X_test),
+        'test_score': test_score,
+        'test_n_samples': _num_samples(X_test),
     }
 
 
@@ -1221,8 +1221,8 @@ class CVEvaluator(object):
     """
 
     def __init__(self, estimator, X, y=None, scoring=None, cv=None, iid=True,
-            n_jobs=1, pre_dispatch='2*n_jobs', verbose=0, fit_params=None,
-            score_func=None):
+                 n_jobs=1, pre_dispatch='2*n_jobs', verbose=0, fit_params=None,
+                 score_func=None):
 
         X, y = check_arrays(X, y, sparse_format='csr', allow_lists=True)
         self.cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
@@ -1245,14 +1245,14 @@ class CVEvaluator(object):
                 "does not." % estimator)
 
         self.parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
-                pre_dispatch=pre_dispatch)
+                                 pre_dispatch=pre_dispatch)
         self.fit_fold_kwargs = {
-                'X': X,
-                'y': y,
-                'estimator': clone(estimator),
-                'scorer': scorer,
-                'verbose': verbose,
-                'fit_params': fit_params,
+            'X': X,
+            'y': y,
+            'estimator': clone(estimator),
+            'scorer': scorer,
+            'verbose': verbose,
+            'fit_params': fit_params,
         }
 
     def calc_means(self, scores, n_samples):
@@ -1290,16 +1290,16 @@ class CVEvaluator(object):
         ]
 
         # dicts to structured arrays (assume keys are same throughout):
-        keys = sorted(iterkeys(out[0][0])) 
-        arrays = ([[fold_results[key] for fold_results in point]
-                              for point in out]
-                 for key in keys)
+        keys = sorted(iterkeys(out[0][0]))
+        arrays = (
+            [[fold_results[key] for fold_results in point] for point in out]
+            for key in keys)
         out = np.rec.fromarrays(arrays, names=keys)
 
         # for now, only one mean:
         means = np.rec.fromarrays(
-                [self.calc_means(out['test_score'], out['test_n_samples'])],
-                names=['test_score']
+            [self.calc_means(out['test_score'], out['test_n_samples'])],
+            names=['test_score']
         )
 
         return means, out
@@ -1312,8 +1312,8 @@ class CVEvaluator(object):
         ----------
         parameters : dict or iterable of dicts, optional
             If provided, the estimator will be cloned and have these parameters
-            set. If an iterable of parameter settings is given, cross-validation
-            is performed for each set of parameters.
+            set. If an iterable of parameter settings is given,
+            cross-validation is performed for each set of parameters.
 
         Returns
         -------
@@ -1343,9 +1343,10 @@ class CVEvaluator(object):
             out_slice = slice(None)
 
         out = self.parallel(
-            delayed(fit_fold)(est_params=est_params,
-                train=train, test=test,
-                **self.fit_fold_kwargs)
+            delayed(fit_fold)(
+                est_params=est_params, train=train, test=test,
+                **self.fit_fold_kwargs
+            )
             for est_params in param_iter for train, test in self.cv)
 
         means, out = self._format_results(out)
@@ -1361,8 +1362,8 @@ class CVEvaluator(object):
         ----------
         parameters : dict or iterable of dicts, optional
             If provided, the estimator will be cloned and have these parameters
-            set. If an iterable of parameter settings is given, cross-validation
-            is performed for each set of parameters.
+            set. If an iterable of parameter settings is given,
+            cross-validation is performed for each set of parameters.
 
         Returns
         -------
@@ -1381,8 +1382,8 @@ class CVEvaluator(object):
         ----------
         parameters : dict or iterable of dicts, optional
             If provided, the estimator will be cloned and have these parameters
-            set. If an iterable of parameter settings is given, cross-validation
-            is performed for each set of parameters.
+            set. If an iterable of parameter settings is given,
+            cross-validation is performed for each set of parameters.
 
         Returns
         -------
@@ -1395,8 +1396,9 @@ class CVEvaluator(object):
 
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
                     verbose=0, fit_params=None, score_func=None):
-    cv_eval = CVEvaluator(estimator, X, y, scoring=scoring, cv=cv, n_jobs=n_jobs,
-            verbose=verbose, fit_params=fit_params, score_func=score_func)
+    cv_eval = CVEvaluator(
+        estimator, X, y, scoring=scoring, cv=cv, n_jobs=n_jobs,
+        verbose=verbose, fit_params=fit_params, score_func=score_func)
     return cv_eval.score_folds()
 
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1165,7 +1165,7 @@ def fit_fold(estimator, X, y, train, test, scorer,
 
 
 class CVEvaluator(object):
-    """Evaluate a score by cross-validation
+    """Parallelized cross-validation for a given estimator and dataset
 
     Parameters
     ----------
@@ -1186,7 +1186,8 @@ class CVEvaluator(object):
         for details.
 
     cv : integer or cross-validation generator, optional
-        A cross-validation generator or number of stratified folds (default 3).
+        A cross-validation generator or number of folds (default 3). Folds will
+        be stratified if the estimator is a classifier.
 
     iid : boolean, optional
         If True (default), the data is assumed to be identically distributed
@@ -1394,8 +1395,63 @@ class CVEvaluator(object):
         return self(parameters)[0]['test_score']
 
 
-def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
-                    verbose=0, fit_params=None, score_func=None):
+def cross_val_score(estimator, X, y=None, scoring=None, cv=None, iid=True,
+                    n_jobs=1, verbose=0, fit_params=None, score_func=None):
+    """Evaluate a score by cross-validation
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit'
+        The object to use to fit the data.
+
+    X : array-like of shape at least 2D
+        The data to fit.
+
+    y : array-like, optional
+        The target variable to try to predict in the case of
+        supervised learning.
+
+    scoring : string or callable, optional
+        Either one of either a string ("zero_one", "f1", "roc_auc", ... for
+        classification, "mse", "r2", ... for regression) or a callable.
+        See 'Scoring objects' in the model evaluation section of the user guide
+        for details.
+
+    cv : integer or cross-validation generator, optional
+        A cross-validation generator or number of folds (default 3). Folds will
+        be stratified if the estimator is a classifier.
+
+    iid : boolean, optional
+        If True (default), the data is assumed to be identically distributed
+        across the folds, and the mean score is the total score per sample,
+        and not the mean score across the folds.
+
+    n_jobs : integer, optional
+        The number of jobs to run in parallel (default 1). -1 means 'all CPUs'.
+
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+
+            - None, in which case all the jobs are immediatly
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+
+            - An int, giving the exact number of total jobs that are
+              spawned
+
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    verbose : integer, optional
+        The verbosity level.
+
+    fit_params : dict, optional
+        Parameters to pass to the fit method of the estimator.
+    """
     cv_eval = CVEvaluator(
         estimator, X, y, scoring=scoring, cv=cv, n_jobs=n_jobs,
         verbose=verbose, fit_params=fit_params, score_func=score_func)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -366,27 +366,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                     "should have a 'score' method. The estimator %s "
                     "does not." % self.estimator)
 
-    def _set_methods(self):
-        """Create predict and  predict_proba if present in best estimator."""
-        if hasattr(self.best_estimator_, 'predict'):
-            self.predict = self.best_estimator_.predict
-        if hasattr(self.best_estimator_, 'predict_proba'):
-            self.predict_proba = self.best_estimator_.predict_proba
-
-    def _merge_result_dicts(self, result_dicts):
-        """
-        From a result dict for each fold, produce a single dict with an array
-        for each key.
-        For example [[{'score': 1}, {'score': 2}],
-                     [{'score': 3}, {'score': 4}]]
-                 -> {'score': np.array([[1, 2], [3, 4]])}"""
-        # assume keys are same throughout
-        result_keys = list(iterkeys(result_dicts[0][0]))
-        arrays = ([[fold_results[key] for fold_results in point]
-                   for point in result_dicts]
-                  for key in result_keys)
-        return np.rec.fromarrays(arrays, names=result_keys)
-
     def _fit(self, X, y, parameter_iterator, **params):
         """Actual fitting,  performing the search over parameters."""
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -187,10 +187,8 @@ class ParameterSampler(object):
         return self.n_iter
 
 
-
-
 @deprecated('fit_grid_point is deprecated and will be removed in 0.15. '
-        'Use cross_validation.fit_fold instead.')
+            'Use cross_validation.fit_fold instead.')
 def fit_grid_point(X, y, base_clf, clf_params, train, test, scorer,
                    verbose, loss_func=None, **fit_params):
     """Run fit on one set of parameters.
@@ -239,8 +237,10 @@ def fit_grid_point(X, y, base_clf, clf_params, train, test, scorer,
     n_samples_test : int
         Number of test samples in this split.
     """
-    res = fit_fold(base_clf, X, y, train, test, scorer, verbose,
-            loss_func=None, est_params=clf_params, fit_params=fit_params)
+    res = fit_fold(
+        base_clf, X, y, train, test, scorer, verbose,
+        loss_func=None, est_params=clf_params, fit_params=fit_params
+    )
     return res['test_score'], clf_params, res['test_n_samples']
 
 
@@ -331,7 +331,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     @property
     def grid_scores_(self):
         warnings.warn("grid_scores_ is deprecated and will be removed in 0.15."
-                      " Use grid_results_ and fold_results_ instead.", DeprecationWarning)
+                      " Use grid_results_ and fold_results_ instead.",
+                      DeprecationWarning)
         return zip(self.grid_results_['parameters'],
                    self.grid_results_['test_score'],
                    self.fold_results_['test_score'])
@@ -376,13 +377,14 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         """
         From a result dict for each fold, produce a single dict with an array
         for each key.
-        For example [[{'score': 1}, {'score': 2}], [{'score': 3}, {'score': 4}]]
+        For example [[{'score': 1}, {'score': 2}],
+                     [{'score': 3}, {'score': 4}]]
                  -> {'score': np.array([[1, 2], [3, 4]])}"""
         # assume keys are same throughout
-        result_keys = list(iterkeys(result_dicts[0][0])) 
+        result_keys = list(iterkeys(result_dicts[0][0]))
         arrays = ([[fold_results[key] for fold_results in point]
-                              for point in result_dicts]
-                 for key in result_keys)
+                   for point in result_dicts]
+                  for key in result_keys)
         return np.rec.fromarrays(arrays, names=result_keys)
 
     def _fit(self, X, y, parameter_iterator, **params):
@@ -415,18 +417,21 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                                  % (len(y), n_samples))
             y = np.asarray(y)
 
-        cv_eval = CVEvaluator(self.estimator, X, y, scoring=self.scorer_,
-                cv=self.cv, iid=self.iid, fit_params=self.fit_params,
-                n_jobs=self.n_jobs, pre_dispatch=self.pre_dispatch,
-                verbose=self.verbose)
+        cv_eval = CVEvaluator(
+            self.estimator, X, y, scoring=self.scorer_, cv=self.cv,
+            iid=self.iid, fit_params=self.fit_params, n_jobs=self.n_jobs,
+            pre_dispatch=self.pre_dispatch, verbose=self.verbose
+        )
         grid_results, cv_results = cv_eval(parameter_iterator)
 
         # Append 'parameters' to grid_results
         # Broken due to https://github.com/numpy/numpy/issues/2346:
         # grid_results = recfunctions.append_fields(grid_results, 'parameters',
         #        np.asarray(list(parameter_iterator)), usemask=False)
-        new_grid_results = np.zeros(grid_results.shape,
-                dtype=grid_results.dtype.descr + [('parameters', 'O')])
+        new_grid_results = np.zeros(
+            grid_results.shape,
+            dtype=grid_results.dtype.descr + [('parameters', 'O')]
+        )
         for name in grid_results.dtype.names:
             new_grid_results[name] = grid_results[name]
         new_grid_results['parameters'] = list(parameter_iterator)
@@ -458,7 +463,9 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         if self.refit:
             # fit the best estimator using the entire dataset
             # clone first to work around broken estimators
-            best_estimator = clone(self.estimator).set_params(**self.best_params_)
+            best_estimator = clone(self.estimator).set_params(
+                **self.best_params_
+            )
             if y is not None:
                 best_estimator.fit(X, y, **self.fit_params)
             else:

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -164,11 +164,15 @@ def test_grid_scores():
             assert_true(grid_search.grid_scores_[i][0]
                         == {'foo_param': foo_i})
             # mean score
-            assert_almost_equal(grid_search.grid_scores_[i][1],
-                        (1. if foo_i > 1 else 0.))
+            assert_almost_equal(
+                grid_search.grid_scores_[i][1],
+                (1. if foo_i > 1 else 0.)
+            )
             # all fold scores
-            assert_array_equal(grid_search.grid_scores_[i][2],
-                        [1. if foo_i > 1 else 0.] * n_folds)
+            assert_array_equal(
+                grid_search.grid_scores_[i][2],
+                [1. if foo_i > 1 else 0.] * n_folds
+            )
 
 
 def test_trivial_results():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -138,7 +138,7 @@ def test_grid_search():
     assert_equal(grid_search.best_score_, 1.)
 
     for i, foo_i in enumerate([1, 2, 3]):
-        assert_true(grid_search.grid_results_['parameters'][i]
+        assert_true(grid_search.search_results_['parameters'][i]
                     == {'foo_param': foo_i})
     # Smoke test the score etc:
     grid_search.score(X, y)
@@ -178,19 +178,19 @@ def test_grid_scores():
 def test_trivial_results():
     """Test search over a "grid" with only one point.
 
-    Non-regression test: grid_results_, etc. wouldn't be set by GridSearchCV.
+    Non-regression test: search_results_, etc. wouldn't be set by GridSearchCV.
     """
     clf = MockClassifier()
     grid_search = GridSearchCV(clf, {'foo_param': [1]})
     grid_search.fit(X, y)
     # Ensure attributes are set
-    grid_search.grid_results_
+    grid_search.search_results_
     grid_search.fold_results_
     grid_search.best_index_
 
     random_search = RandomizedSearchCV(clf, {'foo_param': [0]})
     random_search.fit(X, y)
-    grid_search.grid_results_
+    grid_search.search_results_
     grid_search.fold_results_
     grid_search.best_index_
 
@@ -235,7 +235,7 @@ def test_grid_search_iid():
     assert_array_almost_equal(scores, [1, 1. / 3.])
     # for first split, 1/4 of dataset is in test, for second 3/4.
     # take weighted average
-    average_score = grid_search.grid_results_[0]['test_score']
+    average_score = grid_search.search_results_[0]['test_score']
     assert_almost_equal(average_score, 1 * 1. / 4. + 1. / 3. * 3. / 4.)
 
     # once with iid=False (default)
@@ -246,7 +246,7 @@ def test_grid_search_iid():
     scores = grid_search.fold_results_[0]['test_score']
     assert_array_almost_equal(scores, [1, 1. / 3.])
     # averaged score is just mean of scores
-    average_score = grid_search.grid_results_[0]['test_score']
+    average_score = grid_search.search_results_[0]['test_score']
     assert_almost_equal(average_score, np.mean(scores))
 
 
@@ -457,7 +457,7 @@ def test_X_as_list():
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, cv=cv)
     grid_search.fit(X.tolist(), y).score(X, y)
     # Ensure result attributes are set
-    grid_search.grid_results_
+    grid_search.search_results_
     grid_search.fold_results_
     grid_search.best_index_
 
@@ -506,7 +506,7 @@ def test_randomized_search():
     params = dict(C=distributions.expon())
     search = RandomizedSearchCV(LinearSVC(), param_distributions=params)
     search.fit(X, y)
-    assert_equal(len(search.grid_results_['test_score']), 10)
+    assert_equal(len(search.search_results_['test_score']), 10)
 
 
 def test_grid_search_score_consistency():


### PR DESCRIPTION
`GridSearch` and friends need to be able to return more fields in their results (e.g. #1742, [composite score](http://sourceforge.net/mailarchive/forum.php?thread_name=513C6BDD.8020001%40ais.uni-bonn.de&forum_name=scikit-learn-general)).

More generally, the conceivable results from a parameter search can be classified into:
1. per-parameter setting, per-fold (currently only the test score for each fold)
2. per-parameter setting (currently the parameters and mean test score across folds)
3. per-search (`best_params_`, `best_score_`, `best_estimator_`; however `best_params_` and `best_score_` are redundantly available in `grid_scores_` as long as the index of the best parameters is known.)

Hence this patch changes the output of a parameter search to be (attribute names are open for debate!):
- `grid_results_` (1.) a structured array (a numpy array with named fields) with one record per set of parameters
- `fold_results_` (2.) a structured array with one record per fold per set of parameters
- `best_index_` (3.)
- `best_estimator_` if `refit==True` (3.)

The structured arrays can be indexed by field name to produce an array of values; alternatively they can be indexed as an array to produce a single record, akin to the `namedtuple`s introduced in 0c94b55 (not in 0.13.1). In any case it allows numpy vectorised operations, as used here when calculating the mean score for each parameter setting (in `_aggregate_scores`).

Given this data, the legacy `grid_scores_` (already deprecated), `best_params_` and `best_scores_` are calculated as properties.

This approach is extensible to new fields, in particular new fields within `fold_results_` records, which are compiled from dicts returned from `fit_fold` (formerly `fit_grid_point`).

This PR is cut back from #1768; there you can see this extensibility exemplified to store training scores, training and test times, and precision and recall together with F-score.
