### PR TITLE
MRG: add failing test exposing bug in RandomizedPCA

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -280,8 +280,9 @@ class PCA(BaseEstimator, TransformerMixin):
 
         """
         X = array2d(X)
-        X_transformed = X - self.mean_
-        X_transformed = np.dot(X_transformed, self.components_.T)
+        if self.mean_ is not None and self.copy:
+            X = X - self.mean_
+        X_transformed = np.dot(X, self.components_.T)
         return X_transformed
 
     def inverse_transform(self, X):
@@ -380,7 +381,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         is set to n_features (the second dimension of the training data).
 
     copy : bool
-        If False, data passed to fit are overwritten
+        If False, data passed to fit are overwritten.
 
     iterated_power : int, optional
         Number of iterations for the power method. 3 by default.
@@ -521,7 +522,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         """
         # XXX remove scipy.sparse support here in 0.16
         X = atleast2d_or_csr(X)
-        if self.mean_ is not None:
+        if self.mean_ is not None and self.copy:
             X = X - self.mean_
 
         X = safe_sparse_dot(X, self.components_.T)

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -236,8 +236,9 @@ class PCA(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        X : ndarray, shape (n_samples, n_features)
-            The input data, copied, centered and whitened when requested.
+        U, s, V : ndarrays
+            The SVD of the input data, copied and centered when
+            requested.
         """
         X = array2d(X)
         n_samples, n_features = X.shape

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -123,8 +123,9 @@ class PCA(BaseEstimator, TransformerMixin):
         percentage specified by n_components
 
     copy : bool
-        If False, data passed to fit are overwritten. If copy is False use
-        `fit_transform` to transform the data used on fitting.
+        If False, data passed to fit are overwritten.  You should prefer
+        'fit_transform(X)' to 'fit(X).transform(X)' to transform the data used
+        on fitting.
 
     whiten : bool, optional
         When True (False by default) the `components_` vectors are divided
@@ -281,7 +282,7 @@ class PCA(BaseEstimator, TransformerMixin):
 
         """
         X = array2d(X)
-        if self.mean_ is not None and self.copy:
+        if self.mean_ is not None:
             X = X - self.mean_
         X_transformed = np.dot(X, self.components_.T)
         return X_transformed
@@ -382,8 +383,9 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         is set to n_features (the second dimension of the training data).
 
     copy : bool
-        If False, data passed to fit are overwritten. If copy is False use
-        `fit_transform` to transform the data used on fitting.
+        If False, data passed to fit are overwritten. You should prefer
+        'fit_transform(X)' to 'fit(X).transform(X)' to transform the data used
+        on fitting.
 
     iterated_power : int, optional
         Number of iterations for the power method. 3 by default.
@@ -458,7 +460,24 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self.mean_ = None
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, **params):
+        """Fit the model with X.
+
+        Parameters
+        ----------
+        X: array-like, shape (n_samples, n_features)
+            Training data, where n_samples in the number of samples
+            and n_features is the number of features.
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+        """
+        self._fit(X, **params)
+        return self
+
+    def _fit(self, X, y=None):
         """Fit the model to the data X.
 
         Parameters
@@ -506,9 +525,9 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         else:
             self.components_ = V
 
-        return self
+        return X
 
-    def transform(self, X):
+    def transform(self, X, y=None):
         """Apply dimensionality reduction on X.
 
         Parameters
@@ -530,7 +549,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         X = safe_sparse_dot(X, self.components_.T)
         return X
 
-    def fit_transform(self, X):
+    def fit_transform(self, X, y=None):
         """Apply dimensionality reduction on X.
 
         Parameters
@@ -546,11 +565,11 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         """
         # XXX remove scipy.sparse support here in 0.16
         X = atleast2d_or_csr(X)
-        self.fit(X)
+        X = self._fit(X)
         X = safe_sparse_dot(X, self.components_.T)
         return X
 
-    def inverse_transform(self, X):
+    def inverse_transform(self, X, y=None):
         """Transform data back to its original space.
 
         Returns an array X_original whose transform would be X.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -183,7 +183,7 @@ class PCA(BaseEstimator, TransformerMixin):
         self.copy = copy
         self.whiten = whiten
 
-    def fit(self, X, y=None, **params):
+    def fit(self, X, y=None):
         """Fit the model with X.
 
         Parameters
@@ -197,10 +197,10 @@ class PCA(BaseEstimator, TransformerMixin):
         self : object
             Returns the instance itself.
         """
-        self._fit(X, **params)
+        self._fit(X)
         return self
 
-    def fit_transform(self, X, y=None, **params):
+    def fit_transform(self, X, y=None):
         """Fit the model with X and apply the dimensionality reduction on X.
 
         Parameters
