### PR TITLE
DOC fix comment on svm probability param

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -180,7 +180,7 @@ class SVC(BaseSVC):
 
     probability: boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling predict_proba.
+        to calling `fit`, and will slow down that method.
 
     shrinking: boolean, optional (default=True)
         Whether to use the shrinking heuristic.
@@ -311,7 +311,7 @@ class NuSVC(BaseSVC):
 
     probability: boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling predict_proba.
+        to calling `fit`, and will slow down that method.
 
     shrinking: boolean, optional (default=True)
         Whether to use the shrinking heuristic.
@@ -435,7 +435,7 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     probability: boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling predict_proba.
+        to calling `fit`, and will slow down that method.
 
     shrinking: boolean, optional (default=True)
         Whether to use the shrinking heuristic.
@@ -551,7 +551,7 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     probability: boolean, optional (default=False)
         Whether to enable probability estimates. This must be enabled prior
-        to calling predict_proba.
+        to calling `fit`, and will slow down that method.
 
     shrinking: boolean, optional (default=True)
         Whether to use the shrinking heuristic.


### PR DESCRIPTION
Needs to be set before `fit`, not `predict_proba`.

I assume this sort of change can go into 0.14.
