### PR TITLE
REFACTOR roc_curve and precision_recall_curve

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -628,7 +628,7 @@ def roc_curve(y_true, y_score, pos_label=None):
         # Add an extra threshold position if necessary
         tps = np.r_[0, tps]
         fps = np.r_[0, fps]
-        thresholds = np.r_[np.inf, thresholds]
+        thresholds = np.r_[thresholds[0] + 1, thresholds]
     
     if fps[-1] == 0:
         warnings.warn("No negative samples in y_true, "

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -521,14 +521,17 @@ def precision_recall_curve(y_true, probas_pred):
 
     Returns
     -------
-    precision : array, shape = [n + 1]
-        Precision values.
+    precision : array, shape = [n_thresholds + 1]
+        Precision values such that element i is the precision of predictions
+        with score >= thresholds[i] and the last element is 1.
 
-    recall : array, shape = [n + 1]
-        Recall values.
+    recall : array, shape = [n_thresholds + 1]
+        Recall values such that element i is the recall of predictions with
+        score >= thresholds[i] and the last element is 0.
 
-    thresholds : array, shape = [n]
-        Thresholds on y_score used to compute precision and recall.
+    thresholds : array, shape = [n_thresholds := len(np.unique(probas_pred))]
+        Increasing thresholds on the decision function used to compute
+        precision and recall.
 
     Examples
     --------
@@ -578,13 +581,16 @@ def roc_curve(y_true, y_score, pos_label=None):
     Returns
     -------
     fpr : array, shape = [>2]
-        False Positive Rates.
+        False Positive Rates such that element i is the false positive rate of
+        predictions with score >= thresholds[i].
 
     tpr : array, shape = [>2]
-        True Positive Rates.
+        False Positive Rates such that element i is the true positive rate of
+        predictions with score >= thresholds[i].
 
-    thresholds : array, shape = [>2]
-        Thresholds on ``y_score`` used to compute ``fpr`` and ``fpr``.
+    thresholds : array, shape = [n_thresholds]
+        Decreasing thresholds on the decision function used to compute
+        fpr and tpr.
 
     See also
     --------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -426,9 +426,7 @@ def matthews_corrcoef(y_true, y_pred):
 
 
 def _binary_clf_curve(y_true, y_score, pos_label=None):
-    """
-    Calculate true and false positives across a moving threshold for binary
-    classification.
+    """Calculate true and false positives per binary classification threshold.
 
     Parameters
     ----------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -537,7 +537,8 @@ def precision_recall_curve(y_true, probas_pred):
     >>> from sklearn.metrics import precision_recall_curve
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-    >>> precision, recall, thresholds = precision_recall_curve(y_true, y_scores)
+    >>> precision, recall, thresholds = precision_recall_curve(
+    ...     y_true, y_scores)
     >>> precision  # doctest: +ELLIPSIS
     array([ 0.66...,  0.5       ,  1.        ,  1.        ])
     >>> recall
@@ -629,7 +630,7 @@ def roc_curve(y_true, y_score, pos_label=None):
         tps = np.r_[0, tps]
         fps = np.r_[0, fps]
         thresholds = np.r_[thresholds[0] + 1, thresholds]
-    
+
     if fps[-1] == 0:
         warnings.warn("No negative samples in y_true, "
                       "false positive value should be meaningless")
@@ -643,7 +644,7 @@ def roc_curve(y_true, y_score, pos_label=None):
         tpr = np.repeat(np.nan, tps.shape)
     else:
         tpr = tps / tps[-1]
-    
+
     return fpr, tpr, thresholds
 
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -425,6 +425,74 @@ def matthews_corrcoef(y_true, y_pred):
         return mcc
 
 
+def _binary_clf_curve(y_true, y_score, pos_label=None):
+    """
+    Calculate true and false positives across a moving threshold for binary
+    classification.
+
+    Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        True targets of binary classification
+
+    y_score : array, shape = [n_samples]
+        Estimated probabilities or decision function
+
+    pos_label : int, optional
+        The label of the positive class, defaulting to 1
+
+    Returns
+    -------
+    tps : array, shape = [n_thresholds := len(np.unique(y_score))]
+        An increasing count of true positives, at index i being the number
+        of positive samples assigned a score >= thresholds[i]. The total
+        number of positive samples is equal to tps[-1] (thus false negatives
+        are given by tps[-1] - tps).
+
+    fps : array, shape = [n_thresholds]
+        A count of false positives, at index i being the number of negative
+        samples assigned a score >= thresholds[i]. The total number of
+        negative samples is equal to fps[-1] (thus true negatives are given by
+        fps[-1] - fps).
+
+    thresholds : array, shape = [n_thresholds]
+        Decreasing score values.
+    """
+    y_true = np.ravel(y_true)
+    y_score = np.ravel(y_score)
+
+    # ensure binary classification if pos_label is not specified
+    classes = np.unique(y_true)
+    if (pos_label is None and
+        not (np.all(classes == [0, 1]) or
+             np.all(classes == [-1, 1]) or
+             np.all(classes == [0]) or
+             np.all(classes == [-1]) or
+             np.all(classes == [1]))):
+        raise ValueError("Data is not binary and pos_label is not specified")
+    elif pos_label is None:
+        pos_label = 1.
+
+    # make y_true a boolean vector
+    y_true = (y_true == pos_label)
+
+    # Sort scores and corresponding truth values
+    desc_score_indices = np.argsort(y_score, kind="mergesort")[::-1]
+    y_score = y_score[desc_score_indices]
+    y_true = y_true[desc_score_indices]
+
+    # Probas_pred typically has many tied values. Here we extract
+    # the indices associated with the distinct values. We also
+    # concatenate a value for the end of the curve.
+    distinct_value_indices = np.where(np.diff(y_score))[0]
+    threshold_idxs = np.r_[distinct_value_indices, y_true.size - 1]
+
+    # accumulate the true positives with decreasing threshold
+    tps = y_true.cumsum()[threshold_idxs]
+    fps = 1 + threshold_idxs - tps
+    return tps, fps, y_score[threshold_idxs]
+
+
 def precision_recall_curve(y_true, probas_pred):
     """Compute precision-recall pairs for different probability thresholds
 
@@ -477,64 +545,15 @@ def precision_recall_curve(y_true, probas_pred):
     array([ 0.35,  0.4 ,  0.8 ])
 
     """
-    y_true = np.ravel(y_true)
-    probas_pred = np.ravel(probas_pred)
+    tps, fps, thresholds = _binary_clf_curve(y_true, probas_pred)
 
-    # Make sure input is boolean
-    labels = np.unique(y_true)
-    if np.all(labels == np.array([-1, 1])):
-        # convert {-1, 1} to boolean {0, 1} repr
-        y_true = y_true.copy()
-        y_true[y_true == -1] = 0
-    elif not np.all(labels == np.array([0, 1])):
-        raise ValueError("y_true contains non binary labels: %r" % labels)
+    precision = tps / (tps + fps)
+    recall = tps / tps[-1]
 
-    # Sort pred_probas (and corresponding true labels) by pred_proba value
-    decreasing_probas_indices = np.argsort(probas_pred, kind="mergesort")[::-1]
-    probas_pred = probas_pred[decreasing_probas_indices]
-    y_true = y_true[decreasing_probas_indices]
-
-    # probas_pred typically has many tied values. Here we extract
-    # the indices associated with the distinct values. We also
-    # concatenate values for the beginning and end of the curve.
-    distinct_value_indices = np.where(np.diff(probas_pred))[0] + 1
-    threshold_idxs = np.hstack([0,
-                                distinct_value_indices,
-                                len(probas_pred)])
-
-    # Initialize true and false positive counts, precision and recall
-    total_positive = float(y_true.sum())
-    tp_count, fp_count = 0., 0.  # Must remain floats to prevent int division
-    precision = [1.]
-    recall = [0.]
-    thresholds = []
-
-    # Iterate over indices which indicate distinct values (thresholds) of
-    # probas_pred. Each of these threshold values will be represented in the
-    # curve with a coordinate in precision-recall space. To calculate the
-    # precision and recall associated with each point, we use these indices to
-    # select all labels associated with the predictions. By incrementally
-    # keeping track of the number of positive and negative labels seen so far,
-    # we can calculate precision and recall.
-    for l_idx, r_idx in zip(threshold_idxs[:-1], threshold_idxs[1:]):
-        threshold_labels = y_true[l_idx:r_idx]
-        n_at_threshold = r_idx - l_idx
-        n_pos_at_threshold = threshold_labels.sum()
-        n_neg_at_threshold = n_at_threshold - n_pos_at_threshold
-        tp_count += n_pos_at_threshold
-        fp_count += n_neg_at_threshold
-        fn_count = total_positive - tp_count
-        precision.append(tp_count / (tp_count + fp_count))
-        recall.append(tp_count / (tp_count + fn_count))
-        thresholds.append(probas_pred[l_idx])
-        if tp_count == total_positive:
-            break
-
-    # sklearn expects these in reverse order
-    thresholds = np.array(thresholds)[::-1]
-    precision = np.array(precision)[::-1]
-    recall = np.array(recall)[::-1]
-    return precision, recall, thresholds
+    # stop when full recall attained:
+    last_ind = tps.searchsorted(tps[-1])
+    sl = slice(last_ind, None, -1)
+    return np.r_[precision[sl], 1], np.r_[recall[sl], 0], thresholds[sl]
 
 
 def roc_curve(y_true, y_score, pos_label=None):
@@ -592,105 +611,36 @@ def roc_curve(y_true, y_score, pos_label=None):
     >>> fpr, tpr, thresholds = metrics.roc_curve(y, scores, pos_label=2)
     >>> fpr
     array([ 0. ,  0.5,  0.5,  1. ])
+    >>> tpr
+    array([ 0.5,  0.5,  1. ,  1. ])
 
     """
-    y_true = np.ravel(y_true)
-    y_score = np.ravel(y_score)
-    classes = np.unique(y_true)
+    tps, fps, thresholds = _binary_clf_curve(y_true, y_score, pos_label)
 
-    # ROC only for binary classification if pos_label not given
-    if (pos_label is None and
-        not (np.all(classes == [0, 1]) or
-             np.all(classes == [-1, 1]) or
-             np.all(classes == [0]) or
-             np.all(classes == [-1]) or
-             np.all(classes == [1]))):
-        raise ValueError("ROC is defined for binary classification only or "
-                         "pos_label should be explicitly given")
-    elif pos_label is None:
-        pos_label = 1.
-
-    # y_true will be transformed into a boolean vector
-    y_true = (y_true == pos_label)
-    n_pos = float(y_true.sum())
-    n_neg = y_true.shape[0] - n_pos
-
-    if n_pos == 0:
-        warnings.warn("No positive samples in y_true, "
-                      "true positive value should be meaningless")
-        n_pos = np.nan
-    if n_neg == 0:
+    if tps.size == 0 or fps[0] != 0:
+        # Add an extra threshold position if necessary
+        tps = np.r_[0, tps]
+        fps = np.r_[0, fps]
+        thresholds = np.r_[np.inf, thresholds]
+    
+    if fps[-1] == 0:
         warnings.warn("No negative samples in y_true, "
                       "false positive value should be meaningless")
-        n_neg = np.nan
-
-    thresholds = np.unique(y_score)
-    neg_value, pos_value = False, True
-
-    tpr = np.empty(thresholds.size, dtype=np.float)  # True positive rate
-    fpr = np.empty(thresholds.size, dtype=np.float)  # False positive rate
-
-    # Build tpr/fpr vector
-    current_pos_count = current_neg_count = sum_pos = sum_neg = idx = 0
-
-    signal = np.c_[y_score, y_true]
-    sorted_signal = signal[signal[:, 0].argsort(), :][::-1]
-    last_score = sorted_signal[0][0]
-    for score, value in sorted_signal:
-        if score == last_score:
-            if value == pos_value:
-                current_pos_count += 1
-            else:
-                current_neg_count += 1
-        else:
-            tpr[idx] = (sum_pos + current_pos_count) / n_pos
-            fpr[idx] = (sum_neg + current_neg_count) / n_neg
-            sum_pos += current_pos_count
-            sum_neg += current_neg_count
-            current_pos_count = 1 if value == pos_value else 0
-            current_neg_count = 1 if value == neg_value else 0
-            idx += 1
-            last_score = score
+        fpr = np.repeat(np.nan, fps.shape)
     else:
-        tpr[-1] = (sum_pos + current_pos_count) / n_pos
-        fpr[-1] = (sum_neg + current_neg_count) / n_neg
+        fpr = fps / fps[-1]
 
-    thresholds = thresholds[::-1]
-
-    if not (n_pos is np.nan or n_neg is np.nan):
-        # add (0,0) and (1, 1)
-        if not (fpr[0] == 0 and fpr[-1] == 1):
-            fpr = np.r_[0., fpr, 1.]
-            tpr = np.r_[0., tpr, 1.]
-            thresholds = np.r_[thresholds[0] + 1, thresholds,
-                               thresholds[-1] - 1]
-        elif not fpr[0] == 0:
-            fpr = np.r_[0., fpr]
-            tpr = np.r_[0., tpr]
-            thresholds = np.r_[thresholds[0] + 1, thresholds]
-        elif not fpr[-1] == 1:
-            fpr = np.r_[fpr, 1.]
-            tpr = np.r_[tpr, 1.]
-            thresholds = np.r_[thresholds, thresholds[-1] - 1]
-    elif fpr.shape[0] == 2:
-        # trivial decisions, add (0,0)
-        fpr = np.array([0.0, fpr[0], fpr[1]])
-        tpr = np.array([0.0, tpr[0], tpr[1]])
-        # trivial decisions, add (0,0) and (1,1)
-    elif fpr.shape[0] == 1:
-        fpr = np.array([0.0, fpr[0], 1.0])
-        tpr = np.array([0.0, tpr[0], 1.0])
-
-    if n_pos is np.nan:
-        tpr[0] = np.nan
-
-    if n_neg is np.nan:
-        fpr[0] = np.nan
-
+    if tps[-1] == 0:
+        warnings.warn("No positive samples in y_true, "
+                      "true positive value should be meaningless")
+        tpr = np.repeat(np.nan, tps.shape)
+    else:
+        tpr = tps / tps[-1]
+    
     return fpr, tpr, thresholds
 
 
-###############################################################################
+##############################################################################
 # Multiclass general function
 ###############################################################################
 def confusion_matrix(y_true, y_pred, labels=None):

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -550,7 +550,7 @@ def precision_recall_curve(y_true, probas_pred):
     precision = tps / (tps + fps)
     recall = tps / tps[-1]
 
-    # stop when full recall attained:
+    # stop when full recall attained and reverse the outputs
     last_ind = tps.searchsorted(tps[-1])
     sl = slice(last_ind, None, -1)
     return np.r_[precision[sl], 1], np.r_[recall[sl], 0], thresholds[sl]

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -456,8 +456,8 @@ def _binary_clf_curve(y_true, y_score, pos_label=None):
     thresholds : array, shape = [n_thresholds]
         Decreasing score values.
     """
-    y_true = np.ravel(y_true)
-    y_score = np.ravel(y_score)
+    y_true, y_score = check_arrays(y_true, y_score)
+    y_true, y_score = _check_1d_array(y_true, y_score, ravel=True)
 
     # ensure binary classification if pos_label is not specified
     classes = np.unique(y_true)

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -59,7 +59,9 @@ ALL_METRICS = [accuracy_score,
                mean_absolute_error,
                mean_squared_error,
                explained_variance_score,
-               r2_score]
+               r2_score,
+               auc_score,
+               average_precision_score]
 
 
 def make_prediction(dataset=None, binary=False):

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -191,7 +191,7 @@ def test_roc_curve_one_label():
         assert_equal(len(w), 1)
     # all true labels, all fpr should be nan
     assert_array_equal(fpr,
-                       np.nan * np.ones(len(thresholds) + 1))
+                       np.nan * np.ones(len(thresholds)))
     # assert there are warnings
     with warnings.catch_warnings(record=True) as w:
         fpr, tpr, thresholds = roc_curve([1 - x for x in y_true],
@@ -199,7 +199,7 @@ def test_roc_curve_one_label():
         assert_equal(len(w), 1)
     # all negative labels, all tpr should be nan
     assert_array_equal(tpr,
-                       np.nan * np.ones(len(thresholds) + 1))
+                       np.nan * np.ones(len(thresholds)))
 
 
 def test_auc():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -114,7 +114,8 @@ def test_roc_curve():
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.90, decimal=2)
     assert_almost_equal(roc_auc, auc_score(y_true, probas_pred))
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_roc_curve_end_points():
@@ -126,7 +127,8 @@ def test_roc_curve_end_points():
     fpr, tpr, thr = roc_curve(y_true, y_pred)
     assert_equal(fpr[0], 0)
     assert_equal(fpr[-1], 1)
