### PR TITLE
[MRG] sklearn.tree.export_dict for converting Tree objects into a jsonable format

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -183,7 +183,7 @@ with a recursive navigation of the tree dict:
     >>> def feature_set(node) :
     ...     s = set()
     ...     if node['feature'] :
-    ...         s |= set([node['feature']])
+    ...         s.add(node['feature']))
     ...     if node['left'] :
     ...         s |= feature_set(node['left'])
     ...     if node['right'] :

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -165,6 +165,47 @@ After being fitted, the model can then be used to predict new values::
    :align: center
    :scale: 75
 
+Once trained, we can export the tree to a more pythonic format for
+visualization or introspection with the :func:`export_dict` exporter.
+Below is an example using the same tree fitted above on the iris data
+set.  It is easy to extract the root level feature and threshold:
+
+    >>> d = tree.export_dict(clf, iris.feature_names)
+    >>> d['feature']
+    'petal length (cm)'
+    >>> d['threshold']
+    2.449999988079071
+
+We can also do more interesting operations on the tree.  In this
+example we extract the set of features which were used in the tree
+with a recursive navigation of the tree dict:
+
+    >>> def feature_set(node) :
+    ...     s = set()
+    ...     if node['feature'] :
+    ...         s |= set([node['feature']])
+    ...     if node['left'] :
+    ...         s |= feature_set(node['left'])
+    ...     if node['right'] :
+    ...         s |= feature_set(node['right'])
+    ...     return s
+    >>> feature_set(d)
+    {'petal length (cm)', 'petal width (cm)', 'sepal length (cm)'}
+
+We can also do more interesting operations on the tree.  In this
+example we recursively compute a mean_depth:
+
+    >>> def mean_depth(node, depth=0) :
+    ...     if not node :
+    ...         return depth-1
+    ... 
+    ...     l = mean_depth(node['left'], depth+1)
+    ...     r = mean_depth(node['right'], depth+1)
+    ...     return (l + r) / 2.0
+    >>> mean_depth(d)
+    2.4375
+
+
 .. topic:: Examples:
 
  * :ref:`example_tree_plot_iris.py`

--- a/sklearn/tree/__init__.py
+++ b/sklearn/tree/__init__.py
@@ -8,6 +8,8 @@ from .tree import DecisionTreeRegressor
 from .tree import ExtraTreeClassifier
 from .tree import ExtraTreeRegressor
 from .export import export_graphviz
+from .export import export_dict
 
 __all__ = ["DecisionTreeClassifier", "DecisionTreeRegressor",
-           "ExtraTreeClassifier", "ExtraTreeRegressor", "export_graphviz"]
+           "ExtraTreeClassifier", "ExtraTreeRegressor", "export_graphviz",
+           "export_dict"]

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -165,6 +165,10 @@ def export_dict(tree, feature_names=None, max_depth=None) :
     python types as opposed to numpy types to make exporting to json
     and other pythonic operations easier.
 
+    the value attribute is a list containing a count of the number of
+    training examples of each class which fell into each leaf of the
+    tree.
+
     Examples
     --------
     >>> from sklearn.datasets import load_iris

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -1,12 +1,13 @@
 """
 Testing for export functions of decision trees (sklearn.tree.export).
 """
+import json
 
 from numpy.testing import assert_equal
 from nose.tools import assert_raises
 
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.tree import export_graphviz
+from sklearn.tree import export_graphviz, export_dict
 from sklearn.externals.six import StringIO
 
 # toy sample
@@ -81,6 +82,72 @@ def test_graphviz_errors():
 
     out = StringIO()
     assert_raises(IndexError, export_graphviz, clf, out, feature_names=[])
+
+
+def test_dict_toy():
+    """Check correctness of export_dict"""
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=1,
+                                 criterion="gini",
+                                 random_state=2)
+    clf.fit(X, y)
+
+    # Test export code
+    actual = export_dict(clf)
+    expected = {
+        'right': {
+            'right': None,
+            'impurity': 0.0,
+            'feature': None,
+            'threshold': None,
+            'n_node_samples': 3,
+            'left': None,
+            'value': [[
+                0,
+                3,
+             ]],
+         },
+        'impurity': 0.5,
+        'feature': 0,
+        'value' : None,
+        'threshold': 0.0,
+        'n_node_samples': 6,
+        'left': {
+            'right': None,
+            'impurity': 0.0,
+            'feature': None,
+            'threshold': None,
+            'n_node_samples': 3,
+            'left': None,
+            'value': [[
+                3,
+                0,
+             ]],
+        }
+    }
+
+    assert_equal(expected, actual)
+    json.dumps(actual)
+
+    # ensure types are correct
+    assert_equal(type(actual['n_node_samples']), int)
+
+    # Test with feature_names
+    actual = export_dict(clf, feature_names=["feature0", "feature1"])
+    expected['feature'] = 'feature0'
+
+    assert_equal(expected, actual)
+    json.dumps(actual)
+
+    # Test max_depth
+    actual = export_dict(
+        clf, max_depth=0, feature_names=["feature0", "feature1"]
+    )
+    expected['right'] = None
+    expected['left']  = None
+
+    assert_equal(expected, actual)
+    json.dumps(actual)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is useful for viewing Tree objects in a terminal and working with Tree objects in a simpler, more pythonic form than working directly with Tree.tree_.

One example would be writing a utility which can use the pythonic tree to tell the user **why** a particular decision was made rather than just generating a prediction.  This is especially useful for DecisionTrees which are often enjoyed in this simple form for their very transparency.
