### PR TITLE
Fix for out of bounds error in RBM  with odd # of rows

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -300,7 +300,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         self.h_samples_ = np.zeros((self.batch_size, self.n_components))
 
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
-        #pass n_samples to prevent gen_even_slices from return out of bounds slices on odd row counts
+        # pass n_samples to prevent gen_even_slices from return out of bounds slices on odd row counts
         batch_slices = list(gen_even_slices(n_batches * self.batch_size,
                                             n_batches, n_samples))
         verbose = self.verbose

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -300,8 +300,9 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         self.h_samples_ = np.zeros((self.batch_size, self.n_components))
 
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
+        #pass n_samples to prevent gen_even_slices from return out of bounds slices on odd row counts
         batch_slices = list(gen_even_slices(n_batches * self.batch_size,
-                                            n_batches))
+                                            n_batches,n_samples))
         verbose = self.verbose
         for iteration in xrange(self.n_iter):
             pl = 0.

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -302,7 +302,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
         #pass n_samples to prevent gen_even_slices from return out of bounds slices on odd row counts
         batch_slices = list(gen_even_slices(n_batches * self.batch_size,
-                                            n_batches,n_samples))
+                                            n_batches, n_samples))
         verbose = self.verbose
         for iteration in xrange(self.n_iter):
             pl = 0.

--- a/sklearn/tests/test_gen_even_slices.py
+++ b/sklearn/tests/test_gen_even_slices.py
@@ -20,8 +20,8 @@ def test_gen_even_slices():
     even_slices = list(gen_even_slices(even_batches * batch_size,
                                             even_batches, even.shape[0]))
 
-    assert(test_bounds(even,even_slices)=="passes", "Fails on Even number of rows")
-    assert(test_bounds(odd,odd_slices)=="passes", "Fails on Odd number of rows")
+    assert test_bounds(even,even_slices)=="passes", "Fails on Even number of rows"
+    assert test_bounds(odd,odd_slices)=="passes", "Fails on Odd number of rows" 
 
     print("OK")
 

--- a/sklearn/tests/test_gen_even_slices.py
+++ b/sklearn/tests/test_gen_even_slices.py
@@ -20,8 +20,8 @@ def test_gen_even_slices():
     even_slices = list(gen_even_slices(even_batches * batch_size,
                                             even_batches, even.shape[0]))
 
-    assert test_bounds(even,even_slices)=="passes", "Fails on Even number of rows"
-    assert test_bounds(odd,odd_slices)=="passes", "Fails on Odd number of rows" 
+    assert test_bounds(even,even_slices) == "passes", "Fails on Even number of rows"
+    assert test_bounds(odd,odd_slices) == "passes", "Fails on Odd number of rows" 
 
     print("OK")
 

--- a/sklearn/tests/test_gen_even_slices.py
+++ b/sklearn/tests/test_gen_even_slices.py
@@ -5,7 +5,7 @@ from scipy.sparse import csr_matrix
 import numpy as np
 
 
-def test_gen_even_slices():
+def check_gen_even_slices():
 
     even = csr_matrix((1032,1030))
     odd = csr_matrix((1033,1033))
@@ -20,15 +20,15 @@ def test_gen_even_slices():
     even_slices = list(gen_even_slices(even_batches * batch_size,
                                             even_batches, even.shape[0]))
 
-    assert test_bounds(even,even_slices) == "passes", "Fails on Even number of rows"
-    assert test_bounds(odd,odd_slices) == "passes", "Fails on Odd number of rows" 
+    assert slices_bounds_check(even,even_slices) == "passes", "Fails on Even number of rows"
+    assert slices_bounds_check(odd,odd_slices) == "passes", "Fails on Odd number of rows" 
 
     print("OK")
 
 
 
 
-def test_bounds(matrix, slices):
+def slices_bounds_check(matrix, slices):
     try:
         for batch_slice in slices:
             _= matrix[batch_slice]

