### PR TITLE
Patch extractor doesn't support float values for max patches

### DIFF
--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -181,9 +181,20 @@ def test_patch_extractor_fit():
 
 def test_patch_extractor_max_patches():
     lenas = lena_collection
-    extr = PatchExtractor(patch_size=(8, 8), max_patches=100, random_state=0)
+    i_h, i_w = lenas.shape[1:3]
+    p_h, p_w = 8, 8
+
+    max_patches = 100
+    expected_n_patches = len(lenas) * max_patches
+    extr = PatchExtractor(patch_size=(p_h, p_w), max_patches=max_patches, random_state=0)
     patches = extr.transform(lenas)
-    assert_true(patches.shape == (len(lenas) * 100, 8, 8))
+    assert_true(patches.shape == (expected_n_patches, p_h, p_w))
+
+    max_patches = 0.5
+    expected_n_patches = len(lenas) * int((i_h - p_h + 1) * (i_w - p_w + 1) * max_patches)
+    extr = PatchExtractor(patch_size=(p_h, p_w), max_patches=max_patches, random_state=0)
+    patches = extr.transform(lenas)
+    assert_true(patches.shape == (expected_n_patches, p_h, p_w))
 
 
 def test_patch_extractor_max_patches_default():


### PR DESCRIPTION
I got this error when using max_patches=0.1 with PatchExtractor:

```
ValueError: could not broadcast input array from shape (103632,7,7) into shape (0,7,7)
```

I solved the problem with an auxiliar function to avoid code duplication and I added a test.
