### PR TITLE
[MRG]: use randomized_svd in FactorAnalysis (addresses #1272)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Changelog
      scale up gracefully to large datasets. By `Lars Buitinck`_.
 
   - Add `randomized_svd` option to :class:`decomposition.factor_analysis.FactorAnalysis`
-    to save memory by factor 2 and speedup computation by factor of 9
+    to save memory by factor 2 and speedup computation by factor 9
     by `Denis Engemann`_, and `Alexandre Gramfort`_.
 
 .. _changes_0_14:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,9 @@ Changelog
      sparse matrices and has much lower memory complexity, meaning it will
      scale up gracefully to large datasets. By `Lars Buitinck`_.
 
+  - Add `randomized_svd` option to :class:`decomposition.factor_analysis.FactorAnalysis`
+    to save memory by factor 2 and speedup computation by factor of 9
+    by `Denis Engemann`_, and `Alexandre Gramfort`_.
 
 .. _changes_0_14:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,8 +24,8 @@ Changelog
      scale up gracefully to large datasets. By `Lars Buitinck`_.
 
   - Add `randomized_svd` option to :class:`decomposition.factor_analysis.FactorAnalysis`
-    to save memory by factor 2 and speedup computation by factor 9
-    by `Denis Engemann`_, and `Alexandre Gramfort`_.
+    to save memory and significantly speedup computation by `Denis Engemann`_, and
+    `Alexandre Gramfort`_.
 
 .. _changes_0_14:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,8 +23,9 @@ Changelog
      sparse matrices and has much lower memory complexity, meaning it will
      scale up gracefully to large datasets. By `Lars Buitinck`_.
 
-  - Add `randomized_svd` option to :class:`decomposition.factor_analysis.FactorAnalysis`
-    to save memory and significantly speedup computation by `Denis Engemann`_, and
+  - Add svd_method option with default value to "randomized" to
+    :class:`decomposition.factor_analysis.FactorAnalysis` to save memory and
+    significantly speedup computation by `Denis Engemann`_, and
     `Alexandre Gramfort`_.
 
 .. _changes_0_14:

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -69,7 +69,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     svd_method : str
         Which SVD method to use. If 'svd' use standard SVD from scipy.linalg.
-        If 'randomized-svd' use fast ``randomized_svd`` function.
+        If 'randomized-svd' use fast ``randomized`` function.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling. Only used

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -124,6 +124,12 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
             raise ValueError('SVD method %s is not supported. Please consider'
                              ' the documentation' % svd_method)
         self.svd_method = svd_method
+        if verbose:
+            warnings.warn('The `verbose` parameter has been deprecated and '
+                          'will be removed in 0.16. To reduce verbosity '
+                          'silence Python warnings instead.',
+                          DeprecationWarning)
+
         self.verbose = verbose
         self.noise_variance_init = noise_variance_init
         self.iterated_power = iterated_power
@@ -209,11 +215,10 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
             psi = np.maximum(var - np.sum(W ** 2, axis=0), SMALL)
         else:
-            if self.verbose:
-                warnings.warn('FactorAnalysis did not converge.' +
-                              ' You might want' +
-                              ' to increase the number of iterations.',
-                              ConvergenceWarning)
+            warnings.warn('FactorAnalysis did not converge.' +
+                          ' You might want' +
+                          ' to increase the number of iterations.',
+                          ConvergenceWarning)
 
         self.components_ = W
         self.noise_variance_ = psi

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -84,8 +84,6 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         Pseudo number generator state used for random sampling. Only used
         if ``svd_method`` equals 'randomized'
 
-
-
     Attributes
     ----------
     `components_` : array, [n_components, n_features]

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -9,7 +9,7 @@ Algorithm 21.1
 
 # Author: Christian Osendorfer <osendorf@gmail.com>
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
-#         Denis A. Engemsnn <d.engemann@fz-juelich.de>
+#         Denis A. Engemann <d.engemann@fz-juelich.de>
 
 # Licence: BSD3
 
@@ -67,6 +67,9 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         The initial guess of the noise variance for each feature.
         If None, it defaults to np.ones(n_features)
 
+    use_randomized_svd : int | bool
+        Whether to use randomized SVD or not. Defaults to False.
+
     Attributes
     ----------
     `components_` : array, [n_components, n_features]
@@ -95,8 +98,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         non-Gaussian latent variables.
     """
     def __init__(self, n_components=None, tol=1e-2, copy=True, max_iter=1000,
-                 verbose=0, use_randomized_svd=False,
-                 noise_variance_init=None):
+                 verbose=0, noise_variance_init=None,
+                 use_randomized_svd=False):
         self.n_components = n_components
         self.copy = copy
         self.tol = tol
@@ -160,7 +163,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
             del _
             s **= 2
             # Use 'maximum' here to avoid sqrt problems.
-            W = np.sqrt(np.maximum(s[:n_components] - 1., 0.))[:, np.newaxis] * V
+            W = np.sqrt(np.maximum(s[:n_components] - 1., 0.)
+                        )[:, np.newaxis] * V
             del V
             W *= sqrt_psi
 

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -13,6 +13,7 @@ Algorithm 21.1
 
 # Licence: BSD3
 
+import warnings
 from math import sqrt, log
 import numpy as np
 from scipy import linalg
@@ -22,6 +23,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals.six.moves import xrange
 from ..utils import array2d, check_arrays, check_random_state
 from ..utils.extmath import fast_logdet, fast_dot, randomized_svd
+from ..utils import ConvergenceWarning
 
 
 class FactorAnalysis(BaseEstimator, TransformerMixin):
@@ -208,7 +210,10 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
             psi = np.maximum(var - np.sum(W ** 2, axis=0), SMALL)
         else:
             if self.verbose:
-                print("Did not converge")
+                warnings.warn('FactorAnalysis did not converge.' +
+                              ' You might want' +
+                              ' to increase the number of iterations.',
+                              ConvergenceWarning)
 
         self.components_ = W
         self.noise_variance_ = psi

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -148,10 +148,13 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         old_ll = -np.inf
         SMALL = 1e-12
 
+        # we'll modify svd outputs to return unexplained variance
+        # to allow for unified computation of loglikelihood
         if self.algorithm == 'svd':
             def my_svd(X):
                 U, s, V = linalg.svd(X, full_matrices=False)
-                return s, V[:n_components], np.sum(s[n_components:] ** 2)
+                return (s[:n_components], V[:n_components],
+                        np.sum(s[n_components:] ** 2))
         elif self.algorithm == 'randomized-svd':
             def my_svd(X):
                 U, s, V = randomized_svd(X, n_components)

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -181,7 +181,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
             def my_svd(X):
                 _, s, V = linalg.svd(X, full_matrices=False)
                 return (s[:n_components], V[:n_components],
-                        np.sum(s[n_components:] ** 2))
+                        np.dot(s[n_components:].flat, s[n_components:].flat))
         elif self.svd_method == 'randomized':
             random_state = check_random_state(self.random_state)
 
@@ -189,7 +189,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
                 _, s, V = randomized_svd(X, n_components,
                                          random_state=random_state,
                                          n_iter=self.iterated_power)
-                return s, V, (X ** 2).sum() - np.sum(s ** 2)
+                return s, V, np.dot(X.flat, X.flat) - np.dot(s, s)
         else:
             raise ValueError('SVD method %s is not supported. Please consider'
                              ' the documentation' % self.svd_method)

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -9,6 +9,8 @@ Algorithm 21.1
 
 # Author: Christian Osendorfer <osendorf@gmail.com>
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#         Denis A. Engemsnn <d.engemann@fz-juelich.de>
+
 # Licence: BSD3
 
 from math import sqrt, log

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -71,8 +71,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         Which SVD method to use. If 'svd' use standard SVD from scipy.linalg,
         if 'randomized' use fast ``randomized`` function. Defaults to 'svd'.
         For maximum precision you should choose 'svd'. For most applications
-        'randomized' be sufficiently precise while providing significant
-        speed gains, up to a factor of 8.
+        'randomized' will be sufficiently precise while providing significant
+        speed gains.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling. Only used

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -69,10 +69,10 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     svd_method : {'svd', 'randomized'}
         Which SVD method to use. If 'svd' use standard SVD from scipy.linalg,
-        if 'randomized' use fast ``randomized`` function. Defaults to 'svd'.
-        For maximum precision you should choose 'svd'. For most applications
-        'randomized' will be sufficiently precise while providing significant
-        speed gains.
+        if 'randomized' use fast ``randomized_svd`` function. Defaults to
+        'randomized'. For maximum precision you should choose 'svd'. For most
+        applications 'randomized' will be sufficiently precise while providing
+        significant speed gains.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling. Only used
@@ -112,6 +112,9 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         self.copy = copy
         self.tol = tol
         self.max_iter = max_iter
+        if svd_method not in ['svd', 'randomized']:
+            raise ValueError('SVD method %s is not supported. Please consider'
+                             ' the documentation' % svd_method)
         self.svd_method = svd_method
         self.verbose = verbose
         self.noise_variance_init = noise_variance_init

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -67,9 +67,12 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         The initial guess of the noise variance for each feature.
         If None, it defaults to np.ones(n_features)
 
-    svd_method : str
+    svd_method : {'svd', 'randomized'}
         Which SVD method to use. If 'svd' use standard SVD from scipy.linalg,
-        if 'randomized' use fast ``randomized`` function.
+        if 'randomized' use fast ``randomized`` function. Defaults to 'svd'.
+        For maximum precision you should choose 'svd'. For most applications
+        'randomized' be sufficiently precise while providing significant
+        speed gains, up to a factor of 8.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling. Only used
@@ -109,9 +112,6 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         self.copy = copy
         self.tol = tol
         self.max_iter = max_iter
-        if svd_method not in ['svd', 'randomized']:
-            raise ValueError('SVD method %s is not supported. Please consider'
-                             ' the documentation' % svd_method)
         self.svd_method = svd_method
         self.verbose = verbose
         self.noise_variance_init = noise_variance_init
@@ -171,6 +171,9 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
                 _, s, V = randomized_svd(X, n_components,
                                          random_state=random_state)
                 return s, V, (X ** 2).sum() - np.sum(s ** 2)
+        else:
+            raise ValueError('SVD method %s is not supported. Please consider'
+                             ' the documentation' % self.svd_method)
 
         for i in xrange(self.max_iter):
             # SMALL helps numerics

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -68,8 +68,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         If None, it defaults to np.ones(n_features)
 
     svd_method : str
-        Which SVD method to use. If 'svd' use standard SVD from scipy.linalg.
-        If 'randomized-svd' use fast ``randomized`` function.
+        Which SVD method to use. If 'svd' use standard SVD from scipy.linalg,
+        if 'randomized' use fast ``randomized`` function.
 
     random_state : int or RandomState
         Pseudo number generator state used for random sampling. Only used

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -70,10 +70,11 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     svd_method : {'lapack', 'randomized'}
         Which SVD method to use. If 'lapack' use standard SVD from
         scipy.linalg, if 'randomized' use fast ``randomized_svd`` function.
-        Defaults to 'randomized'. For maximum precision you should choose
-        'lapack'. For most applications 'randomized' will be sufficiently
-        precise while providing significant speed gains. Accuracy can also
-        be improved by setting higher values for `iterated_power`.
+        Defaults to 'randomized'. For most applications 'randomized' will
+        be sufficiently precise while providing significant speed gains.
+        Accuracy can also be improved by setting higher values for
+        `iterated_power`. If this is not sufficient, for maximum precision
+        you should choose 'lapack'.
 
     iterated_power : int, optional
         Number of iterations for the power method. 3 by default. Only used

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -93,7 +93,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         non-Gaussian latent variables.
     """
     def __init__(self, n_components=None, tol=1e-2, copy=True, max_iter=1000,
-                 verbose=0, use_randomized_svd=False, noise_variance_init=None):
+                 verbose=0, use_randomized_svd=False,
+                 noise_variance_init=None):
         self.n_components = n_components
         self.copy = copy
         self.tol = tol
