### PR TITLE
BUG: remove remaining utf-8 characters in docstrings.

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -881,7 +881,7 @@ def _make_int_array():
 class TfidfTransformer(BaseEstimator, TransformerMixin):
     """Transform a count matrix to a normalized tf or tf-idf representation
 
-    Tf means term-frequency while tf–idf means term-frequency times inverse
+    Tf means term-frequency while tf-idf means term-frequency times inverse
     document-frequency. This is a common term weighting scheme in information
     retrieval, that has also found good use in document classification.
 


### PR DESCRIPTION
This is the last non-ascii character in docstring. Adding this on top of other non ascii-related recent commits, I can import MDP 3.3.
