### PR TITLE
[MRG] refactor feature selection by score

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -25,7 +25,8 @@ from nose.tools import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_raises
-from sklearn.utils.testing import assert_in, assert_less, assert_greater
+from sklearn.utils.testing import (assert_in, assert_less, assert_greater,
+                                   ignore_warnings)
 
 from collections import defaultdict, Mapping
 from functools import partial
@@ -569,6 +570,7 @@ def test_vectorizer_max_features():
         assert_equal(vectorizer.stop_words_, expected_stop_words)
 
 
+@ignore_warnings
 def test_count_vectorizer_max_features():
     """Regression test: max_features didn't work correctly in 0.14."""
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -27,6 +27,8 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..externals.six.moves import xrange
 from ..preprocessing import normalize
+from ..feature_selection import mask_by_score
+from ..utils import atleast2d_or_csc, safe_mask
 from .hashing import FeatureHasher
 from .stop_words import ENGLISH_STOP_WORDS
 from sklearn.externals import six
@@ -38,6 +40,14 @@ __all__ = ['CountVectorizer',
            'strip_accents_ascii',
            'strip_accents_unicode',
            'strip_tags']
+
+
+def document_frequency(X, y=None):
+    """Count non-zero feature values"""
+    X = atleast2d_or_csc(X)
+    if sp.issparse(X):
+        return np.diff(X.indptr)
+    return X.astype(bool).sum(axis=1)
 
 
 def strip_accents_unicode(s):
@@ -667,44 +677,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             vocabulary[term] = new_val
         return cscmatrix[:, map_index]
 
-    def _limit_features(self, cscmatrix, vocabulary, high=None, low=None,
-                        limit=None):
-        """Remove too rare or too common features.
-
-        Prune features that are non zero in more samples than high or less
-        documents than low, modifying the vocabulary, and restricting it to
-        at most the limit most frequent.
-
-        This does not prune samples with zero features.
-        """
-        if high is None and low is None and limit is None:
-            return cscmatrix, set()
-
-        # Calculate a mask based on document frequencies
-        dfs = _document_frequency(cscmatrix)
-        tfs = np.asarray(cscmatrix.sum(axis=0)).ravel()
-        mask = np.ones(len(dfs), dtype=bool)
-        if high is not None:
-            mask &= dfs <= high
-        if low is not None:
-            mask &= dfs >= low
-        if limit is not None and mask.sum() > limit:
-            mask_inds = (-tfs[mask]).argsort()[:limit]
-            new_mask = np.zeros(len(dfs), dtype=bool)
-            new_mask[np.where(mask)[0][mask_inds]] = True
-            mask = new_mask
-
-        new_indices = np.cumsum(mask) - 1  # maps old indices to new
-        removed_terms = set()
-        for term, old_index in list(six.iteritems(vocabulary)):
-            if mask[old_index]:
-                vocabulary[term] = new_indices[old_index]
-            else:
-                del vocabulary[term]
-                removed_terms.add(term)
-        kept_indices = np.where(mask)[0]
-        return cscmatrix[:, kept_indices], removed_terms
-
     def _count_vocab(self, raw_documents, fixed_vocab):
         """Create sparse feature matrix, and vocabulary where fixed_vocab=False
         """
@@ -804,12 +776,20 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")
-            X, self.stop_words_ = self._limit_features(X, vocabulary,
-                                                       max_doc_count,
-                                                       min_doc_count,
-                                                       max_features)
+            mask = mask_by_score(document_frequency(X),
+                                 minimum=min_doc_count,
+                                 maximum=max_doc_count)
+
+            if max_features is not None:
+                tfs = np.asarray(X.sum(axis=0)).ravel()
+                mask[mask] = mask_by_score(tfs[mask], limit=max_features)
+
+            if np.any(~mask):
+                X = X[:, safe_mask(X, mask)]
 
             self.vocabulary_ = vocabulary
+            self.stop_words_ = self.restrict(mask,
+                                             return_removed=True)
 
         return X
 
@@ -870,6 +850,36 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         return [t for t, i in sorted(six.iteritems(self.vocabulary_),
                                      key=itemgetter(1))]