@@ -143,10 +144,10 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         SMALL = 1e-12
 
         if self.use_randomized_svd:
-            my_svd = lambda X: use_randomized_svd(X, n_components)
+            my_svd = lambda X: randomized_svd(X, n_components)
         else:
             def my_svd(X):
-                U, s, V = linalg.svd(X)
+                U, s, V = linalg.svd(X, full_matrices=False)
                 V = V[:n_components]
                 return U, s, V
 

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -72,3 +72,7 @@ def test_factor_analysis():
         fa1.verbose = True
         fa1.fit(X)
         assert_true(w[-1].category == ConvergenceWarning)
+
+        warnings.simplefilter('always', DeprecationWarning)
+        FactorAnalysis(verbose=1)
+        assert_true(w[-1].category == DeprecationWarning)

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -5,6 +5,7 @@
 import numpy as np
 
 from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_almost_equal
 
@@ -28,7 +29,7 @@ def test_factor_analysis():
     # generate observations
     # wlog, mean is 0
     X = np.dot(h, W) + noise
-    assert_raises(ValueError, FactorAnalysis, svd_method='foo')
+    assert_raises(ValueError, FactorAnalysis(svd_method='foo').fit, X)
     fas = []
     for method in ['randomized', 'svd']:
         fa = FactorAnalysis(n_components=n_components, svd_method=method)
