### PR TITLE
ENH print number of fits in BaseSearchCV._fit

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -485,6 +485,16 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             y = np.asarray(y)
         cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
 
+        if self.verbose > 0:
+            try:
+                n_candidates = len(parameter_iterable)
+            except TypeError:
+                pass
+            else:
+                print("Fitting {0} folds for each of {1} candidates, totalling"
+                      " {2} fits".format(len(cv), n_candidates,
+                                         n_candidates * len(cv)))
+
         base_estimator = clone(self.estimator)
 
         pre_dispatch = self.pre_dispatch


### PR DESCRIPTION
As mentioned on the ML (@robertlayton), this makes the grid search a little bit friendlier by warning you how big your grids are!

It might be nice to have a method that returns the fit count in advance, but it doesn't fit with the current class model and I don't have the time to change that now.

It is also only smoke-tested (and the case where `parameter_iterator` does not have `__len__` is not tested).
