### PR TITLE
removing NWS from list of stock prices

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -116,7 +116,6 @@ symbol_dict = {
     'MAR': 'Marriott',
     'PG': 'Procter Gamble',
     'CL': 'Colgate-Palmolive',
-    'NWS': 'News Corp',
     'GE': 'General Electrics',
     'WFC': 'Wells Fargo',
     'JPM': 'JPMorgan Chase',


### PR DESCRIPTION
Issue #2389

The reason this is a problem is because News Corp (NWS) was spun-off into two companies earlier this June (21st Century Fox and News Corp). The Yahoo Historical Stock Prices API, which matplotlib.finance calls, won't return historical data for companies that have had this type of readjustment. The same result can be seen when calling historical data for GM:

http://ichart.yahoo.com/table.csv?a=2&b=2&c=2003&d=3&e=3&f=2007&s=NWS&y=0&g=d&ignore=.csv
http://ichart.yahoo.com/table.csv?a=2&b=2&c=2003&d=3&e=3&f=2007&s=GM&y=0&g=d&ignore=.csv

But a company like Google works fine:
http://ichart.yahoo.com/table.csv?a=2&b=2&c=2003&d=3&e=3&f=2007&s=GOOG&y=0&g=d&ignore=.csv

This should be an issue raised with the Yahoo API folks.
