### PR TITLE
SGDClassifier(warm_start=True) crashes on second call to fit() on multiclass problems.

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -268,6 +268,7 @@ def fit_binary(est, i, X, y, alpha, C, learning_rate, n_iter,
     The i'th class is considered the "positive" class.
     """
     y_i, coef, intercept = _prepare_fit_binary(est, y, i)
+
     assert y_i.shape[0] == y.shape[0] == sample_weight.shape[0]
     dataset, intercept_decay = _make_dataset(X, y_i, sample_weight)
 
@@ -361,7 +362,7 @@ class BaseSGDClassifier(BaseSGD, LinearClassifierMixin):
                                                            self.classes_, y_ind)
         sample_weight = self._validate_sample_weight(sample_weight, n_samples)
 
-        if self.coef_ is None:
+        if self.coef_ is None or coef_init is not None:
             self._allocate_parameter_mem(n_classes, n_features,
                                          coef_init, intercept_init)
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -268,7 +268,6 @@ def fit_binary(est, i, X, y, alpha, C, learning_rate, n_iter,
     The i'th class is considered the "positive" class.
     """
     y_i, coef, intercept = _prepare_fit_binary(est, y, i)
-
     assert y_i.shape[0] == y.shape[0] == sample_weight.shape[0]
     dataset, intercept_decay = _make_dataset(X, y_i, sample_weight)
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -104,7 +104,7 @@ true_result5 = [0, 1, 1]
 
 class CommonTest(object):
 
-    def _test_warm_start(self, lr):
+    def _test_warm_start(self, X, Y, lr):
         # Test that explicit warm restart...
         clf = self.factory(alpha=0.01, eta0=0.01, n_iter=5, shuffle=False,
                            learning_rate=lr)
@@ -131,13 +131,16 @@ class CommonTest(object):
         assert_array_almost_equal(clf3.coef_, clf2.coef_)
 
     def test_warm_start_constant(self):
-        self._test_warm_start("constant")
+        self._test_warm_start(X, Y, "constant")
 
     def test_warm_start_invscaling(self):
-        self._test_warm_start("invscaling")
+        self._test_warm_start(X, Y, "invscaling")
 
     def test_warm_start_optimal(self):
-        self._test_warm_start("optimal")
+        self._test_warm_start(X, Y, "optimal")
+
+    def test_warm_start_multiclass(self):
+        self._test_warm_start(X2, Y2, "optimal")
 
     def test_multiple_fit(self):
         """Test multiple calls of fit w/ different shaped inputs."""


### PR DESCRIPTION
Minimum example is at bottom. The problem is that self.coef_ in SGDClassifier is set to F-order and is not unset from it when the chain of calls from the second fit() eventually hits fit_binary(). My solution is to make sure that coef_ is set back to C-order before training. Adding minimal test case that fails without my change.

```
In [1]: from sklearn.linear_model import SGDClassifier

In [2]: X = np.random.rand(100, 10)

In [3]: y = np.random.randint(3, size=100)

In [4]: clf = SGDClassifier(warm_start=False)

In [5]: clf.fit(X, y)
Out[5]:
SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
       fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
       loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
       random_state=None, rho=None, shuffle=False, verbose=0,
       warm_start=False)

In [6]: clf.fit(X, y)
Out[6]:
SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
       fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
       loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
       random_state=None, rho=None, shuffle=False, verbose=0,
       warm_start=False)

In [7]: clf = SGDClassifier(warm_start=True)

In [8]: clf.fit(X, y)
Out[8]:
SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
       fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
       loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
       random_state=None, rho=None, shuffle=False, verbose=0,
       warm_start=True)

In [9]: clf.fit(X, y)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-9-1a154f38b9fb> in <module>()
----> 1 clf.fit(X, y)

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/stochastic_gradient.pyc in fit(self, X, y, coef_init, intercept_init, class_weight, sample_weight)
    522                          coef_init=coef_init, intercept_init=intercept_init,
    523                          class_weight=class_weight,
--> 524                          sample_weight=sample_weight)
    525
    526

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/stochastic_gradient.pyc in _fit(self, X, y, alpha, C, loss, learning_rate, coef_init, intercept_init, class_weight, sample_weight)
    421
    422         self._partial_fit(X, y, alpha, C, loss, learning_rate, self.n_iter,
--> 423                           classes, sample_weight, coef_init, intercept_init)
    424
    425         # fitting is over, we can now transform coef_ to fortran order

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/stochastic_gradient.pyc in _partial_fit(self, X, y, alpha, C, loss, learning_rate, n_iter, classes, sample_weight, coef_init, intercept_init)
    374             self._fit_multiclass(X, y, alpha=alpha, C=C,
    375                                  learning_rate=learning_rate,
--> 376                                  sample_weight=sample_weight, n_iter=n_iter)
    377         elif n_classes == 2:
    378             self._fit_binary(X, y, alpha=alpha, C=C,

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/stochastic_gradient.pyc in _fit_multiclass(self, X, y, alpha, C, learning_rate, sample_weight, n_iter)
    454                                 n_iter, self._expanded_class_weight[i], 1.,
    455                                 sample_weight)
--> 456             for i in range(len(self.classes_)))
    457
    458         for i, (coef, intercept) in enumerate(result):

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.pyc in __call__(self, iterable)
    512         try:
    513             for function, args, kwargs in iterable:
--> 514                 self.dispatch(function, args, kwargs)
    515
    516             self.retrieve()

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.pyc in dispatch(self, func, args, kwargs)
    309         """
    310         if self._pool is None:
--> 311             job = ImmediateApply(func, args, kwargs)
    312             index = len(self._jobs)
    313             if not _verbosity_filter(index, self.verbose):

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.pyc in __init__(self, func, args, kwargs)
    133         # Don't delay the application, to avoid keeping the input
    134         # arguments in memory
--> 135         self.results = func(*args, **kwargs)
    136
    137     def get(self):

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/stochastic_gradient.pyc in fit_binary(est, i, X, y, alpha, C, learning_rate, n_iter, pos_weight, neg_weight, sample_weight)
    281                      pos_weight, neg_weight,
    282                      learning_rate_type, est.eta0,
--> 283                      est.power_t, est.t_, intercept_decay)
    284
    285

/Users/sergeyk/.virtual_envs/system/lib/python2.7/site-packages/sklearn/linear_model/sgd_fast.so in sklearn.linear_model.sgd_fast.plain_sgd (sklearn/linear_model/sgd_fast.c:7362)()

ValueError: ndarray is not C-contiguous
```