-    assert_true(fpr.shape == tpr.shape == thr.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thr.shape)
 
 
 def test_roc_returns_consistency():
@@ -144,7 +146,8 @@ def test_roc_returns_consistency():
 
     # compare tpr and tpr_correct to see if the thresholds' order was correct
     assert_array_almost_equal(tpr, tpr_correct, decimal=2)
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_roc_curve_multi():
@@ -161,7 +164,8 @@ def test_roc_curve_confidence():
     fpr, tpr, thresholds = roc_curve(y_true, probas_pred - 0.5)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.90, decimal=2)
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_roc_curve_hard():
@@ -173,20 +177,23 @@ def test_roc_curve_hard():
     fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.50, decimal=2)
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
     # always predict zero
     trivial_pred = np.zeros(y_true.shape)
     fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.50, decimal=2)
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
     # hard decisions
     fpr, tpr, thresholds = roc_curve(y_true, pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.78, decimal=2)
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_roc_curve_one_label():
@@ -199,7 +206,8 @@ def test_roc_curve_one_label():
     # all true labels, all fpr should be nan
     assert_array_equal(fpr,
                        np.nan * np.ones(len(thresholds)))
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
     # assert there are warnings
     with warnings.catch_warnings(record=True) as w:
@@ -209,7 +217,8 @@ def test_roc_curve_one_label():
     # all negative labels, all tpr should be nan
     assert_array_equal(tpr,
                        np.nan * np.ones(len(thresholds)))
