### PR TITLE
Generalized the label type for some methods in metrics.

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -737,7 +737,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
     if labels is None:
         labels = unique_labels(y_true, y_pred)
     else:
-        labels = np.asarray(labels, dtype=np.int)
+        labels = np.asarray(labels)
 
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
@@ -750,9 +750,14 @@ def confusion_matrix(y_true, y_pred, labels=None):
     y_pred = y_pred[ind]
     y_true = y_true[ind]
 
-    CM = np.asarray(coo_matrix((np.ones(y_true.shape[0]), (y_true, y_pred)),
-                               shape=(n_labels, n_labels),
-                               dtype=np.int).todense())
+    CM = np.asarray(
+        coo_matrix(
+            (np.ones(y_true.shape[0], dtype=np.int), (y_true, y_pred)),
+            shape=(n_labels, n_labels),
+            dtype=np.long
+        ).todense()
+    )
+
     return CM
 
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1275,7 +1275,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if labels is None:
         labels = unique_labels(y_true, y_pred)
     else:
-        labels = np.asarray(labels, dtype=np.int)
+        labels = np.asarray(labels)
 
     n_labels = labels.size
     true_pos = np.zeros(n_labels, dtype=np.double)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -710,7 +710,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
 
     labels : array, shape = [n_classes]
         List of all labels occurring in the dataset.
