### PR TITLE
[MRG]: add fast_dot function that directly calls BLAS with appropriate data input

### DIFF
--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -90,16 +90,14 @@ saves additional copies and speed by directly calling the Fortran routines with 
 appropriate data input while preserving the nunpy.dot call signature. This
 means it can be used as a replacement for `numpy.dot`. example::
 
-  In [1]: import numpy as np
+  >>> import numpy as np
 
-  In [2]: from sklearn.utils.extmath import fast_dot
+  >>> from sklearn.utils.extmath import fast_dot
 
-  In [3]: X = rng.random_sample([2, 10])
+  >>> X = np.random.random_sample([2, 10])
 
-  In [4]: (np.dot(X, X.T) == fast_dot(X, X.T)).all()
-
-  Out[1]: True # doctest: +SKIP
-
+  >>> (np.dot(X, X.T) == fast_dot(X, X.T)).all()
+  True
 
 However this requires data to be exactly 2 dimensional and of the same type,
 either single or double precision float. If these requirements aren't met or
@@ -108,11 +106,11 @@ the BLAS package is not available, the call is silently dispatched to
 invoked and when our `fast_dot` function has been used you can activate the
 related warning which is silenced by default. example::
 
-  In [1]: import warnings
+  >>> import warnings
 
-  In [2]: from sklearn.utils.validation import NotBLASDotWarning
+  >>> from sklearn.utils.validation import NonBLASDotWarning
 
-  In [3]: warnings.simplefilter('always', NotBLASDotWarning) # doctest: +SKIP
+  >>> warnings.simplefilter('always', NonBLASDotWarning) # doctest: +SKIP
 
 
 .. _profiling-python-code:

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -81,13 +81,14 @@ Memory and implicit copies
 
 Some of the numpy and scipy core functions are optimized for Fortran contiguous
 data. In the case of the dot product this often leads to implicit copies