+
+    def restrict(self, support, indices=False, return_removed=False):
+        """Restrict the features to those in support.
+
+        Parameters
+        ----------
+        support : array-like
+            Boolean mask or list of indices (as returned by the get_support
+            member of feature selectors).
+        indices : boolean, optional
+            Whether support is a list of indices.
+        """
+        vocabulary = self.vocabulary_
+        if indices:
+            tmp = np.zeros(len(vocabulary), dtype=bool)
+            tmp[support] = True
+            support = tmp
+
+        new_indices = np.cumsum(support) - 1  # maps old indices to new
+        removed_terms = set()
+        for term, old_index in list(six.iteritems(vocabulary)):
+            if support[old_index]:
+                vocabulary[term] = new_indices[old_index]
+            else:
+                del vocabulary[term]
+                removed_terms.add(term)
+
+        if return_removed:
+            return removed_terms
+        return self
 
 
 def _make_int_array():

--- a/sklearn/feature_selection/__init__.py
+++ b/sklearn/feature_selection/__init__.py
@@ -4,6 +4,9 @@ algorithms. It currently includes univariate filter selection methods and the
 recursive feature elimination algorithm.
 """
 
+from .by_score import mask_by_score
+from .by_score import SelectByScore
+
 from .univariate_selection import chi2
 from .univariate_selection import f_classif
 from .univariate_selection import f_oneway
@@ -23,6 +26,8 @@ from .rfe import RFECV
 __all__ = ['GenericUnivariateSelect',
            'RFE',
            'RFECV',
+           'mask_by_score',
+           'SelectByScore',
            'SelectFdr',
            'SelectFpr',
            'SelectFwe',

--- a/sklearn/feature_selection/by_score.py
+++ b/sklearn/feature_selection/by_score.py
@@ -1,0 +1,241 @@
+"""Utilities for selecting among features where each is assigned some score
+
+Features can be thus selected by:
+    * selecting a limited number of features with the best score
+    * applying a lower or upper bound to the score
+
+These bounding parameters may be expressed absolutely or relative to the data
+so that they may be meaningful when ported to different data.
+"""
+# Authors: Joel Nothman, Gilles Louppe
+# License: BSD 3 clause
+
+import numbers
+from warnings import warn
+
+import numpy as np
+
+from ..externals import six
+from ..base import BaseEstimator
+
+from .base import SelectorMixin
+
+
+THRESHOLD_SUBS = {
+    'mean': np.mean,
+    'median': np.median,
+    'min': np.min,
+    'max': np.max,
+    'sum': np.sum,
+    'length': np.size,
+}
+
+
+###### mask_by_score and its helpers ######
+
+def _calc_threshold(scores, val):
+    if callable(val):
+        return val(scores)
+    elif isinstance(val, six.string_types):
+        res = 1.
+        for part in val.split('*'):
+            try:
+                res *= float(part)
+            except ValueError:
+                try:
+                    part = THRESHOLD_SUBS[part.strip()]
+                except KeyError:
+                    raise ValueError('Unknown reference: %r' % part)
+                else:
+                    res *= part(scores)
+        return res
+    return val
+
+
+def _limit_support(support, scores, limit):
+    """
+    Limits the number of True values in support to limit
+
+    Modifies support in-place: if it had more than limit True values,
+    it will be left with exactly limit True values.
+
+    A positive limit keeps the highest supported scores, while a negative
+    limit keeps the lowest supported scores.
+
+    If limit is a float strictly between 0 and +-1, it will be treated as a
+    proportion of the number of scores.
+
+    In case of tied scores, features with a higher index are selected.
+    """
+    limit, greatest = abs(limit), limit > 0
+    if not isinstance(limit, numbers.Integral):
+        if limit < 0. or limit > 1.:
+            raise ValueError('Float limit must be between 0 and 1')
+        limit = int(limit * len(scores))
+
+    n_support = support.sum()
+    if n_support <= limit:
+        # already meet the limit
+        return
+    elif limit == 0:
+        support[:] = False
+        return
+
+    percentile = 100. * min(limit - 1, n_support - 1) / (n_support - 1)
+    if greatest:
+        percentile = 100. - percentile
+
+    kept_scores = scores[support]
+    if issubclass(scores.dtype.type, np.inexact):
+        nan_sub = getattr(np.finfo(scores.dtype), 'min' if greatest else 'max')
+        kept_scores[np.isnan(kept_scores)] = nan_sub
+    cutoff = np.percentile(kept_scores, percentile)
+
+    # take features strictly better than the cutoff
+    if greatest:
+        support_mask = kept_scores > cutoff
+    else:
+        support_mask = kept_scores < cutoff
+
+    # Because we chose percentile to exactly match some score, there
+    # will always be at least one remaining. Where it matches multiple
+    # score, we may need to arbitrarily break the tie.
+    n_remaining = limit - support_mask.sum()
+    ties = np.where(kept_scores == cutoff)[0]
+    if len(ties) > n_remaining:
+        warn("Tied features are being arbitrarily split. "
+             "There may be duplicate features, or you used a "
+             "classification score for a regression task.")
+    kept_ties = ties[-n_remaining:]
+    support_mask[kept_ties] = True
+
+    # finally, update support
+    support[support] = support_mask
+
+
+def mask_by_score(scores, minimum=None, maximum=None, limit=None):
+    """Calculate a support mask given a set of feature scores and thresholds
+
+    Parameters
+    ----------
+    scores : array-like, shape [number of features]
+        A real number calculated for each feature representing its importance.
+
+    minimum : float, string or callable, optional
+        Where a score is greater than `minimum`, `support` is set to False.
+        If a callable, the value is first calculated by applying to `scores`.
+        If a string, it is interpreted as the product of '*'-delimited
+        expressions, which may be floats or keywords 'mean', 'median', 'min',
+        'max', 'sum' or 'size' which evaluate as functions applied to `scores`.
+
+    maximum : float, string or callable, optional
+        Where a score is greater than `maximum`, `support` is set to False.
+        If a callable, the value is first calculated by applying to `scores`.
+        If a string, it is interpreted as the product of '*'-delimited
+        expressions, which may be floats or keywords 'mean', 'median', 'min',
+        'max', 'sum' or 'size' which evaluate as functions applied to `scores`.
+
+    limit : int, or float, optional
+        Limits the number of returned features. If the value is positive, takes
+        the `limit` highest-scoring features (after `maximum` and `minimum` are
+        applied); if negative, takes the `limit` lowest scoring features.
+        A float (from 0 to 1) is treated as a proportion of the number of
+        features. In case of tied scores, features with a higher index are
+        selected.
+
+    Returns
+    -------
+    support : array of bools, shape=[number of features]
+
+    Examples
+    --------
+    >>> from __future__ import print_function
+    >>> print(mask_by_score([5, 3, 2, 4, 1], maximum=4, limit=2))
+    ...                                        #doctest: +NORMALIZE_WHITESPACE
+    [False True False True False]
+    >>> print(mask_by_score([5, 3, 2, 4, 1], minimum='mean'))
+    ...                                        #doctest: +NORMALIZE_WHITESPACE
+    [ True True False True False]
+    >>> print(mask_by_score([5, 3, 2, 4, 1], limit=0.5))
+    ...                                        #doctest: +NORMALIZE_WHITESPACE
+    [ True False False True False]
+    """
+    scores = np.asarray(scores)
+    support = np.ones(scores.shape, dtype=bool)
+
+    lo = _calc_threshold(scores, minimum)
+    hi = _calc_threshold(scores, maximum)
+    if lo is not None or hi is not None:
+        if lo is not None:
+            support &= scores >= lo
+        if hi is not None:
+            support &= scores <= hi
+
+    if limit is not None:
+        _limit_support(support, scores, limit)
+
+    return support
+
+
+##### Standalone feature selector ######
+
+class SelectByScore(BaseEstimator, SelectorMixin):
+    """Select features according to a single score given to each
+
+    Parameters
+    ----------
+    score_func : callable (X, y) -> array shape=[number of features]
+        A function that calculates a real score for each feature representing
+        its importance.
+
+    minimum : float, string or callable, optional
+        Where a score is greater than `minimum`, `support` is set to False.
+        If a callable, the value is first calculated by applying to `scores`.
+        If a string, it is interpreted as the product of '*'-delimited
+        expressions, which may be floats or keywords 'mean', 'median', 'min',
+        'max', 'sum' or 'size' which evaluate as functions applied to `scores`.
+
+    maximum : float, string or callable, optional
+        Where a score is greater than `maximum`, `support` is set to False.
+        If a callable, the value is first calculated by applying to `scores`.
+        If a string, it is interpreted as the product of '*'-delimited
+        expressions, which may be floats or keywords 'mean', 'median', 'min',
+        'max', 'sum' or 'size' which evaluate as functions applied to `scores`.
+
+    limit : int, or float, optional
+        Limits the number of returned features. If the value is positive, takes
+        the `limit` highest-scoring features (after `maximum` and `minimum` are
+        applied); if negative, takes the `limit` lowest scoring features.
+        A float (from 0 to 1) is treated as a proportion of the number of
+        features.
+
+    Attributes
+    ----------
+    scores_ : array, shape=[number of features]
+        The scores calculated on the given data.
+    """
+    def __init__(self, score_func, minimum=None, maximum=None,
+                 limit=None):
+        self.score_func = score_func
+        self.minimum = minimum
+        self.maximum = maximum
+        self.limit = limit
+
+    def fit(self, X, y=None):
+        """Evaluate the score function on samples X with outputs y.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, n_features]
+            Samples
+
+        y : array-like, shape=[n_features], optional
+            Targets
+        """
+        self.scores_ = self.score_func(X, y)
+        return self
+
+    def _get_support_mask(self):
+        return mask_by_score(self.scores_,
+                             minimum=self.minimum, maximum=self.maximum,
+                             limit=self.limit)

--- a/sklearn/feature_selection/tests/test_by_score.py
+++ b/sklearn/feature_selection/tests/test_by_score.py
@@ -1,0 +1,146 @@
+import warnings
+
+import numpy as np
+
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_raises
+
+from sklearn.feature_selection.by_score import mask_by_score
+from sklearn.feature_selection.by_score import SelectByScore
+
+SCORES = np.array([2, 1, np.nan, 5, 1])
+SCORES_NO_NAN = np.array([2, 1, 0, 5, 1])
+
+
+def test_no_args():
+    assert_equal(mask_by_score(SCORES).dtype, np.bool)
+    assert_array_equal(mask_by_score(SCORES), [1, 1, 1, 1, 1])
+
+
+def test_max_min_number():
+    assert_equal(mask_by_score(SCORES, minimum=2).dtype, np.bool)
+    assert_array_equal(mask_by_score(SCORES, minimum=2), [1, 0, 0, 1, 0])
+    assert_array_equal(mask_by_score(SCORES, minimum=2.1), [0, 0, 0, 1, 0])
+    assert_array_equal(mask_by_score(SCORES, maximum=2), [1, 1, 0, 0, 1])
+    assert_array_equal(mask_by_score(SCORES, maximum=1.9), [0, 1, 0, 0, 1])
+    assert_array_equal(mask_by_score(SCORES, minimum=2, maximum=4),
+                       [1, 0, 0, 0, 0])
+
+
+def test_max_min_string():
+    tests = [
+        ('mean', 1.8),
+        ('.5 * mean', 0.9),
+        ('median', 1.0),
+        ('min', 0.0),
+        ('max', 5.0),
+        ('sum * .5', 4.5),
+        ('length * .5', 2.5),
+    ]
+    for arg, val in tests:
+        print arg, val
+        assert_array_equal(mask_by_score(SCORES_NO_NAN, minimum=arg),
+                           mask_by_score(SCORES_NO_NAN, minimum=val))
+        assert_array_equal(mask_by_score(SCORES_NO_NAN, maximum=arg),
+                           mask_by_score(SCORES_NO_NAN, maximum=val))
+
+
+def test_max_min_callable():
+    val = 2
+
+    def fn(scores):
+        assert_array_equal(scores, SCORES)
+        return 2
+
+    assert_array_equal(mask_by_score(SCORES, minimum=fn),
+                       mask_by_score(SCORES, minimum=val))
+    assert_array_equal(mask_by_score(SCORES, maximum=fn),
+                       mask_by_score(SCORES, maximum=val))
+
+
+def test_limit_int():
+    assert_equal(mask_by_score(SCORES, limit=2).dtype, np.bool)
+    assert_array_equal(mask_by_score(SCORES, limit=2), [1, 0, 0, 1, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=-2), [0, 1, 0, 0, 1])
+
+    # Bounds
+    assert_array_equal(mask_by_score(SCORES, limit=0), [0, 0, 0, 0, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=5), [1, 1, 1, 1, 1])
+    assert_array_equal(mask_by_score(SCORES, limit=10), [1, 1, 1, 1, 1])
+
+    # Tie-breaking
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        top3 = mask_by_score(SCORES, limit=3)
+        assert_equal(top3.sum(), 3)
+        assert_equal((SCORES[top3] == 1).sum(), 1)
+        assert_equal(len(w), 1)
+        del w[:]
+        bottom1 = mask_by_score(SCORES, limit=-1)
+        assert_equal(bottom1.sum(), 1)
+        assert_equal((SCORES[bottom1] == 1).sum(), 1)
+        assert_equal(len(w), 1)
+
+    # Combination with min/maximum
+    assert_array_equal(mask_by_score(SCORES, limit=1, maximum=3),
+                       [1, 0, 0, 0, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=-1, minimum=3),
+                       [0, 0, 0, 1, 0])
+
+    # Checking nan support
+    assert_array_equal(mask_by_score(SCORES, limit=4), [1, 1, 0, 1, 1])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        assert_equal(mask_by_score([np.nan, np.nan], limit=1).sum(), 1)
+        assert_equal(len(w), 1)
+        del w[:]
+
+
+def test_limit_float():
+    assert_raises(ValueError, mask_by_score, SCORES, limit=1.1)
+    assert_raises(ValueError, mask_by_score, SCORES, limit=-1.1)
+    assert_raises(ValueError, mask_by_score, SCORES, limit=2.0)
+    assert_raises(ValueError, mask_by_score, SCORES, limit=-2.0)
+    assert_array_equal(mask_by_score(SCORES, limit=0.4), [1, 0, 0, 1, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=-0.4), [0, 1, 0, 0, 1])
+    assert_array_equal(mask_by_score(SCORES, limit=0.5), [1, 0, 0, 1, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=-0.5), [0, 1, 0, 0, 1])
+
+    # Bounds
+    assert_array_equal(mask_by_score(SCORES, limit=0.0), [0, 0, 0, 0, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=1.0), [1, 1, 1, 1, 1])
+
+    # Tie-breaking
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        top3 = mask_by_score(SCORES, limit=0.6)
+        assert_equal(top3.sum(), 3)
+        assert_equal((SCORES[top3] == 1).sum(), 1)
+        assert_equal(len(w), 1)
+        del w[:]
+        bottom1 = mask_by_score(SCORES, limit=-0.2)
+        assert_equal(bottom1.sum(), 1)
+        assert_equal((SCORES[bottom1] == 1).sum(), 1)
+        assert_equal(len(w), 1)
+
+    # Combination with min/maximum
+    assert_array_equal(mask_by_score(SCORES, limit=0.2, maximum=3),
+                       [1, 0, 0, 0, 0])
+    assert_array_equal(mask_by_score(SCORES, limit=-0.2, minimum=3),
+                       [0, 0, 0, 1, 0])
+
+    # Checking nan support
+    assert_array_equal(mask_by_score(SCORES, limit=0.8), [1, 1, 0, 1, 1])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        assert_equal(mask_by_score([np.nan, np.nan], limit=0.5).sum(), 1)
+        assert_equal(len(w), 1)
+        del w[:]
+
+
+def test_transformer():
+    transformer = SelectByScore(lambda X, y: [5, 3, 2, 4, 1],
+                                minimum=2, maximum=4, limit=2)
+    X = [[10, 20, 30, 40, 50]]
+    assert_array_equal(transformer.fit_transform(X, [1]), [[20, 40]])

--- a/sklearn/feature_selection/tests/test_by_score.py
+++ b/sklearn/feature_selection/tests/test_by_score.py
@@ -1,10 +1,9 @@
-import warnings
-
 import numpy as np
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns
 
 from sklearn.feature_selection.by_score import mask_by_score
 from sklearn.feature_selection.by_score import SelectByScore
@@ -70,17 +69,14 @@ def test_limit_int():
     assert_array_equal(mask_by_score(SCORES, limit=10), [1, 1, 1, 1, 1])
 
     # Tie-breaking
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        top3 = mask_by_score(SCORES, limit=3)
-        assert_equal(top3.sum(), 3)
-        assert_equal((SCORES[top3] == 1).sum(), 1)
-        assert_equal(len(w), 1)
-        del w[:]
-        bottom1 = mask_by_score(SCORES, limit=-1)
-        assert_equal(bottom1.sum(), 1)
-        assert_equal((SCORES[bottom1] == 1).sum(), 1)
-        assert_equal(len(w), 1)
+    top3 = assert_warns(UserWarning, mask_by_score,
+                        SCORES, limit=3)
+    assert_equal(top3.sum(), 3)
+    assert_equal((SCORES[top3] == 1).sum(), 1)
+    bottom1 = assert_warns(UserWarning, mask_by_score,
+                           SCORES, limit=-1)
+    assert_equal(bottom1.sum(), 1)
+    assert_equal((SCORES[bottom1] == 1).sum(), 1)
 
     # Combination with min/maximum
     assert_array_equal(mask_by_score(SCORES, limit=1, maximum=3),
@@ -90,11 +86,8 @@ def test_limit_int():
 
     # Checking nan support
     assert_array_equal(mask_by_score(SCORES, limit=4), [1, 1, 0, 1, 1])
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        assert_equal(mask_by_score([np.nan, np.nan], limit=1).sum(), 1)
-        assert_equal(len(w), 1)
-        del w[:]
+    mask = assert_warns(UserWarning, mask_by_score, [np.nan, np.nan], limit=1)
+    assert_equal(mask.sum(), 1)
 
 
 def test_limit_float():
@@ -112,17 +105,13 @@ def test_limit_float():
     assert_array_equal(mask_by_score(SCORES, limit=1.0), [1, 1, 1, 1, 1])
 
     # Tie-breaking
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        top3 = mask_by_score(SCORES, limit=0.6)
-        assert_equal(top3.sum(), 3)
-        assert_equal((SCORES[top3] == 1).sum(), 1)
-        assert_equal(len(w), 1)
-        del w[:]
-        bottom1 = mask_by_score(SCORES, limit=-0.2)
-        assert_equal(bottom1.sum(), 1)
-        assert_equal((SCORES[bottom1] == 1).sum(), 1)
-        assert_equal(len(w), 1)
+    top3 = assert_warns(UserWarning, mask_by_score, SCORES, limit=0.6)
+    assert_equal(top3.sum(), 3)
+    assert_equal((SCORES[top3] == 1).sum(), 1)
+
+    bottom1 = assert_warns(UserWarning, mask_by_score, SCORES, limit=-0.2)
+    assert_equal(bottom1.sum(), 1)
+    assert_equal((SCORES[bottom1] == 1).sum(), 1)
 
     # Combination with min/maximum
     assert_array_equal(mask_by_score(SCORES, limit=0.2, maximum=3),
@@ -132,11 +121,8 @@ def test_limit_float():
 
     # Checking nan support
     assert_array_equal(mask_by_score(SCORES, limit=0.8), [1, 1, 0, 1, 1])
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        assert_equal(mask_by_score([np.nan, np.nan], limit=0.5).sum(), 1)
-        assert_equal(len(w), 1)
-        del w[:]
+    m = assert_warns(UserWarning, mask_by_score, [np.nan, np.nan], limit=0.5)
+    assert_equal(m.sum(), 1)
 
 
 def test_transformer():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -9,7 +9,7 @@ import warnings
 
 from nose.tools import assert_equal, assert_raises, assert_true
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from sklearn.utils.testing import assert_not_in
+from sklearn.utils.testing import assert_not_in, ignore_warnings
 
 from sklearn.utils import safe_mask
 from sklearn.datasets.samples_generator import (make_classification,
@@ -481,6 +481,7 @@ def test_tied_pvalues():
         assert_not_in(9998, Xt)
 
 
+@ignore_warnings
 def test_tied_scores():
     """Test for stable sorting in k-best with tied scores."""
     X_train = np.array([[0, 0, 0], [1, 1, 1]])

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -7,7 +7,6 @@
 
 
 from abc import ABCMeta, abstractmethod
-from warnings import warn
 from functools import reduce
 
 import numpy as np
@@ -21,19 +20,8 @@ from ..utils import (array2d, as_float_array,
                      safe_mask)
 from ..utils.extmath import norm, safe_sparse_dot
 from ..externals import six
+from .by_score import mask_by_score
 from .base import SelectorMixin
-
-
-def _clean_nans(scores):
-    """
-    Fixes Issue #1240: NaNs can't be properly compared, so change them to the
-    smallest value of scores's dtype. -inf seems to be unreliable.
-    """
-    # XXX where should this function be called? fit? scoring functions
-    # themselves?
-    scores = as_float_array(scores, copy=True)
-    scores[np.isnan(scores)] = np.finfo(scores.dtype).min
-    return scores
 
 
 ######################################################################
@@ -266,9 +254,9 @@ def f_regression(X, y, center=True):
 ######################################################################
 # Base classes
 
-class _BaseFilter(six.with_metaclass(ABCMeta, BaseEstimator,
-                                     SelectorMixin)):
+class _BaseFilter(six.with_metaclass(ABCMeta, BaseEstimator, SelectorMixin)):
 
+    @abstractmethod
     def __init__(self, score_func):
         """ Initialize the univariate feature selection.
 
