### PR TITLE
ENH Feature selection should use CSC matrices

### DIFF
--- a/sklearn/feature_selection/selector_mixin.py
+++ b/sklearn/feature_selection/selector_mixin.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ..base import TransformerMixin
 from ..externals import six
-from ..utils import safe_mask, atleast2d_or_csr
+from ..utils import safe_mask, atleast2d_or_csc
 
 
 class SelectorMixin(TransformerMixin):
@@ -37,7 +37,7 @@ class SelectorMixin(TransformerMixin):
         X_r : array of shape [n_samples, n_selected_features]
             The input samples with only the selected features.
         """
-        X = atleast2d_or_csr(X)
+        X = atleast2d_or_csc(X)
         # Retrieve importance vector
         if hasattr(self, "feature_importances_"):
             importances = self.feature_importances_

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -16,8 +16,9 @@ from scipy.sparse import issparse
 
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import LabelBinarizer
-from ..utils import (array2d, as_float_array, atleast2d_or_csr, check_arrays,
-                     safe_asarray, safe_sqr, safe_mask)
+from ..utils import (array2d, as_float_array, atleast2d_or_csc,
+                     atleast2d_or_csr, check_arrays, safe_asarray, safe_sqr,
+                     safe_mask)
 from ..utils.extmath import safe_sparse_dot
 from ..externals import six
 
@@ -285,11 +286,11 @@ class _BaseFilter(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         Transform a new matrix using the selected features
         """
-        X = atleast2d_or_csr(X)
+        X = atleast2d_or_csc(X)
         mask = self._get_support_mask()
         if len(mask) != X.shape[1]:
             raise ValueError("X has a different shape than during fitting.")
-        return atleast2d_or_csr(X)[:, safe_mask(X, mask)]
+        return X[:, safe_mask(X, mask)]
 
     def inverse_transform(self, X):
         """


### PR DESCRIPTION
Feature selection involves slicing over columns. It should therefore be done with CSC rather than CSR for sparse `X`.
