### PR TITLE
add optional banner to index page to advertise code sprints

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,8 @@ html_theme = 'scikit-learn'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {'oldversion': False, 'collapsiblesidebar': True,
-                      'google_analytics': True, 'surveybanner': False}
+                      'google_analytics': True, 'surveybanner': False,
+                      'sprintbanner' : True}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['themes']

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -162,6 +162,16 @@
     for {{project}} <strong>version {{ release|e }}</strong>
     &mdash; <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
     {% else %}
+
+    {%- if theme_sprintbanner == true %}
+      <div class="sprint-wrapper"><a href="https://github.com/scikit-learn/administrative/blob/master/sprint_paris_2013/proposal.rst">
+       <p>The <strong> {{project}} international code sprint</strong>
+	  is around the corner! <strong>Please, sponsor us</strong>
+       </p>
+       </a>
+      </div>
+    {%- endif %}
+
     <h3><a href="{{pathto('whats_new')}}">News</a></h3>
 
     <p>scikit-learn 0.13 is available

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -164,7 +164,7 @@
     {% else %}
 
     {%- if theme_sprintbanner == true %}
-      <div class="sprint-wrapper"><a href="https://github.com/scikit-learn/administrative/blob/master/sprint_paris_2013/proposal.rst">
+      <div class="sprint-wrapper"><a href="https://github.com/scikit-learn/administrative/blob/master/sprint_paris_2013/proposal.rst#13funding-contact-information">
        <p>The <strong> {{project}} international code sprint</strong>
 	  is around the corner! <strong>Please, sponsor us</strong>
        </p>

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -593,6 +593,40 @@ div.header-wrapper {
 }
 {% endif %}
 
+/*-----------------------The Code Sprint Sponser Banner---------------------*/
+
+div.sprint-wrapper {
+    font-weight: bold;
+    font-size: 110%;
+    padding: 5px;
+    margin: 7px 7px 3px 7px;
+    background-color: #FFC588;
+    border-radius: 15px;
+    -o-transition:.5s;
+    -ms-transition:.5s;
+    -moz-transition:.5s;
+    -webkit-transition:.5s;
+    transition:.5s;
+}
+
+div.sprint-wrapper a {
+    display: block;
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    cursor: pointer;
+    color: black;
+}
+
+div.sprint-wrapper p {
+    padding: 0px 0px 0px 2px;
+    font-weight: initial;
+}
+
+div.sprint-wrapper:hover  {
+    background-color: #FF9C34;
+}
+
 /*-----------------------The Examples Gallery-------------------------------*/
 
 /* ------- Fix maximum size of thumbnails in example gallery -------------- */

--- a/doc/themes/scikit-learn/theme.conf
+++ b/doc/themes/scikit-learn/theme.conf
@@ -8,3 +8,4 @@ oldversion = False
 collapsiblesidebar = True
 google_analytics = True
 surveybanner = False
+sprintbanner = True


### PR DESCRIPTION
As discussed with @NelleV and @GaelVaroquaux .

This is just to add it to the dev master so long.
I'll push it, once approved, to the stable version too

Online build available [here](http://jaquesgrobler.github.io/online-sklearn-build/index.html)
