### PR TITLE
DOC add copybutton to code examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -224,3 +224,8 @@ latex_preamble = r"""
 #latex_use_modindex = True
 
 trim_doctests_flags = True
+
+# Add the 'copybutton' javascript, to hide/show the prompt in code
+# examples
+def setup(app):
+    app.add_javascript('js/copybutton.js')

--- a/doc/themes/scikit-learn/static/js/copybutton.js
+++ b/doc/themes/scikit-learn/static/js/copybutton.js
@@ -1,0 +1,57 @@
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-python .highlight,' +
+                '.highlight-python3 .highlight,' + 
+                '.highlight-pycon .highlight')
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide the prompts and output';
+    var show_text = 'Show the prompts and output';
+    var border_width = pre.css('border-top-width');
+    var border_style = pre.css('border-top-style');
+    var border_color = pre.css('border-top-color');
+    var button_styles = {
+        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+        'border-color': border_color, 'border-style': border_style,
+        'border-width': border_width, 'color': border_color, 'text-size': '75%',
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em'
+    }
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+            button.css(button_styles)
+            button.attr('title', hide_text);
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').toggle(
+        function() {
+            var button = $(this);
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+        },
+        function() {
+            var button = $(this);
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+        });
+});
+

--- a/doc/themes/scikit-learn/static/js/copybutton.js
+++ b/doc/themes/scikit-learn/static/js/copybutton.js
@@ -1,7 +1,9 @@
 $(document).ready(function() {
     /* Add a [>>>] button on the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
-     * copyable. */
+     * copyable. 
+     * Note: This JS snippet was taken from the official python.org
+     * documentation site.*/
     var div = $('.highlight-python .highlight,' +
                 '.highlight-python3 .highlight,' + 
                 '.highlight-pycon .highlight')


### PR DESCRIPTION
This adds a non-intrusive button to codeblocks in the docs

It hides the `.>>>' ect and makes it easy to copy into ipython

See [scipy-lecture-notes](http://scipy-lectures.github.io/intro/language/control_flow.html#while-break-continue) for an example of this.

![screenshot at 2013-10-14 09 32 35](https://f.cloud.github.com/assets/1378870/1323993/120cc974-34a3-11e3-8afc-040122d35b85.png)

becomes

![screenshot at 2013-10-14 09 32 46](https://f.cloud.github.com/assets/1378870/1323996/1aad8334-34a3-11e3-9dfe-0dd21dc9c42e.png)
