### PR TITLE
MRG - Add SVD-based solver to ridge regression.

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -232,7 +232,8 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
                                       alpha=self.alpha,
                                       sample_weight=sample_weight,
                                       max_iter=self.max_iter,
-                                      tol=self.tol)
+                                      tol=self.tol,
+                                      solver=self.solver)
         self._set_intercept(X_mean, y_mean, X_std)
         return self
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -101,7 +101,7 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         solver = 'dense_cholesky'
 
     if solver not in ('sparse_cg', 'dense_cholesky', 'svd', 'lsqr'):
-        NotImplementedError('Solver %s not understood' % solver)
+        ValueError('Solver %s not understood' % solver)
 
     if solver == 'sparse_cg':
         # gradient descent

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -167,9 +167,6 @@ def ridge_regression(X, y, alpha, sample_weight=1.0, solver='auto',
         d[idx] = (s / (s ** 2 + alpha))
         Ud = np.dot(U.T, y).T * d
         coef_ = np.dot(Ud, Vt)
-        if y.ndim == 1:
-            coef_ = coef_.ravel()
-            assert coef_.size == X.shape[1]
         return coef_
     elif solver in ('dense_cholesky', 'cholesky'):
         # normal equations (cholesky) method

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -48,7 +48,7 @@ def test_ridge():
     rng = np.random.RandomState(0)
     alpha = 1.0
 
-    for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
+    for solver in ("svd", "sparse_cg", "dense_cholesky", "lsqr"):
         # With more samples than features
         n_samples, n_features = 6, 5
         y = rng.randn(n_samples)
@@ -78,7 +78,7 @@ def test_ridge_sample_weights():
     rng = np.random.RandomState(0)
     alpha = 1.0
 
-    for solver in ("sparse_cg", "dense_cholesky", "lsqr"):
+    for solver in ("svd", "sparse_cg", "dense_cholesky", "lsqr"):
         for n_samples, n_features in ((6, 5), (5, 10)):
             y = rng.randn(n_samples)
             X = rng.randn(n_samples, n_features)


### PR DESCRIPTION
I added a solver based on the thin SVD of X to compute the ridge
coefficients. This is much more stable than the cholesky decomposition
for singular matrices.

While in the Ridge regression the Gram matrix becomes nonsingular
because of the regularization, I've come across problems when the
regularization parameter is very small. This pull request remedies it,
making the algorithm defined and stable even for the border case
alpha=0 (useful for cross validating over a grid of parameters)

I took the liberty to change the default algorithm of to this one
(when there are no sample weights). I haven't done any benchmarks.
It should be slower than dense_cholesky but not much ...
