### PR TITLE
[MRG] export randomized_svd publicly

### DIFF
--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -44,7 +44,7 @@ import numpy as np
 
 from scipy import sparse
 
-from sklearn.utils.extmath import randomized_svd
+from sklearn.decomposition import randomized_svd
 from sklearn.externals.joblib import Memory
 
 

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -14,6 +14,7 @@ from .dict_learning import (dict_learning, dict_learning_online, sparse_encode,
                             DictionaryLearning, MiniBatchDictionaryLearning,
                             SparseCoder)
 from .factor_analysis import FactorAnalysis
+from ..utils.extmath import randomized_svd
 
 __all__ = ['DictionaryLearning',
            'FastICA',
@@ -30,6 +31,7 @@ __all__ = ['DictionaryLearning',
            'dict_learning',
            'dict_learning_online',
            'fastica',
+           'randomized_svd',
            'sparse_encode',
            'FactorAnalysis',
            'TruncatedSVD']


### PR DESCRIPTION
This patch makes `randomized_svd` a public function in `sklearn.decomposition`, so that the Wikipedia eigenvectors example no longer has to import it from `sklearn.utils`.
