### PR TITLE
[WIP] rewrite precision_recall_fscore_support

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -972,7 +972,7 @@ a score (``greater_is_better=True``) or a loss (``greater_is_better=False``),
 whether the function you provided takes predictions as input
 (``needs_threshold=False``) or needs confidence scores
 (``needs_threshold=True``) and any additional parameters, such as ``beta`` in
-the example above.
+the previous example.
 
 
 Implementing your own scoring object

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -102,7 +102,7 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
         super(LogisticRegression, self).__init__(
             penalty=penalty, dual=dual, loss='lr', tol=tol, C=C,
             fit_intercept=fit_intercept, intercept_scaling=intercept_scaling,
-            class_weight=class_weight, random_state=None)
+            class_weight=class_weight, random_state=random_state)
 
     def predict_proba(self, X):
         """Probability estimates.

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1584,7 +1584,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if beta <= 0:
         raise ValueError("beta should be >0 in the F-beta score")
 
-    labels, y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
+    labels, y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred,
+                                                        ravel=True)
 
     ### Calculate tp_sum, pos_sum, true_sum ###
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -27,7 +27,7 @@ from ..preprocessing import LabelBinarizer
 from ..utils import check_arrays
 from ..utils import deprecated
 from ..utils.fixes import divide
-from ..utils.multiclass import check_multilabel_type
+from ..utils.multiclass import is_multilabel
 from ..utils.multiclass import unique_labels
 
 
@@ -928,7 +928,7 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True, pos_label=1):
     y_true, y_pred = check_arrays(y_true, y_pred, allow_lists=True)
 
     # Compute accuracy for each possible representation
-    ml_type = check_multilabel_type(y_true, y_pred)
+    ml_type = is_multilabel(y_true, y_pred)
     if ml_type:
         if ml_type == 'mixed':
             labels = unique_labels(y_true, y_pred)
@@ -1049,7 +1049,7 @@ def accuracy_score(y_true, y_pred, normalize=True):
     y_true, y_pred = check_arrays(y_true, y_pred, allow_lists=True)
 
     # Compute accuracy for each possible representation
-    ml_type = check_multilabel_type(y_true, y_pred)
+    ml_type = is_multilabel(y_true, y_pred)
     if ml_type:
         if ml_type == 'mixed':
             labels = unique_labels(y_true, y_pred)
@@ -1421,7 +1421,7 @@ def _tp_tn_fp_fn(y_true, y_pred, labels=None, pos_label=1):
     false_pos = np.zeros((n_labels), dtype=np.int)
     false_neg = np.zeros((n_labels), dtype=np.int)
 
-    ml_type = check_multilabel_type(y_true, y_pred)
+    ml_type = is_multilabel(y_true, y_pred)
     if ml_type:
         if ml_type == 'mixed':
             labels = unique_labels(y_true, y_pred)
@@ -1651,7 +1651,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     n_labels = labels.size
 
     if average == "samples":
-        ml_type = check_multilabel_type(y_true, y_pred)
+        ml_type = is_multilabel(y_true, y_pred)
         if ml_type:
             if ml_type == 'mixed':
                 labels = unique_labels(y_true, y_pred)
@@ -2226,7 +2226,7 @@ def hamming_loss(y_true, y_pred, classes=None):
     else:
         classes = np.asarray(classes, dtype=np.int)
 
-    ml_type = check_multilabel_type(y_true, y_pred)
+    ml_type = is_multilabel(y_true, y_pred)
     if ml_type:
         lb = LabelBinarizer()
         lb.fit([classes.tolist()])

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1593,6 +1593,9 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if y_type == 'multilabel-indicator':
         ## sum (common) 1s in each column, or each row for average='samples' ##
         sum_axis = 1 if average == 'samples' else 0
+        # pos_label should always be 1, but we need to zero the negative indicators
+        y_true = y_true == pos_label
+        y_pred = y_pred == pos_label
         tp_sum = np.sum(np.logical_and(y_true, y_pred), axis=sum_axis)
         pos_sum = np.sum(y_pred, axis=sum_axis, dtype=int)
         true_sum = np.sum(y_true, axis=sum_axis, dtype=int)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1378,7 +1378,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     0.54...
     >>> fbeta_score(y_true, y_pred, average='samples', beta=0.5)
     ... # doctest: +ELLIPSIS
-    0.66...
+    0.779...
     >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
     ... # doctest: +ELLIPSIS
     array([ 0.38...,  0.71...,  0.38...])
@@ -1398,8 +1398,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     ... # doctest: +ELLIPSIS
     0.66...
     >>> fbeta_score(y_true, y_pred, average='samples', beta=0.5)
-    ... # doctest: +ELLIPSIS
-    0.42...
+    0.5
     >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
     array([ 1.,  1.,  0.])
 
@@ -1722,7 +1721,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
             precision = size_inter / size_true
             recall = size_inter / size_pred
-            f_score = ((1 + beta2 ** 2) * size_inter /
+            f_score = ((1 + beta2) * size_inter /
                        (beta2 * size_pred + size_true))
         finally:
             np.seterr(**old_err_settings)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1659,26 +1659,28 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         # labels are now from 0 to len(labels) - 1 -> use bincount
 
         if y_type == 'multilabel-sequences':
-            intersect_all = multilabel_vectorize(np.intersect1d)
-            tp_bins = np.hstack([np.intersect1d(sample1, sample2)
-                                 for sample1, sample2 in zip(y_pred, y_true)])
-            # merge samples
-            pos_bins = np.hstack(y_pred)
-            true_bins = np.hstack(y_true)
+            # if all samples were assured unique, could use np.bincount
+            tp_sum = np.zeros(len(labels), dtype=int)
+            true_sum = tp_sum.copy()
+            pos_sum = tp_sum.copy()
+            for sample1, sample2 in zip(y_true, y_pred):
+                tp_sum[np.intersect1d(sample1, sample2)] += 1
+                true_sum[np.unique(sample1)] += 1
+                pos_sum[np.unique(sample2)] += 1
         else:
             tp_bins = y_true[y_true == y_pred]
             pos_bins = y_pred
             true_bins = y_true
 
-        if len(tp_bins):
-            tp_sum = np.bincount(tp_bins, minlength=len(labels))
-        else:
-            # Pathological case
-            true_sum = pos_sum = tp_sum = np.zeros(len(labels))
-        if len(pos_bins):
-            pos_sum = np.bincount(pos_bins, minlength=len(labels))
-        if len(true_bins):
-            true_sum = np.bincount(true_bins, minlength=len(labels))
+            if len(tp_bins):
+                tp_sum = np.bincount(tp_bins, minlength=len(labels))
+            else:
+                # Pathological case
+                true_sum = pos_sum = tp_sum = np.zeros(len(labels))
+            if len(pos_bins):
+                pos_sum = np.bincount(pos_bins, minlength=len(labels))
+            if len(true_bins):
+                true_sum = np.bincount(true_bins, minlength=len(labels))
 
     ### Select labels to keep ###
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -937,7 +937,7 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True, pos_label=1):
             y_true = lb.transform(y_true)
             y_pred = lb.transform(y_pred)
 
-        if ml_type != 'sos':
+        if ml_type != 'sequences':
             try:
                 # oddly, we may get an "invalid" rather than a "divide"
                 # error here
@@ -1058,7 +1058,7 @@ def accuracy_score(y_true, y_pred, normalize=True):
             y_true = lb.transform(y_true)
             y_pred = lb.transform(y_pred)
 
-        if ml_type != 'sos':
+        if ml_type != 'sequences':
             score = (y_pred != y_true).sum(axis=1) == 0
         else:
             score = np.array([len(set(true) ^ set(pred)) == 0
@@ -1430,7 +1430,7 @@ def _tp_tn_fp_fn(y_true, y_pred, labels=None, pos_label=1):
             y_true = lb.transform(y_true)
             y_pred = lb.transform(y_pred)
 
-        if ml_type != 'sos':
+        if ml_type != 'sequences':
             true_pos = np.sum(np.logical_and(y_true == pos_label,
                                              y_pred == pos_label), axis=0)
             false_pos = np.sum(np.logical_and(y_true != pos_label,
@@ -1660,7 +1660,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                 y_true = lb.transform(y_true)
                 y_pred = lb.transform(y_pred)
 
-            if ml_type != 'sos':
+            if ml_type != 'sequences':
                 y_true_pos_label = y_true == pos_label
                 y_pred_pos_label = y_pred == pos_label
                 size_inter = np.sum(np.logical_and(y_true_pos_label,
@@ -2235,7 +2235,7 @@ def hamming_loss(y_true, y_pred, classes=None):
             y_true = lb.transform(y_true)
             y_pred = lb.transform(y_pred)
 
-        if ml_type != 'sos':
+        if ml_type != 'sequences':
             return np.mean(y_true != y_pred)
         else:
             loss = np.array([len(set(pred) ^ set(true))

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1702,7 +1702,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         old_err_settings = np.seterr(divide='ignore', invalid='ignore')
         precision = tp_sum / pos_sum
         recall = tp_sum / true_sum
-        precision[pos_sum == 0] = 0.0  # XXX: Joel thinks these should be set to 1.
+        # TODO: warn before setting these
+        precision[pos_sum == 0] = 0.0
         recall[true_sum == 0] = 0.0
 
         f_score = (1 + beta2) * precision * recall / (beta2 * precision + recall)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1679,7 +1679,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     (0.66..., 0.66..., 0.66..., None)
     >>> precision_recall_fscore_support(y_true, y_pred, average='samples')
     ... # doctest: +ELLIPSIS
-    (1.0, 0.5, 0.5, None)
+    (0.5, 0.5, 0.5, None)
 
     """
     if beta <= 0:
