### PR TITLE
MRG disable memory-blowing SVD for sparse input in RidgeCV

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -88,6 +88,9 @@ API changes summary
      kernel PCA was always documented; previously, the removal of components
      with zero eigenvalues was tacitly performed on all data.
 
+   - `gcv_mode="auto"` no longer tries to perform SVD on a densified
+     sparse matrix in :class:`sklearn.linear_model.RidgeCV`.
+
 
 .. _changes_0_13_1:
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -512,8 +512,8 @@ class _RidgeGCV(LinearModel):
         return y - (c / G_diag), c
 
     def _pre_compute_svd(self, X, y):
-        if sparse.issparse(X) and hasattr(X, 'toarray'):
-            X = X.toarray()
+        if sparse.issparse(X):
+            raise TypeError("SVD not supported for sparse matrices")
         U, s, _ = np.linalg.svd(X, full_matrices=0)
         v = s ** 2
         UT_y = np.dot(U.T, y)
@@ -568,7 +568,7 @@ class _RidgeGCV(LinearModel):
         with_sw = len(np.shape(sample_weight))
 
         if gcv_mode is None or gcv_mode == 'auto':
-            if n_features > n_samples or with_sw:
+            if sparse.issparse(X) or n_features > n_samples or with_sw:
                 gcv_mode = 'eigen'
             else:
                 gcv_mode = 'svd'
@@ -735,12 +735,15 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
         Flag indicating which strategy to use when performing
         Generalized Cross-Validation. Options are::
 
-            'auto' : use svd if n_samples > n_features, otherwise use eigen
+            'auto' : use svd if n_samples > n_features or when X is a sparse
+                     matrix, otherwise use eigen
             'svd' : force computation via singular value decomposition of X
+                    (does not work for sparse matrices)
             'eigen' : force computation via eigendecomposition of X^T X
 
-        The 'auto' mode is the default and is intended to pick the cheaper \
-        option of the two depending upon the shape of the training data.
+        The 'auto' mode is the default and is intended to pick the cheaper
+        option of the two depending upon the shape and format of the training
+        data.
 
     store_cv_values : boolean, default=False
         Flag indicating if the cross-validation values corresponding to

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raises
 
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
@@ -343,6 +344,12 @@ def test_dense_sparse():
         # test that the outputs are the same
         if ret_dense is not None and ret_sparse is not None:
             assert_array_almost_equal(ret_dense, ret_sparse, decimal=3)
+
+
+def test_ridge_cv_sparse_svd():
+    X = sp.csr_matrix(X_diabetes)
+    ridge = RidgeCV(gcv_mode="svd")
+    assert_raises(TypeError, RidgeCV.fit, X)
 
 
 def test_class_weights():


### PR DESCRIPTION
I've just disallowed `gcv_mode="svd"` for sparse `X` and set `"auto"` to select `"eigen"` instead.

Fixes #1921.
