### PR TITLE
[WIP] Implementation of logistic_regression_path and LogisticRegressionCV

### DIFF
--- a/sklearn/linear_model/__init__.py
+++ b/sklearn/linear_model/__init__.py
@@ -21,7 +21,8 @@ from .sgd_fast import Hinge, Log, ModifiedHuber, SquaredLoss, Huber
 from .stochastic_gradient import SGDClassifier, SGDRegressor
 from .ridge import (Ridge, RidgeCV, RidgeClassifier, RidgeClassifierCV,
                     ridge_regression)
-from .logistic import LogisticRegression
+from .logistic import (LogisticRegression, LogisticRegressionCV,
+                       logistic_regression_path)
 from .omp import (orthogonal_mp, orthogonal_mp_gram, OrthogonalMatchingPursuit,
                   OrthogonalMatchingPursuitCV)
 from .passive_aggressive import PassiveAggressiveClassifier
@@ -46,6 +47,7 @@ __all__ = ['ARDRegression',
            'LinearRegression',
            'Log',
            'LogisticRegression',
+           'LogisticRegressionCV',
            'ModifiedHuber',
            'MultiTaskElasticNet',
            'MultiTaskLasso',
@@ -67,6 +69,7 @@ __all__ = ['ARDRegression',
            'lars_path',
            'lasso_path',
            'lasso_stability_path',
+           'logistic_regression_path',
            'orthogonal_mp',
            'orthogonal_mp_gram',
            'ridge_regression']

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1,8 +1,323 @@
-import numpy as np
+"""
+Logistic Regression
+"""
 
-from .base import LinearClassifierMixin, SparseCoefMixin
+# Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
+#         Fabian Pedregosa <f@bianp.net>
+#         Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+
+import numbers
+import numpy as np
+from scipy import optimize, sparse
+
+from .base import LinearClassifierMixin, SparseCoefMixin, BaseEstimator
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..svm.base import BaseLibLinear
+from ..utils import as_float_array
+from ..cross_validation import check_cv
+from ..utils.optimize import newton_cg
+
+
+# .. some helper functions for logistic_regression_path ..
+def _phi(t, copy=True):
+    # helper function: return 1. / (1 + np.exp(-t))
+    if copy:
+        t = np.copy(t)
+    t *= -1.
+    t = np.exp(t, t)
+    t += 1
+    t = np.reciprocal(t, t)
+    return t
+
+
+def _logistic_loss_and_grad(w, X, y, alpha):
+    # the logistic loss and its gradient
+    z = X.dot(w)
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+
+    z = _phi(yz, copy=False)
+    z0 = (z - 1) * y
+    grad = X.T.dot(z0) + alpha * w
+    return out, grad
+
+
+def _logistic_loss(w, X, y, alpha):
+    # the logistic loss and
+    z = X.dot(w)
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+    #print 'Loss %r' % out
+    return out
+
+
+def _logistic_loss_grad_hess(w, X, y, alpha):
+    # the logistic loss, its gradient, and the matvec application of the
+    # Hessian
+    z = X.dot(w)
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+
+    z = _phi(yz, copy=False)
+    z0 = (z - 1) * y
+    grad = X.T.dot(z0) + alpha * w
+
+    # The mat-vec product of the Hessian
+    d = z * (1 - z)
+    if sparse.issparse(X):
+        def Hs(s):
+            ret = d * X.dot(s)
+            return X.T.dot(ret) + alpha * s
+    else:
+        # Precompute as much as possible
+        d = np.sqrt(d, d)
+        # XXX: how to do this with sparse matrices?
+        dX = d[:, np.newaxis] * X
+        def Hs(s):
+            ret = dX.T.dot(dX.dot(s))
+            ret += alpha * s
+            return ret
+    #print 'Loss/grad/hess %r, %r' % (out, grad.dot(grad))
+    return out, grad, Hs
+
+
+def _logistic_loss_and_grad_intercept(w_c, X, y, alpha):
+    w = w_c[:-1]
+    c = w_c[-1]
+
+    z = X.dot(w)
+    z += c
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+
+    z = _phi(yz, copy=False)
+    z0 = (z - 1) * y
+    grad = np.empty_like(w_c)
+    grad[:-1] = X.T.dot(z0) + alpha * w
+    grad[-1] = z0.sum()
+    return out, grad
+
+
+def _logistic_loss_intercept(w_c, X, y, alpha):
+    w = w_c[:-1]
+    c = w_c[-1]
+
+    z = X.dot(w)
+    z += c
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+
+    #print 'Loss %r' % out
+    return out
+
+
+def _logistic_loss_grad_hess_intercept(w_c, X, y, alpha):
+    w = w_c[:-1]
+    c = w_c[-1]
+
+    z = X.dot(w)
+    z += c
+    yz = y * z
+    out = np.empty(yz.shape, yz.dtype)
+    idx = yz > 0
+    out[idx] = np.log(1 + np.exp(-yz[idx]))
+    out[~idx] = (-yz[~idx] + np.log(1 + np.exp(yz[~idx])))
+    out = out.sum() + .5 * alpha * w.dot(w)
+
+    z = _phi(yz, copy=False)
+    z0 = (z - 1) * y
+    grad = np.empty_like(w_c)
+    grad[:-1] = X.T.dot(z0) + alpha * w
+    z0_sum = z0.sum()
+    grad[-1] = z0_sum
+    # The mat-vec product of the Hessian
+    d = z * (1 - z)
+    if sparse.issparse(X):
+        def Hs(s):
+            ret = np.empty_like(s)
+            ret[:-1] = d * X.dot(s[:-1])
+            ret[:-1] += X.T.dot(ret[:-1]) + alpha * s
+            ret[-1] = z0_sum * s[-1]
+            return
+    else:
+        # Precompute as much as possible
+        d = np.sqrt(d, d)
+        dX = d[:, np.newaxis] * X
+        #print 'Loss/grad/hess %r, %r' % (out, grad.dot(grad))
+        def Hs(s):
+            ret = np.empty_like(s)
+            ret[:-1] = dX.T.dot(dX.dot(s[:-1]))
+            ret[:-1] += alpha * s[:-1]
+            # XXX: I am not sure that this last line of the Hessian is right
+            # Without the intercept the Hessian is right, though
+            ret[-1] = z0_sum * s[-1]
+            return ret
+
+    return out, grad, Hs
+
+def logistic_regression_path(X, y, Cs=10, fit_intercept=True,
+                             max_iter=100, gtol=1e-4, verbose=0,
+                             method='trust-ncg', callback=None):
+    """
+    Compute a Logistic Regression model for a list of regularization
+    parameters.
+
+    This is an implementation that uses the result of the previous model
+    to speed up computations along the set of solutions, making it faster
+    than sequentially calling LogisticRegression for the different parameters.
+
+    Parameters
+    ----------
+    X : array-like or sparse matrix, shape (n_samples, n_features)
+        Input data
+
+    y : array-like, shape (n_samples,)
+        Input data, target values
+
+    Cs : array-like or integer of shape (n_cs,)
+        List of values for the regularization parameter or integer specifying
+        the number of regularization parameters that should be used. In this
+        case, the parameters will be chosen in a logarithmic scale between
+        1e-4 and 1e4.
+
+    fit_intercept : boolean
+        Whether to fit an intercept for the model. In this case the shape of
+        the returned array is (n_cs, n_features + 1).
+
+    max_iter : integer
+        Maximum number of iterations for the solver.
+
+    gtol : float
+        Stopping criterion. The iteration will stop when
+        ``max{|g_i | i = 1, ..., n} <= gtol``
+        where ``g_i`` is the i-th component of the gradient. Only used
+        by the methods 'lbfgs' and 'trust-ncg'
+
+    verbose: int
+        Print convergence message if True.
+
+    method : {'lbfgs', 'newton-cg', 'liblinear'}
+        Numerical solver to use.
+
+    callback : callable
+        Function to be called before and after the fit of each regularization
+        parameter. Must have the signature callback(w, X, y, alpha).
+
+
+    Returns
+    -------
+    coefs: array of shape (n_cs, n_features) or (n_cs, n_features + 1)
+        List of coefficients for the Logistic Regression model. If
+        fit_intercept is set to True then the seconds dimension will be
+        n_features + 1, where the last item represents the intercept.
+
+
+    Notes
+    -----
+    You might get slighly different results with the solver trust-ncg than
+    with the others since this uses LIBLINEAR penalizes the intercept.
+    """
+    if isinstance(Cs, numbers.Integral):
+        Cs = np.logspace(-4, 4, Cs)
+    Cs = np.sort(Cs)
+    y = np.sign(y - np.asarray(y).mean())
+    X = as_float_array(X, copy=False)
+    if not (np.unique(y).size == 2):
+        raise NotImplementedError('logistic_regression_path is currently only '
+                                  'implemented for the binary class case')
+    if fit_intercept:
+        w0 = np.zeros(X.shape[1] + 1)
+        func = _logistic_loss_and_grad_intercept
+    else:
+        w0 = np.zeros(X.shape[1])
+        func = _logistic_loss_and_grad
+    coefs = list()
+
+    for C in Cs:
+        if callback is not None:
+            callback(w0, X, y, 1. / C)
+        if method == 'lbfgs':
+            out = optimize.fmin_l_bfgs_b(
+                func, w0, fprime=None,
+                args=(X, y, 1./C),
+                iprint=verbose > 0, pgtol=gtol, maxiter=max_iter)
+            w0 = out[0]
+        elif method == 'newton-cg':
+            if fit_intercept:
+                func_grad_hess = _logistic_loss_grad_hess_intercept
+                func = _logistic_loss_intercept
+            else:
+                func_grad_hess = _logistic_loss_grad_hess
+                func = _logistic_loss
+
+            w0 = newton_cg(func_grad_hess, func, w0, args=(X, y, 1./C),
+                        maxiter=max_iter)
+        elif method == 'liblinear':
+            lr = LogisticRegression(C=C, fit_intercept=fit_intercept, tol=gtol)
+            lr.fit(X, y)
+            if fit_intercept:
+                w0 = np.concatenate([lr.coef_.ravel(), lr.intercept_])
+            else:
+                w0 = lr.coef_.ravel()
+        else:
+            raise ValueError("method must be one of {'trust-ncg', 'lbfgs', "
+                             "'newton-cg'}")
+        if callback is not None:
+            callback(w0, X, y, 1. / C)
+        coefs.append(w0)
+    return coefs, Cs
+
+
+# helper function for LogisticCV
+def _log_reg_scoring_path(X, y, train, test, Cs=10, scoring=None,
+                          fit_intercept=False,
+                          max_iter=100, gtol=1e-4,
+                          tol=1e-4, verbose=0):
+    log_reg = LogisticRegression(fit_intercept=fit_intercept)
+    log_reg._enc = LabelEncoder()
+    log_reg._enc.fit_transform([-1, 1])
+
+    coefs, Cs = logistic_regression_path(X[train], y[train], Cs=Cs,
+                                         fit_intercept=fit_intercept,
+                                         solver=solver,
+                                         max_iter=max_iter,
+                                         gtol=gtol, tol=tol, verbose=verbose)
+    scores = list()
+    X_test = X[test]
+    y_test = y[test]
+    if isinstance(scoring, six.string_types):
+        scoring = SCORERS[scoring]
+    for w in coefs:
+        if fit_intercept:
+            log_reg.coef_ = w[np.newaxis, :-1]
+            log_reg.intercept_ = w[-1]
+        else:
+            log_reg.coef_ = w[np.newaxis, :]
+        if scoring is None:
+            scores.append(log_reg.score(X_test, y_test))
+        else:
+            scores.append(scoring(log_reg, X_test, y_test))
+    return coefs, Cs, np.array(scores)
 
 
 class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
@@ -138,3 +453,133 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
             model, where classes are ordered as they are in ``self.classes_``.
         """
         return np.log(self.predict_proba(X))
+
+
+class LogisticRegressionCV(BaseEstimator, LinearClassifierMixin,
+                           _LearntSelectorMixin):
+    """Logistic Regression (aka logit, MaxEnt) classifier.
+
+    This class implements L2 regularized logistic regression using and
+    LBFGS optimizer.
+
+    Parameters
+    ----------
+    Cs : list of floats, integer
+
+    fit_intercept : bool, default: True
+        Specifies if a constant (a.k.a. bias or intercept) should be
+        added the decision function.
+
+    tol: float, optional
+        Tolerance for stopping criteria.
+
+    Attributes
+    ----------
+    `coef_` : array, shape = [n_classes-1, n_features]
+        Coefficient of the features in the decision function.
+
+        `coef_` is readonly property derived from `raw_coef_` that \
+        follows the internal memory layout of liblinear.
+
+    `intercept_` : array, shape = [n_classes-1]
+        Intercept (a.k.a. bias) added to the decision function.
+        It is available only when parameter intercept is set to True.
+
+    See also
+    --------
+    LogisticRegression
+
+    """
+
+
+    def __init__(self, Cs=10, fit_intercept=True, cv=None, scoring=None,
+                 solver='newton', tol=1e-4, gtol=1e-4, max_iter=100,
+                 n_jobs=1, verbose=False):
+        self.Cs = Cs
+        self.fit_intercept = fit_intercept
+        self.cv = cv
+        self.scoring = scoring
+        self.tol = tol
+        self.gtol = gtol
+        self.max_iter = max_iter
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.solver = solver
+
+    def fit(self, X, y):
+        """Fit the model according to the given training data.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            Training vector, where n_samples in the number of samples and
+            n_features is the number of features.
+
+        y : array-like, shape = [n_samples]
+            Target vector relative to X
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self._enc = LabelEncoder()
+        y = self._enc.fit_transform(y)
+        if len(self.classes_) != 2:
+            raise ValueError("LogisticRegressionCV works only on 2 "
+                             "class problems. Please use "
+                             "OneVsOneClassifier or OneVsRestClassifier")
+
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y have incompatible shapes.\n"
+                             "X has %s samples, but y has %s." %
+                             (X.shape[0], y.shape[0]))
+
+        # Transform to [-1, 1] classes, as y is [0, 1]
+        y = 2 * y
+        y -= 1
+
+        # init cross-validation generator
+        cv = check_cv(self.cv, X, y, classifier=True)
+        folds = list(cv)
+
+        fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
+                            delayed(_log_reg_scoring_path)(X, y, train, test,
+                                        Cs=self.Cs,
+                                        fit_intercept=self.fit_intercept,
+                                        solver=self.solver,
+                                        max_iter=self.max_iter,
+                                        gtol=self.gtol, tol=self.tol,
+                                        verbose=max(0, self.verbose - 1),
+                                        scoring=self.scoring,
+                                    )
+                              for train, test in folds
+                            )
+        coefs_paths, Cs, scores = zip(*fold_coefs_)
+        self.Cs_ = Cs[0]
+        self.coefs_paths_ = coefs_paths
+        self.scores_ = np.array(scores)
+        best_index = self.scores_.sum(axis=0).argmax()
+        self.C_ = self.Cs_[best_index]
+        coef_init = np.mean([c[best_index] for c in coefs_paths], axis=0)
+        w = logistic_regression_path(X, y, C=[self.C_],
+                                fit_intercept=self.fit_intercept,
+                                w0=coef_init,
+                                solver=self.solver,
+                                max_iter=self.max_iter,
+                                gtol=self.gtol, tol=self.tol,
+                                verbose=max(0, self.verbose-1),
+                               )
+        w = w[0]
+        if self.fit_intercept:
+            self.coef_ = w[np.newaxis, :-1]
+            self.intercept_ = w[-1]
+        else:
+            self.coef_ = w[np.newaxis, :]
+            self.intercept_ = 0
+        return self
+
+    @property
+    def classes_(self):
+        return self._enc.classes_
+

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -1,0 +1,103 @@
+"""
+Our own implementation of the Newton algorithm
+
+Unlike the scipy.optimize version, this version of the Newton conjugate
+gradient solver uses only one function call to retrieve the
+func value, the gradient value and a callable for the Hessian matvec
+product. If the function call is very expensive (e.g. for logistic
+regression with large design matrix), this approach gives very
+significant speedups.
+"""
+# This is a modified file from scipy.optimize
+# Original authors: Travis Oliphant, Eric Jones
+# Modifications by Gael Varoquaux
+# License: BSD
+
+import numpy as np
+from scipy.optimize.linesearch import line_search_BFGS
+
+def newton_cg(func_grad_hess, func, x0, args=(), xtol=1e-5, eps=1e-4,
+              maxiter=100, disp=False):
+    """
+    Minimization of scalar function of one or more variables using the
+    Newton-CG algorithm.
+
+    func: callable
+        Should return the value of the function, the gradient, and a
+        callable returning the matvec product of the Hessian
+    """
+    avextol = xtol
+
+    x0 = np.asarray(x0).flatten()
+    xtol = len(x0)*avextol
+    update = [2*xtol]
+    xk = x0
+    k = 0
+    old_fval = None
+
+    # Outer loop: our Newton iteration
+    while (np.sum(np.abs(update)) > xtol) and (k < maxiter):
+        # Compute a search direction pk by applying the CG method to
+        #  del2 f(xk) p = - grad f(xk) starting from 0.
+        fval, grad, fhess_p = func_grad_hess(xk, *args)
+        maggrad = np.sum(np.abs(grad))
+        eta = min([0.5, np.sqrt(maggrad)])
+        termcond = eta * maggrad
+        xsupi = np.zeros(len(x0), dtype=x0.dtype)
+        ri = grad
+        psupi = -ri
+        i = 0
+        dri0 = np.dot(ri, ri)
+
+        # Inner loop: solve the Newton update by conjugate gradient, to
+        # avoid inverting the Hessian
+        while np.sum(np.abs(ri)) > termcond:
+            Ap = fhess_p(psupi)
+            # check curvature
+            curv = np.dot(psupi, Ap)
+            if 0 <= curv <= 3*np.finfo(np.float64).eps:
+                break
+            elif curv < 0:
+                if (i > 0):
+                    break
+                else:
+                    xsupi = xsupi + dri0 / curv * psupi
+                    break
+            alphai = dri0 / curv
+            xsupi = xsupi + alphai * psupi
+            ri = ri + alphai * Ap
+            dri1 = np.dot(ri, ri)
+            betai = dri1 / dri0
+            psupi = -ri + betai * psupi
+            i = i + 1
+            dri0 = dri1          # update np.dot(ri,ri) for next time.
+
+        if old_fval is None:
+            old_fval = fval
+        alphak, fc, gc, old_fval = line_search_BFGS(func, xk, xsupi, grad,
+                                                    old_fval, args=args)
+
+        update = alphak * xsupi
+        xk = xk + update        # upcast if necessary
+        k += 1
+
+    return xk
+
+
+###############################################################################
+# Tests
+
+if __name__ == "__main__":
+    A = np.random.normal(size=(10, 10))
+
+    def func(x):
+        print 'Call to f: x %r' % x
+        Ax = A.dot(x)
+        return .5*(Ax).dot(Ax)
+
+    def func_grad_hess(x):
+        print 'Call to f_g_h: x %r' % x
+        return func(x), A.T.dot(A.dot(x)), lambda x: A.T.dot(A.dot(x))
+
+    x0 = np.ones(10)
+    out = newton_cg(func_grad_hess, func, x0)


