### PR TITLE
Issue #2455: Make RBM work with sparse input when verbose=True.

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -185,7 +185,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         free_energy : array-like, shape (n_samples,)
             The value of the free energy.
         """
-        return - np.dot(v, self.intercept_visible_) - np.log(1. + np.exp(
+        return - safe_sparse_dot(v, self.intercept_visible_) - np.log(1. + np.exp(
             safe_sparse_dot(v, self.components_.T) + self.intercept_hidden_)) \
             .sum(axis=1)
 
@@ -262,7 +262,10 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         rng = check_random_state(self.random_state)
         fe = self._free_energy(v)
 
-        v_ = v.copy()
+        if issparse(v):
+            v_ = v.toarray()
+        else:
+            v_ = v.copy()
         i_ = rng.randint(0, v.shape[1], v.shape[0])
         v_[np.arange(v.shape[0]), i_] = 1 - v_[np.arange(v.shape[0]), i_]
         fe_ = self._free_energy(v_)

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-
 from numpy.testing import assert_almost_equal, assert_array_equal
 
 from sklearn.datasets import load_digits
@@ -121,3 +120,24 @@ def test_rbm_verbose():
         rbm.fit(Xdigits)
     finally:
         sys.stdout = old_stdout
+
+
+
+
+def test_sparse_and_verbose():
+    """
+    Make sure RBM works with sparse input when verbose=True
+    """
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    from scipy.sparse import csc_matrix
+    X = csc_matrix([[0.], [1.]])
+    rbm = BernoulliRBM(n_components=2, batch_size=2, n_iter=1, 
+        random_state=42, verbose=True)
+    is_working = False
+    try:
+        rbm.fit(X)
+        is_working = True # we should reach here
+    finally:
+        sys.stdout = old_stdout
+    assert(is_working)


### PR DESCRIPTION
This fixes Issue #2455:

the BernoulliRBM class was unable to handle sparse inputs when `verbose=True` was set.
