### PR TITLE
MRG: Give export_graphviz some love

### DIFF
--- a/sklearn/tree/__init__.py
+++ b/sklearn/tree/__init__.py
@@ -7,7 +7,7 @@ from .tree import DecisionTreeClassifier
 from .tree import DecisionTreeRegressor
 from .tree import ExtraTreeClassifier
 from .tree import ExtraTreeRegressor
-from .tree import export_graphviz
+from .export import export_graphviz
 
 __all__ = ["DecisionTreeClassifier", "DecisionTreeRegressor",
            "ExtraTreeClassifier", "ExtraTreeRegressor", "export_graphviz"]

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -66,9 +66,19 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
         if tree.n_outputs == 1:
             value = value[0, :]
 
+        if isinstance(tree.criterion, _tree.Gini):
+            criterion = "gini"
+        elif isinstance(tree.criterion, _tree.Entropy):
+            criterion = "entropy"
+        elif isinstance(tree.criterion, _tree.MSE):
+            criterion = "mse"
+        else:
+            criterion = "impurity"
+
         if tree.children_left[node_id] == _tree.TREE_LEAF:
-            return "error = %.4f\\nsamples = %s\\nvalue = %s" \
-                   % (tree.init_error[node_id],
+            return "%s = %.4f\\nsamples = %s\\nvalue = %s" \
+                   % (criterion,
+                      tree.init_error[node_id],
                       tree.n_samples[node_id],
                       value)
         else:
@@ -77,9 +87,10 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
             else:
                 feature = "X[%s]" % tree.feature[node_id]
 
-            return "%s <= %.4f\\nerror = %s\\nsamples = %s\\nvalue = %s" \
+            return "%s <= %.4f\\n%s = %s\\nsamples = %s\\nvalue = %s" \
                    % (feature,
                       tree.threshold[node_id],
+                      criterion,
                       tree.init_error[node_id],
                       tree.n_samples[node_id],
                       value)

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -1,0 +1,114 @@
+"""
+This module defines export functions of decision trees.
+"""
+
+# Authors: Brian Holt,
+#          Peter Prettenhofer,
+#          Satrajit Ghosh,
+#          Gilles Louppe,
+#          Noel Dawe
+# License: BSD Style.
+
+from ..externals import six
+from . import _tree
+
+
+def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None):
+    """Export a decision tree in DOT format.
+
+    This function generates a GraphViz representation of the decision tree,
+    which is then written into `out_file`. Once exported, graphical renderings
+    can be generated using, for example::
+
+        $ dot -Tps tree.dot -o tree.ps      (PostScript format)
+        $ dot -Tpng tree.dot -o tree.png    (PNG format)
+
+    Parameters
+    ----------
+    decision_tree : decision tree classifier
+        The decision tree to be exported to graphviz.
+
+    out_file : file object or string, optional (default="tree.dot")
+        Handle or name of the output file.
+
+    feature_names : list of strings, optional (default=None)
+        Names of each of the features.
+
+    Returns
+    -------
+    out_file : file object
+        The file object to which the tree was exported.  The user is
+        expected to `close()` this object when done with it.
+
+    Examples
+    --------
+    >>> import os
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn import tree
+
+    >>> clf = tree.DecisionTreeClassifier()
+    >>> iris = load_iris()
+
+    >>> clf = clf.fit(iris.data, iris.target)
+    >>> import tempfile
+    >>> export_file = tree.export_graphviz(clf,
+    ...     out_file='test_export_graphvix.dot')
+    >>> export_file.close()
+    >>> os.unlink(export_file.name)
+    """
+    def node_to_str(tree, node_id):
+        value = tree.value[node_id]
+        if tree.n_outputs == 1:
+            value = value[0, :]
+
+        if tree.children_left[node_id] == _tree.TREE_LEAF:
+            return "error = %.4f\\nsamples = %s\\nvalue = %s" \
+                   % (tree.init_error[node_id],
+                      tree.n_samples[node_id],
+                      value)
+        else:
+            if feature_names is not None:
+                feature = feature_names[tree.feature[node_id]]
+            else:
+                feature = "X[%s]" % tree.feature[node_id]
+
+            return "%s <= %.4f\\nerror = %s\\nsamples = %s\\nvalue = %s" \
+                   % (feature,
+                      tree.threshold[node_id],
+                      tree.init_error[node_id],
+                      tree.n_samples[node_id],
+                      value)
+
+    def recurse(tree, node_id, parent=None):
+        if node_id == _tree.TREE_LEAF:
+            raise ValueError("Invalid node_id %s" % _tree.TREE_LEAF)
+
+        left_child = tree.children_left[node_id]
+        right_child = tree.children_right[node_id]
+
+        # Add node with description
+        out_file.write('%d [label="%s", shape="box"] ;\n' %
+                       (node_id, node_to_str(tree, node_id)))
+
+        if parent is not None:
+            # Add edge to parent
+            out_file.write('%d -> %d ;\n' % (parent, node_id))
+
+        if left_child != _tree.TREE_LEAF:  # and right_child != _tree.TREE_LEAF
+            recurse(tree, left_child, node_id)
+            recurse(tree, right_child, node_id)
+
+    if isinstance(out_file, six.string_types):
+        if six.PY3:
+            out_file = open(out_file, "w", encoding="utf-8")
+        else:
+            out_file = open(out_file, "wb")
+
+    out_file.write("digraph Tree {\n")
+    if isinstance(decision_tree, _tree.Tree):
+        recurse(decision_tree, 0)
+    else:
+        recurse(decision_tree.tree_, 0)
+    out_file.write("}")
+
+    return out_file

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -13,7 +13,8 @@ from ..externals import six
 from . import _tree
 
 
