### PR TITLE
DOC clarify LeavePOut's combinatoric explosion

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -277,8 +277,11 @@ not waste much data as only one sample is removed from the learning set::
 Leave-P-Out - LPO
 -----------------
 
-:class:`LeavePOut` is very similar to *Leave-One-Out*, as it creates all the
-possible training/test sets by removing :math:`P` samples from the complete set.
+:class:`LeavePOut` is very similar to :class:`LeaveOneOut` as it creates all
+the possible training/test sets by removing :math:`p` samples from the complete
+set. For :math:`n` samples, this produces :math:`{n \choose p}` train-test
+pairs. Unlike :class:`LeaveOneOut` and :class:`KFold`, the test sets will
+overlap for :math:`p > 1`.
 
 Example of Leave-2-Out::
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -47,7 +47,8 @@ class LeaveOneOut(object):
     sample is used once as a test set (singleton) while the remaining
     samples form the training set.
 
-    This is equivalent to ``KFold(n, n_folds=n)``.
+    Note: ``LeaveOneOut(n)`` is equivalent to ``KFold(n, n_folds=n)`` and
+    ``LeavePOut(n, p=1)``.
 
     Due to the high number of test sets (which is the same as the
     number of samples) this cross validation method can be very costly.
@@ -125,8 +126,8 @@ class LeavePOut(object):
     in testing on all distinct samples of size p, while the remaining n - p
     samples form the training set in each iteration.
 
-    Note: this is NOT equivalent to ``KFold(n, n_folds=n // p)`` which creates
-    non-overlapping test sets.
+    Note: ``LeavePOut(n, p)`` is NOT equivalent to ``KFold(n, n_folds=n // p)``
+    which creates non-overlapping test sets.
 
     Due to the high number of iterations which grows combinatorically with the
     number of samples this cross validation method can be very costly. For

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -47,6 +47,8 @@ class LeaveOneOut(object):
     sample is used once as a test set (singleton) while the remaining
     samples form the training set.
 
+    This is equivalent to ``KFold(n, n_folds=n)``.
+
     Due to the high number of test sets (which is the same as the
     number of samples) this cross validation method can be very costly.
     For large datasets one should favor KFold, StratifiedKFold or
@@ -119,13 +121,16 @@ class LeaveOneOut(object):
 class LeavePOut(object):
     """Leave-P-Out cross validation iterator
 
-    Provides train/test indices to split data in train test sets. The
-    test set is built using p samples while the remaining samples form
-    the training set.
+    Provides train/test indices to split data in train test sets. This results
+    in testing on all distinct samples of size p, while the remaining n - p
+    samples form the training set in each iteration.
 
-    Due to the high number of iterations which grows with the number of
-    samples this cross validation method can be very costly. For large
-    datasets one should favor KFold, StratifiedKFold or ShuffleSplit.
+    Note: this is NOT equivalent to ``KFold(n, n_folds=n // p)`` which creates
+    non-overlapping test sets.
+
+    Due to the high number of iterations which grows combinatorically with the
+    number of samples this cross validation method can be very costly. For
+    large datasets one should favor KFold, StratifiedKFold or ShuffleSplit.
 
     Parameters
     ----------


### PR DESCRIPTION
`LeavePOut`'s analogy to `LeaveOneOut` needs to be clearer: the former makes _more_ iterations than the latter, not fewer. This clarification intends to avoid confusions like in #2049.
