### PR TITLE
[MRG] Gradient boosting OOB improvement

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -590,17 +590,22 @@ does poorly.
    :align: center
    :scale: 75
 
-For ``subsample < 1``, the improvement in deviance on the out-of-bag samples
-is stored in the attribute :attr:`~GradientBoostingRegressor.oob_improvement_` .
-Out-of-bag estimates can be used for model selection
-(e.g. to determine the optimal number of iterations).
-
 Another strategy to reduce the variance is by subsampling the features
 analogous to the random splits in :class:`RandomForestClassifier` .
 The number of subsampled features can be controlled via the ``max_features``
 parameter.
 
 .. note:: Using a small ``max_features`` value can significantly decrease the runtime.
+
+Stochastic gradient boosting allows to compute out-of-bag estimates of the
+test deviance by computing the improvement in deviance on the examples that are
+not included in the bootstrap sample (i.e. the out-of-bag examples).
+The improvements are stored in the attribute
+:attr:`~GradientBoostingRegressor.oob_improvement_`. ``oob_improvement_[i]`` holds
+the improvement in terms of the loss on the OOB sample if you add the i-th stage
+to the current predictions.
+Out-of-bag estimates can be used for model selection, for example to determine
+the optimal number of iterations.
 
 .. topic:: Examples:
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -440,6 +440,7 @@ the ``feature_importances_`` property.
 .. topic:: Examples:
 
  * :ref:`example_ensemble_plot_gradient_boosting_regression.py`
+ * :ref:`example_ensemble_plot_gradient_boosting_oob.py`
 
 
 Mathematical formulation
@@ -590,13 +591,15 @@ does poorly.
    :scale: 75
 
 For ``subsample < 1``, the improvement in deviance on the out-of-bag samples
-in the i-the iteration is stored in the attribute ``oob_improvement_[i]``.
+is stored in the attribute :attr:`~GradientBoostingRegressor.oob_improvement_` .
 Out-of-bag estimates can be used for model selection
 (e.g. to determine the optimal number of iterations).
 
 Another strategy to reduce the variance is by subsampling the features
-analogous to the random splits in Random Forests. The size of the subsample
-can be controlled via the ``max_features`` parameter.
+analogous to the random splits in :class:`RandomForestClassifier` .
+The size of the subsample can be controlled via the ``max_features`` parameter.
+
+.. note:: Using a small ``max_features`` value can significantly decrease the runtime.
 
 .. topic:: Examples:
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -589,9 +589,10 @@ does poorly.
    :align: center
    :scale: 75
 
-For ``subsample < 1``, the deviance on the out-of-bag samples in the i-the iteration
-is stored in the attribute ``oob_score_[i]``. Out-of-bag estimates can be
-used for model selection (e.g. to determine the optimal number of iterations).
+For ``subsample < 1``, the improvement in deviance on the out-of-bag samples
+in the i-the iteration is stored in the attribute ``oob_improvement_[i]``.
+Out-of-bag estimates can be used for model selection
+(e.g. to determine the optimal number of iterations).
 
 Another strategy to reduce the variance is by subsampling the features
 analogous to the random splits in Random Forests. The size of the subsample
@@ -600,6 +601,7 @@ can be controlled via the ``max_features`` parameter.
 .. topic:: Examples:
 
  * :ref:`example_ensemble_plot_gradient_boosting_regularization.py`
+ * :ref:`example_ensemble_plot_gradient_boosting_oob.py`
 
 Interpretation
 --------------

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -597,7 +597,8 @@ Out-of-bag estimates can be used for model selection
 
 Another strategy to reduce the variance is by subsampling the features
 analogous to the random splits in :class:`RandomForestClassifier` .
-The size of the subsample can be controlled via the ``max_features`` parameter.
+The number of subsampled features can be controlled via the ``max_features``
+parameter.
 
 .. note:: Using a small ``max_features`` value can significantly decrease the runtime.
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -58,7 +58,7 @@ clf = ensemble.GradientBoostingClassifier(**params)
 
 clf.fit(X_train, y_train)
 acc = clf.score(X_test, y_test)
