### PR TITLE
REV: reverted back to python3 style division instead of np.divide

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1286,8 +1286,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         old_err_settings = np.seterr(divide='ignore', invalid='ignore')
 
         # precision and recall
-        precision = np.divide(true_pos, true_pos + false_pos, dtype=np.double)
-        recall = np.divide(true_pos, true_pos + false_neg, dtype=np.double)
+        precision = true_pos / (true_pos + false_pos)
+        recall = true_pos / (true_pos + false_neg)
 
         # handle division by 0 in precision and recall
         precision[(true_pos + false_pos) == 0] = 0.0
@@ -1295,9 +1295,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
         # fbeta score
         beta2 = beta ** 2
-        fscore = np.divide((1 + beta2) * precision * recall,
-                           beta2 * precision + recall,
-                           dtype=np.double)
+        fscore = (1 + beta2) * precision * recall / \
+                 (beta2 * precision + recall)
 
         # handle division by 0 in fscore
         fscore[(precision + recall) == 0] = 0.0
@@ -1317,15 +1316,10 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     else:
         average_options = (None, 'micro', 'macro', 'weighted')
         if average == 'micro':
-            avg_precision = np.divide(true_pos.sum(),
-                                      true_pos.sum() + false_pos.sum(),
-                                      dtype=np.double)
-            avg_recall = np.divide(true_pos.sum(),
-                                   true_pos.sum() + false_neg.sum(),
-                                   dtype=np.double)
-            avg_fscore = np.divide((1 + beta2) * (avg_precision * avg_recall),
-                                   beta2 * avg_precision + avg_recall,
-                                   dtype=np.double)
+            avg_precision = true_pos.sum() / (true_pos.sum() + false_pos.sum())
+            avg_recall = true_pos.sum() / (true_pos.sum() + false_neg.sum())
+            avg_fscore = (1 + beta2) * (avg_precision * avg_recall) / \
+                         (beta2 * avg_precision + avg_recall)
         elif average == 'macro':
             avg_precision = np.mean(precision)
             avg_recall = np.mean(recall)


### PR DESCRIPTION
Reverted back to using python3 style division since older numpy doesn't support dtype argument in np.division

(I really hope this one is appended to https://github.com/scikit-learn/scikit-learn/pull/1913)
