### PR TITLE
ENH support multilabel targets in LabelEncoder

### DIFF
--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -852,7 +852,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : array-like of shape [n_samples]
+        y : array-like of shape [n_samples] or sequence of sequences
             Target values.
 
         Returns
@@ -867,12 +867,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : array-like of shape [n_samples]
+        y : array-like of shape [n_samples] or sequence of sequences
             Target values.
 
         Returns
         -------
-        y : array-like of shape [n_samples]
+        y : array-like of shape [n_samples] or sequence of sequences
         """
         if is_multilabel(y):
             self.fit(y)
@@ -890,7 +890,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        y : array-like of shape [n_samples]
+        y : array-like of shape [n_samples] or sequence of sequences
         """
         self._check_fitted()
         if is_multilabel(y):
@@ -913,12 +913,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array of shape [n_samples]
+        y : numpy array of shape [n_samples] or sequence of sequences
             Target values.
 
         Returns
         -------
-        y : numpy array of shape [n_samples] or list of arrays for multilabel
+        y : numpy array of shape [n_samples] or sequence of sequences
         """
         self._check_fitted()
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -21,7 +21,6 @@ from .utils.fixes import unique
 from .utils.multiclass import unique_labels
 from .utils.multiclass import is_multilabel
 from .utils.multiclass import is_label_indicator_matrix
-from .utils.multiclass import multilabel_vectorize
 
 from .utils.sparsefuncs import inplace_csr_row_normalize_l1
 from .utils.sparsefuncs import inplace_csr_row_normalize_l2
@@ -836,8 +835,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> targets = [["paris", "tokyo"], ["amsterdam", "paris"]]
-    >>> le.fit_transform(targets)
-    array([[1 2], [0 1]], dtype=object)
+    >>> list(map(list, le.fit_transform(targets)))
+    [[1, 2], [0, 1]]
     >>> list(map(list, le.inverse_transform([[1, 2], [0, 1]])))
     [['paris', 'tokyo'], ['amsterdam', 'paris']]
 
@@ -886,7 +885,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : array-like of shape [n_samples]
+        y : array-like of shape [n_samples] or sequence of sequences
             Target values.
 
         Returns
@@ -899,7 +898,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 raise ValueError(
                     '{} does not support label indicator matrices'.format(
                         self.__class__.__name__))
-            return multilabel_vectorize(self._transform)(y)
+            return list(map(self._transform, y))
 
         return self._transform(y)
 
@@ -919,14 +918,13 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        y : numpy array of shape [n_samples]
+        y : numpy array of shape [n_samples] or list of arrays for multilabel
         """
         self._check_fitted()
 
         if is_multilabel(y):
             # np.vectorize does not work with np.ndarray.take!
-            take = functools.partial(np.take, self.classes_)
-            return multilabel_vectorize(take)(y)
+            return list(map(self.classes_.take, y))
         y = np.asarray(y)
         return self.classes_[y]
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1055,7 +1055,7 @@ class LabelBinarizer(LabelEncoder, TransformerMixin):
         else:
             n_columns = 1
         Y = np.empty((len(y), n_columns), dtype=np.int)
-        Y[...] = self.neg_label
+        Y.fill(self.neg_label)
 
         y_is_multilabel = is_multilabel(y)
 
@@ -1126,9 +1126,9 @@ class LabelBinarizer(LabelEncoder, TransformerMixin):
         if threshold is None:
             threshold = np.mean([self.pos_label, self.neg_label])
 
-        Y = np.array(Y > threshold, dtype=int)
-
         if self.multilabel:
+            Y = np.array(Y > threshold, dtype=int)
+
             # Return the predictions in the same format as in fit
             if self.indicator_matrix_:
                 # Label indicator matrix format

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -4,6 +4,7 @@
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: BSD 3 clause
 
+import functools
 import warnings
 import numbers
 
@@ -19,6 +20,7 @@ from .utils.fixes import unique
 from .utils.multiclass import unique_labels
 from .utils.multiclass import is_multilabel
 from .utils.multiclass import is_label_indicator_matrix
+from .utils.multiclass import multilabel_vectorize
 
 from .utils.sparsefuncs import inplace_csr_row_normalize_l1
 from .utils.sparsefuncs import inplace_csr_row_normalize_l2
@@ -829,6 +831,15 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']
 
+    It can also be used to transform multi-label sequences of sequences:
+
+    >>> le = preprocessing.LabelEncoder()
+    >>> targets = [["paris", "tokyo"], ["amsterdam", "paris"]]
+    >>> le.fit_transform(targets)
+    array([[1 2], [0 1]], dtype=object)
+    >>> list(map(list, le.inverse_transform([[1, 2], [0, 1]])))
+    [['paris', 'tokyo'], ['amsterdam', 'paris']]
+
     """
 
     def _check_fitted(self):
@@ -847,7 +858,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         self : returns an instance of self.
         """
