### PR TITLE
DOC fix in the hierarchical clustering

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -74,7 +74,7 @@ def ward_tree(X, connectivity=None, n_components=None, copy=True,
         to leaves of the tree. A greater value `i` indicates a node with
         children `children[i - n_samples]`.
 
-    n_components : sparse matrix.
+    n_components : int
         The number of connected components in the graph.
 
     n_leaves : int


### PR DESCRIPTION
I'm pretty sure that `n_components` is not a sparse matrix but an integer.
