### PR TITLE
adding classification_table

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1607,6 +1607,91 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     return report
 
 
+def classification_table(y_true, y_pred):
+    """
+    Generates a classification table of true and false positives and negatives
+    for either the binary or multiclass situation.
+
+    Inputs
+    ------
+
+    y_true : array, shape = [n_samples]
+        Ground truth (correct) target values.
+
+    y_pred : array, shape = [n_samples]
+        Estimated targets as returned by a classifier.
+
+    Returns
+    ------
+
+    table : string
+        Classification table of true and false positives and negatives
+
+    Examples
+    -------
+
+    >>> #Binary Case
+    >>> y_true = np.array([0, 1, 1, 0, 0])
+    >>> y_pred = np.array([0, 1, 0, 1, 0])
+    >>> print classification_table(y_true, y_pred)
+
+            Predicted
+
+    Actual  0	    1
+
+    0	    2	    1
+
+    1	    1	    1
+
+    #Multiclass
+    >>> y_true = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    >>> y_pred = np.array([0, 1, 2, 2, 0, 1, 1, 0, 2])
+    >>> print classification_table(y_true, y_pred)
+
+        True Pos	False Pos	 True Neg
+    0		1		2		4
+    1		1		2		4
+    2		2		1		5
+    """
+    false_pos = 0
+    false_neg = 0
+    true_pos = 0
+    true_neg = 0
+
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+
+    classes = np.unique(y_true, y_pred)
+
+    if len(classes) > 2:
+        table = '\tTrue Pos\tFalse Pos\tTrue Neg\tFalse Neg\n'
+
+        for label in classes:
+            true_pos = np.sum(y_pred[y_true == label] == label)
+            false_pos = np.sum(y_pred[y_true != label] == label)
+            true_neg = np.sum(y_pred[y_true != label] != label)
+
+            table += '{}\t\t{}\t\t{}\t\t{}\n'.format(label, true_pos,
+                                                     false_pos, true_neg)
+
+    elif len(classes) == 2:
+        true_pos = np.sum(y_pred[y_true == classes[1]] == classes[1])
+        false_pos = np.sum(y_pred[y_true != classes[1]] == classes[1])
+        true_neg = np.sum(y_pred[y_true != classes[1]] != classes[1])
+        false_neg = np.sum(y_pred[y_true == classes[1]] != classes[1])
+        table = """
+    \tPredicted\n
+Actual\t{0}\t{1}\n
+{0}\t{2}\t{3}\n
+{1}\t{4}\t{5}\n
+    """.format(classes[0], classes[1], true_neg, false_pos, false_neg,
+               true_pos)
+    else:
+        raise ValueError('Only one category, results will be meaningless.')
+
+    return table
+
+
 ###############################################################################
 # Multilabel loss function
 ###############################################################################


### PR DESCRIPTION
I needed to see the actual numbers for the true/false positives and negatives for a project I was working on. I noticed sklearn didn't have an implementation of a table like this, so I coded this up. I'm relatively new to coding, and very new to contributing to large projects like this, so the code may not be at an adequate level, but I thought this would be a feature that would be useful to some people. The implementation draws heavily from the code in `metrics.classification_report`. 
