### PR TITLE
[MRG] Ensure that classification metrics support string label

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,7 @@
 
 Changelog
 ---------
+
    - Missing values with sparse and dense matrices can be imputed with the
      transformer :class:`preprocessing.Imputer` by `Nicolas Trésegnie`_.
 
@@ -132,6 +133,7 @@ Changelog
    - Python 3 support fixes by `Justin Vincent`_, `Lars Buitinck`_ and
      `Olivier Grisel`_. All tests now pass under Python 3.3.
 
+<<<<<<< HEAD
    - Reduce memory footprint of FastICA by `Denis Engemann`_ and
      `Alexandre Gramfort`_.
 
@@ -146,6 +148,10 @@ Changelog
      By `Peter Prettenhofer`_.
 
 
+=======
+   - Most metrics now support string labels for multiclass classification
+     by `Arnaud Joly`_ and `Lars Buitinck`_.
+>>>>>>> Update what's new
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -133,7 +133,6 @@ Changelog
    - Python 3 support fixes by `Justin Vincent`_, `Lars Buitinck`_ and
      `Olivier Grisel`_. All tests now pass under Python 3.3.
 
-<<<<<<< HEAD
    - Reduce memory footprint of FastICA by `Denis Engemann`_ and
      `Alexandre Gramfort`_.
 
@@ -147,11 +146,9 @@ Changelog
      how to use OOB estimates to select the number of trees was added.
      By `Peter Prettenhofer`_.
 
-
-=======
    - Most metrics now support string labels for multiclass classification
      by `Arnaud Joly`_ and `Lars Buitinck`_.
->>>>>>> Update what's new
+
 
 API changes summary
 -------------------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1073,7 +1073,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     labels : array
         Integer array of labels.
 
-    pos_label : int, 1 by default
+    pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1197,7 +1197,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     labels : array
         Integer array of labels.
 
-    pos_label : int, 1 by default
+    pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1460,7 +1460,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     labels : array
         Integer array of labels.
 
-    pos_label : int, 1 by default
+    pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1743,7 +1743,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     labels : array
         Integer array of labels.
 
-    pos_label : int, 1 by default
+    pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
@@ -1865,7 +1865,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
     labels : array
         Integer array of labels.
 
-    pos_label : int, 1 by default
+    pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1673,8 +1673,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
             if len(labels) == 1:
                 # Only negative labels
                 return (0., 0., 0., 0)
-            raise ValueError("pos_label=%d is not a valid label: %r" %
-                             (pos_label, labels))
+            raise ValueError("pos_label=%r is not a valid label: %r" %
+                             (pos_label, list(labels)))
         pos_label_idx = list(labels).index(pos_label)
         return (precision[pos_label_idx], recall[pos_label_idx],
                 fscore[pos_label_idx], support[pos_label_idx])

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -2058,7 +2058,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     for i, label in enumerate(labels):
         values = [target_names[i]]
         for v in (p[i], r[i], f1[i]):
-            values += ["{0:0.2f}".format(float(v))]
+            values += ["{0:0.2f}".format(v)]
         values += ["{0}".format(s[i])]
         report += fmt % tuple(values)
 
@@ -2069,8 +2069,8 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     for v in (np.average(p, weights=s),
               np.average(r, weights=s),
               np.average(f1, weights=s)):
-        values += ["%0.2f" % float(v)]
-    values += ['%d' % np.sum(s)]
+        values += ["{0:0.2f}".format(v)]
+    values += ['{0}'.format(np.sum(s))]
     report += fmt % tuple(values)
     return report
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -27,7 +27,6 @@ from ..preprocessing import LabelBinarizer
 from ..utils import check_arrays
 from ..utils import deprecated
 from ..utils.fixes import divide
-from ..utils.fixes import unique
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function
 
 import warnings
-import inspect
 import numpy as np
 
 from functools import partial
@@ -113,6 +112,21 @@ ALL_METRICS = dict()
 ALL_METRICS.update(THRESHOLDED_METRICS)
 ALL_METRICS.update(CLASSIFICATION_METRICS)
 ALL_METRICS.update(REGRESSION_METRICS)
