### PR TITLE
[WIP] Estimator.iter_fits for efficient parameter search

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -10,6 +10,8 @@ import numpy as np
 from scipy import sparse
 from .externals import six
 
+from .utils.iter_fits import group_params
+
 
 ###############################################################################
 def clone(estimator, safe=True):
@@ -259,6 +261,20 @@ class BaseEstimator(object):
         return '%s(%s)' % (class_name,
                            _pprint(self.get_params(deep=True),
                                    offset=len(class_name), printer=str,),)
+
+    def iter_fits(self, param_iter, *args, **kwargs):
+        if not hasattr(self, '_non_fit_params'):
+            for params in param_iter:
+                self.set_params(**params)
+                yield params, self.fit(*args, **kwargs)
+            return
+        non_fit_params = set(self._non_fit_params)
+        for group, entries in group_params(param_iter, lambda k: k not in non_fit_params):
+            entries = list(entries)
+            self.set_params(**entries[0])
+            self.fit(*args, **kwargs)
+            for params in entries:
+                yield params, self
 
 
 ###############################################################################

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -274,6 +274,7 @@ class BaseEstimator(object):
             self.set_params(**entries[0])
             self.fit(*args, **kwargs)
             for params in entries:
+                self.set_params(**params)
                 yield params, self
 
 

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -380,6 +380,7 @@ class SelectPercentile(_ScoreFilter):
     way.
 
     """
+    _non_fit_params = ['percentile']
 
     def __init__(self, score_func=f_classif, percentile=10):
         if not 0 <= percentile <= 100:
@@ -437,6 +438,7 @@ class SelectKBest(_ScoreFilter):
     way.
 
     """
+    _non_fit_params = ['k']
 
     def __init__(self, score_func=f_classif, k=10):
         self.k = k
@@ -483,6 +485,7 @@ class SelectFpr(_PvalueFilter):
     `pvalues_` : array-like, shape=(n_features,)
         p-values of feature scores.
     """
+    _non_fit_params = ['alpha']
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
         self.alpha = alpha
@@ -517,6 +520,7 @@ class SelectFdr(_PvalueFilter):
     `pvalues_` : array-like, shape=(n_features,)
         p-values of feature scores.
     """
+    _non_fit_params = ['alpha']
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
         self.alpha = alpha
@@ -549,6 +553,7 @@ class SelectFwe(_PvalueFilter):
     `pvalues_` : array-like, shape=(n_features,)
         p-values of feature scores.
     """
+    _non_fit_params = ['alpha']
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
         self.alpha = alpha
@@ -588,6 +593,7 @@ class GenericUnivariateSelect(_PvalueFilter):
     `pvalues_` : array-like, shape=(n_features,)
         p-values of feature scores.
     """
