### PR TITLE
Fixes #2039 Image in tutorial misaligned

### DIFF
--- a/examples/neighbors/plot_classification.py
+++ b/examples/neighbors/plot_classification.py
@@ -47,8 +47,9 @@ for weights in ['uniform', 'distance']:
 
     # Plot also the training points
     pl.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap_bold)
+    pl.xlim(xx.min(), xx.max())
+    pl.ylim(yy.min(), yy.max())
     pl.title("3-Class classification (k = %i, weights = '%s')"
              % (n_neighbors, weights))
-    pl.axis('tight')
 
 pl.show()


### PR DESCRIPTION
![figure_2](https://f.cloud.github.com/assets/1563421/722960/606f5f96-e00c-11e2-982a-3d5b14b43c47.png)
...(). pl.axis('tight') appears to be adding whitespace around the colormesh