-performed to adjust data to the needs of the underlying Fortran routines
-called. Also see section `Linear Algebra on large Arrays` on
-http://wiki.scipy.org/PerformanceTips. This not only consumes memory but also take time.
+performed to adjust data to the needs of the underlying Fortran routines (See section
+`Linear Algebra on large Arrays` on http://wiki.scipy.org/PerformanceTips).
+This not only consumes memory but also takes additional time.
 
 For convenience, we internally use an alternative `numpy.dot` function that
-saves additional copies and speed by directly calling the Fortran routines with the appropriate data input while preserving the nunpy.dot call signature. This
-means it can be used as a replacement for numpy.dot example::
+saves additional copies and speed by directly calling the Fortran routines with the
+appropriate data input while preserving the nunpy.dot call signature. This
+means it can be used as a replacement for `numpy.dot`. example::
 
   In [1]: import numpy as np
 
@@ -100,11 +101,12 @@ means it can be used as a replacement for numpy.dot example::
   Out[1]: True
 
 
-However this requires data to be exactly 2 dimensional and of the same type, either single or double precision float. If these requirements aren't met or
+However this requires data to be exactly 2 dimensional and of the same type,
+either single or double precision float. If these requirements aren't met or
 the BLAS package is not available, the call is silently dispatched to
-`numpy.dot`. If you want to be sure when the original numpy.dot has been
+`numpy.dot`. If you want to be sure when the original `numpy.dot` has been
 invoked and when our `fast_dot` function has been used you can activate the
-related warning which is silenced by default example::
+related warning which is silenced by default. example::
 
   In [1]: import warnings
 

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -98,7 +98,7 @@ means it can be used as a replacement for `numpy.dot`. example::
 
   In [4]: (np.dot(X, X.T) == fast_dot(X, X.T)).all()
 
-  Out[1]: True
+  Out[1]: True # doctest: +SKIP
 
 
 However this requires data to be exactly 2 dimensional and of the same type,
@@ -112,7 +112,7 @@ related warning which is silenced by default. example::
 
   In [2]: from sklearn.utils.validation import NotBLASDotWarning
 
-  In [3]: warnings.simplefilter('always', NotBLASDotWarning)
+  In [3]: warnings.simplefilter('always', NotBLASDotWarning) # doctest: +SKIP
 
 
 .. _profiling-python-code:

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -114,7 +114,8 @@ related warning which is silenced by default. example::
 
   >>> warnings.simplefilter('always', NonBLASDotWarning) # doctest: +SKIP
 
-If numpy > 1.8 is available the `fast_dot` is not necessary.
+If numpy > 1.8 is available the `fast_dot` is not necessary. In that case
+the `numpy.dot` is being used.
 
 .. _profiling-python-code:
 

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -80,15 +80,17 @@ Memory and implicit copies
 ==========================
 
 Some of the numpy and scipy core functions are optimized for Fortran contiguous
-data. In the case of the dot product this often leads to implicit copies
-performed to adjust data to the needs of the underlying Fortran routines (See section
-`Linear Algebra on large Arrays` on http://wiki.scipy.org/PerformanceTips).
-This not only consumes memory but also takes additional time.
+data. In the case of the dot product, for numpy vetsions < 1.8, this leads to
+implicit copies performed to adjust data to the needs of the underlying
+Fortran routines (See section `Linear Algebra on large Arrays`
+on http://wiki.scipy.org/PerformanceTips). This not only consumes memory
+but also takes additional time.
 
-For convenience, we internally use an alternative `numpy.dot` function that
-saves additional copies and speed by directly calling the Fortran routines with the
-appropriate data input while preserving the nunpy.dot call signature. This
-means it can be used as a replacement for `numpy.dot`. example::
+For convenience, if the numpy version available is older than 1.8, we internally
+use an optimized `numpy.dot` function that saves additional copies and improves
+speed by directly calling the Fortran routines with the appropriate data input
+while preserving the `numpy.dot` call signature. This means it can be used as a
+replacement for `numpy.dot`. example::
 
   >>> import numpy as np
 
@@ -112,6 +114,7 @@ related warning which is silenced by default. example::
 
   >>> warnings.simplefilter('always', NonBLASDotWarning) # doctest: +SKIP
 
+If numpy > 1.8 is available the `fast_dot` is not necessary.
 
 .. _profiling-python-code:
 

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -115,7 +115,8 @@ related warning which is silenced by default. example::
   >>> warnings.simplefilter('always', NonBLASDotWarning) # doctest: +SKIP
 
 If numpy > 1.8 is available the `fast_dot` is not necessary. In that case
-the `numpy.dot` is being used.
+the `numpy.dot` is being used. The issue has also been fixed in the 1.7.2
+maintenance branch.
 
 .. _profiling-python-code:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,6 +10,8 @@ Changelog
 
    - Add predict method to :class:`cluster.AffinityPropagation` and
      :class:`cluster.MeanShift`, by `Mathieu Blondel`_.
+   - Add :func:`utils.extmath.fast_dot` -- a memory efficient replacement for
+   `numpy.dot` by `Denis Engemann`_, and `Alexandre Gramfort`_.
 
    - New unsupervised feature selection algorithm
      :class:`feature_selection.VarianceThreshold`, by `Lars Buitinck`_.

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -296,8 +296,6 @@ def test_minibatch_init_with_large_k():
     with warnings.catch_warnings(record=True) as warn_queue:
         mb_k_means.fit(X)
 
-    # filter expected warning
-    warn_queue = [w for w in warn_queue if 'init_size' in '%s' % w.message]
     assert_equal(len(warn_queue), 1)
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -296,6 +296,8 @@ def test_minibatch_init_with_large_k():
     with warnings.catch_warnings(record=True) as warn_queue:
         mb_k_means.fit(X)
 
+    # filter expected warning
+    warn_queue = [w for w in warn_queue if 'init_size' in '%s' % w.message]
     assert_equal(len(warn_queue), 1)
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -104,8 +104,7 @@ def _fast_dot(A, B):
                       'Falling back to np.dot.', NonBLASDotWarning)
         return np.dot(A, B)
 
-    if ((A.ndim == 1 or B.ndim == 1) or
-        (min(A.shape) == 1) or (min(B.shape) == 1) or
+    if ((min(A.shape) == 1) or (min(B.shape) == 1) or
         (A.ndim != 2) or (B.ndim != 2)):
         warnings.warn('Data must be 2D with more than one colum / row.'
                       'Falling back to np.dot', NonBLASDotWarning)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -100,6 +100,8 @@ try:
     fast_dot = _fast_dot
 except (ImportError, AttributeError):
     fast_dot = np.dot
+    warnings.warn('Could not import BLAS, falling back to np.dot',
+                   DataConversionWarning)
 
 
 def density(w, **kwargs):

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -13,7 +13,7 @@ from . import check_random_state
 from .fixes import qr_economic
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from ..externals.six.moves import xrange
-from .validation import array2d
+from .validation import array2d, DataConversionWarning
 
 
 def norm(v):
@@ -86,7 +86,7 @@ def _fast_dot(A, B):
         for x in [A, B]):
         warnings.warn('Data must be of same type. Supported types '
                       'are 32 and 64 bit float. '
-                      'Falling back to np.dot.')
+                      'Falling back to np.dot.', DataConversionWarning)
         return np.dot(A, B)
 
     dot = linalg.get_blas_funcs('gemm', (A, B))

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -93,7 +93,8 @@ def _fast_dot(A, B):
                       'Falling back to np.dot.', DataConversionWarning)
         return np.dot(A, B)
     if ((A.ndim == 1 or B.ndim == 1) or
-        (min(A.shape) == 1) or (min(B.shape) == 1)):
+        (min(A.shape) == 1) or (min(B.shape) == 1) or
+        (A.ndim != 2) or (B.ndim != 2)):
         warnings.warn('Data must be 2D with more than one colum / row.'
                       'Falling back to np.dot', DataConversionWarning)
         return np.dot(A, B)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -64,7 +64,7 @@ def _impose_f_order(X):
     # important to access flags instead of calling np.isfortran,
     # this catches corner cases.
     if X.flags.c_contiguous:
-        return (array2d(X.T, copy=False, order='F'), True)
+        return array2d(X.T, copy=False, order='F'), True
     else:
         return array2d(X, copy=False, order='F'), False
 
@@ -132,18 +132,6 @@ def safe_sparse_dot(a, b, dense_output=False):
         return ret
     else:
         return fast_dot(a, b)
-
-
-def safe_sparse_dot2(a, b, dense_output=False):
-    """Dot product that handle the sparse matrix case correctly"""
-    from scipy import sparse
-    if sparse.issparse(a) or sparse.issparse(b):
-        ret = a * b
-        if dense_output and hasattr(ret, "toarray"):
-            ret = ret.toarray()
-        return ret
-    else:
-        return np.dot(a, b)
 
 
 def randomized_range_finder(A, size, n_iter, random_state=None,

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -137,7 +137,11 @@ def density(w, **kwargs):
 
 
 def safe_sparse_dot(a, b, dense_output=False):
-    """Dot product that handle the sparse matrix case correctly"""
+    """Dot product that handle the sparse matrix case correctly
+
+    Uses BLAS GEMM as replacement for numpy.dot where possible
+    to avoid unnecessary copies.
+    """
     from scipy import sparse
     if sparse.issparse(a) or sparse.issparse(b):
         ret = a * b

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -119,7 +119,7 @@ def _fast_dot(A, B):
 #  only try to use fast_dot for older numpy versions.
 #  the related issue has been tackled meanwhile. Also, depending on the build
 #  the current numpy master's dot can about 3 times faster.
-if LooseVersion(np.__version__) < '1.8':
+if LooseVersion(np.__version__) < '1.7.2':  # backported
     try:
         linalg.get_blas_funcs('gemm')
         fast_dot = _fast_dot

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -82,6 +82,10 @@ def _fast_dot(A, B):
     A, B: instance of np.ndarray
         input matrices.
     """
+
+    if B.shape[0] != A.shape[A.ndim - 1]:  # check adopted from '_dotblas.c'
+        raise ValueError('matrices are not aligned')
+
     if A.dtype != B.dtype or any(x.dtype not in (np.float32, np.float64)
         for x in [A, B]):
         warnings.warn('Data must be of same type. Supported types '

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -91,8 +91,7 @@ def _fast_dot(A, B):
     if ((A.ndim == 1 or B.ndim == 1) or
         (min(A.shape) == 1) or (min(B.shape) == 1)):
         warnings.warn('Data must be 2D with more than one colum / row.'
-                      'Falling back to np.dot',
-                      DataConversionWarning)
+                      'Falling back to np.dot', DataConversionWarning)
         return np.dot(A, B)
 
     dot = linalg.get_blas_funcs('gemm', (A, B))

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -59,6 +59,49 @@ else:
     fast_logdet = _fast_logdet
 
 
+def _impose_f_order(X):
+    """Helper Function"""
+    # important to access flags instead of calling np.isfortran,
+    # this catches corner cases.
+    if X.flags.c_contiguous:
+        return array2d(X.T, copy=False, order='F'), True
+    else:
+        return array2d(X, copy=False, order='F'), False
+
+
+def _fast_dot(A, B):
+    """Compute fast dot products directly calling BLAS.
+
+    This function calls BLAS directly while warranting Fortran contiguity.
+    This helps avoiding extra copies `np.dot` would have created.
+    For details see section `Linear Algebra on large Arrays`:
+    http://wiki.scipy.org/PerformanceTips
+
+    Parameters
+    ----------
+    A, B: instance of np.ndarray
+        input matrices.
+    """
+    if A.dtype != B.dtype or any(x.dtype not in (np.float32, np.float64)
+        for x in [A, B]):
+        warnings.warn('Data must be of same type. Supported types '
+                      'are 32 and 64 bit float. '
+                      'Falling back to np.dot.')
+        return np.dot(A, B)
+
+    dot = linalg.get_blas_funcs('gemm', (A, B))
+    A, trans_a = _impose_f_order(A)
+    B, trans_b = _impose_f_order(B)
+    return dot(alpha=1.0, a=A, b=B, trans_a=trans_a, trans_b=trans_b)
+
+
+try:
+    linalg.get_blas_funcs('gemm')
+    fast_dot = _fast_dot
+except (ImportError, AttributeError):
+    fast_dot = np.dot
+
+
 def density(w, **kwargs):
     """Compute density of a sparse vector
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -6,6 +6,9 @@ at which the fixe is no longer needed.
 # Authors: Emmanuelle Gouillart <emmanuelle.gouillart@normalesup.org>
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Fabian Pedregosa <fpedregosa@acm.org>
+#          Lars Buitinck <L.J.Buitinck@uva.nl>
+#          Denis Engemann <d.engemann@fz-juelich.de>
+#
 # License: BSD 3 clause
 
 from operator import itemgetter

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -7,7 +7,6 @@ at which the fixe is no longer needed.
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Fabian Pedregosa <fpedregosa@acm.org>
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
-#          Denis Engemann <d.engemann@fz-juelich.de>
 #
 # License: BSD 3 clause
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -6,7 +6,6 @@ at which the fixe is no longer needed.
 # Authors: Emmanuelle Gouillart <emmanuelle.gouillart@normalesup.org>
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Fabian Pedregosa <fpedregosa@acm.org>
-#          Lars Buitinck <L.J.Buitinck@uva.nl>
 #
 # License: BSD 3 clause
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -295,12 +295,13 @@ def test_fast_dot():
     rng = np.random.RandomState(42)
     A = rng.random_sample([2, 10])
     B = rng.random_sample([2, 10])
-    # test cov-like use case + dtypes
     for dt1, dt2 in [['f8', 'f4'], ['i4', 'i4']]:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", DataConversionWarning)
             fast_dot(A.astype(dt1), B.astype(dt2).T)
             assert_true(len(w) == 1)
+
+    # test cov-like use case + dtypes
     for dtype in ['f8', 'f4']:
         A = A.astype(dtype)
         B = B.astype(dtype)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -24,6 +24,7 @@ from sklearn.utils.extmath import weighted_mode
 from sklearn.utils.extmath import cartesian
 from sklearn.utils.extmath import logistic_sigmoid
 from sklearn.utils.extmath import fast_dot
+from sklearn.utils.validation import DataConversionWarning
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
 
@@ -297,9 +298,9 @@ def test_fast_dot():
     # test cov-like use case + dtypes
     for dt1, dt2 in [['f8', 'f4'], ['i4', 'i4']]:
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            warnings.simplefilter("always", DataConversionWarning)
             fast_dot(A.astype(dt1), B.astype(dt2).T)
-            assert_true('DataConversionWarning' in '%s' % w[0].category)
+            assert_true(len(w) == 1)
     for dtype in ['f8', 'f4']:
         A = A.astype(dtype)
         B = B.astype(dtype)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -341,6 +341,21 @@ def test_fast_dot():
         C_ = fast_dot(A.T, B)
         assert_array_equal(C, C_)
 
+    # test special case of 1-column vectors
+    A = rng.random_sample([1, 10])
+    B = rng.random_sample([10, 5])
+    for dtype in ['f8', 'f4']:
+        A = A.astype(dtype)
+        B = B.astype(dtype)
+
+        C = np.dot(A, B)
+        C_ = fast_dot(A, B)
+        assert_array_almost_equal(C, C_)
+
+        C = np.dot(A.T, B)
+        C_ = fast_dot(A.T, B)
+        assert_array_almost_equal(C, C_)
+
     if has_blas:
         for x in [np.array([[d] * 10] * 2) for d in [np.inf, np.nan]]:
             assert_raises(ValueError, fast_dot, x, x.T)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -326,11 +326,12 @@ def test_fast_dot():
             assert_true(type(w.pop(-1)) == NonBLASDotWarning)
         # test for matrix mismatch error
         msg = ('Invalid array shapes: A.shape[%d] should be the same as '
-+              'B.shape[0]. Got A.shape=%r B.shape=%r' % (A.ndim - 1,
-+               A.shape, A.shape))
+               'B.shape[0]. Got A.shape=%r B.shape=%r' % (A.ndim - 1,
+                A.shape, A.shape))
         assert_raise_message(msg, fast_dot, A, A)
 
     # test cov-like use case + dtypes
