### PR TITLE
[WIP] Label power set multilabel classification strategy

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -930,6 +930,7 @@ See the :ref:`metrics` section of the user guide for further details.
     multiclass.OneVsRestClassifier
     multiclass.OneVsOneClassifier
     multiclass.OutputCodeClassifier
+    multiclass.LabelPowerSetClassifier
 
 .. _naive_bayes_ref:
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -33,7 +33,7 @@ by decomposing such problems into binary classification problems.
     several joint classification tasks. This is a generalization
     of the multi-label classification task, where the set of classification
     problem is restricted to binary classification, and of the multi-class
-    classification task. *The output format is a 2d numpy array or sparse 
+    classification task. *The output format is a 2d numpy array or sparse
     matrix.*
 
     The set of labels can be different for each output variable.
@@ -110,8 +110,9 @@ format.
 One-Vs-The-Rest
 ===============
 
-This strategy, also known as **one-vs-all**, is implemented in
-:class:`OneVsRestClassifier`.  The strategy consists in fitting one classifier
+This strategy, also known as **one-vs-all** or as **binary relevance**, is
+implemented in :class:`OneVsRestClassifier`.  The strategy consists in fitting
+one classifier
 per class. For each classifier, the class is fitted against all the other
 classes. In addition to its computational efficiency (only `n_classes`
 classifiers are needed), one advantage of this approach is its
@@ -143,9 +144,8 @@ Multilabel learning
 -------------------
 
 :class:`OneVsRestClassifier` also supports multilabel classification.
-To use this feature, feed the classifier an indicator matrix, in which cell
-[i, j] indicates the presence of label j in sample i.
-
+To use this feature, feed the classifier with a binary indicator matrix.
+In this context, one-versus-rest is also called binary relevance.
 
 .. figure:: ../auto_examples/images/plot_multilabel_001.png
     :target: ../auto_examples/plot_multilabel.html
@@ -276,3 +276,34 @@ Below is an example of multiclass learning using Output-Codes::
     .. [3] "The Elements of Statistical Learning",
         Hastie T., Tibshirani R., Friedman J., page 606 (second-edition)
         2008.
