### PR TITLE
ENH method to index ParameterGrid points by parameter values

### DIFF
--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -28,7 +28,7 @@ from sklearn.svm import SVC
 from sklearn.preprocessing import StandardScaler
 from sklearn.datasets import load_iris
 from sklearn.cross_validation import StratifiedKFold
-from sklearn.grid_search import GridSearchCV
+from sklearn.grid_search import GridSearchCV, ParameterGrid
 
 ##############################################################################
 # Load and prepare data set
@@ -110,7 +110,8 @@ score_dict = grid.cv_scores_
 
 # We extract just the scores
 scores = [x[1] for x in score_dict]
-scores = np.array(scores).reshape(len(C_range), len(gamma_range))
+_, index = ParameterGrid(grid.param_grid).build_index(['C', 'gamma'])
+scores = np.asarray(scores)[index]
 
 # draw heatmap of accuracy as a function of gamma and C
 pl.figure(figsize=(8, 6))

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -106,7 +106,7 @@ class ParameterGrid(object):
         """Number of points for a single param dict"""
         return product(len(v) for v in params.values())
 
-    def build_index(self, order=(), grid=0):
+    def build_index(self, order=(), grid=0, ravel=False):
         """Build an index over grid points by parameter values.
 
         Parameters
@@ -116,11 +116,17 @@ class ParameterGrid(object):
             index. Any remaining parameters will be returned in arbitrary order.
         `grid` : integer, default 0
             The grid index if an array of grids are represented.
+        `ravel` : boolean, default False
+            When True, only parameters listed in `order` are assigned their own
+            dimension, so the output index has `len(order) + 1` dimensions.
+            This simplifies aggregating over the indexed data grouped by
+            selected parameters.
         
         Returns
         -------
         `order` : sequence of strings
-            Parameter names corresponding to axes in `index`.
+            Parameter names corresponding to axes in `index`. Where `ravel` is
+            True, the final axis is not included.
         `index` : array
             An integer index into the list of grid points, such that each
             parameter corresponds to an axis.
@@ -144,6 +150,10 @@ class ParameterGrid(object):
 
             keys = np.asarray(keys)[axis_order]
             index = index.transpose(axis_order)
+
+        if ravel:
+            keys = keys[:len(order)]
+            index = index.reshape(index.shape[:len(order)] + (-1,))
 
         return list(keys), index
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -113,7 +113,8 @@ class ParameterGrid(object):
         ----------
         `order` : sequence of strings, optional
             Parameter names corresponding to the first axes of the returned
-            index. Any remaining parameters will be returned in arbitrary order.
+            index. Any remaining parameters will be returned in arbitrary
+            order.
         `grid` : integer, default 0
             The grid index if an array of grids are represented.
         `ravel` : boolean, default False
@@ -121,7 +122,7 @@ class ParameterGrid(object):
             dimension, so the output index has `len(order) + 1` dimensions.
             This simplifies aggregating over the indexed data grouped by
             selected parameters.
-        
+
         Returns
         -------
         `order` : sequence of strings
@@ -146,7 +147,7 @@ class ParameterGrid(object):
             if len(axis_order) > len(set(axis_order)):
                 raise ValueError('order contains duplicate keys')
             axis_order.extend(i for i in xrange(len(keys))
-                    if i not in axis_order)
+                              if i not in axis_order)
 
             keys = np.asarray(keys)[axis_order]
             index = index.transpose(axis_order)

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -157,8 +157,11 @@ def test_build_index():
                  np.asarray([{"foo": y, "bar": x}
                      for x, y in product(params["bar"], params["foo"])]))
 
+    # Test bad `order`s
     assert_raises(ValueError, grid.build_index, ['foo', 'foo'])
     assert_raises(ValueError, grid.build_index, ['argh'])
+
+    # Test a list of grids and the `grid` parameter
 
     grid2 = ParameterGrid([params, {'foo': [3]}])
 
@@ -174,6 +177,18 @@ def test_build_index():
     assert_equal(keys, ['foo'])
     assert_array_equal(index3, np.array([len(grid2) - 1]))
 
+    params3 = {"foo": [4, 2],
+               "bar": ["ham", "spam", "eggs"],
+               "jon": [2.0, 1.0]}
+    grid3 = ParameterGrid(params3)
+    keys, index = grid3.build_index(['foo'])
+    assert_true(keys == ['foo', 'bar', 'jon'] or keys == ['foo', 'jon', 'bar'])
+    keys, index_ravel = grid3.build_index(['foo'], ravel=True)
+    assert_equal(keys, ['foo'])
+    assert_equal(index.ndim, 3)
+    assert_equal(index_ravel.ndim, 2)
+    for row, row_ravel in zip(index, index_ravel):
+        assert_equal(sorted(row.flat), sorted(row_ravel))
 
 
 def test_grid_search():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -123,9 +123,10 @@ def test_parameter_grid():
                      set(("foo", x, "bar", y)
                          for x, y in product(params2["foo"], params2["bar"])))
 
+
 def test_build_index():
     params = {"foo": [4, 2],
-               "bar": ["ham", "spam", "eggs"]}
+              "bar": ["ham", "spam", "eggs"]}
     grid = ParameterGrid(params)
 
     keys, index1a = grid.build_index(['foo', 'bar'])
@@ -144,18 +145,20 @@ def test_build_index():
     assert_equal(keys, ['bar', 'foo'])
     assert_array_equal(index2a, index2b)
 
-    keys, index = grid.build_index()  # dimensions are implementation-specific? 
+    keys, index = grid.build_index()  # dimensions are implementation-specific?
     assert_true(keys == ['foo', 'bar'] or keys == ['bar', 'foo'])
     assert_true(np.all(index == index1a) or np.all(index == index2a))
 
     points = np.asarray(list(grid))
     points[index1a]
-    assert_array_equal(points[index1a].ravel(),
-                 np.asarray([{"foo": x, "bar": y}
-                     for x, y in product(params["foo"], params["bar"])]))
-    assert_array_equal(points[index2a].ravel(),
-                 np.asarray([{"foo": y, "bar": x}
-                     for x, y in product(params["bar"], params["foo"])]))
+    assert_array_equal(
+        points[index1a].ravel(),
+        np.asarray([{"foo": x, "bar": y}
+                    for x, y in product(params["foo"], params["bar"])]))
+    assert_array_equal(
+        points[index2a].ravel(),
+        np.asarray([{"foo": y, "bar": x}
+                    for x, y in product(params["bar"], params["foo"])]))
 
     # Test bad `order`s
     assert_raises(ValueError, grid.build_index, ['foo', 'foo'])


### PR DESCRIPTION
This extension intends to solve #1020 for regular grids: it provides an index into the grid points output by `ParameterGrid`, such that results from `GridSearchCV` (particularly when returned as an array as in #1787) can be accessed by parameter value.

For example, I could get the mean `test_score` for each `'max_depth'` value:

``` python
grid_search = GridSearchCV(clf, {'max_depth': range(1, 5), 'max_features': range(1, 3)})
grid_search.fit(...)
grid = ParameterGrid(grid_search.param_grid) # should we make it easier to get the ParameterGrid?
keys, index = grid.build_index(['max_depth'], ravel=True)
indexed = np.array(candidate.mean_validation_score for candidate in [grid_search.cv_scores_])[index]
print(indexed.mean(axis=1))
```

This PR aims to account for most of the functionality of #1034 within the current parameter search framework. The examples from there should be adopted.