+    my_assert = assert_array_almost_equal
     for dtype in ['f8', 'f4']:
         A = A.astype(dtype)
         B = B.astype(dtype)
@@ -338,15 +339,15 @@ def test_fast_dot():
         #  col < row
         C = np.dot(A.T, A)
         C_ = fast_dot(A.T, A)
-        assert_array_equal(C, C_)
+        my_assert(C, C_)
 
         C = np.dot(A.T, B)
         C_ = fast_dot(A.T, B)
-        assert_array_equal(C, C_)
+        my_assert(C, C_)
 
         C = np.dot(A, B.T)
         C_ = fast_dot(A, B.T)
-        assert_array_equal(C, C_)
+        my_assert(C, C_)
 
     # test square matrix * rectangular use case
     A = rng.random_sample([2, 2])
@@ -356,11 +357,11 @@ def test_fast_dot():
 
         C = np.dot(A, B)
         C_ = fast_dot(A, B)
-        assert_array_equal(C, C_)
+        my_assert(C, C_)
 
         C = np.dot(A.T, B)
         C_ = fast_dot(A.T, B)
-        assert_array_equal(C, C_)
+        my_assert(C, C_)
 
     if has_blas:
         for x in [np.array([[d] * 10] * 2) for d in [np.inf, np.nan]]:

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -331,5 +331,5 @@ def test_fast_dot():
         C_ = fast_dot(A.T, B)
         assert_array_equal(C, C_)
 
