### PR TITLE
MRG backwards compatibility in FastICA estimator

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -133,7 +133,7 @@ def _cube(x, fun_args):
 
 
 def fastica(X, n_components=None, algorithm="parallel", whiten=True,
-            fun="logcosh", fun_args={}, max_iter=200, tol=1e-04, w_init=None,
+            fun="logcosh", fun_args=None, max_iter=200, tol=1e-04, w_init=None,
             random_state=None, return_X_mean=False, compute_sources=True):
     """Perform Fast Independent Component Analysis.
 
@@ -165,7 +165,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
             return x ** 3, 3 * x ** 2
     fun_args : dictionary, optional
         Arguments to send to the functional form.
-        If empty and if fun='logcosh', fun_args will take value
+        If empty or None and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}
     max_iter : int, optional
         Maximum number of iterations to perform
@@ -226,6 +226,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
     """
     random_state = check_random_state(random_state)
+    fun_args = {} if fun_args is None else fun_args
     # make interface compatible with other decompositions
     # a copy is required only for non whitened data
     X = array2d(X, copy=whiten).T

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -369,7 +369,9 @@ class FastICA(BaseEstimator, TransformerMixin):
     `mixing_` : array, shape = [n_features, n_components]
         Mixing matrix.
     `sources_` : 2D array, [n_samples, n_components]
-        The estimated latent sources of the data.
+        The estimated latent sources of the data. This attribute is deprecated
+        and will be removed in 0.16. Use `fit_transform` instead and store
+        the result.
 
     Notes
     -----

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -361,9 +361,6 @@ class FastICA(BaseEstimator, TransformerMixin):
         The mixing matrix to be used to initialize the algorithm.
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
-    compute_sources : bool, optional
-        If False, sources are not computed but only the rotation matrix. This
-        can save memory when working with big data. Defaults to True.
 
     Attributes
     ----------
@@ -384,7 +381,7 @@ class FastICA(BaseEstimator, TransformerMixin):
 
     def __init__(self, n_components=None, algorithm='parallel', whiten=True,
                  fun='logcosh', fun_args=None, max_iter=200, tol=1e-4,
-                 w_init=None, random_state=None, compute_sources=True):
+                 w_init=None, random_state=None):
         super(FastICA, self).__init__()
         self.n_components = n_components
         self.algorithm = algorithm
@@ -395,7 +392,45 @@ class FastICA(BaseEstimator, TransformerMixin):
         self.tol = tol
         self.w_init = w_init
         self.random_state = random_state
-        self.compute_sources = compute_sources
+
+    def _fit(self, X, compute_sources=False):
+        """Fit the model
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Training data, where n_samples is the number of samples
+            and n_features is the number of features.
+
+        compute_sources : bool
+            If False, sources are not computes but only the rotation matrix.
+            This can save memory when working with big data. Defaults to False.
+
+        Returns
+        -------
+            X_new : array-like, shape (n_samples, n_components)
+        """
+        fun_args = {} if self.fun_args is None else self.fun_args
+        whitening, unmixing, sources, X_mean = fastica(
+            X=X, n_components=self.n_components, algorithm=self.algorithm,
+            whiten=self.whiten, fun=self.fun, fun_args=fun_args,
+            max_iter=self.max_iter, tol=self.tol, w_init=self.w_init,
+            random_state=self.random_state, return_X_mean=True,
+            compute_sources=compute_sources)
+
+        if self.whiten:
+            self.components_ = np.dot(unmixing, whitening)
+            self.mean_ = X_mean
+            self.whitening_ = whitening
+        else:
+            self.components_ = unmixing
+
+        self.mixing_ = linalg.pinv(self.components_)
+
+        if compute_sources:
+            self.__sources = sources
+
+        return sources
 
     def fit_transform(self, X, y=None):
         """Fit the model and recover the sources from X.
@@ -410,26 +445,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
-        fun_args = {} if self.fun_args is None else self.fun_args
-        whitening_, unmixing_, sources_, X_mean = fastica(
-            X=X, n_components=self.n_components, algorithm=self.algorithm,
-            whiten=self.whiten, fun=self.fun, fun_args=fun_args,
-            max_iter=self.max_iter, tol=self.tol, w_init=self.w_init,
-            random_state=self.random_state, return_X_mean=True,
-            compute_sources=self.compute_sources)
-        if self.whiten:
-            self.components_ = np.dot(unmixing_, whitening_)
-            self.mean_ = X_mean
-            self.whitening_ = whitening_
-        else:
-            self.components_ = unmixing_
-
-        self.mixing_ = linalg.pinv(self.components_)
-
-        if self.compute_sources:
-            self.sources_ = sources_
-
-        return sources_
+        return self._fit(X, compute_sources=True)
 
     def fit(self, X, y=None):
         """Fit the model to X.
