### PR TITLE
[MRG] FIX corner cases with `unique_labels`

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -27,7 +27,7 @@ def _unique_sequence_of_sequence(y):
 
 
 def _unique_indicator(y):
-    return np.arange(y.shape[0])
+    return np.arange(y.shape[1])
 
 
 _FN_UNIQUE_LABELS = {
@@ -98,13 +98,13 @@ def unique_labels(*ys):
     if not _unique_labels:
         raise ValueError("Unknown label type")
 
-    y_labels = set(chain.from_iterable(imap(_unique_labels, ys)))
+    ys_labels = set(chain.from_iterable(imap(_unique_labels, ys)))
 
     # Check that we don't mix string type with number type
-    if (len(set(isinstance(label, string_types) for label in y_labels)) > 1):
+    if (len(set(isinstance(label, string_types) for label in ys_labels)) > 1):
         raise ValueError("Mix of label input types (string and number)")
 
-    return np.array(sorted(y_labels))
+    return np.array(sorted(ys_labels))
 
 
 def _is_integral_float(y):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -37,6 +37,15 @@ _FN_UNIQUE_LABELS = {
 def unique_labels(*ys):
     """Extract an ordered array of unique labels
 
+    We don't allow:
+        - mix of multilabel and multiclass (single label) targets
+        - mix of label indicator matrix and anything else,
+          because there are no explicit labels)
+        - mix of label indicator matrices of different sizes
+        - mix of string and integer labels
+
+    At the moment, we also don't allow "mutliclass-multioutput" input type.
+
     Parameters
     ----------
     ys : array-likes,
@@ -71,7 +80,7 @@ def unique_labels(*ys):
             label_type = "multiclass"
 
         else:
-            raise ValueError("Mix type of y not allowed, got type %s"
+            raise ValueError("Mix type of y not allowed, got types %s"
                              % ys_types)
     else:
         label_type = ys_types[0]
@@ -89,11 +98,10 @@ def unique_labels(*ys):
 
     # Combine every labels
     ys_labels = [_unique_labels(y) for y in ys]
-    ys_is_string = [y_labels.dtype.type is np.string_
-                    for y_labels in ys_labels]
 
-    if len(set(ys_is_string)) != 1:
-        raise ValueError("Mix of label input type s(string and number)")
+    if (len(set(y_labels.dtype.type is np.string_
+                for y_labels in ys_labels)) != 1):
+        raise ValueError("Mix of label input types (string and number)")
 
     return np.unique(np.hstack(ys_labels))
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -81,10 +81,10 @@ def unique_labels(*ys):
 
     # Combine every labels
     ys_labels = [_unique_labels(y) for y in ys]
-    y_is_string = [y_labels.dtype.type is np.string_
-                   for y_labels in ys_labels]
+    ys_is_string = [y_labels.dtype.type is np.string_
+                    for y_labels in ys_labels]
 
-    if len(set(y_is_string)) != 1:
+    if len(set(ys_is_string)) != 1:
         raise ValueError("Mix of string and number type: "
                          "can't infered unique labels set")
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -92,10 +92,10 @@ def unique_labels(*ys):
 
     # Check that we don't mix string type with number type
     if ((label_type in ("binary", "multiclass") and
-            len(set([isinstance(x, basestring)
+            len(set([isinstance(x, string_types)
                      for y in ys for x in y])) > 1) or
         (label_type == "multilabel-sequences" and
-            len(set.union(*[set(imap(lambda x: isinstance(x, basestring),
+            len(set.union(*[set(imap(lambda x: isinstance(x, string_types),
                                      chain(*y))) for y in ys])) > 1)):
         raise ValueError("Mix of label input types (string and number)")
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -90,8 +90,10 @@ def unique_labels(*ys):
 
     # Combine every labels
     ys_labels = [_unique_labels(y) for y in ys]
+    labels_type_set = set(y_labels.dtype.kind for y_labels in ys_labels)
 
-    if len(set(y_labels.dtype.kind for y_labels in ys_labels)) > 1:
+    if (not (labels_type_set <= set(["b", "i", "u","f"])) and
+            not (labels_type_set <= set(["S", "a"," U"]))):
         raise ValueError("Mix of dtype.kind, can't infered labels set")
 
     return np.unique(np.hstack(ys_labels))

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -8,7 +8,6 @@ Multi-class / multi-label utility function
 """
 from collections import Sequence
 from itertools import chain
-from itertools import imap
 
 import numpy as np
 
@@ -98,7 +97,7 @@ def unique_labels(*ys):
     if not _unique_labels:
         raise ValueError("Unknown label type")
 
-    ys_labels = set(chain.from_iterable(imap(_unique_labels, ys)))
+    ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
 
     # Check that we don't mix string type with number type
     if (len(set(isinstance(label, string_types) for label in ys_labels)) > 1):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -75,16 +75,14 @@ def unique_labels(*ys):
         raise ValueError('No argument has been passed.')
 
     # Check that we don't mix label format
-    ys_types = [type_of_target(x) for x in ys]
-    if len(set(ys_types)) != 1:
-        if set(ys_types) == set(["binary", "multiclass"]):
-            label_type = "multiclass"
+    ys_types = set(type_of_target(x) for x in ys)
+    if ys_types == set(["binary", "multiclass"]):
+        ys_types = set(["multiclass"])
 
-        else:
-            raise ValueError("Mix type of y not allowed, got types %s"
-                             % ys_types)
-    else:
-        label_type = ys_types[0]
+    if len(ys_types) > 1:
+        raise ValueError("Mix type of y not allowed, got types %s" % ys_types)
+
+    label_type = ys_types.pop()
 
     # Check consistency for the indicator format
     if (label_type == "multilabel-indicator" and
@@ -92,7 +90,7 @@ def unique_labels(*ys):
         raise ValueError("Multi-label binary indicator input with "
                          "different numbers of labels")
 
-    # Check that we don't mix string and number type
+    # Check that we don't mix string type with number type
     if ((label_type in ("binary", "multiclass") and
             len(set([isinstance(x, basestring)
                      for y in ys for x in y])) > 1) or
@@ -106,7 +104,7 @@ def unique_labels(*ys):
     if not _unique_labels:
         raise ValueError("Unknown label type")
 
-    # Combine every labels
+    # Combine labels
     return np.unique(np.hstack(_unique_labels(y) for y in ys))
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -58,7 +58,7 @@ def unique_labels(*ys):
     ys_is_multilabels = [is_multilabel(y) for y in ys]
 
     if len(set(ys_is_multilabels)) != 1:
-        raise ValueError("Mix of binary / mutliclass and multilabel type")
+        raise ValueError("Mix of binary / mutliclass and multilabel types")
 
     if all(ys_is_multilabels):
         ys_is_indicator = [is_label_indicator_matrix(y) for y in ys]
@@ -66,7 +66,7 @@ def unique_labels(*ys):
         # Only indicator multilabel format
         if all(ys_is_indicator):
             if len(set(y.shape[1] for y in ys)) > 1:
-                raise ValueError("Multi-label binary indicator input with "
+                raise ValueError("Multi-label binary indicator inputs with "
                                  "different number of labels")
             else:
                 return _unique_indicator(ys[0])
@@ -74,7 +74,7 @@ def unique_labels(*ys):
             # Only indicator sequence of sequence multilabel format
             _unique_labels = _unique_sequence_of_sequence
         else:
-            raise ValueError("Mix multilabel input format")
+            raise ValueError("Mix of multilabel input format")
 
     else:
         _unique_labels = _unique_multiclass
@@ -85,8 +85,7 @@ def unique_labels(*ys):
                     for y_labels in ys_labels]
 
     if len(set(ys_is_string)) != 1:
-        raise ValueError("Mix of string and number type: "
-                         "can't infered unique labels set")
+        raise ValueError("Mix of label input type s(string and number)")
 
     return np.unique(np.hstack(ys_labels))
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -81,11 +81,12 @@ def unique_labels(*ys):
 
     # Combine every labels
     ys_labels = [_unique_labels(y) for y in ys]
-    labels_type_set = set(y_labels.dtype.kind for y_labels in ys_labels)
+    y_is_string = [y_labels.dtype.type is np.string_
+                   for y_labels in ys_labels]
 
-    if (not (labels_type_set <= set(["b", "i", "u", "f"])) and
-            not (labels_type_set <= set(["S", "a", " U"]))):
-        raise ValueError("Mix of dtype.kind, can't infered labels set")
+    if len(set(y_is_string)) != 1:
+        raise ValueError("Mix of string and number type: "
+                         "can't infered unique labels set")
 
     return np.unique(np.hstack(ys_labels))
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -234,6 +234,7 @@ def test_unique_labels():
     # Mix input type
     assert_raises(ValueError, unique_labels, [[1, 2], [3]],
                   [["a", "d"]])
+    assert_array_equal(unique_labels([(2,), (0, 2,)], [(), ()]), [0, 2])
 
 
 def test_is_multilabel():

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -117,57 +117,6 @@ NON_ARRAY_LIKE_EXAMPLES = [
 ]
 
 
-EXAMPLES = {
-    'multilabel-indicator': [
-        np.random.randint(2, size=(10, 10)),
-        np.array([[0, 1], [1, 0]]),
-        np.array([[0, 0], [0, 0]]),
-        np.array([[-1, 1], [1, -1]]),
-        np.array([[-3, 3], [3, -3]]),
-
-        # XXX : not considered as multilabel-indicator at the moment
-        #       see is_label_indicator_matrix
-        # np.array([[0, 1]]),
-    ],
-    'multilabel-sequences': [
-        [[0, 1]],
-        [[0], [1]],
-        [[1, 2, 3]],
-        [[1, 2, 1]],  # duplicate values, why not?
-        [[1], [2], [0, 1]],
-        [[1], [2]],
-        [[]],
-        [()],
-        np.array([[], [1, 2]], dtype='object'),
-    ],
-    'multiclass': [
-        [1, 0, 2, 2, 1, 4, 2, 4, 4, 4],
-        np.array([1, 0, 2]),
-        np.array([[1], [0], [2]]),
-        [0, 1, 2],
-        ['a', 'b', 'c'],
-    ],
-    'multiclass-multioutput': [
-        np.array([[1, 0, 2, 2], [1, 4, 2, 4]]),
-        np.array([['a', 'b'], ['c', 'd']]),
-        np.array([[1, 0, 2]]),
-    ],
-    'binary': [
-        [0, 1],
-        [1, 1],
-        [],
-        [0],
-        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1]),
-        np.array([[0], [1]]),
-        [1, -1],
-        [3, 5],
-        ['a'],
-        ['a', 'b'],
-        ['abc', 'def'],
-    ],
-
-}
-
 
 def test_unique_labels():
     # Empty iterable
@@ -218,6 +167,14 @@ def test_unique_labels():
                              EXAMPLES["multilabel-sequences"],
                              EXAMPLES["multiclass"] +
                              EXAMPLES["binary"])
+
+    for example in NON_ARRAY_LIKE_EXAMPLES:
+        assert_raises(ValueError, unique_labels, example)
+
+    for y_type in ["unknown", "continuous", 'continuous-multioutput',
+                   'multiclass-multioutput']:
+        for example in EXAMPLES[y_type]:
+            assert_raises(ValueError, unique_labels, example)
 
     for y_multilabel, y_multiclass in mix_clf_format:
         assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -155,6 +155,12 @@ def test_unique_labels():
     assert_array_equal(unique_labels([["a", "b"], ["c"]], [["d"]]),
                        ["a", "b", "c", "d"])
 
+    # Smoke test for all supported format
+    for format in ["binary", "multiclass", "multilabel-sequences",
+                   "multilabel-indicator"]:
+        for y in EXAMPLES[format]:
+            unique_labels(y)
+
     #Mix of multilabel-indicator and multilabel-sequences
     mix_multilabel_format = product(EXAMPLES["multilabel-indicator"],
                                     EXAMPLES["multilabel-sequences"])

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -207,27 +207,19 @@ def test_unique_labels():
                        ["a", "b", "c", "d"])
 
     #Mix of multilabel-indicator and multilabel-sequences
