### PR TITLE
[MRG] partial_fit for the discrete naive Bayes models

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -976,6 +976,7 @@ Pairwise metrics
 
    preprocessing.add_dummy_feature
    preprocessing.binarize
+   preprocessing.label_binarize
    preprocessing.normalize
    preprocessing.scale
 

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -47,14 +47,14 @@ and we can use Maximum A Posteriori (MAP) estimation to estimate
 the former is then the relative frequency of class :math:`y`
 in the training set.
 
-The different Naive Bayes classifiers differ mainly by the assumptions they make
-regarding the distribution of :math:`P(x_i \mid y)`.
+The different naive Bayes classifiers differ mainly by the assumptions they
+make regarding the distribution of :math:`P(x_i \mid y)`.
 
-In spite of their apparently over-simplified assumptions, Naive Bayes
+In spite of their apparently over-simplified assumptions, naive Bayes
 classifiers have worked quite well in many real-world situations, famously
 document classification and spam filtering. They requires a small amount
 of training data to estimate the necessary parameters. (For theoretical
-reasons why Naive Bayes works well, and on which types of data it does, see
+reasons why naive Bayes works well, and on which types of data it does, see
 the references below.)
 
 Naive Bayes learners and classifiers can be extremely fast compared to more
@@ -64,7 +64,7 @@ distribution can be independently estimated as a one dimensional distribution.
 This in turn helps to alleviate problems stemming from the curse of
 dimensionality.
 
-On the flip side, although Naive Bayes is known as a decent classifier,
+On the flip side, although naive Bayes is known as a decent classifier,
 it is known to be a bad estimator, so the probability outputs from
 ``predict_proba`` are not to be taken too seriously.
 
@@ -101,8 +101,8 @@ are estimated using maximum likelihood.
 Multinomial Naive Bayes
 -----------------------
 
-:class:`MultinomialNB` implements the Naive Bayes algorithm for multinomially
-distributed data, and is one of the two classic Naive Bayes variants used in
+:class:`MultinomialNB` implements the naive Bayes algorithm for multinomially
+distributed data, and is one of the two classic naive Bayes variants used in
 text classification (where the data are typically represented as word vector
 counts, although tf-idf vectors are also known to work well in practice).
 The distribution is parametrized by vectors
@@ -137,7 +137,7 @@ while :math:`\alpha < 1` is called Lidstone smoothing.
 Bernoulli Naive Bayes
 ---------------------
 
-:class:`BernoulliNB` implements the Naive Bayes training and classification
+:class:`BernoulliNB` implements the naive Bayes training and classification
 algorithms for data that is distributed according to multivariate Bernoulli
 distributions; i.e., there may be multiple features but each one is assumed
 to be a binary-valued (Bernoulli, boolean) variable.
@@ -145,7 +145,7 @@ Therefore, this class requires samples to be represented as binary-valued
 feature vectors; if handed any other kind of data, a ``BernoulliNB`` instance
 may binarize its input (depending on the ``binarize`` parameter).
 
-The decision rule for Bernoulli Naive Bayes is based on
+The decision rule for Bernoulli naive Bayes is based on
 
 .. math::
 