-print("ACC: %.4f" % acc)
+print("ACC: {:.4f}".format(acc))
 
 n_estimators = params['n_estimators']
 x = np.arange(n_estimators) + 1

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -20,7 +20,7 @@ print(__doc__)
 # License: BSD 3 clause
 
 import numpy as np
-import pylab as plt
+import pylab as pl
 
 from sklearn import ensemble
 from sklearn.cross_validation import KFold
@@ -80,7 +80,7 @@ test_score = heldout_score(clf, X_test, y_test)
 cv_score = cv_estimate(3)
 
 
-#plt.plot(x, -np.cumsum(clf.oob_score_))
+#pl.plot(x, -np.cumsum(clf.oob_score_))
 cumsum = -np.cumsum(clf.oob_improvement_)
 oob_best_iter = x[np.argmin(cumsum)]
 test_score -= test_score[0]
@@ -92,14 +92,14 @@ oob_color = map(lambda x: x / 256.0, (190, 174, 212))
 test_color = map(lambda x: x / 256.0, (127, 201, 127))
 cv_color = map(lambda x: x / 256.0, (253, 192, 134))
 
-plt.plot(x, cumsum, label='OOB loss', color=oob_color)
-plt.plot(x, test_score, label='Test loss', color=test_color)
-plt.plot(x, cv_score, label='CV loss', color=cv_color)
-plt.axvline(x=oob_best_iter, color=oob_color)
-plt.axvline(x=test_best_iter, color=test_color)
-plt.axvline(x=cv_best_iter, color=cv_color)
+pl.plot(x, cumsum, label='OOB loss', color=oob_color)
+pl.plot(x, test_score, label='Test loss', color=test_color)
+pl.plot(x, cv_score, label='CV loss', color=cv_color)
+pl.axvline(x=oob_best_iter, color=oob_color)
+pl.axvline(x=test_best_iter, color=test_color)
+pl.axvline(x=cv_best_iter, color=cv_color)
 
-plt.legend(loc='upper right')
-plt.ylabel('normalized loss')
+pl.legend(loc='upper right')
+pl.ylabel('normalized loss')
 
-plt.show()
+pl.show()

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -3,7 +3,15 @@
 Gradient Boosting OOB estimates
 ===============================
 
+Out-of-bag estimates can be used to estimate the "optimal" number of
+boosting iterations. To compute OOB estimates the ``subsample``
+argument has to be smaller than 1.
+The argument ``oob_improvement_[i]`` holds the improvement in loss for the i-th
+iteration.
 