-    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+    assert_equal(fpr.shape, tpr.shape)
+    assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_auc():
@@ -538,7 +547,8 @@ def test_precision_recall_curve():
     assert_array_almost_equal(p, np.array([0.5, 0.33333333, 0.5, 1., 1.]))
     assert_array_almost_equal(r, np.array([1., 0.5, 0.5, 0.5, 0.]))
     assert_array_almost_equal(t, np.array([1, 2, 3, 4]))
-    assert_true(p.size == r.size == t.size + 1)
+    assert_equal(p.size, r.size)
+    assert_equal(p.size, t.size + 1)
 
 
 def _test_precision_recall_curve(y_true, probas_pred):
@@ -548,13 +558,15 @@ def _test_precision_recall_curve(y_true, probas_pred):
     assert_array_almost_equal(precision_recall_auc, 0.85, 2)
     assert_array_almost_equal(precision_recall_auc,
                               average_precision_score(y_true, probas_pred))
-    assert_true(p.size == r.size == thresholds.size + 1)
+    assert_equal(p.size, r.size)
+    assert_equal(p.size, thresholds.size + 1)
     # Smoke test in the case of proba having only one value
     p, r, thresholds = precision_recall_curve(y_true,
                                               np.zeros_like(probas_pred))
     precision_recall_auc = auc(r, p)
     assert_array_almost_equal(precision_recall_auc, 0.75, 3)
