### PR TITLE
[MRG] faster, flatter precision_recall_fscore_support

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -26,7 +26,7 @@ from scipy.sparse import coo_matrix
 from scipy.spatial.distance import hamming as sp_hamming
 
 from ..externals.six.moves import zip
-from ..preprocessing import LabelBinarizer
+from ..preprocessing import LabelBinarizer, label_binarize
 from ..preprocessing import LabelEncoder
 from ..utils import check_arrays
 from ..utils import deprecated
@@ -1416,10 +1416,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     if y_type.startswith('multilabel'):
         if y_type == 'multilabel-sequences':
-            lb = LabelBinarizer()
-            lb.fit([labels.tolist()])
-            y_true = lb.transform(y_true)
-            y_pred = lb.transform(y_pred)
+            y_true = label_binarize(y_true, labels, multilabel=True)
+            y_pred = label_binarize(y_pred, labels, multilabel=True)
         else:
             # set negative labels to zero
             y_true = y_true == 1

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1723,17 +1723,17 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
     Examples
     --------
     >>> from sklearn.metrics import classification_report
-    >>> y_true = [0, 1, 2, 2, 0]
-    >>> y_pred = [0, 0, 2, 2, 0]
+    >>> y_true = [0, 1, 2, 2, 2]
+    >>> y_pred = [0, 0, 2, 2, 1]
     >>> target_names = ['class 0', 'class 1', 'class 2']
     >>> print(classification_report(y_true, y_pred, target_names=target_names))
                  precision    recall  f1-score   support
     <BLANKLINE>
-        class 0       0.67      1.00      0.80         2
+        class 0       0.50      1.00      0.67         1
         class 1       0.00      0.00      0.00         1
-        class 2       1.00      1.00      1.00         2
+        class 2       1.00      0.67      0.80         3
     <BLANKLINE>
-    avg / total       0.67      0.80      0.72         5
+    avg / total       0.70      0.60      0.61         5
     <BLANKLINE>
 
     """

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -463,7 +463,8 @@ def matthews_corrcoef(y_true, y_pred):
     lb.fit(np.hstack([y_true, y_pred]))
     y_true = lb.transform(y_true)
     y_pred = lb.transform(y_pred)
-    mcc = np.corrcoef(y_true, y_pred)[0, 1]
+    with np.errstate(divide='warn', invalid='warn'):
+        mcc = np.corrcoef(y_true, y_pred)[0, 1]
 
     if np.isnan(mcc):
         return 0.
@@ -1256,6 +1257,9 @@ def _prf_divide(numerator, denominator, metric, modifier, average):
 
     On zero-division, sets the corresponding result elements to zero
     and raises a warning.
+
+    The metric, modifier and average arguments are used only for determining
+    an appropriate warning.
     """
     result = numerator / denominator
     mask = denominator == 0.0

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -463,7 +463,7 @@ def matthews_corrcoef(y_true, y_pred):
     lb.fit(np.hstack([y_true, y_pred]))
     y_true = lb.transform(y_true)
     y_pred = lb.transform(y_pred)
-    with np.errstate(divide='warn', invalid='warn'):
+    with np.errstate(invalid='ignore'):
         mcc = np.corrcoef(y_true, y_pred)[0, 1]
 
     if np.isnan(mcc):

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -195,6 +195,10 @@ def auc(x, y, reorder=False):
     return area
 
 
+class UndefinedMetricWarning(UserWarning):
+    pass
+
+
 ###############################################################################
 # Binary classification loss
 ###############################################################################
@@ -681,14 +685,16 @@ def roc_curve(y_true, y_score, pos_label=None):
 
     if fps[-1] == 0:
         warnings.warn("No negative samples in y_true, "
-                      "false positive value should be meaningless")
+                      "false positive value should be meaningless",
+                      UndefinedMetricWarning)
         fpr = np.repeat(np.nan, fps.shape)
     else:
         fpr = fps / fps[-1]
 
     if tps[-1] == 0:
         warnings.warn("No positive samples in y_true, "
-                      "true positive value should be meaningless")
+                      "true positive value should be meaningless",
+                      UndefinedMetricWarning)
         tpr = np.repeat(np.nan, tps.shape)
     else:
         tpr = tps / tps[-1]
@@ -1283,7 +1289,7 @@ def _prf_divide(numerator, denominator, metric, modifier, average):
         msg = msg.format('due to')
     else:
         msg = msg.format('in {}s with'.format(axis1))
