### PR TITLE
[MRG] Missing values imputation

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -961,6 +961,7 @@ Pairwise metrics
    :template: class.rst
 
    preprocessing.Binarizer
+   preprocessing.Imputer
    preprocessing.KernelCenterer
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -466,3 +466,6 @@ Note that, here, missing values are encoded by 0 and are thus implicitly stored
 in the matrix. This format is thus suitable when there are many more missing
 values than observed values.
 
+:class:`Imputer` can be used in a Pipeline as a way to build a black-box
+estimator that supports imputation. See :ref:`example_imputation.py`
+

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -415,3 +415,54 @@ hashable and comparable) to numerical labels::
   ================
 
   Please @mblondel or someone else write me!
+
+
+Imputation of missing values
+============================
+
+For various reasons, many real world datasets contain missing values, often
+encoded as blanks, `NaN`s or other placeholders. Such datasets however are
+incompatible with scikit-learn estimators which assume that all values in an
+array are numerical, and that all have and hold meaning. A basic strategy to use
+incomplete datasets is to discard entire rows and/or columns containing missing
+values. However, this comes at the price of losing data  which may be valuable
+(even though incomplete). A better strategy is to impute the missing values,
+i.e., to infer them from the known part of the data.
+
+The :class:`Imputer` class provides basic strategies for imputing missing
+values, either using the mean, the median or the most frequent value of
+the row or column in which the missing values are located. This class
+also allows for different missing values encoding.
+
+As an example, the following snippet demonstrates how to replace missing values,
+encoded as `np.nan`, using the mean value of the columns in which the missing
+values are.
+
+    >>> import numpy as np
+    >>> from sklearn.preprocessing import Imputer
+    >>> imp = Imputer(missing_values="NaN", strategy="mean", axis=0)
+    >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
+    Imputer(axis=0, copy=True, missing_values="NaN", strategy="mean", verbose=0)
+    >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
+    >>> print(imp.transform(X))
+    [[ 4.          2.        ]
+     [ 6.          3.66666667]
+     [ 7.          6.        ]]
+
+The :class:`Imputer` class also supports sparse matrices:
+
+    >>> import scipy.sparse as sp
+    >>> X = sp.csc_matrix([[1, 2], [0, 3], [7, 6]])
+    >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
+    >>> imp.fit(X)
+    Imputer(axis=0, copy=True, missing_values=0, strategy='mean', verbose=0)
+    >>> X = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
+    >>> print(imp.transform(X))
+    [[ 4.          2.        ]
+     [ 6.          3.66666667]
+     [ 7.          6.        ]]
+
+Note that, here, missing values are encoded by 0 and are thus implicitly stored
+in the matrix. This format is thus suitable when there are many more missing
+values than observed values.
+

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -440,9 +440,9 @@ values are.
 
     >>> import numpy as np
     >>> from sklearn.preprocessing import Imputer
-    >>> imp = Imputer(missing_values="NaN", strategy="mean", axis=0)
+    >>> imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
     >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