+The generated plot shows the cumulative sum of the negative OOB improvements
+as a function of the boosting iteration. This function should track the
+loss on the test set.
 """
 print(__doc__)
 
@@ -14,12 +22,11 @@ print(__doc__)
 import numpy as np
 import pylab as plt
 
-from scipy.stats.distributions import binom
-
 from sklearn import ensemble
+from sklearn.cross_validation import KFold
 
 ###############################################################################
-# Generate data
+# Generate data (adapted from G. Ridgeway's gbm example)
 
 n = 1000
 rs = np.random.RandomState(13)
@@ -28,7 +35,8 @@ x2 = rs.uniform(size=n)
 x3 = rs.randint(0, 4, size=n)
 
 p = 1 / (1.0 + np.exp(-(np.sin(3 * x1) - 4 * x2 + x3)))
-y = binom.rvs(1, p, size=n)
+y = rs.binomial(1, p, size=n)
+
 X = np.c_[x1, x2, x3]
 
 X = X.astype(np.float32)
@@ -38,7 +46,7 @@ X_test, y_test = X[offset:], y[offset:]
 
 ###############################################################################
 # Fit regression model
-params = {'n_estimators': 3000, 'max_depth': 4, 'subsample': 0.5,
+params = {'n_estimators': 2000, 'max_depth': 4, 'subsample': 0.5,
           'learning_rate': 0.01, 'min_samples_leaf': 1, 'random_state': 3}
 clf = ensemble.GradientBoostingClassifier(**params)
 
@@ -49,25 +57,49 @@ print("ACC: %.4f" % acc)
 n_estimators = params['n_estimators']
 x = np.arange(n_estimators) + 1
 
-test_score = np.zeros((n_estimators,), dtype=np.float64)
 
-for i, y_pred in enumerate(clf.staged_decision_function(X_test)):
-    test_score[i] = clf.loss_(y_test, y_pred)
+def heldout_score(clf, X_test, y_test):
+    score = np.zeros((n_estimators,), dtype=np.float64)
+    for i, y_pred in enumerate(clf.staged_decision_function(X_test)):
+        score[i] = clf.loss_(y_test, y_pred)
+    return score
+
+
+def cv_estimate(n_folds=3):
+    cv = KFold(n=X_train.shape[0], n_folds=n_folds)
+    cv_clf = ensemble.GradientBoostingClassifier(**params)
+    val_scores = np.zeros((n_estimators,), dtype=np.float64)
+    for train, test in cv:
+        cv_clf.fit(X_train[train], y_train[train])
+        val_scores += heldout_score(cv_clf, X_train[test], y_train[test])
+    val_scores /= n_folds
+    return val_scores
+
+
+test_score = heldout_score(clf, X_test, y_test)
+cv_score = cv_estimate(3)
 
 
 #plt.plot(x, -np.cumsum(clf.oob_score_))
-cumsum = np.cumsum(clf.oob_improvement_)
-best_iter = x[np.argmax(cumsum)]
-true_best_iter = np.argmin(test_score)
-print("best_iter: %d" % best_iter)
-print("true_best_iter: %d" % true_best_iter)
+cumsum = -np.cumsum(clf.oob_improvement_)
+oob_best_iter = x[np.argmin(cumsum)]
+test_score -= test_score[0]
+test_best_iter = np.argmin(test_score)
+cv_score -= cv_score[0]
+cv_best_iter = np.argmin(cv_score)
 
-plt.plot(x, cumsum, label='oob', color='cyan')
-plt.plot(x, test_score, label='test', color='red')
+oob_color = map(lambda x: x / 256.0, (190, 174, 212))
+test_color = map(lambda x: x / 256.0, (127, 201, 127))
+cv_color = map(lambda x: x / 256.0, (253, 192, 134))
 
-plt.plot([best_iter, best_iter], [0.0, 1.0], color='cyan')
-plt.plot([true_best_iter, true_best_iter], [0.0, 1.0], color='red')
+plt.plot(x, cumsum, label='OOB loss', color=oob_color)
+plt.plot(x, test_score, label='Test loss', color=test_color)
+plt.plot(x, cv_score, label='CV loss', color=cv_color)
+plt.axvline(x=oob_best_iter, color=oob_color)
+plt.axvline(x=test_best_iter, color=test_color)
+plt.axvline(x=cv_best_iter, color=cv_color)
 
 plt.legend(loc='upper right')
+plt.ylabel('normalized loss')
 
 plt.show()

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -30,14 +30,14 @@ from sklearn.cross_validation import train_test_split
 
 
 # Generate data (adapted from G. Ridgeway's gbm example)
-n = 1000
+n_samples = 1000
 rs = np.random.RandomState(13)
-x1 = rs.uniform(size=n)
-x2 = rs.uniform(size=n)
-x3 = rs.randint(0, 4, size=n)
+x1 = rs.uniform(size=n_samples)
+x2 = rs.uniform(size=n_samples)
+x3 = rs.randint(0, 4, size=n_samples)
 
 p = 1 / (1.0 + np.exp(-(np.sin(3 * x1) - 4 * x2 + x3)))
-y = rs.binomial(1, p, size=n)
+y = rs.binomial(1, p, size=n_samples)
 
 X = np.c_[x1, x2, x3]
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -6,12 +6,14 @@ Gradient Boosting OOB estimates
 Out-of-bag estimates can be used to estimate the "optimal" number of
 boosting iterations. To compute OOB estimates the ``subsample``
 argument has to be smaller than 1.
-The argument ``oob_improvement_[i]`` holds the improvement in loss for the i-th
-iteration.
+The argument ``oob_improvement_[i]`` holds the improvement in loss on
+the out-of-bag samples for the i-th iteration.
 
 The generated plot shows the cumulative sum of the negative OOB improvements
 as a function of the boosting iteration. This function should track the
 loss on the test set.
+The plot also shows the performance of 3-fold cross validation which
+usually gives a better estimate but is computationally more demanding.
 """
 print(__doc__)
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -58,7 +58,7 @@ clf = ensemble.GradientBoostingClassifier(**params)
 
 clf.fit(X_train, y_train)
 acc = clf.score(X_test, y_test)