-    assert_true(p.size == r.size == thresholds.size + 1)
+    assert_equal(p.size, r.size)
+    assert_equal(p.size, thresholds.size + 1)
 
 
 def test_precision_recall_curve_errors():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -114,6 +114,7 @@ def test_roc_curve():
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.90, decimal=2)
     assert_almost_equal(roc_auc, auc_score(y_true, probas_pred))
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
 
 def test_roc_curve_end_points():
@@ -125,6 +126,7 @@ def test_roc_curve_end_points():
     fpr, tpr, thr = roc_curve(y_true, y_pred)
     assert_equal(fpr[0], 0)
     assert_equal(fpr[-1], 1)
+    assert_true(fpr.shape == tpr.shape == thr.shape)
 
 
 def test_roc_returns_consistency():
@@ -142,6 +144,7 @@ def test_roc_returns_consistency():
 
     # compare tpr and tpr_correct to see if the thresholds' order was correct
     assert_array_almost_equal(tpr, tpr_correct, decimal=2)
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
 
 def test_roc_curve_multi():
@@ -158,6 +161,7 @@ def test_roc_curve_confidence():
     fpr, tpr, thresholds = roc_curve(y_true, probas_pred - 0.5)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.90, decimal=2)
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
 
 def test_roc_curve_hard():
