### PR TITLE
[MRG] preprocessing.normalize_proba

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -72,6 +72,11 @@ Changelog
      the fraction or the number of correctly classified sample
      by `Arnaud Joly`_.
 
+   - Fixed bug in :func:`hmm.normalize` causing non-inplace normalization.
+
+   - The :func:`hmm.normalize` is now deprecated and superseded by
+     :func:`utils.extmath.normalize_proba`.
+
 
 API changes summary
 -------------------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -411,7 +411,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble, SelectorMixin)):
                         warn("Some inputs do not have OOB scores. "
                              "This probably means too few trees were used "
                              "to compute any reliable oob estimates.")
-                    decision = normalize_proba(predictions[k])
+                    decision = normalize_proba(predictions[k], copy=False)
                     self.oob_decision_function_.append(decision)
                     self.oob_score_ += np.mean(
                         (y[:, k] == classes_[k].take(

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -48,7 +48,7 @@ from ..externals import six
 from ..externals.six.moves import xrange
 from ..feature_selection.selector_mixin import SelectorMixin
 from ..metrics import r2_score
-from ..preprocessing import OneHotEncoder
+from ..preprocessing import OneHotEncoder, normalize_proba
 from ..tree import (DecisionTreeClassifier, DecisionTreeRegressor,
                     ExtraTreeClassifier, ExtraTreeRegressor)
 from ..tree._tree import DTYPE, DOUBLE
@@ -411,9 +411,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble, SelectorMixin)):
                         warn("Some inputs do not have OOB scores. "
                              "This probably means too few trees were used "
                              "to compute any reliable oob estimates.")
-
-                    decision = (predictions[k] /
-                                predictions[k].sum(axis=1)[:, np.newaxis])
+                    decision = normalize_proba(predictions[k])
                     self.oob_decision_function_.append(decision)
                     self.oob_score_ += np.mean(
                         (y[:, k] == classes_[k].take(

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -48,12 +48,13 @@ from ..externals import six
 from ..externals.six.moves import xrange
 from ..feature_selection.selector_mixin import SelectorMixin
 from ..metrics import r2_score
-from ..preprocessing import OneHotEncoder, normalize_proba
+from ..preprocessing import OneHotEncoder
 from ..tree import (DecisionTreeClassifier, DecisionTreeRegressor,
                     ExtraTreeClassifier, ExtraTreeRegressor)
 from ..tree._tree import DTYPE, DOUBLE
 from ..utils import array2d, check_random_state, check_arrays, safe_asarray
 from ..utils.fixes import bincount
+from ..utils.extmath import normalize_proba
 
 
 from .base import BaseEnsemble

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -40,7 +40,7 @@ decoder_algorithms = ("viterbi", "map")
 @deprecated("Function `sklearn.hmm.normalize` has "
             "been superseded by `sklearn.preprocessing.normalize_proba`")
 def normalize(A, axis=None):
-    """ Deprecated, use preprocessing.normalizel_proba instead.
+    """ Deprecated, use preprocessing.normalize_proba instead.
     Normalize the input array so that it sums to 1.
 
     Parameters

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -17,9 +17,8 @@ import string
 import numpy as np
 
 from .utils import check_random_state, deprecated
-from .utils.extmath import logsumexp
+from .utils.extmath import logsumexp, normalize_proba
 from .base import BaseEstimator
-from .preprocessing import normalize_proba
 from .mixture import (
     GMM, log_multivariate_normal_density, sample_gaussian,
     distribute_covar_matrix_to_match_covariance_type, _validate_covars)

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -38,9 +38,9 @@ decoder_algorithms = ("viterbi", "map")
 
 
 @deprecated("Function `sklearn.hmm.normalize` has "
-            "been superseded by `sklearn.preprocessing.normalize_proba`")
+            "been superseded by `sklearn.utils.extmath.normalize_proba`")
 def normalize(A, axis=None):
-    """ Deprecated, use preprocessing.normalize_proba instead.
+    """ Deprecated, use utils.extmath.normalize_proba instead.
     Normalize the input array so that it sums to 1.
 
     Parameters

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -36,9 +36,11 @@ EPS = np.finfo(float).eps
 NEGINF = -np.inf
 decoder_algorithms = ("viterbi", "map")
 
-
+@deprecated("Function `sklearn.hmm.normalize` has "
+            "been superseded by `sklearn.preprocessing.normalize_proba`")
 def normalize(A, axis=None):
-    """ Normalize the input array so that it sums to 1.
+    """ Deprecated, use preprocessing.normalizel_proba instead.
+    Normalize the input array so that it sums to 1.
 
     Parameters
     ----------

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -62,7 +62,9 @@ def normalize(A, axis=None):
         shape = list(A.shape)
         shape[axis] = 1
         Asum.shape = shape
-    return A / Asum
+    A /= Asum
+
+    return A
 
 
 class _BaseHMM(BaseEstimator):

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -37,6 +37,7 @@ EPS = np.finfo(float).eps
 NEGINF = -np.inf
 decoder_algorithms = ("viterbi", "map")
 
+
 @deprecated("Function `sklearn.hmm.normalize` has "
             "been superseded by `sklearn.preprocessing.normalize_proba`")
 def normalize(A, axis=None):
@@ -569,11 +570,11 @@ class _BaseHMM(BaseEstimator):
 
         if 's' in params:
             self.startprob_ = normalize_proba(
-                np.maximum(self.startprob_prior - 1.0 + stats['start'], 1e-20), 
+                np.maximum(self.startprob_prior - 1.0 + stats['start'], 1e-20),
                 copy=False)
         if 't' in params:
             transmat_ = normalize_proba(
-                np.maximum(self.transmat_prior - 1.0 + stats['trans'], 1e-20), 
+                np.maximum(self.transmat_prior - 1.0 + stats['trans'], 1e-20),
                 copy=False)
             self.transmat_ = transmat_
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -274,7 +274,7 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         # up to a multiplicative constant.
         likelihood = np.exp(values - values.max(axis=1)[:, np.newaxis])
         # compute posterior probabilities
-        probabilities = normalize_proba(likelihood, copy=True)
+        probabilities = normalize_proba(likelihood, copy=False)
         return probabilities
 
     def predict_log_proba(self, X):

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -14,6 +14,7 @@ from .base import BaseEstimator, ClassifierMixin, TransformerMixin
 from .utils.extmath import logsumexp
 from .utils.fixes import unique
 from .utils import check_arrays, array2d
+from .preprocessing import normalize_proba
 
 __all__ = ['LDA']
 
@@ -273,7 +274,8 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         # up to a multiplicative constant.
         likelihood = np.exp(values - values.max(axis=1)[:, np.newaxis])
         # compute posterior probabilities
-        return likelihood / likelihood.sum(axis=1)[:, np.newaxis]
+        probabilities = normalize_proba(likelihood, copy=True)
+        return probabilities
 
     def predict_log_proba(self, X):
         """

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -11,10 +11,9 @@ import numpy as np
 from scipy import linalg
 
 from .base import BaseEstimator, ClassifierMixin, TransformerMixin
-from .utils.extmath import logsumexp
+from .utils.extmath import logsumexp, normalize_proba
 from .utils.fixes import unique
 from .utils import check_arrays, array2d
-from .preprocessing import normalize_proba
 
 __all__ = ['LDA']
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -37,7 +37,7 @@ import warnings
 
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MetaEstimatorMixin
-from .preprocessing import LabelBinarizer
+from .preprocessing import LabelBinarizer, normalize_proba
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
 from .externals.joblib import Parallel
@@ -113,7 +113,7 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
     if not is_multilabel:
         # Then, probabilities should be normalized to 1.
-        Y /= np.sum(Y, axis=1)[:, np.newaxis]
+        Y = normalize_proba(Y, copy=False) 
     return Y
 
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -37,9 +37,10 @@ import warnings
 
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MetaEstimatorMixin
-from .preprocessing import LabelBinarizer, normalize_proba
+from .preprocessing import LabelBinarizer
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
+from .utils.extmath import normalize_proba
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -113,7 +113,7 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
     if not is_multilabel:
         # Then, probabilities should be normalized to 1.
-        Y = normalize_proba(Y, copy=False) 
+        Y = normalize_proba(Y, copy=False)
     return Y
 
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 from scipy import stats
 from ..utils.extmath import weighted_mode
+from ..preprocessing import normalize_proba
 
 from .base import \
     _check_weights, _get_weights, \
@@ -168,16 +169,15 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if weights is None:
             weights = np.ones_like(pred_labels)
 
-        probabilities = np.zeros((X.shape[0], self.classes_.size))
+        votes = np.zeros((X.shape[0], self.classes_.size))
 
         # a simple ':' index doesn't work right
         all_rows = np.arange(X.shape[0])
 
         for i, idx in enumerate(pred_labels.T):  # loop is O(n_neighbors)
-            probabilities[all_rows, idx] += weights[:, i]
+            votes[all_rows, idx] += weights[:, i]
 
-        # normalize 'votes' into real [0,1] probabilities
-        probabilities = (probabilities.T / probabilities.sum(axis=1)).T
+        probabilities = normalize_proba(votes, copy=True)
 
         return probabilities
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -177,7 +177,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         for i, idx in enumerate(pred_labels.T):  # loop is O(n_neighbors)
             votes[all_rows, idx] += weights[:, i]
 
-        probabilities = normalize_proba(votes, copy=True)
+        probabilities = normalize_proba(votes, copy=False)
 
         return probabilities
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -11,8 +11,7 @@ import warnings
 
 import numpy as np
 from scipy import stats
-from ..utils.extmath import weighted_mode
-from ..preprocessing import normalize_proba
+from ..utils.extmath import weighted_mode, normalize_proba
 
 from .base import \
     _check_weights, _get_weights, \

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -38,6 +38,7 @@ __all__ = ['Binarizer',
            'StandardScaler',
            'binarize',
            'normalize',
+           'normalize_proba',
            'scale']
 
 
@@ -455,6 +456,44 @@ def normalize(X, norm='l2', axis=1, copy=True):
     if axis == 0:
         X = X.T
 
+    return X
+
+
+def normalize_proba(X, copy=True):
+    """Normalize a probability or an array of probabilties.
+
+    Parameters
+    ----------
+    X : array with shape [n_probabilties, n_values] or [n_values]
+
+    copy : boolean, optional, default is True
+        set to False to perform inplace normalization and avoid a
+        copy.
+
+    See also
+    --------
+    :func:`sklearn.preprocessing.normalize` to perform L1 or L2
+    normalization.
+    """
+    if hasattr(X, 'ndim') and X.ndim not in (1,2):
+        raise ValueError(
+            "Number of dimensions other than 1 or 2 not supported.")
+    
+    X = check_arrays(X, copy=copy)[0]
+    warn_if_not_float(X, 'The normalize_proba function')
+    
+    if np.any(X < 0.0):
+        raise ValueError("X is not a probability or probability array.")
+
+    if X.ndim == 1:
+        norms = X.sum()
+        norms = 1.0 if norms == 0.0 else norms
+    else:
+        norms = X.sum(axis=1)[:, np.newaxis]
+        norms[norms == 0.0] = 1.0
+
+    X /= norms
+    
     return X
 
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -475,13 +475,13 @@ def normalize_proba(X, copy=True):
     :func:`sklearn.preprocessing.normalize` to perform L1 or L2
     normalization.
     """
-    if hasattr(X, 'ndim') and X.ndim not in (1,2):
+    if hasattr(X, 'ndim') and X.ndim not in (1, 2):
         raise ValueError(
             "Number of dimensions other than 1 or 2 not supported.")
-    
+
     X = check_arrays(X, copy=copy)[0]
     warn_if_not_float(X, 'The normalize_proba function')
-    
+
     if np.any(X < 0.0):
         raise ValueError("X is not a probability or probability array.")
 
@@ -493,7 +493,7 @@ def normalize_proba(X, copy=True):
         norms[norms == 0.0] = 1.0
 
     X /= norms
-    
+
     return X
 
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -38,7 +38,6 @@ __all__ = ['Binarizer',
            'StandardScaler',
            'binarize',
            'normalize',
-           'normalize_proba',
            'scale']
 
 
@@ -455,44 +454,6 @@ def normalize(X, norm='l2', axis=1, copy=True):
 
     if axis == 0:
         X = X.T
-
-    return X
-
-
-def normalize_proba(X, copy=True):
-    """Normalize a probability or an array of probabilties.
-
-    Parameters
-    ----------
-    X : array with shape [n_probabilties, n_values] or [n_values]
-
-    copy : boolean, optional, default is True
-        set to False to perform inplace normalization and avoid a
-        copy.
-
-    See also
-    --------
-    :func:`sklearn.preprocessing.normalize` to perform L1 or L2
-    normalization.
-    """
-    if hasattr(X, 'ndim') and X.ndim not in (1, 2):
-        raise ValueError(
-            "Number of dimensions other than 1 or 2 not supported.")
-
-    X = check_arrays(X, copy=copy)[0]
-    warn_if_not_float(X, 'The normalize_proba function')
-
-    if np.any(X < 0.0):
-        raise ValueError("X is not a probability or probability array.")
-
-    if X.ndim == 1:
-        norms = X.sum()
-        norms = 1.0 if norms == 0.0 else norms
-    else:
-        norms = X.sum(axis=1)[:, np.newaxis]
-        norms[norms == 0.0] = 1.0
-
-    X /= norms
 
     return X
 

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -14,6 +14,7 @@ from .base import BaseEstimator, ClassifierMixin
 from .externals.six.moves import xrange
 from .utils.fixes import unique
 from .utils import check_arrays, array2d
+from .preprocessing import normalize_proba
 
 __all__ = ['QDA']
 
@@ -213,7 +214,10 @@ class QDA(BaseEstimator, ClassifierMixin):
         # up to a multiplicative constant.
         likelihood = np.exp(values - values.min(axis=1)[:, np.newaxis])
         # compute posterior probabilities
-        return likelihood / likelihood.sum(axis=1)[:, np.newaxis]
+        probabilities = normalize_proba(likelihood, copy=True)
+        
+        return probabilities
+
 
     def predict_log_proba(self, X):
         """Return posterior probabilities of classification.

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -13,8 +13,8 @@ import numpy as np
 from .base import BaseEstimator, ClassifierMixin
 from .externals.six.moves import xrange
 from .utils.fixes import unique
+from .utils.extmath import normalize_proba
 from .utils import check_arrays, array2d
-from .preprocessing import normalize_proba
 
 __all__ = ['QDA']
 

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -215,9 +215,8 @@ class QDA(BaseEstimator, ClassifierMixin):
         likelihood = np.exp(values - values.min(axis=1)[:, np.newaxis])
         # compute posterior probabilities
         probabilities = normalize_proba(likelihood, copy=True)
-        
-        return probabilities
 
+        return probabilities
 
     def predict_log_proba(self, X):
         """Return posterior probabilities of classification.

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -214,7 +214,7 @@ class QDA(BaseEstimator, ClassifierMixin):
         # up to a multiplicative constant.
         likelihood = np.exp(values - values.min(axis=1)[:, np.newaxis])
         # compute posterior probabilities
-        probabilities = normalize_proba(likelihood, copy=True)
+        probabilities = normalize_proba(likelihood, copy=False)
 
         return probabilities
 

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -181,7 +181,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator, Classifier
         else:
             weight_matrices = weight_matrices.T
             probabilities = np.dot(weight_matrices, self.label_distributions_)
-        
+
         probabilities = normalize_proba(probabilities, copy=False)
         return probabilities
 

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -59,6 +59,7 @@ from scipy import sparse
 import numpy as np
 
 from ..base import BaseEstimator, ClassifierMixin
+from ..preprocessing import normalize_proba
 from ..metrics.pairwise import rbf_kernel
 from ..utils.graph import graph_laplacian
 from ..utils.extmath import safe_sparse_dot
@@ -180,8 +181,8 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator, Classifier
         else:
             weight_matrices = weight_matrices.T
             probabilities = np.dot(weight_matrices, self.label_distributions_)
-        normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
-        probabilities /= normalizer
+        
+        probabilities = normalize_proba(probabilities, copy=False)
         return probabilities
 
     def fit(self, X, y):

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -59,10 +59,9 @@ from scipy import sparse
 import numpy as np
 
 from ..base import BaseEstimator, ClassifierMixin
-from ..preprocessing import normalize_proba
 from ..metrics.pairwise import rbf_kernel
 from ..utils.graph import graph_laplacian
-from ..utils.extmath import safe_sparse_dot
+from ..utils.extmath import safe_sparse_dot, normalize_proba
 from ..externals import six
 from ..neighbors.unsupervised import NearestNeighbors
 

--- a/sklearn/tests/test_hmm.py
+++ b/sklearn/tests/test_hmm.py
@@ -7,8 +7,7 @@ from unittest import TestCase
 from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn import hmm
 from sklearn import mixture
-from sklearn.preprocessing import normalize_proba
-from sklearn.utils.extmath import logsumexp
+from sklearn.utils.extmath import logsumexp, normalize_proba
 from sklearn.utils import check_random_state
 
 from nose import SkipTest

--- a/sklearn/tests/test_hmm.py
+++ b/sklearn/tests/test_hmm.py
@@ -500,10 +500,10 @@ class MultinomialHMMTestCase(TestCase):
 
         # Mess up the parameters and see if we can re-learn them.
         h.startprob_ = normalize_proba(
-            self.prng.rand(self.n_components), 
+            self.prng.rand(self.n_components),
             copy=False)
         h.transmat_ = normalize_proba(
-            self.prng.rand(self.n_components, self.n_components), 
+            self.prng.rand(self.n_components, self.n_components),
             copy=False)
         h.emissionprob_ = normalize_proba(
             self.prng.rand(self.n_components, self.n_symbols),
@@ -648,7 +648,7 @@ class GMMHMMBaseTester(object):
             self.prng.rand(self.n_components, self.n_components),
             copy=False)
         h.startprob_ = normalize_proba(
-            self.prng.rand(self.n_components), 
+            self.prng.rand(self.n_components),
             copy=False)
 
         trainll = train_hmm_and_keep_track_of_log_likelihood(

--- a/sklearn/tests/test_hmm.py
+++ b/sklearn/tests/test_hmm.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn import hmm
 from sklearn import mixture
+from sklearn.preprocessing import normalize_proba
 from sklearn.utils.extmath import logsumexp
 from sklearn.utils import check_random_state
 
@@ -276,8 +277,9 @@ class GaussianHMMBaseTester(object):
     def test_fit(self, params='stmc', n_iter=5, verbose=False, **kwargs):
         h = hmm.GaussianHMM(self.n_components, self.covariance_type)
         h.startprob_ = self.startprob
-        h.transmat_ = hmm.normalize(
-            self.transmat + np.diag(self.prng.rand(self.n_components)), 1)
+        h.transmat_ = normalize_proba(
+            self.transmat + np.diag(self.prng.rand(self.n_components)),
+            copy=False)
         h.means_ = 20 * self.means
         h.covars_ = self.covars[self.covariance_type]
 
@@ -325,8 +327,9 @@ class GaussianHMMBaseTester(object):
         h = hmm.GaussianHMM(self.n_components, self.covariance_type)
         h.startprob_ = self.startprob
         h.startprob_prior = startprob_prior
-        h.transmat_ = hmm.normalize(
-            self.transmat + np.diag(self.prng.rand(self.n_components)), 1)
+        h.transmat_ = hmm.normalize_proba(
+            self.transmat + np.diag(self.prng.rand(self.n_components)),
+            copy=False)
         h.transmat_prior = transmat_prior
         h.means_ = 20 * self.means
         h.means_prior = means_prior
@@ -496,11 +499,15 @@ class MultinomialHMMTestCase(TestCase):
         train_obs = [h.sample(n=10)[0] for x in range(10)]
 
         # Mess up the parameters and see if we can re-learn them.
-        h.startprob_ = hmm.normalize(self.prng.rand(self.n_components))
-        h.transmat_ = hmm.normalize(self.prng.rand(self.n_components,
-                                                   self.n_components), axis=1)
-        h.emissionprob_ = hmm.normalize(
-            self.prng.rand(self.n_components, self.n_symbols), axis=1)
+        h.startprob_ = normalize_proba(
+            self.prng.rand(self.n_components), 
+            copy=False)
+        h.transmat_ = normalize_proba(
+            self.prng.rand(self.n_components, self.n_components), 
+            copy=False)
+        h.emissionprob_ = normalize_proba(
+            self.prng.rand(self.n_components, self.n_symbols),
+            copy=False)
 
         trainll = train_hmm_and_keep_track_of_log_likelihood(
             h, train_obs, n_iter=n_iter, params=params, **kwargs)[1:]
@@ -551,7 +558,7 @@ def create_random_gmm(n_mix, n_features, covariance_type, prng=0):
             [make_spd_matrix(n_features, random_state=prng)
              + mincv * np.eye(n_features) for x in range(n_mix)])
     }[covariance_type]
-    g.weights_ = hmm.normalize(prng.rand(n_mix))
+    g.weights_ = normalize_proba(prng.rand(n_mix), copy=False)
     return g
 
 
@@ -625,8 +632,9 @@ class GMMHMMBaseTester(object):
     def test_fit(self, params='stmwc', n_iter=5, verbose=False, **kwargs):
         h = hmm.GMMHMM(self.n_components, covars_prior=1.0)
         h.startprob_ = self.startprob
-        h.transmat_ = hmm.normalize(
-            self.transmat + np.diag(self.prng.rand(self.n_components)), 1)
+        h.transmat_ = normalize_proba(
+            self.transmat + np.diag(self.prng.rand(self.n_components)),
+            copy=False)
         h.gmms_ = self.gmms_
 
         # Create training data by sampling from the HMM.
@@ -636,9 +644,12 @@ class GMMHMMBaseTester(object):
         # Mess up the parameters and see if we can re-learn them.
         h.n_iter = 0
         h.fit(train_obs)
-        h.transmat_ = hmm.normalize(self.prng.rand(self.n_components,
-                                                   self.n_components), axis=1)
-        h.startprob_ = hmm.normalize(self.prng.rand(self.n_components))
+        h.transmat_ = normalize_proba(
+            self.prng.rand(self.n_components, self.n_components),
+            copy=False)
+        h.startprob_ = normalize_proba(
+            self.prng.rand(self.n_components), 
+            copy=False)
 
         trainll = train_hmm_and_keep_track_of_log_likelihood(
             h, train_obs, n_iter=n_iter, params=params)[1:]

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -434,9 +434,9 @@ def test_probability_normalize():
             X0_norm is not X0
         else:
             X0_norm is X0
-        assert_almost_equal(X0_norm, X0) 
-        
-        for ndim in (1,2):
+        assert_almost_equal(X0_norm, X0)
+
+        for ndim in (1, 2):
             X1 = np.abs(rng.randn(*([5]*ndim)))
             X1_norm = normalize_proba(X1, copy=copy)
             if copy:
@@ -444,7 +444,7 @@ def test_probability_normalize():
             else:
                 X1_norm is X1
             for component in X1_norm.sum(
-                    axis=(0 if ndim==1 else 1), 
+                    axis=(0 if ndim == 1 else 1),
                     keepdims=(True if ndim == 1 else 2)):
                 assert_almost_equal(component, 1.0)
 
@@ -457,14 +457,15 @@ def test_probability_normalize_errors():
                 [[-1.0, 1.0], [1.0, 1.0]]
             ],
             [False, True]
-        ):
+    ):
         assert_raises(ValueError, normalize_proba, X, copy=copy)
