### PR TITLE
Fix probabilitic pca

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -235,7 +235,6 @@ Samples generator
    :template: class.rst
 
    decomposition.PCA
-   decomposition.ProbabilisticPCA
    decomposition.ProjectedGradientNMF
    decomposition.RandomizedPCA
    decomposition.KernelPCA

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -31,11 +31,6 @@ the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm. However in that case the inverse transform is no
 longer exact since some information is lost while forward transforming.
 
-The :class:`PCA` object also provides a
-probabilistic interpretation of the PCA that can give a likelihood of
-data based on the amount of variance it explains. As such it implements a
-`score` method that can be used in cross-validation.
-
 Below is an example of the iris dataset, which is comprised of 4
 features, projected on the 2 dimensions that explain most variance:
 
@@ -48,6 +43,15 @@ features, projected on the 2 dimensions that explain most variance:
 
     * :ref:`example_decomposition_plot_pca_vs_lda.py`
 
+The :class:`PCA` object also provides a
+probabilistic interpretation of the PCA that can give a likelihood of
+data based on the amount of variance it explains. As such it implements a
+`score` method that can be used in cross-validation:
+
+.. figure:: ../auto_examples/decomposition/images/plot_pca_vs_fa_model_selection_1.png
+    :target: ../auto_examples/decomposition/plot_pca_vs_fa_model_selection.html
+    :align: center
+    :scale: 75%
 
 .. _RandomizedPCA:
 
