### PR TITLE
[MRG] charset -> encoding in load_files

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -292,7 +292,7 @@ reasonable (please see  the :ref:`reference documentation
   >>> vectorizer = CountVectorizer(min_df=1)
   >>> vectorizer                            # doctest: +NORMALIZE_WHITESPACE
   CountVectorizer(analyzer=u'word', binary=False, charset=u'utf-8',
-          charset_error=u'strict', dtype=<type 'numpy.int64'>,
+          decode_error=u'strict', dtype=<type 'numpy.int64'>,
           input=u'content', lowercase=True, max_df=1.0, max_features=None,
           min_df=1, ngram_range=(1, 1), preprocessor=None, 
           stop_words=None, strip_accents=None,

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -141,6 +141,9 @@ API changes summary
      :class:`cross_validation.StratifiedKFold` now enforce `n_folds >= 2`
      otherwise a ``ValueError`` is raised. By `Olivier Grisel`_.
 
+   - :func:`datasets.load_files`'s ``charset`` and ``charset_errors``
+     parameters were renamed ``encoding`` and ``decode_errors``.
+
 .. _changes_0_13_1:
 
 0.13.1

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -65,9 +65,8 @@ def clear_data_home(data_home=None):
 
 
 def load_files(container_path, description=None, categories=None,
-               load_content=True, shuffle=True, charset=None,
-               charset_error='strict', random_state=0,
-               charse_error=None):
+               load_content=True, shuffle=True, encoding=None,
+               decode_error='strict', random_state=0):
     """Load text files with categories as subfolder names.
 
     Individual samples are assumed to be files stored a two levels folder
@@ -97,8 +96,8 @@ def load_files(container_path, description=None, categories=None,
     problem.
 
     If you set load_content=True, you should also specify the encoding of
-    the text using the 'charset' parameter. For many modern text files,
-    'utf-8' will be the correct encoding. If you leave charset equal to None,
+    the text using the 'encoding' parameter. For many modern text files,
+    'utf-8' will be the correct encoding. If you leave encoding equal to None,
     then the content will be made of bytes instead of Unicode, and you will
     not be able to use most functions in `sklearn.feature_extraction.text`.
 
@@ -124,17 +123,16 @@ def load_files(container_path, description=None, categories=None,
         in the data structure returned. If not, a filenames attribute
         gives the path to the files.
 
-    charset : string or None (default is None)
+    encoding : string or None (default is None)
         If None, do not try to decode the content of the files (e.g. for
         images or other non-text content).
-        If not None, charset to use to decode text files if load_content is
-        True.
+        If not None, encoding to use to decode text files to Unicode if
+        load_content is True.
 
-    charset_error: {'strict', 'ignore', 'replace'}
+    decode_error: {'strict', 'ignore', 'replace'}, optional
         Instruction on what to do if a byte sequence is given to analyze that
-        contains characters not of the given `charset`. By default, it is
-        'strict', meaning that a UnicodeDecodeError will be raised. Other
-        values are 'ignore' and 'replace'.
+        contains characters not of the given `encoding`. Passed as keyword
+        argument 'errors' to bytes.decode.
 
     shuffle : bool, optional (default=True)
         Whether or not to shuffle the data: might be important for models that
@@ -156,14 +154,6 @@ def load_files(container_path, description=None, categories=None,
         'target_names', the meaning of the labels, and 'DESCR', the full
         description of the dataset.
     """
-    # In 0.13, the parameter named 'charset_error' was typoed as
-    # 'charse_error'. Check that parameter for backward compatibility.
-    if charse_error is not None:
-        warnings.warn("The parameter 'charse_error' was renamed to"
-                      " 'charset_error' and will be removed in 0.16.",
-                      DeprecationWarning)
-        charset_error = charse_error
-
     target = []
     target_names = []
     filenames = []
@@ -195,8 +185,8 @@ def load_files(container_path, description=None, categories=None,
 
     if load_content:
         data = [open(filename, 'rb').read() for filename in filenames]
-        if charset is not None:
-            data = [d.decode(charset, charset_error) for d in data]
+        if encoding is not None:
+            data = [d.decode(encoding, decode_error) for d in data]
         return Bunch(data=data,
                      filenames=filenames,
                      target_names=target_names,

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -97,10 +97,10 @@ def test_default_load_files():
 
 
 @nose.tools.with_setup(setup_load_files, teardown_load_files)
-def test_load_files_w_categories_desc_and_charset():
+def test_load_files_w_categories_desc_and_encoding():
     category = os.path.abspath(TEST_CATEGORY_DIR1).split('/').pop()
     res = load_files(LOAD_FILES_ROOT, description="test",
-                     categories=category, charset="utf-8")
+                     categories=category, encoding="utf-8")
     assert_equal(len(res.filenames), 1)
     assert_equal(len(res.target_names), 1)
     assert_equal(res.DESCR, "test")

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -85,8 +85,8 @@ def download_20newsgroups(target_dir, cache_path):
     os.remove(archive_path)
 
     # Store a zipped pickle
-    cache = dict(train=load_files(train_path, charset='latin1'),
-                 test=load_files(test_path, charset='latin1'))
+    cache = dict(train=load_files(train_path, encoding='latin1'),
+                 test=load_files(test_path, encoding='latin1'))
     open(cache_path, 'wb').write(pickle.dumps(cache).encode('zip'))
     shutil.rmtree(target_dir)
     return cache


### PR DESCRIPTION
Fixes #2107. Very quick PR to see if I interpreted the :+1:'s right.

Removed the deprecation of `charse_error`; this isn't going to be pickled anyway. Renamed `charset_error` to `decode_error`, which I think is more suggestive of its meaning than `encoding_error`.
