### PR TITLE
#1979 Added Hamming loss and Jaccard similarity to Scorers and make Hamming loss default

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from . import (r2_score, mean_squared_error, accuracy_score, f1_score,
                auc_score, average_precision_score, precision_score,
-               recall_score)
+               recall_score, hamming_loss, jaccard_similarity_score)
 
 from .cluster import adjusted_rand_score
 
@@ -129,8 +129,12 @@ recall_scorer = Scorer(recall_score)
 # Clustering scores
 ari_scorer = Scorer(adjusted_rand_score)
 
+# Multilabel scores
+hamming_scorer = Scorer(hamming_loss, greater_is_better=False)
+jaccard_scorer = Scorer(jaccard_similarity_score)
+
 SCORERS = dict(r2=r2_scorer, mse=mse_scorer, accuracy=accuracy_scorer,
                f1=f1_scorer, roc_auc=auc_scorer,
                average_precision=average_precision_scorer,
                precision=precision_scorer, recall=recall_scorer,
-               ari=ari_scorer)
+               ari=ari_scorer, hamming=hamming_scorer, jaccard=jaccard_scorer)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -3,13 +3,14 @@ import pickle
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 
-from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score
+from sklearn.metrics import f1_score, r2_score, auc_score, fbeta_score, hamming_loss, jaccard_similarity_score
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.metrics import SCORERS, Scorer
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.multiclass import OneVsRestClassifier
 from sklearn.datasets import make_blobs, load_diabetes
 from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.grid_search import GridSearchCV
@@ -84,6 +85,23 @@ def test_unsupervised_scores():
     km.fit(X_train)
     score1 = SCORERS['ari'](km, X_test, y_test)
     score2 = adjusted_rand_score(y_test, km.predict(X_test))
+    assert_almost_equal(score1, score2)
+
+
+def test_multilabel_scores():
+    X, y = make_blobs(random_state=0, centers=4)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = OneVsRestClassifier(LogisticRegression(random_state=0))
+    clf.fit(X_train, y_train)
+
+    # Hamming loss
+    score1 = SCORERS['hamming'](clf, X_test, y_test)
+    score2 = hamming_loss(y_test, clf.predict(X_test))
+    assert_almost_equal(score1, score2)
+
+    # Jaccard similarity
+    score1 = SCORERS['jaccard'](clf, X_test, y_test)
+    score2 = jaccard_similarity_score(y_test, clf.predict(X_test))
     assert_almost_equal(score1, score2)
 
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -11,7 +11,7 @@ from sklearn.cluster import KMeans
 from sklearn.linear_model import Ridge, LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.multiclass import OneVsRestClassifier
-from sklearn.datasets import make_blobs, load_diabetes
+from sklearn.datasets import make_blobs, load_diabetes, make_multilabel_classification
 from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.grid_search import GridSearchCV
 
@@ -89,7 +89,7 @@ def test_unsupervised_scores():
 
 
 def test_multilabel_scores():
-    X, y = make_blobs(random_state=0, centers=4)
+    X, y = make_multilabel_classification(n_samples=100, n_features=30, n_classes=5)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = OneVsRestClassifier(LogisticRegression(random_state=0))
     clf.fit(X_train, y_train)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -38,6 +38,7 @@ import warnings
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MetaEstimatorMixin
 from .preprocessing import LabelBinarizer
+from .metrics import hamming_loss
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
 from .externals.joblib import Parallel
@@ -255,8 +256,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     def score(self, X, y):
         if self.multilabel_:
-            raise NotImplementedError(
-                "score is not supported for multilabel classifiers")
+            # use Hamming loss as default score for multilabel classification
+            return hamming_loss(y, self.predict(X))
         else:
             return super(OneVsRestClassifier, self).score(X, y)
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -15,6 +15,7 @@ from sklearn.multiclass import OutputCodeClassifier
 
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
+from sklearn.metrics import hamming_loss
 
 from sklearn.svm import LinearSVC
 from sklearn.naive_bayes import MultinomialNB
@@ -153,6 +154,28 @@ def test_ovr_multilabel_predict_proba():
         # sample has the label is greater than 0.5.
         pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
         assert_equal(pred, Y_pred)
+
+
+def test_ovr_score():
+    base_clf = MultinomialNB(alpha=1)
+    for au in (False, True):
+        X, Y = datasets.make_multilabel_classification(n_samples=100,
+                                                       n_features=20,
+                                                       n_classes=5,
+                                                       n_labels=3,
+                                                       length=50,
+                                                       allow_unlabeled=au,
+                                                       random_state=0)
+
+        X_train, Y_train = X[:80], Y[:80]
+        X_test, Y_test = X[80:], Y[80:]
+        clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
+        Y_pred = clf.predict(X_test)
+
+        # clf.score defaults to Hamming loss
+        score = clf.score(X_test, Y_test)
+        score_hamming = hamming_loss(Y_pred, Y_test)
+        assert_almost_equal(score, score_hamming, decimal=2)
 
 
 def test_ovr_single_label_predict_proba():


### PR DESCRIPTION
Fixed scikit-learn/scikit-learn#1979.

Hi, this is my first contribution to the scikit-learn project. I added the Hamming loss to SCORERS and made it default score for OneVsRestClassifier.

If you have any comments please let me know.

Best,
Andreas 