-    
+
     for X, copy in product(
-            [np.ones([1, 1, 1]), np.ones([])], 
+            [np.ones([1, 1, 1]), np.ones([])],
             [False, True]
-        ):
+    ):
         assert_raises(ValueError, normalize_proba, X, copy=copy)
+
 
 def test_binarizer():
     X_ = np.array([[1, 0, 5], [2, 3, 0]])

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -436,17 +436,18 @@ def test_probability_normalize():
             X0_norm is X0
         assert_almost_equal(X0_norm, X0)
 
+        size = 5
         for ndim in (1, 2):
-            X1 = np.abs(rng.randn(*([5]*ndim)))
+            X1 = np.abs(rng.randn(*([size]*ndim)))
             X1_norm = normalize_proba(X1, copy=copy)
             if copy:
                 X1_norm is not X1
             else:
                 X1_norm is X1
-            for component in X1_norm.sum(
-                    axis=(0 if ndim == 1 else 1),
-                    keepdims=(True if ndim == 1 else 2)):
-                assert_almost_equal(component, 1.0)
+            if ndim == 1:
+                assert_almost_equal(X1_norm.sum(), 1.0)
+            else:
+                assert_almost_equal(X1_norm.sum(axis=1), np.ones((size,)))
 
 
 def test_probability_normalize_errors():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -11,6 +11,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