-    assert_array_equal(unique_labels([["a", "b"], ["c"]], np.ones((3, 3))),
-                       ["a", "b", "c"])
-    assert_raises(ValueError, unique_labels, [["a", "b"], ["c"]],
-                  np.ones((3, 4)))
-    assert_raises(ValueError, unique_labels, [["a", "b"], ["c", 'd']],
-                  np.ones((3, 3)))
-
-    assert_array_equal(unique_labels([[1, 2], [3]], np.ones((3, 3))),
-                       [1, 2, 3])
-    assert_raises(ValueError, unique_labels, [[1, 2], [3]],
-                  np.ones((3, 4)))
-    assert_raises(ValueError, unique_labels, [[1, 2], [3, 4]],
-                  np.ones((3, 3)))
+    mix_multilabel_format = product(EXAMPLES["multilabel-indicator"],
+                                    EXAMPLES["multilabel-sequences"])
+    for y_multilabel, y_multiclass in mix_multilabel_format:
+        assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)
+        assert_raises(ValueError, unique_labels, y_multilabel, y_multiclass)
 
     #Mix with binary or multiclass and multilabel
-    pair_multiclass_multilabel = product(EXAMPLES["multilabel-indicator"] +
-                                         EXAMPLES["multilabel-sequences"],
-                                         EXAMPLES["multiclass"] +
-                                         EXAMPLES["binary"])
+    mix_clf_format = product(EXAMPLES["multilabel-indicator"] +
+                             EXAMPLES["multilabel-sequences"],
+                             EXAMPLES["multiclass"] +
+                             EXAMPLES["binary"])
 
