### PR TITLE
[MRG]: improve logcosh function + tests

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -550,7 +550,10 @@ Independent component analysis (ICA)
 Independent component analysis separates a multivariate signal into
 additive subcomponents that are maximally independent. It is
 implemented in scikit-learn using the :class:`Fast ICA <FastICA>`
-algorithm.
+algorithm. Typically, ICA is not used for reducing dimensionality but
+for separating superimposed signals. Since the ICA model does not include
+a noise term, for the model to be correct, whitening must be applied. This can be done internally using the whiten argument or manually using one of the PCA
+variants.
 
 It is classically used to separate mixed signals (a problem known as
 *blind source separation*), as in the example below:

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -552,8 +552,9 @@ additive subcomponents that are maximally independent. It is
 implemented in scikit-learn using the :class:`Fast ICA <FastICA>`
 algorithm. Typically, ICA is not used for reducing dimensionality but
 for separating superimposed signals. Since the ICA model does not include
-a noise term, for the model to be correct, whitening must be applied. This can be done internally using the whiten argument or manually using one of the PCA
-variants.
+a noise term, for the model to be correct, whitening must be applied.
+This can be done internally using the whiten argument or manually using one
+of the PCA variants.
 
 It is classically used to separate mixed signals (a problem known as
 *blind source separation*), as in the example below:

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -27,7 +27,9 @@ def _gs_decorrelation(w, W, j):
     Parameters
     ----------
     w: array of shape(n), to be orthogonalized
+
     W: array of shape(p, n), null space definition
+
     j: int < p
 
     caveats
@@ -145,17 +147,21 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     X : array-like, shape (n_samples, n_features)
         Training vector, where n_samples is the number of samples and
         n_features is the number of features.
+
     n_components : int, optional
         Number of components to extract. If None no dimension reduction
         is performed.
+
     algorithm : {'parallel', 'deflation'}, optional
         Apply a parallel or deflational FASTICA algorithm.
+
     whiten : boolean, optional
         If True perform an initial whitening of the data.
         If False, the data is assumed to have already been
         preprocessed: it should be centered, normed and white.
         Otherwise you will get incorrect results.
         In this case the parameter n_components will be ignored.
+
     fun : string or function, optional. Default: 'logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
@@ -166,22 +172,29 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
         def my_g(x):
             return x ** 3, 3 * x ** 2
+
     fun_args : dictionary, optional
         Arguments to send to the functional form.
         If empty or None and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}
+
     max_iter : int, optional
         Maximum number of iterations to perform
+
     tol: float, optional
         A positive scalar giving the tolerance at which the
         un-mixing matrix is considered to have converged
+
     w_init : (n_components, n_components) array, optional
         Initial un-mixing array of dimension (n.comp,n.comp).
         If None (default) then an array of normal r.v.'s is used
+
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
+
     return_X_mean : bool, optional
         If True, X_mean is returned too.
+
     compute_sources : bool, optional
         If False, sources are not computes but only the rotation matrix. This
         can save memory when working with big data. Defaults to True.
@@ -329,17 +342,20 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
 
 class FastICA(BaseEstimator, TransformerMixin):
-    """FastICA: a fast algorithm for Independent Component Analysis
+    """FastICA: a fast algorithm for Independent Component Analysis.
 
     Parameters
     ----------
     n_components : int, optional
         Number of components to use. If none is passed, all are used.
+
     algorithm : {'parallel', 'deflation'}
         Apply parallel or deflational algorithm for FastICA
+
     whiten : boolean, optional
         If whiten is false, the data is already considered to be
         whitened, and no whitening is performed.
+
     fun : string or function, optional. Default: 'logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
@@ -350,16 +366,21 @@ class FastICA(BaseEstimator, TransformerMixin):
 
         def my_g(x):
             return x ** 3, 3 * x ** 2
+
     fun_args : dictionary, optional
         Arguments to send to the functional form.
         If empty and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}
+
     max_iter : int, optional
         Maximum number of iterations during fit
+
     tol : float, optional
         Tolerance on update at each iteration
+
     w_init : None of an (n_components, n_components) ndarray
         The mixing matrix to be used to initialize the algorithm.
+
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
 
@@ -367,8 +388,10 @@ class FastICA(BaseEstimator, TransformerMixin):
     ----------
     `components_` : 2D array, shape (n_components, n_features)
         The unmixing matrix.
+
     `mixing_` : array, shape (n_features, n_components)
         The mixing matrix.