### PR DESCRIPTION
This code implements a function logistic_regression_path and an object LogisticRegressionCV

This is mostly the code from @GaelVaroquaux logistic_cv branch. My work is only some minor cleanup some added tests and benchmarking.
## Rationale

We currently use LIBLINEAR for LogisticRegression and while it is very fast on most problems it cannot be warm-restarted, which means that fitting a LogisticRegression on a grid of parameters takes as much time as fitting it independently on each parameter separately. In this pull request we implement the code to perform an efficient fit of logistic regression models across a sequence of regularization parameters by using the solution to the previous model as initialization point for the current optimization problem. We also get (almost for free) an efficient implementation of a cross-validated Logistic Regression estimator in LogisticRegressionCV
## Code

The important functions are `logistic_regression_path` and `LogisticRegressionCV`, both in `linear_models/logistic.py`. Our benchmarks have shown that the most competitive method is either lbfgs or the newton-cg solver adapted from the SciPy codebase, depending on the problem. The changes made to the newton-cg code are essentially to allow the function to minimize to provide the gradient and hessian in the same call, thus being able to reuse several computations. These changes are extremely important for this model but unfortunately these changes are incompatible with the SciPy API and extending the SciPy API to support our changes is not straightforward. That is why I've added the solver to sklearn.utils.optimize.

