### PR TITLE
Allow build to succeed with OpenBLAS.

### DIFF
--- a/sklearn/_build_utils.py
+++ b/sklearn/_build_utils.py
@@ -17,6 +17,9 @@ def get_blas_info():
                 # how do we do that now?
                 return True
             if x[0] == "ATLAS_INFO":
+                if "None" in x[1] and 'openblas' in blas_info.get('libraries', []):
+                    # allow compilation with OpenBLAS
+                    return False
                 if "None" in x[1]:
                     # this one turned up on FreeBSD
                     return True


### PR DESCRIPTION
On Ubuntu 13.04 with OpenBLAS installed according to instructions in
http://osdf.github.io/blog/numpyscipy-with-openblas-for-ubuntu-1204-second-try.html
numpy.distutils.system_info.get_info returns

{'define_macros': [('ATLAS_INFO', '"\"None\""')],
 'include_dirs': ['/usr/local/include'],
 'language': 'c',
 'libraries': ['openblas'],
 'library_dirs': ['/usr/local/lib']}.

The build then fails when unable to import lcblas.

This change allows the build to succeed.
