### PR TITLE
[MRG] Enforce n_folds >= 2 for k-fold cross-validation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -129,6 +129,9 @@ API changes summary
    - Sparse matrix support in :class:`sklearn.decomposition.RandomizedPCA`
      is now deprecated in favor of the new ``TruncatedSVD``.
 
+   - :class:`cross_valiation.KFold` and
+     :class:`cross_valiation.StratifiedKFold` now enforce `n_folds >= 2`
+     otherwise a ``ValueError`` is raised. By `Olivier Grisel`_.
 
 .. _changes_0_13_1:
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -244,12 +244,15 @@ class _BaseKFold(with_metaclass(ABCMeta, _PartitionIterator)):
             raise ValueError("n_folds must be an integer")
         self.n_folds = n_folds = int(n_folds)
 
-        if n_folds <= 0:
-            raise ValueError("Cannot have number of folds below 1.")
+        if n_folds <= 1:
+            raise ValueError(
+                "k-fold cross validation requires at least one"
+                " train / test split by setting n_folds=2 or more,"
+                " got n_folds=%d.".format(n_folds))
         if n_folds > self.n:
-            raise ValueError("Cannot have number of folds n_folds=%d greater "
-                             "than the number of samples: %d."
-                             % (self.n_folds, self.n))
+            raise ValueError(
+                ("Cannot have number of folds n_folds={0} greater"
+                 "than the number of samples: {1}.").format(n_folds, n))
 
 
 class KFold(_BaseKFold):
@@ -267,7 +270,7 @@ class KFold(_BaseKFold):
         Total number of elements.
 
     n_folds : int, default=3
-        Number of folds.
+        Number of folds. Must be at least 2.
 
     indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean
@@ -355,7 +358,7 @@ class StratifiedKFold(_BaseKFold):
         Samples to split in K folds.
 
     n_folds : int, default=3
-        Number of folds.
+        Number of folds. Must be at least 2.
 
     indices : boolean, optional (default True)
         Return train/test split as arrays of indices, rather than a boolean

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -107,14 +107,18 @@ def test_kfold_valueerrors():
         # a characteristic of the code and not a behavior
         assert_true("The least populated class" in str(w[0]))
 
-    # Error when number of folds is <= 0
+    # Error when number of folds is <= 1
     assert_raises(ValueError, cval.KFold, 2, 0)
+    assert_raises(ValueError, cval.KFold, 2, 1)
+    assert_raises(ValueError, cval.StratifiedKFold, y, 0)
+    assert_raises(ValueError, cval.StratifiedKFold, y, 1)
 
     # When n is not integer:
-    assert_raises(ValueError, cval.KFold, 2.5, 1)
+    assert_raises(ValueError, cval.KFold, 2.5, 2)
 
     # When n_folds is not integer:
     assert_raises(ValueError, cval.KFold, 5, 1.5)
+    assert_raises(ValueError, cval.StratifiedKFold, y, 1.5)
 
 
 def test_kfold_indices():


### PR DESCRIPTION
Users might be confused if they set `n_folds=1` in `KFold` or `StratifiedKFold` as they would get empty training sets that can often results in model fit weird error messages.

This can happen if they naively use `cv=1` in `GridSearchCV` for instance. See: #2048 .
