### PR TITLE
MRG multiclass probability estimates for SGDClassifier

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,9 @@ Changelog
      converts their ``coef_`` into a sparse matrix, meaning stored models
      trained using these estimators can be made much more compact.
 
+   - :class:`linear_model.SGDClassifier` now produces multiclass probability
+     estimates when trained under log loss.
+
    - Hyperlinks to documentation in example code on the website by
      `Martin Luessi`_.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -52,7 +52,7 @@ Changelog
      trained using these estimators can be made much more compact.
 
    - :class:`linear_model.SGDClassifier` now produces multiclass probability
-     estimates when trained under log loss.
+     estimates when trained under log loss or modified Huber loss.
 
    - Hyperlinks to documentation in example code on the website by
      `Martin Luessi`_.

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -223,7 +223,12 @@ class LinearClassifierMixin(ClassifierMixin):
         return self.classes_[indices]
 
     def _predict_proba_lr(self, X):
-        # 1. / (1. + np.exp(-scores)), computed in-place
+        """Probability estimation for OvR logistic regression.
+
+        Positive class probabilities are computed as
+        1. / (1. + np.exp(-self.decision_function(X)));
+        multiclass is handled by normalizing that over all classes.
+        """
         prob = self.decision_function(X)
         prob *= -1
         np.exp(prob, prob)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -222,6 +222,20 @@ class LinearClassifierMixin(ClassifierMixin):
             indices = scores.argmax(axis=1)
         return self.classes_[indices]
 
+    def _predict_proba_lr(self, X):
+        # 1. / (1. + np.exp(-scores)), computed in-place
+        prob = self.decision_function(X)
+        prob *= -1
+        np.exp(prob, prob)
+        prob += 1
+        np.reciprocal(prob, prob)
+        if len(prob.shape) == 1:
+            return np.vstack([1 - prob, prob]).T
+        else:
+            # OvR normalization, like LibLinear's predict_probability
+            prob /= prob.sum(axis=1).reshape((prob.shape[0], -1))
+            return prob
+
 
 class SparseCoefMixin(object):
     """Mixin for converting coef_ to and from CSR format.

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -120,18 +120,7 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin, SelectorMixin,
             Returns the probability of the sample for each class in the model,
             where classes are ordered as they are in ``self.classes_``.
         """
