### PR TITLE
ENH: improve FA vs PCA example

### DIFF
--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -19,7 +19,7 @@ One can observe that with homoscedastic noise both FA and PCA succeed
 in recovering the size of the low rank subspace. The likelihood with PCA
 is higher than FA in this case. However PCA fails and overestimates
 the rank when heteroscedastic noise is present. Under appropriate
-circumstances the low rank models are more likily than shrinkage models.
+circumstances the low rank models are more likely than shrinkage models.
 
 The automatic estimation from
 Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604


### PR DESCRIPTION
This improves the plot FactorAnalysis VS PCA example in demonstrating that the selected model's covariance is more appropriate for our low rank scenario than the ones obtained from other covariance estimators.

cf.
![screenshot 2013-10-25 12 48 36](https://f.cloud.github.com/assets/1908618/1407680/abdfa76e-3d73-11e3-86cd-17c4b9789c6d.png)
![screenshot 2013-10-25 12 48 46](https://f.cloud.github.com/assets/1908618/1407681/abe211d4-3d73-11e3-9b73-4bc6ebac0b36.png)
