### PR TITLE
[MRG] Added code for sklearn.preprocessing.RankScaler

### DIFF
--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -437,7 +437,7 @@ class RankScaler(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `sort_X_` : array of ints with shape [n_samples, n_features]
+    `sort_X_` : array of ints, shape (n_samples, n_features)
         The rank-index of every feature in the fit X.
 
     See also
@@ -501,22 +501,22 @@ class RankScaler(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like with shape [n_samples, n_features]
+        X : array-like, shape (n_samples, n_features)
             The data used to scale along the features axis.
         """
         X = array2d(X)
         warn_if_not_float(X, estimator=self)
-        newX = []
+        # TODO: Can add a copy parameter, and simply overwrite X if copy=False
+        X2 = np.zeros(X.shape)
         for j in range(X.shape[1]):
             lidx = np.searchsorted(self.sort_X_[:, j], X[:, j], side='left')
             ridx = np.searchsorted(self.sort_X_[:, j], X[:, j], side='right')
-            newX.append(1. * (lidx + ridx) / (2 * self.sort_X_.shape[0]))
-        X = np.vstack(newX).T
-        return X
+            v = 1. * (lidx + ridx) / (2 * self.sort_X_.shape[0])
+            X2[:,j] = v
+        return X2
 
-#    def inverse_transform(self, X):
-##       Not implemented, but I believe we could reuse the approximation
-##       code in `fit`.
+    # TODO : Add inverse_transform method.
+    #        I believe we could reuse the approximation code in `fit`.
 
 def normalize(X, norm='l2', axis=1, copy=True):
     """Normalize a dataset along any axis

--- a/sklearn/preprocessing.py
+++ b/sklearn/preprocessing.py
@@ -429,13 +429,13 @@ class RankScaler(BaseEstimator, TransformerMixin):
     ----------
     resolution : int, 1000 by default
         The number of different ranks possible.
-	    i.e. The number of indices in the compressed ranking matrix
-    	`sort_X_`.
-	    This is an approximation, to save memory and transform
-    	computation time.
+        i.e. The number of indices in the compressed ranking matrix
+        `sort_X_`.
+        This is an approximation, to save memory and transform
+        computation time.
         e.g. if 1000, transformed values will have resolution 0.001.
-	    If `None`, we store the full size matrix, comparable
-	    in size to the initial fit `X`.
+        If `None`, we store the full size matrix, comparable
+        in size to the initial fit `X`.
 
     Attributes
     ----------
@@ -488,16 +488,17 @@ class RankScaler(BaseEstimator, TransformerMixin):
                     iorighi = ioriglo + 1
 
                     if ioriglo == X.shape[0]:
-                        self.sort_X_[i,j] = full_sort_X_[ioriglo,j]
+                        self.sort_X_[i, j] = full_sort_X_[ioriglo, j]
                     else:
-		                # And use linear interpolation to combine the
-            		    # original values.
+                        # And use linear interpolation to combine the
+                        # original values.
                         wlo = (1 - (iorig - ioriglo))
                         whi = (1 - (iorighi - iorig))
                         assert wlo >= 0 and wlo <= 1
                         assert whi >= 0 and whi <= 1
                         assert_almost_equal(wlo+whi, 1.)
-                        self.sort_X_[i,j] = wlo * full_sort_X_[ioriglo,j] + whi * full_sort_X_[iorighi,j]
+                        self.sort_X_[i, j] = wlo * full_sort_X_[ioriglo, j] \
+                                           + whi * full_sort_X_[iorighi, j]
         return self
 
     def transform(self, X):

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -23,6 +23,7 @@ from sklearn.preprocessing import normalize
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import scale
 from sklearn.preprocessing import MinMaxScaler
+from sklearn.preprocessing import RankScaler
 from sklearn.preprocessing import add_dummy_feature
 
 from sklearn import datasets
@@ -62,6 +63,9 @@ def test_scaler_1d():
     X_scaled = scale(X)
     assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.std(axis=0), 1.0)
+
+#    rank_scaler = RankScaler()
+#    X_rank_scaled = rank_scaler.fit(X).transform(X)
 
 
 def test_scaler_2d_arrays():
@@ -111,6 +115,25 @@ def test_scaler_2d_arrays():
     assert_array_almost_equal(X_scaled.std(axis=0), [0., 1., 1., 1., 1.])
     # Check that X has not been copied
     assert_true(X_scaled is not X)
+
+
+    X = np.array([[1, 0, 0, 0, 1],
+                   [2, 1, 4, 1, 1],
+                   [3, 2, 3, 1, 0],
+                   [3, 0, 0, 4, 1]])
+
+    rank_scaler = RankScaler()
+    rank_scaler.fit(X)
+    X_scaled = rank_scaler.transform(X)
+    assert_array_almost_equal(X_scaled, [[ 0.125,  0.25 ,  0.25 ,  0.125,  0.625],
+                                         [ 0.375,  0.625,  0.875,  0.5  ,  0.625],
+                                         [ 0.75 ,  0.875,  0.625,  0.5  ,  0.125],
+                                         [ 0.75 ,  0.25 ,  0.25 ,  0.875,  0.625]])
+
+    X2 = np.array([[0, 1.5, 0, 5, 10]])
+    X2_scaled = rank_scaler.transform(X2)
+    assert_array_almost_equal(X2_scaled, [[ 0.  ,  0.75,  0.25,  1.  ,  1.  ]])
+
 
 
 def test_min_max_scaler_iris():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -136,8 +136,8 @@ def test_scaler_2d_arrays():
     # Check RankScaler at different n_ranks
     n_features = 100
     for n_samples in [10, 100, 1000]:
-        for n_ranks in [n_samples+1, n_samples, n_samples-1,
-                        int(n_samples/2), int(n_samples/7), int(n_samples/10)]:
+        for n_ranks in [n_samples + 1, n_samples, n_samples - 1,
+                        int(n_samples / 2), int(n_samples / 7), int(n_samples / 10)]:
             X = rng.randn(n_samples, n_features)
             rank_scaler1 = RankScaler(n_ranks=None)
             rank_scaler2 = RankScaler(n_ranks=n_ranks)
@@ -150,7 +150,7 @@ def test_scaler_2d_arrays():
 
             # In the approximate version X22, all values must
             # be within 1./n_ranks of the exact value X11.
-            assert_true(np.all(np.fabs(X21 - X22) < 1./n_ranks))
+            assert_true(np.all(np.fabs(X21 - X22) < 1. / n_ranks))
 
 
 def test_min_max_scaler_iris():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -67,6 +67,7 @@ def test_scaler_1d():
 #    rank_scaler = RankScaler()
 #    X_rank_scaled = rank_scaler.fit(X).transform(X)
 
+
 def test_scaler_2d_arrays():
     """Test scaling of 2d array along first axis"""
     rng = np.random.RandomState(0)
@@ -115,43 +116,41 @@ def test_scaler_2d_arrays():
     # Check that X has not been copied
     assert_true(X_scaled is not X)
 
-
     X = np.array([[1, 0, 0, 0, 1],
-                   [2, 1, 4, 1, 1],
-                   [3, 2, 3, 1, 0],
-                   [3, 0, 0, 4, 1]])
+                  [2, 1, 4, 1, 1],
+                  [3, 2, 3, 1, 0],
+                  [3, 0, 0, 4, 1]])
 
     rank_scaler = RankScaler()
     rank_scaler.fit(X)
     X_scaled = rank_scaler.transform(X)
