### PR TITLE
DOC clarification of parameter search

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -6,13 +6,13 @@
 Grid Search: Searching for estimator parameters
 ===============================================
 
-Parameters that are not directly learnt within estimators (e.g. ``C``,
-``kernel`` and ``gamma`` for Support Vector Classifier, ``alpha`` for Lasso,
-etc.) can be set by searching a parameter space for the best
-:ref:`cross_validation` score.
+Parameters that are not directly learnt within estimators can be set by
+searching a parameter space for the best :ref:`cross_validation` score.
+Typical examples include ``C``, ``kernel`` and ``gamma`` for Support Vector
+Classifier, ``alpha`` for Lasso, etc.
 
 Any parameter provided when constructing an estimator may be optimized in this
-manner.  In particular, to find the names and current values for all parameters
+manner.  Specifically, to find the names and current values for all parameters
 for a given estimator, use::
 
   estimator.get_params()
@@ -32,7 +32,8 @@ A search consists of:
 Two generic approaches to sampling search candidates are provided in
 scikit-learn: for given values, :class:`GridSearchCV` exhaustively considers
 all parameter combinations, while :class:`RandomizedSearchCV` can sample a
-specified number of candidates from a continuous parameter space.
+given number of candidates from a parameter space with a specified
+distribution.
 
 Exhaustive Grid Search
 ======================

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -2,23 +2,44 @@
 
 .. currentmodule:: sklearn.grid_search
 
-==========================================
-Grid Search: setting estimator parameters
-==========================================
+===============================================
+Grid Search: Searching for estimator parameters
+===============================================
 
-Grid Search is used to optimize the parameters of a model (e.g. ``C``,
-``kernel`` and ``gamma`` for Support Vector Classifier, ``alpha`` for
-Lasso, etc.) using an internal :ref:`cross_validation` scheme.
+Parameters that are not directly learnt within estimators (e.g. ``C``,
+``kernel`` and ``gamma`` for Support Vector Classifier, ``alpha`` for Lasso,
+etc.) can be set by searching a parameter space for the best
+:ref:`cross_validation` score.
 
+Any parameter provided when constructing an estimator may be optimized in this
+manner.  In particular, to find the names and current values for all parameters
+for a given estimator, use::
 
-GridSearchCV
-============
+  estimator.get_params()
 
