### PR TITLE
[MRG] Ensure delegated ducktyping in MetaEstimators

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -325,19 +325,50 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
     @property
     def predict(self):
+        """Call predict on the best estimator"""
         return self.best_estimator_.predict
 
     @property
     def predict_proba(self):
+        """Call predict_proba on the best estimator"""
         return self.best_estimator_.predict_proba
 
     @property
+    def predict_log_proba(self):
+        """Call predict_log_proba on the best estimator"""
+        return self.best_estimator_.predict_log_proba
+
+    @property
     def decision_function(self):
+        """Call decision_function on the best estimator"""
         return self.best_estimator_.decision_function
 
     @property
     def transform(self):
+        """Call transform on the best estimator"""
         return self.best_estimator_.transform
+
+    @property
+    def inverse_transform(self):
+        """Call inverse_transform on the best estimator"""
+        return self.best_estimator_.inverse_transform
+
+    def _check_estimator(self):
+        """Check that estimator can be fitted and score can be computed."""
+        if (not hasattr(self.estimator, 'fit') or
+                not (hasattr(self.estimator, 'predict')
+                     or hasattr(self.estimator, 'score'))):
+            raise TypeError("estimator should a be an estimator implementing"
+                            " 'fit' and 'predict' or 'score' methods,"
+                            " %s (type %s) was passed" %
+                            (self.estimator, type(self.estimator)))
+        if (self.scoring is None and self.loss_func is None and self.score_func
+                is None):
+            if not hasattr(self.estimator, 'score'):
+                raise TypeError(
+                    "If no scoring is specified, the estimator passed "
+                    "should have a 'score' method. The estimator %s "
+                    "does not." % self.estimator)
 
     def _fit(self, X, y, parameter_iterable):
         """Actual fitting,  performing the search over parameters."""

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -110,6 +110,19 @@ class Pipeline(BaseEstimator):
                     out['%s__%s' % (name, key)] = value
             return out
 
+    @property
+    def named_steps(self):
+        return dict(self.steps)
+
+    @property
+    def _transforms(self):
+        """Non-final estimators in (name, est) tuples."""
+        return self.steps[:-1]
+
+    @property
+    def _final_estimator(self):
+        return self.steps[-1][1]
+
     # Estimator interface
 
     def _pre_transform(self, X, y=None, **fit_params):
@@ -118,7 +131,9 @@ class Pipeline(BaseEstimator):
             step, param = pname.split('__', 1)
             fit_params_steps[step][param] = pval
         Xt = X
-        for name, transform in self.steps[:-1]:
+        for name, transform in self._transforms:
+            if transform is None:
+                continue
             if hasattr(transform, "fit_transform"):
                 Xt = transform.fit_transform(Xt, y, **fit_params_steps[name])
             else:
@@ -129,79 +144,192 @@ class Pipeline(BaseEstimator):
     def fit(self, X, y=None, **fit_params):
         """Fit all the transforms one after the other and transform the
         data, then fit the transformed data using the final estimator.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Training data, where n_samples in the number of samples and
+            n_features is the number of features.
+        y : array-like, shape = [n_samples], optional
+            Target vector relative to X for classification;
+            None for unsupervised learning.
+        fit_params : dict of string -> object
+            Parameters passed to the `fit` method of each step, where
+            each parameter name is prefixed such that parameter ``p`` for step
+            ``s`` has key ``s__p``.
         """
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
-        self.steps[-1][-1].fit(Xt, y, **fit_params)
+        self._final_estimator.fit(Xt, y, **fit_params)
         return self
 
-    def fit_transform(self, X, y=None, **fit_params):
-        """Fit all the transforms one after the other and transform the
+    @property
+    def fit_transform(self):
+        """Pipeline.fit_transform(X, y=None, **fit_params)
+
+        Fit all the transforms one after the other and transform the
         data, then use fit_transform on transformed data using the final
-        estimator."""
-        Xt, fit_params = self._pre_transform(X, y, **fit_params)
-        if hasattr(self.steps[-1][-1], 'fit_transform'):
-            return self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
-        else:
-            return self.steps[-1][-1].fit(Xt, y, **fit_params).transform(Xt)
+        estimator.
 
-    def predict(self, X):
-        """Applies transforms to the data, and the predict method of the
-        final estimator. Valid only if the final estimator implements
-        predict."""
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Training data, where n_samples in the number of samples and
+            n_features is the number of features.
+        y : array-like, shape = [n_samples], optional
+            Target vector relative to X for classification;
+            None for unsupervised learning.
+        fit_params : dict of string -> object
+            Parameters passed to the `fit` method of each step, where
+            each parameter name is prefixed such that parameter ``p`` for step
+            ``s`` has key ``s__p``.
+        """
+        last_step = self._final_estimator
+        if (
+                not hasattr(last_step, 'fit_transform')
+                and not hasattr(last_step, 'transform')):
+            raise AttributeError(
+                'last step has neither `transform` nor `fit_transform`')
+
+        def fn(X, y=None, **fit_params):
+            Xt, fit_params = self._pre_transform(X, y, **fit_params)
+            if hasattr(last_step, 'fit_transform'):
+                return last_step.fit_transform(Xt, y, **fit_params)
+            else:
+                return last_step.fit(Xt, y, **fit_params).transform(Xt)
+        return fn
+
+    def _run_pipeline(self, est_fn, X, *args, **kwargs):
         Xt = X
-        for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict(Xt)
+        for name, transform in self._transforms:
+            if transform is not None:
+                Xt = transform.transform(Xt)
+        return est_fn(Xt, *args, **kwargs)
 
-    def predict_proba(self, X):
-        """Applies transforms to the data, and the predict_proba method of the
+    @property
+    def predict(self):
+        """Pipeline.predict(X)
+
+        Applies transforms to the data, and the `predict` method of the
         final estimator. Valid only if the final estimator implements
