### PR TITLE
[MRG] Add filters on newsgroup text for the 20newsgroups evaluation.

### DIFF
--- a/doc/datasets/twenty_newsgroups.rst
+++ b/doc/datasets/twenty_newsgroups.rst
@@ -79,6 +79,9 @@ list of the categories to load to the ``fetch_20newsgroups`` function::
   >>> newsgroups_train.target[:10]
   array([1, 1, 1, 0, 1, 0, 0, 1, 1, 1])
 
+Converting text to vectors
+--------------------------
+
 In order to feed predictive or clustering models with the text data,
 one first need to turn the text into vectors of numerical values suitable
 for statistical analysis. This can be achieved with the utilities of the
@@ -86,19 +89,19 @@ for statistical analysis. This can be achieved with the utilities of the
 example that extract `TF-IDF`_ vectors of unigram tokens::
 
 
-  >>> from sklearn.feature_extraction.text import Vectorizer
-  >>> documents = [open(f).read() for f in newsgroups_train.filenames]
-  >>> vectorizer = Vectorizer()
-  >>> vectors = vectorizer.fit_transform(documents)
+  >>> from sklearn.feature_extraction.text import TfidfVectorizer
+  >>> newsgroups_train = fetch_20newsgroups(subset='train')
+  >>> vectorizer = TfidfVectorizer()
+  >>> vectors = vectorizer.fit_transform(newsgroups_train.data)
   >>> vectors.shape
-  (1073, 21108)
+  (11314, 129792)
 
-The extracted TF-IDF vectors are very sparse with an average of 118 non zero
+The extracted TF-IDF vectors are very sparse, with an average of 110 non zero
 components by sample in a more than 20000 dimensional space (less than 1% non
 zero features)::
 
   >>> vectors.nnz / vectors.shape[0]
-  118
+  110
 
 ``sklearn.datasets.fetch_20newsgroups_vectorized`` is a function which returns
 ready-to-use tfidf features instead of file names.
@@ -106,6 +109,116 @@ ready-to-use tfidf features instead of file names.
 .. _`20 newsgroups website`: http://people.csail.mit.edu/jrennie/20Newsgroups/
 .. _`TF-IDF`: http://en.wikipedia.org/wiki/Tf-idf
 
