### PR TITLE
small change to hmm documentation (believe predict should use model2, not model)

### DIFF
--- a/doc/modules/hmm.rst
+++ b/doc/modules/hmm.rst
@@ -94,12 +94,13 @@ The inferred optimal hidden states can be obtained by calling `predict` method.
 The `predict` method can be specified with decoder algorithm.
 Currently the Viterbi algorithm (`viterbi`), and maximum a posteriori
 estimation (`map`) are supported.
-This time, the input is a single sequence of observed values.::
+This time, the input is a single sequence of observed values.  Note, the states
+in model2 will have a different order than those in the generating model.::
 
     >>> model2 = hmm.GaussianHMM(3, "full")
     >>> model2.fit([X]) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
     GaussianHMM(algorithm='viterbi',...
-    >>> Z2 = model.predict(X)
+    >>> Z2 = model2.predict(X)
 
 
 .. topic:: Examples:


### PR DESCRIPTION
Should use model2.predict(X) instead of model.predict(X).  The predicted states, though, will have a different sort order than the generating model.
