### PR TITLE
Pipeline string formatting TypeError

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -78,7 +78,7 @@ class Pipeline(BaseEstimator):
         self.named_steps = dict(steps)
         names, estimators = zip(*steps)
         if len(self.named_steps) != len(steps):
-            raise ValueError("Names provided are not unique: %s" % names)
+            raise ValueError("Names provided are not unique: %s" % (names,))
 
         # shallow copy of steps
         self.steps = tosequence(zip(names, estimators))

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -82,6 +82,9 @@ def test_pipeline_init():
     filter1 = SelectKBest(f_classif)
     pipe = Pipeline([('anova', filter1), ('svc', clf)])
 
+    # Check that we can't use the same stage name twice
+    assert_raises(ValueError, Pipeline, [('svc', SVC()), ('svc', SVC())])
+
     # Check that params are set
     pipe.set_params(svc__C=0.1)
     assert_equal(clf.C, 0.1)


### PR DESCRIPTION
When pipeline tries to raise a ValueError because of non-unique names, Python tries to look into the tuple and throws a `TypeError: Not all strings converted during formatting`.

This is fixed by wrapping names in a 1-tuple.
