### PR TITLE
[MRG] Switch BernoulliRBM to CSR format

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -16,6 +16,7 @@ from ..externals.six.moves import xrange
 from ..utils import check_arrays
 from ..utils import check_random_state
 from ..utils import gen_even_slices
+from ..utils import issparse
 from ..utils.extmath import safe_sparse_dot
 from ..utils.extmath import logistic_sigmoid
 

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -49,8 +49,10 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         Number of iterations/sweeps over the training dataset to perform
         during training.
 
-    verbose : bool, optional
-        The verbosity level.
+    verbose : int, optional
+        The verbosity level. Enabling it (with a non-zero value) will compute 
+        the log-likelihood of each mini-batch and hence cause a runtime overhead
+        in the order of 10%.
 
     random_state : integer or numpy.RandomState, optional
         A random number generator instance to define the state of the

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -186,9 +186,9 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         free_energy : array-like, shape (n_samples,)
             The value of the free energy.
         """
-        return - safe_sparse_dot(v, self.intercept_visible_) - np.log(1. + np.exp(
-            safe_sparse_dot(v, self.components_.T) + self.intercept_hidden_)) \
-            .sum(axis=1)
+        return (- safe_sparse_dot(v, self.intercept_visible_)
+                - np.log(1. + np.exp(safe_sparse_dot(v, self.components_.T)
+                            + self.intercept_hidden_)).sum(axis=1))
 
     def gibbs(self, v):
         """Perform one Gibbs sampling step.

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -112,7 +112,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         h : array, shape (n_samples, n_components)
             Latent representations of the data.
         """
-        X, = check_arrays(X, sparse_format='csc', dtype=np.float)
+        X, = check_arrays(X, sparse_format='csr', dtype=np.float)
         return self._mean_hiddens(X)
 
     def _mean_hiddens(self, v):
@@ -285,7 +285,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         self : BernoulliRBM
             The fitted model.
         """
-        X, = check_arrays(X, sparse_format='csc', dtype=np.float)
+        X, = check_arrays(X, sparse_format='csr', dtype=np.float)
         n_samples = X.shape[0]
         rng = check_random_state(self.random_state)
 

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -185,7 +185,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         free_energy : array-like, shape (n_samples,)
             The value of the free energy.
         """
-        return - np.dot(v, self.intercept_visible_) - np.log(1. + np.exp(
+        return - safe_sparse_dot(v, self.intercept_visible_) - np.log(1. + np.exp(
             safe_sparse_dot(v, self.components_.T) + self.intercept_hidden_)) \
             .sum(axis=1)
 
@@ -262,7 +262,10 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         rng = check_random_state(self.random_state)
         fe = self._free_energy(v)
 
-        v_ = v.copy()
+        if issparse(v):
+            v_ = v.toarray()
+        else:
+            v_ = v.copy()
         i_ = rng.randint(0, v.shape[1], v.shape[0])
         v_[np.arange(v.shape[0]), i_] = 1 - v_[np.arange(v.shape[0]), i_]
         fe_ = self._free_energy(v_)

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -1,4 +1,5 @@
 import sys
+import re
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -130,9 +131,14 @@ def test_sparse_and_verbose():
     sys.stdout = StringIO()
     from scipy.sparse import csc_matrix
     X = csc_matrix([[0.], [1.]])
-    rbm = BernoulliRBM(n_components=2, batch_size=2, n_iter=1, 
-        random_state=42, verbose=True)
+    rbm = BernoulliRBM(n_components=2, batch_size=2, n_iter=1,
+                       random_state=42, verbose=True)
     try:
         rbm.fit(X)
+        s = sys.stdout.getvalue()
+        # make sure output is sound
+        assert(re.match(r"Iteration 0, pseudo-likelihood = -?(\d)+(\.\d+)?",
+                        s))
     finally:
+        sio = sys.stdout
         sys.stdout = old_stdout

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-
 from numpy.testing import assert_almost_equal, assert_array_equal
 
 from sklearn.datasets import load_digits
@@ -121,3 +120,24 @@ def test_rbm_verbose():
         rbm.fit(Xdigits)
     finally:
         sys.stdout = old_stdout
+
+
+
+
+def test_sparse_and_verbose():
+    """
+    Make sure RBM works with sparse input when verbose=True
+    """
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    from scipy.sparse import csc_matrix
+    X = csc_matrix([[0.], [1.]])
+    rbm = BernoulliRBM(n_components=2, batch_size=2, n_iter=1, 
+        random_state=42, verbose=True)
+    is_working = False
+    try:
+        rbm.fit(X)
+        is_working = True # we should reach here
+    finally:
+        sys.stdout = old_stdout
+    assert(is_working)

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -122,8 +122,6 @@ def test_rbm_verbose():
         sys.stdout = old_stdout
 
 
-
-
 def test_sparse_and_verbose():
     """
     Make sure RBM works with sparse input when verbose=True
@@ -134,10 +132,7 @@ def test_sparse_and_verbose():
     X = csc_matrix([[0.], [1.]])
     rbm = BernoulliRBM(n_components=2, batch_size=2, n_iter=1, 
         random_state=42, verbose=True)
-    is_working = False
     try:
         rbm.fit(X)
-        is_working = True # we should reach here
     finally:
         sys.stdout = old_stdout
-    assert(is_working)


### PR DESCRIPTION
While taking a look at Issue #2455, I've noticed that `BernoulliRBM`  enforces CSC format for sparse data. However it accesses the data row-wise (it trains in Minibatches of `batch_size` rows). Thus CSR format seems like a much more natural choice.

I ran some short tests on a 2000x100000 sparse matrix with 95% sparsity on an RBM with 128 components, and saw a speedup of ~ 5% when switching from CSC to CSR matrices... (I'd expect the speedup to be larger on larger matrices).
