### PR TITLE
Issue #2559: Added normalize option to LogisticRegression 

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .base import LinearClassifierMixin, SparseCoefMixin
+from .base import LinearClassifierMixin, SparseCoefMixin, center_data
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..svm.base import BaseLibLinear
 
@@ -35,6 +35,9 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added the decision function.
+
+    normalize : boolean, optional, default False
+        If True, the regressors X will be normalized before logistic regression.
 
     intercept_scaling : float, default: 1
         when self.fit_intercept is True, instance vector x becomes
@@ -95,12 +98,13 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
     """
 
     def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
-                 fit_intercept=True, intercept_scaling=1, class_weight=None,
-                 random_state=None):
+                 fit_intercept=True, normalize=False, intercept_scaling=1, 
+                 class_weight=None, random_state=None):
 
         super(LogisticRegression, self).__init__(
             penalty=penalty, dual=dual, loss='lr', tol=tol, C=C,
-            fit_intercept=fit_intercept, intercept_scaling=intercept_scaling,
+            fit_intercept=fit_intercept, normalize=normalize, 
+            intercept_scaling=intercept_scaling, 
             class_weight=class_weight, random_state=random_state)
 
     def predict_proba(self, X):
@@ -138,3 +142,10 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
             model, where classes are ordered as they are in ``self.classes_``.
         """
         return np.log(self.predict_proba(X))
+
+    def _center_data(self, X, y, fit_intercept, normalize=False):
+        """Center the data in X but not in y"""
+        X, _, X_mean, _, X_std = center_data(X, y, fit_intercept,
+                                            normalize=normalize)
+        return X, y, X_mean, y, X_std
+

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -37,7 +37,8 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
         added the decision function.
 
     normalize : boolean, optional, default False
-        If True, the regressors X will be normalized before logistic regression.
+        If True, the regressors X will be normalized before
+        logistic regression.
 
     intercept_scaling : float, default: 1
         when self.fit_intercept is True, instance vector x becomes
@@ -98,13 +99,13 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
     """
 
     def __init__(self, penalty='l2', dual=False, tol=1e-4, C=1.0,
-                 fit_intercept=True, normalize=False, intercept_scaling=1, 
+                 fit_intercept=True, normalize=False, intercept_scaling=1,
                  class_weight=None, random_state=None):
 
         super(LogisticRegression, self).__init__(
             penalty=penalty, dual=dual, loss='lr', tol=tol, C=C,
-            fit_intercept=fit_intercept, normalize=normalize, 
-            intercept_scaling=intercept_scaling, 
+            fit_intercept=fit_intercept, normalize=normalize,
+            intercept_scaling=intercept_scaling,
             class_weight=class_weight, random_state=random_state)
 
     def predict_proba(self, X):

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .base import LinearClassifierMixin, SparseCoefMixin, center_data
+from .base import LinearClassifierMixin, SparseCoefMixin
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..svm.base import BaseLibLinear
 
@@ -142,10 +142,3 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
             model, where classes are ordered as they are in ``self.classes_``.
         """
         return np.log(self.predict_proba(X))
-
-    def _center_data(self, X, y, fit_intercept, normalize=False):
-        """Center the data in X but not in y"""
-        X, _, X_mean, _, X_std = center_data(X, y, fit_intercept,
-                                            normalize=normalize)
-        return X, y, X_mean, y, X_std
-

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -37,7 +37,7 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
         added the decision function.
 
     normalize : boolean, optional, default False
-        If True, the regressors X will be normalized before
+        If True, the training data X will be normalized before
         logistic regression.
 
     intercept_scaling : float, default: 1

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -155,3 +155,17 @@ def test_liblinear_random_state():
     lr2 = logistic.LogisticRegression(random_state=0)
     lr2.fit(X, y)
     assert_array_almost_equal(lr1.coef_, lr2.coef_)
+
+def test_normalize():
+    """Test for normalize option in LogisticRegression
+    to verify that prediction of array that already normalize is same as if normalize option is enabled
+    """
+    X, y = iris.data, iris.target
+    X_norm = (X - np.mean(X)) / np.std(X)
+    lr1 = logistic.LogisticRegression(normalize=False)
+    lr1.fit(X_norm, y)
+    lr2 = logistic.LogisticRegression(normalize=True)
+    lr2.fit(X, y)
+    pred1 = lr1.predict_proba(X_norm)
+    pred2 = lr2.predict_proba(X)
+    assert_array_almost_equal(pred1, pred2)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -161,7 +161,7 @@ def test_normalize():
     to verify that prediction of array that already normalize is same as if normalize option is enabled
     """
     X, y = iris.data, iris.target
-    X_norm = (X - np.mean(X)) / np.std(X)
+    X_norm = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
     lr1 = logistic.LogisticRegression(normalize=False)
     lr1.fit(X_norm, y)
     lr2 = logistic.LogisticRegression(normalize=True)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -156,16 +156,18 @@ def test_liblinear_random_state():
     lr2.fit(X, y)
     assert_array_almost_equal(lr1.coef_, lr2.coef_)
 
+
 def test_normalize():
     """Test for normalize option in LogisticRegression
-    to verify that prediction of array that already normalize is same as if normalize option is enabled
+    to verify that the prediction with an array that has already been
+    normalized is the same as if normalize option is enabled.
     """
     X, y = iris.data, iris.target
     X_norm = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
     for kwargs in (
-        {}, 
-        {'fit_intercept': False},
-        {'intercept_scaling': 0.01}):
+            {},
+            {'fit_intercept': False},
+            {'intercept_scaling': 0.01}):
         lr1 = logistic.LogisticRegression(normalize=False, **kwargs)
         lr1.fit(X_norm, y)
         lr2 = logistic.LogisticRegression(normalize=True, **kwargs)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -162,10 +162,14 @@ def test_normalize():
     """
     X, y = iris.data, iris.target
     X_norm = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
-    lr1 = logistic.LogisticRegression(normalize=False)
-    lr1.fit(X_norm, y)
-    lr2 = logistic.LogisticRegression(normalize=True)
-    lr2.fit(X, y)
-    pred1 = lr1.predict_proba(X_norm)
-    pred2 = lr2.predict_proba(X)
-    assert_array_almost_equal(pred1, pred2)
+    for kwargs in (
+        {}, 
+        {'fit_intercept': False},
+        {'intercept_scaling': 0.01}):
+        lr1 = logistic.LogisticRegression(normalize=False, **kwargs)
+        lr1.fit(X_norm, y)
+        lr2 = logistic.LogisticRegression(normalize=True, **kwargs)
+        lr2.fit(X, y)
+        pred1 = lr1.predict_proba(X_norm)
+        pred2 = lr2.predict_proba(X)
+        assert_array_almost_equal(pred1, pred2)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -681,7 +681,7 @@ class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
         
         # Center data if self.normalize
         if self.normalize:
-            X_mean, X_std = np.mean(X), np.std(X)
+            X_mean, X_std = np.mean(X, axis=0), np.std(X, axis=0)
             X = (X - X_mean) / X_std
 
         self.raw_coef_ = liblinear.train_wrap(X, y,


### PR DESCRIPTION
And to BaseLibLinear, which is base class for LogisticRegression and does all computations.

Question, should center_data be moved to general `utils` module, because it's now been used from linear_model and svm packages?