@@ -36,7 +37,7 @@ def test_factor_analysis():
         fas.append(fa)
 
         X_t = fa.transform(X)
-        assert_true(X_t.shape == (n_samples, n_components))
+        assert_equal(X_t.shape, (n_samples, n_components))
 
         assert_almost_equal(fa.loglike_[-1], fa.score(X).sum())
 
@@ -57,5 +58,4 @@ def test_factor_analysis():
     f = lambda x, y: np.abs(getattr(x, y))  # sign will not be equal
     fa1, fa2 = fas
     for attr in ['loglike_', 'components_', 'noise_variance_']:
-
         assert_almost_equal(f(fa1, attr), f(fa2, attr))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -34,7 +34,7 @@ def test_factor_analysis():
     fa_fail.svd_method = 'foo'
     assert_raises(ValueError, fa_fail.fit, X)
     fas = []
-    for method in ['randomized', 'svd']:
+    for method in ['randomized', 'lapack']:
         fa = FactorAnalysis(n_components=n_components, svd_method=method)
         fa.fit(X)
         fas.append(fa)
@@ -44,7 +44,7 @@ def test_factor_analysis():
 
         assert_almost_equal(fa.loglike_[-1], fa.score(X).sum())
 
-        # Make log likelihood increases at each iteration
+        # Make sure log likelihood increases at each iteration
         assert_true(np.all(np.diff(fa.loglike_) > 0.))
 
         # Sample Covariance

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,9 +29,12 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
     assert_raises(ValueError, FactorAnalysis, svd_method='foo')
