### PR TITLE
Add predict method to AffinityPropogation and MeanShift

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: sklearn
 
+.. _changes_0_15:
+
+0.15
+=====
+
+   - Add predict method to :class:`cluster.AffinityPropagation` and
+     :class:`cluster.MeanShift`, by `Mathieu Blondel`_.
+
 .. _changes_0_14:
 
 0.14

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -263,11 +263,6 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             similarities / affinities.
         """
 
-        if X.shape[0] == X.shape[1] and not self._pairwise:
-            warnings.warn("The API of AffinityPropagation has changed."
-                          "Now ``fit`` constructs an affinity matrix from the"
-                          " data. To use a custom affinity matrix, set "
-                          "``affinity=precomputed``.")
         if self.affinity is "precomputed":
             self.affinity_matrix_ = X
         elif self.affinity is "euclidean":

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -295,8 +295,11 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         labels : array, shape [n_samples,]
             Index of the cluster each sample belongs to.
         """
+        if not hasattr(self, "cluster_centers_indices_"):
+            raise ValueError("Estimator is not fitted.")
+
         if not hasattr(self, "cluster_centers_"):
-            raise ValueError("Error: estimator not fitted or "
+            raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")
 
         # FIXME: can use pairwise_distances_argmin when ready.

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -212,6 +212,9 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     `cluster_centers_indices_` : array, [n_clusters]
         Indices of cluster centers
 
+    `cluster_centers_` : array, [n_clusters, n_features]
+        Cluster centers (if affinity != ``precomputed'').
+
     `labels_` : array, [n_samples]
         Labels of each point
 
@@ -278,4 +281,28 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             self.affinity_matrix_, self.preference, max_iter=self.max_iter,
             convergence_iter=self.convergence_iter, damping=self.damping,
             copy=self.copy, verbose=self.verbose)
+
+        if self.affinity != "precomputed":
+            self.cluster_centers_ = X[self.cluster_centers_indices_].copy()
+
         return self
+
+    def predict(self, X):
+        """Predict the closest cluster each sample in X belongs to.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            New data to predict.
+
+        Returns
+        -------
+        labels : array, shape [n_samples,]
+            Index of the cluster each sample belongs to.
+        """
+        if not hasattr(self, "cluster_centers_"):
+            raise ValueError("Error: estimator not fitted or "
+                             "affinity='precomputed'.")
+
+        # FIXME: can use pairwise_distances_argmin when ready.
+        return euclidean_distances(X, self.cluster_centers_).argmin(axis=1)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -768,8 +768,8 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
         Returns
         -------
