### PR TITLE
[MRG] Text dataset loader / vectorizer fixes

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -470,6 +470,59 @@ feature extractor with a classifier:
  * :ref:`example_grid_search_text_feature_extraction.py`
 
 
+Decoding text files
+-------------------
+Text is made of characters, but files are made of bytes. In Unicode,
+there are many more possible characters than possible bytes. Every text
+file is *encoded* so that its characters can be represented as bytes.
+
+When you work with text in Python, it should be Unicode. Most of the
+text feature extractors in scikit-learn will only work with Unicode. So
+to correctly load text from a file (or from the network), you need to
+decode it with the correct encoding.
+
+An encoding can also be called a 'charset' or 'character set', though
+this terminology is less accurate. The :class:`CountVectorizer` takes
+a ``charset`` parameter to tell it what encoding to decode text from.
+
+For modern text files, the correct encoding is probably UTF-8. The
+:class:`CountVectorizer` has ``charset='utf-8'`` as the default. If the
+text you are loading is not actually encoded with UTF-8, however, you
+will get a ``UnicodeDecodeError``.
+
+If you are having trouble decoding text, here are some things to try:
+
+- Find out what the actual encoding of the text is. The file might come
+  with a header that tells you the encoding, or there might be some
+  standard encoding you can assume based on where the text comes from.
+
+- You may be able to find out what kind of encoding it is in general
+  using the UNIX command ``file``. The Python ``chardet`` module comes with
+  a script called ``chardetect.py`` that will guess the specific encoding,
+  though you cannot rely on its guess being correct.
+
+- You could try UTF-8 and disregard the errors. You can decode byte
+  strings with ``bytes.decode(errors='replace')`` to replace all
+  decoding errors with a meaningless character, or set
+  ``charset_error='replace'`` in the vectorizer. This may damage the
+  usefulness of your features.
+
+- Real text may come from a variety of sources that may have used different
+  encodings, or even be sloppily decoded in a different encoding than the
+  one it was encoded with. This is common in text retrieved from the Web.
+  The Python package `ftfy`_ can automatically sort out some classes of
+  decoding errors, so you could try decoding the unknown text as ``latin-1``
+  and then using ``ftfy`` to fix errors.
+
+- If the text is in a mish-mash of encodings that is simply too hard to sort
+  out (which is the case for the 20 Newsgroups dataset), you can fall back on
+  a simple single-byte encoding such as ``latin-1``. Some text may display
+  incorrectly, but at least the same sequence of bytes will always represent
+  the same feature.
+
+.. _`ftfy`: http://github.com/LuminosoInsight/python-ftfy 
+
+
 Applications and examples
 -------------------------
 
@@ -565,58 +618,6 @@ the local structure of sentences and paragraphs should thus be taken
 into account. Many such models will thus be casted as "Structured output"
 problems which are currently outside of the scope of scikit-learn.
 
-
-Decoding text files
--------------------
-Text is made of characters, but files are made of bytes. In Unicode,
-there are many more possible characters than possible bytes. Every text
-file is *encoded* so that its characters can be represented as bytes.
-
-When you work with text in Python, it should be Unicode. Most of the
-text feature extractors in scikit-learn will only work with Unicode. So
-to correctly load text from a file (or from the network), you need to
-decode it with the correct encoding.
-
-An encoding can also be called a 'charset' or 'character set', though
-this terminology is less accurate. The :class:`CountVectorizer` takes
-a ``charset`` parameter to tell it what encoding to decode text from.
-
-For modern text files, the correct encoding is probably UTF-8. The
-:class:`CountVectorizer` has ``charset='utf-8'`` as the default. If the
-text you are loading is not actually encoded with UTF-8, however, you
-will get a ``UnicodeDecodeError``.
-
-If you are having trouble decoding text, here are some things to try:
-
-- Find out what the actual encoding of the text is. The file might come
-  with a header that tells you the encoding, or there might be some
-  standard encoding you can assume based on where the text comes from.
-
-- You may be able to find out what kind of encoding it is in general
-  using the UNIX command ``file``. The Python ``chardet`` module comes with
-  a script called ``chardetect.py`` that will guess the specific encoding,
-  though you cannot rely on its guess being correct.
-
-- You could try UTF-8 and disregard the errors. You can decode byte
-  strings with ``bytes.decode(errors='replace')`` to replace all
-  decoding errors with a meaningless character, or set
-  ``charset_error='replace'`` in the vectorizer. This may damage the
-  usefulness of your features.
-
-- Real text may come from a variety of sources that may have used different
-  encodings, or even be sloppily decoded in a different encoding than the
-  one it was encoded with. This is common in text retrieved from the Web.
-  The Python package `ftfy`_ can automatically sort out some classes of
-  decoding errors, so you could try decoding the unknown text as ``latin-1``
-  and then using ``ftfy`` to fix errors.
-
-- If the text is in a mish-mash of encodings that is simply too hard to sort
-  out (which is the case for the 20 Newsgroups dataset), you can fall back on
-  a simple single-byte encoding such as ``latin-1``. Some text may display
-  incorrectly, but at least the same sequence of bytes will always represent
-  the same feature.
-
-.. _`ftfy`: http://github.com/LuminosoInsight/python-ftfy 
 
 .. _hashing_vectorizer:
 

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -566,6 +566,58 @@ into account. Many such models will thus be casted as "Structured output"
 problems which are currently outside of the scope of scikit-learn.
 
 