-    for x in [np.array([[np.nan] * 10] * 2), A / 0]:
+    for x in [np.array([[d] * 10] * 2) for d in [np.inf, np.nan]]:
         assert_raises(ValueError, fast_dot, x, x.T)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -341,21 +341,6 @@ def test_fast_dot():
         C_ = fast_dot(A.T, B)
         assert_array_equal(C, C_)
 
-    # test special case of 1-column vectors
-    A = rng.random_sample([1, 10])
-    B = rng.random_sample([10, 5])
-    for dtype in ['f8', 'f4']:
-        A = A.astype(dtype)
-        B = B.astype(dtype)
-
-        C = np.dot(A, B)
-        C_ = fast_dot(A, B)
-        assert_array_almost_equal(C, C_)
-
-        C = np.dot(A.T, B)
-        C_ = fast_dot(A.T, B)
-        assert_array_almost_equal(C, C_)
-
     if has_blas:
         for x in [np.array([[d] * 10] * 2) for d in [np.inf, np.nan]]:
             assert_raises(ValueError, fast_dot, x, x.T)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -297,7 +297,7 @@ def test_fast_dot():
     # test cov-like use case + dtypes
     for dt1, dt2 in [['f8', 'f4'], ['i4', 'i4']]:
         with warnings.catch_warnings(record=True) as w:
-            # warnings.simplefilter("always")
+            warnings.simplefilter("always")
             fast_dot(A.astype(dt1), B.astype(dt2).T)
             assert_true('DataConversionWarning' in '%s' % w[0].category)
     for dtype in ['f8', 'f4']:

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -297,9 +297,9 @@ def test_fast_dot():
     # test cov-like use case + dtypes
     for dt1, dt2 in [['f8', 'f4'], ['i4', 'i4']]:
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            # warnings.simplefilter("always")
             fast_dot(A.astype(dt1), B.astype(dt2).T)
-            assert_true(len(w) > 0)  # 1 warning should be raised
+            assert_true('DataConversionWarning' in '%s' % w[0].category)
     for dtype in ['f8', 'f4']:
         A = A.astype(dtype)
         B = B.astype(dtype)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -15,7 +15,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises, assert_raise_message
 
 from sklearn.utils.extmath import density
 from sklearn.utils.extmath import logsumexp
@@ -325,7 +325,10 @@ def test_fast_dot():
             fast_dot(A, A[0, :][None, :])
             assert_true(type(w.pop(-1)) == NonBLASDotWarning)
         # test for matrix mismatch error
-        assert_raises(ValueError, fast_dot, A, A)
+        msg = ('Invalid array shapes: A.shape[%d] should be the same as '
++              'B.shape[0]. Got A.shape=%r B.shape=%r' % (A.ndim - 1,
++               A.shape, A.shape))
+        assert_raise_message(msg, fast_dot, A, A)
 
     # test cov-like use case + dtypes
     for dtype in ['f8', 'f4']:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -16,8 +16,6 @@ class DataConversionWarning(UserWarning):
     "A warning on implicit data conversions happening in the code"
     pass
 
-# silenced to reduce tests' verbosity. Turn on at runtime for
-# performance profiling.
 warnings.simplefilter("always", DataConversionWarning)
 
 
@@ -25,6 +23,8 @@ class NonBLASDotWarning(UserWarning):
     "A warning on implicit dispatch to numpy.dot"
     pass
 
+# silenced to reduce tests' verbosity. Turn on at runtime for
+# performance profiling.
 warnings.simplefilter('ignore', NonBLASDotWarning)
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -16,6 +16,8 @@ class DataConversionWarning(UserWarning):
     "A warning on implicit data conversions happening in the code"
     pass
 
+# silenced to reduce tests' verbosity. Turn on at runtime for
+# performance profiling.
 warnings.simplefilter("always", DataConversionWarning)
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -16,8 +16,14 @@ class DataConversionWarning(UserWarning):
     "A warning on implicit data conversions happening in the code"
     pass
 
-
 warnings.simplefilter("always", DataConversionWarning)
+
+
+class NonBLASDotWarning(UserWarning):
+    "A warning on implicit dispatch to numpy.dot"
+    pass
+
+warnings.simplefilter('ignore', NonBLASDotWarning)
 
 
 def _assert_all_finite(X):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -23,7 +23,8 @@ class NonBLASDotWarning(UserWarning):
     "A warning on implicit dispatch to numpy.dot"
     pass
 
-# silenced to reduce tests' verbosity. Turn on at runtime for
+
+# Silenced by default to reduce verbosity. Turn on at runtime for
 # performance profiling.
 warnings.simplefilter('ignore', NonBLASDotWarning)
 


### PR DESCRIPTION
In this new PR I've isolated the fast_dot from the #2248 ICA related PR.
I improved exception handling and tests. If data input is not appropriate, a DataConversionWarning is thrown and the function falls back on the regular `np.dot`. Once we're happy with tests and the performance we can issues specific PRs implementing the fast_dot as desired.

For convenience the current test-gist can be found here:
https://gist.github.com/dengemann/6094449
