### PR TITLE
Update dict_learning.py

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -623,7 +623,7 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
                        % (ii, dt, dt / 60))
 
         this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
-                                  alpha=alpha).T
+                                  alpha=alpha, n_jobs=n_jobs).T
 
         # Update the auxiliary variables
         if ii < batch_size - 1:


### PR DESCRIPTION
Added parallelisation for online dictionnary learning algorithm. Seems like the option was forgotten, defaulting to n_jobs=1.
