### PR TITLE
[MRG] Blockwise parallel silhouette computation

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -19,11 +19,12 @@ def test_silhouette():
     silhouette = silhouette_score(D, y, metric='precomputed')
     assert(silhouette > 0)
     # Test without calculating D
-    silhouette_metric = silhouette_score(X, y, metric='euclidean')
+    silhouette_metric = silhouette_score(X, y, metric='euclidean',
+                                         blockwise=False)
     assert_almost_equal(silhouette, silhouette_metric)
     # Test with the block method
     silhouette_metric_block = silhouette_score(X, y, metric='euclidean',
-                                               method='blockwise')
+                                               blockwise=True)
     assert_almost_equal(silhouette, silhouette_metric_block)
     # Test with sampling
     silhouette = silhouette_score(D, y, metric='precomputed',

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -21,6 +21,10 @@ def test_silhouette():
     # Test without calculating D
     silhouette_metric = silhouette_score(X, y, metric='euclidean')
     assert_almost_equal(silhouette, silhouette_metric)
+    # Test with the block method
+    silhouette_metric_block = silhouette_score(X, y, metric='euclidean',
+                                               method='blockwise')
+    assert_almost_equal(silhouette, silhouette_metric_block)
     # Test with sampling
     silhouette = silhouette_score(D, y, metric='precomputed',
                                   sample_size=int(X.shape[0] / 2),

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -224,7 +224,7 @@ def silhouette_samples(X, labels, metric='euclidean', method='global',
                     metric, **kwds)
                 for label_a, label_b in combinations(unique_labels, 2))
 
-        # Take the dist to the closest cluster
+        # Take the distance to the closest cluster
         for (label_a, label_b), (values_a, values_b) in \
                     zip(combinations(unique_labels, 2), values):
                 indices_a = np.where(labels == label_a)[0]

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -55,10 +55,11 @@ def silhouette_score(X, labels, metric='euclidean', method='global',
     method: string
         The method used to compute distance matrix between samples. Default is
         ``global`` which means that the full distance matrix is computed
-        yielding in fast computation but high memory consumption. ``blockwise``
-        option compute clusterwise distance matrices, dividing approximately
-        memory consumption by the squared number of clusters. ``blockwise``
-        method allows parallelization though ``n_jobs`` parameter.
+        yielding in fast computation but high memory consumption. The
+        ``blockwise`` option computes clusterwise distance matrices, dividing
+        memory consumption by approximately the squared number of clusters.
+        The ``blockwise`` method allows parallelization through ``n_jobs``
+        parameter.
 
     sample_size : int or None
         The size of the sample to use when computing the Silhouette Coefficient 
@@ -159,10 +160,11 @@ def silhouette_samples(X, labels, metric='euclidean', method='global',
     method: string
         The method used to compute distance matrix between samples. Default is
         ``global`` which means that the full distance matrix is computed
-        yielding in fast computation but high memory consumption. ``blockwise``
-        option compute clusterwise distance matrices, dividing approximately
-        memory consumption by the squared number of clusters. ``blockwise``
-        method allows parallelization though ``n_jobs`` parameter.
+        yielding in fast computation but high memory consumption. The
+        ``blockwise`` option computes clusterwise distance matrices, dividing
+        memory consumption by approximately the squared number of clusters.
+        The ``blockwise`` method allows parallelization through ``n_jobs``
+        parameter.
 
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
@@ -234,7 +236,7 @@ def silhouette_samples(X, labels, metric='euclidean', method='global',
                 B[indices_b] = np.minimum(values_b, B[indices_b])
                 del indices_b
     else:
-        raise ValueError('Unknow method: %s' % method)
+        raise ValueError('Unknown method: %s' % method)
     sil_samples = (B - A) / np.maximum(A, B)
     return sil_samples
 

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -113,11 +113,6 @@ def silhouette_score(X, labels, metric='euclidean', blockwise='auto',
         random_state = check_random_state(random_state)
         indices = random_state.permutation(X.shape[0])[:sample_size]
         if metric == "precomputed":
-            #if blockwise is True:
-            #    raise ValueError('Precomputed matrix is not compatible with'
-            #            ' blockwise computation')
-            #blockwise = False
-            #n_jobs = 1
             X, labels = X[indices].T[indices].T, labels[indices]
         else:
             X, labels = X[indices], labels[indices]
@@ -205,16 +200,24 @@ def silhouette_samples(X, labels, metric='euclidean', blockwise='auto',
     if blockwise not in [True, False, 'auto']:
         raise ValueError("Blockwise parameter must be True, False or 'auto'. "
                          "You have set it to %s." % str(blockwise))
+
+    if metric == "precomputed" and blockwise is True:
+        raise ValueError('Precomputed matrix is not compatible with'
+                         ' blockwise computation')
     if blockwise is False and n_jobs != 1:
         warnings.warn('Parallelization is only available for blockwise method')
         n_jobs = 1
-
     if blockwise == 'auto':
-        #n_labels = len(np.unique(labels))
-        #if n_jobs is None:
-        #    n_jobs = cpu_count()
-        #blockwise = not (n_labels / n_jobs > 50 and X.shape[0] < 5 * n_labels)
-        blackwise = False
+        if metric == 'precomputed':
+            blockwise = False
+            n_jobs = 1
+        else:
+            n_labels = len(np.unique(labels))
+            if n_jobs is None:
+                n_jobs = cpu_count()
+            blockwise = not (n_labels / n_jobs > 50 and
+                             X.shape[0] < 5 * n_labels)
+
     if not blockwise:
         distances = pairwise_distances(X, metric=metric, **kwds)
         n = labels.shape[0]

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -52,7 +52,7 @@ def silhouette_score(X, labels, metric='euclidean', method='global',
         <sklearn.metrics.pairwise.pairwise_distances>`. If X is the distance
         array itself, use ``metric="precomputed"``.
 
-    method: string
+    method: {'global', 'blockwise'}
         The method used to compute distance matrix between samples. Default is
         ``global`` which means that the full distance matrix is computed
         yielding in fast computation but high memory consumption. The
@@ -157,7 +157,7 @@ def silhouette_samples(X, labels, metric='euclidean', method='global',
         allowed by :func:`sklearn.metrics.pairwise.pairwise_distances`. If X is
         the distance array itself, use "precomputed" as the metric.
 
-    method: string
+    method: {'global', 'blockwise'}
         The method used to compute distance matrix between samples. Default is
         ``global`` which means that the full distance matrix is computed
         yielding in fast computation but high memory consumption. The

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -63,8 +63,8 @@ def silhouette_score(X, labels, metric='euclidean', blockwise='auto',
         heuristics.
 
     sample_size : int or None
-        The size of the sample to use when computing the Silhouette Coefficient 
-        on a random subset of the data. 
+        The size of the sample to use when computing the Silhouette Coefficient
+        on a random subset of the data.
         If ``sample_size is None``, no sampling is used.
 
     n_jobs : integer, optional
@@ -73,7 +73,7 @@ def silhouette_score(X, labels, metric='euclidean', blockwise='auto',
         Memory consumption is proportional to the number of CPUs.
 
     random_state : integer or numpy.RandomState, optional
-        The generator used to randomly select a subset of samples if 
+        The generator used to randomly select a subset of samples if
         ``sample_size is not None``. If an integer is given, it fixes the seed.
         Defaults to the global numpy random number generator.
 
@@ -209,8 +209,8 @@ def silhouette_samples(X, labels, metric='euclidean', blockwise='auto',
         n_jobs = 1
 
     if blockwise == 'auto':
-        # Temporary
-        blockwise = False
+        n_labels = len(np.unique(labels))
+        blockwise = not (n_labels > 50 and X.shape[0] < 5 * n_labels)
     if not blockwise:
         distances = pairwise_distances(X, metric=metric, **kwds)
         n = labels.shape[0]
@@ -222,8 +222,8 @@ def silhouette_samples(X, labels, metric='euclidean', blockwise='auto',
         # Intra distance
         A = np.zeros(labels.size, dtype=float)
         intra_dist = Parallel(n_jobs=n_jobs)(
-            delayed(_intra_cluster_distances_block)
-                (X[np.where(labels == label)[0]], metric, **kwds)
+            delayed(_intra_cluster_distances_block)(
+                X[np.where(labels == label)[0]], metric, **kwds)
             for label in np.unique(labels))
         for label, dist in zip(np.unique(labels), intra_dist):
             A[np.where(labels == label)[0]] = dist
@@ -239,7 +239,7 @@ def silhouette_samples(X, labels, metric='euclidean', blockwise='auto',
                     X[np.where(labels == label_a)[0]],
                     X[np.where(labels == label_b)[0]],
                     metric, **kwds)
-                for label_a, label_b in combinations(unique_labels, 2))
+            for label_a, label_b in combinations(unique_labels, 2))
 
         # Take the distance to the closest cluster
         for (label_a, label_b), (values_a, values_b) in \
@@ -250,8 +250,6 @@ def silhouette_samples(X, labels, metric='euclidean', blockwise='auto',
                 indices_b = np.where(labels == label_b)[0]
                 B[indices_b] = np.minimum(values_b, B[indices_b])
                 del indices_b
-    else:
-        raise ValueError('Unknown method: %s' % method)
     sil_samples = (B - A) / np.maximum(A, B)
     return sil_samples
 


### PR DESCRIPTION
This pull request introduces a blockwise computation of the silhouette, using less memory, but slightly slower.

First, the vocabulary can be debated. I have chosen the word "global" for the original silhouette strategy (as the global distance matrix is computed, I could not come with a better word) and "blockwise" for my method.

The other point is that I have 3 implementations of the silhouette:
- the original one
- a blockwise single threaded version
- a blockwise multi threaded version (which uses a bit more memory than the single threaded version, even if n_jobs=1)

I have decided to leave the original version untouched, as the code is far more readable than mine. Then I have not kept the most efficient blockwise single threaded version because the memory gain is not worth the code complication (I think).

It is in fact possible to have "one implementation to rule them all". This could be done by keeping the same code skeleton and using a "precomputed" distance matrix for the original version. But I think that the code would become too opaque.
