### PR TITLE
[WIP] Dbscan balltrees

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -537,6 +537,13 @@ the order is determined randomly within the code. Other than the ordering of,
 the dataset, the algorithm is deterministic, making the results relatively
 stable between iterations on the same data.
 
+The current implementation relies heavily on :class:'NearestNeighbors': 
+to determine the number of samples within distance eps. This is to take
+advantage of the ball tree and kd-tree methods of speeding up neighbor
+searching and to avoid calculating the full distance matrix.
+We also retain the flexibility of custom metrics -- for details, 
+see :class:'NearestNeighbors':.
+
 In the figure below, the color indicates cluster membership, with large circles
 indicating core samples found by the algorithm. Smaller circles are non-core
 samples that are still part of a cluster. Moreover, the outliers are indicated

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -12,10 +12,11 @@ import numpy as np
 from ..base import BaseEstimator, ClusterMixin
 from ..metrics import pairwise_distances
 from ..utils import check_random_state
+from ..neighbors import NearestNeighbors
 
 
-def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
-           random_state=None):
+def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
+           algorithm='auto', leaf_size=30, p=2, random_state=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
     Parameters
@@ -24,12 +25,15 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
         Array of distances between samples, or a feature array.
         The array is treated as a feature array unless the metric is given as
         'precomputed'.
+
     eps: float, optional
         The maximum distance between two samples for them to be considered
         as in the same neighborhood.
+
     min_samples: int, optional
         The number of samples in a neighborhood for a point to be considered
         as a core point.
+
     metric: string, or callable
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
@@ -37,6 +41,22 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
         metric parameter.
         If metric is "precomputed", X is assumed to be a distance matrix and
         must be square.
+
+    algorithm: {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+        The algorithm to be used by the NearestNeighbors module
+        to compute pointwise distances and find nearest neighbors.
+        See NearestNeighbors module documentation for details.
+
+    leaf_size: int, optional (default = 30)
+        Leaf size passed to BallTree or cKDTree. This can affect the speed
+        of the construction and query, as well as the memory required
+        to store the tree. The optimal value depends
+        on the nature of the problem.
+
+    p: float, optional
+        The power of the Minkowski metric to be used to calculate distance
+        between points.
+
     random_state: numpy.RandomState, optional
         The generator used to initialize the centers. Defaults to numpy.random.
 
@@ -50,7 +70,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
 
     Notes
     -----
-    See examples/cluster/plot_cluster_comparison.py for an example.
+    See examples/plot_dbscan.py for an example.
 
     References
     ----------
@@ -59,44 +79,91 @@ def dbscan(X, eps=0.5, min_samples=5, metric='euclidean',
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
     and Data Mining, Portland, OR, AAAI Press, pp. 226–231. 1996
     """
+    if not eps > 0.0:
+	    raise ValueError("eps must be positive.")
+
     X = np.asarray(X)
     n = X.shape[0]
+
     # If index order not given, create random order.
     random_state = check_random_state(random_state)
     index_order = np.arange(n)
     random_state.shuffle(index_order)
-    D = pairwise_distances(X, metric=metric)
+
+    # check for known metric powers
+    distance_matrix = True
+    if metric == 'precomputed':
+        D = pairwise_distances(X, metric=metric)
+    else:
+        distance_matrix = False
+        neighbors_model = NearestNeighbors(radius=eps, algorithm=algorithm,
+                                           leaf_size=leaf_size,
+                                           metric=metric, p=p)
+        neighbors_model.fit(X)
+
     # Calculate neighborhood for all samples. This leaves the original point
     # in, which needs to be considered later (i.e. point i is the
     # neighborhood of point i. While True, its useless information)
-    neighborhoods = [np.where(x <= eps)[0] for x in D]
+    neighborhoods = []
+    if distance_matrix:
+        neighborhoods = [np.where(x <= eps)[0] for x in D]
+
     # Initially, all samples are noise.
     labels = -np.ones(n)
+
     # A list of all core samples found.
     core_samples = []
+
     # label_num is the label given to the new cluster
     label_num = 0
+
     # Look at all samples and determine if they are core.
     # If they are then build a new cluster from them.
     for index in index_order:
-        if labels[index] != -1 or len(neighborhoods[index]) < min_samples:
-            # This point is already classified, or not enough for a core point.
+        # Already classified
+        if labels[index] != -1:
             continue
+
+        # get neighbors from neighborhoods or ballTree
+        index_neighborhood = []
+        if distance_matrix:
+            index_neighborhood = neighborhoods[index]
+        else:
+            index_neighborhood = neighbors_model.radius_neighbors(
+                X[index], eps, return_distance=False)[0]
+
+        # Too few samples to be core
+        if len(index_neighborhood) < min_samples:
+            continue
+
         core_samples.append(index)
         labels[index] = label_num
         # candidates for new core samples in the cluster.
         candidates = [index]
+
         while len(candidates) > 0:
             new_candidates = []
             # A candidate is a core point in the current cluster that has
             # not yet been used to expand the current cluster.
             for c in candidates:
-                noise = np.where(labels[neighborhoods[c]] == -1)[0]
-                noise = neighborhoods[c][noise]
+                c_neighborhood = []
+                if distance_matrix:
+                    c_neighborhood = neighborhoods[c]
+                else:
+                    c_neighborhood = neighbors_model.radius_neighbors(
+                        X[c], eps, return_distance=False)[0]
+                noise = np.where(labels[c_neighborhood] == -1)[0]
+                noise = c_neighborhood[noise]
                 labels[noise] = label_num
                 for neighbor in noise:
+                    n_neighborhood = []
+                    if distance_matrix:
+                        n_neighborhood = neighborhoods[neighbor]
+                    else:
+                        n_neighborhood = neighbors_model.radius_neighbors(
+                            X[neighbor], eps, return_distance=False)[0]
                     # check if its a core point as well
-                    if len(neighborhoods[neighbor]) >= min_samples:
+                    if len(n_neighborhood) >= min_samples:
                         # is new core point
                         new_candidates.append(neighbor)
                         core_samples.append(neighbor)
@@ -147,7 +214,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
     Notes
     -----
-    See examples/cluster/plot_cluster_comparison.py for an example.
+    See examples/plot_dbscan.py for an example.
 
     References
     ----------
@@ -158,10 +225,13 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     """
 
     def __init__(self, eps=0.5, min_samples=5, metric='euclidean',
-                 random_state=None):
+                 algorithm='auto', leaf_size=30, p=None, random_state=None):
         self.eps = eps
         self.min_samples = min_samples
         self.metric = metric
+        self.algorithm = algorithm
+        self.leaf_size = leaf_size
+        self.p = p
         self.random_state = random_state
 
     def fit(self, X):

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -5,11 +5,14 @@ Tests for DBSCAN clustering algorithm
 import pickle
 
 import numpy as np
+from numpy.testing import assert_raises
+
 from scipy.spatial import distance
 
 from sklearn.utils.testing import assert_equal
 from sklearn.cluster.dbscan_ import DBSCAN, dbscan
 from .common import generate_clustered_data
+from sklearn.metrics.pairwise import pairwise_distances
 
 
 n_clusters = 3
@@ -73,17 +76,77 @@ def test_dbscan_callable():
     # Compute DBSCAN
     # parameters chosen for task
     core_samples, labels = dbscan(X, metric=metric, eps=eps,
+                                  min_samples=min_samples,
+                                  algorithm='ball_tree')
+
+    # number of clusters, ignoring noise if present
+    n_clusters_1 = len(set(labels)) - int(-1 in labels)
+    assert_equal(n_clusters_1, n_clusters)
+
+    db = DBSCAN(metric=metric, eps=eps, min_samples=min_samples,
+                algorithm='ball_tree')
+    labels = db.fit(X).labels_
+
+    n_clusters_2 = len(set(labels)) - int(-1 in labels)
+    assert_equal(n_clusters_2, n_clusters)
+
+
+def test_dbscan_balltree():
+    """Tests the DBSCAN algorithm with balltree for neighbor calculation."""
+    eps = 0.8
+    min_samples = 10
+
+    D = pairwise_distances(X)
+    core_samples, labels = dbscan(D, metric="precomputed", eps=eps,
                                   min_samples=min_samples)
 
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_1, n_clusters)
 