+
+Filtering text for more realistic training
+------------------------------------------
+It is easy for a classifier to overfit on particular things that appear in the
+20 Newsgroups data, such as newsgroup headers. Many classifiers achieve very
+high F-scores, but their results would not generalize to other documents that
+aren't from this window of time.
+
+For example, let's look at the results of a Bernoulli Naive Bayes classifier,
+which is fast to train and achieves a decent F-score::
+
+  >>> from sklearn.naive_bayes import BernoulliNB
+  >>> from sklearn import metrics
+  >>> newsgroups_test = fetch_20newsgroups(subset='test')
+  >>> vectors_test = vectorizer.transform(newsgroups_test.data)
+  >>> clf = BernoulliNB(alpha=.01)
+  >>> clf.fit(vectors, newsgroups_train.target)
+  >>> pred = clf.predict(vectors_test)
+  >>> metrics.f1_score(pred, newsgroups_test.target)
+  0.78117467868044399
+
+(The example :ref:`example_document_classification_20newsgroups.py` shuffles
+the training and test data, instead of segmenting by time, and in that case
+Bernoulli Naive Bayes gets a much higher F-score of 0.88. Are you suspicious
+yet of what's going on inside this classifier?)
+
+Let's take a look at what the most informative features are:
+
+  >>> import numpy as np
+  >>> def show_top10(classifier, vectorizer, categories):
+  ...     feature_names = np.asarray(vectorizer.get_feature_names())
+  ...     for i, category in enumerate(categories):
+  ...         top10 = np.argsort(classifier.coef_[i])[-10:]
+  ...         print("%s: %s" % (category, " ".join(feature_names[top10])))
+  ...  
+  >>> show_top10(clf, vectorizer, newsgroups_train.target_names)
+  alt.atheism: god say think people don com nntp host posting article
+  comp.graphics: like com article know thanks graphics university nntp host posting
+  comp.os.ms-windows.misc: know thanks use com article nntp host posting university windows
+  comp.sys.ibm.pc.hardware: just does article know thanks com university nntp host posting
+  comp.sys.mac.hardware: thanks does apple know article mac university nntp host posting
+  comp.windows.x: like article use reply thanks window com nntp posting host
+  misc.forsale: com usa mail new distribution nntp host posting university sale
+  rec.autos: distribution like just university nntp host posting car article com
+  rec.motorcycles: don just like bike nntp host posting dod com article
+  rec.sport.baseball: think just year com baseball host nntp posting university article
+  rec.sport.hockey: nhl game hockey team nntp host article ca posting university
+  sci.crypt: just nntp host encryption posting article chip key clipper com
+  sci.electronics: does like know university use article com nntp host posting
+  sci.med: like reply university nntp don host know posting com article
+  sci.space: nasa like university just com nntp host posting space article
+  soc.religion.christian: just don like rutgers know university article think people god
+  talk.politics.guns: like university don gun people nntp host posting article com
+  talk.politics.mideast: like just nntp host israeli university posting israel people article
+  talk.politics.misc: like university nntp host just don posting people com article
+  talk.religion.misc: think know christian posting god people just don article com
+
+You can now see many things that these features have overfit to:
+
+- Almost every group is distinguished by whether headers such as
+  ``NNTP-Posting-Host:`` and ``Distribution:`` appear more or less often.
+- Another significant feature involves whether the sender is affiliated with
+  a university, as indicated either by their headers or their signature.
+- The word "article" is a significant feature, based on how often people quote
+  previous posts like this: "In article [article ID], [name] <[e-mail address]>
+  wrote:"
+- Other features match the names and e-mail addresses of particular people who
+  were posting at the time.
+
+With such an abundance of clues that distinguish newsgroups, the classifiers
+barely have to identify topics from text at all, and they all perform at the
+same high level.
+
+For this reason, the functions that load 20 Newsgroups data provide a
+parameter called **remove**, telling it what kinds of information to strip out
+of each file. **remove** should be a tuple containing any subset of
+``('headers', 'footers', 'quotes')``, telling it to remove headers, signature
+blocks, and quotation blocks respectively.
+
+  >>> newsgroups_test = fetch_20newsgroups(subset='test', 
+  ...                                      remove=('headers', 'footers', 'quotes'))
+  >>> vectors_test = vectorizer.transform(newsgroups_test.data)
+  >>> pred = clf.predict(vectors_test)
+  >>> metrics.f1_score(pred, newsgroups_test.target)
+  0.51830104911679742
+
+This classifier lost over a third of its F-score, just because we removed
+metadata that has little to do with topic classification. It recovers only a
+bit if we also strip this metadata from the training data:
+
+  >>> newsgroups_train = fetch_20newsgroups(subset='train',
+                                            remove=('headers', 'footers', 'quotes'))
+  >>> vectors = vectorizer.fit_transform(newsgroups_train.data)
+  >>> clf = BernoulliNB(alpha=.01)
+  >>> clf.fit(vectors, newsgroups_train.target)
+  >>> vectors_test = vectorizer.transform(newsgroups_test.data)
+  >>> pred = clf.predict(vectors_test)
+  >>> metrics.f1_score(pred, newsgroups_test.target)
+  0.56907392353755404
+
+Some other classifiers cope better with this harder version of the task. Try
+running :ref:`example_grid_search_text_feature_extraction.py` with and without
+the ``--filter`` option to compare the results.
+
+.. topic:: Recommendation
+
+  When evaluating natural language classifiers on the 20 Newsgroups data, you
+  should strip newsgroup-related metadata. In scikit-learn, you can do this by
+  setting ``remove=('headers', 'footers', 'quotes')``. The F-score will be
+  lower because it is more realistic.
 
 .. topic:: Examples
 

--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -76,7 +76,10 @@ op.add_option("--use_hashing",
 op.add_option("--n_features",
               action="store", type=int, default=2 ** 16,
               help="n_features when using the hashing vectorizer.")
-
+op.add_option("--filtered",
+              action="store_true",
+              help="Remove newsgroup information that is easily overfit: "
+                   "headers, signatures, and quoting.")
 
 (opts, args) = op.parse_args()
 if len(args) > 0:
@@ -100,14 +103,21 @@ else:
         'sci.space',
     ]
 
+if opts.filtered:
+    remove = ('headers', 'footers', 'quotes')
+else:
+    remove = ()
+
 print("Loading 20 newsgroups dataset for categories:")
 print(categories if categories else "all")
 
 data_train = fetch_20newsgroups(subset='train', categories=categories,
-                                shuffle=True, random_state=42)
+                                shuffle=True, random_state=42,
+                                remove=remove)
 
 data_test = fetch_20newsgroups(subset='test', categories=categories,
-                               shuffle=True, random_state=42)
+                               shuffle=True, random_state=42,
+                               remove=remove)
 print('data loaded')
 
 categories = data_train.target_names    # for case categories == None

