### PR TITLE
WIP: explicitly mark all base classes as ABC with abstractmethod inits

### DIFF
--- a/sklearn/cluster/bicluster/spectral.py
+++ b/sklearn/cluster/bicluster/spectral.py
@@ -4,7 +4,7 @@ Authors : Kemal Eren
 License: BSD 3 clause
 
 """
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
@@ -92,6 +92,7 @@ class BaseSpectral(six.with_metaclass(ABCMeta, BaseEstimator,
                                       BiclusterMixin)):
     """Base class for spectral biclustering."""
 
+    @abstractmethod
     def __init__(self, n_clusters=3, svd_method="randomized",
                  n_svd_vecs=None, mini_batch=False, init="k-means++",
                  n_init=10, n_jobs=1, random_state=None):

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -299,6 +299,7 @@ class BaseSGDClassifier(BaseSGD, LinearClassifierMixin):
                                         DEFAULT_EPSILON),
     }
 
+    @abstractmethod
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001, l1_ratio=0.15,
                  fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
                  epsilon=DEFAULT_EPSILON, n_jobs=1, random_state=None,
@@ -752,6 +753,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
                                         DEFAULT_EPSILON),
     }
 
+    @abstractmethod
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
                  l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
                  verbose=0, epsilon=DEFAULT_EPSILON, random_state=None,

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -653,6 +653,19 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     """
 
+    def __init__(self, loss="hinge", penalty='l2', alpha=0.0001, l1_ratio=0.15,
+                 fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
+                 epsilon=DEFAULT_EPSILON, n_jobs=1, random_state=None,
+                 learning_rate="optimal", eta0=0.0, power_t=0.5,
+                 class_weight=None, warm_start=False, rho=None, seed=None):
+        super(SGDClassifier, self).__init__(
+            loss=loss, penalty=penalty, alpha=alpha, l1_ratio=l1_ratio,
+            fit_intercept=fit_intercept, n_iter=n_iter, shuffle=shuffle,
+            verbose=verbose, epsilon=epsilon, n_jobs=n_jobs,
+            random_state=random_state, learning_rate=learning_rate, eta0=eta0,
+            power_t=power_t, class_weight=class_weight, warm_start=warm_start,
+            rho=rho, seed=seed)
+
     def predict_proba(self, X):
         """Probability estimates.
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -575,7 +575,7 @@ class BaseSVC(BaseLibSVM, ClassifierMixin):
         return self.classes_
 
 
-class BaseLibLinear(BaseEstimator):
+class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
     """Base for classes binding liblinear (dense and sparse versions)"""
 
     _solver_type_dict = {
@@ -589,6 +589,7 @@ class BaseLibLinear(BaseEstimator):
         'PL2_LLR_D1': 7,  # L2 penalty, logistic regression, dual form
     }
 
+    @abstractmethod
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
                  multi_class='ovr', fit_intercept=True, intercept_scaling=1,
                  class_weight=None, verbose=0, random_state=None):

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -134,8 +134,15 @@ class LinearSVC(BaseLibLinear, LinearClassifierMixin, _LearntSelectorMixin,
 
     """
 
-    # all the implementation is provided by the mixins
-    pass
+    def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
+                 multi_class='ovr', fit_intercept=True, intercept_scaling=1,
+                 class_weight=None, verbose=0, random_state=None):
+        super(LinearSVC, self).__init__(
+            penalty=penalty, loss=loss, dual=dual, tol=tol, C=C,
+            multi_class=multi_class, fit_intercept=fit_intercept,
+            intercept_scaling=intercept_scaling,
+            class_weight=class_weight, verbose=verbose,
+            random_state=random_state)
 
 
 class SVC(BaseSVC):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -113,6 +113,13 @@ def test_all_estimators():
                     assert_equal(params[arg], default)
 
 
+def test_all_estimator_no_base_class():
+    for name, Estimator in all_estimators():
+        msg = ("Base estimators such as {0} should not be included"
+               " in all_estimators").format(name)
+        assert_false(name.lower().startswith('base'), msg=msg)
+
+
 def test_estimators_sparse_data():
     # All estimators should either deal with sparse data, or raise an
     # intelligible error message

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -318,7 +318,7 @@ def all_estimators(include_meta_estimators=False, include_other=False,
         estimators = [est for est in estimators
                       if issubclass(est[1], ClusterMixin)]
     elif type_filter is not None:
-        raise ValueError("Parmeter type_filter must be 'classifier', "
+        raise ValueError("Parameter type_filter must be 'classifier', "
                          "'regressor', 'transformer', 'cluster' or None, got"
                          " %s." % repr(type_filter))
 


### PR DESCRIPTION
The goal is to avoid having the base classes end up in `all_estimators` in test_common in python 3.
