### PR TITLE
[MRG] FIX #2481: add warning for bug in old numpy with unicode

### DIFF
--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -853,7 +853,6 @@ def test_classification_report_multiclass_with_unicode_label():
 
 avg / total       0.51      0.53      0.47        75
 """
-    print(np_version)
     if np_version[:3] < (1, 6, 1):
         # check that we get a warning about a bug in numpy
         with warnings.catch_warnings(record=True) as record:

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -13,6 +13,7 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.datasets import make_multilabel_classification
 from sklearn.utils import check_random_state, shuffle
 from sklearn.utils.multiclass import unique_labels
+from sklearn.utils.fixes import np_version
 from sklearn.utils.testing import (assert_true,
                                    assert_raises,
                                    assert_raise_message,
@@ -839,11 +840,11 @@ avg / total       0.51      0.53      0.47        75
 def test_classification_report_multiclass_with_unicode_label():
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    labels = np.array([u("blue\xa2"), u("green\xa2"), u("red\xa2")])
+    labels = np.array([u"blue\xa2", u"green\xa2", u"red\xa2"])
     y_true = labels[y_true]
     y_pred = labels[y_pred]
 
-    expected_report = u("""\
+    expected_report = u"""\
              precision    recall  f1-score   support
 
       blue\xa2       0.83      0.79      0.81        24
@@ -851,9 +852,17 @@ def test_classification_report_multiclass_with_unicode_label():
        red\xa2       0.42      0.90      0.57        20
 
 avg / total       0.51      0.53      0.47        75
-""")
-    report = classification_report(y_true, y_pred)
-    assert_equal(report, expected_report)
+"""
+    print(np_version)
+    if np_version[:3] < (1, 6, 1):
+        # check that we get a warning about a bug in numpy
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter('always')
+            classification_report(y_true, y_pred)
+        assert_true(len(record) != 0)
+    else:
+        report = classification_report(y_true, y_pred)
+        assert_equal(report, expected_report)
 
 
 def test_multilabel_classification_report():

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -854,11 +854,10 @@ def test_classification_report_multiclass_with_unicode_label():
 avg / total       0.51      0.53      0.47        75
 """
     if np_version[:3] < (1, 6, 1):
-        # check that we get a warning about a bug in numpy
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter('always')
-            classification_report(y_true, y_pred)
-        assert_true(len(record) != 0)
+        expected_message = ("NumPy < 1.6.1 does not implement"
+                            " searchsorted on unicode data correctly.")
+        assert_raise_message(RuntimeError, expected_message,
+                             classification_report, y_true, y_pred)
     else:
         report = classification_report(y_true, y_pred)
         assert_equal(report, expected_report)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -4,8 +4,6 @@
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: BSD 3 clause
 
-import warnings
-
 import numpy as np
 
 from ..base import BaseEstimator, TransformerMixin
@@ -27,7 +25,7 @@ __all__ = [
     'LabelEncoder',
 ]
 
-def _warn_numpy_unicode_bug(labels):
+def _check_numpy_unicode_bug(labels):
     """Check that user is not subject to an old numpy bug
 
     Fixed in master before 1.7.0:
@@ -37,9 +35,9 @@ def _warn_numpy_unicode_bug(labels):
     and then backported to 1.6.1.
     """
     if np_version[:3] < (1, 6, 1) and labels.dtype.kind == 'U':
-        warnings.warn("NumPy < 1.6.1 does not implement searchsorted"
-                      " on unicode data correctly. Please upgrade"
-                      " NumPy to use LabelEncoder with unicode inputs.")
+        raise RuntimeError("NumPy < 1.6.1 does not implement searchsorted"
+                           " on unicode data correctly. Please upgrade"
+                           " NumPy to use LabelEncoder with unicode inputs.")
 
 
 class LabelEncoder(BaseEstimator, TransformerMixin):
@@ -97,7 +95,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         y = column_or_1d(y, warn=True)
-        _warn_numpy_unicode_bug(y)
+        _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
         return self
 
@@ -114,7 +112,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         y = column_or_1d(y, warn=True)
-        _warn_numpy_unicode_bug(y)
+        _check_numpy_unicode_bug(y)
         self.classes_, y = unique(y, return_inverse=True)
         return y
 
@@ -133,7 +131,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self._check_fitted()
 
         classes = np.unique(y)
-        _warn_numpy_unicode_bug(classes)
+        _check_numpy_unicode_bug(classes)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
             raise ValueError("y contains new labels: %s" % str(diff))


### PR DESCRIPTION
This is a fix for  #2481 which causes the jenkins tests to fail with numpy 1.3.0.
