### PR TITLE
[MRG] Add tests for splitter="presort-best"

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -4,6 +4,7 @@ Testing for the tree module (sklearn.tree).
 import pickle
 import numpy as np
 
+from functools import partial
 from itertools import product
 
 from sklearn.metrics import accuracy_score
@@ -34,11 +35,15 @@ REG_CRITERIONS = ("mse", )
 
 CLF_TREES = {
     "DecisionTreeClassifier": DecisionTreeClassifier,
+    "Presort-DecisionTreeClassifier": partial(DecisionTreeClassifier,
+                                              splitter="presort-best"),
     "ExtraTreeClassifier": ExtraTreeClassifier,
 }
 
 REG_TREES = {
     "DecisionTreeRegressor": DecisionTreeRegressor,
+    "Presort-DecisionTreeRegressor": partial(DecisionTreeRegressor,
+                                             splitter="presort-best"),
     "ExtraTreeRegressor": ExtraTreeRegressor,
 }
 


### PR DESCRIPTION
This adds trees built with a PresortBestSplitter to the tests in `test_tree.py`.

Waiting for Travis green light to merge this. 