-def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None):
+def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
+                    max_depth=None, close=True):
     """Export a decision tree in DOT format.
 
     This function generates a GraphViz representation of the decision tree,
@@ -26,13 +27,17 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None):
     Parameters
     ----------
     decision_tree : decision tree classifier
-        The decision tree to be exported to graphviz.
+        The decision tree to be exported to GraphViz.
 
     out_file : file object or string, optional (default="tree.dot")
         Handle or name of the output file.
 
     feature_names : list of strings, optional (default=None)
         Names of each of the features.
+
+    max_detph : int, optional (default=None)
+        The maximum depth of the representation. If None, the tree is fully
+        generated.
 
     Returns
     -------
@@ -79,7 +84,7 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None):
                       tree.n_samples[node_id],
                       value)
 
-    def recurse(tree, node_id, parent=None):
+    def recurse(tree, node_id, parent=None, depth=0):
         if node_id == _tree.TREE_LEAF:
             raise ValueError("Invalid node_id %s" % _tree.TREE_LEAF)
 
@@ -87,16 +92,24 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None):
         right_child = tree.children_right[node_id]
 
         # Add node with description
-        out_file.write('%d [label="%s", shape="box"] ;\n' %
-                       (node_id, node_to_str(tree, node_id)))
+        if max_depth is None or depth <= max_depth:
+            out_file.write('%d [label="%s", shape="box"] ;\n' %
+                           (node_id, node_to_str(tree, node_id)))
 
-        if parent is not None:
-            # Add edge to parent
-            out_file.write('%d -> %d ;\n' % (parent, node_id))
+            if parent is not None:
+                # Add edge to parent
+                out_file.write('%d -> %d ;\n' % (parent, node_id))
 
-        if left_child != _tree.TREE_LEAF:  # and right_child != _tree.TREE_LEAF
-            recurse(tree, left_child, node_id)
-            recurse(tree, right_child, node_id)
+            if left_child != _tree.TREE_LEAF:
+                recurse(tree, left_child, parent=node_id, depth=depth + 1)
+                recurse(tree, right_child, parent=node_id, depth=depth + 1)
+
+        else:
+            out_file.write('%d [label="(...)", shape="box"] ;\n' % node_id)
+
+            if parent is not None:
+                # Add edge to parent
+                out_file.write('%d -> %d ;\n' % (parent, node_id))
 
     if isinstance(out_file, six.string_types):
         if six.PY3:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -1,5 +1,5 @@
 """
