### PR TITLE
reduce size of files created by dump_svmlight_file (tests included, pep8/pyflakes pass)

### DIFF
--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -229,15 +229,15 @@ def load_svmlight_files(files, n_features=None, dtype=np.float64,
 
 def _dump_svmlight(X, y, f, one_based, comment, query_id):
     is_sp = int(hasattr(X, "tocsr"))
-    if X.dtype == np.float64:
-        value_pattern = u("%d:%0.16e")
+    if X.dtype.kind == 'i':
+        value_pattern = u("%d:%d")
     else:
-        value_pattern = u("%d:%f")
+        value_pattern = u("%d:%.16g")
 
     if y.dtype.kind == 'i':
         line_pattern = u("%d")
     else:
-        line_pattern = u("%f")
+        line_pattern = u("%.16g")
 
     if query_id is not None:
         line_pattern += u(" qid:%d")


### PR DESCRIPTION
by (1) printing integers as integers and (2) using printf type "g" instead of "e"

```
>>> '%.16e' % 98.7 
'9.8700000000000003e+01' # not very concise!
>>> '%.16g' % 98.7
'98.7' # nice!
>>> '%.16g' % 1.000000000000001
'1.000000000000001'
>>> '%.16g' % 1.0000000000000001
'1'
>>> '%.16e' % 1.0000000000000001
'1.0000000000000000e+00' # precision works the same way in g and e
```