-        self.classes_ = np.unique(y)
+        self.classes_ = unique_labels(y)
         return self
 
     def fit_transform(self, y):
@@ -862,6 +873,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         y : array-like of shape [n_samples]
         """
+        if is_multilabel(y):
+            self.fit(y)
+            return self.transform(y)
         self.classes_, y = unique(y, return_inverse=True)
         return y
 
@@ -878,12 +892,19 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         self._check_fitted()
+        if is_multilabel(y):
+            if is_label_indicator_matrix(y):
+                raise ValueError(
+                    '{} does not support label indicator matrices'.format(
+                        self.__class__.__name__))
+            return multilabel_vectorize(self._transform)(y)
 
-        classes = np.unique(y)
-        if len(np.intersect1d(classes, self.classes_)) < len(classes):
-            diff = np.setdiff1d(classes, self.classes_)
+        return self._transform(y)
+
+    def _transform(self, y):
+        diff = np.setdiff1d(y, self.classes_)
+        if len(diff):
             raise ValueError("y contains new labels: %s" % str(diff))
-
         return np.searchsorted(self.classes_, y)
 
     def inverse_transform(self, y):
@@ -900,6 +921,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         self._check_fitted()
 
+        if is_multilabel(y):
+            # np.vectorize does not work with np.ndarray.take!
+            take = functools.partial(np.take, self.classes_)
+            return multilabel_vectorize(take)(y)
         y = np.asarray(y)
         return self.classes_[y]
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_sequences_equal
 
 from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
@@ -64,7 +65,7 @@ def test_ovr_always_present():
         ovr = OneVsRestClassifier(DecisionTreeClassifier())
         ovr.fit(X, y)
         y_pred = ovr.predict(X)
-        assert_array_equal(np.array(y_pred), np.array(y))
+        assert_sequences_equal(y_pred, y)
 
 
 def test_ovr_multilabel():
@@ -146,13 +147,13 @@ def test_ovr_multilabel_predict_proba():
         decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
         assert_raises(AttributeError, decision_only.predict_proba, X_test)
 
-        Y_pred = clf.predict(X_test)
+        Y_pred = list(clf.predict(X_test))
         Y_proba = clf.predict_proba(X_test)
 
         # predict assigns a label if the probability that the
         # sample has the label is greater than 0.5.
         pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
-        assert_equal(pred, Y_pred)
+        assert_sequences_equal(pred, Y_pred)
 
 
 def test_ovr_single_label_predict_proba():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_sequences_equal
 
 from sklearn.utils.sparsefuncs import mean_variance_axis0
 from sklearn.preprocessing import Binarizer
@@ -510,8 +511,7 @@ def test_label_binarizer_multilabel():
                               [1, 1, 0]])
     got = lb.fit_transform(inp)
     assert_array_equal(indicator_mat, got)
-    assert_equal(list(map(list, lb.inverse_transform(got))),
-                 list(map(list, inp)))
+    assert_sequences_equal(lb.inverse_transform(got), inp)
 
     # test input as label indicator matrix
     lb.fit(indicator_mat)
@@ -528,8 +528,7 @@ def test_label_binarizer_multilabel():
                          [1, 1]])
     got = lb.fit_transform(inp)
     assert_array_equal(expected, got)
-    assert_equal([set(x) for x in lb.inverse_transform(got)],
-                 [set(x) for x in inp])
+    assert_sequences_equal(lb.inverse_transform(got), inp)
 
 
 def test_label_binarizer_errors():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -510,7 +510,8 @@ def test_label_binarizer_multilabel():
                               [1, 1, 0]])
     got = lb.fit_transform(inp)
     assert_array_equal(indicator_mat, got)
-    assert_equal(lb.inverse_transform(got), inp)
+    assert_equal(list(map(list, lb.inverse_transform(got))),
+                 list(map(list, inp)))
 
     # test input as label indicator matrix
     lb.fit(indicator_mat)

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -612,15 +612,45 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_multilabel():
+    """Test LabelEncoder's transform and inverse_transform methods with
+    multilabel data"""
+    le = LabelEncoder()
+    le.fit([[1], [1, 4], [5, -1, 0]])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_sequences_equal(le.transform([[0, 1, 4], [4, 5, -1], [-1]]),
+                       [[1, 2, 3], [3, 4, 0], [0]])
+    assert_sequences_equal(le.inverse_transform([[1, 2, 3], [3, 4, 0], [0]]),
+                       [[0, 1, 4], [4, 5, -1], [-1]])
+    assert_raises(ValueError, le.transform, [[0, 6]])
+    # not handling label encoder matrices presently
+    assert_raises(ValueError, le.transform, np.array([[0, 1], [1, 0]]))
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()
     ret = le.fit_transform([1, 1, 4, 5, -1, 0])
     assert_array_equal(ret, [2, 2, 3, 4, 0, 1])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
 
     le = LabelEncoder()
     ret = le.fit_transform(["paris", "paris", "tokyo", "amsterdam"])
     assert_array_equal(ret, [1, 1, 2, 0])
+
+
+def test_label_encoder_fit_transform_multilabel():
+    """Test fit_transform for multilabel input"""
+    le = LabelEncoder()
+    ret = le.fit_transform([[1], [1, 4, 5], [-1, 0]])
+    assert_sequences_equal(ret, [[2], [2, 3, 4], [0, 1]])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+
+    le = LabelEncoder()
+    ret = le.fit_transform([["paris"], ["paris", "tokyo", "amsterdam"]])
+    assert_sequences_equal(ret, [[1], [1, 2, 0]])
+    # not handling label encoder matrices presently
+    assert_raises(ValueError, le.transform, np.array([[0, 1], [1, 0]]))
 
 
 def test_label_encoder_string_labels():
@@ -633,6 +663,19 @@ def test_label_encoder_string_labels():
                        [2, 2, 1])
     assert_array_equal(le.inverse_transform([2, 2, 1]),
                        ["tokyo", "tokyo", "paris"])
+    assert_raises(ValueError, le.transform, ["london"])
+
+
+def test_label_encoder_strings_multilabel():
+    """Test LabelEncoder's transform and inverse_transform methods with
+    non-numeric multilabel data"""
+    le = LabelEncoder()
+    le.fit([["paris"], ["paris", "tokyo", "amsterdam"]])
+    assert_array_equal(le.classes_, ["amsterdam", "paris", "tokyo"])
+    assert_sequences_equal(le.transform([["tokyo"], ["tokyo", "paris"]]),
+                       [[2], [2, 1]])
+    assert_sequences_equal(le.inverse_transform([[2], [2, 1]]),
+                       [["tokyo"], ["tokyo", "paris"]])
     assert_raises(ValueError, le.transform, ["london"])
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -130,5 +130,7 @@ def is_multilabel(y):
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
-    return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) and
-            not isinstance(y[0], string_types) or is_label_indicator_matrix(y))
+    if getattr(y, 'ndim', 1) != 1:
+        return is_label_indicator_matrix(y)
+    return ((isinstance(y[0], Sequence) and not isinstance(y[0], string_types))
+            or isinstance(y[0], np.ndarray))

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -120,7 +120,9 @@ def is_multilabel(y):
     False
     >>> is_multilabel([[1], [0, 2], []])
     True
-    >>> is_multilabel(np.array([[1, 0], [0, 0]]))
+    >>> is_multilabel(np.array([np.array([1]), np.array([0, 2])]))
+    True
+    >>> is_multilabel(np.array([[1, 0], [0, 0]]))  # label indicator matrix
     True
     >>> is_multilabel(np.array([[1], [0], [0]]))
     False
@@ -130,5 +132,49 @@ def is_multilabel(y):
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
-    return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) and
-            not isinstance(y[0], string_types) or is_label_indicator_matrix(y))
+    if getattr(y, 'ndim', 1) != 1:
+        return is_label_indicator_matrix(y)
+    return ((isinstance(y[0], Sequence) and not isinstance(y[0], string_types))
+            or isinstance(y[0], np.ndarray))
+
+
+def multilabel_as_array(y):
+    """Transform a sequence of sequences into an array of sequences
+
+    Parameters
+    ----------
+    y : sequence or array of sequences
+        Target values. In the multilabel case the nested sequences can
+        have variable lengths. Label indicator matrices are not supported.
+
+    Returns
+    -------
+    out : numpy array of shape [len(y)]
+        The elements of the returned array correspond to the elements of y.
+        If y is an array, it is returned without copying.
+    """
+    if hasattr(y, '__array__'):
+        return np.asarray(y)
+    out = np.empty(len(y), dtype=object)
+    out[:] = y
+    return out
+
+
+def multilabel_vectorize(func, otypes='O'):
+    """Vectorize a function suitably for sequence-of-sequence input and output
+
+    Parameters
+    ----------
+    func : a function to vectorize
+    otypes : the dtypes of the output arrays, default objects
+
+    Returns
+    -------
+    out : callable
+        The returned function will vectorize `func` over its arguments, first
+        ensuring they are arrays of sequences.
+    """
+    vfunc = np.vectorize(func, otypes=otypes)
+    def wrapper(*args):
+        return vfunc(*[multilabel_as_array(arg) for arg in args])
+    return wrapper

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -120,9 +120,7 @@ def is_multilabel(y):
     False
     >>> is_multilabel([[1], [0, 2], []])
     True
-    >>> is_multilabel(np.array([np.array([1]), np.array([0, 2])]))
-    True
-    >>> is_multilabel(np.array([[1, 0], [0, 0]]))  # label indicator matrix
+    >>> is_multilabel(np.array([[1, 0], [0, 0]]))
     True
     >>> is_multilabel(np.array([[1], [0], [0]]))
     False
@@ -132,49 +130,5 @@ def is_multilabel(y):
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
-    if getattr(y, 'ndim', 1) != 1:
-        return is_label_indicator_matrix(y)
-    return ((isinstance(y[0], Sequence) and not isinstance(y[0], string_types))
-            or isinstance(y[0], np.ndarray))
-
-
-def multilabel_as_array(y):
-    """Transform a sequence of sequences into an array of sequences
-
-    Parameters
-    ----------
-    y : sequence or array of sequences
-        Target values. In the multilabel case the nested sequences can
-        have variable lengths. Label indicator matrices are not supported.
-
-    Returns
-    -------
-    out : numpy array of shape [len(y)]
-        The elements of the returned array correspond to the elements of y.
-        If y is an array, it is returned without copying.
-    """
-    if hasattr(y, '__array__'):
-        return np.asarray(y)
-    out = np.empty(len(y), dtype=object)
-    out[:] = y
-    return out
-
-
-def multilabel_vectorize(func, otypes='O'):
-    """Vectorize a function suitably for sequence-of-sequence input and output
-
-    Parameters
-    ----------
-    func : a function to vectorize
-    otypes : the dtypes of the output arrays, default objects
-
-    Returns
-    -------
-    out : callable
-        The returned function will vectorize `func` over its arguments, first
-        ensuring they are arrays of sequences.
-    """
-    vfunc = np.vectorize(func, otypes=otypes)
-    def wrapper(*args):
-        return vfunc(*[multilabel_as_array(arg) for arg in args])
-    return wrapper
+    return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) and
+            not isinstance(y[0], string_types) or is_label_indicator_matrix(y))

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -97,6 +97,24 @@ def assert_raise_message(exception, message, function, *args, **kwargs):
         assert_in(message, error_message)
 
 
+def assert_sequences_equal(first, second, err_msg=''):
+    """Asserts equality of two sequences of sequences
+
+    This compares multilabel targets irrespective of the sequence types.
+    It is necessary because sequence types vary, `assert_array_equal` may
+    misinterpret some formats as 2-dimensional.
+    """
+    if err_msg:
+        err_msg = '\n' + err_msg
+    assert_equal(len(first), len(second),
+                 'Sequence of sequence lengths do not match.'
+                 '{}'.format(err_msg))
+    for i, (first_el, second_el) in enumerate(zip(first, second)):
+        assert_array_equal(len(first_el), len(second_el),
+                           'In sequence of sequence element {}'
+                           '{}'.format(i, err_msg))
+
+
 def fake_mldata(columns_dict, dataname, matfile, ordering=None):
     """Create a fake mldata data set.
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -10,6 +10,7 @@
 import inspect
 import pkgutil
 