+    fas = []
     for method in ['randomized', 'svd']:
         fa = FactorAnalysis(n_components=n_components, svd_method=method)
         fa.fit(X)
+        fas.append(fa)
+
         X_t = fa.transform(X)
         assert_true(X_t.shape == (n_samples, n_components))
 
@@ -47,7 +50,12 @@ def test_factor_analysis():
         mcov = fa.get_covariance()
         diff = np.sum(np.abs(scov - mcov)) / W.size
         assert_true(diff < 0.1, "Mean absolute difference is %f" % diff)
-
         fa = FactorAnalysis(n_components=n_components,
                             noise_variance_init=np.ones(n_features))
         assert_raises(ValueError, fa.fit, X[:, :2])
+
+    f = lambda x, y: np.abs(getattr(x, y))  # sign will not be equal
+    fa1, fa2 = fas
+    for attr in ['loglike_', 'components_', 'noise_variance_']:
+
+        assert_almost_equal(f(fa1, attr), f(fa2, attr))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,7 +29,7 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
 
-    fa = FactorAnalysis(n_components=n_components, use_randomized_svd=True)
+    fa = FactorAnalysis(n_components=n_components, use_randomized_svd=False)
     fa.fit(X)
     X_t = fa.transform(X)
     assert_true(X_t.shape == (n_samples, n_components))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,7 +29,10 @@ def test_factor_analysis():
     # generate observations
     # wlog, mean is 0
     X = np.dot(h, W) + noise
