### PR TITLE
ENH: put fast dot to PCA, ICA and FA

### DIFF
--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -98,7 +98,7 @@ replacement for `numpy.dot`. example::
 
   >>> X = np.random.random_sample([2, 10])
 
-  >>> (np.dot(X, X.T) == fast_dot(X, X.T)).all()
+  >>> np.allclose(np.dot(X, X.T), fast_dot(X, X.T))
   True
 
 However this requires data to be exactly 2 dimensional and of the same type,

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -19,7 +19,7 @@ from scipy import linalg
 from ..base import BaseEstimator, TransformerMixin
 from ..externals.six.moves import xrange
 from ..utils import array2d, check_arrays
-from ..utils.extmath import fast_logdet
+from ..utils.extmath import fast_logdet, fast_dot
 
 
 class FactorAnalysis(BaseEstimator, TransformerMixin):
@@ -193,8 +193,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
         Wpsi = self.components_ / self.noise_variance_
         cov_z = linalg.inv(Ih + np.dot(Wpsi, self.components_.T))
-        tmp = np.dot(X_transformed, Wpsi.T)
-        X_transformed = np.dot(tmp, cov_z)
+        tmp = fast_dot(X_transformed, Wpsi.T)
+        X_transformed = fast_dot(tmp, cov_z)
 
         return X_transformed
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -4,6 +4,8 @@
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Mathieu Blondel <mathieu@mblondel.org>
+#         Denis A. Engemann <d.engemann@fz-juelich.de>
+#
 # License: BSD 3 clause
 
 from math import log, sqrt
@@ -16,9 +18,8 @@ from scipy.special import gammaln
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import array2d, check_random_state, as_float_array
 from ..utils import atleast2d_or_csr
-from ..utils.extmath import fast_logdet
-from ..utils.extmath import safe_sparse_dot
-from ..utils.extmath import randomized_svd
+from ..utils.extmath import fast_logdet, safe_sparse_dot, randomized_svd, \
+                            fast_dot
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
@@ -303,7 +304,7 @@ class PCA(BaseEstimator, TransformerMixin):
         X = array2d(X)
         if self.mean_ is not None:
             X = X - self.mean_
-        X_transformed = np.dot(X, self.components_.T)
+        X_transformed = fast_dot(X, self.components_.T)
         return X_transformed
 
     def inverse_transform(self, X):
@@ -325,7 +326,7 @@ class PCA(BaseEstimator, TransformerMixin):
         If whitening is enabled, inverse_transform does not compute the
         exact inverse operation as transform.
         """
-        return np.dot(X, self.components_) + self.mean_
+        return fast_dot(X, self.components_) + self.mean_
 
 
 class ProbabilisticPCA(PCA):


### PR DESCRIPTION
This PR inserts the recently merged `fast_dot` #2288 into the parts of the decomposition module for which I spotted the related issues back in July. Should be good to go, minor changes which only affect the multiplications between data and weights, that is the nasty square X rectangular use case.