-print("ACC: {:.4f}".format(acc))
+print("Accuracy: {:.4f}".format(acc))
 
 n_estimators = params['n_estimators']
 x = np.arange(n_estimators) + 1

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -10,7 +10,8 @@ they can be computed on-the-fly without the need for repeated model
 fitting.
 OOB estimates are only available for Stochastic Gradient Boosting
 (i.e. ``subsample < 1.0``), the estimates are derived from the improvement
-in loss based on the out-of-bag examples.
+in loss based on the examples not included in the boostrap sample
+(the so-called out-of-bag examples).
 The OOB estimator is a pessimistic estimator of the true
 test loss, but remains a fairly good approximation for a small number of trees.
 
@@ -19,7 +20,8 @@ as a function of the boosting iteration. As you can see, it tracks the test
 loss for the first hundred iterations but then diverges in a
 pessimistic way.
 The figure also shows the performance of 3-fold cross validation which
-usually gives a better estimate but is computationally more demanding.
+usually gives a better estimate of the test loss
+but is computationally more demanding.
 """
 print(__doc__)
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -31,13 +31,13 @@ from sklearn.cross_validation import train_test_split
 
 # Generate data (adapted from G. Ridgeway's gbm example)
 n_samples = 1000
-rs = np.random.RandomState(13)
-x1 = rs.uniform(size=n_samples)
-x2 = rs.uniform(size=n_samples)
-x3 = rs.randint(0, 4, size=n_samples)
+random_state = np.random.RandomState(13)
+x1 = random_state.uniform(size=n_samples)
+x2 = random_state.uniform(size=n_samples)
+x3 = random_state.randint(0, 4, size=n_samples)
 
 p = 1 / (1.0 + np.exp(-(np.sin(3 * x1) - 4 * x2 + x3)))
-y = rs.binomial(1, p, size=n_samples)
+y = random_state.binomial(1, p, size=n_samples)
 
 X = np.c_[x1, x2, x3]
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -5,6 +5,12 @@ Gradient Boosting Out-of-Bag estimates
 
 Out-of-bag (OOB) estimates can be a useful heuristic to estimate
 the "optimal" number of boosting iterations.
+OOB estimates are almost identical to cross-validation estimates but
+they can be computed on-the-fly without the need for repeated model
+fitting.
+OOB estimates are only available for Stochastic Gradient Boosting
+(i.e. ``subsample < 1.0``), the estimates are derived from the improvement
+in loss based on the out-of-bag examples.
 The OOB estimator is a pessimistic estimator of the true
 test loss, but remains a fairly good approximation for a small number of trees.
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -28,7 +28,7 @@ print(__doc__)
 # License: BSD 3 clause
 
 import numpy as np
-import pylab as pl
+from matplotlib import pyplot as plt
 
 from sklearn import ensemble
 from sklearn.cross_validation import KFold
@@ -109,15 +109,15 @@ test_color = map(lambda x: x / 256.0, (127, 201, 127))
 cv_color = map(lambda x: x / 256.0, (253, 192, 134))
 
 # plot curves and vertical lines for best iterations
-pl.plot(x, cumsum, label='OOB loss', color=oob_color)
-pl.plot(x, test_score, label='Test loss', color=test_color)
-pl.plot(x, cv_score, label='CV loss', color=cv_color)
-pl.axvline(x=oob_best_iter, color=oob_color)
-pl.axvline(x=test_best_iter, color=test_color)
-pl.axvline(x=cv_best_iter, color=cv_color)
+plt.plot(x, cumsum, label='OOB loss', color=oob_color)
+plt.plot(x, test_score, label='Test loss', color=test_color)
+plt.plot(x, cv_score, label='CV loss', color=cv_color)
+plt.axvline(x=oob_best_iter, color=oob_color)
+plt.axvline(x=test_best_iter, color=test_color)
+plt.axvline(x=cv_best_iter, color=cv_color)
 
 # add three vertical lines to xticks
-xticks = pl.xticks()
+xticks = plt.xticks()
 xticks_pos = np.array(xticks[0].tolist() +
                       [oob_best_iter, cv_best_iter, test_best_iter])
 xticks_label = np.array(map(lambda t: int(t), xticks[0]) +
@@ -125,10 +125,10 @@ xticks_label = np.array(map(lambda t: int(t), xticks[0]) +
 ind = np.argsort(xticks_pos)
 xticks_pos = xticks_pos[ind]
 xticks_label = xticks_label[ind]
-pl.xticks(xticks_pos, xticks_label)
+plt.xticks(xticks_pos, xticks_label)
 
-pl.legend(loc='upper right')
-pl.ylabel('normalized loss')
-pl.xlabel('number of iterations')
+plt.legend(loc='upper right')
+plt.ylabel('normalized loss')
+plt.xlabel('number of iterations')
 
-pl.show()
+plt.show()

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -1,0 +1,73 @@
+"""
+===============================
+Gradient Boosting OOB estimates
+===============================
+
+
+"""
+print(__doc__)
+
+# Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
+#
+# License: BSD 3 clause
+
+import numpy as np
+import pylab as plt
+
+from scipy.stats.distributions import binom
+
+from sklearn import ensemble
+
+###############################################################################
+# Generate data
+
+n = 1000
+rs = np.random.RandomState(13)
+x1 = rs.uniform(size=n)
+x2 = rs.uniform(size=n)
+x3 = rs.randint(0, 4, size=n)
+
+p = 1 / (1.0 + np.exp(-(np.sin(3 * x1) - 4 * x2 + x3)))
+y = binom.rvs(1, p, size=n)
+X = np.c_[x1, x2, x3]
+
+X = X.astype(np.float32)
+offset = int(X.shape[0] * 0.8)
+X_train, y_train = X[:offset], y[:offset]
+X_test, y_test = X[offset:], y[offset:]
+
+###############################################################################
+# Fit regression model
+params = {'n_estimators': 3000, 'max_depth': 4, 'subsample': 0.5,
+          'learning_rate': 0.01, 'min_samples_leaf': 1, 'random_state': 3}
+clf = ensemble.GradientBoostingClassifier(**params)
+
+clf.fit(X_train, y_train)
+acc = clf.score(X_test, y_test)
+print("ACC: %.4f" % acc)
+
+n_estimators = params['n_estimators']
+x = np.arange(n_estimators) + 1
+
+test_score = np.zeros((n_estimators,), dtype=np.float64)
+
+for i, y_pred in enumerate(clf.staged_decision_function(X_test)):
+    test_score[i] = clf.loss_(y_test, y_pred)
+
+
+#plt.plot(x, -np.cumsum(clf.oob_score_))
+cumsum = np.cumsum(clf.oob_improvement_)
+best_iter = x[np.argmax(cumsum)]
+true_best_iter = np.argmin(test_score)
+print("best_iter: %d" % best_iter)
+print("true_best_iter: %d" % true_best_iter)
+
+plt.plot(x, cumsum, label='oob', color='cyan')
+plt.plot(x, test_score, label='test', color='red')
+
+plt.plot([best_iter, best_iter], [0.0, 1.0], color='cyan')
+plt.plot([true_best_iter, true_best_iter], [0.0, 1.0], color='red')
+
+plt.legend(loc='upper right')
+
+plt.show()

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -23,6 +23,7 @@ The module structure is the following:
 from __future__ import print_function
 from __future__ import division
 from abc import ABCMeta, abstractmethod
+from warnings import warn
 
 import sys
 
@@ -567,34 +568,49 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                                     dtype=np.object)
 
         self.train_score_ = np.zeros((self.n_estimators,), dtype=np.float64)
-        self.oob_score_ = np.zeros((self.n_estimators), dtype=np.float64)
+
+        if self.subsample < 1.0:
+            self._oob_score_ = np.zeros((self.n_estimators), dtype=np.float64)
+            self.oob_improvement_ = np.zeros((self.n_estimators),
+                                             dtype=np.float64)
+
+        # pull some obj into local scope
+        subsample = self.subsample
+        loss_ = self.loss_
+        do_oob = subsample < 1.0
 
         sample_mask = np.ones((n_samples,), dtype=np.bool)
-        n_inbag = max(1, int(self.subsample * n_samples))
+        n_inbag = max(1, int(subsample * n_samples))
 
         # perform boosting iterations
         for i in range(self.n_estimators):
 
             # subsampling
-            if self.subsample < 1.0:
+            if do_oob:
                 # TODO replace with ``np.choice`` if possible.
                 sample_mask = _random_sample_mask(n_samples, n_inbag,
                                                   random_state)
+                # OOB score before this stage
+                old_oob_score = loss_(y[~sample_mask],
+                                      y_pred[~sample_mask])
+
             # fit next stage of trees
             y_pred = self._fit_stage(i, X, y, y_pred, sample_mask,
                                      random_state)
 
             # track deviance (= loss)
-            if self.subsample < 1.0:
-                self.train_score_[i] = self.loss_(y[sample_mask],
-                                                  y_pred[sample_mask])
-                self.oob_score_[i] = self.loss_(y[~sample_mask],
-                                                y_pred[~sample_mask])
+            if do_oob:
+                self.train_score_[i] = loss_(y[sample_mask],
+                                             y_pred[sample_mask])
+                self._oob_score_[i] = loss_(y[~sample_mask],
+                                            y_pred[~sample_mask])
+                self.oob_improvement_[i] = old_oob_score - self._oob_score_[i]
+
                 if self.verbose > 1:
                     print("built tree %d of %d, train score = %.6e, "
-                          "oob score = %.6e" % (i + 1, self.n_estimators,
+                          "oob improvement = %.6e" % (i + 1, self.n_estimators,
                                                 self.train_score_[i],
-                                                self.oob_score_[i]))
+                                                self.oob_improvement_[i]))
 
             else:
                 # no need to fancy index w/ no subsampling
@@ -690,6 +706,17 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         importances = total_sum / len(self.estimators_)
         return importances
+
+    @property
+    def oob_score_(self):
+        warn("The oob_score_ argument is replaced by oob_improvement"
+             "as of version 0.14 and will be removed in 0.16.",
+             DeprecationWarning)
+        try:
+            return self._oob_score_
+        except AttributeError:
+            raise ValueError("Estimator not fitted, "
+                             "call `fit` before `oob_score_`.")
 
 
 class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
@@ -995,10 +1022,17 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     `feature_importances_` : array, shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
+    `oob_improvement_` : array, shape = [n_estimators]
+        The improvement in loss (= deviance) on the out-of-bag samples
+        relative to the previous iteration.
+        ``oob_improvement_[0]`` is the improvement in
+        loss of the first stage over the ``init`` estimator.
+
     `oob_score_` : array, shape = [n_estimators]
         Score of the training dataset obtained using an out-of-bag estimate.
         The i-th score ``oob_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the out-of-bag sample.
+        Deprecated: use `oob_improvement_` instead.
 
     `train_score_` : array, shape = [n_estimators]
         The i-th score ``train_score_[i]`` is the deviance (= loss) of the

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -709,7 +709,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
     @property
     def oob_score_(self):
-        warn("The oob_score_ argument is replaced by oob_improvement"
+        warn("The oob_score_ argument is replaced by oob_improvement_"
              "as of version 0.14 and will be removed in 0.16.",
              DeprecationWarning)
         try:

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -792,10 +792,17 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     `feature_importances_` : array, shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
+    `oob_improvement_` : array, shape = [n_estimators]
+        The improvement in loss (= deviance) on the out-of-bag samples
+        relative to the previous iteration.
+        ``oob_improvement_[0]`` is the improvement in
+        loss of the first stage over the ``init`` estimator.
+
     `oob_score_` : array, shape = [n_estimators]
         Score of the training dataset obtained using an out-of-bag estimate.
         The i-th score ``oob_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the out-of-bag sample.
+        Deprecated: use `oob_improvement_` instead.
 
     `train_score_` : array, shape = [n_estimators]
         The i-th score ``train_score_[i]`` is the deviance (= loss) of the

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -569,15 +569,15 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         self.train_score_ = np.zeros((self.n_estimators,), dtype=np.float64)
 
-        if self.subsample < 1.0:
-            self._oob_score_ = np.zeros((self.n_estimators), dtype=np.float64)
-            self.oob_improvement_ = np.zeros((self.n_estimators),
-                                             dtype=np.float64)
-
         # pull some obj into local scope
         subsample = self.subsample
         loss_ = self.loss_
         do_oob = subsample < 1.0
+
+        if self.subsample < 1.0:
+            self._oob_score_ = np.zeros((self.n_estimators), dtype=np.float64)
+            self.oob_improvement_ = np.zeros((self.n_estimators),
+                                             dtype=np.float64)
 
         sample_mask = np.ones((n_samples,), dtype=np.bool)
         n_inbag = max(1, int(subsample * n_samples))

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -484,5 +484,4 @@ def test_oob_score():
     clf.fit(X, y)
     with warnings.catch_warnings(record=True) as w:
         _ = clf.oob_score_[0]
-        print "waring ....: ", w
         assert_equal(len(w), 1)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -488,11 +488,15 @@ def test_oob_score():
 
 
 def test_oob_improvement():
-    """Test if oob improvement has correct shape. """
+    """Test if oob improvement has correct shape and regression test. """
     clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
                                      subsample=0.5)
     clf.fit(X, y)
     assert clf.oob_improvement_.shape[0] == 100
+    # hard-coded regression test - change if modification in OOB computation
+    assert_array_almost_equal(clf.oob_improvement_[:5],
+                              np.array([ 0.19, 0.15, 0.12,-0.12, -0.11]),
+                              decimal=2)
 
 
 def test_oob_improvement_raise():
@@ -502,3 +506,18 @@ def test_oob_improvement_raise():
     clf.fit(X, y)
     assert_raises(AttributeError, lambda : clf.oob_improvement_)
 
+
+def test_iris():
+    """Check OOB improvement on multi-class dataset."""
+    clf = GradientBoostingClassifier(n_estimators=100, loss='deviance',
+                                     random_state=1, subsample=0.5)
+    clf.fit(iris.data, iris.target)
+    score = clf.score(iris.data, iris.target)
+    assert score > 0.9, "Failed with subsample %.1f " \
+           "and score = %f" % (subsample, score)
+
+    assert clf.oob_improvement_.shape[0] == clf.n_estimators
+    # hard-coded regression test - change if modification in OOB computation
+    assert_array_almost_equal(clf.oob_improvement_[:5],
+                              np.array([12.68, 10.45, 8.18, 6.43, 5.02]),
+                              decimal=2)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -3,6 +3,7 @@ Testing for the gradient boosting module (sklearn.ensemble.gradient_boosting).
 """
 
 import numpy as np