-    for y_multilabel, y_multiclass in pair_multiclass_multilabel:
+    for y_multilabel, y_multiclass in mix_clf_format:
         assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)
         assert_raises(ValueError, unique_labels, y_multilabel, y_multiclass)
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -117,7 +117,6 @@ NON_ARRAY_LIKE_EXAMPLES = [
 ]
 
 
-
 def test_unique_labels():
     # Empty iterable
     assert_raises(ValueError, unique_labels)
@@ -134,6 +133,10 @@ def test_unique_labels():
                        np.arange(3))
     assert_array_equal(unique_labels(np.array([[0, 0, 1],
                                                [1, 0, 1],
+                                               [0, 0, 0]])),
+                       np.arange(3))
+
+    assert_array_equal(unique_labels(np.array([[0, 0, 1],
                                                [0, 0, 0]])),
                        np.arange(3))
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -180,10 +180,16 @@ def test_unique_labels():
         assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)
         assert_raises(ValueError, unique_labels, y_multilabel, y_multiclass)
 
-    # Mix input type
+    # Mix string and number input type
     assert_raises(ValueError, unique_labels, [[1, 2], [3]],
                   [["a", "d"]])
+    assert_raises(ValueError, unique_labels, ["1", 2])
+    assert_raises(ValueError, unique_labels, [["1", 2], [3]])
+    assert_raises(ValueError, unique_labels, [["1", "2"], [3]])
+
     assert_array_equal(unique_labels([(2,), (0, 2,)], [(), ()]), [0, 2])