@@ -535,10 +539,19 @@ about these components (e.g. whether they are orthogonal):
 .. centered:: |pca_img3| |fa_img3|
 
 The main advantage for Factor Analysis (over :class:`PCA` is that
-it can model the variance in every direction of the input space independently:
+it can model the variance in every direction of the input space independently
+(heteroscedastic noise):
 
 .. figure:: ../auto_examples/decomposition/images/plot_faces_decomposition_8.png
     :target: ../auto_examples/decomposition/plot_faces_decomposition.html
+    :align: center
+    :scale: 75%
+
+This allows better model selection than probabilistic PCA in the presence
+of heteroscedastic noise:
+
+.. figure:: ../auto_examples/decomposition/images/plot_pca_vs_fa_model_selection_2.png
+    :target: ../auto_examples/decomposition/plot_pca_vs_fa_model_selection.html
     :align: center
     :scale: 75%
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -39,9 +39,6 @@ features, projected on the 2 dimensions that explain most variance:
     :align: center
     :scale: 75%
 
-.. topic:: Examples:
-
-    * :ref:`example_decomposition_plot_pca_vs_lda.py`
 
 The :class:`PCA` object also provides a
 probabilistic interpretation of the PCA that can give a likelihood of
@@ -52,6 +49,13 @@ data based on the amount of variance it explains. As such it implements a
     :target: ../auto_examples/decomposition/plot_pca_vs_fa_model_selection.html
     :align: center
     :scale: 75%
+
+
+.. topic:: Examples:
+
+    * :ref:`example_decomposition_plot_pca_vs_lda.py`
+    * :ref:`example_decomposition_plot_pca_vs_fa_model_selection.py`
+
 
 .. _RandomizedPCA:
 
@@ -554,6 +558,11 @@ of heteroscedastic noise:
     :target: ../auto_examples/decomposition/plot_pca_vs_fa_model_selection.html
     :align: center
     :scale: 75%
+
+
+.. topic:: Examples:
+
+    * :ref:`example_decomposition_plot_pca_vs_fa_model_selection.py`
 
 .. _ICA:
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -31,7 +31,7 @@ the case for Support Vector Machines with the RBF kernel and the K-Means
 clustering algorithm. However in that case the inverse transform is no
 longer exact since some information is lost while forward transforming.
 
-In addition, the :class:`ProbabilisticPCA` object provides a
+The :class:`PCA` object also provides a
 probabilistic interpretation of the PCA that can give a likelihood of
 data based on the amount of variance it explains. As such it implements a
 `score` method that can be used in cross-validation.
@@ -509,7 +509,7 @@ of these two parameters. A simple additional assumption regards the
 structure of the error covariance :math:`\Psi`:
 
 * :math:`\Psi = \sigma^2 \mathbf{I}`: This assumption leads to
-  :class:`ProbabilisticPCA`.
+  the probabilistic model of :class:`PCA`.
 
 * :math:`\Psi = diag(\psi_1, \psi_2, \dots, \psi_n)`: This model is called Factor
   Analysis, a classical statistical model. The matrix W is sometimes called
@@ -534,7 +534,7 @@ about these components (e.g. whether they are orthogonal):
 
 .. centered:: |pca_img3| |fa_img3|
 
-The main advantage for Factor Analysis (over :class:`ProbabilisticPCA` is that
+The main advantage for Factor Analysis (over :class:`PCA` is that
 it can model the variance in every direction of the input space independently:
 
 .. figure:: ../auto_examples/decomposition/images/plot_faces_decomposition_8.png

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,10 +32,11 @@ Changelog
 API changes summary
 -------------------
 
-   - Add score method to PCA following the model of probabilistic PCA and
-     deprecate ProbabilisticPCA model whose score implementation is not
-     correct. The computation now also exploits the matrix inversion
-     lemma for faster computation. By `Alexandre Gramfort`_.
+   - Add score method to :class:`PCA <decomposition.PCA>` following the model of
+     probabilistic PCA and deprecate
+     :class:`ProbabilisticPCA <decomposition.ProbabilisticPCA>` model whose
+     score implementation is not correct. The computation now also exploits the
+     matrix inversion lemma for faster computation. By `Alexandre Gramfort`_.
 
 
 .. _changes_0_14:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,10 +23,20 @@ Changelog
      sparse matrices and has much lower memory complexity, meaning it will
      scale up gracefully to large datasets. By `Lars Buitinck`_.
 
-  - Add svd_method option with default value to "randomized" to
-    :class:`decomposition.factor_analysis.FactorAnalysis` to save memory and
-    significantly speedup computation by `Denis Engemann`_, and
-    `Alexandre Gramfort`_.
+   - Add svd_method option with default value to "randomized" to
+     :class:`decomposition.factor_analysis.FactorAnalysis` to save memory and
+     significantly speedup computation by `Denis Engemann`_, and
+     `Alexandre Gramfort`_.
+
+
+API changes summary
+-------------------
+
+   - Add score method to PCA following the model of probabilistic PCA and
+     deprecate ProbabilisticPCA model whose score implementation is not
+     correct. The computation now also exploits the matrix inversion
+     lemma for faster computation. By `Alexandre Gramfort`_.
+
 
 .. _changes_0_14:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,9 @@ API changes summary
      score implementation is not correct. The computation now also exploits the
      matrix inversion lemma for faster computation. By `Alexandre Gramfort`_.
 
+   - The score method of :class:`FactorAnalysis <decomposition.FactorAnalysis>`
+     now returns the average log-likelihood of the samples. Use score_samples
+     to get log-likelihood of each sample. By `Alexandre Gramfort`_.
 
 .. _changes_0_14:
 

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -68,7 +68,8 @@ def compute_scores(X):
 
     return pca_scores, fa_scores
 
-for X in [X_homo, X_hetero]:
+for X, title in zip([X_homo, X_hetero],
+                    ['Homoscedastic Noise', 'Heteroscedastic Noise']):
     pca_scores, fa_scores = compute_scores(X)
     n_components_pca = n_components[np.argmax(pca_scores)]
     n_components_fa = n_components[np.argmax(fa_scores)]
@@ -94,4 +95,6 @@ for X in [X_homo, X_hetero]:
     pl.xlabel('nb of components')
     pl.ylabel('CV scores')
     pl.legend(loc='lower right')
-    pl.show()
+    pl.title(title)
+
+pl.show()

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -15,7 +15,7 @@ is the different for each feature).
 
 One can observe that with homoscedastic noise both FA and PCA succeed
 in recovering the size of the low rank subspace. The likelihood with PCA
-is higher than FA in this case. However PCA fails and over estimates
+is higher than FA in this case. However PCA fails and overestimates
 the rank when heteroscedastic noise is present. The automatic estimation from
 Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
 by Thomas P. Minka is also compared.

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -63,8 +63,8 @@ def compute_scores(X):
     for n in n_components:
         pca.n_components = n
         fa.n_components = n
-        pca_scores.append(np.mean(np.concatenate(cross_val_score(pca, X))))
-        fa_scores.append(np.mean(np.concatenate(cross_val_score(fa, X))))
+        pca_scores.append(np.mean(cross_val_score(pca, X)))
+        fa_scores.append(np.mean(cross_val_score(fa, X)))
 
     return pca_scores, fa_scores
 

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+=================================================================
+Model selection with Probabilistic (PCA) and Factor Analysis (FA)
+=================================================================
+
+Probabilistic PCA and Factor Analysis are probabilistic models.
+The consequence is that the likelihood of new data can be used
+for model selection. Here we compare PCA and FA with cross-validation
+on low rank data corrupted with homoscedastic noise (noise variance
+is the same for each feature) or heteroscedastic noise (noise variance
+is the different for each feature).
+
+One can observe that with homoscedastic noise both FA and PCA succeed
+in recovering the size of the low rank subspace. The likelihood with PCA
+is higher than FA in this case. However PCA fails and over estimates
+the rank when heteroscedastic noise is present. The automatic estimation from
+Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
+by Thomas P. Minka is also compared.
+
+"""
+print(__doc__)
+
+# Authors: Alexandre Gramfort
+# License: BSD 3 clause
+
+import numpy as np
+import pylab as pl
+from scipy import linalg
+
+from sklearn.decomposition import PCA, FactorAnalysis
+from sklearn.cross_validation import cross_val_score
+
+###############################################################################
+# Create the data
+
+n_samples, n_features, rank = 1000, 50, 10
+sigma = 1.
+rng = np.random.RandomState(42)
+U, _, _ = linalg.svd(rng.randn(n_features, n_features))
+X = np.dot(rng.randn(n_samples, rank), U[:, :rank].T)
+
+# Adding homoscedastic noise
+X_homo = X + sigma * rng.randn(n_samples, n_features)
+
+# Adding heteroscedastic noise
+sigmas = sigma * rng.rand(n_features) + sigma / 2.
+X_hetero = X + rng.randn(n_samples, n_features) * sigmas
+
+###############################################################################
+# Fit the models
+
+n_components = np.arange(0, n_features, 5)  # options for n_components
+
+
+def compute_scores(X):
+    pca = PCA()
+    fa = FactorAnalysis()
+
+    pca_scores, fa_scores = [], []
+    for n in n_components:
+        pca.n_components = n
+        fa.n_components = n
+        pca_scores.append(np.mean(np.concatenate(cross_val_score(pca, X))))
+        fa_scores.append(np.mean(np.concatenate(cross_val_score(fa, X))))
+
+    return pca_scores, fa_scores
+
+for X in [X_homo, X_hetero]:
+    pca_scores, fa_scores = compute_scores(X)
+    n_components_pca = n_components[np.argmax(pca_scores)]
+    n_components_fa = n_components[np.argmax(fa_scores)]
+
+    pca = PCA(n_components='mle')
+    pca.fit(X)
+    n_components_pca_mle = pca.n_components_
+
+    print("best n_components by PCA CV = %d" % n_components_pca)
+    print("best n_components by FactorAnalysis CV = %d" % n_components_fa)
+    print("best n_components by PCA MLE = %d" % n_components_pca_mle)
+
+    pl.figure()
+    pl.plot(n_components, pca_scores, 'b', label='PCA scores')
+    pl.plot(n_components, fa_scores, 'r', label='FA scores')
+    pl.axvline(rank, color='g', label='TRUTH: %d' % rank, linestyle='-')
+    pl.axvline(n_components_pca, color='b',
+               label='PCA CV: %d' % n_components_pca, linestyle='--')
+    pl.axvline(n_components_fa, color='r',
+               label='FactorAnalysis CV: %d' % n_components_fa, linestyle='--')
+    pl.axvline(n_components_pca_mle, color='k',
+               label='PCA MLE: %d' % n_components_pca_mle, linestyle='--')
+    pl.xlabel('nb of components')
+    pl.ylabel('CV scores')
+    pl.legend(loc='lower right')
+    pl.show()

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -68,8 +68,8 @@ def compute_scores(X):
 
     return pca_scores, fa_scores
 
-for X, title in zip([X_homo, X_hetero],
-                    ['Homoscedastic Noise', 'Heteroscedastic Noise']):
+for X, title in [(X_homo, 'Homoscedastic Noise'),
+                 (X_hetero, 'Heteroscedastic Noise')]:
     pca_scores, fa_scores = compute_scores(X)
     n_components_pca = n_components[np.argmax(pca_scores)]
     n_components_fa = n_components[np.argmax(fa_scores)]

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -1,5 +1,6 @@
 """Factor Analysis.
-A latent linear variable model, similar to ProbabilisticPCA.
+A latent linear variable model, similar to probabilistic PCA
+implemented by PCA.score
 
 This implementation is based on David Barber's Book,
 Bayesian Reasoning and Machine Learning,
@@ -107,9 +108,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    PCA: Principal component analysis, a similar non-probabilistic
-        model model that can be computed in closed form.
-    ProbabilisticPCA: probabilistic PCA.
+    PCA: Principal component analysis that also implements a probabilistic
+        model via a score method but that can be computed in closed form.
     FastICA: Independent component analysis, a latent variable model with
         non-Gaussian latent variables.
     """

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -261,7 +261,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        cov : array, shape=(n_features, n_features)
+        cov : array, shape (n_features, n_features)
             Estimated covariance of data.
         """
         cov = np.dot(self.components_.T, self.components_)
@@ -273,7 +273,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        precision : array, shape=(n_features, n_features)
+        precision : array, shape (n_features, n_features)
             Estimated precision of data.
         """
         n_features = self.components_.shape[1]
@@ -295,18 +295,18 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         precision.flat[::len(precision) + 1] += 1. / self.noise_variance_
         return precision
 
-    def score(self, X, y=None):
-        """Compute score of X under FactorAnalysis model.
+    def score_samples(self, X):
+        """Compute the log-likelihood of each sample
 
         Parameters
         ----------
-        X: array of shape(n_samples, n_features)
-            The data to test
+        X: array, shape (n_samples, n_features)
+            The data
 
         Returns
         -------
-        ll: array of shape (n_samples),
-            log-likelihood of each row of X under the current model
+        ll: array, shape (n_samples,)
+            Log-likelihood of each sample under the current model
         """
         Xr = X - self.mean_
         precision = self.get_precision()
@@ -316,3 +316,18 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         log_like -= .5 * (n_features * log(2. * np.pi)
                           - fast_logdet(precision))
         return log_like
+
+    def score(self, X, y=None):
+        """Compute the average log-likelihood of the samples
+
+        Parameters
+        ----------
+        X: array, shape (n_samples, n_features)
+            The data
+
+        Returns
+        -------
+        ll: float
+            Average log-likelihood of the samples under the current model
+        """
+        return np.mean(self.score_samples(X))

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -3,7 +3,7 @@
 A latent linear variable model.
 
 FactorAnalysis is similar to probabilistic PCA implemented by PCA.score
-While PCA assumes Gaussion noise with the same variance for each
+While PCA assumes Gaussian noise with the same variance for each
 feature, the FactorAnalysis model assumes different variances for
 each of them.
 

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -115,8 +115,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     --------
     PCA: Principal component analysis is also a latent linear variable model
         which however assumes equal noise variance for each feature.
-        This extra assumption makes PCA faster as it can be computed
-        in closed form.
+        This extra assumption makes probabilistic PCA faster as it can be
+        computed in closed form.
     FastICA: Independent component analysis, a latent variable model with
         non-Gaussian latent variables.
     """

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -1,6 +1,11 @@
 """Factor Analysis.
-A latent linear variable model, similar to probabilistic PCA
-implemented by PCA.score
+
+A latent linear variable model.
+
+FactorAnalysis is similar to probabilistic PCA implemented by PCA.score
+While PCA assumes Gaussion noise with the same variance for each
+feature, the FactorAnalysis model assumes different variances for
+each of them.
 
 This implementation is based on David Barber's Book,
 Bayesian Reasoning and Machine Learning,
@@ -108,8 +113,9 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    PCA: Principal component analysis that also implements a probabilistic
-        model via a score method. PCA is faster as it can be computed
+    PCA: Principal component analysis is also a latent linear variable model
+        which however assumes equal noise variance for each feature.
+        This extra assumption makes PCA faster as it can be computed
         in closed form.
     FastICA: Independent component analysis, a latent variable model with
         non-Gaussian latent variables.

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -109,7 +109,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     See also
     --------
     PCA: Principal component analysis that also implements a probabilistic
-        model via a score method but that can be computed in closed form.
+        model via a score method. PCA is faster as it can be computed
+        in closed form.
     FastICA: Independent component analysis, a latent variable model with
         non-Gaussian latent variables.
     """
@@ -289,8 +290,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         precision.flat[::len(precision) + 1] += 1.
         precision = np.dot(components_.T,
                            np.dot(linalg.inv(precision), components_))
-        precision /=  self.noise_variance_[:, np.newaxis]
-        precision /=  -self.noise_variance_[np.newaxis, :]
+        precision /= self.noise_variance_[:, np.newaxis]
+        precision /= -self.noise_variance_[np.newaxis, :]
         precision.flat[::len(precision) + 1] += 1. / self.noise_variance_
         return precision
 
@@ -311,7 +312,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         precision = self.get_precision()
         n_features = X.shape[1]
         log_like = np.zeros(X.shape[0])
-        self.precision_ = precision  # should not store it I guess...
         log_like = -.5 * (Xr * (np.dot(Xr, precision))).sum(axis=1)
-        log_like -= .5 * (-fast_logdet(precision) + n_features * log(2. * np.pi))
+        log_like -= .5 * (n_features * log(2. * np.pi)
+                          - fast_logdet(precision))
         return log_like

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -157,13 +157,20 @@ class PCA(BaseEstimator, TransformerMixin):
     `noise_variance_` : float
         The estimated noise covariance following the Probabilistic PCA model
         from Tipping and Bishop 1999. See "Pattern Recognition and
-        Machine Learning" by C. Bishop, 12.2.1 p. 574. Required to
+        Machine Learning" by C. Bishop, 12.2.1 p. 574 or
+        http://www.miketipping.com/papers/met-mppca.pdf. It is required to
         computed the estimated data covariance and score samples.
 
     Notes
     -----
     For n_components='mle', this class uses the method of `Thomas P. Minka:
     Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604`
+
+    Implements the probabilistic PCA model from:
+    M. Tipping and C. Bishop, Probabilistic Principal Component Analysis,
+    Journal of the Royal Statistical Society, Series B, 61, Part 3, pp. 611–622
+    via the score and score_samples methods.
+    See http://www.miketipping.com/papers/met-mppca.pdf
 
     Due to implementation subtleties of the Singular Value Decomposition (SVD),
     which is used in this implementation, running fit twice on the same matrix
@@ -403,6 +410,7 @@ class PCA(BaseEstimator, TransformerMixin):
 
         See. "Pattern Recognition and Machine Learning"
         by C. Bishop, 12.2.1 p. 574
+        or http://www.miketipping.com/papers/met-mppca.pdf
 
         Parameters
         ----------
@@ -428,6 +436,7 @@ class PCA(BaseEstimator, TransformerMixin):
 
         See. "Pattern Recognition and Machine Learning"
         by C. Bishop, 12.2.1 p. 574
+        or http://www.miketipping.com/papers/met-mppca.pdf
 
         Parameters
         ----------

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -286,7 +286,7 @@ class PCA(BaseEstimator, TransformerMixin):
             n_components = np.sum(ratio_cumsum < n_components) + 1
 
         # Compute noise covariance using Probabilistic PCA model
-        # The sigma2 maximum likely out (cf. eq. 12.46)
+        # The sigma2 maximum likelihood (cf. eq. 12.46)
         sigma2_ml = explained_variance_[n_components:].mean()
         exp_var = explained_variance_.copy()
         exp_var[n_components:] = sigma2_ml

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -368,8 +368,8 @@ class PCA(BaseEstimator, TransformerMixin):
 
 
 @deprecated("ProbabilisticPCA will be removed in 0.16. WARNING: The covariance"
-            " estimation is NOT correct and is now moved and corrected in PCA"
-            " object. To work with homoscedastic=False, you should use"
+            " estimation is NOT correct and is now moved to and corrected in"
+            " PCA. To work with homoscedastic=False, you should use"
             " FactorAnalysis.")
 class ProbabilisticPCA(PCA):
     """Additional layer on top of PCA that adds a probabilistic evaluation"""

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -18,6 +18,7 @@ from scipy.special import gammaln
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import array2d, check_random_state, as_float_array
 from ..utils import atleast2d_or_csr
+from ..utils import deprecated
 from ..utils.extmath import fast_logdet, safe_sparse_dot, randomized_svd, \
                             fast_dot
 
@@ -366,6 +367,10 @@ class PCA(BaseEstimator, TransformerMixin):
         return log_like
 
 
+@deprecated("ProbabilisticPCA will be removed in 0.16. WARNING: The covariance"
+            " estimation is NOT correct and is now moved and corrected in PCA"
+            " object. To work with homoscedastic=False, you should use"
+            " FactorAnalysis.")
 class ProbabilisticPCA(PCA):
     """Additional layer on top of PCA that adds a probabilistic evaluation"""
     __doc__ += PCA.__doc__

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -381,8 +381,8 @@ class PCA(BaseEstimator, TransformerMixin):
         n_features = X.shape[1]
         log_like = np.zeros(X.shape[0])
         covariance = self.get_covariance()
-        self.precision_ = linalg.inv(covariance)
-        log_like = -.5 * (Xr * (np.dot(Xr, self.precision_))).sum(axis=1)
+        precision = linalg.inv(covariance)
+        log_like = -.5 * (Xr * (np.dot(Xr, precision))).sum(axis=1)
         log_like -= .5 * (fast_logdet(covariance)
                           + n_features * log(2. * np.pi))
         return log_like

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -19,8 +19,8 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import array2d, check_random_state, as_float_array
 from ..utils import atleast2d_or_csr
 from ..utils import deprecated
-from ..utils.extmath import fast_logdet, safe_sparse_dot, randomized_svd, \
-                            fast_dot
+from ..utils.extmath import (fast_logdet, safe_sparse_dot, randomized_svd,
+                             fast_dot)
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
@@ -156,7 +156,7 @@ class PCA(BaseEstimator, TransformerMixin):
 
     `noise_variance_` : float
         The estimated noise covariance following the Probabilistic PCA model
-        from Tipping and Bishop 1999. See. "Pattern Recognition and
+        from Tipping and Bishop 1999. See "Pattern Recognition and
         Machine Learning" by C. Bishop, 12.2.1 p. 574. Required to
         computed the estimated data covariance and score samples.
 
@@ -298,8 +298,8 @@ class PCA(BaseEstimator, TransformerMixin):
 
         self.components_ = components_[:n_components]
         self.explained_variance_ = explained_variance_[:n_components]
-        self.explained_variance_ratio_ = \
-                                   explained_variance_ratio_[:n_components]
+        explained_variance_ratio_ = explained_variance_ratio_[:n_components]
+        self.explained_variance_ratio_ = explained_variance_ratio_
         self.n_components_ = n_components
 
         return (U, S, V)
@@ -353,7 +353,7 @@ class PCA(BaseEstimator, TransformerMixin):
         precision.flat[::len(precision) + 1] += 1. / exp_var_diff
         precision = np.dot(components_.T,
                            np.dot(linalg.inv(precision), components_))
-        precision /=  -(self.noise_variance_ ** 2)
+        precision /= -(self.noise_variance_ ** 2)
         precision.flat[::len(precision) + 1] += 1. / self.noise_variance_
         return precision
 
@@ -419,7 +419,8 @@ class PCA(BaseEstimator, TransformerMixin):
         log_like = np.zeros(X.shape[0])
         precision = self.get_precision()
         log_like = -.5 * (Xr * (np.dot(Xr, precision))).sum(axis=1)
-        log_like -= .5 * (n_features * log(2. * np.pi) - fast_logdet(precision))
+        log_like -= .5 * (n_features * log(2. * np.pi)
+                          - fast_logdet(precision))
         return log_like
 
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -300,7 +300,7 @@ class PCA(BaseEstimator, TransformerMixin):
         else:
             self.noise_variance_ = 0.
 
-        # store n_samples to revert whitening when gettting covariance
+        # store n_samples to revert whitening when getting covariance
         self.n_samples_ = n_samples
 
         self.components_ = components_[:n_components]

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -398,21 +398,21 @@ class PCA(BaseEstimator, TransformerMixin):
         """
         return fast_dot(X, self.components_) + self.mean_
 
-    def score(self, X, y=None):
-        """Return a score associated to new data
+    def score_samples(self, X):
+        """Return the log-likelihood of each sample
 
         See. "Pattern Recognition and Machine Learning"
         by C. Bishop, 12.2.1 p. 574
 
         Parameters
         ----------
-        X: array of shape(n_samples, n_features)
-            The data to test
+        X: array, shape(n_samples, n_features)
+            The data.
 
         Returns
         -------
-        ll: array of shape (n_samples),
-            log-likelihood of each row of X under the current model
+        ll: array, shape (n_samples,)
+            Log-likelihood of each sample under the current model
         """
         Xr = X - self.mean_
         n_features = X.shape[1]
@@ -422,6 +422,24 @@ class PCA(BaseEstimator, TransformerMixin):
         log_like -= .5 * (n_features * log(2. * np.pi)
                           - fast_logdet(precision))
         return log_like
+
+    def score(self, X, y=None):
+        """Return the average log-likelihood of all samples
+
+        See. "Pattern Recognition and Machine Learning"
+        by C. Bishop, 12.2.1 p. 574
+
+        Parameters
+        ----------
+        X: array, shape(n_samples, n_features)
+            The data.
+
+        Returns
+        -------
+        ll: float
+            Average log-likelihood of the samples under the current model
+        """
+        return np.mean(self.score_samples(X))
 
 
 @deprecated("ProbabilisticPCA will be removed in 0.16. WARNING: The covariance"

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -11,8 +11,8 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils import ConvergenceWarning
-
 from sklearn.decomposition import FactorAnalysis
 
 
@@ -62,6 +62,7 @@ def test_factor_analysis():
                             noise_variance_init=np.ones(n_features))
         assert_raises(ValueError, fa.fit, X[:, :2])
 
+
     f = lambda x, y: np.abs(getattr(x, y))  # sign will not be equal
     fa1, fa2 = fas
     for attr in ['loglike_', 'components_', 'noise_variance_']:
@@ -76,3 +77,26 @@ def test_factor_analysis():
         warnings.simplefilter('always', DeprecationWarning)
         FactorAnalysis(verbose=1)
         assert_true(w[-1].category == DeprecationWarning)
+
+    fa2 = FactorAnalysis(n_components=n_components,
+                         noise_variance_init=np.ones(n_features))
+    assert_raises(ValueError, fa2.fit, X[:, :2])
+
+    # Test get_covariance and get_precision with n_components < n_features
+    cov = fa.get_covariance()
+    precision = fa.get_precision()
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
+
+    # Test get_covariance and get_precision with n_components == n_features
+    fa.n_components = n_features
+    fa.fit(X)
+    cov = fa.get_covariance()
+    precision = fa.get_precision()
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
+
+    # Test get_covariance and get_precision with n_components == 0
+    fa.n_components = 0
+    fa.fit(X)
+    cov = fa.get_covariance()
+    precision = fa.get_precision()
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -33,6 +33,7 @@ def test_factor_analysis():
     # generate observations
     # wlog, mean is 0
     X = np.dot(h, W) + noise
+
     assert_raises(ValueError, FactorAnalysis, svd_method='foo')
     fa_fail = FactorAnalysis()
     fa_fail.svd_method = 'foo'
@@ -77,6 +78,25 @@ def test_factor_analysis():
         warnings.simplefilter('always', DeprecationWarning)
         FactorAnalysis(verbose=1)
         assert_true(w[-1].category == DeprecationWarning)
+
+    fa = FactorAnalysis(n_components=n_components)
+    fa.fit(X)
+    X_t = fa.transform(X)
+    assert_true(X_t.shape == (n_samples, n_components))
+
+    assert_almost_equal(fa.loglike_[-1], fa.score_samples(X).sum())
+    assert_almost_equal(fa.score_samples(X).mean(), fa.score(X))
+
+    # Make log likelihood increases at each iteration
+    assert_true(np.all(np.diff(fa.loglike_) > 0.))
+
+    # Sample Covariance
+    scov = np.cov(X, rowvar=0., bias=1.)
+
+    # Model Covariance
+    mcov = fa.get_covariance()
+    diff = np.sum(np.abs(scov - mcov)) / W.size
+    assert_true(diff < 0.1, "Mean absolute difference is %f" % diff)
 
     fa2 = FactorAnalysis(n_components=n_components,
                          noise_variance_init=np.ones(n_features))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -47,7 +47,8 @@ def test_factor_analysis():
         X_t = fa.transform(X)
         assert_equal(X_t.shape, (n_samples, n_components))
 
-        assert_almost_equal(fa.loglike_[-1], fa.score(X).sum())
+        assert_almost_equal(fa.loglike_[-1], fa.score_samples(X).sum())
+        assert_almost_equal(fa.score_samples(X).mean(), fa.score(X))
 
         diff = np.all(np.diff(fa.loglike_))
         assert_greater(diff, 0., 'Log likelihood dif not increase')
@@ -78,29 +79,6 @@ def test_factor_analysis():
         warnings.simplefilter('always', DeprecationWarning)
         FactorAnalysis(verbose=1)
         assert_true(w[-1].category == DeprecationWarning)
-
-    fa = FactorAnalysis(n_components=n_components)
-    fa.fit(X)
-    X_t = fa.transform(X)
-    assert_true(X_t.shape == (n_samples, n_components))
-
-    assert_almost_equal(fa.loglike_[-1], fa.score_samples(X).sum())
-    assert_almost_equal(fa.score_samples(X).mean(), fa.score(X))
-
-    # Make log likelihood increases at each iteration
-    assert_true(np.all(np.diff(fa.loglike_) > 0.))
-
-    # Sample Covariance
-    scov = np.cov(X, rowvar=0., bias=1.)
-
-    # Model Covariance
-    mcov = fa.get_covariance()
-    diff = np.sum(np.abs(scov - mcov)) / W.size
-    assert_true(diff < 0.1, "Mean absolute difference is %f" % diff)
-
-    fa2 = FactorAnalysis(n_components=n_components,
-                         noise_variance_init=np.ones(n_features))
-    assert_raises(ValueError, fa2.fit, X[:, :2])
 
     # Test get_covariance and get_precision with n_components == n_features
     # with n_components < n_features and with n_components == 0

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -102,21 +102,11 @@ def test_factor_analysis():
                          noise_variance_init=np.ones(n_features))
     assert_raises(ValueError, fa2.fit, X[:, :2])
 
-    # Test get_covariance and get_precision with n_components < n_features
-    cov = fa.get_covariance()
-    precision = fa.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
-
     # Test get_covariance and get_precision with n_components == n_features
-    fa.n_components = n_features
-    fa.fit(X)
-    cov = fa.get_covariance()
-    precision = fa.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
-
-    # Test get_covariance and get_precision with n_components == 0
-    fa.n_components = 0
-    fa.fit(X)
-    cov = fa.get_covariance()
-    precision = fa.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
+    # with n_components < n_features and with n_components == 0
+    for n_components in [0, 2, X.shape[1]]:
+        fa.n_components = n_components
+        fa.fit(X)
+        cov = fa.get_covariance()
+        precision = fa.get_precision()
+        assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -39,23 +39,13 @@ def test_pca():
     assert_array_almost_equal(X_r, X_r2)
 
     # Test get_covariance and get_precision with n_components == n_features
-    cov = pca.get_covariance()
-    precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
-
-    # Test get_covariance and get_precision with n_components < n_features
-    pca.n_components = 2
-    pca.fit(X)
-    cov = pca.get_covariance()
-    precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
-
-    # Test get_covariance and get_precision with n_components == 0
-    pca.n_components = 0
-    pca.fit(X)
-    cov = pca.get_covariance()
-    precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
+    # with n_components < n_features and with n_components == 0
+    for n_components in [0, 2, X.shape[1]]:
+        pca.n_components = n_components
+        pca.fit(X)
+        cov = pca.get_covariance()
+        precision = pca.get_precision()
+        assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
 
 
 def test_whitening():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -312,6 +312,47 @@ def test_infer_dim_by_explained_variance():
     assert_equal(pca.n_components_, 2)
 
 
+def test_pca_score():
+    """Test that probabilistic PCA scoring yields a reasonable score"""
+    n, p = 1000, 3
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    pca = PCA(n_components=2)
+    pca.fit(X)
+    ll1 = pca.score(X)
+    h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
+    np.testing.assert_almost_equal(ll1.mean() / h, 1, 0)
+
+
+def test_pca_score2():
+    """Test that probabilistic PCA correctly separated different datasets"""
+    n, p = 100, 3
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    pca = PCA(n_components=2)
+    pca.fit(X)
+    ll1 = pca.score(X)
+    ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
+    assert_greater(ll1.mean(), ll2.mean())
+
+
+def test_pca_score3():
+    """Check that probabilistic PCA selects the right model"""
+    n, p = 200, 3
+    rng = np.random.RandomState(0)
+    Xl = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5])
+          + np.array([1, 0, 7]))
+    Xt = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5])
+          + np.array([1, 0, 7]))
+    ll = np.zeros(p)
+    for k in range(p):
+        pca = PCA(n_components=k)
+        pca.fit(Xl)
+        ll[k] = pca.score(Xt).mean()
+
+    assert_true(ll.argmax() == 1)
+
+
 def test_probabilistic_pca_1():
     """Test that probabilistic PCA yields a reasonable score"""
     n, p = 1000, 3

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -340,7 +340,7 @@ def test_pca_score():
     pca.fit(X)
     ll1 = pca.score(X)
     h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
-    np.testing.assert_almost_equal(ll1.mean() / h, 1, 0)
+    np.testing.assert_almost_equal(ll1 / h, 1, 0)
 
 
 def test_pca_score2():
@@ -352,13 +352,13 @@ def test_pca_score2():
     pca.fit(X)
     ll1 = pca.score(X)
     ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
-    assert_greater(ll1.mean(), ll2.mean())
+    assert_greater(ll1, ll2)
 
     # Test that it gives the same scores if whiten=True
     pca = PCA(n_components=2, whiten=True)
     pca.fit(X)
     ll2 = pca.score(X)
-    assert_array_almost_equal(ll1, ll2)
+    assert_almost_equal(ll1, ll2)
 
 
 def test_pca_score3():
@@ -373,7 +373,7 @@ def test_pca_score3():
     for k in range(p):
         pca = PCA(n_components=k)
         pca.fit(Xl)
-        ll[k] = pca.score(Xt).mean()
+        ll[k] = pca.score(Xt)
 
     assert_true(ll.argmax() == 1)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -38,6 +38,25 @@ def test_pca():
 
     assert_array_almost_equal(X_r, X_r2)
 
+    # Test get_covariance and get_precision with n_components == n_features
+    covariance = pca.get_covariance()
+    precision = pca.get_precision()
+    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+
+    # Test get_covariance and get_precision with n_components < n_features
+    pca.n_components = 2
+    pca.fit(X)
+    covariance = pca.get_covariance()
+    precision = pca.get_precision()
+    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+
+    # Test get_covariance and get_precision with n_components == 0
+    pca.n_components = 0
+    pca.fit(X)
+    covariance = pca.get_covariance()
+    precision = pca.get_precision()
+    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+
 
 def test_whitening():
     """Check that PCA output has unit-variance"""

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -39,23 +39,23 @@ def test_pca():
     assert_array_almost_equal(X_r, X_r2)
 
     # Test get_covariance and get_precision with n_components == n_features
-    covariance = pca.get_covariance()
+    cov = pca.get_covariance()
     precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
 
     # Test get_covariance and get_precision with n_components < n_features
     pca.n_components = 2
     pca.fit(X)
-    covariance = pca.get_covariance()
+    cov = pca.get_covariance()
     precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
 
     # Test get_covariance and get_precision with n_components == 0
     pca.n_components = 0
     pca.fit(X)
-    covariance = pca.get_covariance()
+    cov = pca.get_covariance()
     precision = pca.get_precision()
-    assert_array_almost_equal(np.dot(covariance, precision), np.eye(X.shape[1]), 12)
+    assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
 
 
 def test_whitening():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -335,6 +335,12 @@ def test_pca_score2():
     ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
     assert_greater(ll1.mean(), ll2.mean())
 
+    # Test that it gives the same scores if whiten=True
+    pca = PCA(n_components=2, whiten=True)
+    pca.fit(X)
+    ll2 = pca.score(X)
+    assert_array_almost_equal(ll1, ll2)
+
 
 def test_pca_score3():
     """Check that probabilistic PCA selects the right model"""

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -403,7 +403,7 @@ def test_probabilistic_pca_2():
 
 
 def test_probabilistic_pca_3():
-    """The homoscedastic model should work slightly worth
+    """The homoscedastic model should work slightly worse
     than the heteroscedastic one in over-fitting condition
     """
     n, p = 100, 3
@@ -414,7 +414,8 @@ def test_probabilistic_pca_3():
     ll1 = ppca.score(X)
     ppca.fit(X, homoscedastic=False)
     ll2 = ppca.score(X)
-    assert_less(ll1.mean(), ll2.mean())
+    # XXX : Don't test as homoscedastic=False is buggy
+    # Comment to be removed with ProbabilisticPCA is removed
 
 
 def test_probabilistic_pca_4():
@@ -432,6 +433,17 @@ def test_probabilistic_pca_4():
         ll[k] = ppca.score(Xt).mean()
 
     assert_true(ll.argmax() == 1)
+
+
+def test_probabilistic_pca_vs_pca():
+    """Test that PCA matches ProbabilisticPCA with homoscedastic=True
+    """
+    n, p = 100, 3
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    pca = PCA(n_components=2).fit(X)
+    ppca = ProbabilisticPCA(n_components=2).fit(X)
+    assert_array_almost_equal(pca.score_samples(X), ppca.score(X))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
there is a serious bug in ProbabilisticPCA. The estimate of the covariance is wrong.
Rather than fixing it with hacks I moved the score method to PCA and propose to
remove ProbabilisticPCA. Basically I would have need to recompute the SVD
to as PCA.fit drops the extra singular values. Also the homoscedastic=False
mode is much better addressed by the FactorAnalysis estimator.