+import warnings
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_equal
@@ -474,3 +475,14 @@ def test_mem_layout():
     clf.fit(X, y_)
     assert_array_equal(clf.predict(T), true_result)
     assert_equal(100, len(clf.estimators_))
+
+
+def test_oob_score():
+    """Test if oob_score is deprecated. """
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
+                                     subsample=0.5)
+    clf.fit(X, y)
+    with warnings.catch_warnings(record=True) as w:
+        _ = clf.oob_score_[0]
+        print "waring ....: ", w
+        assert_equal(len(w), 1)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -485,3 +485,20 @@ def test_oob_score():
     with warnings.catch_warnings(record=True) as w:
         _ = clf.oob_score_[0]
         assert_equal(len(w), 1)
+
+
+def test_oob_improvement():
+    """Test if oob improvement has correct shape. """
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
+                                     subsample=0.5)
+    clf.fit(X, y)
+    assert clf.oob_improvement_.shape[0] == 100
+
+
+def test_oob_improvement_raise():
+    """Test if oob improvement has correct shape. """
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
+                                     subsample=1.0)
+    clf.fit(X, y)
+    assert_raises(AttributeError, lambda : clf.oob_improvement_)
+


### PR DESCRIPTION
This PR adresses issue #1802 by @yanirs.

It sets `oob_score_` deprecated and introduces `oob_improvement_` which gives the relative improvement of adding the i-th tree on the out-of-bag examples. The PR includes an example that shows how `oob_improvement_` can be used to estimate the "optimal" number of iterations (basically an alternative to cross-validation).

![gbrt_oob_example](https://f.cloud.github.com/assets/111730/836289/9aa0c888-f2ec-11e2-8a03-12b3a337a416.png)