-The main class implementing hyperparameter grid search in
-scikit-learn is :class:`GridSearchCV`. This class is passed
-a base estimator instance (for example ``sklearn.svm.SVC()``) along with a
-grid of potential hyper-parameter values specified with the `param_grid`
-attribute. For instance the following `param_grid`::
+Such parameters are often referred to as *hyperparameters* (particularly in
+Bayesian learning), distinguishing them from the parameters optimised in a
+machine learning procedure.
+
+A search consists of:
+
+- an estimator (regressor or classifier such as ``sklearn.svm.SVC()``);
+- a parameter space;
+- a method for searching or sampling candidates;
+- a cross-validation scheme; and
+- a :ref:`score function <gridsearch_scoring>`.
+
+Two generic approaches to sampling search candidates are provided in
+scikit-learn: for given values, :class:`GridSearchCV` exhaustively considers
+all parameter combinations, while :class:`RandomizedSearchCV` can sample a
+specified number of candidates from a continuous parameter space.
+
+Exhaustive Grid Search
+======================
+
+The grid search provided by :class:`GridSearchCV` exhaustively generates
+candidates from a grid of parameter values specified with the `param_grid`
+attribute. For instance, the following `param_grid`::
 
   param_grid = [
     {'C': [1, 10, 100, 1000], 'kernel': ['linear']},
@@ -30,15 +51,14 @@ C values in [1, 10, 100, 1000], and the second one with an RBF kernel,
 and the cross-product of C values ranging in [1, 10, 100, 1000] and gamma
 values in [0.001, 0.0001].
 
-The :class:`GridSearchCV` instance implements the usual
-estimator API: when "fitting" it on a dataset all the possible
-combinations of hyperparameter values are evaluated and the best
-combination is retained.
+The :class:`GridSearchCV` instance implements the usual estimator API: when
+"fitting" it on a dataset all the possible combinations of parameter values are
+evaluated and the best combination is retained.
 
 .. topic:: Model selection: development and evaluation
 
   Model selection with ``GridSearchCV`` can be seen as a way to use the
-  labeled data to "train" the hyper-parameters of the grid.
+  labeled data to "train" the parameters of the grid.
 
   When evaluating the resulting model it is important to do it on
   held-out samples that were not seen during the grid search process:
@@ -53,16 +73,17 @@ combination is retained.
 
 .. _gridsearch_scoring:
 
-Scoring functions for GridSearchCV
-----------------------------------
+Scoring functions for parameter search
+--------------------------------------
+
 By default, :class:`GridSearchCV` uses the ``score`` function of the estimator
-to evaluate a parameter setting. These are the :func:`sklearn.metrics.accuracy_score` for classification
-and :func:`sklearn.metrics.r2_score` for regression.
-For some applications, other scoring function are better suited (for example in
-unbalanced classification, the accuracy score is often non-informative). An
-alternative scoring function can be specified via the ``scoring`` parameter to
-:class:`GridSearchCV`. 
-See :ref:`score_func_objects` for more details.
+to evaluate a parameter setting. These are the
+:func:`sklearn.metrics.accuracy_score` for classification and
+:func:`sklearn.metrics.r2_score` for regression.  For some applications, other
+scoring functions are better suited (for example in unbalanced classification,
+the accuracy score is often uninformative). An alternative scoring function
+can be specified via the ``scoring`` parameter to :class:`GridSearchCV`.  See
+:ref:`score_func_objects` for more details.
 
 .. topic:: Examples:
 
@@ -78,34 +99,33 @@ See :ref:`score_func_objects` for more details.
 .. note::
 
   Computations can be run in parallel if your OS supports it, by using
-  the keyword n_jobs=-1, see function signature for more details.
+  the keyword ``n_jobs=-1``, see function signature for more details.
 
 
-Randomized Hyper-Parameter Optimization
-=======================================
+Randomized Parameter Optimization
+=================================
 While using a grid of parameter settings is currently the most widely used
-method for hyper-parameter optimization, other search methods have more
+method for parameter optimization, other search methods have more
 favourable properties.
-:class:`RandomizedSearchCV` implements a randomized search over hyperparameters,
+:class:`RandomizedSearchCV` implements a randomized search over parameters,
 where each setting is sampled from a distribution over possible parameter values.
-This has two main benefits over searching over a grid:
+This has two main benefits over an exhaustive search:
 
 * A budget can be chosen independent of the number of parameters and possible values.
-
 * Adding parameters that do not influence the performance does not decrease efficiency.
 
 Specifying how parameters should be sampled is done using a dictionary, very
 similar to specifying parameters for :class:`GridSearchCV`. Additionally,
-a computation budget is specified using ``n_iter``, which is the number
-of iterations (parameter samples) to be used.
-For each parameter, either a distribution over possible values or list of
+a computation budget, being the number of sampled candidates or sampling
+iterations, is specified using the ``n_iter`` parameter.
+For each parameter, either a distribution over possible values or a list of
 discrete choices (which will be sampled uniformly) can be specified::
 
   [{'C': scipy.stats.expon(scale=100), 'gamma': scipy.stats.expon(scale=.1),
     'kernel': ['rbf'], 'class_weight':['auto', None]}]
 
 This example uses the ``scipy.stats`` module, which contains many useful
-distributions for sampling hyperparameters, such as ``expon``, ``gamma``,
+distributions for sampling parameters, such as ``expon``, ``gamma``,
 ``uniform`` or ``randint``.
 In principle, any function can be passed that provides a ``rvs`` (random
 variate sample) method to sample a value. A call to the ``rvs`` function should
@@ -134,8 +154,8 @@ increasing ``n_iter`` will always lead to a finer search.
       The Journal of Machine Learning Research (2012)
 
 
-Alternatives to brute force grid search
-=======================================
+Alternatives to brute force parameter search
+============================================
 
 Model specific cross-validation
 -------------------------------


### PR DESCRIPTION
The `grid_search` documentation is too centered on grid search, and does not describe what parameter space can be tuned (i.e. mentioning `get_params`). This patches up the documentation by firstly outlining the general idea of parameter search, and by making it more consistent in its use of terminology. It refers to _search candidates_ being one setting of parameters, sampled from a _parameter space_ by the _search method_. It eschews use of _hyperparameters_ because of the use of `get_params`, `set_params` and the _Parameters_ heading in `Estimator` docstrings, but it explains the term.
