### PR TITLE
Last of the Python3 Bugs!(?)

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -203,14 +203,17 @@ class BaseEstimator(object):
         # We need deprecation warnings to always be on for this to work.
         # This is set in utils/__init__.py but it gets overwritten
         # when running under python3 somehow.
-        warnings.simplefilter("always", DeprecationWarning)
         for key in self._get_param_names():
             # catch deprecation warnings
-            with warnings.catch_warnings(record=True) as w:
-                value = getattr(self, key, None)
-            if len(w) and w[0].category == DeprecationWarning:
+            warnings.simplefilter("always", DeprecationWarning)
+            try:
+                with warnings.catch_warnings(record=True) as w:
+                    value = getattr(self, key, None)
+                if len(w) and w[0].category == DeprecationWarning:
                 # if the parameter is deprecated, don't show it
-                continue
+                    continue
+            finally:
+                warnings.filters.pop(0)
 
             # XXX: should we rather test if instance of estimator?
             if deep and hasattr(value, 'get_params'):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -200,11 +200,11 @@ class BaseEstimator(object):
             Parameter names mapped to their values.
         """
         out = dict()
-        # We need deprecation warnings to always be on for this to work.
-        # This is set in utils/__init__.py but it gets overwritten
-        # when running under python3 somehow.
         for key in self._get_param_names():
-            # catch deprecation warnings
+            # We need deprecation warnings to always be on in order to
+            # catch deprecated param values.
+            # This is set in utils/__init__.py but it gets overwritten
+            # when running under python3 somehow.
             warnings.simplefilter("always", DeprecationWarning)
             try:
                 with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
I seem to have all tests passing locally for python3 now.

This required changing a lot of doc tests to no longer assert on the output of their values, i.e. changing

``` python
>>> foo()
[u'a', u'b']
```

To

``` python
>>> foo() == ['a', 'b']
True
```

This is because unicode strings do not print with the preceding u in python3.

Two changes in this PR I would like special attention of:

sklearn/base.py:206
This logic required that DeprecationWarnings would show up after calling getattr. This for some reason was getting broken in python3. Adding this here seems a little bit like a hack. We already make a call like that in utils/**init**.py, but it was not sticking around.

sklearn/tests/test_cross_validation.py:71
We were checking the dimensions relative to the global variable 'y' instead of the local variable 'Y'. I switched it to 'Y', that makes more sense relative to the code in cross_validation.py:1035, which resizes the fit parameters relative to the cross validation set size.

Look forward to getting validation of this on the jenkins build so I know I didn't break any python2 stuff in the process.