+
     `sources_` : 2D array, shape (n_samples, n_components)
         The estimated latent sources of the data. This attribute is deprecated
         and will be removed in 0.16. Use `fit_transform` instead and store

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -98,7 +98,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
         W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
                                 - g_wtx[:, np.newaxis] * W)
         del gwtx, g_wtx
-        # builtin max, abse are faster than numpy counter parts.
+        # builtin max, abs are faster than numpy counter parts.
         lim = max(abs(abs(np.diag(np.dot(W1, W.T))) - 1))
         W = W1
         if lim < tol:
@@ -118,11 +118,10 @@ def _logcosh(x, fun_args=None):
 
     x *= alpha
     gx = np.tanh(x, out=x)
-    # compute in chunks to avoid extra allocation
-    g_x = np.zeros(gx.shape[0])
-    for ii, gx_ in enumerate(gx):
-        g_x[ii] = (alpha * (1 - gx_ ** 2)).mean()
-
+    g_x = np.zeros(x.shape[0])
+    # XXX compute in chunks to avoid extra allocation
+    for i, g_x_i in enumerate(gx):  # plase don't vectorize.
+        g_x[i] = (alpha * (1 - g_x_i ** 2)).mean()
     return gx, g_x
 
 
@@ -511,7 +510,7 @@ class FastICA(BaseEstimator, TransformerMixin):
 
         return np.dot(X, self.components_.T)
 