@@ -176,3 +176,22 @@ It is advisable to evaluate both models, if time permits.
    <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.61.5542>`_
    3rd Conf. on Email and Anti-Spam (CEAS).
 
+
+Out-of-core naive Bayes model fitting
+-------------------------------------
+
+Discrete naive Bayes models can be used to tackle large scale text
+classification problems for which the full training set might not fit in
+memory. To handle this case both :class:`MultinomialNB` and
+:class:`BernoulliNB` expose a ``partial_fit`` method that can be used
+incrementally as done with other classifiers as demonstrated in
+:ref:`example_applications_plot_out_of_core_classification.py`.
+
+Contrary to the ``fit`` method, the first call to ``partial_fit`` need to be
+passed the list of all the possible expected class labels.
+
+note::
+
+  The ``partial_fit`` method call of naive Bayes models introduces some
+  computational overhead. It is recommended to use data chunk sizes that are as
+  large as possible, that is as large as the available RAM allows.

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -188,7 +188,7 @@ incrementally as done with other classifiers as demonstrated in
 :ref:`example_applications_plot_out_of_core_classification.py`.
 
 Contrary to the ``fit`` method, the first call to ``partial_fit`` need to be
-passed the list of all the possible expected class labels.
+passed the list of all the expected class labels.
 
 note::
 

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -187,11 +187,11 @@ memory. To handle this case both :class:`MultinomialNB` and
 incrementally as done with other classifiers as demonstrated in
 :ref:`example_applications_plot_out_of_core_classification.py`.
 
-Contrary to the ``fit`` method, the first call to ``partial_fit`` need to be
+Contrary to the ``fit`` method, the first call to ``partial_fit`` needs to be
 passed the list of all the expected class labels.
 
 note::
 
   The ``partial_fit`` method call of naive Bayes models introduces some
   computational overhead. It is recommended to use data chunk sizes that are as
-  large as possible, that is as large as the available RAM allows.
+  large as possible, that is as the available RAM allows.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -852,7 +852,7 @@ Highlights
      ``shrink_threshold`` parameter, which implements **shrunken centroid
      classification**, by `Robert Layton`_.
 
-   - Out-of-core learning support for discreete naive Bayes classifiers
+   - Out-of-core learning support for discrete naive Bayes classifiers
      :class:`sklearn.naive_bayes.MultinomialNB` and
      :class:`sklearn.naive_bayes.BernoulliNB` by adding the ``partial_fit``
      method by `Olivier Grisel`_.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -852,6 +852,11 @@ Highlights
      ``shrink_threshold`` parameter, which implements **shrunken centroid
      classification**, by `Robert Layton`_.
 
+   - Out-of-core learning support for discreete naive Bayes classifiers
+     :class:`sklearn.naive_bayes.MultinomialNB` and
+     :class:`sklearn.naive_bayes.BernoulliNB` by adding the ``partial_fit``
+     method by `Olivier Grisel`_.
+
 Other changes
 ..............
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -17,6 +17,7 @@ from ..base import BaseEstimator, RegressorMixin
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import array2d, atleast2d_or_csr, check_arrays, deprecated
 from ..utils.extmath import safe_sparse_dot
+from ..utils.multiclass import _check_partial_fit_classes_consistency
 from ..externals import six
 
 from .sgd_fast import plain_sgd as plain_sgd
@@ -341,16 +342,7 @@ class BaseSGDClassifier(BaseSGD, LinearClassifierMixin):
         _check_fit_data(X, y)
 
         self._validate_params()
-
-        if self.classes_ is None and classes is None:
-            raise ValueError("classes must be passed on the first call "
-                             "to partial_fit.")
-        elif classes is not None and self.classes_ is not None:
-            if not np.all(self.classes_ == np.unique(classes)):
-                raise ValueError("`classes` is not the same as on last call "
-                                 "to partial_fit.")
-        elif classes is not None:
-            self.classes_ = classes
+        _check_partial_fit_classes_consistency(self, classes)
 
         n_classes = self.classes_.shape[0]
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -17,7 +17,7 @@ from ..base import BaseEstimator, RegressorMixin
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import array2d, atleast2d_or_csr, check_arrays, deprecated
 from ..utils.extmath import safe_sparse_dot
-from ..utils.multiclass import _check_partial_fit_classes_consistency
+from ..utils.multiclass import _check_partial_fit_first_call
 from ..externals import six
 
 from .sgd_fast import plain_sgd as plain_sgd
@@ -342,7 +342,7 @@ class BaseSGDClassifier(BaseSGD, LinearClassifierMixin):
         _check_fit_data(X, y)
 
         self._validate_params()
-        _check_partial_fit_classes_consistency(self, classes)
+        _check_partial_fit_first_call(self, classes)
 
         n_classes = self.classes_.shape[0]
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -270,7 +270,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     @property
     def multilabel_(self):
         """Whether this is a multilabel classifier"""
-        return self.label_binarizer_.multilabel
+        return self.label_binarizer_.multilabel_
 
     def score(self, X, y):
         if self.multilabel_:

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -22,7 +22,9 @@ from scipy.sparse import issparse
 import warnings
 
 from .base import BaseEstimator, ClassifierMixin
-from .preprocessing import binarize, LabelBinarizer
+from .preprocessing import binarize
+from .preprocessing import LabelBinarizer
+from .preprocessing import label_binarize
 from .utils import array2d, atleast2d_or_csr
 from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils import check_arrays
@@ -254,21 +256,14 @@ class BaseDiscreteNB(BaseNB):
         _, n_features = X.shape
 
         if _check_partial_fit_classes_consistency(self, classes):
-            # This is the first call to partial_fit
-
-            # Build a label binarizer instance that will be reused for all the
-            # consecutive calls to partial_fit
-            self._labelbin = LabelBinarizer()
-            self._labelbin.classes_ = self.classes_
-            self._labelbin.multilabel_ = False  # Not supported by NB models
-
-            # Initialize various cumulative counters
+            # This is the first call to partial_fit:
+            # initialize various cumulative counters
             n_effective_classes = len(classes) if len(classes) > 1 else 2
             self.class_count_ = np.zeros(n_effective_classes, dtype=np.float64)
             self.feature_count_ = np.zeros((n_effective_classes, n_features),
                                            dtype=np.float64)
 
-        Y = self._labelbin.transform(y)
+        Y = label_binarize(y, classes=self.classes_)
         if Y.shape[1] == 1:
             Y = np.concatenate((1 - Y, Y), axis=1)
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -422,7 +422,7 @@ class MultinomialNB(BaseDiscreteNB):
         self.fit_prior = fit_prior
         self.class_prior = class_prior
 
-    def _count(self, X, Y, incrementally=False):
+    def _count(self, X, Y):
         """Count and smooth feature occurrences."""
         if np.any((X.data if issparse(X) else X) < 0):
             raise ValueError("Input X must be non-negative")

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -253,7 +253,7 @@ class BaseDiscreteNB(BaseNB):
         self : object
             Returns self.
         """
-        X = atleast2d_or_csr(X)
+        X = atleast2d_or_csr(X).astype(np.float64)
         _, n_features = X.shape
 
         if _check_partial_fit_classes_consistency(self, classes):
@@ -267,12 +267,19 @@ class BaseDiscreteNB(BaseNB):
 
             # Initialize various cumulative counters
             n_effective_classes = len(classes) if len(classes) > 1 else 2
-            self.class_count_ = np.zeros(n_effective_classes, dtype=np.int64)
+            self.class_count_ = np.zeros(n_effective_classes, dtype=np.float64)
             self.feature_count_ = np.zeros((n_effective_classes, n_features),
-                                           dtype=np.int64)
+                                           dtype=np.float64)
 
         Y = self._labelbin.transform(y)
         n_samples, n_classes = Y.shape
+
+        if X.shape[0] != Y.shape[0]:
+            msg = "X.shape[0]=%d and y.shape[0]=%d are incompatible."
+            raise ValueError(msg % (X.shape[0], y.shape[0]))
+
+        # convert to float to support sample weight consistently
+        Y = Y.astype(np.float64)
         if sample_weight is not None:
             Y *= array2d(sample_weight).T
 
@@ -308,7 +315,7 @@ class BaseDiscreteNB(BaseNB):
         self : object
             Returns self.
         """
-        X = atleast2d_or_csr(X)
+        X = atleast2d_or_csr(X).astype(np.float64)
         _, n_features = X.shape
 
         labelbin = LabelBinarizer()
@@ -321,6 +328,8 @@ class BaseDiscreteNB(BaseNB):
             msg = "X.shape[0]=%d and y.shape[0]=%d are incompatible."
             raise ValueError(msg % (X.shape[0], y.shape[0]))
 
+        # convert to float to support sample weight consistently
+        Y = Y.astype(np.float64)
         if sample_weight is not None:
             Y *= array2d(sample_weight).T
 
@@ -334,9 +343,9 @@ class BaseDiscreteNB(BaseNB):
         # Count raw events from data before updating the class log prior
         # and feature log probas
         n_effective_classes = Y.shape[1]
-        self.class_count_ = np.zeros(n_effective_classes, dtype=np.int64)
+        self.class_count_ = np.zeros(n_effective_classes, dtype=np.float64)
         self.feature_count_ = np.zeros((n_effective_classes, n_features),
-                                       dtype=np.int64)
+                                       dtype=np.float64)
         self._count(X, Y)
         self._update_feature_log_prob()
         self._update_class_log_prior(class_prior=class_prior)

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -195,8 +195,7 @@ class BaseDiscreteNB(BaseNB):
     _joint_log_likelihood(X) as per BaseNB
     """
 
-    def partial_fit(self, X, y, classes=None, sample_weight=None,
-                    class_prior=None):
+    def partial_fit(self, X, y, classes=None, sample_weight=None):
         """Incremental fit on a batch of samples.
 
         This method is expected to be called several times consecutively

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -273,8 +273,9 @@ class BaseDiscreteNB(BaseNB):
             self._labelbin.multilabel_ = False  # Not supported by NB models
 
             # Initialize various cumulative counters
-            self.class_count_ = np.zeros(len(classes), dtype=np.int64)
-            self.feature_count_ = np.zeros((len(classes), n_features),
+            n_effective_classes = len(classes) if len(classes) > 1 else 2
+            self.class_count_ = np.zeros(n_effective_classes, dtype=np.int64)
+            self.feature_count_ = np.zeros((n_effective_classes, n_features),
                                            dtype=np.int64)
 
         Y = self._labelbin.transform(y)
@@ -315,7 +316,6 @@ class BaseDiscreteNB(BaseNB):
         labelbin = LabelBinarizer()
         Y = labelbin.fit_transform(y)
         self.classes_ = labelbin.classes_
-        n_classes = len(self.classes_)
         if Y.shape[1] == 1:
             Y = np.concatenate((1 - Y, Y), axis=1)
 
@@ -338,8 +338,9 @@ class BaseDiscreteNB(BaseNB):
 
         # Count raw events from data before updating the class log prior
         # and feature log probas
-        self.class_count_ = np.zeros(n_classes, dtype=np.int64)
-        self.feature_count_ = np.zeros((n_classes, n_features),
+        n_effective_classes = Y.shape[1]
+        self.class_count_ = np.zeros(n_effective_classes, dtype=np.int64)
+        self.feature_count_ = np.zeros((n_effective_classes, n_features),
                                        dtype=np.int64)
         self._count(X, Y)
         self._update_feature_log_prob()
@@ -398,6 +399,10 @@ class MultinomialNB(BaseDiscreteNB):
 
     `class_count_` : array, shape = [n_classes]
         Integer number of samples encountered for each class during fitting.
+
+    `feature_count_` : array, shape = [n_classes, n_features]
+        Integer number of samples encountered for each (class, feature)
+        during fitting.
 
     Examples
     --------
@@ -488,6 +493,10 @@ class BernoulliNB(BaseDiscreteNB):
 
     `class_count_` : array, shape = [n_classes]
         Integer number of samples encountered for each class during fitting.
+
+    `feature_count_` : array, shape = [n_classes, n_features]
+        Integer number of samples encountered for each (class, feature)
+        during fitting.
 
     Examples
     --------

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -232,7 +232,7 @@ class BaseDiscreteNB(BaseNB):
         y : array-like, shape = [n_samples]
             Target values.
 
-        classes: array-like, shape = [n_classes]
+        classes : array-like, shape = [n_classes]
             List of all the classes that can possibly appear in the y vector.
 
             Must be provided at the first call to partial_fit, can be omitted

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -197,12 +197,6 @@ class BaseDiscreteNB(BaseNB):
 
     def _update_class_log_prior(self, class_prior=None):
         n_classes = len(self.classes_)
-        smoothed_fc = self.feature_count_ + self.alpha
-        smoothed_cc = self.class_count_ + self.alpha * n_classes
-
-        self.feature_log_prob_ = (np.log(smoothed_fc)
-                                  - np.log(smoothed_cc.reshape(-1, 1)))
-
         if class_prior is not None:
             if len(class_prior) != n_classes:
                 raise ValueError("Number of priors must match number of"

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -226,6 +226,10 @@ class BaseDiscreteNB(BaseNB):
         This is especially useful when the whole dataset is too big to fit in
         memory at once.
 
+        This method has some performance overhead hence it is better to call
+        partial_fit on chunks of data that are as large as possible
+        (as long as fitting in the memory budget) to hide the overhead.
+
         Parameters
         ----------
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -269,6 +269,9 @@ class BaseDiscreteNB(BaseNB):
                                            dtype=np.float64)
 
         Y = self._labelbin.transform(y)
+        if Y.shape[1] == 1:
+            Y = np.concatenate((1 - Y, Y), axis=1)
+
         n_samples, n_classes = Y.shape
 
         if X.shape[0] != Y.shape[0]:

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -391,11 +391,13 @@ class MultinomialNB(BaseDiscreteNB):
         `feature_log_prob_`, respectively.)
 
     `class_count_` : array, shape = [n_classes]
-        Integer number of samples encountered for each class during fitting.
+        Number of samples encountered for each class during fitting. This
+        value is weighted by the sample weight when provided.
 
     `feature_count_` : array, shape = [n_classes, n_features]
-        Integer number of samples encountered for each (class, feature)
-        during fitting.
+        Number of samples encountered for each (class, feature)
+        during fitting. This value is weighted by the sample weight when
+        provided.
 
     Examples
     --------
@@ -485,11 +487,13 @@ class BernoulliNB(BaseDiscreteNB):
         Empirical log probability of features given a class, P(x_i|y).
 
     `class_count_` : array, shape = [n_classes]
-        Integer number of samples encountered for each class during fitting.
+        Number of samples encountered for each class during fitting. This
+        value is weighted by the sample weight when provided.
 
     `feature_count_` : array, shape = [n_classes, n_features]
-        Integer number of samples encountered for each (class, feature)
-        during fitting.
+        Number of samples encountered for each (class, feature)
+        during fitting. This value is weighted by the sample weight when
+        provided.
 
     Examples
     --------

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -157,9 +157,6 @@ class GaussianNB(BaseNB):
 
         n_samples, n_features = X.shape
 
-        if n_samples != y.shape[0]:
-            raise ValueError("X and y have incompatible shapes")
-
         self.classes_ = unique_y = np.unique(y)
         n_classes = unique_y.shape[0]
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -318,11 +318,8 @@ class BaseDiscreteNB(BaseNB):
             Y = np.concatenate((1 - Y, Y), axis=1)
 
         if X.shape[0] != Y.shape[0]:
-            msg = "X and y have incompatible shapes."
-            if issparse(X):
-                msg += "\nNote: Sparse matrices cannot be indexed w/ boolean \
-                masks (use `indices=True` in CV)."
-            raise ValueError(msg)
+            msg = "X.shape[0]=%d and y.shape[0]=%d are incompatible."
+            raise ValueError(msg % (X.shape[0], y.shape[0]))
 
         if sample_weight is not None:
             Y *= array2d(sample_weight).T

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -275,6 +275,11 @@ class BaseDiscreteNB(BaseNB):
         # Count raw events from data before updating the class log prior
         # and feature log probas
         self._count(X, Y)
+
+        # XXX: OPTIM: we could introduce a public finalization method to
+        # be called by the user explicitly just once after several consecutive
+        # calls to partial_fit and prior any call to predict[_[log_]proba]
+        # to avoid computing the smooth log probas at each call to partial fit
         self._update_feature_log_prob()
         self._update_class_log_prior()
         return self

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -26,6 +26,7 @@ from .preprocessing import binarize, LabelBinarizer
 from .utils import array2d, atleast2d_or_csr
 from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils import check_arrays
+from .utils.multiclass import _check_partial_fit_classes_consistency
 from .externals import six
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB']
@@ -251,20 +252,8 @@ class BaseDiscreteNB(BaseNB):
         X = atleast2d_or_csr(X)
         _, n_features = X.shape
 
-        if getattr(self, 'classes_', None) is None and classes is None:
-            raise ValueError("classes must be passed on the first call "
-                             "to partial_fit.")
-
-        elif (classes is not None
-              and getattr(self, 'classes_', None) is not None):
-            if not np.all(self.classes_ == np.unique(classes)):
-                raise ValueError(
-                    "`classes=%r` is not the same as on last call "
-                    "to partial_fit, was: %r" % (classes, self.classes_))
-
-        elif classes is not None:
+        if _check_partial_fit_classes_consistency(self, classes):
             # This is the first call to partial_fit
-            self.classes_ = classes
 
             # Build a label binarizer instance that will be reused for all the
             # consecutive calls to partial_fit

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -28,7 +28,7 @@ from .preprocessing import label_binarize
 from .utils import array2d, atleast2d_or_csr
 from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils import check_arrays
-from .utils.multiclass import _check_partial_fit_classes_consistency
+from .utils.multiclass import _check_partial_fit_first_call
 from .externals import six
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB']
@@ -249,7 +249,7 @@ class BaseDiscreteNB(BaseNB):
         X = atleast2d_or_csr(X).astype(np.float64)
         _, n_features = X.shape
 
-        if _check_partial_fit_classes_consistency(self, classes):
+        if _check_partial_fit_first_call(self, classes):
             # This is the first call to partial_fit:
             # initialize various cumulative counters
             n_effective_classes = len(classes) if len(classes) > 1 else 2

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1197,11 +1197,13 @@ def label_binarize(y, classes, multilabel=False, neg_label=0, pos_label=1):
     y : array-like
         Sequence of integer labels to encode.
 
-    classes : array of shape [n_class]
+    classes : array of shape [n_classes]
         Uniquely holds the label for each class.
 
     multilabel : boolean
-
+        Set to true if y is encoding a multilabel tasks (with a variable
+        number of label assignements per sample) rather than a multiclass task
+        where one sample has one and only one label assigned.
 
     neg_label: int (default: 0)
         Value with which negative labels must be encoded.
@@ -1215,6 +1217,18 @@ def label_binarize(y, classes, multilabel=False, neg_label=0, pos_label=1):
     >>> label_binarize([1, 6], classes=[1, 2, 4, 6])
     array([[1, 0, 0, 0],
            [0, 0, 0, 1]])
+
+    The class ordering is preserved:
+
+    >>> label_binarize([1, 6], classes=[1, 6, 4, 2])
+    array([[1, 0, 0, 0],
+           [0, 1, 0, 0]])
+
+    >>> label_binarize([(1, 2), (6,), ()], multilabel=True,
+    ...                classes=[1, 6, 4, 2])
+    array([[1, 0, 0, 1],
+           [0, 1, 0, 0],
+           [0, 0, 0, 0]])
 
     See also
     --------

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -1047,6 +1047,11 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     array([1, 2, 3])
     >>> lb.multilabel_
     True
+
+    See also
+    --------
+    label_binarize : function to perform the transform operation of
+        LabelBinarizer with fixed classes.
     """
 
     def __init__(self, neg_label=0, pos_label=1):
@@ -1106,54 +1111,16 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         """
         self._check_fitted()
 
-        y_type = type_of_target(y)
-
-        if self.multilabel_ or len(self.classes_) > 2:
-            if y_type == 'multilabel-indicator':
-                # nothing to do as y is already a label indicator matrix
-                return y
-
-            Y = np.zeros((len(y), len(self.classes_)), dtype=np.int)
-        else:
-            Y = np.zeros((len(y), 1), dtype=np.int)
-
-        Y += self.neg_label
-
-        y_is_multilabel = y_type.startswith('multilabel')
+        y_is_multilabel = type_of_target(y).startswith('multilabel')
 
         if y_is_multilabel and not self.multilabel_:
             raise ValueError("The object was not fitted with multilabel"
-                             " input!")
+                             " input.")
 
-        elif self.multilabel_:
-            if not y_is_multilabel:
-                raise ValueError("y should be a list of label lists/tuples,"
-                                 "got %r" % (y,))
-
-            # inverse map: label => column index
-            imap = dict((v, k) for k, v in enumerate(self.classes_))
-
-            for i, label_tuple in enumerate(y):
-                for label in label_tuple:
-                    Y[i, imap[label]] = self.pos_label
-
-            return Y
-
-        else:
-            y = np.asarray(y)
-
-            if len(self.classes_) == 2:
-                Y[y == self.classes_[1], 0] = self.pos_label
-                return Y
-
-            elif len(self.classes_) >= 2:
-                for i, k in enumerate(self.classes_):
-                    Y[y == k, i] = self.pos_label
-                return Y
-
-            else:
-                # Only one class, returns a matrix with all negative labels.
-                return Y
+        return label_binarize(y, self.classes_,
+                              multilabel=self.multilabel_,
+                              pos_label=self.pos_label,
+                              neg_label=self.neg_label)
 
     def inverse_transform(self, Y, threshold=None):
         """Transform binary labels back to multi-class labels
@@ -1212,6 +1179,92 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
             y = Y.argmax(axis=1)
 
         return self.classes_[y]
+
+
+def label_binarize(y, classes, multilabel=False, neg_label=0, pos_label=1):
+    """Binarize labels in a one-vs-all fashion
+
+    Several regression and binary classification algorithms are
+    available in the scikit. A simple way to extend these algorithms
+    to the multi-class classification case is to use the so-called
+    one-vs-all scheme.
+
+    This function makes it possible to compute this transformation for a
+    fixed set of class labels known ahead of time.
+
+    Parameters
+    ----------
+    y : array-like
+        Sequence of integer labels to encode.
+
+    classes : array of shape [n_class]
+        Uniquely holds the label for each class.
+
+    multilabel : boolean
+
+
+    neg_label: int (default: 0)
+        Value with which negative labels must be encoded.
+
+    pos_label: int (default: 1)
+        Value with which positive labels must be encoded.
+
+    Examples
+    --------
+    >>> from sklearn.preprocessing import label_binarize
+    >>> label_binarize([1, 6], classes=[1, 2, 4, 6])
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 1]])
+
+    See also
+    --------
+    label_binarize : function to perform the transform operation of
+        LabelBinarizer with fixed classes.
+    """
+    y_type = type_of_target(y)
+
+    if multilabel or len(classes) > 2:
+        if y_type == 'multilabel-indicator':
+            # nothing to do as y is already a label indicator matrix
+            return y
+
+        Y = np.zeros((len(y), len(classes)), dtype=np.int)
+    else:
+        Y = np.zeros((len(y), 1), dtype=np.int)
+
+    Y += neg_label
+
+    y_is_multilabel = y_type.startswith('multilabel')
+
+    if multilabel:
+        if not y_is_multilabel:
+            raise ValueError("y should be a list of label lists/tuples,"
+                             "got %r" % (y,))
+
+        # inverse map: label => column index
+        imap = dict((v, k) for k, v in enumerate(classes))
+
+        for i, label_tuple in enumerate(y):
+            for label in label_tuple:
+                Y[i, imap[label]] = pos_label
+
+        return Y
+
+    else:
+        y = np.asarray(y)
+
+        if len(classes) == 2:
+            Y[y == classes[1], 0] = pos_label
+            return Y
+
+        elif len(classes) >= 2:
+            for i, k in enumerate(classes):
+                Y[y == k, i] = pos_label
+            return Y
+
+        else:
+            # Only one class, returns a matrix with all negative labels.
+            return Y
 
 
 class KernelCenterer(BaseEstimator, TransformerMixin):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -97,6 +97,18 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_proba2, y_pred_proba)
         assert_array_almost_equal(y_pred_log_proba2, y_pred_log_proba)
 
+        # Partial fit on the whole data at once should be the same as fit too
+        clf3 = MultinomialNB()
+        clf3.partial_fit(X, y2, classes=np.unique(y2))
+
+        y_pred3 = clf3.predict(X)
+        assert_array_equal(y_pred3, y2)
+        y_pred_proba3 = clf3.predict_proba(X)
+        y_pred_log_proba3 = clf3.predict_log_proba(X)
+        assert_array_almost_equal(np.log(y_pred_proba3), y_pred_log_proba3, 8)
+        assert_array_almost_equal(y_pred_proba3, y_pred_proba)
+        assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
+
 
 def test_discretenb_pickle():
     """Test picklability of discrete naive Bayes classifiers"""
@@ -112,8 +124,11 @@ def test_discretenb_pickle():
         assert_array_equal(y_pred, clf.predict(X2))
 
         if cls is not GaussianNB:
-            # re-enable me when partial_fit is implemented for GaussianNB
-            clf2 = cls().partial_fit(X2, y2, classes=np.unique(y2))
+            # TODO re-enable me when partial_fit is implemented for GaussianNB
+
+            # Test pickling of estimator trained with partial_fit
+            clf2 = cls().partial_fit(X2[:3], y2[:3], classes=np.unique(y2))
+            clf2.partial_fit(X2[3:], y2[3:])
             store = BytesIO()
             pickle.dump(clf2, store)
             clf2 = pickle.load(BytesIO(store.getvalue()))

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -254,20 +254,24 @@ def test_discretenb_provide_prior():
 
 
 def test_deprecated_fit_param():
-    for cls in [BernoulliNB, MultinomialNB]:
-        clf = cls()
-        with warnings.catch_warnings(record=True) as w:
-            clf.fit([[0], [1], [2]], [0, 1, 1], class_prior=[0.5, 0.5])
+    warnings.simplefilter("always", DeprecationWarning)
+    try:
+        for cls in [BernoulliNB, MultinomialNB]:
+            clf = cls()
+            with warnings.catch_warnings(record=True) as w:
+                clf.fit([[0], [1], [2]], [0, 1, 1], class_prior=[0.5, 0.5])
 
-        # Passing class_prior as a fit param should raise a deprecation
-        # warning
-        assert_equal(len(w), 1)
-        assert_equal(w[0].category, DeprecationWarning)
+            # Passing class_prior as a fit param should raise a deprecation
+            # warning
+            assert_equal(len(w), 1)
+            assert_equal(w[0].category, DeprecationWarning)
 
-        with warnings.catch_warnings(record=True):
-            # Inconsistent number of classes with prior
-            assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2],
-                          class_prior=[0.5, 0.5])
+            with warnings.catch_warnings(record=True):
+                # Inconsistent number of classes with prior
+                assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2],
+                              class_prior=[0.5, 0.5])
+    finally:
+        warnings.filters.pop(0)
 
 
 def test_sample_weight_multiclass():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -138,8 +138,12 @@ def test_discretenb_pickle():
 def test_input_check_fit():
     """Test input checks for the fit method"""
     for cls in [BernoulliNB, MultinomialNB, GaussianNB]:
-        # check shape consistency
+        # check shape consistency for number of samples at fit time
         assert_raises(ValueError, cls().fit, X2, y2[:-1])
+
+        # check shape consistency for number of input features at predict time
+        clf = cls().fit(X2, y2)
+        assert_raises(ValueError, clf.predict, X2[:, :-1])
 
 
 def test_input_check_partial_fit():
@@ -211,7 +215,27 @@ def test_discretenb_provide_prior():
         assert_array_equal(prior, np.array([.5, .5]))
 
 
-def test_sample_weight():
+def test_sample_weight_multiclass():
+    for cls in [BernoulliNB, MultinomialNB]:
+        # check shape consistency for number of samples at fit time
+        yield check_sample_weight_multiclass, cls
+
+
+def check_sample_weight_multiclass(cls):
+    X = [
+        [0, 0, 1],
+        [0, 1, 1],
+        [0, 1, 1],
+        [1, 0, 0],
+    ]
+    y = [0, 0, 1, 2]
+    sample_weight = np.array([1, 1, 2, 2], dtype=np.float)
+    sample_weight /= sample_weight.sum()
+    clf = cls().fit(X, y, sample_weight=sample_weight)
+    assert_array_equal(clf.predict(X), [0, 1, 1, 2])
+
+
+def test_sample_weight_mnb():
     clf = MultinomialNB()
     clf.fit([[1, 2], [1, 2], [1, 0]],
             [0, 0, 1],

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -3,6 +3,8 @@ from io import BytesIO
 import numpy as np
 import scipy.sparse
 
+import warnings
+
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -224,6 +226,23 @@ def test_discretenb_provide_prior():
         assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2])
         assert_raises(ValueError, clf.partial_fit, [[0], [1]], [0, 1],
                       classes=[0, 1, 1])
+
+
+def test_deprecated_fit_param():
+    for cls in [BernoulliNB, MultinomialNB]:
+        clf = cls()
+        with warnings.catch_warnings(record=True) as w:
+            clf.fit([[0], [1], [2]], [0, 1, 1], class_prior=[0.5, 0.5])
+
+        # Passing class_prior as a fit param should raise a deprecation
+        # warning
+        assert_equal(len(w), 1)
+        assert_equal(w[0].category, DeprecationWarning)
+
+        with warnings.catch_warnings(record=True):
+            # Inconsistent number of classes with prior
+            assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2],
+                          class_prior=[0.5, 0.5])
 
 
 def test_sample_weight_multiclass():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -350,7 +350,7 @@ def test_check_accuracy_on_digits():
     scores = cross_val_score(BernoulliNB(alpha=10), X_3v8 > 0, y_3v8, cv=10)
     assert_greater(scores.mean(), 0.94)
 
-    # Bernoulli NB (maybe not appropriate for this dataset...)
+    # Gaussian NB (maybe not appropriate for this dataset...)
     scores = cross_val_score(GaussianNB(), X > 0, y, cv=10)
     assert_greater(scores.mean(), 0.68)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -62,7 +62,7 @@ def test_discrete_prior():
 
 
 def test_mnnb():
-    """Multinomial Naive Bayes classification.
+    """Test Multinomial Naive Bayes classification.
 
     This checks that MultinomialNB implements fit and predict and returns
     correct values for a simple toy dataset.

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -344,15 +344,15 @@ def test_check_accuracy_on_digits():
     assert_greater(scores.mean(), 0.95)
 
     # Bernoulli NB
-    scores = cross_val_score(BernoulliNB(alpha=10), X > 0, y, cv=10)
-    assert_greater(scores.mean(), 0.81)
+    scores = cross_val_score(BernoulliNB(alpha=10), X > 4, y, cv=10)
+    assert_greater(scores.mean(), 0.85)
 
-    scores = cross_val_score(BernoulliNB(alpha=10), X_3v8 > 0, y_3v8, cv=10)
+    scores = cross_val_score(BernoulliNB(alpha=10), X_3v8 > 4, y_3v8, cv=10)
     assert_greater(scores.mean(), 0.94)
 
-    # Gaussian NB (maybe not appropriate for this dataset...)
-    scores = cross_val_score(GaussianNB(), X > 0, y, cv=10)
-    assert_greater(scores.mean(), 0.68)
+    # Gaussian NB
+    scores = cross_val_score(GaussianNB(), X, y, cv=10)
+    assert_greater(scores.mean(), 0.81)
 
-    scores = cross_val_score(GaussianNB(), X_3v8 > 0, y_3v8, cv=10)
-    assert_greater(scores.mean(), 0.88)
+    scores = cross_val_score(GaussianNB(), X_3v8, y_3v8, cv=10)
+    assert_greater(scores.mean(), 0.86)

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -112,6 +112,23 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
 
+def test_discretenb_partial_fit():
+    for cls in [MultinomialNB, BernoulliNB]:
+        clf1 = cls()
+        clf1.fit([[0, 1], [1, 0]], [0, 1])
+
+        clf2 = cls()
+        clf2.partial_fit([[0, 1], [1, 0]], [0, 1], classes=[0, 1])
+        assert_array_equal(clf1.class_count_, clf2.class_count_)
+        assert_array_equal(clf1.feature_count_, clf2.feature_count_)
+
+        clf3 = cls()
+        clf3.partial_fit([[0, 1]], [0], classes=[0, 1])
+        clf3.partial_fit([[1, 0]], [1])
+        assert_array_equal(clf1.class_count_, clf3.class_count_)
+        assert_array_equal(clf1.feature_count_, clf3.feature_count_)
+
+
 def test_discretenb_pickle():
     """Test picklability of discrete naive Bayes classifiers"""
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -161,6 +161,12 @@ def test_input_check_partial_fit():
         assert_raises(ValueError, clf.partial_fit, X2, y2,
                       classes=np.arange(42))
 
+        # check consistency of input shape for partial_fit
+        assert_raises(ValueError, clf.partial_fit, X2[:, :-1], y2)
+
+        # check consistency of input shape for predict
+        assert_raises(ValueError, clf.predict, X2[:, :-1])
+
 
 def test_discretenb_predict_proba():
     """Test discrete NB classes' probability scores"""

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -112,21 +112,25 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
 
+def check_partial_fit(cls):
+    clf1 = cls()
+    clf1.fit([[0, 1], [1, 0]], [0, 1])
+
+    clf2 = cls()
+    clf2.partial_fit([[0, 1], [1, 0]], [0, 1], classes=[0, 1])
+    assert_array_equal(clf1.class_count_, clf2.class_count_)
+    assert_array_equal(clf1.feature_count_, clf2.feature_count_)
+
+    clf3 = cls()
+    clf3.partial_fit([[0, 1]], [0], classes=[0, 1])
+    clf3.partial_fit([[1, 0]], [1])
+    assert_array_equal(clf1.class_count_, clf3.class_count_)
+    assert_array_equal(clf1.feature_count_, clf3.feature_count_)
+
+
 def test_discretenb_partial_fit():
     for cls in [MultinomialNB, BernoulliNB]:
-        clf1 = cls()
-        clf1.fit([[0, 1], [1, 0]], [0, 1])
-
-        clf2 = cls()
-        clf2.partial_fit([[0, 1], [1, 0]], [0, 1], classes=[0, 1])
-        assert_array_equal(clf1.class_count_, clf2.class_count_)
-        assert_array_equal(clf1.feature_count_, clf2.feature_count_)
-
-        clf3 = cls()
-        clf3.partial_fit([[0, 1]], [0], classes=[0, 1])
-        clf3.partial_fit([[1, 0]], [1])
-        assert_array_equal(clf1.class_count_, clf3.class_count_)
-        assert_array_equal(clf1.feature_count_, clf3.feature_count_)
+        yield check_partial_fit, cls
 
 
 def test_discretenb_pickle():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -220,6 +220,11 @@ def test_discretenb_provide_prior():
         prior = np.exp(clf.class_log_prior_)
         assert_array_equal(prior, np.array([.5, .5]))
 
+        # Inconsistent number of classes with prior
+        assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2])
+        assert_raises(ValueError, clf.partial_fit, [[0], [1]], [0, 1],
+                      classes=[0, 1, 1])
+
 
 def test_sample_weight_multiclass():
     for cls in [BernoulliNB, MultinomialNB]:

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -240,6 +240,14 @@ def check_sample_weight_multiclass(cls):
     clf = cls().fit(X, y, sample_weight=sample_weight)
     assert_array_equal(clf.predict(X), [0, 1, 1, 2])
 
+    # Check wample weight using the partial_fit method
+    clf = cls()
+    clf.partial_fit(X[:2], y[:2], classes=[0, 1, 2],
+                    sample_weight=sample_weight[:2])
+    clf.partial_fit(X[2:3], y[2:3], sample_weight=sample_weight[2:3])
+    clf.partial_fit(X[3:], y[3:], sample_weight=sample_weight[3:])
+    assert_array_equal(clf.predict(X), [0, 1, 1, 2])
+
 
 def test_sample_weight_mnb():
     clf = MultinomialNB()

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -308,3 +308,36 @@ def type_of_target(y):
         return 'binary'
     else:
         return 'multiclass' + suffix
+
+
+def _check_partial_fit_classes_consistency(clf, classes=None):
+    """Private helper function for factorizing common classes param logic
+
+    Estimator that implement the ``partial_fit`` API need to be provided with
+    the list of possible classes at the first call to partial fit.and
+
+    Subsequent calls to partial_fit should check that ``classes`` is still
+    consistent with a previous value of ``clf.classes_`` when provided.
+
+    This function returns True if it detects that this was the first call to
+    ``partial_fit`` on ``clf``. In that case the ``classes_`` attribute is also
+    set on ``clf``.
+
+    """
+    if getattr(clf, 'classes_', None) is None and classes is None:
+        raise ValueError("classes must be passed on the first call "
+                         "to partial_fit.")
+
+    elif (classes is not None
+          and getattr(clf, 'classes_', None) is not None):
+        if not np.all(clf.classes_ == np.unique(classes)):
+            raise ValueError(
+                "`classes=%r` is not the same as on last call "
+                "to partial_fit, was: %r" % (classes, clf.classes_))
+
+    elif classes is not None:
+        # This is the first call to partial_fit
+        clf.classes_ = classes
+        return True
+
+    return False

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -330,14 +330,14 @@ def _check_partial_fit_classes_consistency(clf, classes=None):
 
     elif classes is not None:
         if getattr(clf, 'classes_', None) is not None:
-            if not np.all(clf.classes_ == np.unique(classes)):
+            if not np.all(clf.classes_ == unique_labels(classes)):
                 raise ValueError(
                     "`classes=%r` is not the same as on last call "
                     "to partial_fit, was: %r" % (classes, clf.classes_))
 
         else:
             # This is the first call to partial_fit
-            clf.classes_ = np.unique(classes)
+            clf.classes_ = unique_labels(classes)
             return True
 
     # classes is None and clf.classes_ has already previously been set:

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -310,7 +310,7 @@ def type_of_target(y):
         return 'multiclass' + suffix
 
 
-def _check_partial_fit_classes_consistency(clf, classes=None):
+def _check_partial_fit_first_call(clf, classes=None):
     """Private helper function for factorizing common classes param logic
 
     Estimator that implement the ``partial_fit`` API need to be provided with

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -328,16 +328,18 @@ def _check_partial_fit_classes_consistency(clf, classes=None):
         raise ValueError("classes must be passed on the first call "
                          "to partial_fit.")
 
-    elif (classes is not None
-          and getattr(clf, 'classes_', None) is not None):
-        if not np.all(clf.classes_ == np.unique(classes)):
-            raise ValueError(
-                "`classes=%r` is not the same as on last call "
-                "to partial_fit, was: %r" % (classes, clf.classes_))
-
     elif classes is not None:
-        # This is the first call to partial_fit
-        clf.classes_ = classes
-        return True
+        if getattr(clf, 'classes_', None) is not None:
+            if not np.all(clf.classes_ == np.unique(classes)):
+                raise ValueError(
+                    "`classes=%r` is not the same as on last call "
+                    "to partial_fit, was: %r" % (classes, clf.classes_))
 
+        else:
+            # This is the first call to partial_fit
+            clf.classes_ = np.unique(classes)
+            return True
+
+    # classes is None and clf.classes_ has already previously been set:
+    # nothing to do
     return False


### PR DESCRIPTION
Early PR to review an implementation of `partial_fit` for the discrete naive Bayes models.

TODO:
- [x] check test coverage and add more tests if necessary
- [x] check on a non-toy datasets such as the out-of-core Reuters example
- [x] identify ways to factorize common code
- [x] update documentation to mention the new method where applicable
- [x] fix broken test: a rebase on master highlighted a regression introduced in this PR

Note generic topical documentation for out-of-core learning in general will be dealt with in #2204.