+Decoding text files
+-------------------
+Text is made of characters, but files are made of bytes. In Unicode,
+there are many more possible characters than possible bytes. Every text
+file is *encoded* so that its characters can be represented as bytes.
+
+When you work with text in Python, it should be Unicode. Most of the
+text feature extractors in scikit-learn will only work with Unicode. So
+to correctly load text from a file (or from the network), you need to
+decode it with the correct encoding.
+
+An encoding can also be called a 'charset' or 'character set', though
+this terminology is less accurate. The :class:`CountVectorizer` takes
+a ``charset`` parameter to tell it what encoding to decode text from.
+
+For modern text files, the correct encoding is probably UTF-8. The
+:class:`CountVectorizer` has ``charset='utf-8'`` as the default. If the
+text you are loading is not actually encoded with UTF-8, however, you
+will get a ``UnicodeDecodeError``.
+
+If you are having trouble decoding text, here are some things to try:
+
+- Find out what the actual encoding of the text is. The file might come
+  with a header that tells you the encoding, or there might be some
+  standard encoding you can assume based on where the text comes from.
+
+- You may be able to find out what kind of encoding it is in general
+  using the UNIX command ``file``. The Python ``chardet`` module comes with
+  a script called ``chardetect.py`` that will guess the specific encoding,
+  though you cannot rely on its guess being correct.
+
+- You could try UTF-8 and disregard the errors. You can decode byte
+  strings with ``bytes.decode(errors='replace')`` to replace all
+  decoding errors with a meaningless character, or set
+  ``charset_error='replace'`` in the vectorizer. This may damage the
+  usefulness of your features.
+
+- Real text may come from a variety of sources that may have used different
+  encodings, or even be sloppily decoded in a different encoding than the
+  one it was encoded with. This is common in text retrieved from the Web.
+  The Python package `ftfy`_ can automatically sort out some classes of
+  decoding errors, so you could try decoding the unknown text as ``latin-1``
+  and then using ``ftfy`` to fix errors.
+
+- If the text is in a mish-mash of encodings that is simply too hard to sort
+  out (which is the case for the 20 Newsgroups dataset), you can fall back on
+  a simple single-byte encoding such as ``latin-1``. Some text may display
+  incorrectly, but at least the same sequence of bytes will always represent
+  the same feature.
+
+.. _`ftfy`: http://github.com/LuminosoInsight/python-ftfy 
+
 .. _hashing_vectorizer:
 
 Vectorizing a large text corpus with the hashing trick

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -10,6 +10,7 @@ Base IO code for all datasets
 import os
 import csv
 import shutil
+import warnings
 from os import environ
 from os.path import dirname
 from os.path import join
@@ -65,7 +66,8 @@ def clear_data_home(data_home=None):
 
 def load_files(container_path, description=None, categories=None,
                load_content=True, shuffle=True, charset=None,
-               charse_error='strict', random_state=0):
+               charset_error='strict', random_state=0,
+               charse_error=None):
     """Load text files with categories as subfolder names.
 
     Individual samples are assumed to be files stored a two levels folder
@@ -148,6 +150,14 @@ def load_files(container_path, description=None, categories=None,
         'target_names', the meaning of the labels, and 'DESCR', the full
         description of the dataset.
     """
+    # In 0.13, the parameter named 'charset_error' was typoed as
+    # 'charse_error'. Check that parameter for backward compatibility.
+    if charse_error is not None:
+        warnings.warn("The parameter 'charse_error' was renamed to"
+                      " 'charset_error' and will be removed in 0.16.",
+                      DeprecationWarning)
+        charset_error = charse_error
+
     target = []
     target_names = []
     filenames = []
@@ -180,7 +190,7 @@ def load_files(container_path, description=None, categories=None,
     if load_content:
         data = [open(filename, 'rb').read() for filename in filenames]
         if charset is not None:
-            data = [d.decode(charset, charse_error) for d in data]
+            data = [d.decode(charset, charset_error) for d in data]
         return Bunch(data=data,
                      filenames=filenames,
                      target_names=target_names,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -84,19 +84,25 @@ def load_files(container_path, description=None, categories=None,
                 file_44.txt
                 ...
 
-    The folder names are used has supervised signal label names. The indivial
-    file names are not important.
+    The folder names are used has supervised signal label names. The
+    individual file names are not important.
 
     This function does not try to extract features into a numpy array or
     scipy sparse matrix. In addition, if load_content is false it
     does not try to load the files in memory.
 
-    To use utf-8 text files in a scikit-learn classification or clustering
-    algorithm you will first need to use the `sklearn.features.text`
+    To use text files in a scikit-learn classification or clustering
+    algorithm, you will need to use the `sklearn.feature_extraction.text`
     module to build a feature extraction transformer that suits your
     problem.
 
-    Similar feature extractors should be build for other kind of unstructured
+    If you set load_content=True, you should also specify the encoding of
+    the text using the 'charset' parameter. For many modern text files,
+    'utf-8' will be the correct encoding. If you leave charset equal to None,
+    then the content will be made of bytes instead of Unicode, and you will
+    not be able to use most functions in `sklearn.feature_extraction.text`.
+
+    Similar feature extractors should be built for other kind of unstructured
     data input such as images, audio, video, ...
 
     Parameters


### PR DESCRIPTION
This branch contains some straightforward revisions to text handling stuff that I talked about with ogrisel at the SciPy sprint.

Most of the changes are in documentation. The only code change here is to rename the parameter "charse_errors" to "charset_errors" in load_files.
