### PR TITLE
Fix setup.py to resolve numpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ DOWNLOAD_URL = 'http://sourceforge.net/projects/scikit-learn/files/'
 # We can actually import a restricted version of sklearn that
 # does not need the compiled code
 import sklearn
+
 VERSION = sklearn.__version__
 
 ###############################################################################
@@ -45,14 +46,12 @@ if len(set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
             )).intersection(sys.argv)) > 0:
     import setuptools
     extra_setuptools_args = dict(
-            zip_safe=False,  # the package can run out of an .egg file
-            include_package_data=True,
-        )
+        zip_safe=False,  # the package can run out of an .egg file
+        include_package_data=True,
+    )
 else:
     extra_setuptools_args = dict()
 
-###############################################################################
-from numpy.distutils.core import setup
 
 def configuration(parent_package='', top_path=None):
     if os.path.exists('MANIFEST'):
@@ -73,29 +72,50 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
-if __name__ == "__main__":
+def setup_package():
+    metadata = dict(name=DISTNAME,
+                    maintainer=MAINTAINER,
+                    maintainer_email=MAINTAINER_EMAIL,
+                    description=DESCRIPTION,
+                    license=LICENSE,
+                    url=URL,
+                    version=VERSION,
+                    download_url=DOWNLOAD_URL,
+                    long_description=LONG_DESCRIPTION,
+                    classifiers=['Intended Audience :: Science/Research',
+                                 'Intended Audience :: Developers',
+                                 'License :: OSI Approved',
+                                 'Programming Language :: C',
+                                 'Programming Language :: Python',
+                                 'Topic :: Software Development',
+                                 'Topic :: Scientific/Engineering',
+                                 'Operating System :: Microsoft :: Windows',
+                                 'Operating System :: POSIX',
+                                 'Operating System :: Unix',
+                                 'Operating System :: MacOS'],
+                    **extra_setuptools_args)
 
-    setup(configuration=configuration,
-          name=DISTNAME,
-          maintainer=MAINTAINER,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=VERSION,
-          download_url=DOWNLOAD_URL,
-          long_description=LONG_DESCRIPTION,
-          classifiers=[
-              'Intended Audience :: Science/Research',
-              'Intended Audience :: Developers',
-              'License :: OSI Approved',
-              'Programming Language :: C',
-              'Programming Language :: Python',
-              'Topic :: Software Development',
-              'Topic :: Scientific/Engineering',
-              'Operating System :: Microsoft :: Windows',
-              'Operating System :: POSIX',
-              'Operating System :: Unix',
-              'Operating System :: MacOS'
-             ],
-      **extra_setuptools_args)
+    if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1]
+       in ('--help-commands', 'egg_info', '--version', 'clean')):
+
+        # For these actions, NumPy is not required.
+        #
+        # They are required to succeed without Numpy for example when
+        # pip is used to install Scikit when Numpy is not yet present in
+        # the system.
+        try:
+            from setuptools import setup
+        except ImportError:
+            from distutils.core import setup
+
+        metadata['version'] = VERSION
+    else:
+        from numpy.distutils.core import setup
+
+        metadata['configuration'] = configuration
+
+    setup(**metadata)
+
+
+if __name__ == "__main__":
+    setup_package()


### PR DESCRIPTION
 If we try to install scikit with some command like:
 "pip install numpy scipy scikit-learn" or via requirements.txt which has:

 numpy 
 scipy
 scikit-learn

 It raises "from numpy.distutils.core import setup
 ImportError: No module named numpy.distutils.core"; because of numpy
 requirement. There was similar issue in scipy which was resolved. I adapted the patch for scikit, and was able to fix it. 

This fix is based of issue and fixes in Scipy:
https://github.com/scipy/scipy/pull/453
https://github.com/branden/scipy/commit/ad0dd3e883ca5b241dda6136eee921eb900077a0

Notes:
 -Please note that this, obviously will work with similarly patched version of scipy.
  [As far as I know the patch is on master but not on the stable release.
  Hence pip install numpy scipy scikit might not work presently unless you install 
  with requirements file which has the link to the scipy source or your own patched version
  with above fixes in place]