--- a/examples/document_classification_20newsgroups.py
+++ b/examples/document_classification_20newsgroups.py
@@ -121,7 +121,7 @@ data_test_size_mb = size_mb(data_test.data)
 
 print("%d documents - %0.3fMB (training set)" % (
     len(data_train.data), data_train_size_mb))
-print("%d documents - %0.3fMB (training set)" % (
+print("%d documents - %0.3fMB (test set)" % (
     len(data_test.data), data_test_size_mb))
 print("%d categories" % len(categories))
 print()
@@ -288,7 +288,7 @@ clf_names, score, training_time, test_time = results
 training_time = np.array(training_time) / np.max(training_time)
 test_time = np.array(test_time) / np.max(test_time)
 
-pl.figure(figsize=(12,10))
+pl.figure(figsize=(12,8))
 pl.title("Score")
 pl.barh(indices, score, .2, label="score", color='r')
 pl.barh(indices + .3, training_time, .2, label="training time", color='g')

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -41,6 +41,7 @@ import logging
 import tarfile
 import pickle
 import shutil
+import re
 
 import numpy as np
 import scipy.sparse as sp
@@ -92,10 +93,54 @@ def download_20newsgroups(target_dir, cache_path):
     return cache
 
 
+def strip_newsgroup_header(text):
+    """
+    Given text in "news" format, strip the headers, by removing everything
+    before the first blank line.
+    """
+    _before, _blankline, after = text.partition(u'\n\n')
+    return after
+
+
+_QUOTE_RE = re.compile(ur'(writes in|writes:|wrote:|says:|said:'
+                      ur'|^In article|^Quoted from|^\||^>)')
+
+def strip_newsgroup_quoting(text):
+    """
+    Given text in "news" format, strip lines beginning with the quote
+    characters > or |, plus lines that often introduce a quoted section
+    (for example, because they contain the string 'writes:'.)
+    """
+    good_lines = [line for line in text.split(u'\n')
+                  if not _QUOTE_RE.search(line)]
+    return u'\n'.join(good_lines)
+
+
+def strip_newsgroup_footer(text):
+    """
+    Given text in "news" format, attempt to remove a signature block.
+
+    As a rough heuristic, we assume that signatures are set apart by either
+    a blank line or a line made of hyphens, and that it is the last such line
+    in the file (disregarding blank lines at the end).
+    """
+    lines = text.strip().split(u'\n')
+    for line_num in range(len(lines) - 1, -1, -1):
+        line = lines[line_num]
+        if line.strip().strip(u'-') == u'':
+            break
+
+    if line_num > 0:
+        return u'\n'.join(lines[:line_num])
+    else:
+        return text
+
+
 def fetch_20newsgroups(data_home=None, subset='train', categories=None,
                        shuffle=True, random_state=42,
+                       remove=(),
                        download_if_missing=True):
-    """Load the filenames of the 20 newsgroups dataset.
+    """Load the filenames and data from the 20 newsgroups dataset.
 
     Parameters
     ----------
@@ -123,6 +168,19 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     download_if_missing: optional, True by default
         If False, raise an IOError if the data is not locally available
         instead of trying to download the data from the source site.
+
+    remove: tuple
+        May contain any subset of ('headers', 'footers', 'quotes'). Each of
+        these are kinds of text that will be detected and removed from the
+        newsgroup posts, preventing classifiers from overfitting on
+        metadata.
+
+        'headers' removes newsgroup headers, 'footers' removes blocks at the
+        ends of posts that look like signatures, and 'quotes' removes lines
+        that appear to be quoting another post.
+
+        'headers' follows an exact standard; the other filters are not always
+        correct.
     """
 
     data_home = get_data_home(data_home=data_home)
@@ -165,6 +223,13 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         raise ValueError(
             "subset can only be 'train', 'test' or 'all', got '%s'" % subset)
 
+    if 'headers' in remove:
+        data.data = [strip_newsgroup_header(text) for text in data.data]
+    if 'footers' in remove:
+        data.data = [strip_newsgroup_footer(text) for text in data.data]
+    if 'quotes' in remove:
+        data.data = [strip_newsgroup_quoting(text) for text in data.data]
+
     if categories is not None:
         labels = [(data.target_names.index(cat), cat) for cat in categories]
         # Sort the categories to have the ordering of the labels
@@ -195,7 +260,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     return data
 
 
-def fetch_20newsgroups_vectorized(subset="train", data_home=None):
+def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None):
     """Load the 20 newsgroups dataset and transform it into tf-idf vectors.
 
     This is a convenience function; the tf-idf transformation is done using the
@@ -214,6 +279,16 @@ def fetch_20newsgroups_vectorized(subset="train", data_home=None):
         Specify an download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
+    remove: tuple
+        May contain any subset of ('headers', 'footers', 'quotes'). Each of
+        these are kinds of text that will be detected and removed from the
+        newsgroup posts, preventing classifiers from overfitting on
+        metadata.
+
+        'headers' removes newsgroup headers, 'footers' removes blocks at the
+        ends of posts that look like signatures, and 'quotes' removes lines
+        that appear to be quoting another post.
+
     Returns
     -------
 
@@ -223,20 +298,25 @@ def fetch_20newsgroups_vectorized(subset="train", data_home=None):
         bunch.target_names: list, length [n_classes]
     """
     data_home = get_data_home(data_home=data_home)
-    target_file = os.path.join(data_home, "20newsgroup_vectorized.pk")
+    filebase = '20newsgroup_vectorized'
+    if remove:
+        filebase += 'remove-' + ('-'.join(remove))
+    target_file = os.path.join(data_home, filebase + ".pk")
 
     # we shuffle but use a fixed seed for the memoization
     data_train = fetch_20newsgroups(data_home=data_home,
                                     subset='train',
                                     categories=None,
                                     shuffle=True,
-                                    random_state=12)
+                                    random_state=12,
+                                    remove=remove)
 
     data_test = fetch_20newsgroups(data_home=data_home,
                                    subset='test',
                                    categories=None,
                                    shuffle=True,
-                                   random_state=12)
+                                   random_state=12,
+                                   remove=remove)
 
     if os.path.exists(target_file):
         X_train, X_test = joblib.load(target_file)


### PR DESCRIPTION
It is easy to overfit on the 20newsgroups dataset, by letting classifiers learn from metadata that commonly appears in newsgroup texts, but would be useless for identifying topics outside of this set of newsgroups in 1993.

For example, many classifiers will tell you that three of the most informative features are "nntp", "posting", and "host", because the NNTP-Posting-Host header appears with different frequency in different groups.

The fetch_20newsgroups function now allows you to ask for any of the following kinds of text to be removed:
- Newsgroup headers (which contain lots of NNTP metadata that can identify the group)
- Signature blocks (which often contain multiple terms that uniquely identify the person posting, which in turn identifies the group)
- Quote blocks (which contain people's e-mail addresses and large amounts of text from another post in the same newsgroup)

The 20newsgroups classification example takes the "--filtered" flag, which will remove all of these. This noticeably decreases the accuracy of all classifiers, leaving room for a better method to improve the accuracy.
