### PR TITLE
clearer decision surface plots and classifier final predictions for the ...

### DIFF
--- a/examples/ensemble/plot_forest_iris.py
+++ b/examples/ensemble/plot_forest_iris.py
@@ -15,22 +15,23 @@ length features only, on the second row using the petal length and sepal length
 only, and on the third row using the petal width and the petal length only.
 
 In descending order of quality, when trained (outside of this example) on all
-4 features using 30 estimators and scored using 10 fold cross validation, we see:
-ExtraTreesClassifier()  # 0.95 score
-RandomForestClassifier()  # 0.94 score
-AdaBoost(DecisionTree(max_depth=3))  # 0.94 score
-DecisionTree(max_depth=None)  # 0.94 score
+4 features using 30 estimators and scored using 10 fold cross validation, we see::
 
-Increasing max_depth for AdaBoost lowers the standard deviation of the scores (but
+    ExtraTreesClassifier()  # 0.95 score
+    RandomForestClassifier()  # 0.94 score
+    AdaBoost(DecisionTree(max_depth=3))  # 0.94 score
+    DecisionTree(max_depth=None)  # 0.94 score``
+
+Increasing `max_depth` for AdaBoost lowers the standard deviation of the scores (but
 the average score does not improve).
 
 See the console's output for further details about each model.
 
 In this example you might try to:
-1) vary the max_depth for the DecisionTreeClassifier and AdaBoostClassifier, perhaps
-   try max_depth=3 for the DecisionTreeClassifier or max_depth=None
+1) vary the `max_depth` for the DecisionTreeClassifier and AdaBoostClassifier, perhaps
+   try ``max_depth=3`` for the DecisionTreeClassifier or ``max_depth=None``
    for AdaBoostClassifier
-2) vary n_estimators
+2) vary `n_estimators`
 
 Remember that RandomForests and ExtraTrees can be fitted in parallel (each tree is
 built independently of the others), AdaBoost's samples are built iteratively.

--- a/examples/ensemble/plot_forest_iris.py
+++ b/examples/ensemble/plot_forest_iris.py
@@ -13,6 +13,27 @@ trees classifier (third column) and by an AdaBoost classifier (fourth column).
 In the first row, the classifiers are built using the sepal width and the sepal
 length features only, on the second row using the petal length and sepal length
 only, and on the third row using the petal width and the petal length only.