+import numpy as np
 import scipy as sp
 from functools import wraps
 try:
@@ -110,7 +111,7 @@ def assert_sequences_equal(first, second, err_msg=''):
                  'Sequence of sequence lengths do not match.'
                  '{}'.format(err_msg))
     for i, (first_el, second_el) in enumerate(zip(first, second)):
-        assert_array_equal(first_el, second_el,
+        assert_array_equal(np.unique(first_el), np.unique(second_el),
                            'In sequence of sequence element {}'
                            '{}'.format(i, err_msg))
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -110,7 +110,7 @@ def assert_sequences_equal(first, second, err_msg=''):
                  'Sequence of sequence lengths do not match.'
                  '{}'.format(err_msg))
     for i, (first_el, second_el) in enumerate(zip(first, second)):
-        assert_array_equal(len(first_el), len(second_el),
+        assert_array_equal(first_el, second_el,
                            'In sequence of sequence element {}'
                            '{}'.format(i, err_msg))
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -105,6 +105,7 @@ def assert_sequences_equal(first, second, err_msg=''):
     It is necessary because sequence types vary, `assert_array_equal` may
     misinterpret some formats as 2-dimensional.
     """
+    # TODO: first assert args are valid sequences of sequences
     if err_msg:
         err_msg = '\n' + err_msg
     assert_equal(len(first), len(second),


### PR DESCRIPTION
Also, support 1d-array of arrays (with the outer array having `dtype=object`) as a multilabel format and their `np.vectorize`d processing.

This makes it easy to support multilabel data with string (or non-consecutive / negative-inclusive) labels. In particular, `bincount` and related operations that can be used on LabelEncoded multiclass targets can also be used with multilabel data.

Also added inheritance of `LabelBinarizer` from `LabelEncoder`.
