### PR TITLE
MRG: Chunking in manhattan distance

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -210,7 +210,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
 
     size_threshold : int, default=5e8
         Avoid creating temporary matrices bigger than size_threshold.
-        If the problem size gets too big, the implementation than
+        If the problem size gets too big, the implementation then
         breaks it down in smaller problems.
 
     Returns

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -189,7 +189,8 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
     return distances if squared else np.sqrt(distances)
 
 
-def manhattan_distances(X, Y=None, sum_over_features=True):
+def manhattan_distances(X, Y=None, sum_over_features=True,
+                        size_threshold=5e8):
     """ Compute the L1 distances between the vectors in X and Y.
 
     With sum_over_features equal to False it returns the componentwise
@@ -206,6 +207,11 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
     sum_over_features : bool, default=True
         If True the function returns the pairwise distance matrix
         else it returns the componentwise L1 pairwise-distances.
+
+    size_threshold : int, default=5e8
+        Avoid creating temporary matrices bigger than size_threshold.
+        If the problem size gets too big, the implementation than
+        breaks it down in smaller problems.
 
     Returns
     -------
@@ -240,11 +246,29 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
         raise ValueError("manhattan_distance does not support sparse"
                          " matrices.")
     X, Y = check_pairwise_arrays(X, Y)
-    D = np.abs(X[:, np.newaxis, :] - Y[np.newaxis, :, :])
-    if sum_over_features:
-        D = np.sum(D, axis=2)
+    temporary_size = X.size * Y.shape[-1]
+    if temporary_size > size_threshold and sum_over_features:
+        # Broadcasting the full thing would be too big: it's on the order
+        # of magnitude of the gigabyte
+        D = np.empty((X.shape[0], Y.shape[0]), dtype=X.dtype)
+        index = 0
+        increment = 1 + int(size_threshold / float(temporary_size) *
+                            X.shape[0])
+        while index < X.shape[0]:
+            this_slice = slice(index, index + increment)
+            tmp = X[this_slice, np.newaxis, :] - Y[np.newaxis, :, :]
+            tmp = np.abs(tmp, out=tmp)
+            tmp = np.sum(tmp, axis=2)
+            D[this_slice] = tmp
+            print "Iteration at index %i" % index
+            index += increment
     else:
-        D = D.reshape((-1, X.shape[1]))
+        D = X[:, np.newaxis, :] - Y[np.newaxis, :, :]
+        D = np.abs(D, out=D)
+        if sum_over_features:
+            D = np.sum(D, axis=2)
+        else:
+            D = D.reshape((-1, X.shape[1]))
     return D
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -260,7 +260,6 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
             tmp = np.abs(tmp, out=tmp)
             tmp = np.sum(tmp, axis=2)
             D[this_slice] = tmp
-            print "Iteration at index %i" % index
             index += increment
     else:
         D = X[:, np.newaxis, :] - Y[np.newaxis, :, :]

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 
 from sklearn.metrics.pairwise import euclidean_distances
+from sklearn.metrics.pairwise import manhattan_distances
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.metrics.pairwise import chi2_kernel, additive_chi2_kernel
 from sklearn.metrics.pairwise import polynomial_kernel
@@ -60,6 +61,10 @@ def test_pairwise_distances():
     # manhattan does not support sparse matrices atm.
     assert_raises(ValueError, pairwise_distances, csr_matrix(X),
                   metric="manhattan")
+    # Low-level function for manhattan can divide in blocks to avoid
+    # using too much memory during the broadcasting
+    S3 = manhattan_distances(X, Y, size_threshold=10)
+    assert_array_almost_equal(S, S3)
     # Test cosine as a string metric versus cosine callable
     S = pairwise_distances(X, Y, metric="cosine")
     S2 = pairwise_distances(X, Y, metric=cosine)


### PR DESCRIPTION
manhattan_distance can use too much memory due to a large temporary. This PR introduces a mode to chunk and use less memory.

@AlexandreAbraham this is related to your PR on silouhette coefficient.