@@ -1726,9 +1726,9 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         finally:
             np.seterr(**old_err_settings)
 
-        precision[size_pred == 0] = 1.0
-        recall[size_true == 0] = 1.0
-        f_score[(beta2 * size_true + size_pred) == 0] = 1.0
+        precision[size_pred == 0] = 0.0
+        recall[size_true == 0] = 0.0
+        f_score[(beta2 * size_true + size_pred) == 0] = 0.0
 
         precision = np.mean(precision)
         recall = np.mean(recall)
@@ -1927,7 +1927,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     >>> precision_score(y_true, y_pred, average='weighted') # doctest: +ELLIPSIS
     0.66...
     >>> precision_score(y_true, y_pred, average='samples')
-    1.0
+    0.5
     >>> precision_score(y_true, y_pred, average=None)
     array([ 1.,  1.,  0.])
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1584,6 +1584,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if beta <= 0:
         raise ValueError("beta should be >0 in the F-beta score")
 
+    label_order = labels  # save this for later
     labels, y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred,
                                                         ravel=True)
 
@@ -1721,6 +1722,12 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         recall = np.average(recall, weights=weights)
         f_score = np.average(f_score, weights=weights)
         true_sum = None  # return no support
+    elif label_order is not None:
+        indices = np.searchsorted(labels, label_order)
+        precision = precision[indices]
+        recall = recall[indices]
+        f_score = f_score[indices]
+        true_sum = true_sum[indices]
 
     return precision, recall, f_score, true_sum
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1591,8 +1591,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if y_type == 'indicator':
         sum_axis = 1 if average == 'samples' else 0
         tp_sum = np.sum(np.logical_and(y_true, y_pred), axis=sum_axis)
-        pos_sum = np.sum(y_pred, axis=sum_axis)
-        true_sum = np.sum(y_true, axis=sum_axis)
+        pos_sum = np.sum(y_pred, axis=sum_axis, dtype=int)
+        true_sum = np.sum(y_true, axis=sum_axis, dtype=int)
 
     elif average == 'samples':
         if y_type != 'multilabel-sequences':

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1378,7 +1378,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     0.54...
     >>> fbeta_score(y_true, y_pred, average='samples', beta=0.5)
     ... # doctest: +ELLIPSIS
-    0.779...
+    0.49...
     >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
     ... # doctest: +ELLIPSIS
     array([ 0.38...,  0.71...,  0.38...])
@@ -1661,7 +1661,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     (0.499..., 1.0, 0.65..., None)
     >>> precision_recall_fscore_support(y_true, y_pred, average='samples')
     ... # doctest: +ELLIPSIS
-    (1.0, 0.44..., 0.59..., None)
+    (0.44..., 1.0, 0.59..., None)
 
     and with a list of labels format:
 
@@ -1679,7 +1679,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     (0.66..., 0.66..., 0.66..., None)
     >>> precision_recall_fscore_support(y_true, y_pred, average='samples')
     ... # doctest: +ELLIPSIS
-    (0.5, 1.0, 0.5, None)
+    (1.0, 0.5, 0.5, None)
 
     """
     if beta <= 0:
@@ -1711,24 +1711,24 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                 size_true[i] = len(true_set)
         else:
             raise ValueError("Example-based precision, recall, fscore is "
-                             "not meaning full outside multilabe"
-                             "classification. See the accuracy_score instead.")
+                             "not meaning full outside multilabel"
+                             "classification. Use accuracy_score instead.")
 
         try:
             # oddly, we may get an "invalid" rather than a "divide" error
             # here
             old_err_settings = np.seterr(divide='ignore', invalid='ignore')
 
-            precision = size_inter / size_true
-            recall = size_inter / size_pred
+            precision = size_inter / size_pred
+            recall = size_inter / size_true
             f_score = ((1 + beta2) * size_inter /
-                       (beta2 * size_pred + size_true))
+                       (beta2 * size_true + size_pred))
         finally:
             np.seterr(**old_err_settings)
 
-        precision[size_true == 0] = 1.0
-        recall[size_pred == 0] = 1.0
-        f_score[(beta2 * size_pred + size_true) == 0] = 1.0
+        precision[size_pred == 0] = 1.0
+        recall[size_true == 0] = 1.0
+        f_score[(beta2 * size_true + size_pred) == 0] = 1.0
 
         precision = np.mean(precision)
         recall = np.mean(recall)
@@ -1909,7 +1909,8 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     ... # doctest: +ELLIPSIS
     0.49...
     >>> precision_score(y_true, y_pred, average='samples')
-    1.0
+    ... # doctest: +ELLIPSIS
+    0.44...
     >>> precision_score(y_true, y_pred, average=None)
     ... # doctest: +ELLIPSIS
     array([ 0.33...,  0.66...,  0.33...])
@@ -1921,14 +1922,12 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     >>> y_pred = [(1, 2), tuple()]
     >>> precision_score(y_true, y_pred, average='macro')  # doctest: +ELLIPSIS
     0.66...
-    >>> precision_score(y_true, y_pred, average='micro')  # doctest: +ELLIPSIS
+    >>> precision_score(y_true, y_pred, average='micro') # doctest: +ELLIPSIS
     1.0
-    >>> precision_score(y_true, y_pred, average='weighted')
-    ... # doctest: +ELLIPSIS
+    >>> precision_score(y_true, y_pred, average='weighted') # doctest: +ELLIPSIS
     0.66...
     >>> precision_score(y_true, y_pred, average='samples')
-    ... # doctest: +ELLIPSIS
-    0.5
+    1.0
     >>> precision_score(y_true, y_pred, average=None)
     array([ 1.,  1.,  0.])
 
@@ -2028,10 +2027,10 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     1.0
     >>> recall_score(y_true, y_pred, average='micro')
     1.0
-    >>> recall_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
+    >>> recall_score(y_true, y_pred, average='weighted')
     1.0
-    >>> recall_score(y_true, y_pred, average='samples')  # doctest: +ELLIPSIS
-    0.44...
+    >>> recall_score(y_true, y_pred, average='samples')
+    1.0
     >>> recall_score(y_true, y_pred, average=None)
     array([ 1.,  1.,  1.])
 
@@ -2047,7 +2046,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     >>> recall_score(y_true, y_pred, average='weighted')  # doctest: +ELLIPSIS
     0.66...
     >>> recall_score(y_true, y_pred, average='samples')
-    1.0
+    0.5
     >>> recall_score(y_true, y_pred, average=None)
     array([ 1.,  1.,  0.])
     """

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1644,7 +1644,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
                               DeprecationWarning)
 
                 if pos_label not in labels:
-                    raise ValueError("pos_label=%d is not a valid label: %r" %
+                    raise ValueError("pos_label=%r is not a valid label: %r" %
                                      (pos_label, labels))
                 if pos_label == neg_label:
                     neg_label = labels[1]
@@ -1658,7 +1658,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         if y_type.startswith('multilabel'):
             raise ValueError('TODO')
         if neg_label not in labels:
-            raise ValueError("neg_label=%s is not a valid label: %r" %
+            raise ValueError("neg_label=%r is not a valid label: %r" %
                              (neg_label, labels))
         # XXX: is labels always sorted?
         mask = np.ones(tp_sum.shape, dtype=bool)

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+from functools import partial
 import warnings
 import numpy as np
 
@@ -49,60 +50,43 @@ from sklearn.externals.six.moves import xrange
 
 ALL_METRICS = {
     "accuracy_score": accuracy_score,
-    "unormalized_accuracy_score":
-    lambda y1, y2: accuracy_score(y1, y2, normalize=False),
+    "unormalized_accuracy_score": partial(accuracy_score, normalize=False),
 
     "hamming_loss": hamming_loss,
 
     "jaccard_similarity_score": jaccard_similarity_score,
     "unormalized_jaccard_similarity_score":
-    lambda y1, y2: jaccard_similarity_score(y1, y2, normalize=False),
+    partial(jaccard_similarity_score, normalize=False),
 
     "zero_one_loss": zero_one_loss,
-    "unnormalized_zero_one_loss":
-    lambda y1, y2: zero_one_loss(y1, y2, normalize=False),
+    "unnormalized_zero_one_loss": partial(zero_one_loss, normalize=False),
 
     "precision_score": precision_score,
     "recall_score": recall_score,
     "f1_score": f1_score,
-    "f2_score": lambda y1, y2: fbeta_score(y1, y2, beta=2),
-    "f0.5_score": lambda y1, y2: fbeta_score(y1, y2, beta=0.5),
+    "f2_score": partial(fbeta_score, beta=2),
+    "f0.5_score": partial(fbeta_score, beta=0.5),
     "matthews_corrcoef_score": matthews_corrcoef,
     "auc_score": auc_score,
     "average_precision_score": average_precision_score,
 
-    "weighted_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=0.5),
-    "weighted_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="weighted"),
-    "weighted_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=2),
-    "weighted_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="weighted"),
-    "weighted_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="weighted"),
+    "weighted_f0.5_score": partial(fbeta_score, average="weighted", beta=0.5),
+    "weighted_f1_score": partial(f1_score, average="weighted"),
+    "weighted_f2_score": partial(fbeta_score, average="weighted", beta=2),
+    "weighted_precision_score": partial(precision_score, average="weighted"),
+    "weighted_recall_score": partial(recall_score, average="weighted"),
 
-    "micro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=0.5),
-    "micro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="micro"),
-    "micro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=2),
-    "micro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="micro"),
-    "micro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="micro"),
+    "micro_f0.5_score": partial(fbeta_score, average="micro", beta=0.5),
+    "micro_f1_score": partial(f1_score, average="micro"),
+    "micro_f2_score": partial(fbeta_score, average="micro", beta=2),
+    "micro_precision_score": partial(precision_score, average="micro"),
+    "micro_recall_score": partial(recall_score, average="micro"),
 
-    "macro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=0.5),
-    "macro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="macro"),
-    "macro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=2),
-    "macro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="macro"),
-    "macro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="macro"),
+    "macro_f0.5_score": partial(fbeta_score, average="macro", beta=0.5),
+    "macro_f1_score": partial(f1_score, average="macro"),
+    "macro_f2_score": partial(fbeta_score, average="macro", beta=2),
+    "macro_precision_score": partial(precision_score, average="macro"),
+    "macro_recall_score": partial(recall_score, average="macro"),
 
     "mean_absolute_error": mean_absolute_error,
     "mean_squared_error": mean_squared_error,
@@ -111,146 +95,96 @@ ALL_METRICS = {
 }
 
 METRICS_WITH_NORMALIZE_OPTION = {
-    "accuracy_score ": lambda y1, y2, normalize:
-    accuracy_score(y1, y2, normalize=normalize),
-    "jaccard_similarity_score": lambda y1, y2, normalize:
-    jaccard_similarity_score(y1, y2, normalize=normalize),
-    "zero_one_loss": lambda y1, y2, normalize:
-    zero_one_loss(y1, y2, normalize=normalize),
+    "accuracy_score ": accuracy_score,
+    "jaccard_similarity_score": jaccard_similarity_score,
+    "zero_one_loss": zero_one_loss,
 }
 
 MULTILABELS_METRICS = {
     "accuracy_score": accuracy_score,
-    "unormalized_accuracy_score":
-    lambda y1, y2: accuracy_score(y1, y2, normalize=False),
+    "unormalized_accuracy_score": partial(accuracy_score, normalize=False),
 
     "hamming_loss": hamming_loss,
 
     "jaccard_similarity_score": jaccard_similarity_score,
     "unormalized_jaccard_similarity_score":
-    lambda y1, y2: jaccard_similarity_score(y1, y2, normalize=False),
+    partial(jaccard_similarity_score, normalize=False),
 
     "zero_one_loss": zero_one_loss,
-    "unnormalized_zero_one_loss":
-    lambda y1, y2: zero_one_loss(y1, y2, normalize=False),
+    "unnormalized_zero_one_loss": partial(zero_one_loss, normalize=False),
 
-    "weighted_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=0.5),
-    "weighted_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="weighted"),
-    "weighted_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=2),
-    "weighted_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="weighted"),
-    "weighted_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="weighted"),
+    "weighted_f0.5_score": partial(fbeta_score, average="weighted", beta=0.5),
+    "weighted_f1_score": partial(f1_score, average="weighted"),
+    "weighted_f2_score": partial(fbeta_score, average="weighted", beta=2),
+    "weighted_precision_score": partial(precision_score, average="weighted"),
+    "weighted_recall_score": partial(recall_score, average="weighted"),
 
-    "samples_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="samples", beta=0.5),
-    "samples_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="samples"),
-    "samples_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="samples", beta=2),
-    "samples_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="samples"),
-    "samples_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="samples"),
+    "samples_f0.5_score": partial(fbeta_score, average="samples", beta=0.5),
+    "samples_f1_score": partial(f1_score, average="samples"),
+    "samples_f2_score": partial(fbeta_score, average="samples", beta=2),
+    "samples_precision_score": partial(precision_score, average="samples"),
+    "samples_recall_score": partial(recall_score, average="samples"),
 
-    "micro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=0.5),
-    "micro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="micro"),
-    "micro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=2),
-    "micro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="micro"),
-    "micro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="micro"),
+    "micro_f0.5_score": partial(fbeta_score, average="micro", beta=0.5),
+    "micro_f1_score": partial(f1_score, average="micro"),
+    "micro_f2_score": partial(fbeta_score, average="micro", beta=2),
+    "micro_precision_score": partial(precision_score, average="micro"),
+    "micro_recall_score": partial(recall_score, average="micro"),
 
-    "macro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=0.5),
-    "macro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="macro"),
-    "macro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=2),
-    "macro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="macro"),
-    "macro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="macro"),
+    "macro_f0.5_score": partial(fbeta_score, average="macro", beta=0.5),
+    "macro_f1_score": partial(f1_score, average="macro"),
+    "macro_f2_score": partial(fbeta_score, average="macro", beta=2),
+    "macro_precision_score": partial(precision_score, average="macro"),
+    "macro_recall_score": partial(recall_score, average="macro"),
 }
 
 MULTILABELS_METRICS_WITH_POS_LABELS = {
     "jaccard_similarity_score": jaccard_similarity_score,
-    "unormalized_jaccard_similarity_score": lambda y1, y2, pos_label=1:
-    jaccard_similarity_score(y1, y2, pos_label=pos_label, normalize=False),
+    "unormalized_jaccard_similarity_score":
+    partial(jaccard_similarity_score, normalize=False),
 
-    "weighted_f0.5_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="weighted", beta=0.5),
-    "weighted_f1_score": lambda y1, y2, pos_label=1:
-    f1_score(y1, y2, pos_label=pos_label, average="weighted"),
-    "weighted_f2_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="weighted", beta=2),
-    "weighted_precision_score": lambda y1, y2, pos_label=1:
-    precision_score(y1, y2, pos_label=pos_label, average="weighted"),
-    "weighted_recall_score": lambda y1, y2, pos_label=1:
-    recall_score(y1, y2, pos_label=pos_label, average="weighted"),
+    "weighted_f0.5_score": partial(fbeta_score, average="weighted", beta=0.5),
+    "weighted_f1_score": partial(f1_score, average="weighted"),
+    "weighted_f2_score": partial(fbeta_score, average="weighted", beta=2),
+    "weighted_precision_score": partial(precision_score, average="weighted"),
+    "weighted_recall_score": partial(recall_score, average="weighted"),
 
-    "samples_f0.5_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="samples", beta=0.5),
-    "samples_f1_score": lambda y1, y2, pos_label=1:
-    f1_score(y1, y2, pos_label=pos_label, average="samples"),
-    "samples_f2_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="samples", beta=2),
-    "samples_precision_score": lambda y1, y2, pos_label=1:
-    precision_score(y1, y2, pos_label=pos_label, average="samples"),
-    "samples_recall_score": lambda y1, y2, pos_label=1:
-    recall_score(y1, y2, pos_label=pos_label, average="samples"),
+    "samples_f0.5_score": partial(fbeta_score, average="samples", beta=0.5),
+    "samples_f1_score": partial(f1_score, average="samples"),
+    "samples_f2_score": partial(fbeta_score, average="samples", beta=2),
+    "samples_precision_score": partial(precision_score, average="samples"),
+    "samples_recall_score": partial(recall_score, average="samples"),
 
-    "micro_f0.5_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="micro", beta=0.5),
-    "micro_f1_score": lambda y1, y2, pos_label=1:
-    f1_score(y1, y2, pos_label=pos_label, average="micro"),
-    "micro_f2_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="micro", beta=2),
-    "micro_precision_score": lambda y1, y2, pos_label=1:
-    precision_score(y1, y2, pos_label=pos_label, average="micro"),
-    "micro_recall_score": lambda y1, y2, pos_label=1:
-    recall_score(y1, y2, pos_label=pos_label, average="micro"),
+    "micro_f0.5_score": partial(fbeta_score, average="micro", beta=0.5),
+    "micro_f1_score": partial(f1_score, average="micro"),
+    "micro_f2_score": partial(fbeta_score, average="micro", beta=2),
+    "micro_precision_score": partial(precision_score, average="micro"),
+    "micro_recall_score": partial(recall_score, average="micro"),
 
-    "macro_f0.5_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="macro", beta=0.5),
-    "macro_f1_score": lambda y1, y2, pos_label=1:
-    f1_score(y1, y2, pos_label=pos_label, average="macro"),
-    "macro_f2_score": lambda y1, y2, pos_label=1:
-    fbeta_score(y1, y2, pos_label=pos_label, average="macro", beta=2),
-    "macro_precision_score": lambda y1, y2, pos_label=1:
-    precision_score(y1, y2, pos_label=pos_label, average="macro"),
-    "macro_recall_score": lambda y1, y2, pos_label=1:
-    recall_score(y1, y2, pos_label=pos_label, average="macro"),
+    "macro_f0.5_score": partial(fbeta_score, average="macro", beta=0.5),
+    "macro_f1_score": partial(f1_score, average="macro"),
+    "macro_f2_score": partial(fbeta_score, average="macro", beta=2),
+    "macro_precision_score": partial(precision_score, average="macro"),
+    "macro_recall_score": partial(recall_score, average="macro"),
 }
 
 SYMETRIC_METRICS = {
     "accuracy_score": accuracy_score,
-    "unormalized_accuracy_score":
-    lambda y1, y2: accuracy_score(y1, y2, normalize=False),
+    "unormalized_accuracy_score": partial(accuracy_score, normalize=False),
 
     "hamming_loss": hamming_loss,
 
     "jaccard_similarity_score": jaccard_similarity_score,
     "unormalized_jaccard_similarity_score":
-    lambda y1, y2: jaccard_similarity_score(y1, y2, normalize=False),
+    partial(jaccard_similarity_score, normalize=False),
 
     "zero_one_loss": zero_one_loss,
-    "unnormalized_zero_one_loss":
-    lambda y1, y2: zero_one_loss(y1, y2, normalize=False),
+    "unnormalized_zero_one_loss": partial(zero_one_loss, normalize=False),
 
     "f1_score": f1_score,
-    "weighted_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="weighted"),
-    "micro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="micro"),
-    "macro_f1_score":
-    lambda y1, y2: f1_score(y1, y2, average="macro"),
+    "weighted_f1_score": partial(f1_score, average="weighted"),
+    "micro_f1_score": partial(f1_score, average="micro"),
+    "macro_f1_score": partial(f1_score, average="macro"),
 
     "matthews_corrcoef_score": matthews_corrcoef,
     "mean_absolute_error": mean_absolute_error,
@@ -263,35 +197,23 @@ NOT_SYMETRIC_METRICS = {
 
     "precision_score": precision_score,
     "recall_score": recall_score,
-    "f2_score": lambda y1, y2: fbeta_score(y1, y2, beta=2),
-    "f0.5_score": lambda y1, y2: fbeta_score(y1, y2, beta=0.5),
+    "f2_score": partial(fbeta_score, beta=2),
+    "f0.5_score": partial(fbeta_score, beta=0.5),
 
-    "weighted_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=0.5),
-    "weighted_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="weighted", beta=2),
-    "weighted_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="weighted"),
-    "weighted_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="weighted"),
+    "weighted_f0.5_score": partial(fbeta_score, average="weighted", beta=0.5),
+    "weighted_f2_score": partial(fbeta_score, average="weighted", beta=2),
+    "weighted_precision_score": partial(precision_score, average="weighted"),
+    "weighted_recall_score": partial(recall_score, average="weighted"),
 
-    "micro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=0.5),
-    "micro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="micro", beta=2),
-    "micro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="micro"),
-    "micro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="micro"),
+    "micro_f0.5_score": partial(fbeta_score, average="micro", beta=0.5),
+    "micro_f2_score": partial(fbeta_score, average="micro", beta=2),
+    "micro_precision_score": partial(precision_score, average="micro"),
+    "micro_recall_score": partial(recall_score, average="micro"),
 
-    "macro_f0.5_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=0.5),
-    "macro_f2_score":
-    lambda y1, y2: fbeta_score(y1, y2, average="macro", beta=2),
-    "macro_precision_score":
-    lambda y1, y2: precision_score(y1, y2, average="macro"),
-    "macro_recall_score":
-    lambda y1, y2: recall_score(y1, y2, average="macro"),
+    "macro_f0.5_score": partial(fbeta_score, average="macro", beta=0.5),
+    "macro_f2_score": partial(fbeta_score, average="macro", beta=2),
+    "macro_precision_score": partial(precision_score, average="macro"),
+    "macro_recall_score": partial(recall_score, average="macro"),
 }
 
 THRESHOLDED_METRICS = {

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -19,7 +19,8 @@ from sklearn.utils.testing import (assert_true,
                                    assert_not_equal,
                                    assert_array_equal,
                                    assert_array_almost_equal,
-                                   assert_greater)
+                                   assert_greater,
+                                   ignore_warnings)
 
 
 from sklearn.metrics import (accuracy_score,
@@ -948,6 +949,7 @@ def test_symmetry():
                             zero_one_score(y_pred, y_true))
 
 
+@ignore_warnings
 def test_sample_order_invariance():
     y_true, y_pred, _ = make_prediction(binary=True)
 
@@ -962,6 +964,7 @@ def test_sample_order_invariance():
                                     % name)
 
 
+@ignore_warnings
 def test_format_invariance_with_1d_vectors():
     y1, y2, _ = make_prediction(binary=True)
 
@@ -1080,6 +1083,7 @@ def test_multioutput_number_of_output_differ():
     assert_raises(ValueError, r2_score, y_true, y_pred)
 
 
+@ignore_warnings
 def test_multioutput_regression_invariance_to_dimension_shuffling():
     # test invariance to dimension shuffling
     y_true, y_pred, _ = make_prediction()
@@ -1097,6 +1101,7 @@ def test_multioutput_regression_invariance_to_dimension_shuffling():
                                 error)
 
 
+@ignore_warnings
 def test_multilabel_representation_invariance():
 
     # Generate some data
@@ -1387,6 +1392,7 @@ def test_precision_recall_f1_score_multilabel_1():
     for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average=None)
+#WARNS
         #tp = [0, 1, 1, 0]
         #fn = [1, 0, 0, 1]
         #fp = [1, 1, 0, 0]
@@ -1398,18 +1404,21 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_array_almost_equal(s, [1, 1, 1, 1], 2)
 
         f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+#WARNS
         support = s
         assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
 
         # Check macro
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
+#WARNS
         assert_almost_equal(p, 1.5 / 4)
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 2.5 / 1.5 * 0.25)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="macro"),
+#WARNS
                             np.mean(f2))
 
         # Check micro