-    warnings.warn(msg, stacklevel=2)
+    warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
     return result
 
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -53,6 +53,7 @@ from sklearn.metrics import (accuracy_score,
                              zero_one_loss)
 from sklearn.metrics.metrics import _check_clf_targets
 from sklearn.metrics.metrics import _check_reg_targets
+from sklearn.metrics.metrics import UndefinedMetricWarning
 
 
 from sklearn.externals.six.moves import xrange
@@ -1746,7 +1747,7 @@ def test_precision_recall_f1_no_labels():
         warnings.simplefilter("always")
 
         for beta in [1]:
-            p, r, f, s = assert_warns(UserWarning,
+            p, r, f, s = assert_warns(UndefinedMetricWarning,
                                       precision_recall_fscore_support,
                                       y_true, y_pred, average=None, beta=beta)
             assert_array_almost_equal(p, [0, 0, 0], 2)
@@ -1754,12 +1755,12 @@ def test_precision_recall_f1_no_labels():
             assert_array_almost_equal(f, [0, 0, 0], 2)
             assert_array_almost_equal(s, [0, 0, 0], 2)
 
-            fbeta = assert_warns(UserWarning, fbeta_score, y_true, y_pred,
-                                 beta=beta, average=None)
+            fbeta = assert_warns(UndefinedMetricWarning, fbeta_score,
+                                 y_true, y_pred, beta=beta, average=None)
             assert_array_almost_equal(fbeta, [0, 0, 0], 2)
 
             for average in ["macro", "micro", "weighted", "samples"]:
-                p, r, f, s = assert_warns(UserWarning,
+                p, r, f, s = assert_warns(UndefinedMetricWarning,
                                           precision_recall_fscore_support,
                                           y_true, y_pred, average=average,
                                           beta=beta)
@@ -1768,7 +1769,8 @@ def test_precision_recall_f1_no_labels():
                 assert_almost_equal(f, 0)
                 assert_equal(s, None)
 
-                fbeta = assert_warns(UserWarning, fbeta_score, y_true, y_pred,
+                fbeta = assert_warns(UndefinedMetricWarning, fbeta_score,
+                                     y_true, y_pred,
                                      beta=beta, average=average)
                 assert_almost_equal(fbeta, 0)
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1775,6 +1775,64 @@ def test_precision_recall_f1_no_labels():
                 assert_almost_equal(fbeta, 0)
 
 
+def test_prf_warnings():
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+
+        # average of per-label scores
+        for average in [None, 'weighted', 'macro']:
+            precision_recall_fscore_support([0, 1, 2], [1, 1, 2],
+                                            average=average)
+            assert_equal(str(record.pop().message),
+                         'Precision and F-score are ill-defined and being '
+                         'set to 0.0 in labels with no predicted samples.')
+            precision_recall_fscore_support([1, 1, 2], [0, 1, 2],
+                                            average=average)
+            assert_equal(str(record.pop().message),
+                         'Recall and F-score are ill-defined and '
+                         'being set to 0.0 in labels with no true samples.')
+
+        # average of per-sample scores
+        precision_recall_fscore_support(np.array([[1, 0], [1, 0]]),
+                                        np.array([[1, 0], [0, 0]]),
+                                        average='samples')
+        assert_equal(str(record.pop().message),
+                     'Precision and F-score are ill-defined and '
+                     'being set to 0.0 in samples with no predicted labels.')
+        precision_recall_fscore_support(np.array([[1, 0], [0, 0]]),
+                                        np.array([[1, 0], [1, 0]]),
+                                        average='samples')
+        assert_equal(str(record.pop().message),
+                     'Recall and F-score are ill-defined and '
+                     'being set to 0.0 in samples with no true labels.')
+
+        # single score: micro-average
+        precision_recall_fscore_support(np.array([[1, 1], [1, 1]]),
+                                        np.array([[0, 0], [0, 0]]),
+                                        average='micro')
+        assert_equal(str(record.pop().message),
+                     'Precision and F-score are ill-defined and '
+                     'being set to 0.0 due to no predicted samples.')
+        precision_recall_fscore_support(np.array([[0, 0], [0, 0]]),
+                                        np.array([[1, 1], [1, 1]]),
+                                        average='micro')
+        assert_equal(str(record.pop().message),
+                     'Recall and F-score are ill-defined and '
+                     'being set to 0.0 due to no true samples.')
+
+        # single postive label
+        precision_recall_fscore_support([1, 1], [-1, -1],
+                                        average='macro')
+        assert_equal(str(record.pop().message),
+                     'Precision and F-score are ill-defined and '
+                     'being set to 0.0 due to no predicted samples.')
+        precision_recall_fscore_support([-1, -1], [1, 1],
+                                        average='macro')
+        assert_equal(str(record.pop().message),
+                     'Recall and F-score are ill-defined and '
+                     'being set to 0.0 due to no true samples.')
+
+
 def test__check_clf_targets():
     """Check that _check_clf_targets correctly merges target types, squeezes
     output and fails if input lengths differ."""

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -555,15 +555,16 @@ def test_precision_recall_f_binary_single_class():
     negative class
 
     Such a case may occur with non-stratified cross-validation"""
-    warnings.simplefilter("ignore")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
 
-    assert_equal(1., precision_score([1, 1], [1, 1]))
-    assert_equal(1., recall_score([1, 1], [1, 1]))
-    assert_equal(1., f1_score([1, 1], [1, 1]))
+        assert_equal(1., precision_score([1, 1], [1, 1]))
+        assert_equal(1., recall_score([1, 1], [1, 1]))
+        assert_equal(1., f1_score([1, 1], [1, 1]))
 
-    assert_equal(0., precision_score([-1, -1], [-1, -1]))
-    assert_equal(0., recall_score([-1, -1], [-1, -1]))
-    assert_equal(0., f1_score([-1, -1], [-1, -1]))
+        assert_equal(0., precision_score([-1, -1], [-1, -1]))
+        assert_equal(0., recall_score([-1, -1], [-1, -1]))
+        assert_equal(0., f1_score([-1, -1], [-1, -1]))
 
 
 def test_average_precision_score_duplicate_values():
@@ -630,7 +631,7 @@ def test_confusion_matrix_binary():
 
 def test_matthews_corrcoef_nan():
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("always")
         assert_equal(matthews_corrcoef([0], [1]), 0.0)
         warnings.simplefilter("error")
         assert_equal(matthews_corrcoef([0, 0], [0, 1]), 0.0)
@@ -1515,71 +1516,72 @@ def test_precision_recall_f1_score_multilabel_1():
     y_true_bi = lb.transform(y_true_ll)
     y_pred_bi = lb.transform(y_pred_ll)
 
-    warnings.simplefilter("ignore")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
 
-    for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
+        for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average=None)
-        #tp = [0, 1, 1, 0]
-        #fn = [1, 0, 0, 1]
-        #fp = [1, 1, 0, 0]
-        # Check per class
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average=None)
+            #tp = [0, 1, 1, 0]
+            #fn = [1, 0, 0, 1]
+            #fp = [1, 1, 0, 0]
+            # Check per class
 
-        assert_array_almost_equal(p, [0.0, 0.5, 1.0, 0.0], 2)
-        assert_array_almost_equal(r, [0.0, 1.0, 1.0, 0.0], 2)
-        assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
-        assert_array_almost_equal(s, [1, 1, 1, 1], 2)
+            assert_array_almost_equal(p, [0.0, 0.5, 1.0, 0.0], 2)
+            assert_array_almost_equal(r, [0.0, 1.0, 1.0, 0.0], 2)
+            assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
+            assert_array_almost_equal(s, [1, 1, 1, 1], 2)
 
-        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
-        support = s
-        assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
+            f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+            support = s
+            assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
 
-        # Check macro
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="macro")
-        assert_almost_equal(p, 1.5 / 4)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, 2.5 / 1.5 * 0.25)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="macro"),
-                            np.mean(f2))
+            # Check macro
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="macro")
+            assert_almost_equal(p, 1.5 / 4)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, 2.5 / 1.5 * 0.25)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="macro"),
+                                np.mean(f2))
 
-        # Check micro
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="micro")
-        assert_almost_equal(p, 0.5)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, 0.5)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="micro"),
-                            (1 + 4) * p * r / (4 * p + r))
+            # Check micro
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="micro")
+            assert_almost_equal(p, 0.5)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, 0.5)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="micro"),
+                                (1 + 4) * p * r / (4 * p + r))
 
-        # Check weigted
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="weighted")
-        assert_almost_equal(p, 1.5 / 4)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, 2.5 / 1.5 * 0.25)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="weighted"),
-                            np.average(f2, weights=support))
-        # Check weigted
-        # |h(x_i) inter y_i | = [0, 1, 1]
-        # |y_i| = [1, 1, 2]
-        # |h(x_i)| = [1, 1, 2]
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="samples")
-        assert_almost_equal(p, 0.5)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, 0.5)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="samples"),
-                            0.5)
+            # Check weigted
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="weighted")
+            assert_almost_equal(p, 1.5 / 4)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, 2.5 / 1.5 * 0.25)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="weighted"),
+                                np.average(f2, weights=support))
+            # Check weigted
+            # |h(x_i) inter y_i | = [0, 1, 1]
+            # |y_i| = [1, 1, 2]
+            # |h(x_i)| = [1, 1, 2]
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="samples")
+            assert_almost_equal(p, 0.5)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, 0.5)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="samples"),
+                                0.5)
 
 
 def test_precision_recall_f1_score_multilabel_2():
@@ -1593,68 +1595,69 @@ def test_precision_recall_f1_score_multilabel_2():
     y_true_bi = lb.transform(y_true_ll)
     y_pred_bi = lb.transform(y_pred_ll)
 
-    warnings.simplefilter("ignore")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
 
-    for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
-        # tp = [ 0.  1.  0.  0.]
-        # fp = [ 1.  0.  0.  2.]
-        # fn = [ 1.  1.  1.  0.]
+        for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
+            # tp = [ 0.  1.  0.  0.]
+            # fp = [ 1.  0.  0.  2.]
+            # fn = [ 1.  1.  1.  0.]
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average=None)
-        assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
-        assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
-        assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
-        assert_array_almost_equal(s, [1, 2, 1, 0], 2)
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average=None)
+            assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
+            assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
+            assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
+            assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
-        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
-        support = s
-        assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
+            f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+            support = s
+            assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="micro")
-        assert_almost_equal(p, 0.25)
-        assert_almost_equal(r, 0.25)
-        assert_almost_equal(f, 2 * 0.25 * 0.25 / 0.5)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="micro"),
-                            (1 + 4) * p * r / (4 * p + r))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="micro")
+            assert_almost_equal(p, 0.25)
+            assert_almost_equal(r, 0.25)
+            assert_almost_equal(f, 2 * 0.25 * 0.25 / 0.5)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="micro"),
+                                (1 + 4) * p * r / (4 * p + r))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="macro")
-        assert_almost_equal(p, 0.25)
-        assert_almost_equal(r, 0.125)
-        assert_almost_equal(f, 2 / 12)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="macro"),
-                            np.mean(f2))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="macro")
+            assert_almost_equal(p, 0.25)
+            assert_almost_equal(r, 0.125)
+            assert_almost_equal(f, 2 / 12)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="macro"),
+                                np.mean(f2))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="weighted")
-        assert_almost_equal(p, 2 / 4)
-        assert_almost_equal(r, 1 / 4)
-        assert_almost_equal(f, 2 / 3 * 2 / 4)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="weighted"),
-                            np.average(f2, weights=support))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="weighted")
+            assert_almost_equal(p, 2 / 4)
+            assert_almost_equal(r, 1 / 4)
+            assert_almost_equal(f, 2 / 3 * 2 / 4)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="weighted"),
+                                np.average(f2, weights=support))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="samples")
-        # Check weigted
-        # |h(x_i) inter y_i | = [0, 0, 1]
-        # |y_i| = [1, 1, 2]
-        # |h(x_i)| = [1, 1, 2]
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="samples")
+            # Check weigted
+            # |h(x_i) inter y_i | = [0, 0, 1]
+            # |y_i| = [1, 1, 2]
+            # |h(x_i)| = [1, 1, 2]
 
-        assert_almost_equal(p, 1 / 6)
-        assert_almost_equal(r, 1 / 6)
-        assert_almost_equal(f, 2 / 4 * 1 / 3)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="samples"),
-                            0.1666, 2)
+            assert_almost_equal(p, 1 / 6)
+            assert_almost_equal(r, 1 / 6)
+            assert_almost_equal(f, 2 / 4 * 1 / 3)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="samples"),
+                                0.1666, 2)
 
 
 def test_precision_recall_f1_score_with_an_empty_prediction():
@@ -1666,65 +1669,66 @@ def test_precision_recall_f1_score_with_an_empty_prediction():
     y_true_bi = lb.transform(y_true_ll)
     y_pred_bi = lb.transform(y_pred_ll)
 
-    warnings.simplefilter("ignore")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
 
-    for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
-        # true_pos = [ 0.  1.  1.  0.]
-        # false_pos = [ 0.  0.  0.  1.]
-        # false_neg = [ 1.  1.  0.  0.]
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average=None)
-        assert_array_almost_equal(p, [0.0, 1.0, 1.0, 0.0], 2)
-        assert_array_almost_equal(r, [0.0, 0.5, 1.0, 0.0], 2)
-        assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
-        assert_array_almost_equal(s, [1, 2, 1, 0], 2)
+        for y_true, y_pred in [(y_true_ll, y_pred_ll), (y_true_bi, y_pred_bi)]:
+            # true_pos = [ 0.  1.  1.  0.]
+            # false_pos = [ 0.  0.  0.  1.]
+            # false_neg = [ 1.  1.  0.  0.]
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average=None)
+            assert_array_almost_equal(p, [0.0, 1.0, 1.0, 0.0], 2)
+            assert_array_almost_equal(r, [0.0, 0.5, 1.0, 0.0], 2)
+            assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
+            assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
-        f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
-        support = s
-        assert_array_almost_equal(f2, [0, 0.55, 1, 0], 2)
+            f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+            support = s
+            assert_array_almost_equal(f2, [0, 0.55, 1, 0], 2)
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="macro")
-        assert_almost_equal(p, 0.5)
-        assert_almost_equal(r, 1.5 / 4)
-        assert_almost_equal(f, 2.5 / (4 * 1.5))
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="macro"),
-                            np.mean(f2))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="macro")
+            assert_almost_equal(p, 0.5)
+            assert_almost_equal(r, 1.5 / 4)
+            assert_almost_equal(f, 2.5 / (4 * 1.5))
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="macro"),
+                                np.mean(f2))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="micro")
-        assert_almost_equal(p, 2 / 3)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, 2 / 3 / (2 / 3 + 0.5))
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="micro"),
-                            (1 + 4) * p * r / (4 * p + r))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="micro")
+            assert_almost_equal(p, 2 / 3)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, 2 / 3 / (2 / 3 + 0.5))
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="micro"),
+                                (1 + 4) * p * r / (4 * p + r))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="weighted")
-        assert_almost_equal(p, 3 / 4)
-        assert_almost_equal(r, 0.5)
-        assert_almost_equal(f, (2 / 1.5 + 1) / 4)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="weighted"),
-                            np.average(f2, weights=support))
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="weighted")
+            assert_almost_equal(p, 3 / 4)
+            assert_almost_equal(r, 0.5)
+            assert_almost_equal(f, (2 / 1.5 + 1) / 4)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="weighted"),
+                                np.average(f2, weights=support))
 
-        p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
-                                                     average="samples")
-        # |h(x_i) inter y_i | = [0, 0, 2]
-        # |y_i| = [1, 1, 2]
-        # |h(x_i)| = [0, 1, 2]
-        assert_almost_equal(p, 1 / 3)
-        assert_almost_equal(r, 1 / 3)
-        assert_almost_equal(f, 1 / 3)
-        assert_equal(s, None)
-        assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
-                                        average="samples"),
-                            0.333, 2)
+            p, r, f, s = precision_recall_fscore_support(y_true, y_pred,
+                                                         average="samples")
+            # |h(x_i) inter y_i | = [0, 0, 2]
+            # |y_i| = [1, 1, 2]
+            # |h(x_i)| = [0, 1, 2]
+            assert_almost_equal(p, 1 / 3)
+            assert_almost_equal(r, 1 / 3)
+            assert_almost_equal(f, 1 / 3)
+            assert_equal(s, None)
+            assert_almost_equal(fbeta_score(y_true, y_pred, beta=2,
+                                            average="samples"),
+                                0.333, 2)
 
 
 def test_precision_recall_f1_no_labels():

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -2,6 +2,7 @@ import pickle
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
                              log_loss)
@@ -102,6 +103,7 @@ def test_unsupervised_scorers():
     assert_almost_equal(score1, score2)
 
 
+@ignore_warnings
 def test_raises_on_score_list():
     """Test that when a list of scores is returned, we raise proper errors."""
     X, y = make_blobs(random_state=0)


### PR DESCRIPTION
- Rewritten for efficiency and neatness. Note the handling of multilabel-sequences format by binarizing is in response to benchmarks. Under the simple benchmarks at https://gist.github.com/jnothman/5734967, this new version is about 1.3x faster than master (for multiclass and label indicators; about 2x faster for sequence of sequences).
- Also fixed some warning handling in tests
- Also reverted the recent reimplementation of mathew's correlation coefficient, using `LabelEncoder` to handle non-int labels instead.