+
+In descending order of quality, when trained (outside of this example) on all
+4 features using 30 estimators and scored using 10 fold cross validation, we see:
+ExtraTreesClassifier()  # 0.95 score
+RandomForestClassifier()  # 0.94 score
+AdaBoost(DecisionTree(max_depth=3))  # 0.94 score
+DecisionTree(max_depth=None)  # 0.94 score
+
+Increasing max_depth for AdaBoost lowers the standard deviation of the scores (but
+the average score does not improve).
+
+See the console's output for further details about each model.
+
+In this example you might try to:
+1) vary the max_depth for the DecisionTreeClassifier and AdaBoostClassifier, perhaps
+   try max_depth=3 for the DecisionTreeClassifier or max_depth=None
+   for AdaBoostClassifier
+2) vary n_estimators
+
+Remember that RandomForests and ExtraTrees can be fitted in parallel (each tree is
+built independently of the others), AdaBoost's samples are built iteratively.
 """
 print(__doc__)
 
@@ -29,27 +50,32 @@ from sklearn.tree import DecisionTreeClassifier
 # Parameters
 n_classes = 3
 n_estimators = 30
-plot_colors = "bry"
-plot_step = 0.02
+plot_colors = "ryb"
+cmap = pl.cm.RdYlBu
+plot_step = 0.02  # fine step width for decision surface contours
+plot_step_coarser = 0.5  # step widths for coarse classifier guesses
+RANDOM_SEED = 13  # fix the seed on each iteration
 
 # Load data
 iris = load_iris()
 
 plot_idx = 1
 
+models = [DecisionTreeClassifier(max_depth=None),
+          RandomForestClassifier(n_estimators=n_estimators),
+          ExtraTreesClassifier(n_estimators=n_estimators),
+          AdaBoostClassifier(DecisionTreeClassifier(max_depth=3),
+                             n_estimators=n_estimators)]
+
 for pair in ([0, 1], [0, 2], [2, 3]):
-    for model in (DecisionTreeClassifier(),
-                  RandomForestClassifier(n_estimators=n_estimators),
-                  ExtraTreesClassifier(n_estimators=n_estimators),
-                  AdaBoostClassifier(DecisionTreeClassifier(),
-                                     n_estimators=n_estimators)):
+    for model in models:
         # We only take the two corresponding features
         X = iris.data[:, pair]
         y = iris.target
 
         # Shuffle
         idx = np.arange(X.shape[0])
-        np.random.seed(13)
+        np.random.seed(RANDOM_SEED)
         np.random.shuffle(idx)
         X = X[idx]
         y = y[idx]
@@ -63,37 +89,61 @@ for pair in ([0, 1], [0, 2], [2, 3]):
         clf = clone(model)
         clf = model.fit(X, y)
 
-        # Plot the decision boundary
-        pl.subplot(3, 4, plot_idx)
+        scores = clf.score(X, y)
+        # Create a title for each column and the console by using str() and
+        # slicing away useless parts of the string
+        model_title = str(type(model)).split(".")[-1][:-2][:-len("Classifier")]
+        model_details = model_title
+        if hasattr(model, "estimators_"):
+            model_details += " with {} estimators".format(len(model.estimators_))
+        print model_details + " with features", pair, "has a score of", scores
 
+        pl.subplot(3, 4, plot_idx)
+        if plot_idx <= len(models):
+            # Add a title at the top of each column
+            pl.title(model_title)
+
+        # Now plot the decision boundary using a fine mesh as input to a
+        # filled contour plot
         x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1
         y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
         xx, yy = np.meshgrid(np.arange(x_min, x_max, plot_step),
                              np.arange(y_min, y_max, plot_step))
 
+        # Plot either a single DecisionTreeClassifier or alpha blend the
+        # decision surfaces of the ensemble of classifiers
         if isinstance(model, DecisionTreeClassifier):
             Z = model.predict(np.c_[xx.ravel(), yy.ravel()])
             Z = Z.reshape(xx.shape)
-            cs = pl.contourf(xx, yy, Z, cmap=pl.cm.Paired)
+            cs = pl.contourf(xx, yy, Z, cmap=cmap)
         else:
+            # Choose alpha blend level with respect to the number of estimators
+            # that are in use (noting that AdaBoost can use fewer estimators
+            # than its maximum if it achieves a good enough fit early on)
+            estimator_alpha = 1.0 / len(model.estimators_)
             for tree in model.estimators_:
                 Z = tree.predict(np.c_[xx.ravel(), yy.ravel()])
                 Z = Z.reshape(xx.shape)
-                cs = pl.contourf(xx, yy, Z, alpha=0.1, cmap=pl.cm.Paired)
+                cs = pl.contourf(xx, yy, Z, alpha=estimator_alpha, cmap=cmap)
 
-        pl.axis("tight")
+        # Build a coarser grid to plot a set of ensemble classifications
+        # to show how these are different to what we see in the decision
+        # surfaces. These points are regularly space and do not have a black outline
+        xx_coarser, yy_coarser = np.meshgrid(np.arange(x_min, x_max, plot_step_coarser),
+                                             np.arange(y_min, y_max, plot_step_coarser))
+        Z_points_coarser = model.predict(np.c_[xx_coarser.ravel(), yy_coarser.ravel()]).reshape(xx_coarser.shape)
+        cs_points = pl.scatter(xx_coarser, yy_coarser, s=15, c=Z_points_coarser, cmap=cmap, edgecolors="none")
 
-        # Plot the training points
+        # Plot the training points, these are clustered together and have a
+        # black outline
         for i, c in zip(xrange(n_classes), plot_colors):
             idx = np.where(y == i)
             pl.scatter(X[idx, 0], X[idx, 1], c=c, label=iris.target_names[i],
-                       cmap=pl.cm.Paired)
+                       cmap=cmap)
 
-        pl.axis("tight")
+        plot_idx += 1  # move on to the next plot in sequence
 
-        plot_idx += 1
+pl.suptitle("Classifiers on feature subsets of the Iris dataset")
+pl.axis("tight")
 
-pl.suptitle("Decision surfaces of DecisionTreeClassifier, "
-            "RandomForestClassifier,\nExtraTreesClassifier"
-            " and AdaBoostClassifier")
 pl.show()


### PR DESCRIPTION
I've made some changes to plot_forest_iris.py to make the demo more useful when teaching, this affects the image shown here:
http://scikit-learn.org/dev/auto_examples/ensemble/plot_forest_iris.html

This is connected with this issue https://github.com/scikit-learn/scikit-learn/issues/2133

I've attached a preview image of the output to this report. Roughly in order of significance I discuss the changes. I have _not_ changed the AdaBoost plot with respect to estimator weights - see below.

1) Changed estimator_alpha from a hardcoded 0.1 to 1/nbr_estimators. At 0.1 it was common for the red channel to dominate the plot, leading to the erroneous visual output in the original diagram (seen at the link above) where e.g. the bottom-right plot in the region -1,1 to 3,2.5 looks like it has a strong red decision surface but has yellow samples plotted on top. The model is correctly predicting yellow in this region but the 0.1 alpha and the red channel obscure this. After this change the same region is still coloured Red but with a much lighter shade (but this still looks wrong). A benefit is that if the user experiments with the size of the ensembles, the plot will still be drawn sensibly.

2) Changed the colour map from Paired (yielding BlueRedOrange) to RedYellowBlue. The distinction between red/orange is weaker than red/yellow, the new colour map shows the erroneous region mentioned in 1) with its correct colour (now blue). The side effect is that the original Blue/Red/Orange colours for the 3 classes change to Red/Yellow/Blue. I don't know if the colour map change is acceptable? Maybe there's a standard for the Iris set that I'm not aware of? This choice does not conflict with the other examples in the /examples/ensemble/ directory.

3) Added a regular coarse grid overlay of predictions in 2 dimensions using a scatter plot, these show as small dots in a grid over each plot. The purpose is to show how the predictor behaves at each plot location, which might _not_ be the same as the average colour that comes through via the decision surfaces and the alpha values. An example is plot 8 (right column, second row) where the yellow region is not a uniform rectangle but is narrower near the red points (on the left) and wider in the blue points (on the right), although to my eye the alpha-blended decision surfaces do not look very different. In the same plot there is a yellow 'spur' from 0,0.5 up to 0,2.5 which runs through the blue region, this region would probably be missed by a student.

4) I did _not_ vary the AdaBoost column's alpha value with respect to the underlying weights. Visually I could see very little difference to the output when using the weights to vary the alpha value. I found the regular coarse grid overlay to be far more informative (see 3).

5) Changed AdaBoost to use a tree max_depth of 3 rather than the usual None (which in this dataset is equivalent to a max_depth of 5) to show that the method combats increased bias by combining votes from weak classifiers (as per OG's note in the forum on 7th July)

6) Added column titles rather than using a long suptitle.

7) Added more output to the console to show the number of estimators (noting that AdaBoost can use fewer estimators if it fits well early on - a student might experiment and not realise this) and the score on the dataset.

![plot_forest_iris_new](https://f.cloud.github.com/assets/273210/774555/405f873a-e95d-11e2-9f5b-9271572c8a5c.png)
...ensembles