@@ -1426,12 +1435,14 @@ def test_precision_recall_f1_score_multilabel_1():
         # Check weigted
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="weighted")
+#WARNS
         assert_almost_equal(p, 1.5 / 4)
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 2.5 / 1.5 * 0.25)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="weighted"),
+#WARNS
                             np.average(f2, weights=support))
         # Check weigted
         # |h(x_i) inter y_i | = [0, 1, 1]
@@ -1465,12 +1476,14 @@ def test_precision_recall_f1_score_multilabel_2():
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average=None)
+#WARNS
         assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
         assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
         assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
         assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
         f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+#WARNS
         support = s
         assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
@@ -1487,22 +1500,26 @@ def test_precision_recall_f1_score_multilabel_2():
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
+#WARNS
         assert_almost_equal(p, 0.25)
         assert_almost_equal(r, 0.125)
         assert_almost_equal(f, 2 / 12)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="macro"),
+#WARNS
                             np.mean(f2))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="weighted")
+#WARNS
         assert_almost_equal(p, 2 / 4)
         assert_almost_equal(r, 1 / 4)
         assert_almost_equal(f, 2 / 3 * 2 / 4)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="weighted"),
+#WARNS
                             np.average(f2, weights=support))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1536,23 +1553,27 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average=None)
+#WARNS
         assert_array_almost_equal(p, [0.0, 1.0, 1.0, 0.0], 2)
         assert_array_almost_equal(r, [0.0, 0.5, 1.0, 0.0], 2)
         assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
         assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
         f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+#WARNS
         support = s
         assert_array_almost_equal(f2, [0, 0.55, 1, 0], 2)
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
+#WARNS
         assert_almost_equal(p, 0.5)
         assert_almost_equal(r, 1.5 / 4)
         assert_almost_equal(f, 2.5 / (4 * 1.5))
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="macro"),
+#WARNS
                             np.mean(f2))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1567,16 +1588,19 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="weighted")
+#WARNS
         assert_almost_equal(p, 3 / 4)
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, (2 / 1.5 + 1) / 4)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="weighted"),
+#WARNS
                             np.average(f2, weights=support))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="samples")
+#WARNS
         # |h(x_i) inter y_i | = [0, 0, 2]
         # |y_i| = [1, 1, 2]
         # |h(x_i)| = [0, 1, 2]
@@ -1586,6 +1610,7 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                         average="samples"),
+#WARNS
                             0.333, 2)
 
 