+
+
+Label power set
+===============
+
+:class:`LabelPowerSetClassifier` is a multilabel problem transformation method:
+each label set of the training is associated to one class. Once the output is
+tranformed, the :class:`LabelPowerSetClassifier`fits one classifier on the
+multi-class task. At prediction time, the classifier predicts the most relevant
+class which is translated to the corresponding label set. Since the number of
+generated classes is equal to ``O(min(2^n_labels), n_samples)``, this method
+suffers from the combinatorial explosion of possible label sets and overfit
+over the data. Nevertheless, this allows to take into account the label
+correlation contrarily to One-Vs-The-Rest.
+
+Below is an example of multi-label learning using
+:class:`LabelPowerSetClassifier`:
+
+  >>> from sklearn.datasets import make_multilabel_classification
+  >>> from sklearn.multiclass import LabelPowerSetClassifier
+  >>> from sklearn.svm import LinearSVC
+  >>> from sklearn.cross_validation import train_test_split
+  >>> from sklearn.metrics import jaccard_similarity_score
+  >>> X, y = make_multilabel_classification(return_indicator=True,
+  ...                                       n_samples=200, random_state=0)
+  >>> X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+  >>> classifier = LabelPowerSetClassifier(LinearSVC(random_state=1))
+  >>> classifier.fit(X_train, y_train)
+  >>> y_pred = classifier.predict(X_test)
+  >>> jaccard_similarity_score(y_test, y_pred)  # doctest: +ELLIPSIS
+  0.45...

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -884,7 +884,7 @@ class LabelPowerSetClassifier(BaseEstimator, ClassifierMixin,
         if self.label_binarizer_.y_type_ == "binary":
             binary_code_size = 1
 
-        shifting_vector =  2 ** np.arange(binary_code_size)
+        shifting_vector = 2 ** np.arange(binary_code_size)
 
         # Shift the binary representation of a class
         y_shifted = y_coded.reshape((-1, 1)) // shifting_vector
@@ -894,7 +894,6 @@ class LabelPowerSetClassifier(BaseEstimator, ClassifierMixin,
         y_decoded = np.bitwise_and(0x1, y_shifted)
 
         return self.label_binarizer_.inverse_transform(y_decoded)
-
 
     def predict_proba(self, X):
         """Predict class probabilities of the input samples X.
@@ -917,19 +916,21 @@ class LabelPowerSetClassifier(BaseEstimator, ClassifierMixin,
         if self.label_binarizer_.y_type_ == "binary":
             binary_code_size = 1
 
-        print binary_code_size
+        print(binary_code_size)
         if len(y_coded_proba.shape) != binary_code_size:
             # Make sure to have the empty label set
             y_coded_proba = np.hstack([np.zeros((y_coded_proba.shape[0], 1)),
                                        y_coded_proba])
+            assert False
 
         mask_code = np.array(list(product([0, 1], repeat=binary_code_size))).T
         y_proba = []
         for k in range(binary_code_size):
-            print y_coded_proba.shape
-            print mask_code[k]
-            proba_k = y_coded_proba[:, mask_code[k]].sum(axis=0)
-            y_proba.append(np.hstack([1 - proba_k, proba_k]))
+            print(y_coded_proba.shape)
+            print(mask_code[k])
+            # print(y_coded_proba)
+            proba_k = y_coded_proba[:, mask_code[k]].sum(axis=1)
+            print(proba_k.shape)
+            y_proba.append(np.vstack([1 - proba_k, proba_k]).T)
 
         return y_proba
-

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -893,3 +893,31 @@ class LabelPowerSetClassifier(BaseEstimator, ClassifierMixin,
         y_decoded = np.bitwise_and(0x1, y_shifted)
 
         return self.label_binarizer_.inverse_transform(y_decoded)
+
+
+    def predict_proba(self, X):
+        """Predict class probabilities of the input samples X.
+
+        Parameters
+        ----------
+        X : array-like of shape = [n_samples, n_features]
+            The input samples.
+
+        Returns
+        -------
+        p : array of shape = [n_samples, n_classes], or a list of n_outputs
+            such arrays if n_outputs > 1.
+            The class probabilities of the input samples. The order of the
+            classes corresponds to that in the attribute `classes_`.
+        """
+        y_coded_proba = self.estimator.predict_proba(X)
+        binary_code_size = len(self.label_binarizer_.classes_)
+
+        if self.label_binarizer_.y_type_ == "binary":
+            binary_code_size = 1
+
+        p = []
+        for j in range(n_labels):
+            pass
+
+        #np.array(list(product([0, 1], repeat=4)))

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -36,8 +36,9 @@ case.
 # License: BSD 3 clause
 
 import array
-import numpy as np
 import warnings
+from itertools import product
+import numpy as np
 import scipy.sparse as sp
 
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
@@ -916,8 +917,19 @@ class LabelPowerSetClassifier(BaseEstimator, ClassifierMixin,
         if self.label_binarizer_.y_type_ == "binary":
             binary_code_size = 1
 
-        p = []
-        for j in range(n_labels):
-            pass
+        print binary_code_size
+        if len(y_coded_proba.shape) != binary_code_size:
+            # Make sure to have the empty label set
+            y_coded_proba = np.hstack([np.zeros((y_coded_proba.shape[0], 1)),
+                                       y_coded_proba])
 
-        #np.array(list(product([0, 1], repeat=4)))
+        mask_code = np.array(list(product([0, 1], repeat=binary_code_size))).T
+        y_proba = []
+        for k in range(binary_code_size):
+            print y_coded_proba.shape
+            print mask_code[k]
+            proba_k = y_coded_proba[:, mask_code[k]].sum(axis=0)
+            y_proba.append(np.hstack([1 - proba_k, proba_k]))
+
+        return y_proba
+

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -637,18 +637,21 @@ def test_lps_binary():
 
     assert_equal(out_lps.shape, Y_test.shape)
     assert_array_equal(out_lps, out_svc)
+    assert_equal(len(lps.label_binarizer_.classes_), 2)
+
 
 
 def test_lps_multiclass():
-    lp = LabelPowerSetClassifier(LinearSVC(random_state=0))
-    lp.fit(iris.data, iris.target)
-    out_lp = lp.predict(iris.data)
+    lps = LabelPowerSetClassifier(LinearSVC(random_state=0))
+    lps.fit(iris.data, iris.target)
+    out_lp = lps.predict(iris.data)
 
     svc = LinearSVC(random_state=0)
     svc.fit(iris.data, iris.target)
     out_svc = svc.predict(iris.data)
 
     assert_array_equal(out_lp, out_svc)
+    assert_equal(len(lps.label_binarizer_.classes_), 3)
 
 
 def test_lps_multilabel():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -640,7 +640,6 @@ def test_lps_binary():
     assert_equal(len(lps.label_binarizer_.classes_), 2)
 
 
-
 def test_lps_multiclass():
     lps = LabelPowerSetClassifier(LinearSVC(random_state=0))
     lps.fit(iris.data, iris.target)
@@ -654,15 +653,23 @@ def test_lps_multiclass():
     assert_equal(len(lps.label_binarizer_.classes_), 3)
 
 
-def test_lps_multilabel():
-    X, Y = datasets.make_multilabel_classification(n_samples=50,
+def test_lps_multilabel(n_samples=50):
+    X, Y = datasets.make_multilabel_classification(n_samples=n_samples,
                                                    n_features=20,
+                                                   n_classes=3,
                                                    random_state=0,
                                                    return_indicator=True)
 
     X_train, X_test, Y_train, Y_test = train_test_split(X, Y, random_state=0)
 
-    lps = LabelPowerSetClassifier(LinearSVC(random_state=0))
+    lps = LabelPowerSetClassifier(DecisionTreeClassifier(random_state=0,
+                                                         max_depth=3))
     lps.fit(X_train, Y_train)
     out_lps = lps.predict(X_test)
     assert_equal(out_lps.shape, Y_test.shape)
+
+    y_predict_proba = lps.predict_proba(X_test)
+    for proba_k in y_predict_proba:
+        assert_equal(proba_k.shape, (n_samples, 2))
+
+    assert False

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -670,6 +670,7 @@ def test_lps_multilabel(n_samples=50):
 
     y_predict_proba = lps.predict_proba(X_test)
     for proba_k in y_predict_proba:
-        assert_equal(proba_k.shape, (n_samples, 2))
+        print(proba_k)
+        assert_equal(proba_k.shape, (X_test.shape[0], 2))
 
     assert False

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -514,7 +514,8 @@ def uninstall_mldata_mock():
 # Meta estimators need another estimator to be instantiated.
 META_ESTIMATORS = ["OneVsOneClassifier",
                    "OutputCodeClassifier", "OneVsRestClassifier", "RFE",
-                   "RFECV", "BaseEnsemble"]
+                   "RFECV", "BaseEnsemble", "LabelPowerSetClassifier"]
+
 # estimators that there is no way to default-construct sensibly
 OTHER = ["Pipeline", "FeatureUnion", "GridSearchCV",
          "RandomizedSearchCV"]


### PR DESCRIPTION
Add one of the simplest and common multi-label classification strategy which use 
a multi-class classifier as a base estimator.

The core code is functional, but there is still things to do:
- [x] Add some word about binary relevance in ovr narrative doc
- [x] Write narrative doc about LP
- [x] Add some references  
- [x] Add some regression tests
- [x] "making your remark about overfitting a bit more explicit maybe?"
