### PR TITLE
BUG: Compare strings for equality, not identity.

### DIFF
--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -380,9 +380,9 @@ class MDS(BaseEstimator):
                           "dissimilarity matrix, set "
                           "``dissimilarity=precomputed``.")
 
-        if self.dissimilarity is "precomputed":
+        if self.dissimilarity == "precomputed":
             self.dissimilarity_matrix_ = X
-        elif self.dissimilarity is "euclidean":
+        elif self.dissimilarity == "euclidean":
             self.dissimilarity_matrix_ = euclidean_distances(X)
         else:
             raise ValueError("Proximity must be 'precomputed' or 'euclidean'."


### PR DESCRIPTION
In a script I found that calling MDS with dissimilarity='precomputed' was failing because strings are compared by identity. A quick way to reproduce the bug is this:

```
from sklearn.manifold import MDS
import numpy as np

mds = MDS(dissimilarity=''.join(list('precomputed')))
X = np.ones(10,10)
pos = mds.fit_transform(X)
```

raises a

```
ValueError: Proximity must be 'precomputed' or 'euclidean'. Got precomputed instead
```

The fix is really simple, but I can add a test case to it or an issue if you prefer that.