+    assert_array_equal(unique_labels([("2",), ("0", "2",)], [(), ()]),
+                       ["0", "2"])
 
 
 def test_is_multilabel():

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -161,6 +161,15 @@ def test_unique_labels():
         for y in EXAMPLES[format]:
             unique_labels(y)
 
+    # We don't support those format at the moment
+    for example in NON_ARRAY_LIKE_EXAMPLES:
+        assert_raises(ValueError, unique_labels, example)
+
+    for y_type in ["unknown", "continuous", 'continuous-multioutput',
+                   'multiclass-multioutput']:
+        for example in EXAMPLES[y_type]:
+            assert_raises(ValueError, unique_labels, example)
+
     #Mix of multilabel-indicator and multilabel-sequences
     mix_multilabel_format = product(EXAMPLES["multilabel-indicator"],
                                     EXAMPLES["multilabel-sequences"])
@@ -173,14 +182,6 @@ def test_unique_labels():
                              EXAMPLES["multilabel-sequences"],
                              EXAMPLES["multiclass"] +
                              EXAMPLES["binary"])
-
-    for example in NON_ARRAY_LIKE_EXAMPLES:
-        assert_raises(ValueError, unique_labels, example)
-
-    for y_type in ["unknown", "continuous", 'continuous-multioutput',
-                   'multiclass-multioutput']:
-        for example in EXAMPLES[y_type]:
-            assert_raises(ValueError, unique_labels, example)
 
     for y_multilabel, y_multiclass in mix_clf_format:
         assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)


### PR DESCRIPTION
Bugs were discovered in `unique_labels` in #1985:
- Mix of multilabel and multiclass format doesn't raise any errors 
- Mix of input data type doesn't raise any error (e.g. [1, 2] and ["a"])
- Mix of indicator matrix with different number of labels doesn't raise
  any error.

~~In my opinion, the implementation could be greatly simplify and improve using `type_of_target` in  #1985 (see https://gist.github.com/arjoly/5665632).~~

~~However this pr is not merged yet .~~

Remaining bugs that won't be treated in this pr: 
- mix of multioutput multiclass format and multiclass / multilabel format
- mix of unknown / continuous / continuous multi-output format and multiclass / multilabel format