@@ -1595,6 +1620,7 @@ def test_precision_recall_f1_no_labels():
 
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average=None)
+#WARNS
     #tp = [0, 0, 0]
     #fn = [0, 0, 0]
     #fp = [0, 0, 0]
@@ -1607,36 +1633,43 @@ def test_precision_recall_f1_no_labels():
     assert_array_almost_equal(s, [0, 0, 0], 2)
     assert_array_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                           average=None), [0, 0, 0], 2)
+#WARNS
 
     # Check macro
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="macro")
+#WARNS
     assert_almost_equal(p, 0)
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="macro"), 0)
+#WARNS
 
     # Check micro
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="micro")
+#WARNS
     assert_almost_equal(p, 0)
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="micro"), 0)
+#WARNS
 
     # Check weighted
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="weighted")
+#WARNS
     assert_almost_equal(p, 0)
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="weighted"), 0)
+#WARNS
 
     # # Check example
     # |h(x_i) inter y_i | = [0, 0, 0]
@@ -1644,14 +1677,17 @@ def test_precision_recall_f1_no_labels():
     # |h(x_i)| = [1, 1, 2]
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="samples")
+#WARNS
     assert_almost_equal(p, 0)
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="samples"), 0)
+#WARNS
 
 
+@ignore_warnings
 def test_multilabel_invariance_with_pos_labels():
     n_classes = 4
     n_samples = 50

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1658,7 +1658,7 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         # |h(x_i) inter y_i | = [0, 0, 2]
         # |y_i| = [1, 1, 2]
         # |h(x_i)| = [0, 1, 2]
-        assert_almost_equal(p, 2 / 3)
+        assert_almost_equal(p, 1 / 3)
         assert_almost_equal(r, 1 / 3)
         assert_almost_equal(f, 1 / 3)
         assert_equal(s, None)
@@ -1706,7 +1706,6 @@ def test_precision_recall_f1_no_labels():
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
                                     average="micro"), 0)
 
-
     # Check weighted
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="weighted")
@@ -1723,12 +1722,12 @@ def test_precision_recall_f1_no_labels():
     # |h(x_i)| = [1, 1, 2]
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                  average="samples")
-    assert_almost_equal(p, 1)
-    assert_almost_equal(r, 1)
-    assert_almost_equal(f, 1)
+    assert_almost_equal(p, 0)
+    assert_almost_equal(r, 0)
+    assert_almost_equal(f, 0)
     assert_equal(s, None)
     assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                    average="samples"), 1)
+                                    average="samples"), 0)
 
 
 def test_multilabel_invariance_with_pos_labels():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -959,7 +959,7 @@ def test_sample_order_invariance():
         assert_almost_equal(metric(y_true, y_pred),
                             metric(y_true_shuffle, y_pred_shuffle),
                             err_msg="%s is not sample order invariant"
-                                    % metric)
+                                    % name)
 
 
 def test_format_invariance_with_1d_vectors():
@@ -981,11 +981,11 @@ def test_format_invariance_with_1d_vectors():
         measure = metric(y1, y2)
 
         assert_almost_equal(metric(y1_list, y2_list), measure,
-                            err_msg="%s is not representation invariant"
+                            err_msg="%s is not representation invariant "
                                     "with list" % name)
 
         assert_almost_equal(metric(y1_1d, y2_1d), measure,
-                            err_msg="%s is not representation invariant"
+                            err_msg="%s is not representation invariant "
                                     "with np-array-1d" % name)
 
         assert_almost_equal(metric(y1_column, y2_column), measure,
@@ -1016,12 +1016,12 @@ def test_format_invariance_with_1d_vectors():
                                     % name)
 
         assert_almost_equal(metric(y1_list, y2_column), measure,
-                            err_msg="%s is not representation invariant"
+                            err_msg="%s is not representation invariant "
                                     "with mix list and np-array-column"
                                     % name)
 
         assert_almost_equal(metric(y1_column, y2_list), measure,
-                            err_msg="%s is not representation invariant"
+                            err_msg="%s is not representation invariant "
                                     "with mix list and np-array-column"
                                     % name)
 
@@ -1169,14 +1169,14 @@ def test_multilabel_representation_invariance():
 
         # Check invariance with mix input representation
         assert_almost_equal(metric(y1, y2_binary_indicator), measure,
-                            err_msg="%s failed mix input representation"
+                            err_msg="%s failed mix input representation "
                                     "invariance: y_true in list of list of "
-                                    "labels format and y_pred in dense binary"
+                                    "labels format and y_pred in dense binary "
                                     "indicator format"
                                     % name)
 
         assert_almost_equal(metric(y1_binary_indicator, y2), measure,
-                            err_msg="%s failed mix input representation"
+                            err_msg="%s failed mix input representation "
                                     "invariance: y_true in dense binary "
                                     "indicator format and y_pred in list of "
                                     "list of labels format."
@@ -1672,6 +1672,6 @@ def test_multilabel_invariance_with_pos_labels():
                                        y2_binary_indicator * pos_label,
                                        pos_label=pos_label),
                                 measure,
-                                err_msg="%s is not representation invariant"
+                                err_msg="%s is not representation invariant "
                                         "with pos_label=%s"
-                                        % (metric, pos_label))
+                                        % (name, pos_label))

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1004,9 +1004,9 @@ def test_symmetry():
 
     # Symmetric metric
     for name, metric in SYMETRIC_METRICS.items():
-        assert_equal(metric(y_true, y_pred),
-                     metric(y_pred, y_true),
-                     msg="%s is not symetric" % name)
+        assert_almost_equal(metric(y_true, y_pred),
+                            metric(y_pred, y_true),
+                            err_msg="%s is not symetric" % name)
 
     # Not symmetric metrics
     for name, metric in NOT_SYMETRIC_METRICS.items():
@@ -1016,14 +1016,14 @@ def test_symmetry():
     # Deprecated metrics
     with warnings.catch_warnings(record=True):
         # Throw deprecated warning
-        assert_equal(zero_one(y_true, y_pred),
-                     zero_one(y_pred, y_true))
+        assert_almost_equal(zero_one(y_true, y_pred),
+                            zero_one(y_pred, y_true))
 
-        assert_equal(zero_one(y_true, y_pred, normalize=False),
-                     zero_one(y_pred, y_true, normalize=False))
+        assert_almost_equal(zero_one(y_true, y_pred, normalize=False),
+                            zero_one(y_pred, y_true, normalize=False))
 
-        assert_equal(zero_one_score(y_true, y_pred),
-                     zero_one_score(y_pred, y_true))
+        assert_almost_equal(zero_one_score(y_true, y_pred),
+                            zero_one_score(y_pred, y_true))
 
 
 def test_sample_order_invariance():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -550,6 +550,9 @@ def test_precision_recall_f1_score_binary():
     fs = f1_score(y_true, y_pred)
     assert_array_almost_equal(fs, 0.76, 2)
 
+    assert_almost_equal(fbeta_score(y_true, y_pred, beta=2),
+                        (1 + 2 ** 2) * ps * rs / (2 ** 2 * ps + rs), 2)
+
 
 def test_average_precision_score_duplicate_values():
     # Duplicate values with precision-recall require a different
@@ -1472,6 +1475,10 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
         assert_array_almost_equal(s, [1, 1, 1, 1], 2)
 
+        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+        support = s
+        assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
+
         # Check macro
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
@@ -1479,6 +1486,9 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 2.5 / 1.5 * 0.25)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="macro"),
+                            np.mean(f2))
 
         # Check micro
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1487,6 +1497,9 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 0.5)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="micro"),
+                            (1 + 4) * p * r / (4 * p + r))
 
         # Check weigted
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1495,7 +1508,9 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 2.5 / 1.5 * 0.25)
         assert_equal(s, None)
-
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="weighted"),
+                            np.average(f2, weights=support))
         # Check weigted
         # |h(x_i) inter y_i | = [0, 1, 1]
         # |y_i| = [1, 1, 2]
@@ -1506,7 +1521,9 @@ def test_precision_recall_f1_score_multilabel_1():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 0.5)
         assert_equal(s, None)
