### PR TITLE
[MRG] Fix FeatureUnion when n_jobs != 1

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -222,15 +222,17 @@ def _fit_transform_one(transformer, name, X, y, transformer_weights,
     if transformer_weights is not None and name in transformer_weights:
         # if we have a weight for this transformer, muliply output
         if hasattr(transformer, 'fit_transform'):
-            return (transformer.fit_transform(X, y, **fit_params)
-                    * transformer_weights[name])
+            X_transformed = transformer.fit_transform(X, y, **fit_params)
+            return X_transformed * transformer_weights[name], transformer
         else:
-            return (transformer.fit(X, y, **fit_params).transform(X)
-                    * transformer_weights[name])
+            X_transformed = transformer.fit(X, y, **fit_params).transform(X)
+            return X_transformed * transformer_weights[name], transformer
     if hasattr(transformer, 'fit_transform'):
-        return transformer.fit_transform(X, y, **fit_params)
+        X_transformed = transformer.fit_transform(X, y, **fit_params)
+        return X_transformed, transformer
     else:
-        return transformer.fit(X, y, **fit_params).transform(X)
+        X_transformed = transformer.fit(X, y, **fit_params).transform(X)
+        return X_transformed, transformer
 
 
 class FeatureUnion(BaseEstimator, TransformerMixin):
@@ -284,13 +286,10 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
         X : array-like or sparse matrix, shape (n_samples, n_features)
             Input data, used to fit transformers.
         """
-        new_list = Parallel(n_jobs=self.n_jobs)(
+        transformers = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_one_transformer)(trans, X, y)
             for name, trans in self.transformer_list)
-        self.transformer_list[:] = [
-            (name, new)
-            for ((name, old), new) in zip(self.transformer_list, new_list)
-        ]
+        self._update_transformer_list(transformers)
         return self
 
     def fit_transform(self, X, y=None, **fit_params):
@@ -308,10 +307,13 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers.
         """
-        Xs = Parallel(n_jobs=self.n_jobs)(
+        result = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_transform_one)(trans, name, X, y,
                                         self.transformer_weights, **fit_params)
             for name, trans in self.transformer_list)
+
+        Xs, transformers = zip(*result)
+        self._update_transformer_list(transformers)
         if any(sparse.issparse(f) for f in Xs):
             Xs = sparse.hstack(Xs).tocsr()
         else:
@@ -350,3 +352,10 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
                 for key, value in iteritems(trans.get_params(deep=True)):
                     out['%s__%s' % (name, key)] = value
             return out
+
+    def _update_transformer_list(self, transformers):
+        self.transformer_list[:] = [
+            (name, new)
+            for ((name, old), new) in zip(self.transformer_list, transformers)
+        ]
+

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -306,12 +306,12 @@ def test_feature_union_parallel():
     fs_parallel = FeatureUnion([
         ("words", CountVectorizer(analyzer='word')),
         ("chars", CountVectorizer(analyzer='char')),
-    ], n_jobs=-1)
+    ], n_jobs=2)
 
     fs_parallel2 = FeatureUnion([
         ("words", CountVectorizer(analyzer='word')),
         ("chars", CountVectorizer(analyzer='char')),
-    ], n_jobs=-1)
+    ], n_jobs=2)
 
     fs.fit(X)
     X_transformed = fs.transform(X)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -22,6 +22,16 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
 
 
+JUNK_FOOD_DOCS = (
+    "the pizza pizza beer copyright",
+    "the pizza burger beer copyright",
+    "the the pizza beer beer copyright",
+    "the burger beer beer copyright",
+    "the coke burger coke copyright",
+    "the coke burger burger",
+)
+
+
 class IncorrectT(BaseEstimator):
     """Small class to test parameter dispatching.
     """
@@ -284,15 +294,42 @@ def test_feature_union_weights():
     assert_equal(X_fit_transformed_wo_method.shape, (X.shape[0], 7))
 
 
-def test_feature_union_feature_names():
-    JUNK_FOOD_DOCS = (
-        "the pizza pizza beer copyright",
-        "the pizza burger beer copyright",
-        "the the pizza beer beer copyright",
-        "the burger beer beer copyright",
-        "the coke burger coke copyright",
-        "the coke burger burger",
+def test_feature_union_parallel():
+    # test that n_jobs work for FeatureUnion
+    X = JUNK_FOOD_DOCS
+
+    fs = FeatureUnion([
+        ("words", CountVectorizer(analyzer='word')),
+        ("chars", CountVectorizer(analyzer='char')),
+    ])
+
+    fs_parallel = FeatureUnion([
+        ("words", CountVectorizer(analyzer='word')),
+        ("chars", CountVectorizer(analyzer='char')),
+    ], n_jobs=-1)
+
+    fs.fit(X)
+    X_transformed = fs.transform(X)
+    assert_equal(X_transformed.shape[0], len(X))
+
+    fs_parallel.fit(X)
+    X_transformed_parallel = fs_parallel.transform(X)
+    assert_equal(X_transformed.shape, X_transformed_parallel.shape)
+    assert_array_equal(
+        X_transformed.toarray(),
+        X_transformed_parallel.toarray()
     )
+
+    # fit_transform should behave the same
+    X_transformed_parallel2 = fs_parallel.fit_transform(X)
+    assert_array_equal(
+        X_transformed.toarray(),
+        X_transformed_parallel2.toarray()
+    )
+
+
+
+def test_feature_union_feature_names():
     word_vect = CountVectorizer(analyzer="word")
     char_vect = CountVectorizer(analyzer="char_wb", ngram_range=(3, 3))
     ft = FeatureUnion([("chars", char_vect), ("words", word_vect)])

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -308,6 +308,11 @@ def test_feature_union_parallel():
         ("chars", CountVectorizer(analyzer='char')),
     ], n_jobs=-1)
 
+    fs_parallel2 = FeatureUnion([
+        ("words", CountVectorizer(analyzer='word')),
+        ("chars", CountVectorizer(analyzer='char')),
+    ], n_jobs=-1)
+
     fs.fit(X)
     X_transformed = fs.transform(X)
     assert_equal(X_transformed.shape[0], len(X))
@@ -321,12 +326,18 @@ def test_feature_union_parallel():
     )
 
     # fit_transform should behave the same
-    X_transformed_parallel2 = fs_parallel.fit_transform(X)
+    X_transformed_parallel2 = fs_parallel2.fit_transform(X)
     assert_array_equal(
         X_transformed.toarray(),
         X_transformed_parallel2.toarray()
     )
 
+    # transformers should stay fit after fit_transform
+    X_transformed_parallel2 = fs_parallel2.transform(X)
+    assert_array_equal(
+        X_transformed.toarray(),
+        X_transformed_parallel2.toarray()
+    )
 
 
 def test_feature_union_feature_names():


### PR DESCRIPTION
It didn't work previously because transformers were fit in another processes, and information they learned was not transferred back.
