### PR TITLE
FIX bug where hinge_loss(..., neg_label=1) would produce incorrect results

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -212,7 +212,7 @@ def auc(x, y, reorder=False):
 ###############################################################################
 # Binary classification loss
 ###############################################################################
-def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
+def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
     """Average hinge loss (non-regularized)
 
     Assuming labels in y_true are encoded with +1 and -1, when a prediction
@@ -256,14 +256,15 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=-1):
     0.30...
 
     """
+    if neg_label is not None:
+        warnings.warn("'neg_label' is unused and will be removed in "
+                "release 0.15.", DeprecationWarning)
+
     # TODO: multi-class hinge-loss
 
-    if pos_label != 1 or neg_label != -1:
-        # the rest of the code assumes that positive and negative labels
-        # are encoded as +1 and -1 respectively
-        y_true = y_true.copy()
-        y_true[y_true == pos_label] = 1
-        y_true[y_true == neg_label] = -1
+    # the rest of the code assumes that positive and negative labels
+    # are encoded as +1 and -1 respectively
+    y_true = (y_true == pos_label) * 2 - 1
 
     margin = y_true * pred_decision
     losses = 1 - margin

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -212,7 +212,7 @@ def auc(x, y, reorder=False):
 ###############################################################################
 # Binary classification loss
 ###############################################################################
-def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
+def hinge_loss(y_true, pred_decision, pos_label=None, neg_label=None):
     """Average hinge loss (non-regularized)
 
     Assuming labels in y_true are encoded with +1 and -1, when a prediction
@@ -224,7 +224,8 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
     Parameters
     ----------
     y_true : array, shape = [n_samples]
-        True target (integers).
+        True target, consisting of integers of two values. The positive label
+        must be greater than the negative label.
 
     pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
         Predicted decisions, as output by decision_function (floats).
@@ -256,6 +257,9 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
     0.30...
 
     """
+    if pos_label is not None:
+        warnings.warn("'pos_label' is deprecated and will be removed in "
+                      "release 0.15.", DeprecationWarning)
     if neg_label is not None:
         warnings.warn("'neg_label' is unused and will be removed in "
                       "release 0.15.", DeprecationWarning)
@@ -264,7 +268,10 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
 
     # the rest of the code assumes that positive and negative labels
     # are encoded as +1 and -1 respectively
-    y_true = (np.asarray(y_true) == pos_label) * 2 - 1
+    if pos_label is not None:
+        y_true = (np.asarray(y_true) == pos_label) * 2 - 1
+    else:
+        y_true = LabelBinarizer(neg_label=-1).fit_transform(y_true)[:, 0]
 
     margin = y_true * np.asarray(pred_decision)
     losses = 1 - margin

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -264,9 +264,9 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
 
     # the rest of the code assumes that positive and negative labels
     # are encoded as +1 and -1 respectively
-    y_true = (y_true == pos_label) * 2 - 1
+    y_true = (np.asarray(y_true) == pos_label) * 2 - 1
 
-    margin = y_true * pred_decision
+    margin = y_true * np.asarray(pred_decision)
     losses = 1 - margin
     # The hinge doesn't penalize good enough predictions.
     losses[losses <= 0] = 0

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -258,7 +258,7 @@ def hinge_loss(y_true, pred_decision, pos_label=1, neg_label=None):
     """
     if neg_label is not None:
         warnings.warn("'neg_label' is unused and will be removed in "
-                "release 0.15.", DeprecationWarning)
+                      "release 0.15.", DeprecationWarning)
 
     # TODO: multi-class hinge-loss
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -783,14 +783,15 @@ def test_hinge_loss_binary():
     assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision))
 
     with warnings.catch_warnings():
-        assert_equal(hinge_loss(-y_true, pred_decision),
+        assert_equal(
+                hinge_loss(-y_true, pred_decision),
                 hinge_loss(y_true, pred_decision, pos_label=-1, neg_label=1))
 
     y_true = np.array([0, 2, 2, 0])
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])
     with warnings.catch_warnings():
         assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision,
-            pos_label=2, neg_label=0))
+                                         pos_label=2, neg_label=0))
 
 
 def test_multioutput_regression():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -783,13 +783,16 @@ def test_hinge_loss_binary():
     assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision))
 
     with warnings.catch_warnings():
+        # Test deprecated pos_label
         assert_equal(
             hinge_loss(-y_true, pred_decision),
             hinge_loss(y_true, pred_decision, pos_label=-1, neg_label=1))
 
     y_true = np.array([0, 2, 2, 0])
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])
+    assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision))
     with warnings.catch_warnings():
+        # Test deprecated pos_label
         assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision,
                                          pos_label=2, neg_label=0))
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -784,8 +784,8 @@ def test_hinge_loss_binary():
 
     with warnings.catch_warnings():
         assert_equal(
-                hinge_loss(-y_true, pred_decision),
-                hinge_loss(y_true, pred_decision, pos_label=-1, neg_label=1))
+            hinge_loss(-y_true, pred_decision),
+            hinge_loss(y_true, pred_decision, pos_label=-1, neg_label=1))
 
     y_true = np.array([0, 2, 2, 0])
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -782,10 +782,15 @@ def test_hinge_loss_binary():
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])
     assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision))
 
+    with warnings.catch_warnings():
+        assert_equal(hinge_loss(-y_true, pred_decision),
+                hinge_loss(y_true, pred_decision, pos_label=-1, neg_label=1))
+
     y_true = np.array([0, 2, 2, 0])
     pred_decision = np.array([-8.5, 0.5, 1.5, -0.3])
-    assert_equal(1.2 / 4,
-                 hinge_loss(y_true, pred_decision, pos_label=2, neg_label=0))
+    with warnings.catch_warnings():
+        assert_equal(1.2 / 4, hinge_loss(y_true, pred_decision,
+            pos_label=2, neg_label=0))
 
 
 def test_multioutput_regression():


### PR DESCRIPTION
The following is bad (consider `neg_label == 1`, or `y_true.dtype == 'S1'` for that matter):

``` python
y_true[y_true == pos_label] = 1
y_true[y_true == neg_label] = -1
```

The following are good:

``` python
y_true = (y_true == pos_label) * 2 -1
```

or 

``` python
orig = y_true
y_true = np.repeat(-1, orig.shape)
y_true[orig == pos_label] = 1
```

Hence I have deprecated `neg_label` in `hinge_loss`.
