### PR TITLE
Use np.uintp_t for offset calculation. 

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -183,9 +183,9 @@ cdef struct NodeHeapData_t:
 #     cdef NodeHeapData_t nhd_tmp
 #     NodeHeapData = np.asarray(<NodeHeapData_t[:1]>(&nhd_tmp)).dtype
 cdef NodeHeapData_t nhd_tmp
-offsets = [<np.intp_t>&(nhd_tmp.val) - <np.intp_t>&nhd_tmp,
-           <np.intp_t>&(nhd_tmp.i1) - <np.intp_t>&nhd_tmp,
-           <np.intp_t>&(nhd_tmp.i2) - <np.intp_t>&nhd_tmp]
+offsets = [<np.uintp_t>&(nhd_tmp.val) - <np.uintp_t>&nhd_tmp,
+           <np.uintp_t>&(nhd_tmp.i1) - <np.uintp_t>&nhd_tmp,
+           <np.uintp_t>&(nhd_tmp.i2) - <np.uintp_t>&nhd_tmp]
 NodeHeapData = np.dtype({'names': ['val', 'i1', 'i2'],
                          'formats': [DTYPE, ITYPE, ITYPE],
                          'offsets': offsets,
@@ -203,10 +203,10 @@ cdef struct NodeData_t:
 #     cdef NodeData_t nd_tmp
 #     NodeData = np.asarray(<NodeData_t[:1]>(&nd_tmp)).dtype
 cdef NodeData_t nd_tmp
-offsets = [<np.intp_t>&(nd_tmp.idx_start) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.idx_end) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.is_leaf) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.radius) - <np.intp_t>&nd_tmp]
+offsets = [<np.uintp_t>&(nd_tmp.idx_start) - <np.uintp_t>&nd_tmp,
+           <np.uintp_t>&(nd_tmp.idx_end) - <np.uintp_t>&nd_tmp,
+           <np.uintp_t>&(nd_tmp.is_leaf) - <np.uintp_t>&nd_tmp,
+           <np.uintp_t>&(nd_tmp.radius) - <np.uintp_t>&nd_tmp]
 NodeData = np.dtype({'names': ['idx_start', 'idx_end', 'is_leaf', 'radius'],
                      'formats': [ITYPE, ITYPE, ITYPE, DTYPE],
                      'offsets': offsets,


### PR DESCRIPTION
Pointers should not be casted to a signed integer. np.uintp_t is an alias for npy_uintp, typedefed to Py_uintptr_t in NumPy npy_common.h. 