+from sklearn.utils.extmath import normalize_proba
 
 from sklearn.utils.sparsefuncs import mean_variance_axis0
 from sklearn.preprocessing import Binarizer
@@ -20,7 +21,6 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import Normalizer
 from sklearn.preprocessing import normalize
-from sklearn.preprocessing import normalize_proba
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import scale
 from sklearn.preprocessing import MinMaxScaler

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from scipy import linalg
 
-from . import check_random_state
+from . import check_random_state, check_arrays, warn_if_not_float
 from .fixes import qr_economic
 from ..externals.six.moves import xrange
 
@@ -17,6 +17,44 @@ def norm(v):
     v = np.asarray(v)
     __nrm2, = linalg.get_blas_funcs(['nrm2'], [v])
     return __nrm2(v)
+
+
+def normalize_proba(X, copy=True):
+    """Normalize a probability or an array of probabilties.
+
+    Parameters
+    ----------
+    X : array with shape [n_probabilties, n_values] or [n_values]
+
+    copy : boolean, optional, default is True
+        set to False to perform inplace normalization and avoid a
+        copy.
+
+    See also
+    --------
+    :func:`sklearn.preprocessing.normalize` to perform L1 or L2
+    normalization.
+    """
+    if hasattr(X, 'ndim') and X.ndim not in (1, 2):
+        raise ValueError(
+            "Number of dimensions other than 1 or 2 not supported.")
+
+    X = check_arrays(X, copy=copy)[0]
+    warn_if_not_float(X, 'The normalize_proba function')
+
+    if np.any(X < 0.0):
+        raise ValueError("X is not a probability or probability array.")
+
+    if X.ndim == 1:
+        norms = X.sum()
+        norms = 1.0 if norms == 0.0 else norms
+    else:
+        norms = X.sum(axis=1)[:, np.newaxis]
+        norms[norms == 0.0] = 1.0
+
+    X /= norms
+
+    return X
 
 
 def _fast_logdet(A):


### PR DESCRIPTION
Deprecated the HMM.normalize and instead used preprocessing.normalize_proba.
Changed the usage of normalizations across the code to instead use preprocessing.normalize_proba.
All tests passes, didn't manage to get the benchmark to work properly so I don't know the performance impact.

In response to: https://github.com/scikit-learn/scikit-learn/issues/1862

Not sure about the name adopted it from predict_proba
