### PR TITLE
Enh rel canonical

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -32,23 +32,11 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
-
 </script>
-
- {%- if theme_oldversion == false %}
-      <script type="text/javascript}">
-	  console.debug("DERP");
-	  var a = {{ master_doc }};
-	  console.debug(a);
-	  console.debug("{{pagename}}");
-
-      </script>
-      <link rel="canonical" href="{{pagename.link}}.html">
-   {%- endif %}
-
-
 {% endif %}
-
+{%- if theme_oldversion == false %}
+      <link rel="canonical" href="http://scikit-learn.org/stable/{{pagename}}.html">
+ {%- endif %}
 {% endblock %}
 
 {%- if pagename == 'index' %}

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -34,9 +34,7 @@
   })();
 </script>
 {% endif %}
-{%- if theme_oldversion == false %}
       <link rel="canonical" href="http://scikit-learn.org/stable/{{pagename}}.html">
- {%- endif %}
 {% endblock %}
 
 {%- if pagename == 'index' %}

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -34,6 +34,19 @@
   })();
 
 </script>
+
+ {%- if theme_oldversion == false %}
+      <script type="text/javascript}">
+	  console.debug("DERP");
+	  var a = {{ master_doc }};
+	  console.debug(a);
+	  console.debug("{{pagename}}");
+
+      </script>
+      <link rel="canonical" href="{{pagename.link}}.html">
+   {%- endif %}
+
+
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This adds **rel=canonical** to all the pages in stable..
turns out it was a lot simpler than I thought. 

---

Just to be clear, this will add a (for example)

`<link rel="canonical" href="http://scikit-learn.org/stable/modules/ensemble.html">`

to that page
and will do so for every auto-generated page on the **stable** docs.
This will appear in the `<head>` tag of each page. I Tested it on an online build too.

Apparently it will take a bit of time before we see any effect, as Googles crawlers need to update this.

For more info on what this is for, see [this article](https://support.google.com/webmasters/answer/139394?hl=en)