@@ -169,17 +173,20 @@ def test_roc_curve_hard():
     fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
     # always predict zero
     trivial_pred = np.zeros(y_true.shape)
     fpr, tpr, thresholds = roc_curve(y_true, trivial_pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.50, decimal=2)
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
     # hard decisions
     fpr, tpr, thresholds = roc_curve(y_true, pred)
     roc_auc = auc(fpr, tpr)
     assert_array_almost_equal(roc_auc, 0.78, decimal=2)
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
 
 def test_roc_curve_one_label():
@@ -192,6 +199,8 @@ def test_roc_curve_one_label():
     # all true labels, all fpr should be nan
     assert_array_equal(fpr,
                        np.nan * np.ones(len(thresholds)))
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
+
     # assert there are warnings
     with warnings.catch_warnings(record=True) as w:
         fpr, tpr, thresholds = roc_curve([1 - x for x in y_true],
@@ -200,6 +209,7 @@ def test_roc_curve_one_label():
     # all negative labels, all tpr should be nan
     assert_array_equal(tpr,
                        np.nan * np.ones(len(thresholds)))
+    assert_true(fpr.shape == tpr.shape == thresholds.shape)
 
 
 def test_auc():
@@ -528,6 +538,7 @@ def test_precision_recall_curve():
     assert_array_almost_equal(p, np.array([0.5, 0.33333333, 0.5, 1., 1.]))
     assert_array_almost_equal(r, np.array([1., 0.5, 0.5, 0.5, 0.]))
     assert_array_almost_equal(t, np.array([1, 2, 3, 4]))
+    assert_true(p.size == r.size == t.size + 1)
 
 
 def _test_precision_recall_curve(y_true, probas_pred):
@@ -537,11 +548,13 @@ def _test_precision_recall_curve(y_true, probas_pred):
     assert_array_almost_equal(precision_recall_auc, 0.85, 2)
     assert_array_almost_equal(precision_recall_auc,
                               average_precision_score(y_true, probas_pred))
+    assert_true(p.size == r.size == thresholds.size + 1)
     # Smoke test in the case of proba having only one value
     p, r, thresholds = precision_recall_curve(y_true,
                                               np.zeros_like(probas_pred))
     precision_recall_auc = auc(r, p)
     assert_array_almost_equal(precision_recall_auc, 0.75, 3)
+    assert_true(p.size == r.size == thresholds.size + 1)
 
 
 def test_precision_recall_curve_errors():


### PR DESCRIPTION
After getting caught on some of the quirks of `roc_curve`*, I decided it and its cousin, `precision_recall_curve` could be neater, especially seeing as they share the need to calculate true positives and false negatives at each threshold.

This is my attempt at cleaning things up.

(\* I'm pretty sure that `and` should be `or` in https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/metrics.py#L662, or else the following two if clauses will never get used.)