-    assert_raises(ValueError, FactorAnalysis(svd_method='foo').fit, X)
+    assert_raises(ValueError, FactorAnalysis, svd_method='foo')
+    fa_fail = FactorAnalysis()
+    fa_fail.svd_method = 'foo'
+    assert_raises(ValueError, fa_fail.fit, X)
     fas = []
     for method in ['randomized', 'svd']:
         fa = FactorAnalysis(n_components=n_components, svd_method=method)

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,7 +29,7 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
 
-    fa = FactorAnalysis(n_components=n_components, use_randomized_svd=False)
+    fa = FactorAnalysis(n_components=n_components, algorithm='randomized-svd')
     fa.fit(X)
     X_t = fa.transform(X)
     assert_true(X_t.shape == (n_samples, n_components))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,24 +29,25 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
 
-    fa = FactorAnalysis(n_components=n_components, algorithm='randomized-svd')
-    fa.fit(X)
-    X_t = fa.transform(X)
-    assert_true(X_t.shape == (n_samples, n_components))
+    for algo in ['randomized-svd', 'svd']:
+        fa = FactorAnalysis(n_components=n_components, algorithm=algo)
+        fa.fit(X)
+        X_t = fa.transform(X)
+        assert_true(X_t.shape == (n_samples, n_components))
 
-    assert_almost_equal(fa.loglike_[-1], fa.score(X).sum())
+        assert_almost_equal(fa.loglike_[-1], fa.score(X).sum())
 
-    # Make log likelihood increases at each iteration
-    assert_true(np.all(np.diff(fa.loglike_) > 0.))
+        # Make log likelihood increases at each iteration
+        assert_true(np.all(np.diff(fa.loglike_) > 0.))
 
-    # Sample Covariance
-    scov = np.cov(X, rowvar=0., bias=1.)
+        # Sample Covariance
+        scov = np.cov(X, rowvar=0., bias=1.)
 
-    # Model Covariance
-    mcov = fa.get_covariance()
-    diff = np.sum(np.abs(scov - mcov)) / W.size
-    assert_true(diff < 0.1, "Mean absolute difference is %f" % diff)
+        # Model Covariance
+        mcov = fa.get_covariance()
+        diff = np.sum(np.abs(scov - mcov)) / W.size
+        assert_true(diff < 0.1, "Mean absolute difference is %f" % diff)
 
-    fa = FactorAnalysis(n_components=n_components,
-                        noise_variance_init=np.ones(n_features))
-    assert_raises(ValueError, fa.fit, X[:, :2])
+        fa = FactorAnalysis(n_components=n_components,
+                            noise_variance_init=np.ones(n_features))
+        assert_raises(ValueError, fa.fit, X[:, :2])

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -29,7 +29,7 @@ def test_factor_analysis():
     # wlog, mean is 0
     X = np.dot(h, W) + noise
 
-    fa = FactorAnalysis(n_components=n_components)
+    fa = FactorAnalysis(n_components=n_components, use_randomized_svd=True)
     fa.fit(X)
     X_t = fa.transform(X)
     assert_true(X_t.shape == (n_samples, n_components))

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -28,9 +28,9 @@ def test_factor_analysis():
     # generate observations
     # wlog, mean is 0
     X = np.dot(h, W) + noise
-
-    for algo in ['randomized-svd', 'svd']:
-        fa = FactorAnalysis(n_components=n_components, algorithm=algo)
+    assert_raises(ValueError, FactorAnalysis, svd_method='foo')
+    for method in ['randomized', 'svd']:
+        fa = FactorAnalysis(n_components=n_components, svd_method=method)
         fa.fit(X)
         X_t = fa.transform(X)
         assert_true(X_t.shape == (n_samples, n_components))


### PR DESCRIPTION
We can change the API later for WIP I'd like to keep the use_randomized_svd flag.
So far there's only one issue, the loglikelihood does not sum up. The error is bigger for lower rank problems. For n_components == n_features there is maximum match, often around 2 decimals as compared to 100 to 10, depending on data.
Downstream applications seem reasonably sane while the speed + memory benefit is highly significant.
![factor_analysis_svd_comparison](https://f.cloud.github.com/assets/1908618/1052929/170a620a-10e6-11e3-81c1-57725462fce6.png)

See https://gist.github.com/dengemann/6379368

Priorities:
- fix test
- settle API
- think about warm start

cc @agramfort @ogrisel