-    Imputer(axis=0, copy=True, missing_values="NaN", strategy="mean", verbose=0)
+    Imputer(axis=0, copy=True, missing_values='NaN', strategy='mean', verbose=0)
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))
     [[ 4.          2.        ]

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -432,11 +432,11 @@ i.e., to infer them from the known part of the data.
 The :class:`Imputer` class provides basic strategies for imputing missing
 values, either using the mean, the median or the most frequent value of
 the row or column in which the missing values are located. This class
-also allows for different missing values encoding.
+also allows for different missing values encodings.
 
-As an example, the following snippet demonstrates how to replace missing values,
-encoded as `np.nan`, using the mean value of the columns in which the missing
-values are.
+The following snippet demonstrates how to replace missing values,
+encoded as `np.nan`, using the mean value of the columns (axis 0) in which
+the missing values are.
 
     >>> import numpy as np
     >>> from sklearn.preprocessing import Imputer
@@ -456,8 +456,8 @@ The :class:`Imputer` class also supports sparse matrices:
     >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
     >>> imp.fit(X)
     Imputer(axis=0, copy=True, missing_values=0, strategy='mean', verbose=0)
-    >>> X = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
-    >>> print(imp.transform(X))
+    >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
+    >>> print(imp.transform(X_test))
     [[ 4.          2.        ]
      [ 6.          3.66666667]
      [ 7.          6.        ]]

--- a/examples/imputation.py
+++ b/examples/imputation.py
@@ -1,0 +1,67 @@
+"""
+======================================================
+Imputing missing values before building an estimator
+======================================================
+
+This example shows that imputing the missing values can give better results
+than discarding the samples containing any missing value.
+
+Missing value can be replaced by the mean, the median or the most frequent
+value using the `strategy` hyper-parameter.
+
+Script output:
+
+  Score with the entire dataset = 0.556914670698
+  Score without the samples containing missing values = 0.520166053514
+  Score after imputation of the missing values = 0.532282005499
+
+"""
+import numpy as np
+
+from sklearn.datasets import load_boston
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import Imputer
+from sklearn.cross_validation import cross_val_score
+
+rng = np.random.RandomState(0)
+missing_values = "NaN" # Missing values are encoded as np.nan
+
+dataset = load_boston()
+X_full, y_full = dataset.data, dataset.target
+n_samples = X_full.shape[0]
+n_features = X_full.shape[1]
+
+# Estimate the score on the entire dataset, with no missing values
+estimator = RandomForestRegressor(random_state=0, n_estimators=100)
+score = cross_val_score(estimator, X_full, y_full).mean()
+print("Score with the entire dataset = %s" % score)
+
+# Add missing values in 50% of the lines
+missing_rate = 0.50
+n_missing_samples = np.floor(n_samples * missing_rate)
+missing_samples = np.hstack((np.zeros(n_samples - n_missing_samples,
+                                      dtype=np.bool),
+                             np.ones(n_missing_samples,
+                                     dtype=np.bool)))
+rng.shuffle(missing_samples)
+missing_features = rng.randint(0, n_features, n_missing_samples)
+
+# Estimate the score without the lines containing missing values
+X_filtered = X_full[~missing_samples, :]
+y_filtered = y_full[~missing_samples, :]
+estimator = RandomForestRegressor(random_state=0, n_estimators=100)
+score = cross_val_score(estimator, X_filtered, y_filtered).mean()
+print("Score without the samples containing missing values = %s" % score)
+
+# Estimate the score after imputation of the missing values
+X_missing = X_full.copy()
+X_missing[np.where(missing_samples)[0], missing_features] = 0
+y_missing = y_full.copy()
+estimator = Pipeline([("imputer", Imputer(missing_values=missing_values,
+                                          strategy="mean",
+                                          axis=0)),
+                      ("forest", RandomForestRegressor(random_state=0,
+                                                       n_estimators=100))])
+score = cross_val_score(estimator, X_missing, y_missing).mean()
+print("Score after imputation of the missing values = %s" % score)

--- a/examples/imputation.py
+++ b/examples/imputation.py
@@ -11,9 +11,9 @@ value using the `strategy` hyper-parameter.
 
 Script output:
 
-  Score with the entire dataset = 0.556914670698
-  Score without the samples containing missing values = 0.520166053514
-  Score after imputation of the missing values = 0.532282005499
+  Score with the entire dataset = 0.56
+  Score without the samples containing missing values = 0.53
+  Score after imputation of the missing values = 0.54
 
 """
 import numpy as np
@@ -35,7 +35,7 @@ n_features = X_full.shape[1]
 # Estimate the score on the entire dataset, with no missing values
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_full, y_full).mean()
-print("Score with the entire dataset = %s" % score)
+print("Score with the entire dataset = %.2f" % score)
 
 # Add missing values in 50% of the lines
 missing_rate = 0.50
@@ -52,7 +52,7 @@ X_filtered = X_full[~missing_samples, :]
 y_filtered = y_full[~missing_samples, :]
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_filtered, y_filtered).mean()
-print("Score without the samples containing missing values = %s" % score)
+print("Score without the samples containing missing values = %.2f" % score)
 
 # Estimate the score after imputation of the missing values
 X_missing = X_full.copy()
@@ -64,4 +64,4 @@ estimator = Pipeline([("imputer", Imputer(missing_values=missing_values,
                       ("forest", RandomForestRegressor(random_state=0,
                                                        n_estimators=100))])
 score = cross_val_score(estimator, X_missing, y_missing).mean()
-print("Score after imputation of the missing values = %s" % score)
+print("Score after imputation of the missing values = %.2f" % score)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1422,12 +1422,12 @@ def _get_median(negative_elements, n_zeros, positive_elements):
 
     if round(median_position) == median_position:
         median = _get_elem_at_rank(negative_elements, n_zeros,
-                              positive_elements, median_position)
+                                   positive_elements, median_position)
     else:
         a = _get_elem_at_rank(negative_elements, n_zeros,
-                         positive_elements, math.floor(median_position))
+                              positive_elements, math.floor(median_position))
         b = _get_elem_at_rank(negative_elements, n_zeros,
-                         positive_elements, math.ceil(median_position))
+                              positive_elements, math.ceil(median_position))
         median = (a + b) / 2.0
 
     return median

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1532,7 +1532,7 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Input data, where ``n_samples`` is the number of samples and
             ``n_features`` is the number of features.
 
@@ -1706,13 +1706,14 @@ class Imputer(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             The input data to complete.
         """
-        X = as_float_array(X, copy=self.copy)
+        if self.copy and not isinstance(X, list):
+            X = X.copy()
 
         # Since two different arrays can be provided in fit(X) and
         # transform(X), the imputation data need to be recomputed
         # when the imputation is done per sample
         if self.axis == 1:
-            X = atleast2d_or_csr(X, force_all_finite=False)
+            X = atleast2d_or_csr(X, force_all_finite=False).astype(np.float)
 
             if sp.issparse(X):
                 self.statistics_ = self._sparse_fit(X,
@@ -1726,7 +1727,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                                                    self.missing_values,
                                                    self.axis)
         else:
-            X = atleast2d_or_csc(X, force_all_finite=False)
+            X = atleast2d_or_csc(X, force_all_finite=False).astype(np.float)
 
         # Delete the invalid rows/columns
         invalid_mask = np.isnan(self.statistics_)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1706,18 +1706,13 @@ class Imputer(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             The input data to complete.
         """
-        # Use copy=copy with as_float_array when this pull request
-        # will be merged:
-        # https://github.com/scikit-learn/scikit-learn/pull/2194 is merged
-        if self.copy and not isinstance(X, list):
-            X = X.copy()
-        #X = as_float_array(X, force_all_finite=False)
+        X = as_float_array(X, copy=self.copy)
 
         # Since two different arrays can be provided in fit(X) and
         # transform(X), the imputation data need to be recomputed
         # when the imputation is done per sample
         if self.axis == 1:
-            X = atleast2d_or_csr(X, force_all_finite=False).astype(np.float)
+            X = atleast2d_or_csr(X, force_all_finite=False)
 
             if sp.issparse(X):
                 self.statistics_ = self._sparse_fit(X,
@@ -1731,7 +1726,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                                                    self.missing_values,
                                                    self.axis)
         else:
-            X = atleast2d_or_csc(X, force_all_finite=False).astype(np.float)
+            X = atleast2d_or_csc(X, force_all_finite=False)
 
         # Delete the invalid rows/columns
         invalid_mask = np.isnan(self.statistics_)

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1734,8 +1734,7 @@ class Imputer(BaseEstimator, TransformerMixin):
         valid_mask = np.logical_not(invalid_mask)
         valid_statistics = self.statistics_[valid_mask]
         valid_statistics_indexes = np.where(valid_mask)[0]
-        missing = ",".join(
-            map(str, np.arange(X.shape[not self.axis])[invalid_mask]))
+        missing = np.arange(X.shape[not self.axis])[invalid_mask]
 
         if self.axis == 0 and invalid_mask.any():
             if self.verbose:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1339,19 +1339,19 @@ def _get_median(negative_elements, n_zeros, positive_elements):
     median_position = (n_elems - 1) / 2.0
 
     if round(median_position) == median_position:
-        median = _get_elem_at(negative_elements, n_zeros,
+        median = _get_elem_at_rank(negative_elements, n_zeros,
                               positive_elements, median_position)
     else:
-        a = _get_elem_at(negative_elements, n_zeros,
+        a = _get_elem_at_rank(negative_elements, n_zeros,
                          positive_elements, math.floor(median_position))
-        b = _get_elem_at(negative_elements, n_zeros,
+        b = _get_elem_at_rank(negative_elements, n_zeros,
                          positive_elements, math.ceil(median_position))
         median = (a + b) / 2.0
 
     return median
 
 
-def _get_elem_at(negative_elements, n_zeros, positive_elements, k):
+def _get_elem_at_rank(negative_elements, n_zeros, positive_elements, k):
     """Compute the kth largest element of the array formed by
        negative_elements, n_zeros zeros and positive_elements."""
     len_neg = len(negative_elements)
@@ -1396,13 +1396,6 @@ def _most_frequent(array, extra_value, n_repeat):
 class Imputer(BaseEstimator, TransformerMixin):
     """Imputation transformer for completing missing values.
 
-    Notes:
-    - When `axis=0`, columns which only contained missing values at `fit`
-      are discarded upon `transform`.
-    - When `axis=1`, an exception is raised if there are rows for which it is
-      not possible to fill in the missing values (e.g., because they only
-      contain missing values).
-
     Parameters
     ----------
     missing_values : integer or string, optional (default="NaN")
@@ -1433,8 +1426,16 @@ class Imputer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `statistics_`: array of shape = [n_features] or [n_samples]
+    `statistics_` : array of shape (n_features,) or (n_samples,)
         The statistics along the imputation axis.
+
+    Notes
+    -----
+    - When ``axis=0``, columns which only contained missing values at `fit`
+      are discarded upon `transform`.
+    - When ``axis=1``, an exception is raised if there are rows for which it is
+      not possible to fill in the missing values (e.g., because they only
+      contain missing values).
     """
     def __init__(self, missing_values="NaN", strategy="mean",
                  axis=0, verbose=0, copy=True):
@@ -1450,8 +1451,8 @@ class Imputer(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
-            Input data, where `n_samples` is the number of samples and
-            `n_features` is the number of features.
+            Input data, where ``n_samples`` is the number of samples and
+            ``n_features`` is the number of features.
 
         Returns
         -------

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1500,16 +1500,16 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         # Count the zeros
         if missing_values == 0:
-            n_zeros = np.zeros(X.shape[not axis])
+            n_zeros_axis = np.zeros(X.shape[not axis])
         else:
-            n_zeros = X.shape[axis] - np.diff(X.indptr)
+            n_zeros_axis = X.shape[axis] - np.diff(X.indptr)
 
         # Mean
         if strategy == "mean":
             if missing_values != 0:
-                n_non_missing = n_zeros
+                n_non_missing = n_zeros_axis
 
-                # Mask the elements != 0
+                # Mask the missing elements
                 mask_missing_values = _get_mask(X.data, missing_values)
                 mask_valids = np.logical_not(mask_missing_values)
 
@@ -1541,11 +1541,11 @@ class Imputer(BaseEstimator, TransformerMixin):
             # Remove the missing values, for each column
             columns_all = np.hsplit(X.data, X.indptr[1:-1])
             mask_missing_values = _get_mask(X.data, missing_values)
-            mask_valids = np.hsplit(~mask_missing_values, X.indptr[1:-1])
-            columns = []
+            mask_valids = np.hsplit(np.logical_not(mask_missing_values),
+                                    X.indptr[1:-1])
 
-            for col, mask in zip(columns_all, mask_valids):
-                columns.append(col[mask.astype(np.bool)])
+            columns = [col[mask.astype(np.bool)]
+                       for col, mask in zip(columns_all, mask_valids)]
 
             # Median
             if strategy == "median":
@@ -1554,7 +1554,9 @@ class Imputer(BaseEstimator, TransformerMixin):
 
                     negatives = column[column < 0]
                     positives = column[column > 0]
-                    median[i] = _get_median(negatives, n_zeros[i], positives)
+                    median[i] = _get_median(negatives,
+                                            n_zeros_axis[i],
+                                            positives)
 
                 return median
 
@@ -1563,7 +1565,9 @@ class Imputer(BaseEstimator, TransformerMixin):
                 most_frequent = np.empty(len(columns))
 
                 for i, column in enumerate(columns):
-                    most_frequent[i] = _most_frequent(column, 0, n_zeros[i])
+                    most_frequent[i] = _most_frequent(column,
+                                                      0,
+                                                      n_zeros_axis[i])
 
                 return most_frequent
 
@@ -1649,7 +1653,7 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         # Delete the invalid rows/columns
         invalid_mask = np.isnan(self.statistics_)
-        valid_mask = ~invalid_mask
+        valid_mask = np.logical_not(invalid_mask)
         valid_statistics = self.statistics_[valid_mask]
         valid_statistics_indexes = np.where(valid_mask)[0]
         missing = ",".join(

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1394,6 +1394,13 @@ def _most_frequent(array, extra_value, n_repeat):
 class Imputer(BaseEstimator, TransformerMixin):
     """Imputation transformer for completing missing values.
 
+    Notes:
+    - When `axis=0`, columns which only contained missing values at `fit`
+      are discarded upon `transform`.
+    - When `axis=1`, an exception is raised if there are rows for which it is
+      not possible to fill in the missing values (e.g., because they only
+      contain missing values).
+
     Parameters
     ----------
     missing_values : integer or string, optional (default="NaN")
@@ -1605,11 +1612,6 @@ class Imputer(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Impute all missing values in X.
 
-        When `axis=0`, columns which only contained missing values at
-        `fit` are discarded upon `transform`. When `axis=1`, rows for which
-        it is not possible to fill in the missing values (e.g., because they
-        only contain missing values) are discarded upon `transform`.
-
         Parameters
         ----------
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
@@ -1656,10 +1658,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                               "observed values: %s" % missing)
             X = X[:, valid_statistics_indexes]
         elif self.axis == 1 and invalid_mask.any():
-            if self.verbose:
-                warnings.warn("Deleting samples without "
-                              "observed values: %s" % missing)
-            X = X[valid_statistics_indexes, :]
+            raise ValueError("Some rows only contain missing values.")
 
         # Do actual imputation
         if sp.issparse(X) and self.missing_values != 0:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -6,13 +6,17 @@
 
 import warnings
 import numbers
+import math
 
 import numpy as np
+import numpy.ma as ma
 import scipy.sparse as sp
+import scipy.stats as st
 
 from .base import BaseEstimator, TransformerMixin
 from .utils import check_arrays
 from .utils import array2d
+from .utils import as_float_array
 from .utils import atleast2d_or_csr
 from .utils import atleast2d_or_csc
 from .utils import safe_asarray
@@ -1310,3 +1314,377 @@ def add_dummy_feature(X, value=1.0):
             return klass(add_dummy_feature(X.tocoo(), value))
     else:
         return np.hstack((np.ones((n_samples, 1)) * value, X))
+
+
+def _get_mask(X, missing_values):
+    """Compute the boolean mask X == missing_values."""
+    if missing_values == "NaN" or np.isnan(missing_values):
+        return np.isnan(X)
+    else:
+        return np.equal(X, missing_values)
+
+
+def _get_median(negative_elements, n_zeros, positive_elements):
+    """Compute the median of the array formed by negative_elements,
+       n_zeros zeros and positive_elements."""
+    negative_elements = np.sort(negative_elements, kind='heapsort')
+    positive_elements = np.sort(positive_elements, kind='heapsort')
+
+    n_elems = len(negative_elements) + n_zeros + len(positive_elements)
+    if not n_elems:
+        return np.nan
+
+    median_position = (n_elems - 1) / 2.0
+
+    if round(median_position) == median_position:
+        median = _get_elem_at(negative_elements, n_zeros,
+                              positive_elements, median_position)
+    else:
+        a = _get_elem_at(negative_elements, n_zeros,
+                         positive_elements, math.floor(median_position))
+        b = _get_elem_at(negative_elements, n_zeros,
+                         positive_elements, math.ceil(median_position))
+        median = (a + b) / 2.0
+
+    return median
+
+
+def _get_elem_at(negative_elements, n_zeros, positive_elements, k):
+    """Compute the kth largest element of the array formed by
+       negative_elements, n_zeros zeros and positive_elements."""
+    len_neg = len(negative_elements)
+    len_pos = len(positive_elements)
+
+    if k < len_neg:
+        return negative_elements[k]
+    elif k >= len_neg + n_zeros:
+        return positive_elements[k - len_neg - n_zeros]
+    else:
+        return 0
+
+
+def _most_frequent(array, extra_value, n_repeat):
+    """Compute the most frequent value in a 1d array extended with
+       [extra_value] * n_repeat, where extra_value is assumed to be not part
+       of the array."""
+    # Compute the most frequent value in array only
+    if array.size > 0:
+        mode = st.mode(array)
+        most_frequent_value = mode[0][0]
+        most_frequent_count = mode[1][0]
+    else:
+        most_frequent_value = 0
+        most_frequent_count = 0
+
+    # Compare to array + [extra_value] * n_repeat
+    if most_frequent_count == 0 and n_repeat == 0:
+        return np.nan
+    elif most_frequent_count < n_repeat:
+        return extra_value
+    elif most_frequent_count > n_repeat:
+        return most_frequent_value
+    elif most_frequent_count == n_repeat:
+        # Ties the breaks. Copy the behaviour of scipy.stats.mode
+        if most_frequent_value < extra_value:
+            return most_frequent_value
+        else:
+            return extra_value
+
+
+class Imputer(BaseEstimator, TransformerMixin):
+    """Imputation transformer for completing missing values.
+
+    Parameters
+    ----------
+    missing_values : integer or string, optional (default="NaN")
+        The placeholder for the missing values. All occurences of
+        `missing_values` will be imputed. For missing values encoded as np.nan,
+        use the string value "NaN".
+
+    strategy : string, optional (default="mean")
+        The imputation strategy.
+          - If "mean", then replace missing values using the mean along
+            the axis.
+          - If "median", then replace missing values using the median along
+            the axis.
+          - If "most_frequent", then replace missing using the most frequent
+            value along the axis.
+
+    axis : integer, optional (default=0)
+        The axis along which to impute.
+         - If `axis=0`, then impute along columns.
+         - If `axis=1`, then impute along rows.
+
+    verbose : integer, optional (default=0)
+        Controls the verbosity of the imputer.
+
+    copy : boolean, optional (default=True)
+        If True, a copy of X will be created. If False, imputation will
+        be done in-place.
+
+    Attributes
+    ----------
+    `statistics_`: array of shape = [n_features] or [n_samples]
+        The statistics along the imputation axis.
+    """
+    def __init__(self, missing_values="NaN", strategy="mean",
+                 axis=0, verbose=0, copy=True):
+        self.missing_values = missing_values
+        self.strategy = strategy
+        self.axis = axis
+        self.verbose = verbose
+        self.copy = copy
+
+    def fit(self, X, y=None):
+        """Fit the imputer on X.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            Input data, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        # Check parameters
+        allowed_strategies = ["mean", "median", "most_frequent"]
+        if self.strategy not in allowed_strategies:
+            raise ValueError("Can only use these strategies: {0} "
+                             " got strategy={1}".format(allowed_strategies,
+                                                        self.strategy))
+
+        if self.axis not in [0, 1]:
+            raise ValueError("Can only impute missing values on axis 0 and 1, "
+                             " got axis={0}".format(self.axis))
+
+        # Since two different arrays can be provided in fit(X) and
+        # transform(X), the imputation data will be computed in transform()
+        # when the imputation is done per sample (i.e., when axis=1).
+        if self.axis == 0:
+            X = atleast2d_or_csc(X, dtype=np.float64, force_all_finite=False)
+
+            if sp.issparse(X):
+                self.statistics_ = self._sparse_fit(X,
+                                                    self.strategy,
+                                                    self.missing_values,
+                                                    self.axis)
+            else:
+                self.statistics_ = self._dense_fit(X,
+                                                   self.strategy,
+                                                   self.missing_values,
+                                                   self.axis)
+
+        return self
+
+    def _sparse_fit(self, X, strategy, missing_values, axis):
+        """Fit the transformer on sparse data."""
+        # Imputation is done "by column", so if we want to do it
+        # by row we only need to convert the matrix to csr format.
+        if axis == 1:
+            X = X.tocsr()
+        else:
+            X = X.tocsc()
+
+        # Count the zeros
+        if missing_values == 0:
+            n_zeros = np.zeros(X.shape[not axis])
+        else:
+            n_zeros = X.shape[axis] - np.diff(X.indptr)
+
+        # Mean
+        if strategy == "mean":
+            if missing_values != 0:
+                n_non_missing = n_zeros
+
+                # Mask the elements != 0
+                mask_missing_values = _get_mask(X.data, missing_values)
+                mask_valids = np.logical_not(mask_missing_values)
+
+                # Sum only the valid elements
+                new_data = X.data.copy()
+                new_data[mask_missing_values] = 0
+                X = sp.csc_matrix((new_data, X.indices, X.indptr), copy=False)
+                sums = X.sum(axis=0)
+
+                # Count the elements != 0
+                mask_non_zeros = sp.csc_matrix((mask_valids.astype(np.float64),
+                                               X.indices,
+                                               X.indptr), copy=False)
+                s = mask_non_zeros.sum(axis=0)
+                n_non_missing = np.add(n_non_missing, s)
+
+            else:
+                sums = X.sum(axis=axis)
+                n_non_missing = np.diff(X.indptr)
+
+            # Ignore the error, columns with a np.nan statistics_
+            # are not an error at this point. These columns will
+            # be removed in transform
+            with np.errstate(all="ignore"):
+                return np.ravel(sums) / np.ravel(n_non_missing)
+
+        # Median + Most frequent
+        else:
+            # Remove the missing values, for each column
+            columns_all = np.hsplit(X.data, X.indptr[1:-1])
+            mask_missing_values = _get_mask(X.data, missing_values)
+            mask_valids = np.hsplit(~mask_missing_values, X.indptr[1:-1])
+            columns = []
+
+            for col, mask in zip(columns_all, mask_valids):
+                columns.append(col[mask.astype(np.bool)])
+
+            # Median
+            if strategy == "median":
+                median = np.empty(len(columns))
+                for i, column in enumerate(columns):
+
+                    negatives = column[column < 0]
+                    positives = column[column > 0]
+                    median[i] = _get_median(negatives, n_zeros[i], positives)
+
+                return median
+
+            # Most frequent
+            elif strategy == "most_frequent":
+                most_frequent = np.empty(len(columns))
+
+                for i, column in enumerate(columns):
+                    most_frequent[i] = _most_frequent(column, 0, n_zeros[i])
+
+                return most_frequent
+
+    def _dense_fit(self, X, strategy, missing_values, axis):
+        """Fit the transformer on dense data."""
+        X = array2d(X, force_all_finite=False)
+        mask = _get_mask(X, missing_values)
+        masked_X = ma.masked_array(X, mask=mask)
+
+        # Mean
+        if strategy == "mean":
+            mean_masked = np.ma.mean(masked_X, axis=axis)
+            # Avoid the warning "Warning: converting a masked element to nan."
+            mean = np.ma.getdata(mean_masked)
+            mean[np.ma.getmask(mean_masked)] = np.nan
+
+            return mean
+
+        # Median
+        elif strategy == "median":
+            median_masked = np.ma.median(masked_X, axis=axis)
+            # Avoid the warning "Warning: converting a masked element to nan."
+            median = np.ma.getdata(median_masked)
+            median[np.ma.getmask(median_masked)] = np.nan
+
+            return median
+
+        # Most frequent
+        elif strategy == "most_frequent":
+            # scipy.stats.mstats.mode cannot be used because it will no work
+            # properly if the first element is masked and if it's frequency
+            # is equal to the frequency of the most frequent valid element
+            # See https://github.com/scipy/scipy/issues/2636
+
+            # To be able access the elements by columns
+            if axis == 0:
+                X = X.transpose()
+                mask = mask.transpose()
+
+            most_frequent = np.empty(X.shape[0])
+
+            for i, (row, row_mask) in enumerate(zip(X[:], mask[:])):
+                row_mask = np.logical_not(row_mask).astype(np.bool)
+                row = row[row_mask]
+                most_frequent[i] = _most_frequent(row, np.nan, 0)
+
+            return most_frequent
+
+    def transform(self, X):
+        """Impute all missing values in X.
+
+        When `axis=0`, columns which only contained missing values at
+        `fit` are discarded upon `transform`. When `axis=1`, rows for which
+        it is not possible to fill in the missing values (e.g., because they
+        only contain missing values) are discarded upon `transform`.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            The input data to complete.
+        """
+        # Use copy=copy with as_float_array when this pull request
+        # will be merged:
+        # https://github.com/scikit-learn/scikit-learn/pull/2194 is merged
+        if self.copy and not isinstance(X, list):
+            X = X.copy()
+        #X = as_float_array(X, force_all_finite=False)
+
+        # Since two different arrays can be provided in fit(X) and
+        # transform(X), the imputation data need to be recomputed
+        # when the imputation is done per sample
+        if self.axis == 1:
+            X = atleast2d_or_csr(X, force_all_finite=False).astype(np.float)
+
+            if sp.issparse(X):
+                self.statistics_ = self._sparse_fit(X,
+                                                    self.strategy,
+                                                    self.missing_values,
+                                                    self.axis)
+
+            else:
+                self.statistics_ = self._dense_fit(X,
+                                                   self.strategy,
+                                                   self.missing_values,
+                                                   self.axis)
+        else:
+            X = atleast2d_or_csc(X, force_all_finite=False).astype(np.float)
+
+        # Delete the invalid rows/columns
+        invalid_mask = np.isnan(self.statistics_)
+        valid_mask = ~invalid_mask
+        valid_statistics = self.statistics_[valid_mask]
+        valid_statistics_indexes = np.where(valid_mask)[0]
+        missing = ",".join(
+            map(str, np.arange(X.shape[not self.axis])[invalid_mask]))
+
+        if self.axis == 0 and invalid_mask.any():
+            if self.verbose:
+                warnings.warn("Deleting features without "
+                              "observed values: %s" % missing)
+            X = X[:, valid_statistics_indexes]
+        elif self.axis == 1 and invalid_mask.any():
+            if self.verbose:
+                warnings.warn("Deleting samples without "
+                              "observed values: %s" % missing)
+            X = X[valid_statistics_indexes, :]
+
+        # Do actual imputation
+        if sp.issparse(X) and self.missing_values != 0:
+            if self.axis == 0:
+                X = X.tocsr()
+            else:
+                X = X.tocsc()
+
+            mask = _get_mask(X.data, self.missing_values)
+            indexes = X.indices[mask]
+
+            X.data[mask] = valid_statistics[indexes].astype(X.dtype)
+        else:
+            if sp.issparse(X):
+                X = X.toarray()
+
+            mask = _get_mask(X, self.missing_values)
+            n_missing = np.sum(mask, axis=self.axis)
+            values = np.repeat(valid_statistics, n_missing)
+
+            if self.axis == 0:
+                coordinates = np.where(mask.transpose())[::-1]
+            else:
+                coordinates = mask
+
+            X[coordinates] = values
+
+        return X

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1658,7 +1658,8 @@ class Imputer(BaseEstimator, TransformerMixin):
                               "observed values: %s" % missing)
             X = X[:, valid_statistics_indexes]
         elif self.axis == 1 and invalid_mask.any():
-            raise ValueError("Some rows only contain missing values.")
+            raise ValueError("Some rows only contain "
+                             "missing values: %s" % missing)
 
         # Do actual imputation
         if sp.issparse(X) and self.missing_values != 0:

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -36,6 +36,7 @@ zip = six.moves.zip
 map = six.moves.map
 
 __all__ = ['Binarizer',
+           'Imputer',
            'KernelCenterer',
            'LabelBinarizer',
            'LabelEncoder',
@@ -1316,17 +1317,18 @@ def add_dummy_feature(X, value=1.0):
         return np.hstack((np.ones((n_samples, 1)) * value, X))
 
 
-def _get_mask(X, missing_values):
+def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
-    if missing_values == "NaN" or np.isnan(missing_values):
+    if value_to_mask == "NaN" or np.isnan(value_to_mask):
         return np.isnan(X)
     else:
-        return np.equal(X, missing_values)
+        return X == value_to_mask
 
 
 def _get_median(negative_elements, n_zeros, positive_elements):
     """Compute the median of the array formed by negative_elements,
-       n_zeros zeros and positive_elements."""
+       n_zeros zeros and positive_elements. This function is used
+       to support sparse matrices."""
     negative_elements = np.sort(negative_elements, kind='heapsort')
     positive_elements = np.sort(positive_elements, kind='heapsort')
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -307,7 +307,7 @@ def test_estimators_nan_inf():
             if name in dont_test:
                 continue
             if name in ('PLSCanonical', 'PLSRegression', 'CCA',
-                        'PLSSVD'):
+                        'PLSSVD', 'Imputer'):
                 continue
 
             # catch deprecation warnings

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -307,7 +307,7 @@ def test_estimators_nan_inf():
             if name in dont_test:
                 continue
             if name in ('PLSCanonical', 'PLSRegression', 'CCA',
-                        'PLSSVD', 'Imputer'):
+                        'PLSSVD', 'Imputer'): # Imputer accepts nan
                 continue
 
             # catch deprecation warnings

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -1040,7 +1040,7 @@ def test_imputation_copy():
 
     # Test default behaviour and with copy=True
     for params in [{}, {'copy' : True}]:
-        X = sparse_random_matrix(l, l, density=0.75)
+        X = sparse_random_matrix(l, l, density=0.75, random_state=0)
 
         # Dense
         imputer = Imputer(missing_values=0, strategy="mean", **params)

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -888,22 +888,24 @@ def test_imputation_mean_median_only_zero():
         [np.nan, 6, 0,  5,  13],
     ])
 
-    mean = np.array([
+    X_imputed_mean = np.array([
         [3,  5],
         [1,  3],
         [2,  7],
         [6, 13],
     ])
+    statistics_mean = [np.nan, 3, np.nan, np.nan, 7]
 
-    median = np.array([
+    X_imputed_median = np.array([
         [2, 5,  5],
         [1, np.nan,  3],
         [2, 5, 5],
         [6, 5,  13],
     ])
+    statistics_median = [np.nan, 2, np.nan, 5, 5]
 
-    _check_statistics(X, mean, "mean", [np.nan, 3, np.nan, np.nan, 7], 0)
-    _check_statistics(X, median, "median", [np.nan, 2, np.nan, 5, 5], 0)
+    _check_statistics(X, X_imputed_mean, "mean", statistics_mean, 0)
+    _check_statistics(X, X_imputed_median, "median", statistics_median, 0)
 
 
 def test_imputation_mean_median():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -1,7 +1,7 @@
 import warnings
 import numpy as np
 import numpy.linalg as la
-import scipy.sparse as sp
+from scipy import sparse
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -190,8 +190,8 @@ def test_scaler_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = sparse.csr_matrix(X)
+    X_csc = sparse.csc_matrix(X)
 
     assert_raises(ValueError, StandardScaler().fit, X_csr)
 
@@ -252,7 +252,7 @@ def test_scaler_without_copy():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
-    X_csr = sp.csr_matrix(X)
+    X_csr = sparse.csr_matrix(X)
 
     X_copy = X.copy()
     StandardScaler(copy=False).fit(X)
@@ -266,7 +266,7 @@ def test_scaler_without_copy():
 def test_scale_sparse_with_mean_raise_exception():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
-    X_csr = sp.csr_matrix(X)
+    X_csr = sparse.csr_matrix(X)
 
     # check scaling and fit with direct calls on sparse data
     assert_raises(ValueError, scale, X_csr, with_mean=True)
@@ -276,7 +276,7 @@ def test_scale_sparse_with_mean_raise_exception():
     scaler = StandardScaler(with_mean=True).fit(X)
     assert_raises(ValueError, scaler.transform, X_csr)
 
-    X_transformed_csr = sp.csr_matrix(scaler.transform(X))
+    X_transformed_csr = sparse.csr_matrix(scaler.transform(X))
     assert_raises(ValueError, scaler.inverse_transform, X_transformed_csr)
 
 
@@ -284,7 +284,7 @@ def test_scale_function_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
     X[:, 0] = 0.0  # first feature is always of zero
-    X_csr = sp.csr_matrix(X)
+    X_csr = sparse.csr_matrix(X)
 
     X_scaled = scale(X, with_mean=False)
     assert_false(np.any(np.isnan(X_scaled)))
@@ -327,7 +327,7 @@ def test_warning_scaling_integers():
 def test_normalizer_l1():
     rng = np.random.RandomState(0)
     X_dense = rng.randn(4, 5)
-    X_sparse_unpruned = sp.csr_matrix(X_dense)
+    X_sparse_unpruned = sparse.csr_matrix(X_dense)
 
     # set the row number 3 to zero
     X_dense[3, :] = 0.0
@@ -338,7 +338,7 @@ def test_normalizer_l1():
     X_sparse_unpruned.data[indptr_3:indptr_4] = 0.0
 
     # build the pruned variant using the regular constructor
-    X_sparse_pruned = sp.csr_matrix(X_dense)
+    X_sparse_pruned = sparse.csr_matrix(X_dense)
 
     # check inputs that support the no-copy optim
     for X in (X_dense, X_sparse_pruned, X_sparse_unpruned):
@@ -360,12 +360,12 @@ def test_normalizer_l1():
             assert_almost_equal(row_sums[3], 0.0)
 
     # check input for which copy=False won't prevent a copy
-    for init in (sp.coo_matrix, sp.csc_matrix, sp.lil_matrix):
+    for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)
         X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
 
         assert_true(X_norm is not X)
-        assert_true(isinstance(X_norm, sp.csr_matrix))
+        assert_true(isinstance(X_norm, sparse.csr_matrix))
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -376,7 +376,7 @@ def test_normalizer_l1():
 def test_normalizer_l2():
     rng = np.random.RandomState(0)
     X_dense = rng.randn(4, 5)
-    X_sparse_unpruned = sp.csr_matrix(X_dense)
+    X_sparse_unpruned = sparse.csr_matrix(X_dense)
 
     # set the row number 3 to zero
     X_dense[3, :] = 0.0
@@ -387,7 +387,7 @@ def test_normalizer_l2():
     X_sparse_unpruned.data[indptr_3:indptr_4] = 0.0
 
     # build the pruned variant using the regular constructor
-    X_sparse_pruned = sp.csr_matrix(X_dense)
+    X_sparse_pruned = sparse.csr_matrix(X_dense)
 
     # check inputs that support the no-copy optim
     for X in (X_dense, X_sparse_pruned, X_sparse_unpruned):
@@ -408,12 +408,12 @@ def test_normalizer_l2():
             assert_almost_equal(la.norm(X_norm[3]), 0.0)
 
     # check input for which copy=False won't prevent a copy
-    for init in (sp.coo_matrix, sp.csc_matrix, sp.lil_matrix):
+    for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)
         X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
 
         assert_true(X_norm is not X)
-        assert_true(isinstance(X_norm, sp.csr_matrix))
+        assert_true(isinstance(X_norm, sparse.csr_matrix))
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -430,7 +430,7 @@ def test_normalize_errors():
 def test_binarizer():
     X_ = np.array([[1, 0, 5], [2, 3, -1]])
 
-    for init in (np.array, list, sp.csr_matrix, sp.csc_matrix):
+    for init in (np.array, list, sparse.csr_matrix, sparse.csc_matrix):
 
         X = init(X_.copy())
 
@@ -439,7 +439,7 @@ def test_binarizer():
         assert_equal(np.sum(X_bin == 0), 4)
         assert_equal(np.sum(X_bin == 1), 2)
         X_bin = binarizer.transform(X)
-        assert_equal(sp.issparse(X), sp.issparse(X_bin))
+        assert_equal(sparse.issparse(X), sparse.issparse(X_bin))
 
         binarizer = Binarizer(copy=True).fit(X)
         X_bin = toarray(binarizer.transform(X))
@@ -472,7 +472,7 @@ def test_binarizer():
         X_bin = binarizer.transform(X)
 
     # Cannot use threshold < 0 for sparse
-    assert_raises(ValueError, binarizer.transform, sp.csc_matrix(X))
+    assert_raises(ValueError, binarizer.transform, sparse.csc_matrix(X))
 
 
 def test_label_binarizer():
@@ -628,7 +628,7 @@ def test_one_hot_encoder():
 
 
 def _check_transform_selected(X, X_expected, sel):
-    for M in (X, sp.csr_matrix(X)):
+    for M in (X, sparse.csr_matrix(X)):
         Xtr = _transform_selected(M, Binarizer().transform, sel)
         assert_array_equal(toarray(Xtr), X_expected)
 
@@ -795,23 +795,23 @@ def test_add_dummy_feature():
 
 
 def test_add_dummy_feature_coo():
-    X = sp.coo_matrix([[1, 0], [0, 1], [0, 1]])
+    X = sparse.coo_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert_true(sp.isspmatrix_coo(X), X)
+    assert_true(sparse.isspmatrix_coo(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
 def test_add_dummy_feature_csc():
-    X = sp.csc_matrix([[1, 0], [0, 1], [0, 1]])
+    X = sparse.csc_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert_true(sp.isspmatrix_csc(X), X)
+    assert_true(sparse.isspmatrix_csc(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
 def test_add_dummy_feature_csr():
-    X = sp.csr_matrix([[1, 0], [0, 1], [0, 1]])
+    X = sparse.csr_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert_true(sp.isspmatrix_csr(X), X)
+    assert_true(sparse.isspmatrix_csr(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
@@ -851,9 +851,10 @@ def _check_statistics(X, X_true,
 
     # Sparse matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
-    X_trans = imputer.fit(sp.csc_matrix(X)).transform(sp.csc_matrix(X.copy()))
+    imputer.fit(sparse.csc_matrix(X))
+    X_trans = imputer.transform(sparse.csc_matrix(X.copy()))
 
-    if sp.issparse(X_trans):
+    if sparse.issparse(X_trans):
         X_trans = X_trans.toarray()
 
     assert_array_equal(imputer.statistics_, statistics,
@@ -862,14 +863,14 @@ def _check_statistics(X, X_true,
 
     # Sparse matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
-    imputer.fit(sp.csc_matrix(X.transpose()))
+    imputer.fit(sparse.csc_matrix(X.transpose()))
     if np.isnan(statistics).any():
         assert_raises(ValueError, imputer.transform,
-                      sp.csc_matrix(X.copy().transpose()))
+                      sparse.csc_matrix(X.copy().transpose()))
     else:
-        X_trans = imputer.transform(sp.csc_matrix(X.copy().transpose()))
+        X_trans = imputer.transform(sparse.csc_matrix(X.copy().transpose()))
 
-        if sp.issparse(X_trans):
+        if sparse.issparse(X_trans):
             X_trans = X_trans.toarray()
 
         assert_array_equal(imputer.statistics_, statistics,

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -1051,7 +1051,7 @@ def test_imputation_copy():
         Xt[0, 0] = np.nan
         # Check that the objects are different and that they don't use
         # the same buffer
-        assert_false(np.equal(X.todense(), Xt).all())
+        assert_false(np.all(X.todense() == Xt))
 
         # Sparse
         imputer = Imputer(missing_values=0, strategy="mean", **params)
@@ -1060,4 +1060,4 @@ def test_imputation_copy():
         Xt[0, 0] = np.nan
         # Check that the objects are different and that they don't use
         # the same buffer
-        assert_false(np.equal(X, Xt).all())
+        assert_false(np.all(X == Xt))

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -816,7 +816,7 @@ def test_add_dummy_feature_csr():
 
 
 def _check_statistics(X, X_true,
-                          strategy, statistics, missing_values):
+                      strategy, statistics, missing_values):
     """Utility function for testing imputation for a given strategy.
 
     Test:
@@ -846,7 +846,8 @@ def _check_statistics(X, X_true,
         X_trans = imputer.transform(X.copy().transpose())
         assert_array_equal(imputer.statistics_, statistics,
                            err_msg.format(1, False))
-        assert_array_equal(X_trans, X_true.transpose(), err_msg.format(1, False))
+        assert_array_equal(X_trans, X_true.transpose(),
+                           err_msg.format(1, False))
 
     # Sparse matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
@@ -972,7 +973,7 @@ def test_imputation_mean_median():
         X_true = X_true[:, cols_to_keep]
 
         _check_statistics(X, X_true, strategy,
-                              true_statistics, test_missing_values)
+                          true_statistics, test_missing_values)
 
 
 def test_imputation_most_frequent():
@@ -1039,7 +1040,7 @@ def test_imputation_copy():
     l = 5
 
     # Test default behaviour and with copy=True
-    for params in [{}, {'copy' : True}]:
+    for params in [{}, {'copy': True}]:
         X = sparse_random_matrix(l, l, density=0.75, random_state=0)
 
         # Dense

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -819,8 +819,8 @@ def _test_statistics(X, X_true,
         - the statistics (mean, median, mode) are correct
         - the missing values are imputed correctly"""
 
-    err_msg = "Parameters: strategy = %s, " \
-              "missing_values = %s" % (strategy, missing_values)
+    err_msg = ("Parameters: strategy = %s, "
+               "missing_values = %s" % (strategy, missing_values))
     err_msg = err_msg + ", axis = %s, sparse = %s"
 
     # Normal matrix, axis = 0

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -25,6 +25,12 @@ from sklearn.preprocessing import scale
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.preprocessing import add_dummy_feature
 
+from sklearn.preprocessing import Imputer
+from sklearn.pipeline import Pipeline
+from sklearn import grid_search
+from sklearn import tree
+from sklearn.random_projection import sparse_random_matrix
+
 from sklearn import datasets
 from sklearn.linear_model.stochastic_gradient import SGDClassifier
 
@@ -799,3 +805,238 @@ def test_add_dummy_feature_csr():
     X = add_dummy_feature(X)
     assert_true(sp.isspmatrix_csr(X), X)
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
+
+
+def _test_statistics(X, X_true,
+                          strategy, statistics, missing_values):
+    """Utility function for testing imputation for a given strategy.
+
+    Test:
+        - along the two axes
+        - with dense and sparse arrays
+
+    Check that:
+        - the statistics (mean, median, mode) are correct
+        - the missing values are imputed correctly"""
+
+    err_msg = "Parameters: strategy = %s, " \
+              "missing_values = %s" % (strategy, missing_values)
+    err_msg = err_msg + ", axis = %s, sparse = %s"
+
+    # Normal matrix, axis = 0
+    imputer = Imputer(missing_values, strategy=strategy, axis=0)
+    X_trans = imputer.fit(X).transform(X.copy())
+    assert_array_equal(imputer.statistics_, statistics,
+                       err_msg % (0, False))
+    assert_array_equal(X_trans, X_true, err_msg % (0, False))
+
+    # Normal matrix, axis = 1
+    imputer = Imputer(missing_values, strategy=strategy, axis=1)
+    X_trans = imputer.fit(X.transpose()).transform(X.copy().transpose())
+    assert_array_equal(imputer.statistics_, statistics,
+                       err_msg % (1, False))
+    assert_array_equal(X_trans, X_true.transpose(), err_msg % (1, False))
+
+    # Sparse matrix, axis = 0
+    imputer = Imputer(missing_values, strategy=strategy, axis=0)
+    X_trans = imputer.fit(sp.csc_matrix(X)).transform(sp.csc_matrix(X.copy()))
+
+    if sp.issparse(X_trans):
+        X_trans = X_trans.toarray()
+
+    assert_array_equal(imputer.statistics_, statistics,
+                       err_msg % (0, True))
+    assert_array_equal(X_trans, X_true, err_msg % (0, True))
+
+    # Sparse matrix, axis = 1
+    imputer = Imputer(missing_values, strategy=strategy, axis=1)
+    imputer.fit(sp.csc_matrix(X.transpose()))
+    X_trans = imputer.transform(sp.csc_matrix(X.copy().transpose()))
+
+    if sp.issparse(X_trans):
+        X_trans = X_trans.toarray()
+
+    assert_array_equal(imputer.statistics_, statistics,
+                       err_msg % (1, True))
+    assert_array_equal(X_trans, X_true.transpose(),
+                       err_msg % (1, True))
+
+
+def test_imputation_mean_median_only_zero():
+    """Test imputation using the mean and median strategies, when
+       missing_values == 0."""
+    X = np.array([
+        [np.nan, 0, 0,  0,  5],
+        [np.nan, 1, 0,  np.nan,  3],
+        [np.nan, 2, 0,  0, 0],
+        [np.nan, 6, 0,  5,  13],
+    ])
+
+    mean = np.array([
+        [3,  5],
+        [1,  3],
+        [2,  7],
+        [6, 13],
+    ])
+
+    median = np.array([
+        [2, 5,  5],
+        [1, np.nan,  3],
+        [2, 5, 5],
+        [6, 5,  13],
+    ])
+
+    _test_statistics(X, mean, "mean", [np.nan, 3, np.nan, np.nan, 7], 0)
+    _test_statistics(X, median, "median", [np.nan, 2, np.nan, 5, 5], 0)
+
+
+def test_imputation_mean_median():
+    """Test imputation using the mean and median strategies, when
+       missing_values != 0."""
+    rng = np.random.RandomState(0)
+
+    dim = 10
+    dec = 10
+    shape = (dim * dim, dim + dec)
+
+    zeros = np.zeros(shape[0])
+    values = np.arange(1, shape[0]+1)
+    values[4::2] = - values[4::2]
+
+    tests = [("mean", "NaN", lambda z, v, p: np.mean(np.hstack((z, v)))),
+             ("mean", 0, lambda z, v, p: np.mean(v)),
+             ("median", "NaN", lambda z, v, p: np.median(np.hstack((z, v)))),
+             ("median", 0, lambda z, v, p: np.median(v))]
+
+    for strategy, test_missing_values, true_value_fun in tests:
+        X = np.empty(shape)
+        X_true = np.empty(shape)
+        true_statistics = np.empty(shape[1])
+
+        # Create a matrix X with columns
+        #    - with only zeros,
+        #    - with only missing values
+        #    - with zeros, missing values and values
+        # And a matrix X_true containing all true values
+        for j in xrange(shape[1]):
+            nb_zeros = (j - dec + 1 > 0) * (j - dec + 1) * (j - dec + 1)
+            nb_missing_values = max(shape[0] + dec * dec
+                                    - (j + dec) * (j + dec), 0)
+            nb_values = shape[0] - nb_zeros - nb_missing_values
+
+            z = zeros[:nb_zeros]
+            p = np.repeat(test_missing_values, nb_missing_values)
+            v = values[rng.permutation(len(values))[:nb_values]]
+
+            true_statistics[j] = true_value_fun(z, v, p)
+
+            # Create the columns
+            X[:, j] = np.hstack((v, z, p))
+
+            if 0 == test_missing_values:
+                X_true[:, j] = np.hstack((v,
+                                          np.repeat(
+                                              true_statistics[j],
+                                              nb_missing_values + nb_zeros)))
+            else:
+                X_true[:, j] = np.hstack((v,
+                                          z,
+                                          np.repeat(true_statistics[j],
+                                                    nb_missing_values)))
+
+            # Shuffle them the same way
+            np.random.RandomState(j).shuffle(X[:, j])
+            np.random.RandomState(j).shuffle(X_true[:, j])
+
+        # Mean doesn't support columns containing NaNs, median does
+        if strategy == "median":
+            cols_to_keep = ~np.isnan(X_true).any(axis=0)
+        else:
+            cols_to_keep = ~np.isnan(X_true).all(axis=0)
+
+        X_true = X_true[:, cols_to_keep]
+
+        _test_statistics(X, X_true, strategy,
+                              true_statistics, test_missing_values)
+
+
+def test_imputation_most_frequent():
+    """Test imputation using the most-frequent strategy."""
+    X = np.array([
+        [-1, -1,  0,  5],
+        [-1,  2, -1,  3],
+        [-1,  1,  3, -1],
+        [-1,  2,  3,  7],
+    ])
+
+    X_true = np.array([
+        [2,  0,  5],
+        [2,  3,  3],
+        [1,  3,  3],
+        [2,  3,  7],
+    ])
+
+    # scipy.stats.mode, used in Imputer, doesn't return the first most
+    # frequent as promised in the doc but the lowest most frequent. When this
+    # test will fail after an update of scipy, Imputer will need to be updated
+    # to be consistent with the new (correct) behaviour
+    _test_statistics(X, X_true, "most_frequent", [np.nan, 2, 3, 3], -1)
+
+
+def test_imputation_pipeline_grid_search():
+    """Test imputation within a pipeline + gridsearch."""
+    pipeline = Pipeline([('imputer', Imputer(missing_values=0)),
+                         ('tree', tree.DecisionTreeRegressor(random_state=0))])
+
+    parameters = {
+        'imputer__strategy': ["mean", "median", "most_frequent"],
+        'imputer__axis': [0, 1]
+    }
+
+    l = 100
+    X = sparse_random_matrix(l, l, density=0.10)
+    Y = sparse_random_matrix(l, 1, density=0.10).todense()
+    gs = grid_search.GridSearchCV(pipeline, parameters)
+    gs.fit(X, Y)
+
+
+def test_imputation_pickle():
+    """Test for pickling imputers."""
+    import pickle
+
+    l = 100
+    X = sparse_random_matrix(l, l, density=0.10)
+
+    for strategy in ["mean", "median", "most_frequent"]:
+        imputer = Imputer(missing_values=0, strategy=strategy)
+        imputer.fit(X)
+
+        imputer_pickled = pickle.loads(pickle.dumps(imputer))
+
+        assert_array_equal(imputer.transform(X.copy()),
+                           imputer_pickled.transform(X.copy()),
+                           "Fail to transform the data after pickling "
+                           "(strategy = %s)" % (strategy))
+
+
+def test_imputation_copy():
+    """Test imputation with copy=True."""
+    l = 5
+    X = sparse_random_matrix(l, l, density=0.75)
+
+    # Dense
+    imputer = Imputer(missing_values=0, strategy="mean", copy=True)
+    Xt = imputer.fit(X).transform(X)
+    Xt[0, 0] = np.nan
+    # Check that the objects are different and that they don't use
+    # the same buffer
+    assert_false(np.equal(X.todense(), Xt).all())
+
+    # Sparse
+    imputer = Imputer(missing_values=0, strategy="mean", copy=True)
+    X = X.todense()
+    Xt = imputer.fit(X).transform(X)
+    Xt[0, 0] = np.nan
+    # Check that the objects are different and that they don't use
+    # the same buffer
+    assert_false(np.equal(X, Xt).all())

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -807,7 +807,7 @@ def test_add_dummy_feature_csr():
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
-def _test_statistics(X, X_true,
+def _check_statistics(X, X_true,
                           strategy, statistics, missing_values):
     """Utility function for testing imputation for a given strategy.
 
@@ -819,16 +819,15 @@ def _test_statistics(X, X_true,
         - the statistics (mean, median, mode) are correct
         - the missing values are imputed correctly"""
 
-    err_msg = ("Parameters: strategy = %s, "
-               "missing_values = %s" % (strategy, missing_values))
-    err_msg = err_msg + ", axis = %s, sparse = %s"
+    err_msg = "Parameters: strategy = %s, missing_values = %s, " \
+              "axis = %%s, sparse = %%s".format(strategy, missing_values)
 
     # Normal matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
     X_trans = imputer.fit(X).transform(X.copy())
     assert_array_equal(imputer.statistics_, statistics,
-                       err_msg % (0, False))
-    assert_array_equal(X_trans, X_true, err_msg % (0, False))
+                       err_msg.format(0, False))
+    assert_array_equal(X_trans, X_true, err_msg.format(0, False))
 
     # Normal matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
@@ -838,8 +837,8 @@ def _test_statistics(X, X_true,
     else:
         X_trans = imputer.transform(X.copy().transpose())
         assert_array_equal(imputer.statistics_, statistics,
-                           err_msg % (1, False))
-        assert_array_equal(X_trans, X_true.transpose(), err_msg % (1, False))
+                           err_msg.format(1, False))
+        assert_array_equal(X_trans, X_true.transpose(), err_msg.format(1, False))
 
     # Sparse matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
@@ -849,8 +848,8 @@ def _test_statistics(X, X_true,
         X_trans = X_trans.toarray()
 
     assert_array_equal(imputer.statistics_, statistics,
-                       err_msg % (0, True))
-    assert_array_equal(X_trans, X_true, err_msg % (0, True))
+                       err_msg.format(0, True))
+    assert_array_equal(X_trans, X_true, err_msg.format(0, True))
 
     # Sparse matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
@@ -865,9 +864,9 @@ def _test_statistics(X, X_true,
             X_trans = X_trans.toarray()
 
         assert_array_equal(imputer.statistics_, statistics,
-                           err_msg % (1, True))
+                           err_msg.format(1, True))
         assert_array_equal(X_trans, X_true.transpose(),
-                           err_msg % (1, True))
+                           err_msg.format(1, True))
 
 
 def test_imputation_mean_median_only_zero():
@@ -894,8 +893,8 @@ def test_imputation_mean_median_only_zero():
         [6, 5,  13],
     ])
 
-    _test_statistics(X, mean, "mean", [np.nan, 3, np.nan, np.nan, 7], 0)
-    _test_statistics(X, median, "median", [np.nan, 2, np.nan, 5, 5], 0)
+    _check_statistics(X, mean, "mean", [np.nan, 3, np.nan, np.nan, 7], 0)
+    _check_statistics(X, median, "median", [np.nan, 2, np.nan, 5, 5], 0)
 
 
 def test_imputation_mean_median():
@@ -964,7 +963,7 @@ def test_imputation_mean_median():
 
         X_true = X_true[:, cols_to_keep]
 
-        _test_statistics(X, X_true, strategy,
+        _check_statistics(X, X_true, strategy,
                               true_statistics, test_missing_values)
 
 
@@ -988,7 +987,7 @@ def test_imputation_most_frequent():
     # frequent as promised in the doc but the lowest most frequent. When this
     # test will fail after an update of scipy, Imputer will need to be updated
     # to be consistent with the new (correct) behaviour
-    _test_statistics(X, X_true, "most_frequent", [np.nan, 2, 3, 3], -1)
+    _check_statistics(X, X_true, "most_frequent", [np.nan, 2, 3, 3], -1)
 
 
 def test_imputation_pipeline_grid_search():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -832,10 +832,14 @@ def _test_statistics(X, X_true,
 
     # Normal matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
-    X_trans = imputer.fit(X.transpose()).transform(X.copy().transpose())
-    assert_array_equal(imputer.statistics_, statistics,
-                       err_msg % (1, False))
-    assert_array_equal(X_trans, X_true.transpose(), err_msg % (1, False))
+    imputer.fit(X.transpose())
+    if np.isnan(statistics).any():
+        assert_raises(ValueError, imputer.transform, X.copy().transpose())
+    else:
+        X_trans = imputer.transform(X.copy().transpose())
+        assert_array_equal(imputer.statistics_, statistics,
+                           err_msg % (1, False))
+        assert_array_equal(X_trans, X_true.transpose(), err_msg % (1, False))
 
     # Sparse matrix, axis = 0
     imputer = Imputer(missing_values, strategy=strategy, axis=0)
@@ -851,15 +855,19 @@ def _test_statistics(X, X_true,
     # Sparse matrix, axis = 1
     imputer = Imputer(missing_values, strategy=strategy, axis=1)
     imputer.fit(sp.csc_matrix(X.transpose()))
-    X_trans = imputer.transform(sp.csc_matrix(X.copy().transpose()))
+    if np.isnan(statistics).any():
+        assert_raises(ValueError, imputer.transform,
+                      sp.csc_matrix(X.copy().transpose()))
+    else:
+        X_trans = imputer.transform(sp.csc_matrix(X.copy().transpose()))
 
-    if sp.issparse(X_trans):
-        X_trans = X_trans.toarray()
+        if sp.issparse(X_trans):
+            X_trans = X_trans.toarray()
 
-    assert_array_equal(imputer.statistics_, statistics,
-                       err_msg % (1, True))
-    assert_array_equal(X_trans, X_true.transpose(),
-                       err_msg % (1, True))
+        assert_array_equal(imputer.statistics_, statistics,
+                           err_msg % (1, True))
+        assert_array_equal(X_trans, X_true.transpose(),
+                           err_msg % (1, True))
 
 
 def test_imputation_mean_median_only_zero():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -1030,21 +1030,24 @@ def test_imputation_pickle():
 def test_imputation_copy():
     """Test imputation with copy=True."""
     l = 5
-    X = sparse_random_matrix(l, l, density=0.75)
 
-    # Dense
-    imputer = Imputer(missing_values=0, strategy="mean", copy=True)
-    Xt = imputer.fit(X).transform(X)
-    Xt[0, 0] = np.nan
-    # Check that the objects are different and that they don't use
-    # the same buffer
-    assert_false(np.equal(X.todense(), Xt).all())
+    # Test default behaviour and with copy=True
+    for params in [{}, {'copy' : True}]:
+        X = sparse_random_matrix(l, l, density=0.75)
 
-    # Sparse
-    imputer = Imputer(missing_values=0, strategy="mean", copy=True)
-    X = X.todense()
-    Xt = imputer.fit(X).transform(X)
-    Xt[0, 0] = np.nan
-    # Check that the objects are different and that they don't use
-    # the same buffer
-    assert_false(np.equal(X, Xt).all())
+        # Dense
+        imputer = Imputer(missing_values=0, strategy="mean", **params)
+        Xt = imputer.fit(X).transform(X)
+        Xt[0, 0] = np.nan
+        # Check that the objects are different and that they don't use
+        # the same buffer
+        assert_false(np.equal(X.todense(), Xt).all())
+
+        # Sparse
+        imputer = Imputer(missing_values=0, strategy="mean", **params)
+        X = X.todense()
+        Xt = imputer.fit(X).transform(X)
+        Xt[0, 0] = np.nan
+        # Check that the objects are different and that they don't use
+        # the same buffer
+        assert_false(np.equal(X, Xt).all())

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -73,48 +73,51 @@ def as_float_array(X, copy=True):
         return X.astype(np.float32 if X.dtype == np.int32 else np.float64)
 
 
-def array2d(X, dtype=None, order=None, copy=False):
+def array2d(X, dtype=None, order=None, copy=False, force_all_finite=True):
     """Returns at least 2-d array with data from X"""
     if sparse.issparse(X):
         raise TypeError('A sparse matrix was passed, but dense data '
                         'is required. Use X.toarray() to convert to dense.')
     X_2d = np.asarray(np.atleast_2d(X), dtype=dtype, order=order)
-    _assert_all_finite(X_2d)
+    if force_all_finite:
+        _assert_all_finite(X_2d)
     if X is X_2d and copy:
         X_2d = safe_copy(X_2d)
     return X_2d
 
 
-def _atleast2d_or_sparse(X, dtype, order, copy, sparse_class, convmethod):
+def _atleast2d_or_sparse(X, dtype, order, copy, sparse_class, convmethod, force_all_finite):
     if sparse.issparse(X):
         if dtype is None or X.dtype == dtype:
             X = getattr(X, convmethod)()
         else:
             X = sparse_class(X, dtype=dtype)
-        _assert_all_finite(X.data)
+        if force_all_finite:
+            _assert_all_finite(X.data)
         X.data = np.array(X.data, copy=False, order=order)
     else:
-        X = array2d(X, dtype=dtype, order=order, copy=copy)
-        _assert_all_finite(X)
+        X = array2d(X, dtype=dtype, order=order, copy=copy, force_all_finite=force_all_finite)
+        if force_all_finite:
+            _assert_all_finite(X)
     return X
 
 
-def atleast2d_or_csc(X, dtype=None, order=None, copy=False):
+def atleast2d_or_csc(X, dtype=None, order=None, copy=False, force_all_finite=True):
     """Like numpy.atleast_2d, but converts sparse matrices to CSC format.
 
     Also, converts np.matrix to np.ndarray.
     """
     return _atleast2d_or_sparse(X, dtype, order, copy, sparse.csc_matrix,
-                                "tocsc")
+                                "tocsc", force_all_finite)
 
 
-def atleast2d_or_csr(X, dtype=None, order=None, copy=False):
+def atleast2d_or_csr(X, dtype=None, order=None, copy=False, force_all_finite=True):
     """Like numpy.atleast_2d, but converts sparse matrices to CSR format
 
     Also, converts np.matrix to np.ndarray.
     """
     return _atleast2d_or_sparse(X, dtype, order, copy, sparse.csr_matrix,
-                                "tocsr")
+                                "tocsr", force_all_finite)
 
 
 def _num_samples(x):


### PR DESCRIPTION
Here's some code for the data imputation. 

It's still a work in progress so _Travis_ will probably be mad at me.

I'll work on the documentation tomorrow. Meanwhile, you can look at the tests if you want to see how it works.

**_What's new**_
I added four classes:
- MeanImputer: replace the missing values with the mean of the row/column
- MedianImputer: replace the missing values with the median of the row/column
- MostFrequentImputer: replace the missing values with the most frequent value in the row/column
- RandomImputer: replace the missing values with one of the values of the row/column

**_Behaviour**_
- Any value can represent a missing value (not only np.nan for dense matrices and 0 for sparse matrices, _any_ value)
- Different missing values can be imputed separately in a pipeline
- Support dense and sparse matrices
- **To determine:** What should the imputer do if he has nothing to work with? For example: What should be done if there's no median value because the whole row/column is missing?
  - 0 for the mean and np.nan for the median/most frequent/random? 
  - always np.nan?
  - Let the user choose with a parameter?

**_What's missing**_
- [x] **Documentation**
- [x] Delete the rows/columns where `np.isnan(imputation_data_)`
- [x] Add tests with copy
- [x] Add tests with grid search
- [x] Test pickling