@@ -444,7 +460,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         -------
         self
         """
-        self.fit_transform(X)
+        self._fit(X, compute_sources=True)  # will become False in 0.16
         return self
 
     def transform(self, X, y=None, copy=True):
@@ -477,6 +493,12 @@ class FastICA(BaseEstimator, TransformerMixin):
         mixing_matrix : array, shape (n_features, n_components)
         """
         return self.mixing_
+
+    @property
+    @deprecated('To be removed in 0.16.  Use `fit_transform` and store the '
+                'output instead.')
+    def sources_(self):
+        return self.__sources
 
     def inverse_transform(self, X, copy=True):
         """Transform the sources back to the mixed data (apply mixing matrix).

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -117,14 +117,13 @@ def test_fastica_simple(add_noise=False):
             assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=1)
 
     # Test FastICA class
+    _, _, sources_fun = fastica(X, fun=nl, algorithm=algo, random_state=0)
     ica = FastICA(fun=nl, algorithm=algo, random_state=0)
-    ica.fit(m.T)
+    sources = ica.fit_transform(m.T)
     assert_equal(ica.components_.shape, (2, 2))
-    assert_equal(ica.sources_.shape, (1000, 2))
+    assert_equal(sources.shape, (1000, 2))
 
-    sources = FastICA(fun=nl, algorithm=algo, random_state=0).\
-                      fit_transform(m.T)
-    assert_array_almost_equal(sources, ica.sources_)
+    assert_array_almost_equal(sources_fun, sources)
     assert_array_almost_equal(sources, ica.transform(m.T))
 
     assert_equal(ica.mixing_.shape, (2, 2))
@@ -203,12 +202,11 @@ def test_fit_transform():
         ica = FastICA(n_components=5, whiten=whiten, random_state=0)
         Xt = ica.fit_transform(X)
         assert_equal(ica.components_.shape, (n_components, 10))
-        assert_equal(ica.sources_.shape, (100, n_components))
+        assert_equal(Xt.shape, (100, n_components))
 
         ica = FastICA(n_components=5, whiten=whiten, random_state=0)
         ica.fit(X)
         assert_equal(ica.components_.shape, (n_components, 10))
-        assert_equal(ica.sources_.shape, (100, n_components))
         Xt2 = ica.transform(X)
 
         assert_array_almost_equal(Xt, Xt2)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -117,7 +117,7 @@ def test_fastica_simple(add_noise=False):
             assert_almost_equal(np.dot(s2_, s2) / n_samples, 1, decimal=1)
 
     # Test FastICA class
-    _, _, sources_fun = fastica(X, fun=nl, algorithm=algo, random_state=0)
+    _, _, sources_fun = fastica(m.T, fun=nl, algorithm=algo, random_state=0)
     ica = FastICA(fun=nl, algorithm=algo, random_state=0)
     sources = ica.fit_transform(m.T)
     assert_equal(ica.components_.shape, (2, 2))


### PR DESCRIPTION
After some thinking I think this is the cleanest way to change the FastICA estimator according to the new compute_sources parameter.

Ideally (if there were no users) the estimator wouldn't have a `compute_sources` init argument, because the use case is different: either you use `FastICA.fit_transform`, in which case you call the underlying function with `compute_sources=True`, or you use `FastICA.fit`, in which case it's more effective not to compute the sources, because presumably the user will subsequently call `.transform` on some other data.  (If they will use the same data, it's their fault for misusing the API)

In order to get there we need to deprecate the `FastICA.sources_` attribute. Because its computation depends on the initial data passed to `fit` I couldn't compute it lazily, so until the deprecation I propose to just compute it all the time.  (this is identical to what FastICA did yesterday night before my nocturnal bugfix anyway).

Alternatively if we want to make the estimator be able to save the memory, we could introduce a deprecated-since-birth init attribute `compute_sources`, `True` by default.  However I think this is just confusing for users; if people want to use fastica and save memory they should simply call the function directly.

In general I think the API can be rethought in many places, many estimators have tons of parameters that are only useful for speedup/optimization and all they do is expose the underlying functions with complicated logic.  I think that users who really work at the limit of their resources should go ahead and use the underlying public functions.

Opinions?
