### PR TITLE
[MRG] DOC improve svm sample weight example

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -251,7 +251,8 @@ that sets the parameter ``C`` of class ``class_label`` to ``C * value``.
 
 :class:`SVC`, :class:`NuSVC`, :class:`SVR`, :class:`NuSVR` and
 :class:`OneClassSVM` implement also weights for individual samples in method
-``fit`` through keyword ``sample_weight``.
+``fit`` through keyword ``sample_weight``. Similar to ``class_weight``, these
+set the parameter ``C`` for the i-th example to ``C * sample_weight[i]``.
 
 
 .. figure:: ../auto_examples/svm/images/plot_weighted_samples_1.png

--- a/examples/svm/plot_weighted_samples.py
+++ b/examples/svm/plot_weighted_samples.py
@@ -5,34 +5,56 @@ SVM: Weighted samples
 
 Plot decision function of a weighted dataset, where the size of points
 is proportional to its weight.
+
+The sample weighting rescales the C parameter, which means that the classifier
+puts more emphasis on getting these points right. The effect might often be
+subtle.
 """
 print(__doc__)
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from sklearn import svm
+
+
+def plot_decision_function(classifier, sample_weight, axis, title):
+    # plot the decision function
+    xx, yy = np.meshgrid(np.linspace(-4, 5, 500), np.linspace(-4, 5, 500))
+
+    Z = classifier.decision_function(np.c_[xx.ravel(), yy.ravel()])
+    Z = Z.reshape(xx.shape)
+
+    # plot the line, the points, and the nearest vectors to the plane
+    axis.contourf(xx, yy, Z, alpha=0.75, cmap=plt.cm.bone)
+    axis.scatter(X[:, 0], X[:, 1], c=Y, s=100 * sample_weight, alpha=0.9,
+                 cmap=plt.cm.bone)
+
+    axis.axis('off')
+    axis.set_title(title)
+
 
 # we create 20 points
 np.random.seed(0)
 X = np.r_[np.random.randn(10, 2) + [1, 1], np.random.randn(10, 2)]
 Y = [1] * 10 + [-1] * 10
-sample_weight = 100 * np.abs(np.random.randn(20))
-# and assign a bigger weight to the last 10 samples
-sample_weight[:10] *= 10
+sample_weight_last_ten = abs(np.random.randn(len(X)))
+sample_weight_constant = np.ones(len(X))
+# and assign a bigger weight to the last 5 samples
+sample_weight_last_ten[15:] *= 5
 
-# # fit the model
-clf = svm.SVC()
-clf.fit(X, Y, sample_weight=sample_weight)
+# for reference, first fit without class weights
 
-# plot the decision function
-xx, yy = np.meshgrid(np.linspace(-4, 5, 500), np.linspace(-4, 5, 500))
+# fit the model
+clf_weights = svm.SVC()
+clf_weights.fit(X, Y, sample_weight=sample_weight_last_ten)
 
-Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
-Z = Z.reshape(xx.shape)
+clf_no_weights = svm.SVC()
+clf_no_weights.fit(X, Y)
 
-# plot the line, the points, and the nearest vectors to the plane
-pl.contourf(xx, yy, Z, alpha=0.75, cmap=pl.cm.bone)
-pl.scatter(X[:, 0], X[:, 1], c=Y, s=sample_weight, alpha=0.9, cmap=pl.cm.bone)
+fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+plot_decision_function(clf_no_weights, sample_weight_constant, axes[0],
+                       "Constant weights")
+plot_decision_function(clf_weights, sample_weight_last_ten, axes[1],
+                       "Modified weights")
 
-pl.axis('off')
-pl.show()
+plt.show()

--- a/examples/svm/plot_weighted_samples.py
+++ b/examples/svm/plot_weighted_samples.py
@@ -9,6 +9,8 @@ is proportional to its weight.
 The sample weighting rescales the C parameter, which means that the classifier
 puts more emphasis on getting these points right. The effect might often be
 subtle.
+To emphasis the effect here, we particularly weight outliers, making the
+deformation of the decision boundary very visible.
 """
 print(__doc__)
 
@@ -39,8 +41,9 @@ X = np.r_[np.random.randn(10, 2) + [1, 1], np.random.randn(10, 2)]
 Y = [1] * 10 + [-1] * 10
 sample_weight_last_ten = abs(np.random.randn(len(X)))
 sample_weight_constant = np.ones(len(X))
-# and assign a bigger weight to the last 5 samples
+# and bigger weights to some outliers
 sample_weight_last_ten[15:] *= 5
+sample_weight_last_ten[9] *= 15
 
 # for reference, first fit without class weights
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -100,16 +100,17 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Training vectors, where n_samples is the number of samples
             and n_features is the number of features.
 
-        y : array-like, shape = [n_samples]
+        y : array-like, shape (n_samples)
             Target values (class labels in classification, real numbers in
             regression)
 
-        sample_weight : array-like, shape = [n_samples], optional
-            Weights applied to individual samples (1. for unweighted).
+        sample_weight : array-like, shape (n_samples,)
+            Per-sample weights. Rescale C per sample. Higher weights
+            force the classifier to put more emphasis on these points.
 
         Returns
         -------
@@ -263,11 +264,11 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
 
         Returns
         -------
-        y_pred : array, shape = [n_samples]
+        y_pred : array, shape (n_samples)
         """
         X = self._validate_for_predict(X)
         predict = self._sparse_predict if self._sparse else self._dense_predict

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -696,9 +696,13 @@ class OneClassSVM(BaseLibSVM):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Set of samples, where n_samples is the number of samples and
             n_features is the number of features.
+
+        sample_weight : array-like, shape (n_samples,)
+            Per-sample weights. Rescale C per sample. Higher weights
+            force the classifier to put more emphasis on these points.
 
         Returns
         -------

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -340,6 +340,14 @@ def test_sample_weights():
     clf.fit(X, Y, sample_weight=sample_weight)
     assert_array_equal(clf.predict(X[2]), [2.])
 
+    # test that rescaling all samples is the same as changing C
+    clf = svm.SVC()
+    clf.fit(X, Y)
+    dual_coef_no_weight = clf.dual_coef_
+    clf.set_params(C=100)
+    clf.fit(X, Y, sample_weight=np.repeat(0.01, len(X)))
+    assert_array_almost_equal(dual_coef_no_weight, clf.dual_coef_)
+
 
 def test_auto_weight():
     """Test class weights for imbalanced data"""


### PR DESCRIPTION
Fixes issue #2191.
The sample weights doc and example were not terribly informative imho.
I tried to improve it.
The example looked like this:
![plot_weighted_samples_1](https://f.cloud.github.com/assets/449558/861421/a03f839c-f5d0-11e2-95cb-f24bfaa40252.png)

Now it looks like this:
![class_weight_example](https://f.cloud.github.com/assets/449558/861516/1e523b2e-f5d3-11e2-9f43-ffb9045271c4.png)

I'll add another sentence to the docs in a minute.
