### PR TITLE
FIX ENH LeaveOneLabelOut and LeavePLabelOut's handling of labels

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -288,7 +288,7 @@ a training set using the samples of all the experiments except one::
 
   >>> lolo = LeaveOneLabelOut(labels)
   >>> print(lolo)
-  sklearn.cross_validation.LeaveOneLabelOut(labels=[1, 1, 2, 2])
+  sklearn.cross_validation.LeaveOneLabelOut(labels=[1 1 2 2])
 
   >>> for train, test in lolo:
   ...     print("%s %s" % (train, test))
@@ -315,7 +315,7 @@ Example of Leave-2-Label Out::
 
   >>> lplo = LeavePLabelOut(labels, 2)
   >>> print(lplo)
-  sklearn.cross_validation.LeavePLabelOut(labels=[1, 1, 2, 2, 3, 3], p=2)
+  sklearn.cross_validation.LeavePLabelOut(labels=[1 1 2 2 3 3], p=2)
 
   >>> for train, test in lplo:
   ...     print("%s %s" % (train, test))

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -452,19 +452,18 @@ class LeaveOneLabelOut(object):
     """
 
     def __init__(self, labels, indices=True):
-        self.labels = labels
-        self.n_unique_labels = len(unique(labels))
+        # We make a copy of labels to avoid side-effects during iteration
+        self.labels = np.array(labels, copy=True)
+        self.unique_labels = unique(labels)
+        self.n_unique_labels = len(self.unique_labels)
         self.indices = indices
 
     def __iter__(self):
-        # We make a copy here to avoid side-effects during iteration
-        labels = np.array(self.labels, copy=True)
         if self.indices:
-            ind = np.arange(len(labels))
-
-        for i in unique(labels):    # also a copy; XXX do we need this?
-            test_index = np.zeros(len(labels), dtype=np.bool)
-            test_index[labels == i] = True
+            ind = np.arange(len(self.labels))
+        for i in self.unique_labels:
+            test_index = np.zeros(len(self.labels), dtype=np.bool)
+            test_index[self.labels == i] = True
             train_index = np.logical_not(test_index)
             if self.indices:
                 train_index = ind[train_index]
@@ -539,24 +538,22 @@ class LeavePLabelOut(object):
     """
 
     def __init__(self, labels, p, indices=True):
-        self.labels = labels
-        self.unique_labels = unique(self.labels)
+        # We make a copy of labels to avoid side-effects during iteration
+        self.labels = np.array(labels, copy=True)
+        self.unique_labels = unique(labels)
         self.n_unique_labels = len(self.unique_labels)
         self.p = p
         self.indices = indices
 
     def __iter__(self):
-        # We make a copy here to avoid side-effects during iteration
-        labels = np.array(self.labels, copy=True)
-        unique_labels = unique(labels)
         comb = combinations(range(self.n_unique_labels), self.p)
         if self.indices:
-            ind = np.arange(len(labels))
+            ind = np.arange(len(self.labels))
         for idx in comb:
-            test_index = np.zeros(len(labels), dtype=np.bool)
+            test_index = np.zeros(len(self.labels), dtype=np.bool)
             idx = np.array(idx)
-            for l in unique_labels[idx]:
-                test_index[labels == l] = True
+            for l in self.unique_labels[idx]:
+                test_index[self.labels == l] = True
             train_index = np.logical_not(test_index)
             if self.indices:
                 train_index = ind[train_index]

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -239,6 +239,22 @@ def test_stratified_shuffle_split_iter_no_indices():
     assert_array_equal(sorted(test_indices), np.where(test_mask)[0])
 
 
+def test_leave_label_out_changing_labels():
+    # Check that LeaveOneLabelOut and LeavePLabelOut work normally if the labels
+    # variable is changed before calling __iter__
+    labels = np.array([0, 1, 2, 1, 1, 2, 0, 0])
+    labels_changing = np.array(labels, copy=True)
+    lolo = cval.LeaveOneLabelOut(labels)
+    lolo_changing = cval.LeaveOneLabelOut(labels_changing)
+    lplo = cval.LeavePLabelOut(labels, p=2)
+    lplo_changing = cval.LeavePLabelOut(labels_changing, p=2)
+    labels_changing[:] = 0
+    for llo, llo_changing in [(lolo, lolo_changing), (lplo, lplo_changing)]:
+        for (train, test), (train_chan, test_chan) in zip(llo, llo_changing):
+            assert_array_equal(train, train_chan)
+            assert_array_equal(test, test_chan)
+
+
 def test_cross_val_score():
     clf = MockClassifier()
     for a in range(-10, 10):


### PR DESCRIPTION
I've fixed `LeaveOneLabelOut` and `LeavePLabelsOut`'s handling of labels as discussed with @larsmans:
https://github.com/scikit-learn/scikit-learn/pull/1775#discussion-diff-3373086.

Here is the summary of changes:
- copying of `labels` is done in `__init__` instead of `__iter__`
- redundant calls to `unique` function are removed
- a test case is added that checks if `LeaveOneLabelOut` and `LeavePLabelsOut` handle changing of `labels` variable properly (current `master` fails the test).
