### PR TITLE
Make it possible to pickle a fit `GridSearchCV` and `RandomizedSearchCV`

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -316,6 +316,11 @@ def _check_param_grid(param_grid):
                                  "list.")
 
 
+_CVScoreTuple = namedtuple('_CVScoreTuple', ('parameters',
+                                           'mean_validation_score',
+                                           'cv_validation_scores'))
+
+
 class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     """Base class for hyper parameter search with cross-validation.
     """
@@ -505,11 +510,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             self.best_estimator_ = best_estimator
 
         # Store the computed scores
-        CVScoreTuple = namedtuple('CVScoreTuple', ('parameters',
-                                                   'mean_validation_score',
-                                                   'cv_validation_scores'))
         self.cv_scores_ = [
-            CVScoreTuple(clf_params, score, all_scores)
+            _CVScoreTuple(clf_params, score, all_scores)
             for clf_params, (score, _), all_scores
             in zip(parameter_iterator, scores, cv_scores)]
         return self

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -340,7 +340,9 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         self._check_estimator()
 
     def score(self, X, y=None):
-        """Returns the mean accuracy on the given test data and labels.
+        """Returns the score on the given test data and labels, if the search
+        estimator has been refit. The ``score`` function of the best estimator
+        is used, or the ``scoring`` parameter where unavailable.
 
         Parameters
         ----------
@@ -364,6 +366,22 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         y_predicted = self.predict(X)
         return self.scorer(y, y_predicted)
 
+    @property
+    def predict(self):
+        return self.best_estimator_.predict
+
+    @property
+    def predict_proba(self):
+        return self.best_estimator_.predict_proba
+
+    @property
+    def decision_function(self):
+        return self.best_estimator_.decision_function
+
+    @property
+    def transform(self):
+        return self.best_estimator_.transform
+
     def _check_estimator(self):
         """Check that estimator can be fitted and score can be computed."""
         if (not hasattr(self.estimator, 'fit') or
@@ -380,13 +398,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                     "If no scoring is specified, the estimator passed "
                     "should have a 'score' method. The estimator %s "
                     "does not." % self.estimator)
-
-    def _set_methods(self):
-        """Create predict and  predict_proba if present in best estimator."""
-        if hasattr(self.best_estimator_, 'predict'):
-            self.predict = self.best_estimator_.predict
-        if hasattr(self.best_estimator_, 'predict_proba'):
-            self.predict_proba = self.best_estimator_.predict_proba
 
     def _fit(self, X, y, parameter_iterator, **params):
         """Actual fitting,  performing the search over parameters."""
@@ -492,7 +503,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             else:
                 best_estimator.fit(X, **self.fit_params)
             self.best_estimator_ = best_estimator
-            self._set_methods()
 
         # Store the computed scores
         CVScoreTuple = namedtuple('CVScoreTuple', ('parameters',

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -6,6 +6,7 @@ Testing for grid search module (sklearn.grid_search)
 from collections import Iterable, Sized
 from cStringIO import StringIO
 from itertools import chain, product
+import pickle
 import sys
 import warnings
 
@@ -490,3 +491,14 @@ def test_grid_search_score_consistency():
                                               clf.decision_function(X[test]))
                 assert_almost_equal(correct_score, scores[i])
                 i += 1
+
+def test_pickle():
+    """Test that a fit search can be pickled"""
+    clf = MockClassifier()
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, refit=True)
+    grid_search.fit(X, y)
+    pickle.dumps(grid_search) # smoke test
+
+    random_search = RandomizedSearchCV(clf, {'foo_param': [1, 2, 3]}, refit=True)
+    random_search.fit(X, y)
+    pickle.dumps(random_search) # smoke test

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -46,6 +46,10 @@ class MockClassifier(object):
     def predict(self, T):
         return T.shape[0]
 
+    predict_proba = predict
+    decision_function = predict
+    transform = predict
+
     def score(self, X=None, Y=None):
         if self.foo_param > 1:
             score = 1.
@@ -132,8 +136,11 @@ def test_grid_search():
     for i, foo_i in enumerate([1, 2, 3]):
         assert_true(grid_search.cv_scores_[i][0]
                     == {'foo_param': foo_i})
-    # Smoke test the score:
+    # Smoke test the score etc:
     grid_search.score(X, y)
+    grid_search.predict_proba(X)
+    grid_search.decision_function(X)
+    grid_search.transform(X)
 
 
 def test_trivial_cv_scores():


### PR DESCRIPTION
Fix for #1789:
- don't make `best_estimator_`'s methods available by copying its methods. Instead link to its attributes by properties (also, added properties for `decision_function` and `transform` where `predict`, `predict_proba` and `score` had been available).
- and don't declare `CVScoresTuple` in a closure.
