### PR TITLE
cosmetic: Changed all instances of nonlinear to non-linear

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -20,7 +20,7 @@ of learning with very large datasets.
 Standard kernelized SVMs do not scale well to large datasets, but using an
 approximate kernel map it is possible to use much more efficient linear SVMs.
 In particularly the combination of kernel map approximations with
-:class:`SGDClassifier` can make nonlinear learning on large datasets possible.
+:class:`SGDClassifier` can make non-linear learning on large datasets possible.
 
 Since there has not been much empirical work using approximate embeddings, it
 is advisable to compare results against exact kernel methods when possible.

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -25,7 +25,7 @@ Manifold learning
    :align: center
    :scale: 60
 
-Manifold learning is an approach to nonlinear dimensionality reduction.
+Manifold learning is an approach to non-linear dimensionality reduction.
 Algorithms for this task are based on the idea that the dimensionality of
 many data sets is only artificially high.
 
@@ -62,7 +62,7 @@ dimensionality reduction frameworks have been designed, such as Principal
 Component Analysis (PCA), Independent Component Analysis, Linear 
 Discriminant Analysis, and others.  These algorithms define specific 
 rubrics to choose an "interesting" linear projection of the data.
-These methods can be powerful, but often miss important nonlinear 
+These methods can be powerful, but often miss important non-linear 
 structure in the data.
 
 
@@ -77,7 +77,7 @@ structure in the data.
 .. centered:: |PCA_img| |LDA_img|
 
 Manifold Learning can be thought of as an attempt to generalize linear
-frameworks like PCA to be sensitive to nonlinear structure in data. Though
+frameworks like PCA to be sensitive to non-linear structure in data. Though
 supervised variants exist, the typical manifold learning problem is
 unsupervised: it learns the high-dimensional structure of the data
 from the data itself, without the use of predetermined classifications.
@@ -154,7 +154,7 @@ Locally Linear Embedding
 Locally linear embedding (LLE) seeks a lower-dimensional projection of the data
 which preserves distances within local neighborhoods.  It can be thought
 of as a series of local Principal Component Analyses which are globally
-compared to find the best nonlinear embedding.
+compared to find the best non-linear embedding.
 
 Locally linear embedding can be performed with function
 :func:`locally_linear_embedding` or its object-oriented counterpart
@@ -303,7 +303,7 @@ Spectral Embedding
 ====================
 
 Spectral Embedding (also known as Laplacian Eigenmaps) is one method
-to calculate nonlinear embedding. It finds a low dimensional representation
+to calculate non-linear embedding. It finds a low dimensional representation
 of the data using a spectral decomposition of the graph Laplacian.
 The graph generated can be considered as a discrete approximation of the 
 low dimensional manifold in the high dimensional space. Minimization of a 

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -369,7 +369,7 @@ depends on a number of factors:
 * data structure: *intrinsic dimensionality* of the data and/or *sparsity*
   of the data. Intrinsic dimensionality refers to the dimension
   :math:`d \le D` of a manifold on which the data lies, which can be linearly
-  or nonlinearly embedded in the parameter space. Sparsity refers to the
+  or non-linearly embedded in the parameter space. Sparsity refers to the
   degree to which the data fills the parameter space (this is to be
   distinguished from the concept as used in "sparse" matrices.  The data
   matrix may have no zero entries, but the **structure** can still be

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -270,7 +270,7 @@ New Estimator Classes
 
    - :class:`manifold.SpectralEmbedding` and function
      :func:`manifold.spectral_embedding`, implementing the "laplacian
-     eigenmaps" transformation for nonlinear dimensionality reduction by Wei
+     eigenmaps" transformation for non-linear dimensionality reduction by Wei
      Li. See :ref:`spectral_embedding` in the user guide.
 
    - :class:`isotonic.IsotonicRegression` by `Fabian Pedregosa`_, `Alexandre Gramfort`_

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -111,7 +111,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     return W
 
 
-# Some standard nonlinear functions.
+# Some standard non-linear functions.
 # XXX: these should be optimized, as they can be a bottleneck.
 def _logcosh(x, fun_args):
     alpha = fun_args.get('alpha', 1.0)  # comment it out?


### PR DESCRIPTION
Purely trivial changes to documentation in order to maintain consistency.  I avoided changing uses of 'nonlinear' when they were referring to paper abstracts or variable names.