-        Y : array, shape [n_samples,]
-            Index of the closest center each sample belongs to.
+        labels : array, shape [n_samples,]
+            Index of the cluster each sample belongs to.
         """
         self._check_fitted()
         X = self._check_test_data(X)

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -11,6 +11,7 @@ from ..externals import six
 from ..utils import extmath, check_random_state
 from ..base import BaseEstimator, ClusterMixin
 from ..neighbors import NearestNeighbors
+from ..metrics.pairwise import euclidean_distances
 
 
 def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
@@ -279,3 +280,19 @@ class MeanShift(BaseEstimator, ClusterMixin):
                        bin_seeding=self.bin_seeding,
                        cluster_all=self.cluster_all)
         return self
+
+    def predict(self, X):
+        """Predict the closest cluster each sample in X belongs to.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            New data to predict.
+
+        Returns
+        -------
+        labels : array, shape [n_samples,]
+            Index of the cluster each sample belongs to.
+        """
+        # FIXME: can use pairwise_distances_argmin when ready.
+        return euclidean_distances(X, self.cluster_centers_).argmin(axis=1)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -70,5 +70,12 @@ def test_affinity_propagation_predict():
 
 def test_affinity_propagation_predict_error():
     """Test exception in AffinityPropagation.predict"""
+    # Not fitted.
     af = AffinityPropagation(affinity="euclidean")
+    assert_raises(ValueError, af.predict, X)
+
+    # Predict not supported when affinity="precomputed".
+    S = np.dot(X, X.T)
+    af = AffinityPropagation(affinity="precomputed")
+    af.fit(S)
     assert_raises(ValueError, af.predict, X)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -22,8 +22,7 @@ X, _ = make_blobs(n_samples=60, n_features=2, centers=centers,
 
 
 def test_affinity_propagation():
-    """Affinity Propagation algorithm
-    """
+    """Affinity Propagation algorithm """
     # Compute similarities
     S = -euclidean_distances(X, squared=True)
     preference = np.median(S) * 10
@@ -62,6 +61,7 @@ def test_affinity_propagation():
 
 
 def test_affinity_propagation_predict():
+    """Test AffinityPropagation.predict"""
     af = AffinityPropagation(affinity="euclidean")
     labels = af.fit_predict(X)
     labels2 = af.predict(X)
@@ -69,5 +69,6 @@ def test_affinity_propagation_predict():
 
 
 def test_affinity_propagation_predict_error():
+    """Test exception in AffinityPropagation.predict"""
     af = AffinityPropagation(affinity="euclidean")
     assert_raises(ValueError, af.predict, X)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,8 +5,11 @@ Testing for Clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import (assert_equal, assert_array_equal,
-                                   assert_raises)
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_array_equal
+
 from sklearn.cluster.affinity_propagation_ import AffinityPropagation
 from sklearn.cluster.affinity_propagation_ import affinity_propagation
 from sklearn.datasets.samples_generator import make_blobs
@@ -56,3 +59,15 @@ def test_affinity_propagation():
     assert_raises(ValueError, affinity_propagation, S, damping=0)
     af = AffinityPropagation(affinity="unknown")
     assert_raises(ValueError, af.fit, X)
+
+
+def test_affinity_propagation_predict():
+    af = AffinityPropagation(affinity="euclidean")
+    labels = af.fit_predict(X)
+    labels2 = af.predict(X)
+    assert_array_equal(labels, labels2)
+
+
+def test_affinity_propagation_predict_error():
+    af = AffinityPropagation(affinity="euclidean")
+    assert_raises(ValueError, af.predict, X)

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -5,7 +5,10 @@ Testing for mean shift clustering methods
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal, assert_false, assert_true
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_array_equal
 
 from sklearn.cluster import MeanShift
 from sklearn.cluster import mean_shift
@@ -40,6 +43,13 @@ def test_mean_shift():
     labels_unique = np.unique(labels)
     n_clusters_ = len(labels_unique)
     assert_equal(n_clusters_, n_clusters)
+
+
+def test_meanshift_predict():
+    ms = MeanShift(bandwidth=1.2)
+    labels = ms.fit_predict(X)
+    labels2 = ms.predict(X)
+    assert_array_equal(labels, labels2)
 
 
 def test_unfitted():

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -19,13 +19,15 @@ X, _ = make_blobs(n_samples=500, n_features=2, centers=centers,
                   cluster_std=0.4, shuffle=True, random_state=0)
 
 
+def test_estimate_bandwidth():
+    bandwidth = estimate_bandwidth(X, n_samples=300)
+    assert_true(0.9 <= bandwidth <= 1.5)
+
+
 def test_mean_shift():
     """ Test MeanShift algorithm
     """
     bandwidth = 1.2
-
-    bandwidth_ = estimate_bandwidth(X, n_samples=300)
-    assert_true(0.9 <= bandwidth_ <= 1.5)
 
     ms = MeanShift(bandwidth=bandwidth)
     labels = ms.fit(X).labels_

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -23,13 +23,13 @@ X, _ = make_blobs(n_samples=500, n_features=2, centers=centers,
 
 
 def test_estimate_bandwidth():
+    """Test estimate_bandwidth"""
     bandwidth = estimate_bandwidth(X, n_samples=300)
     assert_true(0.9 <= bandwidth <= 1.5)
 
 
 def test_mean_shift():
-    """ Test MeanShift algorithm
-    """
+    """ Test MeanShift algorithm """
     bandwidth = 1.2
 
     ms = MeanShift(bandwidth=bandwidth)
@@ -46,6 +46,7 @@ def test_mean_shift():
 
 
 def test_meanshift_predict():
+    """Test MeanShift.predict"""
     ms = MeanShift(bandwidth=1.2)
     labels = ms.fit_predict(X)
     labels2 = ms.predict(X)

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -493,8 +493,8 @@ def test_unsupervised_grid_search():
 def test_bad_estimator():
     # test grid-search with clustering algorithm which doesn't support
     # "predict"
-    ms = SpectralClustering()
-    assert_raises(TypeError, GridSearchCV, ms,
+    sc = SpectralClustering()
+    assert_raises(TypeError, GridSearchCV, sc,
                   param_grid=dict(gamma=[.1, 1, 10]),
                   scoring='ari')
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -33,7 +33,7 @@ from sklearn.grid_search import (GridSearchCV, RandomizedSearchCV,
 from sklearn.svm import LinearSVC, SVC
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.cluster import KMeans, MeanShift
+from sklearn.cluster import KMeans, SpectralClustering
 from sklearn.metrics import f1_score
 from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_auc_score
@@ -491,8 +491,9 @@ def test_unsupervised_grid_search():
 
 
 def test_bad_estimator():
-    # test grid-search with unsupervised estimator
-    ms = MeanShift()
+    # test grid-search with clustering algorithm which doesn't support
+    # "predict"
+    ms = SpectralClustering()
     assert_raises(TypeError, GridSearchCV, ms,
                   param_grid=dict(gamma=[.1, 1, 10]),
                   scoring='ari')


### PR DESCRIPTION
This is a simple PR for adding predict() to AffinityPropagation and MeanShift.

For SpectralClustering, I'm not sure if it's possible to directly generalize to new data (it's always possible to fit a classifier with the labels obtained from fit_predict, though).

For DBSCAN, it seems like it should be possible but I'm not familiar enough with the algorithm so I didn't do it.
