### PR TITLE
[MRG] refactor partitioning cross-validation strategies

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -14,7 +14,7 @@ import warnings
 from itertools import combinations
 from math import ceil, floor, factorial
 import numbers
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 import scipy.sparse as sp
@@ -225,6 +225,8 @@ class LeavePOut(PartitionIterator):
 
 class BaseKFold(with_metaclass(ABCMeta, PartitionIterator)):
     """Base class to validate KFold approaches"""
+
+    @abstractmethod
     def __init__(self, n, n_folds, indices, k=None):
         super(BaseKFold, self).__init__(n, indices)
         if k is not None:  # pragma: no cover

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -479,7 +479,7 @@ class LeaveOneLabelOut(PartitionIterator):
         return self.n_unique_labels
 
 
-class LeavePLabelOut(object):
+class LeavePLabelOut(PartitionIterator):
     """Leave-P-Label_Out cross-validation iterator
 
     Provides train/test indices to split data according to a third-party
@@ -537,26 +537,20 @@ class LeavePLabelOut(object):
 
     def __init__(self, labels, p, indices=True):
         # We make a copy of labels to avoid side-effects during iteration
+        super(LeavePLabelOut, self).__init__(len(labels), indices)
         self.labels = np.array(labels, copy=True)
         self.unique_labels = unique(labels)
         self.n_unique_labels = len(self.unique_labels)
         self.p = p
-        self.indices = indices
 
-    def __iter__(self):
+    def iter_test_masks(self):
         comb = combinations(range(self.n_unique_labels), self.p)
-        if self.indices:
-            ind = np.arange(len(self.labels))
         for idx in comb:
-            test_index = np.zeros(len(self.labels), dtype=np.bool)
+            test_index = self.empty_mask()
             idx = np.array(idx)
             for l in self.unique_labels[idx]:
                 test_index[self.labels == l] = True
-            train_index = np.logical_not(test_index)
-            if self.indices:
-                train_index = ind[train_index]
-                test_index = ind[test_index]
-            yield train_index, test_index
+            yield test_index
 
     def __repr__(self):
         return '%s.%s(labels=%s, p=%s)' % (

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -223,12 +223,12 @@ class LeavePOut(_PartitionIterator):
                    / factorial(self.p))
 
 
-class BaseKFold(with_metaclass(ABCMeta, _PartitionIterator)):
+class _BaseKFold(with_metaclass(ABCMeta, _PartitionIterator)):
     """Base class to validate KFold approaches"""
 
     @abstractmethod
     def __init__(self, n, n_folds, indices, k=None):
-        super(BaseKFold, self).__init__(n, indices)
+        super(_BaseKFold, self).__init__(n, indices)
         if k is not None:  # pragma: no cover
             warnings.warn("The parameter k was renamed to n_folds and will be"
                           " removed in 0.15.", DeprecationWarning)
@@ -246,7 +246,7 @@ class BaseKFold(with_metaclass(ABCMeta, _PartitionIterator)):
                              % (self.n_folds, self.n))
 
 
-class KFold(BaseKFold):
+class KFold(_BaseKFold):
     """K-Folds cross validation iterator.
 
     Provides train/test indices to split data in train test sets. Split
@@ -334,7 +334,7 @@ class KFold(BaseKFold):
         return self.n_folds
 
 
-class StratifiedKFold(BaseKFold):
+class StratifiedKFold(_BaseKFold):
     """Stratified K-Folds cross validation iterator
 
     Provides train/test indices to split data in train test sets.


### PR DESCRIPTION
There was a lot of repeated code in cross validation `__iter__` methods.

The refactor aims to make the differences between individual strategies clearer by not having them handle masking, negation, etc.
