### PR TITLE
Added contributing subsection to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing code
 =================
 
 **Note: This document is just to get started, visit [**Contributing
-page**](http://scikit-learn.org/stable/developers/index.html#coding-guidelines)
+page**](http://scikit-learn.org/stable/developers/index.html)
 for the full contributor's guide. Please be sure to read it carefully to make
 the code review process go as smoothly as possible and maximize the
 likelihood of your contribution being merged.**

--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,22 @@ GIT
 
 You can check the latest sources with the command::
 
-    git clone git://github.com/scikit-learn/scikit-learn.git
+    git clone https://github.com/scikit-learn/scikit-learn.git
 
 or if you have write privileges::
 
     git clone git@github.com:scikit-learn/scikit-learn.git
+
+
+Contributing
+~~~~~~~~~~~~
+
+Quick tutorial on how to go about setting up your environment to
+contribute to scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
+
+Before opening a Pull Request, have a look at the 
+full Contributing page to make sure your code complies
+with our guidelines: http://scikit-learn.org/stable/developers/index.html
 
 
 Testing
@@ -91,3 +102,8 @@ for more information.
 
     Random number generation can be controlled during testing by setting
     the ``SKLEARN_SEED`` environment variable.
+
+
+
+
+

--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,3 @@ for more information.
 
     Random number generation can be controlled during testing by setting
     the ``SKLEARN_SEED`` environment variable.
-
-
-
-
-


### PR DESCRIPTION
As discussed on the mailing list, I believe it's better to link both pages in the README, as developers who come from within GitHub (e.g. by searching for python projects) may miss the website and the file on the repository.
