### PR TITLE
WIP/ENH: improve ICA memory profile by 40%

### DIFF
--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -317,7 +317,6 @@ a maximum amount of independent information. It is able to recover
     >>> # Compute ICA
     >>> ica = decomposition.FastICA()
     >>> S_ = ica.fit_transform(X)  # Get the estimated sources
-    Converged after 2 iterations.
     >>> A_ = ica.mixing_.T
     >>> np.allclose(X,  np.dot(S_, A_) + ica.mean_)
     True

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -317,6 +317,7 @@ a maximum amount of independent information. It is able to recover
     >>> # Compute ICA
     >>> ica = decomposition.FastICA()
     >>> S_ = ica.fit_transform(X)  # Get the estimated sources
+    Converged after 2 iterations.
     >>> A_ = ica.mixing_.T
     >>> np.allclose(X,  np.dot(S_, A_) + ica.mean_)
     True

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -129,6 +129,9 @@ Changelog
    - Python 3 support fixes by `Justin Vincent`_, `Lars Buitinck`_ and
      `Olivier Grisel`_. All tests now pass under Python 3.3.
 
+   - Reduce memory footprint of FastICA by `Denis Engemann`_ and
+     `Alexandre Gramfort`_.
+
 
 API changes summary
 -------------------
@@ -2004,3 +2007,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Eustache Diemert: https://github.com/oddskool
 
 .. _Justin Vincent: https://github.com/justinvf
+
+.. _Denis Engemann: https://github.com/dengemann

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -92,7 +92,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     W = _sym_decorrelation(w_init)
     del w_init
     p_ = float(X.shape[1])
-    for _ in moves.xrange(max_iter):
+    for ii in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
         W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
                                - g_wtx[:, np.newaxis] * W)
@@ -275,8 +275,6 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         # see (13.6) p.267 Here X1 is white and data
         # in X has been projected onto a subspace by PCA
         X1 *= np.sqrt(p)
-        if not compute_sources:
-            del X  # destroy original
     else:
         # X must be casted to floats to avoid typing issues with numpy
         # 2.0 and the line below
@@ -308,13 +306,19 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     del X1
 
     if whiten:
-        S = np.dot(np.dot(W, K), X).T if compute_sources else None
+        if compute_sources:
+            S = np.dot(np.dot(W, K), X).T
+        else:
+            S = None
         if return_X_mean:
             return K, W, S, X_mean
         else:
             return K, W, S
     else:
-        S = np.dot(W, X).T if compute_sources else None
+        if compute_sources:
+            S = np.dot(W, X).T
+        else:
+            S = None
         if return_X_mean:
             return None, W, S, None
         else:

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -100,10 +100,11 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
         lim = max(abs(abs(np.diag(np.dot(W1, W.T))) - 1))
         W = W1
         if lim < tol:
-            print 'Converged after %i iterations.' % (ii + 1)
             break
     else:
-        print 'Did not converge.'
+        warnings.warn('FastICA did not converge.' +
+                      ' You might want' +
+                      ' to increase the number of iterations.')
 
     return W
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -39,6 +39,7 @@ def _gs_decorrelation(w, W, j):
     w -= np.dot(np.dot(w, W[:j].T), W[:j])
     return w
 
+
 def _sym_decorrelation(W):
     """ Symmetric decorrelation
     i.e. W <- (W * W.T) ^{-1/2} * W
@@ -81,17 +82,17 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
 
     return W
 
+
 def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     """Parallel FastICA.
 
     Used internally by FastICA --main loop
 
     """
-    # with profile.timestamp('init-W'):
     W = _sym_decorrelation(w_init)
     del w_init
     p_ = float(X.shape[1])
-    for ii, _ in enumerate(moves.xrange(max_iter), 1):
+    for _ in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
         W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
                                - g_wtx[:, np.newaxis] * W)
@@ -99,10 +100,8 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
         lim = max(abs(abs(np.diag(np.dot(W1, W.T))) - 1))
         W = W1
         if lim < tol:
+            print 'Converged after %i iterations.' % (ii + 1)
             break
-
-    if ii < max_iter:
-        print 'Converged after %i iterations.' % ii
     else:
         print 'Did not converge.'
 
@@ -130,6 +129,7 @@ def _exp(x, fun_args):
 
 def _cube(x, fun_args):
     return x ** 3, (3 * x ** 2).mean(axis=-1)
+
 
 def fastica(X, n_components=None, algorithm="parallel", whiten=True,
             fun="logcosh", fun_args={}, max_iter=200, tol=1e-04, w_init=None,
@@ -280,8 +280,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     else:
         # X must be casted to floats to avoid typing issues with numpy
         # 2.0 and the line below
-        # X1 = as_float_array(X, copy=False)  # copy has been taken care of above
-        X1 = X
+        X1 = as_float_array(X, copy=False)  # copy has been taken care of
 
     if w_init is None:
         w_init = np.asarray(random_state.normal(size=(n_components,
@@ -357,7 +356,7 @@ class FastICA(BaseEstimator, TransformerMixin):
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
     compute_sources : bool, optional
-        If False, sources are not computes but only the rotation matrix. This
+        If False, sources are not computed but only the rotation matrix. This
         can save memory when working with big data. Defaults to True.
 
     Attributes

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -11,7 +11,7 @@ from nose.tools import assert_raises
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_true, assert_false
+from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_equal
 
@@ -79,7 +79,7 @@ def test_fastica_simple(add_noise=False):
 
     # function as fun arg
     def g_test(x):
-        return x ** 3, 3 * x ** 2
+        return x ** 3, (3 * x ** 2).mean(axis=-1)
 
     algos = ['parallel', 'deflation']
     nls = ['logcosh', 'exp', 'cube', g_test]


### PR DESCRIPTION
Using the new memory profiler by @fabianp @garvais I was able to track down the memory issues I had witnessed during the last weeks.
This proposal cut's down memory consumption by 50-40% - that is instead of 5-6 GB of ram on 1GB data input we now end up consuming 3 GB.
I pushed things into inplace operations where possible and removed local variables which previously had been ratcheting up across cycles of iteration. Finally, cost functions now return a mean vector as second value which further cuts memory consumption.

cc @GaelVaroquaux @agramfort @mblondel