The available solvers are (I've tried to use as much the vocabulary from scipy.optimize):
- **lbfgs**: this uses scipy.optimize.fmin_lbfgs_b
- **newton-cg**: this uses our modificed version of scipy's newton-cg implementation
- **liblinear**: this uses the LIBLINEAR implementation, which in turn is a trust-region newton type algorithm.

The solvers make use of the private functions `_logistic*` defined in `logistic.py`.
## Benchmarks

I have run benchmarks on real and synthetic datasets. 

Each vertical line corresponds to the convergence of the method for a particular parameter and each axis is done with a different method. The important quantity is the timing for the last line, that is, when the algorithm finishes to optimize all models in the path (i.e. total time).
### Real datasets

This if from the haxby dataset from https://github.com/nilearn/nilearn. 216 samples x 6222 features. I'll upload this data somewhere as soon as I have decent wifi connection. The notebook to run the benchmarks can be found [here](http://nbviewer.ipython.org/url/fa.bianp.net/tmp/2013/logistic_path_bench_PR.ipynb).

![image](https://f.cloud.github.com/assets/277639/875580/365ac6d4-f8a6-11e2-824c-f0628d95cc58.png)
### Synthetic dataset

From a linear model with gaussian noise (see notebook), 10K samples x 100 features. 

![image](https://f.cloud.github.com/assets/277639/875643/fd2b3d38-f8a7-11e2-877c-b492fc18fa1b.png)
## TODO
- [ ] I think the some of the private functions in `logistic.py` can be simplified. In particular, it is my intuition that we could squash some of the functions `_logistic*` and `_logistic_*_intercept` without sacrificing a significant amount of performance
- [x] Compatibility with old scipy that do not have keyword max_iter in the lbfgs solver (Travis build failure)
- [ ] sparse matrix support (any help from the people who actually use sparse matrices would be great here)
- [ ] implement multinomial logistic or raise a meaningful error for multiclass pointing to OvA, OvO meta-estimators
- [ ] More tests for LogisticCV object (and some are failing)
- [ ] Document tolerance and stopping criterions
