### PR TITLE
[MRG] as_float_array doesn't copy

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -9,6 +9,7 @@ from nose.tools import assert_raises, assert_true, assert_false, assert_equal
 from sklearn.utils import (array2d, as_float_array, atleast2d_or_csr,
                            atleast2d_or_csc, check_arrays, safe_asarray)
 
+from sklearn.random_projection import sparse_random_matrix
 
 def test_as_float_array():
     """Test function for as_float_array"""
@@ -30,6 +31,17 @@ def test_as_float_array():
     # Test that if X is fortran ordered it stays
     X = np.asfortranarray(X)
     assert_true(np.isfortran(as_float_array(X, copy=True)))
+
+    # Test the copy parameter with some matrices
+    matrices = [
+        np.matrix(np.arange(5)),
+        sp.csc_matrix(np.arange(5)).todense(),
+        sparse_random_matrix(10, 10, density=0.10).todense()
+    ]
+    for M in matrices:
+        N = as_float_array(M, copy=True)
+        N[0, 0] = np.nan
+        assert_false(np.isnan(M).any())
 
 
 def test_check_arrays_exceptions():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -64,6 +64,7 @@ def as_float_array(X, copy=True):
     """
     if isinstance(X, np.matrix) or (not isinstance(X, np.ndarray)
                                     and not sparse.issparse(X)):
+        X = X.copy() if copy else X
         return safe_asarray(X, dtype=np.float64)
     elif sparse.issparse(X) and X.dtype in [np.float32, np.float64]:
         return X.copy() if copy else X

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -35,7 +35,8 @@ def safe_asarray(X, dtype=None, order=None, copy=False):
 
     Prevents copying X when possible; sparse matrices are passed through."""
     if sparse.issparse(X):
-        X = X.copy() if copy else X
+        if copy:
+            X = X.copy()
         assert_all_finite(X.data)
     else:
         X = np.array(X, dtype=dtype, order=order, copy=copy)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -30,14 +30,15 @@ def assert_all_finite(X):
     _assert_all_finite(X.data if sparse.issparse(X) else X)
 
 
-def safe_asarray(X, dtype=None, order=None):
+def safe_asarray(X, dtype=None, order=None, copy=False):
     """Convert X to an array or sparse matrix.
 
     Prevents copying X when possible; sparse matrices are passed through."""
     if sparse.issparse(X):
+        X = X.copy() if copy else X
         assert_all_finite(X.data)
     else:
-        X = np.asarray(X, dtype, order)
+        X = np.array(X, dtype=dtype, order=order, copy=copy)
         assert_all_finite(X)
     return X
 
@@ -64,8 +65,7 @@ def as_float_array(X, copy=True):
     """
     if isinstance(X, np.matrix) or (not isinstance(X, np.ndarray)
                                     and not sparse.issparse(X)):
-        X = X.copy() if copy else X
-        return safe_asarray(X, dtype=np.float64)
+        return safe_asarray(X, dtype=np.float64, copy=copy)
     elif sparse.issparse(X) and X.dtype in [np.float32, np.float64]:
         return X.copy() if copy else X
     elif X.dtype in [np.float32, np.float64]:  # is numpy array


### PR DESCRIPTION
The function `as_float_array` doesn't copy as expected when the matrix was created with `sparse_random_matrix`. This code should fix that.

Example:

``` python
import numpy as np
import scipy.sparse as sp

from sklearn.random_projection import sparse_random_matrix
from sklearn.utils import as_float_array

matrices = [
    np.matrix(np.arange(5)),
    sp.csc_matrix(np.arange(5)).todense(),
    sparse_random_matrix(10, 10, density=0.10).todense(),
]

for M in matrices:
    print type(M) # <class 'numpy.matrixlib.defmatrix.matrix'>

    N = as_float_array(M, copy=True)
    print type(N) # <type 'numpy.ndarray'>

    print np.isnan(M).any() # False
    N[0, 0] = np.nan
    print np.isnan(N).any() # True
    # False in the first and the second case
    # True in the third...
    print np.isnan(M).any()
    assert np.isnan(M).any() == False
```
