### PR TITLE
[WIP] Write narrative documentation for out-of-core learning

### DIFF
--- a/doc/out-of-core.rst
+++ b/doc/out-of-core.rst
@@ -1,0 +1,7 @@
+.. include:: includes/big_toc_css.rst
+
+.. _out-of-core:
+
+Out-of-core Learning
+--------------------
+


### PR DESCRIPTION
This is a WIP to track progress of this [issue](https://github.com/scikit-learn/scikit-learn/issues/2204).

Here is a copy of the mission statement:

"""
- [ ] Update the out of core example to plot the behavior of Perceptron, PassiveAggressiveClassifier and MultinomialNB on the Reuters dataset. Handle separatly in this PR: #2222
- [ ] Write narrative documentation to explain the motivation, explain the partial_fit method usage in general and refer to the example in particular and give hints implementation constraints (stateless feature extraction, knowing all the classes ahead of time for classification).
- [ ] Models to be linked to in this section:

For classification:

Perceptron
MultinomialNB
BernoulliNB
SGDClassifier
PassiveAggressiveClassifier

For regression:
SGDRegressor
PassiveAggressiveRegressor

For out of core clustering / feature extraction:
MinibatchKMeans

For out of core decomposition / feature extraction:
MinibatchDictionaryLearning
"""
