### PR TITLE
Fixes issue #2445.

### DIFF
--- a/sklearn/metrics/cluster/bicluster/bicluster_metrics.py
+++ b/sklearn/metrics/cluster/bicluster/bicluster_metrics.py
@@ -77,4 +77,4 @@ def consensus_score(a, b, similarity="jaccard"):
     indices = linear_assignment(1. - matrix)
     n_a = len(a[0])
     n_b = len(b[0])
-    return np.trace(matrix[:, indices[:, 1]]) / max(n_a, n_b)
+    return matrix[indices[:, 0], indices[:, 1]].sum() / max(n_a, n_b)


### PR DESCRIPTION
This commit fixes issue #2445: When comparing bicluster-results that contain 
different number of biclusters, `sklearn.metrics.consensus_score` can sometimes
give wrong results. This is fixed here.