-        If none is given, those that appear at least once
+        If ``None`` is given, those that appear at least once
         in ``y_true`` or ``y_pred`` are used.
 
     Returns

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -734,6 +734,9 @@ def confusion_matrix(y_true, y_pred, labels=None):
            [1, 0, 2]])
 
     """
+    y_true, y_pred = check_arrays(y_true, y_pred)
+    y_true, y_pred = _check_1d_array(y_true, y_pred)
+
     if labels is None:
         labels = unique_labels(y_true, y_pred)
     else:

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1278,10 +1278,10 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         labels = np.asarray(labels)
 
     n_labels = labels.size
-    true_pos = np.zeros(n_labels, dtype=np.double)
-    false_pos = np.zeros(n_labels, dtype=np.double)
-    false_neg = np.zeros(n_labels, dtype=np.double)
-    support = np.zeros(n_labels, dtype=np.long)
+    true_pos = np.empty(n_labels, dtype=np.long)
+    false_pos = np.empty(n_labels, dtype=np.long)
+    false_neg = np.empty(n_labels, dtype=np.long)
+    support = np.empty(n_labels, dtype=np.long)
 
     for i, label_i in enumerate(labels):
         true_pos[i] = np.sum(y_pred[y_true == label_i] == label_i)
@@ -1294,20 +1294,21 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         old_err_settings = np.seterr(divide='ignore', invalid='ignore')
 
         # precision and recall
-        precision = true_pos / (true_pos + false_pos)
-        recall = true_pos / (true_pos + false_neg)
+        precision = np.divide(true_pos, true_pos + false_pos, dtype=np.double)
+        recall = np.divide(true_pos, true_pos + false_neg, dtype=np.double)
 
-        # handle division by 0.0 in precision and recall
-        precision[(true_pos + false_pos) == 0.0] = 0.0
-        recall[(true_pos + false_neg) == 0.0] = 0.0
+        # handle division by 0 in precision and recall
+        precision[(true_pos + false_pos) == 0] = 0.0
+        recall[(true_pos + false_neg) == 0] = 0.0
 
         # fbeta score
         beta2 = beta ** 2
-        fscore = (1 + beta2) * (precision * recall) / (
-            beta2 * precision + recall)
+        fscore = np.divide((1 + beta2) * precision * recall,
+                           beta2 * precision + recall,
+                           dtype=np.double)
 
-        # handle division by 0.0 in fscore
-        fscore[(precision + recall) == 0.0] = 0.0
+        # handle division by 0 in fscore
+        fscore[(precision + recall) == 0] = 0.0
     finally:
         np.seterr(**old_err_settings)
 
@@ -1324,11 +1325,15 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     else:
         average_options = (None, 'micro', 'macro', 'weighted')
         if average == 'micro':
-            avg_precision = true_pos.sum() / (true_pos.sum() +
-                                              false_pos.sum())
-            avg_recall = true_pos.sum() / (true_pos.sum() + false_neg.sum())
-            avg_fscore = (1 + beta2) * (avg_precision * avg_recall) / \
-                         (beta2 * avg_precision + avg_recall)
+            avg_precision = np.divide(true_pos.sum(),
+                                      true_pos.sum() + false_pos.sum(),
+                                      dtype=np.double)
+            avg_recall = np.divide(true_pos.sum(),
+                                   true_pos.sum() + false_neg.sum(),
+                                   dtype=np.double)
+            avg_fscore = np.divide((1 + beta2) * (avg_precision * avg_recall),
+                                   beta2 * avg_precision + avg_recall,
+                                   dtype=np.double)
         elif average == 'macro':
             avg_precision = np.mean(precision)
             avg_recall = np.mean(recall)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -991,10 +991,12 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    labels : array, shape = [n_classes]
+        List of all labels occurring in the dataset.
+        If ``None`` is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used.
 
-    pos_label : int, 1 by default
+    pos_label : 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1075,10 +1077,12 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     beta: float
         Weight of precision in harmonic mean.
 
-    labels : array
-        Integer array of labels.
+    labels : array, shape = [n_classes]
+        List of all labels occurring in the dataset.
+        If ``None`` is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used.
 
-    pos_label : int, 1 by default
+    pos_label : 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1189,10 +1193,12 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     beta : float, 1.0 by default
         The strength of recall versus precision in the F-score.
 
-    labels : array
-        Integer array of labels.
+    labels : array, shape = [n_classes]
+        List of all labels occurring in the dataset.
+        If ``None`` is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used.
 
-    pos_label : int, 1 by default
+    pos_label : 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1368,10 +1374,12 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    labels : array, shape = [n_classes]
+        List of all labels occurring in the dataset.
+        If ``None`` is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used.
 
-    pos_label : int, 1 by default
+    pos_label : 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1446,10 +1454,12 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     y_pred : array, shape = [n_samples]
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
+    labels : array, shape = [n_classes]
+        List of all labels occurring in the dataset.
+        If ``None`` is given, those that appear at least once
+        in ``y_true`` or ``y_pred`` are used.
 
-    pos_label : int, 1 by default
+    pos_label : 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -367,48 +367,73 @@ def test_precision_recall_f1_score_multiclass():
     """Test Precision Recall and F1 Score for multiclass classification task"""
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    # compute scores with default labels introspection
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None)
-    assert_array_almost_equal(p, [0.83, 0.33, 0.42], 2)
-    assert_array_almost_equal(r, [0.79, 0.09, 0.90], 2)
-    assert_array_almost_equal(f, [0.81, 0.15, 0.57], 2)
-    assert_array_equal(s, [24, 31, 20])
+    def test(y_true, y_pred, string_type=False):
+        # compute scores with default labels introspection
+        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                     average=None)
+        assert_array_almost_equal(p, [0.83, 0.33, 0.42], 2)
+        assert_array_almost_equal(r, [0.79, 0.09, 0.90], 2)
+        assert_array_almost_equal(f, [0.81, 0.15, 0.57], 2)
+        assert_array_equal(s, [24, 31, 20])
 
-    # averaging tests
-    ps = precision_score(y_true, y_pred, pos_label=1, average='micro')
-    assert_array_almost_equal(ps, 0.53, 2)
+        # averaging tests
+        pos_label = '1' if string_type else 1
 
-    rs = recall_score(y_true, y_pred, average='micro')
-    assert_array_almost_equal(rs, 0.53, 2)
+        ps = precision_score(y_true, y_pred,
+                             pos_label=pos_label,
+                             average='micro')
+        assert_array_almost_equal(ps, 0.53, 2)
 
-    fs = f1_score(y_true, y_pred, average='micro')
-    assert_array_almost_equal(fs, 0.53, 2)
+        rs = recall_score(y_true, y_pred,
+                          average='micro')
+        assert_array_almost_equal(rs, 0.53, 2)
 
-    ps = precision_score(y_true, y_pred, average='macro')
-    assert_array_almost_equal(ps, 0.53, 2)
+        fs = f1_score(y_true, y_pred,
+                      average='micro')
+        assert_array_almost_equal(fs, 0.53, 2)
 
-    rs = recall_score(y_true, y_pred, average='macro')
-    assert_array_almost_equal(rs, 0.60, 2)
+        ps = precision_score(y_true, y_pred,
+                             pos_label=pos_label,
+                             average='macro')
+        assert_array_almost_equal(ps, 0.53, 2)
 
-    fs = f1_score(y_true, y_pred, average='macro')
-    assert_array_almost_equal(fs, 0.51, 2)
+        rs = recall_score(y_true, y_pred,
+                          average='macro')
+        assert_array_almost_equal(rs, 0.60, 2)
 
-    ps = precision_score(y_true, y_pred, average='weighted')
-    assert_array_almost_equal(ps, 0.51, 2)
+        fs = f1_score(y_true, y_pred,
+                      average='macro')
+        assert_array_almost_equal(fs, 0.51, 2)
 
-    rs = recall_score(y_true, y_pred, average='weighted')
-    assert_array_almost_equal(rs, 0.53, 2)
+        ps = precision_score(y_true, y_pred,
+                             pos_label=pos_label,
+                             average='weighted')
+        assert_array_almost_equal(ps, 0.51, 2)
 
-    fs = f1_score(y_true, y_pred, average='weighted')
-    assert_array_almost_equal(fs, 0.47, 2)
+        rs = recall_score(y_true, y_pred,
+                          average='weighted')
+        assert_array_almost_equal(rs, 0.53, 2)
 
-    # same prediction but with and explicit label ordering
-    p, r, f, s = precision_recall_fscore_support(
-        y_true, y_pred, labels=[0, 2, 1], average=None)
-    assert_array_almost_equal(p, [0.83, 0.41, 0.33], 2)
-    assert_array_almost_equal(r, [0.79, 0.90, 0.10], 2)
-    assert_array_almost_equal(f, [0.81, 0.57, 0.15], 2)
-    assert_array_equal(s, [24, 20, 31])
+        fs = f1_score(y_true, y_pred,
+                      average='weighted')
+        assert_array_almost_equal(fs, 0.47, 2)
+
+        # same prediction but with and explicit label ordering
+        labels = ['0', '2', '1'] if string_type else [0, 2, 1]
+
+        p, r, f, s = precision_recall_fscore_support(
+            y_true, y_pred, labels=labels, average=None)
+
+        assert_array_almost_equal(p, [0.83, 0.41, 0.33], 2)
+        assert_array_almost_equal(r, [0.79, 0.90, 0.10], 2)
+        assert_array_almost_equal(f, [0.81, 0.57, 0.15], 2)
+        assert_array_equal(s, [24, 20, 31])
+
+    test(y_true,
+         y_pred)
+    test(map(str, y_true),
+         map(str, y_pred),
+         string_type=True)
 
 
 def test_precision_recall_f1_score_multiclass_pos_label_none():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -338,22 +338,23 @@ def test_confusion_matrix_binary():
     """Test confusion matrix - binary classification case"""
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    cm = confusion_matrix(y_true, y_pred)
-    assert_array_equal(cm, [[22, 3], [8, 17]])
+    def test(y_true, y_pred):
+        cm = confusion_matrix(y_true, y_pred)
+        assert_array_equal(cm, [[22, 3], [8, 17]])
 
-    tp = cm[0, 0]
-    tn = cm[1, 1]
-    fp = cm[0, 1]
-    fn = cm[1, 0]
-    num = (tp * tn - fp * fn)
-    den = np.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
-    if den == 0.:
-        true_mcc = 0
-    else:
-        true_mcc = num / den
-    mcc = matthews_corrcoef(y_true, y_pred)
-    assert_array_almost_equal(mcc, true_mcc, decimal=2)
-    assert_array_almost_equal(mcc, 0.57, decimal=2)
+        tp, fp, fn, tn = cm.flatten()
+        num = (tp * tn - fp * fn)
+        den = np.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+
+        true_mcc = 0 if den == 0 else num / den
+        mcc = matthews_corrcoef(y_true, y_pred)
+        assert_array_almost_equal(mcc, true_mcc, decimal=2)
+        assert_array_almost_equal(mcc, 0.57, decimal=2)
+
+    test(y_true,
+         y_pred)
+    test(map(str, y_true),
+         map(str, y_pred))
 
 
 def test_matthews_corrcoef_nan():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -475,17 +475,26 @@ def test_confusion_matrix_multiclass():
     """Test confusion matrix - multi-class case"""
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    # compute confusion matrix with default labels introspection
-    cm = confusion_matrix(y_true, y_pred)
-    assert_array_equal(cm, [[19, 4, 1],
-                            [4, 3, 24],
-                            [0, 2, 18]])
+    def test(y_true, y_pred, string_type=False):
+        # compute confusion matrix with default labels introspection
+        cm = confusion_matrix(y_true, y_pred)
+        assert_array_equal(cm, [[19, 4, 1],
+                                [4, 3, 24],
+                                [0, 2, 18]])
 
-    # compute confusion matrix with explicit label ordering
-    cm = confusion_matrix(y_true, y_pred, labels=[0, 2, 1])
-    assert_array_equal(cm, [[19, 1, 4],
-                            [0, 18, 2],
-                            [4, 24, 3]])
+        # compute confusion matrix with explicit label ordering
+        labels = ['0', '2', '1'] if string_type else [0, 2, 1]
+        cm = confusion_matrix(y_true,
+                              y_pred,
+                              labels=labels)
+        assert_array_equal(cm, [[19, 1, 4],
+                                [0, 18, 2],
+                                [4, 24, 3]])
+
+    test(y_true,
+         y_pred)
+    test(map(str, y_true),
+         map(str, y_pred), string_type=True)
 
 
 def test_confusion_matrix_multiclass_subset_labels():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -265,24 +265,33 @@ def test_precision_recall_f1_score_binary():
     """Test Precision Recall and F1 Score for binary classification task"""
     y_true, y_pred, _ = make_prediction(binary=True)
 
-    # detailed measures for each class
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None)
-    assert_array_almost_equal(p, [0.73, 0.85], 2)
-    assert_array_almost_equal(r, [0.88, 0.68], 2)
-    assert_array_almost_equal(f, [0.80, 0.76], 2)
-    assert_array_equal(s, [25, 25])
+    def test(y_true, y_pred, string_type=False):
+        # detailed measures for each class
+        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                     average=None)
+        assert_array_almost_equal(p, [0.73, 0.85], 2)
+        assert_array_almost_equal(r, [0.88, 0.68], 2)
+        assert_array_almost_equal(f, [0.80, 0.76], 2)
+        assert_array_equal(s, [25, 25])
 
-    # individual scoring function that can be used for grid search: in the
-    # binary class case the score is the value of the measure for the positive
-    # class (e.g. label == 1)
-    ps = precision_score(y_true, y_pred)
-    assert_array_almost_equal(ps, 0.85, 2)
+        # individual scoring function that can be used for grid search: in
+        # the binary class case the score is the value of the measure for
+        # the positive class (e.g. label == 1)
+        pos_label = '1' if string_type else 1
 
-    rs = recall_score(y_true, y_pred)
-    assert_array_almost_equal(rs, 0.68, 2)
+        ps = precision_score(y_true, y_pred, pos_label=pos_label)
+        assert_array_almost_equal(ps, 0.85, 2)
 
-    fs = f1_score(y_true, y_pred)
-    assert_array_almost_equal(fs, 0.76, 2)
+        rs = recall_score(y_true, y_pred, pos_label=pos_label)
+        assert_array_almost_equal(rs, 0.68, 2)
+
+        fs = f1_score(y_true, y_pred, pos_label=pos_label)
+        assert_array_almost_equal(fs, 0.76, 2)
+
+    test(y_true,
+         y_pred)
+    test(map(str, y_true),
+         map(str, y_pred), True)
 
 
 def test_average_precision_score_duplicate_values():


### PR DESCRIPTION
Response to: https://github.com/scikit-learn/scikit-learn/issues/1835

Added support for non-integer labels in `confusion_matrix`, `precision_recall_fscore_support`, `f1_score`, `fbeta_score`, `precision_score` and `recall_score`.