-        predict_proba."""
-        Xt = X
-        for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_proba(Xt)
+        predict.
 
-    def decision_function(self, X):
-        """Applies transforms to the data, and the decision_function method of
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        return partial(self._run_pipeline, self._final_estimator.predict)
+
+    @property
+    def predict_proba(self):
+        """Pipeline.predict_proba(X)
+
+        Applies transforms to the data, and the `predict_proba` method of
         the final estimator. Valid only if the final estimator implements
-        decision_function."""
-        Xt = X
-        for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
-        return self.steps[-1][-1].decision_function(Xt)
+        predict_proba.
 
-    def predict_log_proba(self, X):
-        Xt = X
-        for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_log_proba(Xt)
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        return partial(self._run_pipeline, self._final_estimator.predict_proba)
 
-    def transform(self, X):
-        """Applies transforms to the data, and the transform method of the
+    @property
+    def predict_log_proba(self):
+        """Pipeline.predict_log_proba(X)
+
+        Applies transforms to the data, and the `predict_log_proba` method
+        of the final estimator. Valid only if the final estimator implements
+        predict_log_proba.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        return partial(self._run_pipeline,
+            self._final_estimator.predict_log_proba)
+
+    @property
+    def decision_function(self):
+        """Pipeline.decision_function(X)
+
+        Applies transforms to the data, and the `decision_function` method
+        of the final estimator. Valid only if the final estimator implements
+        decision_function.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        return partial(self._run_pipeline,
+            self._final_estimator.decision_function)
+
+    @property
+    def transform(self):
+        """Pipeline.transform(X)
+
+        Applies transforms to the data, and the `transform` method of the
         final estimator. Valid only if the final estimator implements