-        # 1. / (1. + np.exp(-scores)), computed in-place
-        prob = self.decision_function(X)
-        prob *= -1
-        np.exp(prob, prob)
-        prob += 1
-        np.reciprocal(prob, prob)
-        if len(prob.shape) == 1:
-            return np.vstack([1 - prob, prob]).T
-        else:
-            # OvR, not softmax, like Liblinear's predict_probability
-            prob /= prob.sum(axis=1).reshape((prob.shape[0], -1))
-            return prob
+        return self._predict_proba_lr(X)
 
     def predict_log_proba(self, X):
         """Log of probability estimates.

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -320,17 +320,39 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         assert_raises(NotImplementedError, clf.predict_proba, [3, 2])
 
         # the log and modified_huber losses can output "probability" estimates
-        for loss in ("log", "modified_huber"):
-            clf = self.factory(loss=loss, alpha=0.01, n_iter=10).fit(X, Y)
-            p = clf.predict_proba([3, 2])
-            assert_true(p[0, 1] > 0.5)
-            p = clf.predict_proba([-1, -1])
-            assert_true(p[0, 1] < 0.5)
+        clf = self.factory(loss="modified_huber", alpha=0.01, n_iter=10)
+        clf.fit(X, Y)
+        p = clf.predict_proba([3, 2])
+        assert_true(p[0, 1] > 0.5)
+        p = clf.predict_proba([-1, -1])
+        assert_true(p[0, 1] < 0.5)
 
-            p = clf.predict_log_proba([3, 2])
-            assert_true(p[0, 1] > p[0, 0])
-            p = clf.predict_log_proba([-1, -1])
-            assert_true(p[0, 1] < p[0, 0])
+        p = clf.predict_log_proba([3, 2])
+        assert_true(p[0, 1] > p[0, 0])
+        p = clf.predict_log_proba([-1, -1])
+        assert_true(p[0, 1] < p[0, 0])
+
+
+        # log loss supports multiclass probability estimates
+        clf = self.factory(loss="log", alpha=0.01, n_iter=10).fit(X2, Y2)
+
+        d = clf.decision_function([[.1, -.1], [.3, .2]])
+        p = clf.predict_proba([[.1, -.1], [.3, .2]])
+        assert_array_equal(np.argmax(p, axis=1), np.argmax(d, axis=1))
+        assert_almost_equal(p[0].sum(), 1)
+        assert_true(np.all(p[0] >= 0))
+
+        p = clf.predict_proba([-1, -1])
+        d = clf.decision_function([-1, -1])
+        assert_array_equal(np.argsort(p[0]), np.argsort(d[0]))
+
+        l = clf.predict_log_proba([3, 2])
+        p = clf.predict_proba([3, 2])
+        assert_array_almost_equal(np.log(p), l)
+
+        l = clf.predict_log_proba([-1, -1])
+        p = clf.predict_proba([-1, -1])
+        assert_array_almost_equal(np.log(p), l)
 
     def test_sgd_l1(self):
         """Test L1 regularization"""

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -319,21 +319,22 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         clf = self.factory(loss="hinge", alpha=0.01, n_iter=10).fit(X, Y)
         assert_raises(NotImplementedError, clf.predict_proba, [3, 2])
 
-        # the log and modified_huber losses can output "probability" estimates
-        clf = self.factory(loss="modified_huber", alpha=0.01, n_iter=10)
-        clf.fit(X, Y)
-        p = clf.predict_proba([3, 2])
-        assert_true(p[0, 1] > 0.5)
-        p = clf.predict_proba([-1, -1])
-        assert_true(p[0, 1] < 0.5)
+        # log and modified_huber losses can output probability estimates
+        # binary case
+        for loss in ["log", "modified_huber"]:
+            clf = self.factory(loss="modified_huber", alpha=0.01, n_iter=10)
+            clf.fit(X, Y)
+            p = clf.predict_proba([3, 2])
+            assert_true(p[0, 1] > 0.5)
+            p = clf.predict_proba([-1, -1])
+            assert_true(p[0, 1] < 0.5)
 
-        p = clf.predict_log_proba([3, 2])
-        assert_true(p[0, 1] > p[0, 0])
-        p = clf.predict_log_proba([-1, -1])
-        assert_true(p[0, 1] < p[0, 0])
+            p = clf.predict_log_proba([3, 2])
+            assert_true(p[0, 1] > p[0, 0])
+            p = clf.predict_log_proba([-1, -1])
+            assert_true(p[0, 1] < p[0, 0])
 
-
-        # log loss supports multiclass probability estimates
+        # log loss multiclass probability estimates
         clf = self.factory(loss="log", alpha=0.01, n_iter=10).fit(X2, Y2)
 
         d = clf.decision_function([[.1, -.1], [.3, .2]])
@@ -353,6 +354,28 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         l = clf.predict_log_proba([-1, -1])
         p = clf.predict_proba([-1, -1])
         assert_array_almost_equal(np.log(p), l)
+
+        # Modified Huber multiclass probability estimates; requires a separate
+        # test because the hard zero/one probabilities may destroy the
+        # ordering present in decision_function output.
+        clf = self.factory(loss="modified_huber", alpha=0.01, n_iter=10)
+        clf.fit(X2, Y2)
+        d = clf.decision_function([3, 2])
+        p = clf.predict_proba([3, 2])
+        if not isinstance(self, SparseSGDClassifierTestCase):
+            assert_equal(np.argmax(d, axis=1), np.argmax(p, axis=1))
+        else:   # XXX the sparse test gets a different X2 (?)
+            assert_equal(np.argmin(d, axis=1), np.argmin(p, axis=1))
+
+        # the following sample produces decision_function values < -1,
+        # which would cause naive normalization to fail (see comment
+        # in SGDClassifier.predict_proba)
+        x = X.mean(axis=0)
+        d = clf.decision_function(x)
+        if np.all(d < -1):  # XXX not true in sparse test case (why?)
+            p = clf.predict_proba(x)
+            assert_array_almost_equal(p[0], [1/3.] * 3)
+
 
     def test_sgd_l1(self):
         """Test L1 regularization"""


### PR DESCRIPTION
As discussed on the ML. Not done for `loss="modified_huber"` since I didn't see how to generalize its way of producing probabilities to the multiclass case.

Cc @pprett.