-    assert_array_almost_equal(X_scaled, [[ 0.125,  0.25 ,  0.25 ,  0.125,  0.625],
-                                         [ 0.375,  0.625,  0.875,  0.5  ,  0.625],
-                                         [ 0.75 ,  0.875,  0.625,  0.5  ,  0.125],
-                                         [ 0.75 ,  0.25 ,  0.25 ,  0.875,  0.625]])
+    assert_array_almost_equal(X_scaled, [[0.125, 0.25,  0.25,  0.125, 0.625],
+                                         [0.375, 0.625, 0.875, 0.5,   0.625],
+                                         [0.75,  0.875, 0.625, 0.5,   0.125],
+                                         [0.75,  0.25,  0.25,  0.875, 0.625]])
 
     X2 = np.array([[0, 1.5, 0, 5, 10]])
     X2_scaled = rank_scaler.transform(X2)
-    assert_array_almost_equal(X2_scaled, [[ 0.  ,  0.75,  0.25,  1.  ,  1.  ]])
+    assert_array_almost_equal(X2_scaled, [[0., 0.75, 0.25, 1., 1.]])
 
-
-    # Check RankScaler at different resolution
-    for ninstances in [10, 100, 1000]:
-        for resolution in [ninstances+1, ninstances, ninstances-1, \
-                int(ninstances/2), int(ninstances/7), int(ninstances/10)]:
-            X = rng.randn(ninstances, 100)
-            rank_scaler1 = RankScaler(resolution=None)
-            rank_scaler2 = RankScaler(resolution=resolution)
+    # Check RankScaler at different n_ranks
+    n_features = 100
+    for n_samples in [10, 100, 1000]:
+        for n_ranks in [n_samples+1, n_samples, n_samples-1,
+                        int(n_samples/2), int(n_samples/7), int(n_samples/10)]:
+            X = rng.randn(n_samples, n_features)
+            rank_scaler1 = RankScaler(n_ranks=None)
+            rank_scaler2 = RankScaler(n_ranks=n_ranks)
             rank_scaler1.fit(X)
             rank_scaler2.fit(X)
 