-    @deprecated('To be removed in 0.16. Use `mixing_` attribute.')
+    @deprecated('To be removed in 0.16. Use the `mixing_` attribute.')
     def get_mixing_matrix(self):
         """Compute the mixing matrix.
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -120,8 +120,8 @@ def _logcosh(x, fun_args=None):
     gx = np.tanh(x, out=x)
     g_x = np.empty(x.shape[0])
     # XXX compute in chunks to avoid extra allocation
-    for i, g_x_i in enumerate(gx):  # plase don't vectorize.
-        g_x[i] = (alpha * (1 - g_x_i ** 2)).mean()
+    for i, gx_i in enumerate(gx):  # please don't vectorize.
+        g_x[i] = (alpha * (1 - gx_i ** 2)).mean()
     return gx, g_x
 
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -179,15 +179,15 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         {'alpha' : 1.0}
 
     max_iter : int, optional
-        Maximum number of iterations to perform
+        Maximum number of iterations to perform.
 
     tol: float, optional
         A positive scalar giving the tolerance at which the
-        un-mixing matrix is considered to have converged
+        un-mixing matrix is considered to have converged.
 
     w_init : (n_components, n_components) array, optional
         Initial un-mixing array of dimension (n.comp,n.comp).
-        If None (default) then an array of normal r.v.'s is used
+        If None (default) then an array of normal r.v.'s is used.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
@@ -350,7 +350,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         Number of components to use. If none is passed, all are used.
 
     algorithm : {'parallel', 'deflation'}
-        Apply parallel or deflational algorithm for FastICA
+        Apply parallel or deflational algorithm for FastICA.
 
     whiten : boolean, optional
         If whiten is false, the data is already considered to be
@@ -370,13 +370,13 @@ class FastICA(BaseEstimator, TransformerMixin):
     fun_args : dictionary, optional
         Arguments to send to the functional form.
         If empty and if fun='logcosh', fun_args will take value
-        {'alpha' : 1.0}
+        {'alpha' : 1.0}.
 
     max_iter : int, optional
-        Maximum number of iterations during fit
+        Maximum number of iterations during fit.
 
     tol : float, optional
-        Tolerance on update at each iteration
+        Tolerance on update at each iteration.
 
     w_init : None of an (n_components, n_components) ndarray
         The mixing matrix to be used to initialize the algorithm.

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -17,7 +17,6 @@ from ..externals import six
 from ..externals.six import moves
 from ..utils import array2d, as_float_array, check_random_state, deprecated
 
-
 __all__ = ['fastica', 'FastICA']
 
 
@@ -94,9 +93,10 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     p_ = float(X.shape[1])
     for ii in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
-        W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
-                                - g_wtx[:, np.newaxis] * W)
+        W1 = _sym_decorrelation(np.dot(gwtx, X.T) /
+                                p_ - g_wtx[:, np.newaxis] * W)
         del gwtx, g_wtx
+        # builtin max, abse are faster than numpy counter parts.
         lim = max(abs(abs(np.diag(np.dot(W1, W.T))) - 1))
         W = W1
         if lim < tol:
@@ -111,14 +111,17 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
 
 # Some standard non-linear functions.
 # XXX: these should be optimized, as they can be a bottleneck.
-def _logcosh(x, fun_args=None):
+def _logcosh(x, fun_args):
     alpha = fun_args.get('alpha', 1.0)  # comment it out?
-    gx = np.tanh(alpha * x, x)
-    # then compute g_x = alpha * (1 - gx ** 2) avoiding extra allocation
-    g_x = gx ** 2
-    g_x -= 1.
-    g_x *= -alpha
-    return gx, g_x.mean(axis=-1)
+
+    x *= alpha
+    gx = np.tanh(x, out=x)
+    # compute in chunks to avoid extra allocation
+    g_x = np.zeros(gx.shape[0])
+    for ii, gx_ in enumerate(gx):
+        g_x[ii] = (alpha * (1 - gx_ ** 2)).mean()
+
+    return gx, g_x
 
 
 def _exp(x, fun_args):
@@ -142,21 +145,17 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
     X : array-like, shape (n_samples, n_features)
         Training vector, where n_samples is the number of samples and
         n_features is the number of features.
-
     n_components : int, optional
         Number of components to extract. If None no dimension reduction
         is performed.
-
     algorithm : {'parallel', 'deflation'}, optional
         Apply a parallel or deflational FASTICA algorithm.
-
     whiten : boolean, optional
         If True perform an initial whitening of the data.
         If False, the data is assumed to have already been
         preprocessed: it should be centered, normed and white.
         Otherwise you will get incorrect results.
         In this case the parameter n_components will be ignored.
-
     fun : string or function, optional. Default: 'logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
@@ -167,32 +166,22 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
         def my_g(x):
             return x ** 3, 3 * x ** 2
-
     fun_args : dictionary, optional
         Arguments to send to the functional form.
         If empty or None and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}
-
     max_iter : int, optional
         Maximum number of iterations to perform
-
     tol: float, optional
         A positive scalar giving the tolerance at which the
         un-mixing matrix is considered to have converged
-
     w_init : (n_components, n_components) array, optional
         Initial un-mixing array of dimension (n.comp,n.comp).
         If None (default) then an array of normal r.v.'s is used
-
-    source_only : boolean, optional
-        If True, only the sources matrix is returned.
-
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
-
     return_X_mean : bool, optional
         If True, X_mean is returned too.
-
     compute_sources : bool, optional
         If False, sources are not computes but only the rotation matrix. This
         can save memory when working with big data. Defaults to True.
@@ -340,20 +329,17 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
 
 class FastICA(BaseEstimator, TransformerMixin):
-    """FastICA: a fast algorithm for Independent Component Analysis.
+    """FastICA: a fast algorithm for Independent Component Analysis
 
     Parameters
     ----------
     n_components : int, optional
         Number of components to use. If none is passed, all are used.
-
     algorithm : {'parallel', 'deflation'}
-        Apply parallel or deflational algorithm for FastICA.
-
+        Apply parallel or deflational algorithm for FastICA
     whiten : boolean, optional
         If whiten is false, the data is already considered to be
         whitened, and no whitening is performed.
-
     fun : string or function, optional. Default: 'logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
@@ -364,21 +350,16 @@ class FastICA(BaseEstimator, TransformerMixin):
 
         def my_g(x):
             return x ** 3, 3 * x ** 2
-
     fun_args : dictionary, optional
         Arguments to send to the functional form.
         If empty and if fun='logcosh', fun_args will take value
-        {'alpha' : 1.0}.
-
+        {'alpha' : 1.0}
     max_iter : int, optional
-        Maximum number of iterations during fit.
-
+        Maximum number of iterations during fit
     tol : float, optional
-        Tolerance on update at each iteration.
-
+        Tolerance on update at each iteration
     w_init : None of an (n_components, n_components) ndarray
         The mixing matrix to be used to initialize the algorithm.
-
     random_state : int or RandomState
         Pseudo number generator state used for random sampling.
 
@@ -386,10 +367,8 @@ class FastICA(BaseEstimator, TransformerMixin):
     ----------
     `components_` : 2D array, shape (n_components, n_features)
         The unmixing matrix.
-
     `mixing_` : array, shape (n_features, n_components)
         The mixing matrix.
-
     `sources_` : 2D array, shape (n_samples, n_components)
         The estimated latent sources of the data. This attribute is deprecated
         and will be removed in 0.16. Use `fit_transform` instead and store
@@ -495,7 +474,6 @@ class FastICA(BaseEstimator, TransformerMixin):
         X : array-like, shape (n_samples, n_features)
             Data to transform, where n_samples is the number of samples
             and n_features is the number of features.
-
         copy : bool (optional)
             If False, data passed to fit are overwritten. Defaults to True.
 
@@ -509,7 +487,7 @@ class FastICA(BaseEstimator, TransformerMixin):
 
         return np.dot(X, self.components_.T)
 
-    @deprecated('To be removed in 0.16. Use the ``mixing_`` attribute.')
+    @deprecated('To be removed in 0.16. Use the mixing_ attribute.')
     def get_mixing_matrix(self):
         """Compute the mixing matrix.
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -93,8 +93,8 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
     p_ = float(X.shape[1])
     for ii in moves.xrange(max_iter):
         gwtx, g_wtx = g(np.dot(W, X), fun_args)