@@ -284,41 +272,43 @@ class _BaseFilter(six.with_metaclass(ABCMeta, BaseEstimator,
                 "was passed." % (score_func, type(score_func)))
         self.score_func = score_func
 
-    @abstractmethod
-    def fit(self, X, y):
-        """Run score function on (X, y) and get the appropriate features."""
-
-
-class _PvalueFilter(_BaseFilter):
-    def fit(self, X, y):
-        """Evaluate the score function on samples X with outputs y.
-
-        Records and selects features according to the p-values output by the
-        score function.
-        """
-        self.scores_, self.pvalues_ = self.score_func(X, y)
-        self.scores_ = np.asarray(self.scores_)
-        self.pvalues_ = np.asarray(self.pvalues_)
-        return self
-
-
-class _ScoreFilter(_BaseFilter):
     def fit(self, X, y):
         """Evaluate the score function on samples X with outputs y.
 
         Records and selects features according to their scores.
         """
+        if not issparse(X):
+            X = np.asarray(X)
         self.scores_, self.pvalues_ = self.score_func(X, y)
         self.scores_ = np.asarray(self.scores_)
+        if len(self.scores_) != X.shape[1]:
+            raise ValueError("Scores size differs from number of features")
         self.pvalues_ = np.asarray(self.pvalues_)
         return self
+
+
+class _PvalueCutoffFilter(_BaseFilter):
+    def __init__(self, score_func=f_classif, alpha=5e-2):
+        self.alpha = alpha
+        super(_PvalueCutoffFilter, self).__init__(score_func)
+
+    def _get_support_mask(self):
+        return mask_by_score(self.pvalues_, maximum=self._get_threshold())
+
+    def _get_threshold(self):
+        raise NotImplemented
+
+
+class _ScoreLimitFilter(_BaseFilter):
+    def _get_support_mask(self):
+        return mask_by_score(self.scores_, limit=self._get_limit())
 
 
 ######################################################################
 # Specific filters
 ######################################################################
 
-class SelectPercentile(_ScoreFilter):
+class SelectPercentile(_ScoreLimitFilter):
     """Select features according to a percentile of the highest scores.
 
     Parameters
@@ -352,29 +342,15 @@ class SelectPercentile(_ScoreFilter):
         self.percentile = percentile
         super(SelectPercentile, self).__init__(score_func)
 
-    def _get_support_mask(self):
+    def _get_limit(self):
         percentile = self.percentile
         if percentile > 100:
             raise ValueError("percentile should be between 0 and 100"
                              " (%f given)" % (percentile))
-        # Cater for NaNs
-        if percentile == 100:
-            return np.ones(len(self.scores_), dtype=np.bool)
-        elif percentile == 0:
-            return np.zeros(len(self.scores_), dtype=np.bool)
-        scores = _clean_nans(self.scores_)
-
-        alpha = stats.scoreatpercentile(scores, 100 - percentile)
-        mask = scores > alpha
-        ties = np.where(scores == alpha)[0]
-        if len(ties):
-            max_feats = len(scores) * percentile // 100
-            kept_ties = ties[:max_feats - mask.sum()]
-            mask[kept_ties] = True
-        return mask
+        return percentile / 100.
 
 
-class SelectKBest(_ScoreFilter):
+class SelectKBest(_ScoreLimitFilter):
     """Select features according to the k highest scores.
 
     Parameters
@@ -406,29 +382,18 @@ class SelectKBest(_ScoreFilter):
         self.k = k
         super(SelectKBest, self).__init__(score_func)
 
-    def _get_support_mask(self):
+    def _get_limit(self):
         k = self.k
         if k == 'all':
-            return np.ones(self.scores_.shape, dtype=bool)
+            return None
         if k > len(self.scores_):
             raise ValueError("Cannot select %d features among %d. "
                              "Use k='all' to return all features."
                              % (k, len(self.scores_)))
-
-        scores = _clean_nans(self.scores_)
-        # XXX This should be refactored; we're getting an array of indices
-        # from argsort, which we transform to a mask, which we probably
-        # transform back to indices later.
-        mask = np.zeros(scores.shape, dtype=bool)
-
-        # Request a stable sort. Mergesort takes more memory (~40MB per
-        # megafeature on x86-64), but blows heapsort out of the water in
-        # terms of speed.
-        mask[np.argsort(scores, kind="mergesort")[-k:]] = 1
-        return mask
+        return int(k)
 
 
-class SelectFpr(_PvalueFilter):
+class SelectFpr(_PvalueCutoffFilter):
     """Filter: Select the pvalues below alpha based on a FPR test.
 
     FPR test stands for False Positive Rate test. It controls the total
@@ -452,16 +417,11 @@ class SelectFpr(_PvalueFilter):
         p-values of feature scores.
     """
 
-    def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
-        super(SelectFpr, self).__init__(score_func)
-
-    def _get_support_mask(self):
-        alpha = self.alpha
-        return self.pvalues_ < alpha
+    def _get_threshold(self):
+        return self.alpha
 
 
-class SelectFdr(_PvalueFilter):
+class SelectFdr(_PvalueCutoffFilter):
     """Filter: Select the p-values for an estimated false discovery rate
 
     This uses the Benjamini-Hochberg procedure. ``alpha`` is the target false
@@ -486,18 +446,12 @@ class SelectFdr(_PvalueFilter):
         p-values of feature scores.
     """
 
-    def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
-        super(SelectFdr, self).__init__(score_func)
-
-    def _get_support_mask(self):
-        alpha = self.alpha
+    def _get_threshold(self):
         sv = np.sort(self.pvalues_)
-        threshold = sv[sv < alpha * np.arange(len(self.pvalues_))].max()
-        return self.pvalues_ <= threshold
+        return sv[sv < self.alpha * np.arange(len(sv))].max()
 
 
-class SelectFwe(_PvalueFilter):
+class SelectFwe(_PvalueCutoffFilter):
     """Filter: Select the p-values corresponding to Family-wise error rate
 
     Parameters
@@ -518,13 +472,8 @@ class SelectFwe(_PvalueFilter):
         p-values of feature scores.
     """
 
-    def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
-        super(SelectFwe, self).__init__(score_func)
-
-    def _get_support_mask(self):
-        alpha = self.alpha
-        return (self.pvalues_ < alpha / len(self.pvalues_))
+    def _get_threshold(self):
+        return self.alpha / len(self.pvalues_)
 
 
 ######################################################################
@@ -533,7 +482,7 @@ class SelectFwe(_PvalueFilter):
 
 # TODO this class should fit on either p-values or scores,
 # depending on the mode.
-class GenericUnivariateSelect(_PvalueFilter):
+class GenericUnivariateSelect(_BaseFilter):
     """Univariate feature selector with configurable strategy.
 
     Parameters

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -49,7 +49,7 @@ dont_test = ['SparseCoder', 'EllipticEnvelope', 'EllipticEnvelop',
              'DictVectorizer', 'LabelBinarizer', 'LabelEncoder',
              'TfidfTransformer', 'IsotonicRegression', 'OneHotEncoder',
              'RandomTreesEmbedding', 'FeatureHasher', 'DummyClassifier',
-             'DummyRegressor', 'TruncatedSVD']
+             'DummyRegressor', 'TruncatedSVD', 'SelectByScore']
 
 
 def test_all_estimators():


### PR DESCRIPTION
A number of places across the package perform feature selection by score, bounding the scores (specified absolutely or relatively) and/or limiting the number of features (specified absolutely or relatively).

While I think a `mask_by_score` utility could be useful for anyone playing with feature selection, I have particularly used it to assure correctness and common functionality in the many places this selection appears (univariate selection, learnt selector mixin, randomized l1, feature extraction).

I am not sure whether `mask_by_score`, or its realisation as a transformer, `SelectByScore`, should be part of the public API, or how they might come into examples or narrative documentation, and opinions are certainly welcome. It may be confusing that `univariate_selection` is also selection by score, but there the `score_func` returns both scores and p-values, and here we don't care what the scores are as long as they are orderable.

And I apologize for not having a negative total line count (but I think we lose a couple of lines if we remove comments, tests and blank lines)!
