### PR TITLE
BUG: use correct algorithm for callable metric

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -115,8 +115,8 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
             alg_check = algorithm
 
         if metric not in VALID_METRICS[alg_check]:
-            # callable metric is valid for brute force, kd_tree, and ball_tree
-            if callable(metric):
+            # callable metric is valid for brute force and ball_tree
+            if callable(metric) and algorithm != 'kd_tree':
                 pass
             else:
                 raise ValueError("metric '%s' not valid for algorithm '%s'"
@@ -199,8 +199,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
             # and KDTree is generally faster when available
             if (self.n_neighbors is None
                     or self.n_neighbors < self._fit_X.shape[0] // 2):
-                if (callable(self.effective_metric_)
-                        or self.effective_metric_ in VALID_METRICS['kd_tree']):
+                if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
                 else:
                     self._fit_method = 'ball_tree'

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -642,7 +642,7 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
 def test_callable_metric():
     metric = lambda x1, x2: np.sqrt(np.sum(x1 ** 2 + x2 ** 2))
 
-    X = np.random.random((20, 2))
+    X = np.random.RandomState(42).rand(20, 2)
     nbrs1 = neighbors.NearestNeighbors(3, algorithm='auto', metric=metric)
     nbrs2 = neighbors.NearestNeighbors(3, algorithm='brute', metric=metric)
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -639,6 +639,22 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
         assert_array_almost_equal(results[0][1], results[1][1])
 
 
+def test_callable_metric():
+    metric = lambda x1, x2: np.sqrt(np.sum(x1 ** 2 + x2 ** 2))
+
+    X = np.random.random((20, 2))
+    nbrs1 = neighbors.NearestNeighbors(3, algorithm='auto', metric=metric)
+    nbrs2 = neighbors.NearestNeighbors(3, algorithm='brute', metric=metric)
+
+    nbrs1.fit(X)
+    nbrs2.fit(X)
+
+    dist1, ind1 = nbrs1.kneighbors(X)
+    dist2, ind2 = nbrs2.kneighbors(X)
+
+    assert_array_almost_equal(dist1, dist2)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
Fixes bug reported in #2151.  The neighbors base object was choosing  the wrong algorithm given a callable metric.
