### PR TITLE
ENH store per-transformer index into feature space in FeatureUnion

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -109,9 +109,8 @@ convenience and joint parameter estimation and validation.
 create complex models.
 
 (A :class:`FeatureUnion` has no way of checking whether two transformers
-might produce identical features. It only produces a union when the
-feature sets are disjoint, and making sure they are is the caller's
-responsibility.)
+might produce identical features. Making sure the features are disjoint
+is the caller's responsibility.)
 
 
 Usage
@@ -135,6 +134,9 @@ and ``value`` is an estimator object::
         n_components=None, remove_zero_eig=False, tol=0))],
         transformer_weights=None)
 
+After ``fit_transform`` is called, ``FeatureUnion`` will store a `feature_ptr_`
+attribute indicating which slices of the transfiormed matrix's features
+correspond to which constituent transformers.
 
                                                                        
 .. topic:: Examples:

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -252,6 +252,13 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
         Multiplicative weights for features per transformer.
         Keys are transformer names, values the weights.
 
+    Attributes
+    ----------
+    feature_ptr_: array of shape (len(transformers) + 1)
+        Stores the feature slice corresponding to each transformer.
+        Transformer `i` generates feature columns `k` where
+       `feature_ptr_[i] <= k < feature_ptr_[i + 1]`.
+       Only available if `fit_transform` is used.
     """
     def __init__(self, transformer_list, n_jobs=1, transformer_weights=None):
         self.transformer_list = transformer_list
@@ -307,6 +314,8 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
             delayed(_fit_transform_one)(trans, name, X, y,
                                         self.transformer_weights, **fit_params)
             for name, trans in self.transformer_list)
+        print(len(Xs), len(self.transformer_list), [f.shape for f in Xs])
+        self.feature_ptr_ = np.hstack([0, np.cumsum([f.shape[1] for f in Xs])])
         if any(sparse.issparse(f) for f in Xs):
             Xs = sparse.hstack(Xs).tocsr()
         else:


### PR DESCRIPTION
`FeatureUnion` provided no simple way to tell which parts of the stack belonged to which transformer. This provides a `feature_ptr_` attribute (of the form of `csr_matrix.indptr`) to solve that.

Caveats:
- it can only be determined when `fit_transform`, not `fit`, is called
- it will be incorrect if one of the sub-transformers has a change of parameters that affects the output size at `transform` time without a re`fit`.

Both these caveats would be solved if each transformer in sklearn provided a way to get the number of output features. I suggest a `transformed_width_` attribute or `get_transformed_width()` method (better name?), the latter making it more clear that the output can be affected by `set_params`. I also suggest this be posed as an Easy Issue for someone to tackle.

Finally, `feature_ptr_` is compact and versatile, but it might be more usable if I add a method to get this data as a dict from transformer-name to `slice`s.