-
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="samples"),
+                            0.5)
 
 def test_precision_recall_f1_score_multilabel_2():
     """ Test precision_recall_f1_score on a crafted multilabel example 2
@@ -1531,12 +1548,20 @@ def test_precision_recall_f1_score_multilabel_2():
         assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
         assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
+        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+        support = s
+        assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
+
+
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="micro")
         assert_almost_equal(p, 0.25)
         assert_almost_equal(r, 0.25)
         assert_almost_equal(f, 2 * 0.25 * 0.25 / 0.5)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="micro"),
+                            (1 + 4) * p * r / (4 * p + r))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
@@ -1544,6 +1569,9 @@ def test_precision_recall_f1_score_multilabel_2():
         assert_almost_equal(r, 0.125)
         assert_almost_equal(f, 2 / 12)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="macro"),
+                            np.mean(f2))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="weighted")
@@ -1551,6 +1579,9 @@ def test_precision_recall_f1_score_multilabel_2():
         assert_almost_equal(r, 1 / 4)
         assert_almost_equal(f, 2 / 3 * 2 / 4)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="weighted"),
+                            np.average(f2, weights=support))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="samples")
@@ -1562,6 +1593,9 @@ def test_precision_recall_f1_score_multilabel_2():
         assert_almost_equal(r, 1 / 6)
         assert_almost_equal(f, 2 / 4 * 1 / 3)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="samples"),
+                            0.1666, 2)
 
 
 def test_precision_recall_f1_score_with_an_empty_prediction():
@@ -1585,12 +1619,19 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
         assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
+        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+        support = s
+        assert_array_almost_equal(f2, [0, 0.55, 1, 0], 2)
+
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="macro")
         assert_almost_equal(p, 0.5)
         assert_almost_equal(r, 1.5 / 4)
         assert_almost_equal(f, 2.5 / (4 * 1.5))
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="macro"),
+                            np.mean(f2))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="micro")
@@ -1598,6 +1639,9 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, 2 / 3 / (2 / 3 + 0.5))
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="micro"),
+                            (1 + 4) * p * r / (4 * p + r))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="weighted")
@@ -1605,6 +1649,9 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         assert_almost_equal(r, 0.5)
         assert_almost_equal(f, (2 / 1.5 + 1) / 4)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="weighted"),
+                            np.average(f2, weights=support))
 
         p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
                                                      average="samples")
@@ -1615,6 +1662,9 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         assert_almost_equal(r, 2 / 3)
         assert_almost_equal(f, 1 / 3)
         assert_equal(s, None)
+        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                        average="samples"),
+                            0.333, 2)
 
 
 def test_precision_recall_f1_no_labels():
@@ -1633,6 +1683,8 @@ def test_precision_recall_f1_no_labels():
     assert_array_almost_equal(r, [0, 0, 0], 2)
     assert_array_almost_equal(f, [0, 0, 0], 2)
     assert_array_almost_equal(s, [0, 0, 0], 2)
+    assert_array_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                          average=None), [0, 0, 0], 2)
 
     # Check macro
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1641,6 +1693,8 @@ def test_precision_recall_f1_no_labels():
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
+    assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                    average="macro"), 0)
 
     # Check micro
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1649,6 +1703,9 @@ def test_precision_recall_f1_no_labels():
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
+    assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                    average="micro"), 0)
+
 
     # Check weighted
     p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
@@ -1657,6 +1714,8 @@ def test_precision_recall_f1_no_labels():
     assert_almost_equal(r, 0)
     assert_almost_equal(f, 0)
     assert_equal(s, None)
+    assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                    average="weighted"), 0)
 
     # # Check example
     # |h(x_i) inter y_i | = [0, 0, 0]
@@ -1668,6 +1727,8 @@ def test_precision_recall_f1_no_labels():
     assert_almost_equal(r, 1)
     assert_almost_equal(f, 1)
     assert_equal(s, None)
+    assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                    average="samples"), 1)
 
 
 def test_multilabel_invariance_with_pos_labels():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1658,8 +1658,8 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
         # |h(x_i) inter y_i | = [0, 0, 2]
         # |y_i| = [1, 1, 2]
         # |h(x_i)| = [0, 1, 2]
-        assert_almost_equal(p, 1 / 3)
-        assert_almost_equal(r, 2 / 3)
+        assert_almost_equal(p, 2 / 3)
+        assert_almost_equal(r, 1 / 3)
         assert_almost_equal(f, 1 / 3)
         assert_equal(s, None)
         assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -897,9 +897,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 raise ValueError(
                     '{} does not support label indicator matrices'.format(
                         self.__class__.__name__))
-            y = multilabel_vectorize(self._transform)(y)
             # remove redundant labels:
-            return multilabel_vectorize(np.unique)(y)
+            return multilabel_vectorize(self._transform)(y)
             
         return self._transform(y)
 

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -897,7 +897,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 raise ValueError(
                     '{} does not support label indicator matrices'.format(
                         self.__class__.__name__))
-            return multilabel_vectorize(self._transform)(y)
+            y = multilabel_vectorize(self._transform)(y)
+            # remove redundant labels:
+            return multilabel_vectorize(np.unique)(y)
             
         return self._transform(y)
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -132,3 +132,43 @@ def is_multilabel(y):
     # versions of Numpy might want to register ndarray as a Sequence
     return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) and
             not isinstance(y[0], string_types) or is_label_indicator_matrix(y))
+
+
+def check_multilabel_type(*ys):
+    """Checks if all data is multilabel, and what types
+
+    Parameters
+    ----------
+    *ys : array-likes
+
+    Returns
+    -------
+    type_name : string or False
+        Returns False if none of `ys` is multilabel. Returns 'matrix' if all
+        are label indicator matrices, 'sos' if all are sequence-of-sequences,
+        and 'mixed' if both occur. If all are label indicator matrices, but
+        not all have the same shape, or not all data has the same number of
+        samples, raises a `ValueError`.
+
+    Examples:
+    >>> from 
+    """
+    if not ys:
+        raise ValueError('Need at least one set of targets to check')
+
+    if all(is_label_indicator_matrix(y) for y in ys):
+        if len(set(y.shape for y in ys)) > 1:
+            raise ValueError('Indicator matrices are not all the same shape')
+        return 'matrix'
+    
+    if all(is_multilabel(y) for y in ys[1:]):
+        if len(set(getattr(y, 'shape', (len(y),))[0] for y in ys)) > 1:
+            raise ValueError('Multilabel targets have different sample sizes')
+        if any(is_label_indicator_matrix(y) for y in ys):
+            return 'mixed'
+        return 'sos'
+
+    if any(is_multilabel(y) for y in ys):
+        raise ValueError('Received a mix of single-label and multi-label data')
+    return False
+

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -211,21 +211,3 @@ def is_multilabel(*ys):
         elif ret == False:
             raise _mixed_error
     return ret
-
-
-    if all(is_label_indicator_matrix(y) for y in ys):
-        if len(set(y.shape for y in ys)) > 1:
-            raise ValueError('Indicator matrices are not all the same shape')
-        return 'matrix'
-    
-    if all(is_multilabel(y) for y in ys):
-        if len(set(getattr(y, 'shape', (len(y),))[0] for y in ys)) > 1:
-            raise ValueError('Multilabel targets have different sample sizes')
-        if any(is_label_indicator_matrix(y) for y in ys):
-            return 'mixed'
-        return 'sos'
-
-    if any(is_multilabel(y) for y in ys):
-        raise ValueError('Received a mix of single-label and multi-label data')
-    return False
-

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -121,6 +121,8 @@ def is_sequence_of_sequences(y):
     True
     >>> is_sequence_of_sequences([(1,), (0, 2), ()])
     True
+    >>> is_sequence_of_sequences(np.array([np.array([1]), np.array([0, 2])]))
+    True
     >>> is_sequence_of_sequences(np.array([[1, 0], [0, 0]]))
     False
     >>> is_sequence_of_sequences(np.array([[1], [0], [0]]))
@@ -130,11 +132,10 @@ def is_sequence_of_sequences(y):
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
-    try:
-        return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence)
-                and not isinstance(y[0], string_types))
-    except IndexError:
+    if getattr(y, 'ndim', 1) != 1:
         return False
+    return ((isinstance(y[0], Sequence) and not isinstance(y[0], string_types))
+            or isinstance(y[0], np.ndarray))
 
 
 def is_multilabel(y):
@@ -225,3 +226,45 @@ def type_of_target(y):
     else:
         # XXX: any validation?
         return 'multiclass'
+
+
+def multilabel_as_array(y):
+    """Transform a sequence of sequences into an array of sequences
+
+    Parameters
+    ----------
+    y : sequence or array of sequences
+        Target values. In the multilabel case the nested sequences can
+        have variable lengths. Label indicator matrices are not supported.
+
+    Returns
+    -------
+    out : numpy array of shape [len(y)]
+        The elements of the returned array correspond to the elements of y.
+        If y is an array, it is returned without copying.
+    """
+    if hasattr(y, '__array__'):
+        return np.asarray(y)
+    out = np.empty(len(y), dtype=object)
+    out[:] = y
+    return out
+
+
+def multilabel_vectorize(func, otypes='O'):
+    """Vectorize a function suitably for sequence-of-sequence input and output
+
+    Parameters
+    ----------
+    func : a function to vectorize
+    otypes : the dtypes of the output arrays, default objects
+    
+    Returns
+    -------
+    out : callable
+        The returned function will vectorize `func` over its arguments, first
+        ensuring they are arrays of sequences.
+    """
+    vfunc = np.vectorize(func, otypes=otypes)
+    def wrapper(*args):
+        return vfunc(*[multilabel_as_array(arg) for arg in args])
+    return wrapper

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -179,6 +179,10 @@ def is_multilabel(*ys):
     False
     >>> is_multilabel(other, other)
     False
+    >>> is_multilabel(['label1', 'label2'])
+    False
+    >>> is_multilabel([['label1', 'label2']])
+    'sequences'
     >>> assert_raises(ValueError, is_multilabel, other, seq1)
     >>> assert_raises(ValueError, is_multilabel, other, ind)
     >>> assert_raises(ValueError, is_multilabel, seq1, other)

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -146,12 +146,48 @@ def check_multilabel_type(*ys):
     type_name : string or False
         Returns False if none of `ys` is multilabel. Returns 'matrix' if all
         are label indicator matrices, 'sos' if all are sequence-of-sequences,
-        and 'mixed' if both occur. If all are label indicator matrices, but
-        not all have the same shape, or not all data has the same number of
-        samples, raises a `ValueError`.
+        and 'mixed' if both occur.
+
+    Any of the following raise `ValueError`s:
+
+        * All `ys` are label indicator matrices, but not all have the same
+          shape;
+        * All `ys` are multilabel but not all have the same sample size; or
+        * Some `ys` are multilabel and some are not.
 
     Examples:
-    >>> from 
+    >>> from sklearn.utils.multiclass import check_multilabel_type
+    >>> import numpy as np
+    >>> from nose.tools import assert_raises
+    >>> mat1 = np.array([[0, 1], [1, 0]])
+    >>> mat_long = np.array([[0, 1], [1, 0], [1, 0]])
+    >>> sos1 = [[0], [0, 2]]
+    >>> sos2 = np.array([[0, 2], [1]])
+    >>> sos_long = [[0], [1], [2]]
+    >>> other = [1, 2, 3]
+    >>> check_multilabel_type(mat1)
+    'matrix'
+    >>> check_multilabel_type(mat_long)
+    'matrix'
+    >>> check_multilabel_type(sos1)
+    'sos'
+    >>> check_multilabel_type(sos2)
+    'sos'
+    >>> check_multilabel_type(sos_long)
+    'sos'
+    >>> check_multilabel_type(sos1, sos2)
+    'sos'
+    >>> check_multilabel_type(mat1, mat1)
+    'matrix'
+    >>> check_multilabel_type(mat1, sos1)
+    'mixed'
+    >>> check_multilabel_type(other)
+    False
+    >>> assert_raises(ValueError, check_multilabel_type, mat1, mat_long)
+    >>> assert_raises(ValueError, check_multilabel_type, sos1, mat_long)
+    >>> assert_raises(ValueError, check_multilabel_type, sos1, sos_long)
+    >>> assert_raises(ValueError, check_multilabel_type, other, sos1)
+    >>> assert_raises(ValueError, check_multilabel_type, other, mat1)
     """
     if not ys:
         raise ValueError('Need at least one set of targets to check')