-            X2 = rng.randn(1000, 100)
+            X2 = rng.randn(1000, n_features)
             X21 = rank_scaler1.transform(X2)
             X22 = rank_scaler2.transform(X2)
 
             # In the approximate version X22, all values must
-        	# be within resolution of the exact value X11.
-            assert_true(np.all(np.fabs(X21 - X22) < 1./resolution))
-
+            # be within 1./n_ranks of the exact value X11.
+            assert_true(np.all(np.fabs(X21 - X22) < 1./n_ranks))
 
 
 def test_min_max_scaler_iris():

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -67,7 +67,6 @@ def test_scaler_1d():
 #    rank_scaler = RankScaler()
 #    X_rank_scaled = rank_scaler.fit(X).transform(X)
 
-
 def test_scaler_2d_arrays():
     """Test scaling of 2d array along first axis"""
     rng = np.random.RandomState(0)
@@ -133,6 +132,25 @@ def test_scaler_2d_arrays():
     X2 = np.array([[0, 1.5, 0, 5, 10]])
     X2_scaled = rank_scaler.transform(X2)
     assert_array_almost_equal(X2_scaled, [[ 0.  ,  0.75,  0.25,  1.  ,  1.  ]])
+
+
+    # Check RankScaler at different resolution
+    for ninstances in [10, 100, 1000]:
+        for resolution in [ninstances+1, ninstances, ninstances-1, \
+                int(ninstances/2), int(ninstances/7), int(ninstances/10)]:
+            X = rng.randn(ninstances, 100)
+            rank_scaler1 = RankScaler(resolution=None)
+            rank_scaler2 = RankScaler(resolution=resolution)
+            rank_scaler1.fit(X)
+            rank_scaler2.fit(X)
+
+            X2 = rng.randn(1000, 100)
+            X21 = rank_scaler1.transform(X2)
+            X22 = rank_scaler2.transform(X2)
+
+            # In the approximate version X22, all values must
+        	be within resolution of the exact value X11.
+            assert_true(np.all(np.fabs(X21 - X22) < 1./resolution))
 
 
 

--- a/sklearn/tests/test_preprocessing.py
+++ b/sklearn/tests/test_preprocessing.py
@@ -149,7 +149,7 @@ def test_scaler_2d_arrays():
             X22 = rank_scaler2.transform(X2)
 
             # In the approximate version X22, all values must
-        	be within resolution of the exact value X11.
+        	# be within resolution of the exact value X11.
             assert_true(np.all(np.fabs(X21 - X22) < 1./resolution))
 
 


### PR DESCRIPTION
I wrote code for doing rank-scaling. This scaling technique is more robust than StandardScaler (unit variance, zero mean).

I believe that "scale" is the wrong term for this operation. It's actually feature "normalization". This name-conflicts with the "normalize" method, though.

I wrote documentation and tests. However, I was unable to get the doc-suite or test-suite to build for the current sklearn HEAD, so I couldn't double-check all my documentation and tests.