+
+METRICS_WITH_POS_LABEL = [
+    "roc_curve",
+
+    "precision_score", "recall_score", "f1_score", "f2_score", "f0.5_score",
+
+    "weighted_f0.5_score", "weighted_f1_score", "weighted_f2_score",
+    "weighted_precision_score", "weighted_recall_score",
+
+    "micro_f0.5_score", "micro_f1_score", "micro_f2_score",
+    "micro_precision_score", "micro_recall_score",
+
+    "macro_f0.5_score", "macro_f1_score", "macro_f2_score",
+    "macro_precision_score", "macro_recall_score",
+]
 
 METRICS_WITH_NORMALIZE_OPTION = {
     "accuracy_score ": accuracy_score,
@@ -1063,17 +1077,9 @@ def test_invariance_string_vs_numbers_labels():
         measure_with_number = metric(y1, y2)
 
         # Ugly, but handle case with a pos_label and label
-        if hasattr(metric, "func"):
-            argspect = inspect.getargspec(metric.func)
-        else:
-            argspect = inspect.getargspec(metric)
-
         metric_str = metric
-        if "pos_label" in argspect[0]:
+        if name in METRICS_WITH_POS_LABEL:
             metric_str = partial(metric_str, pos_label=pos_label_str)
-
-        if "labels" in argspect[0]:
-            metric_str = partial(metric_str, labels=labels_str)
 
         measure_with_str = metric_str(y1_str, y2_str)
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -128,6 +128,21 @@ METRICS_WITH_POS_LABEL = [
     "macro_precision_score", "macro_recall_score",
 ]
 
+METRICS_WITH_LABELS = [
+    "confusion_matrix",
+
+    "precision_score", "recall_score", "f1_score", "f2_score", "f0.5_score",
+
+    "weighted_f0.5_score", "weighted_f1_score", "weighted_f2_score",
+    "weighted_precision_score", "weighted_recall_score",
+
+    "micro_f0.5_score", "micro_f1_score", "micro_f2_score",
+    "micro_precision_score", "micro_recall_score",
+
+    "macro_f0.5_score", "macro_f1_score", "macro_f2_score",
+    "macro_precision_score", "macro_recall_score",
+]
+
 METRICS_WITH_NORMALIZE_OPTION = {
     "accuracy_score ": accuracy_score,
     "jaccard_similarity_score": jaccard_similarity_score,
@@ -1076,6 +1091,13 @@ def test_invariance_string_vs_numbers_labels():
         assert_array_equal(measure_with_number, measure_with_str,
                            err_msg="{0} failed string vs number invariance "
                                    "test".format(name))
+
+        if name in METRICS_WITH_LABELS:
+            metric_str = partial(metric_str, labels=labels_str)
+            measure_with_str = metric_str(y1_str, y2_str)
+            assert_array_equal(measure_with_number, measure_with_str,
+                               err_msg="{0} failed string vs number  "
+                                       "invariance test".format(name))
 
     # TODO Currently not supported
     for name, metrics in THRESHOLDED_METRICS.items():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -740,14 +740,8 @@ avg / total       0.51      0.53      0.47        75
 def test_classification_report_multiclass_with_string_label():
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    y_true = y_true.astype(np.str)
-    y_true[y_true == "0"] = "blue"
-    y_true[y_true == "1"] = "green"
-    y_true[y_true == "2"] = "red"
-    y_pred = y_pred.astype(np.str)
-    y_pred[y_pred == "0"] = "blue"
-    y_pred[y_pred == "1"] = "green"
-    y_pred[y_pred == "2"] = "red"
+    y_true = np.array(["blue", "green", "red"])[y_true]
+    y_pred = np.array(["blue", "green", "red"])[y_pred]
 
     expected_report = """\
              precision    recall  f1-score   support
@@ -1063,12 +1057,8 @@ def test_invariance_string_vs_numbers_labels():
     """Ensure that classification metrics with string labels"""
     y1, y2, _ = make_prediction(binary=True)
 
-    y1_str = y1.astype(np.str)
-    y1_str[y1_str == "0"] = "eggs"
-    y1_str[y1_str == "1"] = "spam"
-    y2_str = y2.astype(np.str)
-    y2_str[y2_str == "0"] = "eggs"
-    y2_str[y2_str == "1"] = "spam"
+    y1_str = np.array(["eggs", "spam"])[y1]
+    y2_str = np.array(["eggs", "spam"])[y2]
 
     pos_label_str = "spam"
     labels_str = ["eggs", "spam"]

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1060,10 +1060,9 @@ def test_invariance_string_vs_numbers_labels():
     labels_str = ["eggs", "spam"]
 
     for name, metric in CLASSIFICATION_METRICS.items():
-        print(name)
         measure_with_number = metric(y1, y2)
 
-        # Ugly, but handle case with a pos_label
+        # Ugly, but handle case with a pos_label and label
         if hasattr(metric, "func"):
             argspect = inspect.getargspec(metric.func)
         else:
@@ -1082,7 +1081,7 @@ def test_invariance_string_vs_numbers_labels():
                            err_msg="{0} failed string vs number invariance "
                                    "test".format(name))
 
-    # Currently not supported
+    # TODO Currently not supported
     for name, metrics in THRESHOLDED_METRICS.items():
         assert_raises(ValueError, metrics, y1_str, y2_str)
 


### PR DESCRIPTION
Since most estimators accept string as input, I make sure that most metrics will do.

This pr doesn't include metrics with y_score.

This should fix #2168, #1989
