### PR TITLE
BUG: add new preprocessing module to setup.py

### DIFF
--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -42,6 +42,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('gaussian_process/tests')
     config.add_subpackage('neighbors')
     config.add_subpackage('neural_network')
+    config.add_subpackage('preprocessing')
     config.add_subpackage('manifold')
     config.add_subpackage('metrics')
     config.add_subpackage('semi_supervised')


### PR DESCRIPTION
Preprocessing was made a module; it needs to be added to setup.py in order to install correctly.
