### PR TITLE
MRG: fix inconsistent cv_scores_ generation for randomized search and re-add example

### DIFF
--- a/examples/randomized_search.py
+++ b/examples/randomized_search.py
@@ -51,7 +51,7 @@ def report(cv_scores, n_top=3):
 
 
 # specify parameters and distributions to sample from
-param_dist = {"max_depth": sp_randint(1, 11),
+param_dist = {"max_depth": [3, None],
               "max_features": sp_randint(1, 11),
               "min_samples_split": sp_randint(1, 11),
               "min_samples_leaf": sp_randint(1, 11),
@@ -70,7 +70,7 @@ print("RandomizedSearchCV took %.2f seconds for %d candidate"
 report(random_search.cv_scores_)
 
 # use a full grid over all parameters
-param_grid = {"max_depth": [1, 3, 10],
+param_grid = {"max_depth": [3, None],
               "max_features": [1, 3, 10],
               "min_samples_split": [1, 3, 10],
               "min_samples_leaf": [1, 3, 10],

--- a/examples/randomized_search.py
+++ b/examples/randomized_search.py
@@ -9,7 +9,7 @@ All parameters that influence the learning are searched simultaneously
 (except for the number of estimators, which poses a time / quality tradeoff).
 
 The randomized search and the grid search explore exactly the same space of
-parameters.  The result in parameter settings is quite similar, while the run
+parameters. The result in parameter settings is quite similar, while the run
 time for randomized search is drastically lower.
 
 The performance is slightly worse for the randomized search, though this

--- a/examples/randomized_search.py
+++ b/examples/randomized_search.py
@@ -81,6 +81,6 @@ param_grid = {"max_depth": [3, None],
 grid_search = GridSearchCV(clf, param_grid=param_grid)
 grid_search.fit(X, y)
 
-print("GridSearchCV took %.2f seconds for %d parameter settings."
+print("GridSearchCV took %.2f seconds for %d candidate parameter settings."
       % (time() - start, len(grid_search.cv_scores_)))
 report(grid_search.cv_scores_)

--- a/examples/randomized_search.py
+++ b/examples/randomized_search.py
@@ -1,0 +1,85 @@
+"""
+=========================================================================
+Comparing randomized search and grid search for hyperparameter estimation
+=========================================================================
+
+Compare randomized search and grid search for optimizing hyperparameters of a
+random forest.
+All parameters that influence the learning are searched simultaneously
+(except for the number of estimators, which poses a time / quality tradeoff).
+
+The randomized search and the grid search explore exactly the same space of
+parameters.  The result in parameter settings is quite similar, while the run
+time for randomized search is drastically lower.
+
+The performance is slightly worse for the randomized search, though this
+is most likely a noise effect and would not carry over to a hold-out test set.
+
+Note that in practice, one would not search over this many different parameters
+simultaneously using grid search, but pick only the ones deemed most important.
+"""
+print __doc__
+
+import numpy as np
+
+from time import time
+from operator import itemgetter
+from scipy.stats import randint as sp_randint
+
+from sklearn.grid_search import GridSearchCV, RandomizedSearchCV
+from sklearn.datasets import load_digits
+from sklearn.ensemble import RandomForestClassifier
+
+# get some data
+iris = load_digits()
+X, y = iris.data, iris.target
+
+# build a classifier
+clf = RandomForestClassifier(n_estimators=20)
+
+
+# Utility function to report best scores
+def report(cv_scores, n_top=3):
+    top_scores = sorted(cv_scores, key=itemgetter(1), reverse=True)[:n_top]
+    for i, score in enumerate(top_scores):
+        print("Model with rank: {0}".format(i + 1))
+        print("Mean validation score: {0:.3f} (std: {1:.3f})".format(
+              score.mean_validation_score,
+              np.std(score.cv_validation_scores)))
+        print("Parameters: {0}".format(score.parameters))
+        print("")
+
+
+# specify parameters and distributions to sample from
+param_dist = {"max_depth": sp_randint(1, 11),
+              "max_features": sp_randint(1, 11),
+              "min_samples_split": sp_randint(1, 11),
+              "min_samples_leaf": sp_randint(1, 11),
+              "bootstrap": [True, False],
+              "criterion": ["gini", "entropy"]}
+
+# run randomized search
+random_search = RandomizedSearchCV(clf, param_distributions=param_dist,
+                                   n_iter=20)
+
+start = time()
+random_search.fit(X, y)
+print("RandomizedSearchCV took %.2f seconds for 20 iterations."
+      % (time() - start))
+report(random_search.cv_scores_)
+
+# use a full grid over all parameters
+param_grid = {"max_depth": [1, 3, 10],
+              "max_features": [1, 3, 10],
+              "min_samples_split": [1, 3, 10],
+              "min_samples_leaf": [1, 3, 10],
+              "bootstrap": [True, False],
+              "criterion": ["gini", "entropy"]}
+
+# run grid search
+grid_search = GridSearchCV(clf, param_grid=param_grid)
+grid_search.fit(X, y)
+
+print("GridSearchCV took %.2f seconds for %d parameter settings."
+      % (time() - start, len(grid_search.cv_scores_)))
+report(grid_search.cv_scores_)

--- a/examples/randomized_search.py
+++ b/examples/randomized_search.py
@@ -13,7 +13,7 @@ parameters.  The result in parameter settings is quite similar, while the run
 time for randomized search is drastically lower.
 
 The performance is slightly worse for the randomized search, though this
-is most likely a noise effect and would not carry over to a hold-out test set.
+is most likely a noise effect and would not carry over to a held-out test set.
 
 Note that in practice, one would not search over this many different parameters
 simultaneously using grid search, but pick only the ones deemed most important.
@@ -59,13 +59,14 @@ param_dist = {"max_depth": sp_randint(1, 11),
               "criterion": ["gini", "entropy"]}
 
 # run randomized search
+n_iter_search = 20
 random_search = RandomizedSearchCV(clf, param_distributions=param_dist,
-                                   n_iter=20)
+                                   n_iter=n_iter_search)
 
 start = time()
 random_search.fit(X, y)
-print("RandomizedSearchCV took %.2f seconds for 20 iterations."
-      % (time() - start))
+print("RandomizedSearchCV took %.2f seconds for %d candidate"
+      " parameter settings." % ((time() - start), n_iter_search))
 report(random_search.cv_scores_)
 
 # use a full grid over all parameters

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>,
 #         Gael Varoquaux <gael.varoquaux@normalesup.org>
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#         Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -807,10 +807,11 @@ class RandomizedSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  loss_func=None, score_func=None, fit_params=None, n_jobs=1,
                  iid=True, refit=True, cv=None, verbose=0,
-                 pre_dispatch='2*n_jobs'):
+                 pre_dispatch='2*n_jobs', random_state=None):
 
         self.param_distributions = param_distributions
         self.n_iter = n_iter
+        self.random_state = random_state
         super(RandomizedSearchCV, self).__init__(
             estimator, scoring, loss_func, score_func, fit_params, n_jobs, iid,
             refit, cv, verbose, pre_dispatch)
@@ -831,5 +832,6 @@ class RandomizedSearchCV(BaseSearchCV):
 
         """
         sampled_params = ParameterSampler(self.param_distributions,
-                                          self.n_iter)
+                                          self.n_iter,
+                                          random_state=self.random_state)
         return self._fit(X, y, sampled_params, **params)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -413,7 +413,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                     "should have a 'score' method. The estimator %s "
                     "does not." % self.estimator)
 
-    def _fit(self, X, y, parameter_iterator, **params):
+    def _fit(self, X, y, parameter_iterable, **params):
         """Actual fitting,  performing the search over parameters."""
 
         if params:
@@ -462,7 +462,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                 delayed(fit_grid_point)(
                     X, y, base_clf, clf_params, train, test, scorer,
                     self.verbose, **self.fit_params)
-                for clf_params in parameter_iterator
+                for clf_params in parameter_iterable
                 for train, test in cv)
 
         # Out is a list of triplet: score, estimator, n_test_samples

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -135,6 +135,15 @@ class IterGrid(ParameterGrid):
 class ParameterSampler(object):
     """Generator on parameters sampled from given distributions.
 
+    Non-deterministic iterable over random candidate combinations for hyper-
+    parameter search.
+
+    Note that as of SciPy 0.12, the ``scipy.stats.distributions`` do not accept
+    a custom RNG instance and always use the singleton RNG from
+    ``numpy.random``. Hence setting ``random_state`` will not guarantee a
+    deterministic iteration whenever ``scipy.stats`` distributions are used to
+    define the parameter search space.
+
     Parameters
     ----------
     param_distributions : dict
@@ -148,7 +157,8 @@ class ParameterSampler(object):
         Number of parameter settings that are produced.
 
     random_state : int or RandomState
-            Pseudo number generator state used for random sampling.
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
 
     Returns
     -------

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -495,7 +495,8 @@ def test_param_sampler():
 
 
 def test_randomized_search_cv_scores():
-    # Make a dataset with a log of noise
+    # Make a dataset with a lot of noise to get various kind of prediction
+    # errors across CV folds and parameter settings
     X, y = make_classification(n_samples=200, n_features=100, n_informative=3,
                                random_state=0)
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -514,9 +514,9 @@ def test_randomized_search_cv_scores():
     # Check consistency of the structure of each cv_score item
     for cv_score in search.cv_scores_:
         assert_equal(len(cv_score.cv_validation_scores), n_cv_iter)
-
-        # Because of iid=False, the sample-wise mean CV score is the
-        # same as the fold-wise mean CV score
+        # Because we set iid to False, the mean_validation score is the
+        # mean of the fold mean scores instead of the aggregate sample-wise
+        # mean score
         assert_almost_equal(np.mean(cv_score.cv_validation_scores),
                             cv_score.mean_validation_score)
         assert_equal(list(sorted(cv_score.parameters.keys())),

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -227,21 +227,25 @@ def test_grid_search_iid():
     # once with iid=True (default)
     grid_search = GridSearchCV(svm, param_grid={'C': [1, 10]}, cv=cv)
     grid_search.fit(X, y)
-    _, average_score, scores = grid_search.cv_scores_[0]
-    assert_array_almost_equal(scores, [1, 1. / 3.])
+    first = grid_search.cv_scores_[0]
+    assert_equal(first.parameters['C'], 1)
+    assert_array_almost_equal(first.cv_validation_scores, [1, 1. / 3.])
     # for first split, 1/4 of dataset is in test, for second 3/4.
     # take weighted average
-    assert_almost_equal(average_score, 1 * 1. / 4. + 1. / 3. * 3. / 4.)
+    assert_almost_equal(first.mean_validation_score,
+                        1 * 1. / 4. + 1. / 3. * 3. / 4.)
 
-    # once with iid=False (default)
+    # once with iid=False
     grid_search = GridSearchCV(svm, param_grid={'C': [1, 10]}, cv=cv,
                                iid=False)
     grid_search.fit(X, y)
-    _, average_score, scores = grid_search.cv_scores_[0]
+    first = grid_search.cv_scores_[0]
+    assert_equal(first.parameters['C'], 1)
     # scores are the same as above
-    assert_array_almost_equal(scores, [1, 1. / 3.])
+    assert_array_almost_equal(first.cv_validation_scores, [1, 1. / 3.])
     # averaged score is just mean of scores
-    assert_almost_equal(average_score, np.mean(scores))
+    assert_almost_equal(first.mean_validation_score,
+                        np.mean(first.cv_validation_scores))
 
 
 def test_grid_search_one_grid_point():
@@ -490,14 +494,46 @@ def test_param_sampler():
         assert_true(0 <= sample["C"] <= 1)
 
 
-def test_randomized_search():
-    # very basic smoke test
-    X, y = make_classification(n_samples=200, n_features=100, random_state=0)
+def test_randomized_search_cv_scores():
+    # Make a dataset with a log of noise
+    X, y = make_classification(n_samples=200, n_features=100, n_informative=3,
+                               random_state=0)
 
-    params = dict(C=distributions.expon())
-    search = RandomizedSearchCV(LinearSVC(), param_distributions=params)
+    # XXX: as of today (scipy 0.12) it's not possible to set the random seed
+    # of scipy.stats distributions: the assertions in this test should thus
+    # not depend on the randomization
+    params = dict(C=distributions.expon(scale=10),
+                  gamma=distributions.expon(scale=0.1))
+    n_cv_iter = 3
+    n_search_iter = 30
+    search = RandomizedSearchCV(SVC(), n_iter=n_search_iter, cv=n_cv_iter,
+                                param_distributions=params, iid=False)
     search.fit(X, y)
-    assert_equal(len(search.cv_scores_), 10)
+    assert_equal(len(search.cv_scores_), n_search_iter)
+
+    # Check consistency of the structure of each cv_score item
+    for cv_score in search.cv_scores_:
+        assert_equal(len(cv_score.cv_validation_scores), n_cv_iter)
+
+        # Because of iid=False, the sample-wise mean CV score is the
+        # same as the fold-wise mean CV score
+        assert_almost_equal(np.mean(cv_score.cv_validation_scores),
+                            cv_score.mean_validation_score)
+        assert_equal(list(sorted(cv_score.parameters.keys())),
+                     list(sorted(params.keys())))
+
+    # Check the consistency with the best_score_ and best_params_ attributes
+    sorted_cv_scores = list(sorted(search.cv_scores_,
+                            key=lambda x: x.mean_validation_score))
+    best_score = sorted_cv_scores[-1].mean_validation_score
+    assert_equal(search.best_score_, best_score)
+
+    tied_best_params = [s.parameters for s in sorted_cv_scores
+                        if s.mean_validation_score == best_score]
+    assert_true(search.best_params_ in tied_best_params,
+                "best_params_={} is not part of the"
+                " tied best models: {}".format(
+                    search.best_params_, tied_best_params))
 
 
 def test_grid_search_score_consistency():


### PR DESCRIPTION
The `RandomizedSearchCV.cv_scores_` was completely inconsistent with the `best_params_` / `best_score_` attribute.

Also for some reason the merge of this feature dropped an example along the way. 

@amueller I would appreciate it if you could have a look at it.
