### PR TITLE
[MRG] Simplify linear models

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -126,8 +126,8 @@ class LinearModel(six.with_metaclass(ABCMeta, BaseEstimator)):
     def fit(self, X, y):
         """Fit model."""
 
-    def decision_function(self, X):
-        """Decision function of the linear model.
+    def predict(self, X):
+        """Predict using the linear model.
 
         Parameters
         ----------
@@ -142,21 +142,6 @@ class LinearModel(six.with_metaclass(ABCMeta, BaseEstimator)):
         X = safe_asarray(X)
         return safe_sparse_dot(X, self.coef_.T,
                                dense_output=True) + self.intercept_
-
-    def predict(self, X):
-        """Predict using the linear model
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix}, shape = (n_samples, n_features)
-            Samples.
-
-        Returns
-        -------
-        C : array, shape = (n_samples,)
-            Returns predicted values.
-        """
-        return self.decision_function(X)
 
     _center_data = staticmethod(center_data)
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -628,24 +628,6 @@ class ElasticNet(LinearModel, RegressorMixin):
         """ sparse representation of the fitted coef """
         return sparse.csr_matrix(self.coef_)
 
-    def decision_function(self, X):
-        """Decision function of the linear model
-
-        Parameters
-        ----------
-        X : numpy array or scipy.sparse matrix of shape (n_samples, n_features)
-
-        Returns
-        -------
-        T : array, shape = (n_samples,)
-            The predicted decision function
-        """
-        if sparse.isspmatrix(X):
-            return np.ravel(safe_sparse_dot(self.coef_, X.T, dense_output=True)
-                            + self.intercept_)
-        else:
-            return super(ElasticNet, self).decision_function(X)
-
 
 ###############################################################################
 # Lasso model

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -14,7 +14,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from scipy import sparse
 
-from .base import LinearModel, _pre_fit
+from .base import LinearModel, _pre_fit, SparseCoefMixin
 from ..base import RegressorMixin
 from .base import center_data
 from ..utils import array2d, atleast2d_or_csc, deprecated
@@ -445,7 +445,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 # ElasticNet model
 
 
-class ElasticNet(LinearModel, RegressorMixin):
+class ElasticNet(LinearModel, RegressorMixin, SparseCoefMixin):
     """Linear Model trained with L1 and L2 prior as regularizer
 
     Minimizes the objective function::
@@ -625,7 +625,10 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     @property
     def sparse_coef_(self):
-        """ sparse representation of the fitted coef """
+        """Sparse representation of the fitted coef_."""
+        warnings.warn("sparse_coef_ is deprecated and will be removed in 0.17."
+                      " Call the sparsify method instead.",
+                      DeprecationWarning)
         return sparse.csr_matrix(self.coef_)
 
 

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -399,8 +399,6 @@ def test_multitarget():
     for estimator in (linear_model.LassoLars(), linear_model.Lars()):
         estimator.fit(X, Y)
         Y_pred = estimator.predict(X)
-        Y_dec = estimator.decision_function(X)
-        assert_array_almost_equal(Y_pred, Y_dec)
         alphas, active, coef, path = (estimator.alphas_, estimator.active_,
                                       estimator.coef_, estimator.coef_path_)
         for k in range(n_targets):


### PR DESCRIPTION
Two changes to streamline the `sklearn.linear_model` module:
- to fix #1404, I removed `decision_function` from regression estimators;
- CD estimators now have `densify` and `sparsify`, like the SGD ones, to support sparse coefficients. Deprecated the previous hack.
