### PR TITLE
Custom vocabulary checks for CountVectorizer 

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -258,6 +258,19 @@ def test_countvectorizer_custom_vocabulary_pipeline():
                  set(what_we_like))
     assert_equal(X.shape[1], len(what_we_like))
 
+def test_countvectorizer_custom_vocabulary_repeated_indeces():
+    vocab = {"pizza": 0, "beer": 0}
+    try:
+        vect = CountVectorizer(vocabulary=vocab)
+    except ValueError as e:
+        assert_in("the vocabulary contains repeated indices",str(e).lower())
+
+def test_countvectorizer_custom_vocabulary_gap_index():
+    vocab = {"pizza": 1, "beer": 2}
+    try:
+        vect = CountVectorizer(vocabulary=vocab)
+    except ValueError as e:
+        assert_in("doesn't contain index",str(e).lower())
 
 def test_countvectorizer_stop_words():
     cv = CountVectorizer()

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -736,7 +736,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         values = np.ones(len(j_indices))
 
         X = sp.csr_matrix((values, j_indices, indptr),
-                          shape=(len(indptr) - 1, len(vocabulary)),
+                          shape=(len(indptr) - 1, max(vocabulary.itervalues()) + 1),
                           dtype=self.dtype)
         X.sum_duplicates()
         return vocabulary, X

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -565,7 +565,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     vocabulary : Mapping or iterable, optional
         Either a Mapping (e.g., a dict) where keys are terms and values are
         indices in the feature matrix, or an iterable over terms. If not
-        given, a vocabulary is determined from the input documents.
+        given, a vocabulary is determined from the input documents. Indices
+        in the mapping should not be repeated and should not have any gap
+        between 0 and the largest index.
 
     binary : boolean, False by default.
         If True, all non zero counts are set to 1. This is useful for discrete
@@ -639,7 +641,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 vocabulary = dict((t, i) for i, t in enumerate(vocabulary))
             if not vocabulary:
                 raise ValueError("empty vocabulary passed to fit")
-            indices = set(vocabulary.values())
+            indices = set(six.itervalues(vocabulary))
             if len(indices) != len(vocabulary):
                 raise ValueError("the vocabulary contains repeated indices")
             for i in xrange(len(vocabulary)):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -639,6 +639,12 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 vocabulary = dict((t, i) for i, t in enumerate(vocabulary))
             if not vocabulary:
                 raise ValueError("empty vocabulary passed to fit")
+            indices = set(vocabulary.values())
+            if len(indices) != len(vocabulary):
+                raise ValueError("the vocabulary contains repeated indices")
+            for i in xrange(len(vocabulary)):
+                if i not in indices:
+                    raise ValueError("the vocabulary of size %d, doesn't contain index %d" % (len(vocabulary),i))
             self.fixed_vocabulary = True
             self.vocabulary_ = dict(vocabulary)
         else:
@@ -736,7 +742,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         values = np.ones(len(j_indices))
 
         X = sp.csr_matrix((values, j_indices, indptr),
-                          shape=(len(indptr) - 1, max(vocabulary.itervalues()) + 1),
+                          shape=(len(indptr) - 1, len(vocabulary)),
                           dtype=self.dtype)
         X.sum_duplicates()
         return vocabulary, X


### PR DESCRIPTION
added check for repeating indices and gaps in custom vocabulary for CountVectorizer
added test with wrong custom vocabs
this commit fixes #2353 
