### PR TITLE
WIP: extend Pipeline transform and inverse_transform behavior

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -60,6 +60,10 @@ Changelog
    - Added :class:`linear_model.RANSACRegressor` meta-estimator for the robust
      fitting of regression models. By Johannes Schönberger.
 
+   - Extended transform and inverse_transform methods from
+     :class:`pipeline.Pipeline` to ignore the last step if it does not
+     implement the corresponding methods, by `Yannick Schwartz`_.
+
 
 API changes summary
 -------------------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -196,6 +196,16 @@ class Pipeline(BaseEstimator):
         return Xt
 
     def inverse_transform(self, X):
+        """Applies inverse transforms to the data.
+
+        All the estimators in the pipeline need to implement
+        an inverse transform, except for the final one that
+        is ignored in the case it lacks the method.
+
+        As an example, calling inverse transform can be useful to
+        map back to the original space the `coef_` attribute
+        from a linear classifier.
+        """
         if X.ndim == 1:
             X = X[None, :]
         Xt = X

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -235,19 +235,28 @@ def test_pipeline_transform():
     # Also test pipeline.transform and pipeline.inverse_transform
     iris = load_iris()
     X = iris.data
+    y = iris.target
     pca = PCA(n_components=2)
+    clf = SVC()
     pipeline = Pipeline([('pca', pca)])
+    pipeline2 = Pipeline([('pca', pca), ('clf', clf)])
 
     # test transform and fit_transform:
     X_trans = pipeline.fit(X).transform(X)
     X_trans2 = pipeline.fit_transform(X)
     X_trans3 = pca.fit_transform(X)
+    X_trans4 = pipeline2.fit(X, y).transform(X)
+    X_trans5 = pipeline2.fit_transform(X, y)
     assert_array_almost_equal(X_trans, X_trans2)
     assert_array_almost_equal(X_trans, X_trans3)
+    assert_array_almost_equal(X_trans, X_trans4)
+    assert_array_almost_equal(X_trans, X_trans5)
 
     X_back = pipeline.inverse_transform(X_trans)
     X_back2 = pca.inverse_transform(X_trans)
+    X_back3 = pipeline2.inverse_transform(X_trans)
     assert_array_almost_equal(X_back, X_back2)
+    assert_array_almost_equal(X_back, X_back3)
 
 
 def test_pipeline_fit_transform():


### PR DESCRIPTION
Pipeline transform and inverse_transform skip last step if it lacks corresponding methods.

The extension is useful to:
- extract the features before the last step of the pipeline for debugging purposes
- inverse_transform the `coef_` attribute of a linear classifier for example

Design discussion here: Issue #2562 