-This module defines export functions of decision trees.
+This module defines export functions for decision trees.
 """
 
 # Authors: Brian Holt,

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -1,0 +1,66 @@
+"""
+Testing for export functions of decision trees (sklearn.tree.export).
+"""
+
+import numpy as np
+from numpy.testing import assert_equal
+from nose.tools import assert_raises
+
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree import export_graphviz
+from sklearn.externals.six import StringIO
+
+# toy sample
+X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
+y = [-1, -1, -1, 1, 1, 1]
+T = [[-1, -1], [2, 2], [3, 2]]
+true_result = [-1, 1, 1]
+
+
+def test_graphviz_toy():
+    """Check correctness of graphviz output on a toy dataset."""
+    clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
+    clf.fit(X, y)
+
+    # Test export code
+    out = StringIO()
+    export_graphviz(clf, out_file=out)
+    contents1 = out.getvalue()
+    contents2 = "digraph Tree {\n" \
+                "0 [label=\"X[0] <= 0.0000\\nerror = 0.5\\n" \
+                "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
+                "1 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
+                "0 -> 1 ;\n" \
+                "2 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
+                "0 -> 2 ;\n" \
+                "}"
+
+    assert_equal(contents1, contents2)
+
+    # Test with feature_names
+    out = StringIO()
+    out = export_graphviz(clf, out_file=out, feature_names=["feature1", ""])
+    contents1 = out.getvalue()
+    contents2 = "digraph Tree {\n" \
+                "0 [label=\"feature1 <= 0.0000\\nerror = 0.5\\n" \
+                "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
+                "1 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
+                "0 -> 1 ;\n" \
+                "2 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
+                "0 -> 2 ;\n" \
+                "}"
+
+    assert_equal(contents1, contents2)
+
+    # test improperly formed feature_names
+    out = StringIO()
+    assert_raises(IndexError, export_graphviz, clf, out, feature_names=[])
+
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -18,7 +18,7 @@ true_result = [-1, 1, 1]
 
 
 def test_graphviz_toy():
-    """Check correctness of graphviz output on a toy dataset."""
+    """Check correctness of export_graphviz"""
     clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
     clf.fit(X, y)
 
@@ -56,7 +56,27 @@ def test_graphviz_toy():
 
     assert_equal(contents1, contents2)
 
-    # test improperly formed feature_names
+    # Test max_depth
+    out = StringIO()
+    export_graphviz(clf, out_file=out, max_depth=0)
+    contents1 = out.getvalue()
+    contents2 = "digraph Tree {\n" \
+                "0 [label=\"X[0] <= 0.0000\\nerror = 0.5\\n" \
+                "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
+                "1 [label=\"(...)\", shape=\"box\"] ;\n" \
+                "0 -> 1 ;\n" \
+                "2 [label=\"(...)\", shape=\"box\"] ;\n" \
+                "0 -> 2 ;\n" \
+                "}"
+
+    assert_equal(contents1, contents2)
+
+
+def test_graphviz_errors():
+    """Check for errors of export_graphviz"""
+    clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
+    clf.fit(X, y)
+
     out = StringIO()
     assert_raises(IndexError, export_graphviz, clf, out, feature_names=[])
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -19,7 +19,9 @@ true_result = [-1, 1, 1]
 
 def test_graphviz_toy():
     """Check correctness of export_graphviz"""
-    clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=1,
+                                 criterion="gini")
     clf.fit(X, y)
 
     # Test export code
@@ -27,12 +29,12 @@ def test_graphviz_toy():
     export_graphviz(clf, out_file=out)
     contents1 = out.getvalue()
     contents2 = "digraph Tree {\n" \
-                "0 [label=\"X[0] <= 0.0000\\nerror = 0.5\\n" \
+                "0 [label=\"X[0] <= 0.0000\\ngini = 0.5\\n" \
                 "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
-                "1 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "1 [label=\"gini = 0.0000\\nsamples = 3\\n" \
                 "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
                 "0 -> 1 ;\n" \
-                "2 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "2 [label=\"gini = 0.0000\\nsamples = 3\\n" \
                 "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
                 "0 -> 2 ;\n" \
                 "}"
@@ -44,12 +46,12 @@ def test_graphviz_toy():
     out = export_graphviz(clf, out_file=out, feature_names=["feature1", ""])
     contents1 = out.getvalue()
     contents2 = "digraph Tree {\n" \
-                "0 [label=\"feature1 <= 0.0000\\nerror = 0.5\\n" \
+                "0 [label=\"feature1 <= 0.0000\\ngini = 0.5\\n" \
                 "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
-                "1 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "1 [label=\"gini = 0.0000\\nsamples = 3\\n" \
                 "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
                 "0 -> 1 ;\n" \
-                "2 [label=\"error = 0.0000\\nsamples = 3\\n" \
+                "2 [label=\"gini = 0.0000\\nsamples = 3\\n" \
                 "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
                 "0 -> 2 ;\n" \
                 "}"
@@ -61,7 +63,7 @@ def test_graphviz_toy():
     export_graphviz(clf, out_file=out, max_depth=0)
     contents1 = out.getvalue()
     contents2 = "digraph Tree {\n" \
-                "0 [label=\"X[0] <= 0.0000\\nerror = 0.5\\n" \
+                "0 [label=\"X[0] <= 0.0000\\ngini = 0.5\\n" \
                 "samples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n" \
                 "1 [label=\"(...)\", shape=\"box\"] ;\n" \
                 "0 -> 1 ;\n" \

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -117,60 +117,6 @@ def test_xor():
     assert_equal(clf.score(X, y), 1.0)
 
 
-def test_graphviz_toy():
-    """Check correctness of graphviz output on a toy dataset."""
-    clf = tree.DecisionTreeClassifier(max_depth=3, min_samples_split=1)
-    clf.fit(X, y)
-
-    # test export code
-    out = StringIO()
-    tree.export_graphviz(clf, out_file=out)
-    contents1 = out.getvalue()
-
-    tree_toy = StringIO(
-        "digraph Tree {\n"
-        "0 [label=\"X[0] <= 0.0000\\nerror = 0.5"
-        "\\nsamples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n"
-        "1 [label=\"error = 0.0000\\nsamples = 3\\n"
-        "value = [ 3.  0.]\", shape=\"box\"] ;\n"
-        "0 -> 1 ;\n"
-        "2 [label=\"error = 0.0000\\nsamples = 3\\n"
-        "value = [ 0.  3.]\", shape=\"box\"] ;\n"
-        "0 -> 2 ;\n"
-        "}")
-    contents2 = tree_toy.getvalue()
-
-    assert contents1 == contents2, \
-        "graphviz output test failed\n: %s != %s" % (contents1, contents2)
-
-    # test with feature_names
-    out = StringIO()
-    out = tree.export_graphviz(clf, out_file=out,
-                               feature_names=["feature1", ""])
-    contents1 = out.getvalue()
-
-    tree_toy = StringIO(
-        "digraph Tree {\n"
-        "0 [label=\"feature1 <= 0.0000\\nerror = 0.5"
-        "\\nsamples = 6\\nvalue = [ 3.  3.]\", shape=\"box\"] ;\n"
-        "1 [label=\"error = 0.0000\\nsamples = 3\\n"
-        "value = [ 3.  0.]\", shape=\"box\"] ;\n"
-        "0 -> 1 ;\n"
-        "2 [label=\"error = 0.0000\\nsamples = 3\\n"
-        "value = [ 0.  3.]\", shape=\"box\"] ;\n"
-        "0 -> 2 ;\n"
-        "}")
-    contents2 = tree_toy.getvalue()
-
-    assert contents1 == contents2, \
-        "graphviz output test failed\n: %s != %s" % (contents1, contents2)
-
-    # test improperly formed feature_names
-    out = StringIO()
-    assert_raises(IndexError, tree.export_graphviz,
-                  clf, out, feature_names=[])
-
-
 def test_iris():
     """Check consistency on dataset iris."""
     for c in ('gini',

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -7,9 +7,12 @@ randomized trees. Single and multi-output problems are both handled.
 # Copyright (C) 2008-2011, Luis Pedro Coelho <luis@luispedro.org>
 # License: MIT. See COPYING.MIT file in the milk distribution
 
-# Authors: Brian Holt, Peter Prettenhofer, Satrajit Ghosh, Gilles Louppe,
+# Authors: Brian Holt,
+#          Peter Prettenhofer,
+#          Satrajit Ghosh,
+#          Gilles Louppe,
 #          Noel Dawe
-# License: BSD3
+# License: BSD Style.
 
 from __future__ import division
 
@@ -44,110 +47,6 @@ CLASSIFICATION = {
 REGRESSION = {
     "mse": _tree.MSE,
 }
-
-
-def export_graphviz(decision_tree, out_file=None, feature_names=None):
-    """Export a decision tree in DOT format.
-
-    This function generates a GraphViz representation of the decision tree,
-    which is then written into `out_file`. Once exported, graphical renderings
-    can be generated using, for example::
-
-        $ dot -Tps tree.dot -o tree.ps      (PostScript format)
-        $ dot -Tpng tree.dot -o tree.png    (PNG format)
-
-    Parameters
-    ----------
-    decision_tree : decision tree classifier
-        The decision tree to be exported to graphviz.
-
-    out : file object or string, optional (default=None)
-        Handle or name of the output file.
-
-    feature_names : list of strings, optional (default=None)
-        Names of each of the features.
-
-    Returns
-    -------
-    out_file : file object
-        The file object to which the tree was exported.  The user is
-        expected to `close()` this object when done with it.
-
-    Examples
-    --------
-    >>> import os
-    >>> from sklearn.datasets import load_iris
-    >>> from sklearn import tree
-
-    >>> clf = tree.DecisionTreeClassifier()
-    >>> iris = load_iris()
-
-    >>> clf = clf.fit(iris.data, iris.target)
-    >>> import tempfile
-    >>> export_file = tree.export_graphviz(clf,
-    ...     out_file='test_export_graphvix.dot')
-    >>> export_file.close()
-    >>> os.unlink(export_file.name)
-    """
-    def node_to_str(tree, node_id):
-        value = tree.value[node_id]
-        if tree.n_outputs == 1:
-            value = value[0, :]
-
-        if tree.children_left[node_id] == _tree.TREE_LEAF:
-            return "error = %.4f\\nsamples = %s\\nvalue = %s" \
-                   % (tree.init_error[node_id],
-                      tree.n_samples[node_id],
-                      value)
-        else:
-            if feature_names is not None:
-                feature = feature_names[tree.feature[node_id]]
-            else:
-                feature = "X[%s]" % tree.feature[node_id]
-
-            return "%s <= %.4f\\nerror = %s\\nsamples = %s\\nvalue = %s" \
-                   % (feature,
-                      tree.threshold[node_id],
-                      tree.init_error[node_id],
-                      tree.n_samples[node_id],
-                      value)
-
-    def recurse(tree, node_id, parent=None):
-        if node_id == _tree.TREE_LEAF:
-            raise ValueError("Invalid node_id %s" % _tree.TREE_LEAF)
-
-        left_child = tree.children_left[node_id]
-        right_child = tree.children_right[node_id]
-
-        # Add node with description
-        out_file.write('%d [label="%s", shape="box"] ;\n' %
-                       (node_id, node_to_str(tree, node_id)))
-
-        if parent is not None:
-            # Add edge to parent
-            out_file.write('%d -> %d ;\n' % (parent, node_id))
-
-        if left_child != _tree.TREE_LEAF:  # and right_child != _tree.TREE_LEAF
-            recurse(tree, left_child, node_id)
-            recurse(tree, right_child, node_id)
-
-    if out_file is None:
-        out_file = "tree.dot"
-
-    if isinstance(out_file, six.string_types):
-        if six.PY3:
-            out_file = open(out_file, "w", encoding="utf-8")
-        else:
-            out_file = open(out_file, "wb")
-
-    out_file.write("digraph Tree {\n")
-    if isinstance(decision_tree, _tree.Tree):
-        recurse(decision_tree, 0)
-    else:
-        recurse(decision_tree.tree_, 0)
-    out_file.write("}")
-
-    return out_file
 
 
 class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator, SelectorMixin)):


### PR DESCRIPTION
This solves both #1851 and #1844.

I also moved `export_graphviz` into `sklearn/tree/export.py`. This does not change anything for the users, but I find this clearer for us as developers. 