-    db = DBSCAN(metric=metric, eps=eps, min_samples=min_samples)
+    db = DBSCAN(p=2.0, eps=eps, min_samples=min_samples, algorithm='ball_tree')
     labels = db.fit(X).labels_
 
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_2, n_clusters)
+
+    db = DBSCAN(p=2.0, eps=eps, min_samples=min_samples, algorithm='kd_tree')
+    labels = db.fit(X).labels_
+
+    n_clusters_3 = len(set(labels)) - int(-1 in labels)
+    assert_equal(n_clusters_3, n_clusters)
+
+    db = DBSCAN(p=1.0, eps=eps, min_samples=min_samples, algorithm='ball_tree')
+    labels = db.fit(X).labels_
+
+    n_clusters_4 = len(set(labels)) - int(-1 in labels)
+    assert_equal(n_clusters_4, n_clusters)
+
+    db = DBSCAN(leaf_size=20, eps=eps, min_samples=min_samples,
+                algorithm='ball_tree')
+    labels = db.fit(X).labels_
+
+    n_clusters_5 = len(set(labels)) - int(-1 in labels)
+    assert_equal(n_clusters_5, n_clusters)
+
+
+def test_dbscan_badargs():
+    """Test bad argument values: these should all raise ValueErrors"""
+    assert_raises(ValueError,
+                  dbscan,
+                  X, eps=-1.0)
+    assert_raises(ValueError,
+                  dbscan,
+                  X, algorithm='blah')
+    assert_raises(ValueError,
+                  dbscan,
+                  X, metric='blah')
+    assert_raises(ValueError,
+                  dbscan,
+                  X, leaf_size=-1)
+    assert_raises(ValueError,
+                  dbscan,
+                  X, p=-1)
 
 
 def test_pickle():

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -711,7 +711,6 @@ def confusion_matrix(y_true, y_pred, labels=None):
     if y_type not in ("binary", "multiclass"):
         raise ValueError("%s is not supported" % y_type)
 
-
     if labels is None:
         labels = unique_labels(y_true, y_pred)
     else:

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -584,7 +584,8 @@ def test_matthews_corrcoef_nan():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         assert_equal(matthews_corrcoef([0], [1]), 0.0)
-
+        warnings.simplefilter("error")
+        assert_equal(matthews_corrcoef([0,0],[0,1]), 0.0)
 
 def test_precision_recall_f1_score_multiclass():
     """Test Precision Recall and F1 Score for multiclass classification task"""


### PR DESCRIPTION
DBSCAN modified to use balltrees for neighborhood calculations for the case of a Minkowski metric. The restriction to Minkowski metrics is a direct result of a limitation of the balltree implementation.  Additional, optional parameter added to DBSCAN for the power of Minkowski metric. Precomputed metrics or other metrics still be useable.

TODO:
- [x] wait for #1732 to be completed and merged to update this branch on top of the latest change in the neighbors module