@@ -214,7 +214,7 @@ class PCA(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
 
         """
-        U, S, V = self._fit(X, **params)
+        U, S, V = self._fit(X)
         U = U[:, :self.n_components]
 
         if self.whiten:
@@ -460,7 +460,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self.mean_ = None
         self.random_state = random_state
 
-    def fit(self, X, y=None, **params):
+    def fit(self, X, y=None):
         """Fit the model with X.
 
         Parameters
@@ -474,7 +474,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self : object
             Returns the instance itself.
         """
-        self._fit(X, **params)
+        self._fit(X)
         return self
 
     def _fit(self, X, y=None):
@@ -563,9 +563,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
 
         """
-        # XXX remove scipy.sparse support here in 0.16
-        X = atleast2d_or_csr(X)
-        X = self._fit(X)
+        X = self._fit(atleast2d_or_csr(X))
         X = safe_sparse_dot(X, self.components_.T)
         return X
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -123,7 +123,8 @@ class PCA(BaseEstimator, TransformerMixin):
         percentage specified by n_components
 
     copy : bool
-        If False, data passed to fit are overwritten
+        If False, data passed to fit are overwritten. If copy is False use
+        `fit_transform` to transform the data used on fitting.
 
     whiten : bool, optional
         When True (False by default) the `components_` vectors are divided
@@ -381,7 +382,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         is set to n_features (the second dimension of the training data).
 
     copy : bool
-        If False, data passed to fit are overwritten.
+        If False, data passed to fit are overwritten. If copy is False use
+        `fit_transform` to transform the data used on fitting.
 
     iterated_power : int, optional
         Number of iterations for the power method. 3 by default.
@@ -522,9 +524,29 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         """
         # XXX remove scipy.sparse support here in 0.16
         X = atleast2d_or_csr(X)
-        if self.mean_ is not None and self.copy:
+        if self.mean_ is not None:
             X = X - self.mean_
 
+        X = safe_sparse_dot(X, self.components_.T)
+        return X
+
+    def fit_transform(self, X):
+        """Apply dimensionality reduction on X.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            New data, where n_samples in the number of samples
+            and n_features is the number of features.
+
+        Returns
+        -------
+        X_new : array-like, shape (n_samples, n_components)
+
+        """
+        # XXX remove scipy.sparse support here in 0.16
+        X = atleast2d_or_csr(X)
+        self.fit(X)
         X = safe_sparse_dot(X, self.components_.T)
         return X
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -533,8 +533,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self.explained_variance_ratio_ = exp_var / exp_var.sum()
 
         if self.whiten:
-            n = X.shape[0]
-            self.components_ = V / S[:, np.newaxis] * np.sqrt(n)
+            self.components_ = V / S[:, np.newaxis] * np.sqrt(n_samples)
         else:
             self.components_ = V
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -123,9 +123,9 @@ class PCA(BaseEstimator, TransformerMixin):
         percentage specified by n_components
 
     copy : bool
-        If False, data passed to fit are overwritten.  You should prefer
-        'fit_transform(X)' to 'fit(X).transform(X)' to transform the data used
-        on fitting.
+        If False, data passed to fit are overwritten and running
+        fit(X).transform(X) will not yield the expected results,
+        use fit_transform(X) instead.
 
     whiten : bool, optional
         When True (False by default) the `components_` vectors are divided
@@ -383,9 +383,9 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         is set to n_features (the second dimension of the training data).
 
     copy : bool
-        If False, data passed to fit are overwritten. You should prefer
-        'fit_transform(X)' to 'fit(X).transform(X)' to transform the data used
-        on fitting.
+        If False, data passed to fit are overwritten and running
+        fit(X).transform(X) will not yield the expected results,
+        use fit_transform(X) instead.
 
     iterated_power : int, optional
         Number of iterations for the power method. 3 by default.

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -227,6 +227,18 @@ class PCA(BaseEstimator, TransformerMixin):
         return U
 
     def _fit(self, X):
+        """ Fit the model on X
+        Parameters
+        ----------
+        X: array-like, shape (n_samples, n_features)
+            Training vector, where n_samples in the number of samples and
+            n_features is the number of features.
+
+        Returns
+        -------
+        X : ndarray, shape (n_samples, n_features)
+            The input data, copied, centered and whitened when requested.
+        """
         X = array2d(X)
         n_samples, n_features = X.shape
         X = as_float_array(X, copy=self.copy)
@@ -477,7 +489,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self._fit(X)
         return self
 
-    def _fit(self, X, y=None):
+    def _fit(self, X):
         """Fit the model to the data X.
 
         Parameters
@@ -488,8 +500,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        self : object
-            Returns the instance itself.
+        X : ndarray, shape (n_samples, n_features)
+            The input data, copied, centered and whitened when requested.
         """
         random_state = check_random_state(self.random_state)
         if hasattr(X, 'todense'):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -60,61 +60,28 @@ def test_whitening():
     # the component-wise variance is thus highly varying:
     assert_almost_equal(X.std(axis=0).std(), 43.9, 1)
 
-    # whiten the data while projecting to the lower dim subspace
-    pca = PCA(n_components=n_components, whiten=True)
-
-    # test fit_transform
-    X_whitened = pca.fit_transform(X)
-    assert_equal(X_whitened.shape, (n_samples, n_components))
-    X_whitened2 = pca.transform(X)
-    assert_array_almost_equal(X_whitened, X_whitened2)
-
-    # all output component have unit variances
-    assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components))
-
-    # is possible to project on the low dim space without scaling by the
-    # singular values
-    pca = PCA(n_components=n_components, whiten=False).fit(X)
-    X_unwhitened = pca.transform(X)
-    assert_equal(X_unwhitened.shape, (n_samples, n_components))
-
-    # in that case the output components still have varying variances
-    assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
-
-
-def test_randomized_whitening():
-    """Check that PCA output has unit-variance"""
-    rng = np.random.RandomState(0)
-    n_samples = 100
-    n_features = 80
-    n_components = 30
-    rank = 50
-
-    # some low rank data with correlated features
-    X = np.dot(rng.randn(n_samples, rank),
-               np.dot(np.diag(np.linspace(10.0, 1.0, rank)),
-                      rng.randn(rank, n_features)))
-    # the component-wise variance of the first 50 features is 3 times the
-    # mean component-wise variance of the remaingin 30 features
-    X[:, :50] *= 3
-
-    assert_equal(X.shape, (n_samples, n_features))
-
-    # the component-wise variance is thus highly varying:
-    assert_almost_equal(X.std(axis=0).std(), 43.9, 1)
-
-    # whiten the data while projecting to the lower dim subspace
-    for copy in [True, False]:
-        pca = RandomizedPCA(n_components=n_components, whiten=True, copy=copy)
-
+    for this_PCA, copy in [(x, y) for x in PCA, RandomizedPCA
+                           for y in True, False]:
+        # whiten the data while projecting to the lower dim subspace
+        pca = this_PCA(n_components=n_components, whiten=True, copy=False)
         # test fit_transform
         X_whitened = pca.fit_transform(X)
         assert_equal(X_whitened.shape, (n_samples, n_components))
         X_whitened2 = pca.transform(X)
         assert_array_almost_equal(X_whitened, X_whitened2)
+
         # all output component have unit variances
         assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components))
         assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
+
+        # is possible to project on the low dim space without scaling by the
+        # singular values
+        pca = PCA(n_components=n_components, whiten=False).fit(X)
+        X_unwhitened = pca.transform(X)
+        assert_equal(X_unwhitened.shape, (n_samples, n_components))
+
+        # in that case the output components still have varying variances
+        assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
 
 
 def test_pca_check_projection():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -5,7 +5,6 @@ from scipy.sparse import csr_matrix
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_less, assert_greater

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -63,25 +63,31 @@ def test_whitening():
     for this_PCA, copy in [(x, y) for x in PCA, RandomizedPCA
                            for y in True, False]:
         # whiten the data while projecting to the lower dim subspace
-        pca = this_PCA(n_components=n_components, whiten=True, copy=False)
+        X_ = X
+        pca = this_PCA(n_components=n_components, whiten=True, copy=copy)
         # test fit_transform
-        X_whitened = pca.fit_transform(X)
-        assert_equal(X_whitened.shape, (n_samples, n_components))
-        X_whitened2 = pca.transform(X)
-        assert_array_almost_equal(X_whitened, X_whitened2)
+        if copy == True:
+            X_whitened = pca.fit_transform(X_)
+            assert_equal(X_whitened.shape, (n_samples, n_components))
+            X_whitened2 = pca.transform(X_)
+            assert_array_almost_equal(X_whitened, X_whitened2)
+        else:
+            X_whitened = pca.fit_transform(X_)
 
-        # all output component have unit variances
+        # all output component have unit variances and zero mean
         assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components))
         assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
 
         # is possible to project on the low dim space without scaling by the
         # singular values
-        pca = PCA(n_components=n_components, whiten=False).fit(X)
-        X_unwhitened = pca.transform(X)
+        pca = this_PCA(n_components=n_components, whiten=False,
+                       copy=copy).fit(X_)
+        X_unwhitened = pca.transform(X_)
         assert_equal(X_unwhitened.shape, (n_samples, n_components))
 
         # in that case the output components still have varying variances
         assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
+        assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
 
 
 def test_pca_check_projection():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -5,6 +5,7 @@ from scipy.sparse import csr_matrix
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_less, assert_greater
@@ -63,7 +64,8 @@ def test_whitening():
     for this_PCA, copy in [(x, y) for x in PCA, RandomizedPCA
                            for y in True, False]:
         # whiten the data while projecting to the lower dim subspace
-        X_ = X
+        X_ = X.copy()
+        assert X_ is not X
         pca = this_PCA(n_components=n_components, whiten=True, copy=copy)
         # test fit_transform
         if copy == True:
@@ -80,6 +82,7 @@ def test_whitening():
 
         # is possible to project on the low dim space without scaling by the
         # singular values
+        X_ = X.copy()
         pca = this_PCA(n_components=n_components, whiten=False,
                        copy=copy).fit(X_)
         X_unwhitened = pca.transform(X_)
@@ -87,7 +90,7 @@ def test_whitening():
 
         # in that case the output components still have varying variances
         assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
-        assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
+        # we always center, so no test for non-centering
 
 
 def test_pca_check_projection():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -82,6 +82,41 @@ def test_whitening():
     assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
 
 
+def test_randomized_whitening():
+    """Check that PCA output has unit-variance"""
+    rng = np.random.RandomState(0)
+    n_samples = 100
+    n_features = 80
+    n_components = 30
+    rank = 50
+
+    # some low rank data with correlated features
+    X = np.dot(rng.randn(n_samples, rank),
+               np.dot(np.diag(np.linspace(10.0, 1.0, rank)),
+                      rng.randn(rank, n_features)))
+    # the component-wise variance of the first 50 features is 3 times the
+    # mean component-wise variance of the remaingin 30 features
+    X[:, :50] *= 3
+
+    assert_equal(X.shape, (n_samples, n_features))
+
+    # the component-wise variance is thus highly varying:
+    assert_almost_equal(X.std(axis=0).std(), 43.9, 1)
+
+    # whiten the data while projecting to the lower dim subspace
+    for copy in [True, False]:
+        pca = RandomizedPCA(n_components=n_components, whiten=True, copy=copy)
+
+        # test fit_transform
+        X_whitened = pca.fit_transform(X)
+        assert_equal(X_whitened.shape, (n_samples, n_components))
+        X_whitened2 = pca.transform(X)
+        assert_array_almost_equal(X_whitened, X_whitened2)
+        # all output component have unit variances
+        assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components))
+        assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
+
+
 def test_pca_check_projection():
     """Test that the projection of data is correct"""
     rng = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -63,10 +63,9 @@ def test_whitening():
     for this_PCA, copy in [(x, y) for x in PCA, RandomizedPCA
                            for y in True, False]:
         # whiten the data while projecting to the lower dim subspace
-        X_ = X.copy()
+        X_ = X.copy()  # make sure we keep an original across iterations.
         pca = this_PCA(n_components=n_components, whiten=True, copy=copy)
         # test fit_transform
-        # if copy == True:
         X_whitened = pca.fit_transform(X_.copy())
         assert_equal(X_whitened.shape, (n_samples, n_components))
         X_whitened2 = pca.transform(X_)
@@ -83,7 +82,7 @@ def test_whitening():
 
         # in that case the output components still have varying variances
         assert_almost_equal(X_unwhitened.std(axis=0).std(), 74.1, 1)
-        # we always center, so no test for non-centering
+        # we always center, so no test for non-centering.
 
 
 def test_pca_check_projection():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -65,23 +65,17 @@ def test_whitening():
                            for y in True, False]:
         # whiten the data while projecting to the lower dim subspace
         X_ = X.copy()
-        assert X_ is not X
         pca = this_PCA(n_components=n_components, whiten=True, copy=copy)
         # test fit_transform
-        if copy == True:
-            X_whitened = pca.fit_transform(X_)
-            assert_equal(X_whitened.shape, (n_samples, n_components))
-            X_whitened2 = pca.transform(X_)
-            assert_array_almost_equal(X_whitened, X_whitened2)
-        else:
-            X_whitened = pca.fit_transform(X_)
+        # if copy == True:
+        X_whitened = pca.fit_transform(X_.copy())
+        assert_equal(X_whitened.shape, (n_samples, n_components))
+        X_whitened2 = pca.transform(X_)
+        assert_array_almost_equal(X_whitened, X_whitened2)
 
-        # all output component have unit variances and zero mean
         assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components))
         assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
 
-        # is possible to project on the low dim space without scaling by the
-        # singular values
         X_ = X.copy()
         pca = this_PCA(n_components=n_components, whiten=False,
                        copy=copy).fit(X_)


### PR DESCRIPTION
This test exposes a bug, probably in all classes that center twice in fit and transform while not overwriting the `fit_transform` inherited from TransformerMixin. This should be fixed. Any clues which other classes might be affected?

cc @agramfort @GaelVaroquaux @vene
