### PR TITLE
Use float64 inside metrics.r2_score() to preserve FP accuracy

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -2392,8 +2392,8 @@ def r2_score(y_true, y_pred):
     if len(y_true) == 1:
         raise ValueError("r2_score can only be computed given more than one"
                          " sample.")
-    numerator = ((y_true - y_pred) ** 2).sum()
-    denominator = ((y_true - y_true.mean(axis=0)) ** 2).sum()
+    numerator = ((y_true - y_pred) ** 2).sum(dtype=np.float64)
+    denominator = ((y_true - y_true.mean(axis=0)) ** 2).sum(dtype=np.float64)
 
     if denominator == 0.0:
         if numerator == 0.0:


### PR DESCRIPTION
Without this, if the input arrays are of type np.float32, their sums may be computed with an large accumulated error, resulting in the wrong score.  This can often be seen with very long arrays (millions of elements).  The "1 - numerator / denominator" calculation at the very end produces a float64 when the inputs are float32 anyway, so the returned type does not change--only the accuracy.

The existing metrics tests pass after this change; someone may with to further review other uses of sum() in this file and elsewhere to see if similar improvements can be made.
