### PR TITLE
[MRG] Use projected gradient solver in transform to support sparse matrices

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -16,6 +16,7 @@ import numbers
 
 import numpy as np
 import scipy.sparse as sp
+from scipy.optimize import nnls
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import atleast2d_or_csr, check_random_state, check_arrays
@@ -571,8 +572,13 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         """
         X, = check_arrays(X, sparse_format='csc')
         Wt = np.zeros((self.n_components_, X.shape[0]))
-        Wt, _, _ = _nls_subproblem(X.T, self.components_.T, Wt, tol=self.tol,
-                                   max_iter=self.nls_max_iter)
+        if sp.issparse(X):
+            Wt, _, _ = _nls_subproblem(X.T, self.components_.T, Wt,
+                                       tol=self.tol,
+                                       max_iter=self.nls_max_iter)
+        else:
+            for j in range(0, X.shape[0]):
+                Wt[:, j], _ = nnls(self.components_.T, X[j, :])
         return Wt.T
 
 

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -15,7 +15,6 @@ import warnings
 import numbers
 
 import numpy as np
-from scipy.optimize import nnls
 import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
@@ -572,10 +571,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         """
         X, = check_arrays(X, sparse_format='csc')
         Wt = np.zeros((self.n_components_, X.shape[0]))
-        Wt, _, _ = _nls_subproblem(X.T, self.components_.T, Wt, tol=1e-10,
-                                  max_iter=1000000)
-        #for j in range(0, X.shape[0]):
-        #    W[j, :], _ = nnls(self.components_.T, X[j, :])
+        Wt, _, _ = _nls_subproblem(X.T, self.components_.T, Wt, tol=self.tol,
+                                   max_iter=self.nls_max_iter)
         return Wt.T
 
 

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -140,14 +140,14 @@ def test_projgrad_nmf_sparseness():
 
 def test_sparse_input():
     """Test that sparse matrices are accepted as input"""
-    from scipy.sparse import csr_matrix
+    from scipy.sparse import csc_matrix
 
     A = np.abs(random_state.randn(10, 10))
     A[:, 2 * np.arange(5)] = 0
     T1 = nmf.ProjectedGradientNMF(n_components=5, init='random',
                                   random_state=999).fit_transform(A)
 
-    A_sparse = csr_matrix(A)
+    A_sparse = csc_matrix(A)
     pg_nmf = nmf.ProjectedGradientNMF(n_components=5, init='random',
                                       random_state=999)
     T2 = pg_nmf.fit_transform(A_sparse)
@@ -164,6 +164,21 @@ def test_sparse_input():
     T1 = nmf.ProjectedGradientNMF(
         n_components=5, init='random', sparseness='data',
         random_state=999).fit_transform(A)
+
+
+def test_sparse_transform():
+    """Test that transform works on sparse data.  Issue #2124"""
+    from scipy.sparse import csc_matrix
+
+    A = np.abs(random_state.randn(5, 4))
+    A[A > 1.0] = 0
+    A = csc_matrix(A)
+
+    model = nmf.NMF()
+    A_fit_tr = model.fit_transform(A)
+    A_tr = model.transform(A)
+    # This solver seems pretty inconsistent
+    assert_array_almost_equal(A_fit_tr, A_tr, decimal=2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of using the scipy.optimize.nnls (as until now) or the l-bfgs solver (as I am experimenting in #2263.

Fixes #2124.