+    _non_fit_params = ['param', 'mode']
 
     _selection_modes = {'percentile':   SelectPercentile,
                         'k_best':       SelectKBest,

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -213,12 +213,13 @@ class ElasticNet(LinearModel, RegressorMixin):
             precompute = np.dot(X.T, X)
         self.precompute = precompute
 
+        self.coef_ = coef_init  # XXX: even if warm_start = True?
         for params in param_iter:
             self.set_params(**params)
             yield params, self.fit(X, y, Xy, self.coef_)
 
     def iter_fits(self, param_iter, X, y, Xy=None, coef_init=None):
-        if self.precompute:
+        if self.precompute is not None:
             if sparse.isspmatrix(X):
                 warnings.warn("precompute is ignored for sparse data")
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -23,6 +23,7 @@ from ..externals.joblib import Parallel, delayed
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils.extmath import safe_sparse_dot
+from ..utils.iter_fits import group_params
 
 from . import cd_fast
 
@@ -186,6 +187,48 @@ class ElasticNet(LinearModel, RegressorMixin):
         fit = self._sparse_fit if sparse.isspmatrix(X) else self._dense_fit
         fit(X, y, Xy, coef_init)
         return self
+
+    def _iter_fits(self, param_iter, X, y, Xy=None, coef_init=None):
+        # Expects param_iter where only alpha varies,
+        # and sorted by decreasing alpha
+        X = atleast2d_or_csc(X, dtype=np.float64, order='F',
+                             copy=self.copy_X and self.fit_intercept)
+        if not sparse.isspmatrix(X):
+            X, y, X_mean, y_mean, X_std = center_data(X, y, self.fit_intercept,
+                                                      self.normalize, copy=False)
+        if Xy is None:
+            Xy = safe_sparse_dot(X.T, y, dense_output=True)
+
+        n_samples, n_features = X.shape
+        precompute = self.precompute
+        if (hasattr(precompute, '__array__')
+                and not np.allclose(X_mean, np.zeros(n_features))
+                and not np.allclose(X_std, np.ones(n_features))):
+            # recompute Gram
+            precompute = 'auto'
+            Xy = None
+        if precompute == 'auto':
+            precompute = (n_samples > n_features)
+        if not sparse.isspmatrix(X):
+            precompute = np.dot(X.T, X)
+        self.precompute = precompute
+
+        for params in param_iter:
+            self.set_params(**params)
+            yield params, self.fit(X, y, Xy, self.coef_)
+
+    def iter_fits(self, param_iter, X, y, Xy=None, coef_init=None):
+        if self.precompute:
+            if sparse.isspmatrix(X):
+                warnings.warn("precompute is ignored for sparse data")
+
+        orig_params = self.get_params()
+        for group, entries in group_params(param_iter, lambda k: k != 'alpha'):
+            self.set_params(**orig_params)
+            self.set_params(**group)
+            entries = sorted(entries, key=lambda x: -x.get('alpha', self.alpha))
+            for tup in self._iter_fits(entries, X, y, Xy, coef_init):
+                yield tup
 
     def _dense_fit(self, X, y, Xy=None, coef_init=None):
 

--- a/sklearn/utils/iter_fits.py
+++ b/sklearn/utils/iter_fits.py
@@ -1,0 +1,100 @@
+from collections import defaultdict
+from six import iteritems
+
+
+def _default_iter_fits(est, fit, param_iter, *args, **kwargs):
+    for params in param_iter:
+        est.set_params(**params)
+        yield params, fit(*args, **kwargs)
+
+
+def iter_fits(est, param_iter, *args, **kwargs):
+    if hasattr(est, 'iter_fits'):
+        return est.iter_fits(param_iter, *args, **kwargs)
+    return _default_iter_fits(est, est.fit, param_iter, *args, **kwargs)
+
+
+def _fit_transform(est):
+    if hasattr(est, 'fit_transform'):
+        return est.fit_transform
+    def fn(X, *args, **kwargs):
+        est.fit(X, *args, **kwargs)
+        return est.transform(X)
+    return fn
+
+
+def iter_fit_transforms(est, param_iter, X, *args, **kwargs):
+    if hasattr(est, 'iter_fit_transforms'):
+        return est.iter_fit_transforms(param_iter, X, *args, **kwargs)
+    if hasattr(est, 'iter_fits'):
+        return ((params, new_est.transform(X))
+                for params, new_est
+                in est.iter_fits(param_iter, X, *args, **kwargs))
+    return _default_iter_fits(est, _fit_transform, param_iter, X, *args, **kwargs)
+
+
+def group_params(items, key_name=lambda x: True):
+    """bin by sub-dicts where values are compared by id if not hashable
+    
+    >>> a = ('boo', 6)
+    >>> b = ('boo', 6)
+    >>> id(a) == id(b)
+    False
+    >>> import numpy
+    >>> c = numpy.array([1, 2, 3])
+    >>> items = [{'p': a, 'q': 1}, {'p': b, 'q': 2}, {'p': c, 'q': 3}, {'p': c, 'q': 4}]
+    >>> groups = list(group_params(items, lambda x: x == "p"))
+    >>> len(groups)
+    2
+    >>> groups
+    >>> sorted([[x['q'] for x in gitems] for g, gitems in groups if g['p'] == a][0])
+    [1, 2]
+    >>> sorted([[x['q'] for x in gitems] for g, gitems in groups if g['p'] is c][0])
+    [3, 4]
+    """
+    # can reduce work if input is sorted tuples rather than dict
+
+    groups = defaultdict(list)
+    canonical = {}  # maps hashable x to a canonical instance of x
+    id_to_obj = {}
+
+    for params in items:
+        group = []
+        for k, v in iteritems(params):
+            if key_name(k):
+                try:
+                    v_id = id(canonical.setdefault(v, v))
+                except TypeError:
+                    v_id = id(v)
+                id_to_obj[v_id] = v
+                group.append((k, v_id))
+        groups[tuple(sorted(group))].append(params)
+
+    return [({k: id_to_obj[v_id] for k, v_id in group}, group_items)
+            for group, group_items in iteritems(groups)]
+
+
+def find_group(haystack, needle):
+    """Given the output of group_params, gets the entries for a single group value.
+    
+    Again designed to deal with non-hashable, non-comparable types..."""
+    for group, entries in haystack:
+        if len(group) != len(needle):
+            continue
+        for key, val in iteritems(group):
+            try:
+                other_val = needle[key]
+            except KeyError:
+                break
+            if val is other_val:
+                continue
+            try:
+                if val == other_val:
+                    continue
+            except (ValueError, TypeError):
+                # can't convert numpy equality to boolean
+                continue
+            break
+        else:
+            return entries
+    raise ValueError('Could not find {!r} in given groups:\n{!r}'.format(needle, haystack))


### PR DESCRIPTION
This implements an approach to generalised cross validation (#1626) by allowing each estimator to control its fitting over a sequence of parameter settings. `estimator.iter_fits` returns an iterator (usually a generator) over parameters and models fit with those parameters.

_This PR is to open comment, rather than to finalize the implementation in the near term._

The default implementation allows an estimator to specify parameters which when changed do not require `fit` to be called again. Estimators where it is possible to warm start from the model attributes learnt with the previous parameters may utilise that fact; in particular, this approach emphasises that the same data is being used, where multiple calls to `fit` does not. A `Pipeline` resolves its ordering through a depth-first traversal of the parameters affecting each pipeline step (ordered by that step's estimator), and the use of generators means the output of `transform` from higher levels is retained in the stack, which adds a memory cost (it may be possible to optionally reduce this cost later) but cuts a lot of repeated work. The model iterator approach means regularization paths can be easily incorporated if rewritten as generators.

[Grid search](https://gist.github.com/jnothman/5624440) (cv=3, n_jobs=1) over a simple pipeline of (StandardScaler, SelectKBest, ElasticNet) ran in 67% of the baseline time (repeated calls to `Pipeline.fit`) using this implementation, with the following call counts:

| Method | calls@master | calls@iter_fits |
| --- | --- | --- |
| `StandardScaler.fit` | 241 | 7 |
| `StandardScaler.transform` | 481 | 247 |
| `SelectKBest.fit` | 241 | 7 |
| `SelectKBest.transform` | 481 | 265 |
| `ElasticNet.fit` | 241 | 241 |

(Note: many calls to `transform` are at predict time, which is not affected by this change.)

Caveats and comments:
- `iter_fits` will often overwrite attributes of the same object in each iteration. It's therefore necessary to _copy_ any data off the models or call any of their methods _while iterating_. This may make it a dangerous method for public use, and it may be worthwhile to require that each iteration yields a clone of the estimator, at some added expense and complication.
- a common pattern for implementing `iter_fits` is to group the list of parameter settings by the values of some "higher-order" parameters (those requiring substantial work to be done at each change) within which groups lower-order parameters are iterated. Thus:
  - the parameter settings need to be grouped by each estimator, making the dict form in which parameters are transmitted cumbersome
  - parameter values may be objects that are unorderable and/or unhashable and/or un-boolean-comparable (`ndarray` is all of these), making the grouping operation and other generic parameter equality evaluations not trivial to code
  - in many cases it should be possible instead to order merely on the basis of parameter names and some simple ordering rules for each parameter, resulting in less repeated reordering work (and on the scale of number of parameter names, not number of parameter value combinations). Setting a pipeline step (#1769) presents a case where parameter names are not sufficient information for an estimator to return an ordering.
- user-intended candidate ordering, and the manner of their generation, is ignored. This makes the solution generic, but it's harder to harness the properties of a grid, for example. The reordering also means parameter search may return a different best candidate with the same top score.
- since the ordering is performed at `fit` time, each fold of a cv-search process may operate in parallel. To recombine the outputs, it is easiest if the reordering is deterministic, and therefore the same across all folds. Also because the reordering is coupled with fitting,  parallelisation beyond one-process-per-fold may require arbitrary splits in the candidate sequence.
