### PR TITLE
ENH Special-case where LabelEncoder need not copy

### DIFF
--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -835,6 +835,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         if not hasattr(self, "classes_"):
             raise ValueError("LabelNormalizer was not fitted yet.")
 
+    def _set_do_nothing(self):
+        self._do_nothing = np.all(self.classes_ ==
+                                  np.arange(len(self.classes_)))
+
     def fit(self, y):
         """Fit label encoder
 
@@ -848,6 +852,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         self.classes_ = np.unique(y)
+        self._set_do_nothing()
         return self
 
     def fit_transform(self, y):
@@ -863,6 +868,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         self.classes_, y = unique(y, return_inverse=True)
+        self._set_do_nothing()
         return y
 
     def transform(self, y):
@@ -878,6 +884,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         self._check_fitted()
+
+        if getattr(self, '_do_nothing', False):
+            # XXX: should we use asarray?
+            return y
 
         classes = np.unique(y)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
@@ -901,6 +911,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self._check_fitted()
 
         y = np.asarray(y)
+        if getattr(self, '_do_nothing', False):
+            return y
         return self.classes_[y]
 
 

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -636,6 +636,15 @@ def test_label_encoder_string_labels():
     assert_raises(ValueError, le.transform, ["london"])
 
 
+def test_label_encoder_do_nothing():
+    """Test that if classes are a 0-based range, y is not copied"""
+    le = LabelEncoder()
+    le.fit([5, 4, 3, 2, 1, 1, 0])
+    y = np.asarray([5, 7, 3, 5, 7, 4, 2, 4, 6])
+    assert_true(y is le.transform(y))
+    assert_true(y is le.inverse_transform(y))
+
+
 def test_label_encoder_errors():
     """Check that invalid arguments yield ValueError"""
     le = LabelEncoder()


### PR DESCRIPTION
If the classes are a range starting at 0, no operation needs to be done by `LabelEncoder`. This makes it more reasonable to use `LabelEncoder` in validation-type transformations.
