### PR TITLE
Fix typo in the Gaussian PDF in Naive Bayes docs

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -83,7 +83,7 @@ classification. The likelihood of the features is assumed to be Gaussian:
 
 .. math::
 
-   P(x_i \mid y) &= \frac{1}{\sqrt{2\pi\sigma^2_y}} \exp\left(-\frac{ (x_i - \mu_y)^2}{2\pi\sigma^2_y}\right)
+   P(x_i \mid y) &= \frac{1}{\sqrt{2\pi\sigma^2_y}} \exp\left(-\frac{(x_i - \mu_y)^2}{2\sigma^2_y}\right)
 
 The parameters :math:`\sigma_y` and :math:`\mu_y`
 are estimated using maximum likelihood.


### PR DESCRIPTION
Hopefully, this same issue doesn't exist in the code.

I would also feel more comfortable if mu_y and sigma_y were mu_iy and sigma_iy, respectively, seeing as there are separate distributions per feature, per class.
