### PR TITLE
[MRG]: add fast_dot function calling BLAS directly and consume only twice the memory of your data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -185,7 +185,8 @@ Changelog
      :class:`neighbors.RadiusNeighborsClassifier` support multioutput data
      by `Arnaud Joly`_.
 
-
+   - Add `fast_dot` wrapper allowing to call `BLAS gemm` directly and avoiding
+   extra memory copies by `Denis Engemann`_ and `Alexandre Gramfort`_.
 
 
 API changes summary

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -199,12 +199,12 @@ def test_fit_transform():
     X = rng.random_sample((100, 10))
     for whiten, n_components in [[True, 5], [False, 10]]:
 
-        ica = FastICA(n_components=5, whiten=whiten, random_state=0)
+        ica = FastICA(n_components=n_components, whiten=whiten, random_state=0)
         Xt = ica.fit_transform(X)
         assert_equal(ica.components_.shape, (n_components, 10))
         assert_equal(Xt.shape, (100, n_components))
 
-        ica = FastICA(n_components=5, whiten=whiten, random_state=0)
+        ica = FastICA(n_components=n_components, whiten=whiten, random_state=0)
         ica.fit(X)
         assert_equal(ica.components_.shape, (n_components, 10))
         Xt2 = ica.transform(X)
@@ -214,18 +214,17 @@ def test_fit_transform():
 
 def test_inverse_transform():
     """Test FastICA.inverse_transform"""
+    n_features = 10
+    n_samples = 100
+    n1, n2 = 5, 10
     rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    n_features = X.shape[1]
-    expected = {(True, 5): (n_features, 5),
-                (True, 10): (n_features, 10),
-                (False, 5): (n_features, 10),
-                (False, 10): (n_features, 10)}
-
+    X = rng.random_sample((n_samples, n_features))
+    expected = {(True, n1): (n_features, n1),
+                (True, n2): (n_features, n2),
+                (False, n1): (n_features, n2),
+                (False, n2): (n_features, n2)}
     for whiten in [True, False]:
-        for n_components in [5, 10]:
+        for n_components in [n1, n2]:
             ica = FastICA(n_components=n_components, random_state=rng,
                           whiten=whiten)
             Xt = ica.fit_transform(X)


### PR DESCRIPTION
Hi there, I finally got it running.

This implements a feature 'advocated' on this scipy page (section on large arrays and linalg):

http://wiki.scipy.org/PerformanceTips

When directly calling blass instead of np.dot it's possible to avoid copying when data are passed in F-contiguous order. In addition I've added chunking to the `_logcosh` function which avoids an extra copy.
This is now how it looks on 1GB testing data:

![fast_dot_chunking_logcosh](https://f.cloud.github.com/assets/1908618/861320/cb8e7c78-f5cc-11e2-8e1e-59727b66f4b2.png)

This was how the same test would have looked on the current master (plot from the last memory PR):
![memory_ica_par_w1_computation_del_gwx](https://f.cloud.github.com/assets/1908618/861329/f0928b36-f5cc-11e2-82b6-01d17d79190a.png)

To make this functionality available for other use cases I've added a `fast_dot` function to `utils.extmath` with almost stupid but explicit tests that exemplify the mapping between `np.dot` and `fast_dot` which can be a hell.
Finally I've made sure that down-stream applications are still workin. For example with this local branch the mne-python ICA looks as good as it had looked before.

cc @agramfort @GaelVaroquaux @mblondel 