@@ -161,7 +197,7 @@ def check_multilabel_type(*ys):
             raise ValueError('Indicator matrices are not all the same shape')
         return 'matrix'
     
-    if all(is_multilabel(y) for y in ys[1:]):
+    if all(is_multilabel(y) for y in ys):
         if len(set(getattr(y, 'shape', (len(y),))[0] for y in ys)) > 1:
             raise ValueError('Multilabel targets have different sample sizes')
         if any(is_label_indicator_matrix(y) for y in ys):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -98,44 +98,49 @@ def is_label_indicator_matrix(y):
             y.shape[0] > 1 and np.size(np.unique(y)) <= 2)
 
 
-def is_multilabel(y):
-    """ Check if ``y`` is in a multilabel format.
+def is_sequence_of_sequences(y):
+    """ Check if ``y`` is in the sequence of sequences format (multilabel).
 
     Parameters
     ----------
-    y : numpy array of shape [n_samples] or sequence of sequences
-        Target values. In the multilabel case the nested sequences can
-        have variable lengths.
+    y : sequence or array.
 
     Returns
     -------
     out : bool,
-        Return ``True``, if ``y`` is in a multilabel format, else ```False``.
+        Return ``True``, if ``y`` is a sequence of sequences else ``False``.
 
-    Examples
-    --------
     >>> import numpy as np
     >>> from sklearn.utils.multiclass import is_multilabel
-    >>> is_multilabel([0, 1, 0, 1])
+    >>> is_sequence_of_sequences([0, 1, 0, 1])
     False
-    >>> is_multilabel([[1], [0, 2], []])
+    >>> is_sequence_of_sequences([[1], [0, 2], []])
     True
-    >>> is_multilabel(np.array([[1, 0], [0, 0]]))
+    >>> is_sequence_of_sequences(np.array([[1], [0, 2], []]))
     True
-    >>> is_multilabel(np.array([[1], [0], [0]]))
+    >>> is_sequence_of_sequences([(1,), (0, 2), ()])
+    True
+    >>> is_sequence_of_sequences(np.array([[1, 0], [0, 0]]))
     False
-    >>> is_multilabel(np.array([[1, 0, 0]]))
+    >>> is_sequence_of_sequences(np.array([[1], [0], [0]]))
     False
-
+    >>> is_sequence_of_sequences(np.array([[1, 0, 0]]))
+    False
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
     return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence) and
-            not isinstance(y[0], string_types) or is_label_indicator_matrix(y))
+            not isinstance(y[0], string_types))
 
 
-def check_multilabel_type(*ys):
-    """Checks if all data is multilabel, and what types
+_mixed_error = ValueError(
+    'Received a mix of single-label and multi-label data')
+
+
+def is_multilabel(*ys):
+    """Checks if all of `ys` are multilabel, and what types
+
+    If `ys` is a mix of multilabel and non-multilabel data, raises `ValueError`.
 
     Parameters
     ----------
@@ -148,49 +153,65 @@ def check_multilabel_type(*ys):
         are label indicator matrices, 'sos' if all are sequence-of-sequences,
         and 'mixed' if both occur.
 
-    Any of the following raise `ValueError`s:
-
-        * All `ys` are label indicator matrices, but not all have the same
-          shape;
-        * All `ys` are multilabel but not all have the same sample size; or
-        * Some `ys` are multilabel and some are not.
-
     Examples:
-    >>> from sklearn.utils.multiclass import check_multilabel_type
     >>> import numpy as np
+    >>> from sklearn.utils.multiclass import is_multilabel
     >>> from nose.tools import assert_raises
-    >>> mat1 = np.array([[0, 1], [1, 0]])
-    >>> mat_long = np.array([[0, 1], [1, 0], [1, 0]])
-    >>> sos1 = [[0], [0, 2]]
-    >>> sos2 = np.array([[0, 2], [1]])
-    >>> sos_long = [[0], [1], [2]]
+    >>> ind = np.array([[0, 1], [1, 0]])
+    >>> seq1 = [[0], [0, 2]]
+    >>> seq2 = np.array([[0, 2], [1]])
     >>> other = [1, 2, 3]
-    >>> check_multilabel_type(mat1)
-    'matrix'
-    >>> check_multilabel_type(mat_long)
-    'matrix'
-    >>> check_multilabel_type(sos1)
-    'sos'
-    >>> check_multilabel_type(sos2)
-    'sos'
-    >>> check_multilabel_type(sos_long)
-    'sos'
-    >>> check_multilabel_type(sos1, sos2)
-    'sos'
-    >>> check_multilabel_type(mat1, mat1)
-    'matrix'
-    >>> check_multilabel_type(mat1, sos1)
+    >>> is_multilabel(ind)
+    'indicator'
+    >>> is_multilabel(seq1)
+    'sequences'
+    >>> is_multilabel(seq2)
+    'sequences'
+    >>> is_multilabel(seq1, seq2)
+    'sequences'
+    >>> is_multilabel(ind, ind)
+    'indicator'
+    >>> is_multilabel(ind, seq1)
     'mixed'
-    >>> check_multilabel_type(other)
+    >>> is_multilabel(ind, seq1, ind)
+    'mixed'
+    >>> is_multilabel(other)
     False
-    >>> assert_raises(ValueError, check_multilabel_type, mat1, mat_long)
-    >>> assert_raises(ValueError, check_multilabel_type, sos1, mat_long)
-    >>> assert_raises(ValueError, check_multilabel_type, sos1, sos_long)
-    >>> assert_raises(ValueError, check_multilabel_type, other, sos1)
-    >>> assert_raises(ValueError, check_multilabel_type, other, mat1)
+    >>> is_multilabel(other, other)
+    False
+    >>> assert_raises(ValueError, is_multilabel, other, seq1)
+    >>> assert_raises(ValueError, is_multilabel, other, ind)
+    >>> assert_raises(ValueError, is_multilabel, seq1, other)
+    >>> assert_raises(ValueError, is_multilabel, ind, other)
     """
     if not ys:
         raise ValueError('Need at least one set of targets to check')
+
+    ret = None
+    for y in ys:
+        is_ml = is_label_indicator_matrix(y)
+        if is_ml:
+            if ret is None:
+                ret = 'indicator'
+            elif ret == 'sequences':
+                ret = 'mixed'
+            elif ret == False:
+                raise _mixed_error
+            continue
+
+        is_ml = is_sequence_of_sequences(y)
+        if not is_ml:
+            if ret:
+                raise _mixed_error
+            ret = False
+        elif ret is None:
+            ret = 'sequences'
+        elif ret == 'indicator':
+            ret = 'mixed'
+        elif ret == False:
+            raise _mixed_error
+    return ret
+
 
     if all(is_label_indicator_matrix(y) for y in ys):
         if len(set(y.shape for y in ys)) > 1:

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -9,6 +9,7 @@
 # License: BSD 3 clause
 import inspect
 import pkgutil
+import warnings
 
 import scipy as sp
 from functools import wraps
@@ -293,3 +294,16 @@ def if_matplotlib(func):
         else:
             return func(*args, **kwargs)
     return run_test
+
+
+def ignore_warnings(func):
+    """Test decorator to ignore warnings
+    
+    Useful for invariance tests; functional warnings should otherwise be
+    tested for.
+    """
+    @wraps(func)
+    def run_without_warnings(*args, **kwargs):
+        with warnings.catch_warnings():
+            func(*args, **kwargs)
+    return run_without_warnings

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.externals.six.moves import xrange
 
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
@@ -10,6 +11,62 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.multiclass import is_label_indicator_matrix
 from sklearn.utils.multiclass import is_multilabel
+from sklearn.utils.multiclass import is_sequence_of_sequences
+from sklearn.utils.multiclass import type_of_target
+
+INDICATOR_EXAMPLES = [
+    np.random.randint(2, size=(10, 10)),
+    np.array([[0, 1], [1, 0]]),
+    np.array([[0, 0], [0, 0]]),
+    np.array([[-1, 1], [1, -1]]),
+    np.array([[-3, 3], [3, -3]]),
+]
+
+SEQUENCES_EXAMPLES = [
+    [[0, 1]],
+    [[0], [1]],
+    [[1, 2, 3]],
+    [[1], [2], [0, 1]],
+    [[1], [2]],
+    [[]],
+    [()],
+    np.array([[], [1, 2]], dtype='object'),
+]
+
+MULTICLASS_EXAMPLES = [
+    [1, 0, 2, 2, 1, 4, 2, 4, 4, 4],
+    np.array([1, 0, 2]),
+    np.array([[1], [0], [2]]),
+    np.array([[1, 0, 2]]),
+    [],
+    [0],
+    [0, 1, 2],
+    ['a', 'b', 'c'],
+]
+
+BINARY_EXAMPLES = [
+    [0, 1],
+    np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1]),
+    np.array([[0], [1]]),
+    np.array([[0, 1]]),
+    [1, -1],
+    [3, 5],
+    ['a', 'b'],
+    ['abc', 'def'],
+]
+
+CONTINUOUS_EXAMPLES = [
+    [1e-5],
+    [0, .5],
+]
+
+BAD_EXAMPLES = [
+    # Could be confused for indicator or other:
+    np.array([[0.1, 0.2], [0.2, 0.1]]),
+    np.array([[1, 2], [3, 1]]),
+    # not currently supported sequence of sequences
+    np.array([np.array([]), np.array([1, 2, 3])], dtype=object),
+]
 
 
 def test_unique_labels():
@@ -39,31 +96,52 @@ def test_unique_labels():
 
 
 def test_is_multilabel():
-    assert_true(is_multilabel([[1], [2], [0, 1]]))
-    assert_true(is_multilabel([[1], [2]]))
-    assert_true(is_multilabel([[1], [2], []]))
-    assert_true(is_multilabel([[1], [0, 2], []]))
-    assert_true(is_multilabel(np.random.randint(2, size=(10, 10))))
+    for example in SEQUENCES_EXAMPLES + INDICATOR_EXAMPLES:
+        assert_true(is_multilabel(example),
+                    msg='is_multilabel(%r) should be True' % example)
 
-    assert_false(is_multilabel(range(10)))
-    assert_false(is_multilabel(np.arange(10)))
-    assert_false(is_multilabel(np.reshape(np.arange(10), (1, -1))))
-    assert_false(is_multilabel(np.reshape(np.arange(10), (-1, 1))))
-    assert_false(is_multilabel(np.random.randint(2, size=(10, ))))
-    assert_false(is_multilabel(np.random.randint(2, size=(10, 1))))
+    for example in (MULTICLASS_EXAMPLES + BINARY_EXAMPLES +
+                    CONTINUOUS_EXAMPLES + BAD_EXAMPLES):
+        assert_false(is_multilabel(example),
+                     msg='is_multilabel(%r) should be False' % example)
 
 
 def test_is_label_indicator_matrix():
-    assert_true(is_label_indicator_matrix(np.random.randint(2, size=(10, 10))))
+    for example in INDICATOR_EXAMPLES:
+        assert_true(is_label_indicator_matrix(example),
+                    msg='is_label_indicator_matrix(%r) should be True'
+                    % example)
 
-    assert_false(is_label_indicator_matrix([[1], [2], [0, 1]]))
-    assert_false(is_label_indicator_matrix([[1], [2]]))
-    assert_false(is_label_indicator_matrix([[1], [2], []]))
-    assert_false(is_label_indicator_matrix([[1], [0, 2], []]))
-    assert_false(is_label_indicator_matrix(range(10)))
-    assert_false(is_label_indicator_matrix(np.arange(10)))
-    assert_false(is_label_indicator_matrix(np.reshape(np.arange(9), (3, 3))))
-    assert_false(is_label_indicator_matrix(np.reshape(np.arange(10), (-1, 1))))
-    assert_false(is_label_indicator_matrix(np.reshape(np.arange(10), (1, -1))))
-    assert_false(is_label_indicator_matrix(np.random.randint(2, size=(10, ))))
-    assert_false(is_label_indicator_matrix(np.random.randint(2, size=(10, 1))))
+    for example in (SEQUENCES_EXAMPLES + MULTICLASS_EXAMPLES +
+                    BINARY_EXAMPLES + CONTINUOUS_EXAMPLES + BAD_EXAMPLES):
+        assert_false(is_label_indicator_matrix(example),
+                     msg='is_label_indicator_matrix(%r) should be False'
+                     % example)
+
+
+def test_is_sequence_of_sequences():
+    for example in SEQUENCES_EXAMPLES:
+        assert_true(is_sequence_of_sequences(example),
+                    msg='is_sequence_of_sequences(%r) should be True'
+                    % example)
+
+    for example in (INDICATOR_EXAMPLES + MULTICLASS_EXAMPLES +
+                    BINARY_EXAMPLES + CONTINUOUS_EXAMPLES + BAD_EXAMPLES):
+        assert_false(is_sequence_of_sequences(example),
+                     msg='is_sequence_of_sequences(%r) should be False'
+                     % example)
+
+
+def test_type_of_target():
+    for example in SEQUENCES_EXAMPLES:
+        assert_equal(type_of_target(example), 'multilabel-sequences')
+    for example in INDICATOR_EXAMPLES:
+        assert_equal(type_of_target(example), 'multilabel-indicator')
+    for example in MULTICLASS_EXAMPLES:
+        assert_equal(type_of_target(example), 'multiclass')
+    for example in BINARY_EXAMPLES:
+        assert_equal(type_of_target(example), 'binary')
+    for example in CONTINUOUS_EXAMPLES:
+        assert_equal(type_of_target(example), 'continuous')
+#    for example in BAD_EXAMPLES:
+#        assert_raises(ValueError, type_of_target, example)


### PR DESCRIPTION
`precision_recall_fscore_support` was getting gargantuan, because the similarities between the different input formats and metric variations weren't being exploited; rather, almost everything was special-cased. As a result, some bugs and inconsistencies crept in (admittedly on my watch as a reviewer).

This implementation:
- is much smaller and less nested in code, and should be faster in some cases, taking advantage of `LabelEncoder` to use `bincount` (and building upon vectorized multilabel support in #1985, #1987).
- deprecates `pos_label` and introduces `neg_label`, which allows micro-averaging to be interesting in the multiclass case (see #1983).
- `neg_label` has not yet been tested.
- to do so, will assume that multilabel indicator matrices are represented with <1 and 1 (or False and True)
- ~~has not yet implemented support for the `labels` argument, largely because I don't know what it means (see #1989). It's not hard to implement, but~~ I wish `labels` were deprecated in favour of stating a convention regarding label ordering in the `average=None` case.
- ~~has not yet fixed some broken tests for multilabel `average='samples'`~~
- has not yet updated the documentation or signatures of `precision_score`, etc. derivative functions regarding `pos/neg_label`
- currently assumes P and R go to 0 when their denominators are 0. ~~I think this is incorrect behaviour, but it is backward-compatible (except with the `average='samples'` implementation; again, whoops): precision should be perfect when recalling nothing; recall should be perfect when there are no instances to retrieve. (And not realising that scikit-learn had adopted the 0 approach, I suggested in the documentation that 1 should be used.)~~ The decision made elsewhere is to use 0 and warn. This is not yet implemented.
