### PR TITLE
[MRG + 1] support X_norm_squared in euclidean_distances

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -363,6 +363,31 @@ def test_euclidean_distances():
     D = euclidean_distances(X, Y)
     assert_array_almost_equal(D, [[1., 2.]])
 
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((10, 4))
+    Y = rng.random_sample((20, 4))
+    X_norm_sq = (X ** 2).sum(axis=1)
+    Y_norm_sq = (Y ** 2).sum(axis=1)
+
+    # check that we still get the right answers with {X,Y}_norm_squared
+    D1 = euclidean_distances(X, Y)
+    D2 = euclidean_distances(X, Y, X_norm_squared=X_norm_sq)
+    D3 = euclidean_distances(X, Y, Y_norm_squared=Y_norm_sq)
+    D4 = euclidean_distances(X, Y, X_norm_squared=X_norm_sq,
+                             Y_norm_squared=Y_norm_sq)
+    assert_array_almost_equal(D2, D1)
+    assert_array_almost_equal(D3, D1)
+    assert_array_almost_equal(D4, D1)
+
+    # check we get the wrong answer with wrong {X,Y}_norm_squared
+    X_norm_sq *= 0.5
+    Y_norm_sq *= 0.5
+    wrong_D = euclidean_distances(X, Y,
+                                  X_norm_squared=np.zeros_like(X_norm_sq),
+                                  Y_norm_squared=np.zeros_like(Y_norm_sq))
+    assert_greater(np.max(np.abs(wrong_D - D1)), .01)
+
+
 
 # Paired distances
 


### PR DESCRIPTION
There's a comment in `euclidean_distances` saying

```
# should not need X_norm_squared because if you could precompute that as
# well as Y, then you should just pre-compute the output and not even
# call this function.
```

That's not necessarily true, though. I've run into a situation today where I have a whole bunch of sets, and need to do something based on the distances between each pair of sets. It's helpful to cache the squared norms for each of the sets; if I did that and called it with just `Y_norm_squared` for each pair, that'd still be recomputing the norms for `X` all the time. (Of course, I can just do it without the helper function, which is what I'm doing now, but it's nicer to use helpers....)

Another situation is when you happen to already have the squared norms for a set `X` and then you want `euclidean_distances(X)`. I guessed that maybe `euclidean_distances(X, Y_norm_squared=X_norm_sq)` would work, but looking at the code that doesn't actually use `X_norm_sq`. Now `euclidean_distances` can handle that case too.

This also adds an extremely simple test that passing `X_norm_squared` and/or `Y_norm_squared` gives the same result; previously there was no test that used `Y_norm_squared.`

As an aside: I have no idea why `XX` is being computed with `X * X` and `YY` with `Y ** 2` (which necessitates the annoying copy code when it's sparse); it seems like it should be exactly the same situation, except for the very minor difference of the shape. I left it as-is, though.