--- a/sklearn/tests/test_gen_even_slices.py
+++ b/sklearn/tests/test_gen_even_slices.py
@@ -1,0 +1,44 @@
+""" test gen_even_slices"""
+
+from sklearn.utils import gen_even_slices
+from scipy.sparse import csr_matrix
+import numpy as np
+
+
+def test_gen_even_slices():
+
+    even = csr_matrix((1032,1030))
+    odd = csr_matrix((1033,1033))
+    batch_size = 100
+
+    even_batches = int(np.ceil(float(even.shape[0]) / batch_size))
+    odd_batches = int(np.ceil(float(odd.shape[0]) / batch_size))
+
+    odd_slices = list(gen_even_slices(odd_batches * batch_size,
+                                            odd_batches, odd.shape[0]))
+
+    even_slices = list(gen_even_slices(even_batches * batch_size,
+                                            even_batches, even.shape[0]))
+
+    assert(test_bounds(even,even_slices)=="passes", "Fails on Even number of rows")
+    assert(test_bounds(odd,odd_slices)=="passes", "Fails on Odd number of rows")
+
+    print("OK")
+
+
+
+
+def test_bounds(matrix, slices):
+    try:
+        for batch_slice in slices:
+            _= matrix[batch_slice]
+        return "passes"
+
+    except IndexError:
+        return "oob"
+
+
+
+
+
+

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -350,8 +350,20 @@ def gen_batches(n, batch_size):
         yield slice(start, n)
 
 
-def gen_even_slices(n, n_packs):
+def gen_even_slices(n, n_packs,n_max=None):
     """Generator to create n_packs slices going up to n.
+
+    Args:
+
+        n : int
+            correct end_point if dimensions are even_slices
+        max_n: 
+            int
+            maximum dimension, correct is dimension are odd
+        n_pack:
+            number of packs to slice 
+
+
 
     Examples
     --------
@@ -366,12 +378,13 @@ def gen_even_slices(n, n_packs):
     [slice(0, 4, None), slice(4, 7, None), slice(7, 10, None)]
     """
     start = 0
+    n_max= n_max if n_max else n
     for pack_num in range(n_packs):
         this_n = n // n_packs
         if pack_num < n % n_packs:
             this_n += 1
         if this_n > 0:
-            end = start + this_n
+            end = start + this_n if end<n_max else n_max
             yield slice(start, end, None)
             start = end
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -384,7 +384,8 @@ def gen_even_slices(n, n_packs,n_max=None):
         if pack_num < n % n_packs:
             this_n += 1
         if this_n > 0:
-            end = start + this_n if end<n_max else n_max
+            end = start + this_n 
+            end= end if end<n_max else n_max
             yield slice(start, end, None)
             start = end
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -385,7 +385,7 @@ def gen_even_slices(n, n_packs,n_max=None):
             this_n += 1
         if this_n > 0:
             end = start + this_n 
-            end= end if end<n_max else n_max
+            end = end if end<n_max else n_max
             yield slice(start, end, None)
             start = end
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -385,7 +385,7 @@ def gen_even_slices(n, n_packs,n_max=None):
             this_n += 1
         if this_n > 0:
             end = start + this_n 
-            end = end if end<n_max else n_max
+            end = end if end < n_max else n_max
             yield slice(start, end, None)
             start = end
 


### PR DESCRIPTION
Fixes out of bounds error in RBM with odd numbered matrix rows due to
gen_even_slices generating even slices that overshoot bounds of matrix.

```
/usr/local/lib/python2.7/dist-packages/sklearn/neural_network/rbm.pyc
in fit(self, X, y)
    310
    311             for batch_slice in batch_slices:
--> 312                 pl_batch = self._fit(X[batch_slice], rng)
    313
    314                 if verbose:

/usr/lib/python2.7/dist-packages/scipy/sparse/csr.pyc in
__getitem__(self, key)
    279
    280         elif isintlike(key) or isinstance(key,slice):
--> 281             return self[key,:]
#[i] or [1:2]
    282         else:
    283             return self[asindices(key),:]
#[[1,2]]

/usr/lib/python2.7/dist-packages/scipy/sparse/csr.pyc in
__getitem__(self, key)
    239                 #[1:2,??]
    240                 if isintlike(col) or isinstance(col, slice):
--> 241                     return self._get_submatrix(row, col)
#[1:2,j]
    242                 else:
    243                     P = extractor(col,self.shape[1]).T
#[1:2,[1,2]]

/usr/lib/python2.7/dist-packages/scipy/sparse/csr.pyc in
_get_submatrix(self, row_slice, col_slice)
    380         i0, i1 = process_slice( row_slice, M )
    381         j0, j1 = process_slice( col_slice, N )
--> 382         check_bounds( i0, i1, M )
    383         check_bounds( j0, j1, N )
    384

/usr/lib/python2.7/dist-packages/scipy/sparse/csr.pyc in
check_bounds(i0, i1, num)
    376                 raise IndexError( \
    377                       "index out of bounds: 0<=%d<%d, 0<=%d<%d,
%d<%d" %\
--> 378                       (i0, num, i1, num, i0, i1) )
    379
    380         i0, i1 = process_slice( row_slice, M )

IndexError: index out of bounds: 0<=113000<113966, 0<=114000<113966,
113000<114000
```