-        W1 = _sym_decorrelation(np.dot(gwtx, X.T) /
-                                p_ - g_wtx[:, np.newaxis] * W)
+        W1 = _sym_decorrelation(np.dot(gwtx, X.T) / p_
+                                - g_wtx[:, np.newaxis] * W)
         del gwtx, g_wtx
         # builtin max, abse are faster than numpy counter parts.
         lim = max(abs(abs(np.diag(np.dot(W1, W.T))) - 1))
@@ -487,7 +487,7 @@ class FastICA(BaseEstimator, TransformerMixin):
 
         return np.dot(X, self.components_.T)
 
-    @deprecated('To be removed in 0.16. Use the mixing_ attribute.')
+    @deprecated('To be removed in 0.16. Use `mixing_` attribute.')
     def get_mixing_matrix(self):
         """Compute the mixing matrix.
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -113,7 +113,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
 
 # Some standard non-linear functions.
 # XXX: these should be optimized, as they can be a bottleneck.
-def _logcosh(x, fun_args):
+def _logcosh(x, fun_args=None):
     alpha = fun_args.get('alpha', 1.0)  # comment it out?
 
     x *= alpha
@@ -497,6 +497,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         X : array-like, shape (n_samples, n_features)
             Data to transform, where n_samples is the number of samples
             and n_features is the number of features.
+
         copy : bool (optional)
             If False, data passed to fit are overwritten. Defaults to True.
 

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -118,7 +118,7 @@ def _logcosh(x, fun_args=None):
 
     x *= alpha
     gx = np.tanh(x, out=x)
-    g_x = np.zeros(x.shape[0])
+    g_x = np.empty(x.shape[0])
     # XXX compute in chunks to avoid extra allocation
     for i, g_x_i in enumerate(gx):  # plase don't vectorize.
         g_x[i] = (alpha * (1 - g_x_i ** 2)).mean()

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -199,12 +199,12 @@ def test_fit_transform():
     X = rng.random_sample((100, 10))
     for whiten, n_components in [[True, 5], [False, 10]]:
 
-        ica = FastICA(n_components=5, whiten=whiten, random_state=0)
+        ica = FastICA(n_components=n_components, whiten=whiten, random_state=0)
         Xt = ica.fit_transform(X)
         assert_equal(ica.components_.shape, (n_components, 10))
         assert_equal(Xt.shape, (100, n_components))
 
-        ica = FastICA(n_components=5, whiten=whiten, random_state=0)
+        ica = FastICA(n_components=n_components, whiten=whiten, random_state=0)
         ica.fit(X)
         assert_equal(ica.components_.shape, (n_components, 10))
         Xt2 = ica.transform(X)
@@ -214,18 +214,17 @@ def test_fit_transform():
 
 def test_inverse_transform():
     """Test FastICA.inverse_transform"""
+    n_features = 10
+    n_samples = 100
+    n1, n2 = 5, 10
     rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    n_features = X.shape[1]
-    expected = {(True, 5): (n_features, 5),
-                (True, 10): (n_features, 10),
-                (False, 5): (n_features, 10),
-                (False, 10): (n_features, 10)}
-
+    X = rng.random_sample((n_samples, n_features))
+    expected = {(True, n1): (n_features, n1),
+                (True, n2): (n_features, n2),
+                (False, n1): (n_features, n2),
+                (False, n2): (n_features, n2)}
     for whiten in [True, False]:
-        for n_components in [5, 10]:
+        for n_components in [n1, n2]:
             ica = FastICA(n_components=n_components, random_state=rng,
                           whiten=whiten)
             Xt = ica.fit_transform(X)


### PR DESCRIPTION
This PR inclides the additions and edits from #2248 that were independent from the `fast_dot`. Besides STY/DOC/COSMITS the `_logcosh` function's memory footprint was improved via chunking and and tests got fixed.

cc @agramfort @ogrisel
