### PR TITLE
Fix for sidebar bug on index page

### DIFF
--- a/doc/themes/scikit-learn/static/sidebar.js
+++ b/doc/themes/scikit-learn/static/sidebar.js
@@ -148,5 +148,7 @@ $(function() {
 
   add_sidebar_button();
   var sidebarbutton = $('#sidebarbutton');
-  set_position_from_cookie();
+  // set_position_from_cookie();
+  // Uncomment the above to have cookies remember sidebar position
+  // Causes problems on pages without sidebar like index
 });


### PR DESCRIPTION
Simple fix for #1869 .

Currently it would remember the last position (expanded or collapsed) which is fine while browsing the docs, but it creates a problem on the home page, as it uses no sidebar button
and i.e can't be re-expanded.

This is a quick fix that works fine.. I've added a comment to serve as a futre-TODO to make it still use cookies while not affecting the main page. right now I don't have time for that.

But this works for now :)