-        transform."""
-        Xt = X
-        for name, transform in self.steps:
-            Xt = transform.transform(Xt)
-        return Xt
+        transform.
 
-    def inverse_transform(self, X):
-        if X.ndim == 1:
-            X = X[None, :]
-        Xt = X
-        for name, step in self.steps[::-1]:
-            Xt = step.inverse_transform(Xt)
-        return Xt
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        return partial(self._run_pipeline, self._final_estimator.transform)
 
-    def score(self, X, y=None):
-        """Applies transforms to the data, and the score method of the
+    @property
+    def inverse_transform(self):
+        """Pipeline.inverse_transform(X)
+
+        Applies inverse transforms to the data from the last step to the
+        first.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        """
+        inverse_transforms = [step.inverse_transform
+            for name, step in self.steps[::-1] if step is not None]
+
+        def fn(X):
+            if X.ndim == 1:
+                X = X[None, :]
+            Xt = X
+            for inv_transform in inverse_transforms:
+                Xt = inv_transform(Xt)
+            return Xt
+        return fn
+
+    @property
+    def score(self):
+        """Pipeline.score(X, y=None)
+
+        Applies transforms to the data, and the `score` method of the
         final estimator. Valid only if the final estimator implements
-        score."""
-        Xt = X
-        for name, transform in self.steps[:-1]:
-            Xt = transform.transform(Xt)
-        return self.steps[-1][-1].score(Xt, y)
+        score.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Data samples, where n_samples in the number of samples and
+            n_features is the number of features.
+        y : array-like, shape = [n_samples], optional
+            Target vector relative to X;
+            None for unsupervised learning.
+        """
+        return partial(self._run_pipeline, self._final_estimator.score)
 
     @property
     def _pairwise(self):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -11,6 +11,8 @@ estimator, as a chain of transforms and estimators.
 
 from collections import defaultdict
 
+from functools import partial
+
 import numpy as np
 from scipy import sparse
 
@@ -78,7 +80,7 @@ class Pipeline(BaseEstimator):
     # BaseEstimator interface
 
     def __init__(self, steps):
-        self.named_steps = dict(steps)
+        self.steps = steps
         names, estimators = zip(*steps)
         if len(self.named_steps) != len(steps):
             raise ValueError("Names provided are not unique: %s" % (names,))

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -22,7 +22,7 @@ class DelegatorData(object):
         self.skip_methods = skip_methods
 
 
-DELEGATING_METAESTIMATORS = {
+DELEGATING_METAESTIMATORS = [
     DelegatorData('Pipeline', lambda est: Pipeline([('est', est)])),
     DelegatorData('GridSearchCV',
                   lambda est: GridSearchCV(
@@ -30,11 +30,11 @@ DELEGATING_METAESTIMATORS = {
                   skip_methods=['score']),
     DelegatorData('RandomizedSearchCV',
                   lambda est: RandomizedSearchCV(
-                      est, param_grid={'param': [5]}, cv=2),
+                      est, param_distributions={'param': [5]}, cv=2),
                   skip_methods=['score']),
     DelegatorData('RFECV', RFECV,
                   skip_methods=['transform', 'inverse_transform']),
-}
+]
 
 
 def test_metaestimator_delegation():
@@ -53,6 +53,7 @@ def test_metaestimator_delegation():
             self.hidden_method = hidden_method
 
         def fit(self, X, y=None, *args, **kwargs):
+            self.coef_ = np.arange(X.shape[1])
             return True
 
         @hides

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -1,0 +1,100 @@
+"""Common tests for metaestimators"""
+
+import functools
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.externals.six import iterkeys
+from sklearn.datasets import make_classification
+from sklearn.utils.testing import assert_true, assert_false
+from sklearn.pipeline import Pipeline
+
+
+class DelegatorData(object):
+    def __init__(self, name, construct, skip_methods=(),
+                 fit_args=make_classification()):
+        self.name = name
+        self.construct = construct
+        self.fit_args = fit_args
+        self.skip_methods = skip_methods
+
+
+DELEGATING_METAESTIMATORS = {
+    DelegatorData('pipeline', lambda est: Pipeline([('est', est)])),
+    DelegatorData('pipeline', lambda est: Pipeline([('est', est)])),
+}
+
+
+def test_metaestimator_delegation():
+    def hides(method):
+        @property
+        def wrapper(obj):
+            if obj.hidden_method == method.__name__:
+                raise AttributeError
+            return functools.partial(method, obj)
+        return wrapper
+
+    class SubEstimator(BaseEstimator):
+        def __init__(self, param=1, hidden_method=None):
+            self.param = param
+            self.hidden_method = hidden_method
+        
+        def fit(self, X, y=None, *args, **kwargs):
+            return True
+        
+        @hides
+        def inverse_transform(self, X, *args, **kwargs):
+            return X
+
+        @hides
+        def transform(self, X, *args, **kwargs):
+            return X
+
+        @hides
+        def predict(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def predict_proba(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def predict_log_proba(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def decision_function(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def score(self, X, *args, **kwargs):
+            return 1.0
+
+
+    methods = [k for k in iterkeys(SubEstimator.__dict__)
+               if not k.startswith('_') and not k.startswith('fit')]
+
+    for delegator_data in DELEGATING_METAESTIMATORS:
+        delegate = SubEstimator()
+        delegator = delegator_data.construct(delegate)
+        delegator.fit(*delegator_data.fit_args)
+        for method in methods:
+            if method in delegator_data.skip_methods:
+                continue
+            assert_true(hasattr(delegate, method))
+            assert_true(hasattr(delegator, method),
+                        msg="%s does not have method %r when its delegate does"
+                            % (delegator_data.name, method))
+        
+        for method in methods:
+            if method in delegator_data.skip_methods:
+                continue
+            delegate = SubEstimator(hidden_method=method)
+            delegator = delegator_data.construct(delegate)
+            delegator.fit(*delegator_data.fit_args)
+            assert_false(hasattr(delegate, method))
+            assert_false(hasattr(delegator, method),
+                        msg="%s has method %r when its delegate does not"
+                            % (delegator_data.name, method))
+        

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -23,254 +23,254 @@ from sklearn.feature_extraction.text import CountVectorizer
 
 
 JUNK_FOOD_DOCS = (
-"the pizza pizza beer copyright",
-"the pizza burger beer copyright",
-"the the pizza beer beer copyright",
-"the burger beer beer copyright",
-"the coke burger coke copyright",
-"the coke burger burger",
+    "the pizza pizza beer copyright",
+    "the pizza burger beer copyright",
+    "the the pizza beer beer copyright",
+    "the burger beer beer copyright",
+    "the coke burger coke copyright",
+    "the coke burger burger",
 )
 
 
 class IncorrectT(BaseEstimator):
-"""Small class to test parameter dispatching.
-"""
+    """Small class to test parameter dispatching.
+    """
 
-def __init__(self, a=None, b=None):
-    self.a = a
-    self.b = b
+    def __init__(self, a=None, b=None):
+        self.a = a
+        self.b = b
 
 
 class T(IncorrectT):
 
-def fit(self, X, y):
-    return self
+    def fit(self, X, y):
+        return self
 
 
 class TransfT(T):
 
-def transform(self, X, y=None):
-    return X
+    def transform(self, X, y=None):
+        return X
 
 
 class FitParamT(BaseEstimator):
-"""Mock classifier
-"""
+    """Mock classifier
+    """
 
-def __init__(self):
-    self.successful = False
-    pass
+    def __init__(self):
+        self.successful = False
+        pass
 
-def fit(self, X, y, should_succeed=False):
-    self.successful = should_succeed
+    def fit(self, X, y, should_succeed=False):
+        self.successful = should_succeed
 
-def predict(self, X):
-    return self.successful
+    def predict(self, X):
+        return self.successful
 
 
 def test_pipeline_init():
-""" Test the various init parameters of the pipeline.
-"""
-assert_raises(TypeError, Pipeline)
-# Check that we can't instantiate pipelines with objects without fit
-# method
-pipe = assert_raises(TypeError, Pipeline, [('svc', IncorrectT)])
-# Smoke test with only an estimator
-clf = T()
-pipe = Pipeline([('svc', clf)])
-assert_equal(pipe.get_params(deep=True),
-             dict(svc__a=None, svc__b=None, svc=clf))
+    """ Test the various init parameters of the pipeline.
+    """
+    assert_raises(TypeError, Pipeline)
+    # Check that we can't instantiate pipelines with objects without fit
+    # method
+    pipe = assert_raises(TypeError, Pipeline, [('svc', IncorrectT)])
+    # Smoke test with only an estimator
+    clf = T()
+    pipe = Pipeline([('svc', clf)])
+    assert_equal(pipe.get_params(deep=True),
+                 dict(svc__a=None, svc__b=None, svc=clf))
 
-# Check that params are set
-pipe.set_params(svc__a=0.1)
-assert_equal(clf.a, 0.1)
-# Smoke test the repr:
-repr(pipe)
+    # Check that params are set
+    pipe.set_params(svc__a=0.1)
+    assert_equal(clf.a, 0.1)
+    # Smoke test the repr:
+    repr(pipe)
 
-# Test with two objects
-clf = SVC()
-filter1 = SelectKBest(f_classif)
-pipe = Pipeline([('anova', filter1), ('svc', clf)])
+    # Test with two objects
+    clf = SVC()
+    filter1 = SelectKBest(f_classif)
+    pipe = Pipeline([('anova', filter1), ('svc', clf)])
 
-# Check that we can't use the same stage name twice
-assert_raises(ValueError, Pipeline, [('svc', SVC()), ('svc', SVC())])
+    # Check that we can't use the same stage name twice
+    assert_raises(ValueError, Pipeline, [('svc', SVC()), ('svc', SVC())])
 
-# Check that params are set
-pipe.set_params(svc__C=0.1)
-assert_equal(clf.C, 0.1)
-# Smoke test the repr:
-repr(pipe)
+    # Check that params are set
+    pipe.set_params(svc__C=0.1)
+    assert_equal(clf.C, 0.1)
+    # Smoke test the repr:
+    repr(pipe)
 
-# Check that params are not set when naming them wrong
-assert_raises(ValueError, pipe.set_params, anova__C=0.1)
+    # Check that params are not set when naming them wrong
+    assert_raises(ValueError, pipe.set_params, anova__C=0.1)
 
-# Test clone
-pipe2 = clone(pipe)
-assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
+    # Test clone
+    pipe2 = clone(pipe)
+    assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
 
-# Check that apart from estimators, the parameters are the same
-params = pipe.get_params()
-params2 = pipe2.get_params()
-# Remove estimators that where copied
-params.pop('svc')
-params.pop('anova')
-params2.pop('svc')
-params2.pop('anova')
-assert_equal(params, params2)
+    # Check that apart from estimators, the parameters are the same
+    params = pipe.get_params()
+    params2 = pipe2.get_params()
+    # Remove estimators that where copied
+    params.pop('svc')
+    params.pop('anova')
+    params2.pop('svc')
+    params2.pop('anova')
+    assert_equal(params, params2)
 
 
 def test_pipeline_methods_anova():
-""" Test the various methods of the pipeline (anova).
-"""
-iris = load_iris()
-X = iris.data
-y = iris.target
-# Test with Anova + LogisticRegression
-clf = LogisticRegression()
-filter1 = SelectKBest(f_classif, k=2)
-pipe = Pipeline([('anova', filter1), ('logistic', clf)])
-pipe.fit(X, y)
-pipe.predict(X)
-pipe.predict_proba(X)
-pipe.predict_log_proba(X)
-pipe.score(X, y)
-
-
-def test_pipeline_fit_params():
-"""Test that the pipeline can take fit parameters
-"""
-pipe = Pipeline([('transf', TransfT()), ('clf', FitParamT())])
-pipe.fit(X=None, y=None, clf__should_succeed=True)
-# classifier should return True
-assert_true(pipe.predict(None))
-# and transformer params should not be changed
-assert_true(pipe.named_steps['transf'].a is None)
-assert_true(pipe.named_steps['transf'].b is None)
-
-
-def test_pipeline_methods_pca_svm():
-"""Test the various methods of the pipeline (pca + svm)."""
-iris = load_iris()
-X = iris.data
-y = iris.target
-# Test with PCA + SVC
-clf = SVC(probability=True, random_state=0)
-pca = PCA(n_components='mle', whiten=True)
-pipe = Pipeline([('pca', pca), ('svc', clf)])
-pipe.fit(X, y)
-pipe.predict(X)
-pipe.predict_proba(X)
-pipe.predict_log_proba(X)
-pipe.score(X, y)
-
-
-def test_pipeline_methods_preprocessing_svm():
-"""Test the various methods of the pipeline (preprocessing + svm)."""
-iris = load_iris()
-X = iris.data
-y = iris.target
-n_samples = X.shape[0]
-n_classes = len(np.unique(y))
-scaler = StandardScaler()
-pca = RandomizedPCA(n_components=2, whiten=True)
-clf = SVC(probability=True, random_state=0)
-
-for preprocessing in [scaler, pca]:
-    pipe = Pipeline([('preprocess', preprocessing), ('svc', clf)])
+    """ Test the various methods of the pipeline (anova).
+    """
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    # Test with Anova + LogisticRegression
+    clf = LogisticRegression()
+    filter1 = SelectKBest(f_classif, k=2)
+    pipe = Pipeline([('anova', filter1), ('logistic', clf)])
     pipe.fit(X, y)
-
-    # check shapes of various prediction functions
-    predict = pipe.predict(X)
-    assert_equal(predict.shape, (n_samples,))
-
-    proba = pipe.predict_proba(X)
-    assert_equal(proba.shape, (n_samples, n_classes))
-
-    log_proba = pipe.predict_log_proba(X)
-    assert_equal(log_proba.shape, (n_samples, n_classes))
-
-    decision_function = pipe.decision_function(X)
-    assert_equal(decision_function.shape, (n_samples, n_classes))
-
+    pipe.predict(X)
+    pipe.predict_proba(X)
+    pipe.predict_log_proba(X)
     pipe.score(X, y)
 
 
+def test_pipeline_fit_params():
+    """Test that the pipeline can take fit parameters
+    """
+    pipe = Pipeline([('transf', TransfT()), ('clf', FitParamT())])
+    pipe.fit(X=None, y=None, clf__should_succeed=True)
+    # classifier should return True
+    assert_true(pipe.predict(None))
+    # and transformer params should not be changed
+    assert_true(pipe.named_steps['transf'].a is None)
+    assert_true(pipe.named_steps['transf'].b is None)
+
+
+def test_pipeline_methods_pca_svm():
+    """Test the various methods of the pipeline (pca + svm)."""
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    # Test with PCA + SVC
+    clf = SVC(probability=True, random_state=0)
+    pca = PCA(n_components='mle', whiten=True)
+    pipe = Pipeline([('pca', pca), ('svc', clf)])
+    pipe.fit(X, y)
+    pipe.predict(X)
+    pipe.predict_proba(X)
+    pipe.predict_log_proba(X)
+    pipe.score(X, y)
+
+
+def test_pipeline_methods_preprocessing_svm():
+    """Test the various methods of the pipeline (preprocessing + svm)."""
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    n_samples = X.shape[0]
+    n_classes = len(np.unique(y))
+    scaler = StandardScaler()
+    pca = RandomizedPCA(n_components=2, whiten=True)
+    clf = SVC(probability=True, random_state=0)
+
+    for preprocessing in [scaler, pca]:
+        pipe = Pipeline([('preprocess', preprocessing), ('svc', clf)])
+        pipe.fit(X, y)
+
+        # check shapes of various prediction functions
+        predict = pipe.predict(X)
+        assert_equal(predict.shape, (n_samples,))
+
+        proba = pipe.predict_proba(X)
+        assert_equal(proba.shape, (n_samples, n_classes))
+
+        log_proba = pipe.predict_log_proba(X)
+        assert_equal(log_proba.shape, (n_samples, n_classes))
+
+        decision_function = pipe.decision_function(X)
+        assert_equal(decision_function.shape, (n_samples, n_classes))
+
+        pipe.score(X, y)
+
+
 def test_feature_union():
-# basic sanity check for feature union
-iris = load_iris()
-X = iris.data
-X -= X.mean(axis=0)
-y = iris.target
-svd = TruncatedSVD(n_components=2, random_state=0)
-select = SelectKBest(k=1)
-fs = FeatureUnion([("svd", svd), ("select", select)])
-fs.fit(X, y)
-X_transformed = fs.transform(X)
-assert_equal(X_transformed.shape, (X.shape[0], 3))
+    # basic sanity check for feature union
+    iris = load_iris()
+    X = iris.data
+    X -= X.mean(axis=0)
+    y = iris.target
+    svd = TruncatedSVD(n_components=2, random_state=0)
+    select = SelectKBest(k=1)
+    fs = FeatureUnion([("svd", svd), ("select", select)])
+    fs.fit(X, y)
+    X_transformed = fs.transform(X)
+    assert_equal(X_transformed.shape, (X.shape[0], 3))
 
-# check if it does the expected thing
-assert_array_almost_equal(X_transformed[:, :-1], svd.fit_transform(X))
-assert_array_equal(X_transformed[:, -1],
-                   select.fit_transform(X, y).ravel())
+    # check if it does the expected thing
+    assert_array_almost_equal(X_transformed[:, :-1], svd.fit_transform(X))
+    assert_array_equal(X_transformed[:, -1],
+                       select.fit_transform(X, y).ravel())
 
-# test if it also works for sparse input
-# We use a different svd object to control the random_state stream
-fs = FeatureUnion([("svd", svd), ("select", select)])
-X_sp = sparse.csr_matrix(X)
-X_sp_transformed = fs.fit_transform(X_sp, y)
-assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
+    # test if it also works for sparse input
+    # We use a different svd object to control the random_state stream
+    fs = FeatureUnion([("svd", svd), ("select", select)])
+    X_sp = sparse.csr_matrix(X)
+    X_sp_transformed = fs.fit_transform(X_sp, y)
+    assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
-# test setting parameters
-fs.set_params(select__k=2)
-assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))
+    # test setting parameters
+    fs.set_params(select__k=2)
+    assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))
 
-# test it works with transformers missing fit_transform
-fs = FeatureUnion([("mock", TransfT()), ("svd", svd), ("select", select)])
-X_transformed = fs.fit_transform(X, y)
-assert_equal(X_transformed.shape, (X.shape[0], 8))
+    # test it works with transformers missing fit_transform
+    fs = FeatureUnion([("mock", TransfT()), ("svd", svd), ("select", select)])
+    X_transformed = fs.fit_transform(X, y)
+    assert_equal(X_transformed.shape, (X.shape[0], 8))
 
 
 def test_make_union():
-pca = PCA()
-mock = TransfT()
-fu = make_union(pca, mock)
-names, transformers = zip(*fu.transformer_list)
-assert_equal(names, ("pca", "transft"))
-assert_equal(transformers, (pca, mock))
+    pca = PCA()
+    mock = TransfT()
+    fu = make_union(pca, mock)
+    names, transformers = zip(*fu.transformer_list)
+    assert_equal(names, ("pca", "transft"))
+    assert_equal(transformers, (pca, mock))
 
 
 def test_pipeline_transform():
-# Test whether pipeline works with a transformer at the end.
-# Also test pipeline.transform and pipeline.inverse_transform
-iris = load_iris()
-X = iris.data
-pca = PCA(n_components=2)
-pipeline = Pipeline([('pca', pca)])
+    # Test whether pipeline works with a transformer at the end.
+    # Also test pipeline.transform and pipeline.inverse_transform
+    iris = load_iris()
+    X = iris.data
+    pca = PCA(n_components=2)
+    pipeline = Pipeline([('pca', pca)])
 
-# test transform and fit_transform:
-X_trans = pipeline.fit(X).transform(X)
-X_trans2 = pipeline.fit_transform(X)
-X_trans3 = pca.fit_transform(X)
-assert_array_almost_equal(X_trans, X_trans2)
-assert_array_almost_equal(X_trans, X_trans3)
+    # test transform and fit_transform:
+    X_trans = pipeline.fit(X).transform(X)
+    X_trans2 = pipeline.fit_transform(X)
+    X_trans3 = pca.fit_transform(X)
+    assert_array_almost_equal(X_trans, X_trans2)
+    assert_array_almost_equal(X_trans, X_trans3)
 
-X_back = pipeline.inverse_transform(X_trans)
-X_back2 = pca.inverse_transform(X_trans)
-assert_array_almost_equal(X_back, X_back2)
+    X_back = pipeline.inverse_transform(X_trans)
+    X_back2 = pca.inverse_transform(X_trans)
+    assert_array_almost_equal(X_back, X_back2)
 
 
 def test_pipeline_fit_transform():
-# Test whether pipeline works with a transformer missing fit_transform
-iris = load_iris()
-X = iris.data
-y = iris.target
-transft = TransfT()
-pipeline = Pipeline([('mock', transft)])
+    # Test whether pipeline works with a transformer missing fit_transform
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    transft = TransfT()
+    pipeline = Pipeline([('mock', transft)])
 
-# test fit_transform:
-X_trans = pipeline.fit_transform(X, y)
-X_trans2 = transft.fit(X, y).transform(X)
-assert_array_almost_equal(X_trans, X_trans2)
+    # test fit_transform:
+    X_trans = pipeline.fit_transform(X, y)
+    X_trans2 = transft.fit(X, y).transform(X)
+    assert_array_almost_equal(X_trans, X_trans2)
 
 
 def test_make_pipeline():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -289,6 +289,28 @@ def test_make_pipeline():
     assert_equal(pipe.steps[2][0], "fitparamt")
 
 
+def test_pipeline_attributes():
+    """Ensure that the Pipeline only provides post-fit methods that are present
+    on the last step"""
+
+    def make(method):
+        """Make a pipeline whose estimator has specified method"""
+        transf = TransfT()
+        setattr(transf, method, lambda *args, **kwargs: True)
+        return Pipeline([('est', transf)]).fit([[1]], [1])
+
+    attribs = ['predict_proba', 'predict_log_proba', 'predict',
+               'decision_function', 'score', 'inverse_transform']
+
+    for attrib in attribs:
+        pipeline = make(attrib)
+        getattr(pipeline, attrib)(np.asarray([[1]]))
+        for attrib2 in attribs:
+            if attrib2 != attrib:
+                assert_false(hasattr(pipeline, attrib2))
+>>>>>>> FIX make Pipeline methods properties as per #1805
+
+
 def test_feature_union_weights():
     # test feature union with transformer weights
     iris = load_iris()

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -23,254 +23,254 @@ from sklearn.feature_extraction.text import CountVectorizer
 
 
 JUNK_FOOD_DOCS = (
-    "the pizza pizza beer copyright",
-    "the pizza burger beer copyright",
-    "the the pizza beer beer copyright",
-    "the burger beer beer copyright",
-    "the coke burger coke copyright",
-    "the coke burger burger",
+"the pizza pizza beer copyright",
+"the pizza burger beer copyright",
+"the the pizza beer beer copyright",
+"the burger beer beer copyright",
+"the coke burger coke copyright",
+"the coke burger burger",
 )
 
 
 class IncorrectT(BaseEstimator):
-    """Small class to test parameter dispatching.
-    """
+"""Small class to test parameter dispatching.
+"""
 
-    def __init__(self, a=None, b=None):
-        self.a = a
-        self.b = b
+def __init__(self, a=None, b=None):
+    self.a = a
+    self.b = b
 
 
 class T(IncorrectT):
 
-    def fit(self, X, y):
-        return self
+def fit(self, X, y):
+    return self
 
 
 class TransfT(T):
 
-    def transform(self, X, y=None):
-        return X
+def transform(self, X, y=None):
+    return X
 
 
 class FitParamT(BaseEstimator):
-    """Mock classifier
-    """
+"""Mock classifier
+"""
 
-    def __init__(self):
-        self.successful = False
-        pass
+def __init__(self):
+    self.successful = False
+    pass
 
-    def fit(self, X, y, should_succeed=False):
-        self.successful = should_succeed
+def fit(self, X, y, should_succeed=False):
+    self.successful = should_succeed
 
-    def predict(self, X):
-        return self.successful
+def predict(self, X):
+    return self.successful
 
 
 def test_pipeline_init():
-    """ Test the various init parameters of the pipeline.
-    """
-    assert_raises(TypeError, Pipeline)
-    # Check that we can't instantiate pipelines with objects without fit
-    # method
-    pipe = assert_raises(TypeError, Pipeline, [('svc', IncorrectT)])
-    # Smoke test with only an estimator
-    clf = T()
-    pipe = Pipeline([('svc', clf)])
-    assert_equal(pipe.get_params(deep=True),
-                 dict(svc__a=None, svc__b=None, svc=clf))
+""" Test the various init parameters of the pipeline.
+"""
+assert_raises(TypeError, Pipeline)
+# Check that we can't instantiate pipelines with objects without fit
+# method
+pipe = assert_raises(TypeError, Pipeline, [('svc', IncorrectT)])
+# Smoke test with only an estimator
+clf = T()
+pipe = Pipeline([('svc', clf)])
+assert_equal(pipe.get_params(deep=True),
+             dict(svc__a=None, svc__b=None, svc=clf))
 
-    # Check that params are set
-    pipe.set_params(svc__a=0.1)
-    assert_equal(clf.a, 0.1)
-    # Smoke test the repr:
-    repr(pipe)
+# Check that params are set
+pipe.set_params(svc__a=0.1)
+assert_equal(clf.a, 0.1)
+# Smoke test the repr:
+repr(pipe)
 
-    # Test with two objects
-    clf = SVC()
-    filter1 = SelectKBest(f_classif)
-    pipe = Pipeline([('anova', filter1), ('svc', clf)])
+# Test with two objects
+clf = SVC()
+filter1 = SelectKBest(f_classif)
+pipe = Pipeline([('anova', filter1), ('svc', clf)])
 
-    # Check that we can't use the same stage name twice
-    assert_raises(ValueError, Pipeline, [('svc', SVC()), ('svc', SVC())])
+# Check that we can't use the same stage name twice
+assert_raises(ValueError, Pipeline, [('svc', SVC()), ('svc', SVC())])
 
-    # Check that params are set
-    pipe.set_params(svc__C=0.1)
-    assert_equal(clf.C, 0.1)
-    # Smoke test the repr:
-    repr(pipe)
+# Check that params are set
+pipe.set_params(svc__C=0.1)
+assert_equal(clf.C, 0.1)
+# Smoke test the repr:
+repr(pipe)
 
-    # Check that params are not set when naming them wrong
-    assert_raises(ValueError, pipe.set_params, anova__C=0.1)
+# Check that params are not set when naming them wrong
+assert_raises(ValueError, pipe.set_params, anova__C=0.1)
 
-    # Test clone
-    pipe2 = clone(pipe)
-    assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
+# Test clone
+pipe2 = clone(pipe)
+assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
 
-    # Check that apart from estimators, the parameters are the same
-    params = pipe.get_params()
-    params2 = pipe2.get_params()
-    # Remove estimators that where copied
-    params.pop('svc')
-    params.pop('anova')
-    params2.pop('svc')
-    params2.pop('anova')
-    assert_equal(params, params2)
+# Check that apart from estimators, the parameters are the same
+params = pipe.get_params()
+params2 = pipe2.get_params()
+# Remove estimators that where copied
+params.pop('svc')
+params.pop('anova')
+params2.pop('svc')
+params2.pop('anova')
+assert_equal(params, params2)
 
 
 def test_pipeline_methods_anova():
-    """ Test the various methods of the pipeline (anova).
-    """
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
-    # Test with Anova + LogisticRegression
-    clf = LogisticRegression()
-    filter1 = SelectKBest(f_classif, k=2)
-    pipe = Pipeline([('anova', filter1), ('logistic', clf)])
-    pipe.fit(X, y)
-    pipe.predict(X)
-    pipe.predict_proba(X)
-    pipe.predict_log_proba(X)
-    pipe.score(X, y)
+""" Test the various methods of the pipeline (anova).
+"""
+iris = load_iris()
+X = iris.data
+y = iris.target
+# Test with Anova + LogisticRegression
+clf = LogisticRegression()
+filter1 = SelectKBest(f_classif, k=2)
+pipe = Pipeline([('anova', filter1), ('logistic', clf)])
+pipe.fit(X, y)
+pipe.predict(X)
+pipe.predict_proba(X)
+pipe.predict_log_proba(X)
+pipe.score(X, y)
 
 
 def test_pipeline_fit_params():
-    """Test that the pipeline can take fit parameters
-    """
-    pipe = Pipeline([('transf', TransfT()), ('clf', FitParamT())])
-    pipe.fit(X=None, y=None, clf__should_succeed=True)
-    # classifier should return True
-    assert_true(pipe.predict(None))
-    # and transformer params should not be changed
-    assert_true(pipe.named_steps['transf'].a is None)
-    assert_true(pipe.named_steps['transf'].b is None)
+"""Test that the pipeline can take fit parameters
+"""
+pipe = Pipeline([('transf', TransfT()), ('clf', FitParamT())])
+pipe.fit(X=None, y=None, clf__should_succeed=True)
+# classifier should return True
+assert_true(pipe.predict(None))
+# and transformer params should not be changed
+assert_true(pipe.named_steps['transf'].a is None)
+assert_true(pipe.named_steps['transf'].b is None)
 
 
 def test_pipeline_methods_pca_svm():
-    """Test the various methods of the pipeline (pca + svm)."""
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
-    # Test with PCA + SVC
-    clf = SVC(probability=True, random_state=0)
-    pca = PCA(n_components='mle', whiten=True)
-    pipe = Pipeline([('pca', pca), ('svc', clf)])
-    pipe.fit(X, y)
-    pipe.predict(X)
-    pipe.predict_proba(X)
-    pipe.predict_log_proba(X)
-    pipe.score(X, y)
+"""Test the various methods of the pipeline (pca + svm)."""
+iris = load_iris()
+X = iris.data
+y = iris.target
+# Test with PCA + SVC
+clf = SVC(probability=True, random_state=0)
+pca = PCA(n_components='mle', whiten=True)
+pipe = Pipeline([('pca', pca), ('svc', clf)])
+pipe.fit(X, y)
+pipe.predict(X)
+pipe.predict_proba(X)
+pipe.predict_log_proba(X)
+pipe.score(X, y)
 
 
 def test_pipeline_methods_preprocessing_svm():
-    """Test the various methods of the pipeline (preprocessing + svm)."""
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
-    n_samples = X.shape[0]
-    n_classes = len(np.unique(y))
-    scaler = StandardScaler()
-    pca = RandomizedPCA(n_components=2, whiten=True)
-    clf = SVC(probability=True, random_state=0)
+"""Test the various methods of the pipeline (preprocessing + svm)."""
+iris = load_iris()
+X = iris.data
+y = iris.target
+n_samples = X.shape[0]
+n_classes = len(np.unique(y))
+scaler = StandardScaler()
+pca = RandomizedPCA(n_components=2, whiten=True)
+clf = SVC(probability=True, random_state=0)
 
-    for preprocessing in [scaler, pca]:
-        pipe = Pipeline([('preprocess', preprocessing), ('svc', clf)])
-        pipe.fit(X, y)
+for preprocessing in [scaler, pca]:
+    pipe = Pipeline([('preprocess', preprocessing), ('svc', clf)])
+    pipe.fit(X, y)
 
-        # check shapes of various prediction functions
-        predict = pipe.predict(X)
-        assert_equal(predict.shape, (n_samples,))
+    # check shapes of various prediction functions
+    predict = pipe.predict(X)
+    assert_equal(predict.shape, (n_samples,))
 
-        proba = pipe.predict_proba(X)
-        assert_equal(proba.shape, (n_samples, n_classes))
+    proba = pipe.predict_proba(X)
+    assert_equal(proba.shape, (n_samples, n_classes))
 
-        log_proba = pipe.predict_log_proba(X)
-        assert_equal(log_proba.shape, (n_samples, n_classes))
+    log_proba = pipe.predict_log_proba(X)
+    assert_equal(log_proba.shape, (n_samples, n_classes))
 
-        decision_function = pipe.decision_function(X)
-        assert_equal(decision_function.shape, (n_samples, n_classes))
+    decision_function = pipe.decision_function(X)
+    assert_equal(decision_function.shape, (n_samples, n_classes))
 
-        pipe.score(X, y)
+    pipe.score(X, y)
 
 
 def test_feature_union():
-    # basic sanity check for feature union
-    iris = load_iris()
-    X = iris.data
-    X -= X.mean(axis=0)
-    y = iris.target
-    svd = TruncatedSVD(n_components=2, random_state=0)
-    select = SelectKBest(k=1)
-    fs = FeatureUnion([("svd", svd), ("select", select)])
-    fs.fit(X, y)
-    X_transformed = fs.transform(X)
-    assert_equal(X_transformed.shape, (X.shape[0], 3))
+# basic sanity check for feature union
+iris = load_iris()
+X = iris.data
+X -= X.mean(axis=0)
+y = iris.target
+svd = TruncatedSVD(n_components=2, random_state=0)
+select = SelectKBest(k=1)
+fs = FeatureUnion([("svd", svd), ("select", select)])
+fs.fit(X, y)
+X_transformed = fs.transform(X)
+assert_equal(X_transformed.shape, (X.shape[0], 3))
 
-    # check if it does the expected thing
-    assert_array_almost_equal(X_transformed[:, :-1], svd.fit_transform(X))
-    assert_array_equal(X_transformed[:, -1],
-                       select.fit_transform(X, y).ravel())
+# check if it does the expected thing
+assert_array_almost_equal(X_transformed[:, :-1], svd.fit_transform(X))
+assert_array_equal(X_transformed[:, -1],
+                   select.fit_transform(X, y).ravel())
 
-    # test if it also works for sparse input
-    # We use a different svd object to control the random_state stream
-    fs = FeatureUnion([("svd", svd), ("select", select)])
-    X_sp = sparse.csr_matrix(X)
-    X_sp_transformed = fs.fit_transform(X_sp, y)
-    assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
+# test if it also works for sparse input
+# We use a different svd object to control the random_state stream
+fs = FeatureUnion([("svd", svd), ("select", select)])
+X_sp = sparse.csr_matrix(X)
+X_sp_transformed = fs.fit_transform(X_sp, y)
+assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
-    # test setting parameters
-    fs.set_params(select__k=2)
-    assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))
+# test setting parameters
+fs.set_params(select__k=2)
+assert_equal(fs.fit_transform(X, y).shape, (X.shape[0], 4))
 
-    # test it works with transformers missing fit_transform
-    fs = FeatureUnion([("mock", TransfT()), ("svd", svd), ("select", select)])
-    X_transformed = fs.fit_transform(X, y)
-    assert_equal(X_transformed.shape, (X.shape[0], 8))
+# test it works with transformers missing fit_transform
+fs = FeatureUnion([("mock", TransfT()), ("svd", svd), ("select", select)])
+X_transformed = fs.fit_transform(X, y)
+assert_equal(X_transformed.shape, (X.shape[0], 8))
 
 
 def test_make_union():
-    pca = PCA()
-    mock = TransfT()
-    fu = make_union(pca, mock)
-    names, transformers = zip(*fu.transformer_list)
-    assert_equal(names, ("pca", "transft"))
-    assert_equal(transformers, (pca, mock))
+pca = PCA()
+mock = TransfT()
+fu = make_union(pca, mock)
+names, transformers = zip(*fu.transformer_list)
+assert_equal(names, ("pca", "transft"))
+assert_equal(transformers, (pca, mock))
 
 
 def test_pipeline_transform():
-    # Test whether pipeline works with a transformer at the end.
-    # Also test pipeline.transform and pipeline.inverse_transform
-    iris = load_iris()
-    X = iris.data
-    pca = PCA(n_components=2)
-    pipeline = Pipeline([('pca', pca)])
+# Test whether pipeline works with a transformer at the end.
+# Also test pipeline.transform and pipeline.inverse_transform
+iris = load_iris()
+X = iris.data
+pca = PCA(n_components=2)
+pipeline = Pipeline([('pca', pca)])
 
-    # test transform and fit_transform:
-    X_trans = pipeline.fit(X).transform(X)
-    X_trans2 = pipeline.fit_transform(X)
-    X_trans3 = pca.fit_transform(X)
-    assert_array_almost_equal(X_trans, X_trans2)
-    assert_array_almost_equal(X_trans, X_trans3)
+# test transform and fit_transform:
+X_trans = pipeline.fit(X).transform(X)
+X_trans2 = pipeline.fit_transform(X)
+X_trans3 = pca.fit_transform(X)
+assert_array_almost_equal(X_trans, X_trans2)
+assert_array_almost_equal(X_trans, X_trans3)
 
-    X_back = pipeline.inverse_transform(X_trans)
-    X_back2 = pca.inverse_transform(X_trans)
-    assert_array_almost_equal(X_back, X_back2)
+X_back = pipeline.inverse_transform(X_trans)
+X_back2 = pca.inverse_transform(X_trans)
+assert_array_almost_equal(X_back, X_back2)
 
 
 def test_pipeline_fit_transform():
-    # Test whether pipeline works with a transformer missing fit_transform
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
-    transft = TransfT()
-    pipeline = Pipeline([('mock', transft)])
+# Test whether pipeline works with a transformer missing fit_transform
+iris = load_iris()
+X = iris.data
+y = iris.target
+transft = TransfT()
+pipeline = Pipeline([('mock', transft)])
 
-    # test fit_transform:
-    X_trans = pipeline.fit_transform(X, y)
-    X_trans2 = transft.fit(X, y).transform(X)
-    assert_array_almost_equal(X_trans, X_trans2)
+# test fit_transform:
+X_trans = pipeline.fit_transform(X, y)
+X_trans2 = transft.fit(X, y).transform(X)
+assert_array_almost_equal(X_trans, X_trans2)
 
 
 def test_make_pipeline():
@@ -287,28 +287,6 @@ def test_make_pipeline():
     assert_equal(pipe.steps[0][0], "transft-1")
     assert_equal(pipe.steps[1][0], "transft-2")
     assert_equal(pipe.steps[2][0], "fitparamt")
-
-
-def test_pipeline_attributes():
-    """Ensure that the Pipeline only provides post-fit methods that are present
-    on the last step"""
-
-    def make(method):
-        """Make a pipeline whose estimator has specified method"""
-        transf = TransfT()
-        setattr(transf, method, lambda *args, **kwargs: True)
-        return Pipeline([('est', transf)]).fit([[1]], [1])
-
-    attribs = ['predict_proba', 'predict_log_proba', 'predict',
-               'decision_function', 'score', 'inverse_transform']
-
-    for attrib in attribs:
-        pipeline = make(attrib)
-        getattr(pipeline, attrib)(np.asarray([[1]]))
-        for attrib2 in attribs:
-            if attrib2 != attrib:
-                assert_false(hasattr(pipeline, attrib2))
->>>>>>> FIX make Pipeline methods properties as per #1805
 
 
 def test_feature_union_weights():


### PR DESCRIPTION
This intends to solve #1805, ensuring that appropriate metaestimators have `hasattr(metaest, method) == True` iff the sub-estimator does for the set of standard methods: `inverse_transform`, `transform`, `predict`, `predict_proba`, `predict_log_proba`, `decision_function`, `score`.

I posted this as a WIP so that you can:
- check the testing is reasonable;
- confirm the set of methods is correct;
- contribute patches to relevant estimators.

I currently take the approach of testing for attributes only after fitting. There may be problems if ducktyping is used before fitting on, say, a `GridSearchCV`, but I guess that's just something we'll have to be aware of when working with ducktyping.

I also am not currently dealing with metaestimators that delegate their `fit` methods. (I'm not sure if they exist, but I have considered some.)

(I have pulled in the relevant commit from #1769 and removed its Pipeline-particular testing.)
