### PR TITLE
Gaussian Process extension: multiple hyperparameters

### DIFF
--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -39,7 +39,7 @@ def absolute_exponential(theta, d):
         autocorrelation model.
     """
 
-    if len(theta.shape) > 1:
+    if theta.shape[0] > 1:
         raise ValueError("This correlation model only takes one hyperparameter. "
                          "Shape of theta should be (n, ).")
 
@@ -86,7 +86,7 @@ def squared_exponential(theta, d):
         autocorrelation model.
     """
 
-    if len(theta.shape) > 1:
+    if theta.shape[0] > 1:
         raise ValueError("This correlation model only takes one hyperparameter. "
                          "Shape of theta should be (n, ).")
 
@@ -134,7 +134,7 @@ def generalized_exponential(theta, d):
         model.
     """
 
-    if len(theta.shape) > 1:
+    if theta.shape[0] > 1:
         raise ValueError("This correlation model only takes one hyperparameter. "
                          "Shape of theta should be (n, ).")
 
@@ -224,7 +224,7 @@ def cubic(theta, d):
         model.
     """
 
-    if len(theta.shape) > 1:
+    if theta.shape[0] > 1:
         raise ValueError("This correlation model only takes one hyperparameter. "
                          "Shape of theta should be (n, ).")
 
@@ -278,7 +278,7 @@ def linear(theta, d):
         model.
     """
 
-    if len(theta.shape) > 1:
+    if theta.shape[0] > 1:
         raise ValueError("This correlation model only takes one hyperparameter. "
                          "Shape of theta should be (n, ).")
 

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -40,8 +40,9 @@ def absolute_exponential(theta, d):
     """
 
     if theta.shape[0] > 1:
-        raise ValueError("This correlation model only takes one hyperparameter. "
-                         "Shape of theta should be (n, ).")
+        raise ValueError("This correlation model only takes one "
+                         "hyperparameter. Shape of theta should be "
+                         "(n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.abs(np.asarray(d, dtype=np.float))
@@ -87,8 +88,9 @@ def squared_exponential(theta, d):
     """
 
     if theta.shape[0] > 1:
-        raise ValueError("This correlation model only takes one hyperparameter. "
-                         "Shape of theta should be (n, ).")
+        raise ValueError("This correlation model only takes one "
+                         "hyperparameter. Shape of theta should be "
+                         "(n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
@@ -135,8 +137,9 @@ def generalized_exponential(theta, d):
     """
 
     if theta.shape[0] > 1:
-        raise ValueError("This correlation model only takes one hyperparameter. "
-                         "Shape of theta should be (n, ).")
+        raise ValueError("This correlation model only takes one "
+                         "hyperparameter. Shape of theta should be "
+                         "(n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
@@ -225,8 +228,9 @@ def cubic(theta, d):
     """
 
     if theta.shape[0] > 1:
-        raise ValueError("This correlation model only takes one hyperparameter. "
-                         "Shape of theta should be (n, ).")
+        raise ValueError("This correlation model only takes one "
+                         "hyperparameter. Shape of theta should be "
+                         "(n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
@@ -279,8 +283,9 @@ def linear(theta, d):
     """
 
     if theta.shape[0] > 1:
-        raise ValueError("This correlation model only takes one hyperparameter. "
-                         "Shape of theta should be (n, ).")
+        raise ValueError("This correlation model only takes one "
+                         "hyperparameter. Shape of theta should be "
+                         "(n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -38,6 +38,11 @@ def absolute_exponential(theta, d):
         An array with shape (n_eval, ) containing the values of the
         autocorrelation model.
     """
+
+    if len(theta.shape) > 1:
+        raise ValueError("This correlation model only takes one hyperparameter. "
+                         "Shape of theta should be (n, ).")
+
     theta = np.asarray(theta, dtype=np.float)
     d = np.abs(np.asarray(d, dtype=np.float))
 
@@ -80,6 +85,10 @@ def squared_exponential(theta, d):
         An array with shape (n_eval, ) containing the values of the
         autocorrelation model.
     """
+
+    if len(theta.shape) > 1:
+        raise ValueError("This correlation model only takes one hyperparameter. "
+                         "Shape of theta should be (n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
@@ -124,6 +133,10 @@ def generalized_exponential(theta, d):
         An array with shape (n_eval, ) with the values of the autocorrelation
         model.
     """
+
+    if len(theta.shape) > 1:
+        raise ValueError("This correlation model only takes one hyperparameter. "
+                         "Shape of theta should be (n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
@@ -211,6 +224,10 @@ def cubic(theta, d):
         model.
     """
 
+    if len(theta.shape) > 1:
+        raise ValueError("This correlation model only takes one hyperparameter. "
+                         "Shape of theta should be (n, ).")
+
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)
 
@@ -260,6 +277,10 @@ def linear(theta, d):
         An array with shape (n_eval, ) with the values of the autocorrelation
         model.
     """
+
+    if len(theta.shape) > 1:
+        raise ValueError("This correlation model only takes one hyperparameter. "
+                         "Shape of theta should be (n, ).")
 
     theta = np.asarray(theta, dtype=np.float)
     d = np.asarray(d, dtype=np.float)

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -445,9 +445,11 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             # Get pairwise componentwise L1-distances to the input training set
             dx = manhattan_distances(X, Y=self.X, sum_over_features=False)
+            # Convert theta to correct shape
+            theta = self.theta_.reshape(self.theta0.shape)
             # Get regression function and correlation
             f = self.regr(X)
-            r = self.corr(self.theta_, dx).reshape(n_eval, n_samples)
+            r = self.corr(theta, dx).reshape(n_eval, n_samples)
 
             # Scaled predictor
             y_ = np.dot(f, self.beta) + np.dot(r, self.gamma)
@@ -579,6 +581,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             # Use built-in autocorrelation parameters
             theta = self.theta_
 
+        # Convert theta to original form
+        theta = theta.reshape(self.theta0.shape)
+
         # Initialize output
         reduced_likelihood_function_value = - np.inf
         par = {}
@@ -696,41 +701,49 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         percent_completed = 0.
 
         # Force optimizer to fmin_cobyla if the model is meant to be isotropic
-        if self.optimizer == 'Welch' and self.theta0.size == 1:
+        # or if there are multiple hyperparameters
+        if self.optimizer == 'Welch' and (self.theta0.size == 1 or 
+                                          len(self.theta0.shape) > 1)
             self.optimizer = 'fmin_cobyla'
 
         if self.optimizer == 'fmin_cobyla':
 
             def minus_reduced_likelihood_function(log10t):
-                return - self.reduced_likelihood_function(
+                return -self.reduced_likelihood_function(
                     theta=10. ** log10t)[0]
 
             constraints = []
-            for i in range(self.theta0.size):
+
+            # Convert theta to vector (in case it is a matrix)
+            thetaLVec = np.array(self.thetaL).flatten()
+            thetaUVec = np.array(self.thetaU).flatten()
+            theta0Vec = np.array(self.theta0).flatten()
+                
+            for i in range(theta0Vec.size):
                 constraints.append(lambda log10t:
-                                   log10t[i] - np.log10(self.thetaL[0, i]))
+                                   log10t[i] - np.log10(thetaLVec[i]))
                 constraints.append(lambda log10t:
-                                   np.log10(self.thetaU[0, i]) - log10t[i])
+                                   np.log10(thetaUVec[i]) - log10t[i])
 
             for k in range(self.random_start):
 
                 if k == 0:
                     # Use specified starting point as first guess
-                    theta0 = self.theta0
+                    theta0 = theta0Vec
                 else:
                     # Generate a random starting point log10-uniformly
                     # distributed between bounds
-                    log10theta0 = np.log10(self.thetaL) \
-                        + rand(self.theta0.size).reshape(self.theta0.shape) \
-                        * np.log10(self.thetaU / self.thetaL)
+                    log10theta0 = np.log10(thetaLVec) \
+                        + rand(theta0Vec.size).reshape(theta0Vec.shape) \
+                        * np.log10(thetaUVec / thetaLVec)
                     theta0 = 10. ** log10theta0
 
                 # Run Cobyla
                 try:
                     log10_optimal_theta = \
                         optimize.fmin_cobyla(minus_reduced_likelihood_function,
-                                             np.log10(theta0), constraints,
-                                             iprint=0)
+                                             np.log10(theta0Vec), constraints,
+                                             disp=0)
                 except ValueError as ve:
                     print("Optimization failed. Try increasing the ``nugget``")
                     raise ve
@@ -754,7 +767,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     if (20 * k) / self.random_start > percent_completed:
                         percent_completed = (20 * k) / self.random_start
                         print("%s completed" % (5 * percent_completed))
-
+                
             optimal_rlf_value = best_optimal_rlf_value
             optimal_par = best_optimal_par
             optimal_theta = best_optimal_theta
@@ -811,6 +824,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             raise NotImplementedError("This optimizer ('%s') is not "
                                       "implemented yet. Please contribute!"
                                       % self.optimizer)
+
+        if self.verbose:
+            print("Optimal theta:\n", np.matrix(optimal_theta).reshape(self.theta0.shape))
 
         return optimal_theta, optimal_rlf_value, optimal_par
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -428,8 +428,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
         if X.shape[1] != n_features:
             raise ValueError(("The number of features in X (X.shape[1] = %d) "
-                             "should match the number of features used for fit() "
-                             "which is %d.") % (X.shape[1], n_features))
+                             "should match the number of features used for "
+                             "fit() which is %d.") % (X.shape[1], n_features))
 
         if batch_size is None:
             # No memory management
@@ -704,7 +704,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
         # Force optimizer to fmin_cobyla if the model is meant to be isotropic
         # or if there are multiple hyperparameters
-        if self.optimizer == 'Welch' and (self.theta0.size == 1 or 
+        if self.optimizer == 'Welch' and (self.theta0.size == 1 or
                                           len(self.theta0.shape) > 1):
             self.optimizer = 'fmin_cobyla'
 
@@ -720,7 +720,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             thetaLVec = np.array(self.thetaL).flatten()
             thetaUVec = np.array(self.thetaU).flatten()
             theta0Vec = np.array(self.theta0).flatten()
-                
+
             for i in range(theta0Vec.size):
                 constraints.append(lambda log10t:
                                    log10t[i] - np.log10(thetaLVec[i]))
@@ -769,7 +769,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     if (20 * k) / self.random_start > percent_completed:
                         percent_completed = (20 * k) / self.random_start
                         print("%s completed" % (5 * percent_completed))
-                
+
             optimal_rlf_value = best_optimal_rlf_value
             optimal_par = best_optimal_par
             optimal_theta = best_optimal_theta
@@ -828,7 +828,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                                       % self.optimizer)
 
         if self.verbose:
-            print("Optimal theta:\n", np.matrix(optimal_theta).reshape(self.theta0.shape))
+            print("Optimal theta:\n",
+                  np.matrix(optimal_theta).reshape(self.theta0.shape))
 
         return optimal_theta, optimal_rlf_value, optimal_par
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -105,22 +105,22 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         A boolean specifying the verbose level.
         Default is verbose = False.
 
-    theta0 : double array_like, optional
-        An array with shape (n_features, ) or (1, ).
+    theta0 : double array_like or ndarray, optional
+        An array with shape (n_features, ), (n_features, n_params), or (1, ).
         The parameters in the autocorrelation model.
         If thetaL and thetaU are also specified, theta0 is considered as
         the starting point for the maximum likelihood estimation of the
         best set of parameters.
         Default assumes isotropic autocorrelation model with theta0 = 1e-1.
 
-    thetaL : double array_like, optional
+    thetaL : double array_like or ndarray, optional
         An array with shape matching theta0's.
         Lower bound on the autocorrelation parameters for maximum
         likelihood estimation.
         Default is None, so that it skips maximum likelihood estimation and
         it uses theta0.
 
-    thetaU : double array_like, optional
+    thetaU : double array_like or ndarray, optional
         An array with shape matching theta0's.
         Upper bound on the autocorrelation parameters for maximum
         likelihood estimation.
@@ -545,11 +545,11 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
         Parameters
         ----------
-        theta : array_like, optional
+        theta : array_like or ndarray, optional
             An array containing the autocorrelation parameters at which the
             Gaussian Process model parameters should be determined.
             Default uses the built-in autocorrelation parameters
-            (ie ``theta = self.theta_``).
+            (i.e. ``theta = self.theta_``).
 
         Returns
         -------
@@ -679,7 +679,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         -------
         optimal_theta : array_like
             The best set of autocorrelation parameters (the sought maximizer of
-            the reduced likelihood function).
+            the reduced likelihood function). Outputs a multidimensional theta
+            as an array.
 
         optimal_reduced_likelihood_function_value : double
             The optimal reduced likelihood function value.

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -704,7 +704,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         # Force optimizer to fmin_cobyla if the model is meant to be isotropic
         # or if there are multiple hyperparameters
         if self.optimizer == 'Welch' and (self.theta0.size == 1 or 
-                                          len(self.theta0.shape) > 1)
+                                          len(self.theta0.shape) > 1):
             self.optimizer = 'fmin_cobyla'
 
         if self.optimizer == 'fmin_cobyla':

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -447,6 +447,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             dx = manhattan_distances(X, Y=self.X, sum_over_features=False)
             # Convert theta to correct shape
             theta = self.theta_.reshape(self.theta0.shape)
+
             # Get regression function and correlation
             f = self.regr(X)
             r = self.corr(theta, dx).reshape(n_eval, n_samples)
@@ -585,7 +586,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         theta = theta.reshape(self.theta0.shape)
 
         # Initialize output
-        reduced_likelihood_function_value = - np.inf
+        reduced_likelihood_function_value = -np.inf
         par = {}
 
         # Retrieve data
@@ -743,7 +744,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                 try:
                     log10_optimal_theta = \
                         optimize.fmin_cobyla(minus_reduced_likelihood_function,
-                                             np.log10(theta0Vec), constraints,
+                                             np.log10(theta0), constraints,
                                              disp=0)
                 except ValueError as ve:
                     print("Optimization failed. Try increasing the ``nugget``")


### PR DESCRIPTION
Hello.

I made some simple changes to the gaussian process module. Previously, the hyperparameters theta (parameters to optimize from the kernel function) were limited to one, though that one hyperparam could be multifeatured. This is no good if you want to combine kernels (like in Rasmussen & Williams' book) because each part of the new kernel will have its own hyperparams, so I modified the code to allow this.

Theta can now be a matrix, where columns are features / dimensions (just as before), but rows now correspond to different hyperparameters.

I also added a test for it and added a check in the built-in correlation functions to make sure they aren't taking in bad parameters. All the tests seemed to pass for me.

P.S. I hope I'm following the right procedure, I've never contributed before so please let me know if I'm missing anything.
