### PR TITLE
[MRG] ENH: add PolynomialFeatures preprocessor

### DIFF
--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -18,18 +18,21 @@ points raised to some power). The matrix is akin to (but different from) the
 matrix induced by a polynomial kernel.
 
 This example shows that you can do non-linear regression with a linear model,
-by manually adding non-linear features. Kernel methods extend this idea and can
-induce very high (even infinite) dimensional feature spaces.
+using a pipeline to add non-linear features. Kernel methods extend this idea
+and can induce very high (even infinite) dimensional feature spaces.
 """
 print(__doc__)
 
 # Author: Mathieu Blondel
+#         Jake Vanderplas
 # License: BSD 3 clause
 
 import numpy as np
-import pylab as pl
+import pylab as plt
 
 from sklearn.linear_model import Ridge
+from sklearn.preprocessing import PolynomialFeatures
+from sklearn.pipeline import Pipeline
 
 
 def f(x):
@@ -46,15 +49,20 @@ rng.shuffle(x)
 x = np.sort(x[:20])
 y = f(x)
 
-pl.plot(x_plot, f(x_plot), label="ground truth")
-pl.scatter(x, y, label="training points")
+# create matrix versions of these arrays
+X = x[:, np.newaxis]
+X_plot = x_plot[:, np.newaxis]
+
+plt.plot(x_plot, f(x_plot), label="ground truth")
+plt.scatter(x, y, label="training points")
 
 for degree in [3, 4, 5]:
-    ridge = Ridge()
-    ridge.fit(np.vander(x, degree + 1), y)
-    pl.plot(x_plot, ridge.predict(np.vander(x_plot, degree + 1)),
-            label="degree %d" % degree)
+    model = Pipeline([('poly', PolynomialFeatures(degree)),
+                      ('ridge', Ridge())])
+    model.fit(X, y)
+    y_plot = model.predict(X_plot)
+    plt.plot(x_plot, y_plot, label="degree %d" % degree)
 
-pl.legend(loc='lower left')
+plt.legend(loc='lower left')
 
-pl.show()
+plt.show()

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -28,7 +28,7 @@ print(__doc__)
 # License: BSD 3 clause
 
 import numpy as np
-import pylab as plt
+import matplotlib.pyplot as plt
 
 from sklearn.linear_model import Ridge
 from sklearn.preprocessing import PolynomialFeatures

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -15,6 +15,9 @@ from .data import normalize
 from .data import scale
 from .data import OneHotEncoder
 
+from .data import polynomial_features
+from .data import PolynomialFeatures
+
 from .label import label_binarize
 from .label import LabelBinarizer
 from .label import LabelEncoder
@@ -34,6 +37,8 @@ __all__ = [
     'Scaler',
     'StandardScaler',
     'add_dummy_feature',
+    'polynomial_features',
+    'PolynomialFeatures',
     'binarize',
     'normalize',
     'scale',

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -15,7 +15,6 @@ from .data import normalize
 from .data import scale
 from .data import OneHotEncoder
 
-from .data import polynomial_features
 from .data import PolynomialFeatures
 
 from .label import label_binarize
@@ -37,7 +36,6 @@ __all__ = [
     'Scaler',
     'StandardScaler',
     'add_dummy_feature',
-    'polynomial_features',
     'PolynomialFeatures',
     'binarize',
     'normalize',

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -408,10 +408,11 @@ def polynomial_features(X, degree=2, include_bias=True):
     X : array_like
         The input features, of shape (n_samples, n_features)
     degree : integer
-        The degree of the polynomial features
+        The degree of the polynomial features. Default = 2.
     include_bias : integer
-        Whether to include the bias term, where all polynomial powers are
-        zero (i.e. a column of ones).
+        If True (default), then include a bias column, the feature in which
+        all polynomial powers are zero (i.e. a column of ones - acts as an
+        intercept term in a linear model).
 
     Returns
     -------
@@ -459,17 +460,18 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     degree : integer
-        The degree of the polynomial features
+        The degree of the polynomial features. Default = 2.
     include_bias : integer
-        Whether to include the bias term, where all polynomial powers are
-        zero (i.e. a column of ones).  
+        If True (default), then include a bias column, the feature in which
+        all polynomial powers are zero (i.e. a column of ones - acts as an
+        intercept term in a linear model).
 
     Notes
     -----
     This estimator is stateless (besides constructor parameters), the
     fit method does nothing but is useful when used in a pipeline.
     Be aware that the number of features in the output array scales
-    ass approximately (n_features ** degree), so this is not suitable for
+    as approximately (n_features ** degree), so this is not suitable for
     higher-dimensional data.
 
     See also
@@ -497,6 +499,12 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         ----------
         X : array with shape [n_samples, n_features]
             The data to transform, row by row.
+
+        Returns
+        -------
+        XP : np.ndarray shape [n_samples, NP]
+            The matrix of features, where NP is the number of polynomial
+            features generated from the combination of inputs.
         """
         return polynomial_features(X, degree=self.degree,
                                    include_bias=self.include_bias)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -443,7 +443,7 @@ def polynomial_features(X, degree=2, include_bias=True):
 
     # Find permutations/combinations which add to degree or less
     deg_min = 0 if include_bias else 1
-    combs = itertools.product(*(xrange(degree + 1) for i in range(n_features)))
+    combs = itertools.product(*(range(degree + 1) for i in range(n_features)))
     combs = np.array([c for c in combs if deg_min <= sum(c) <= degree])
 
     return (X[:, np.newaxis, :] ** combs).prod(-1).reshape(n_samples, -1)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -484,8 +484,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     This estimator is stateless (besides constructor parameters), the
     fit method does nothing but is useful when used in a pipeline.
     Be aware that the number of features in the output array scales
-    as approximately (n_features ** degree), so this is not suitable for
-    higher-dimensional data.
+    exponentially in the number of features of the input array, so this
+    is not suitable for higher-dimensional data.
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -427,9 +427,9 @@ def polynomial_features(X, degree=2, include_bias=True):
            [2, 3],
            [4, 5]])
     >>> polynomial_features(X, 2)
-    array([[ 1  1  1  0  0  0]
-           [ 1  3  9  2  6  4]
-           [ 1  5 25  4 20 16]])
+    array([[ 1,  1,  1,  0,  0,  0],
+           [ 1,  3,  9,  2,  6,  4],
+           [ 1,  5, 25,  4, 20, 16]])
 
     See also
     --------
@@ -466,6 +466,19 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         all polynomial powers are zero (i.e. a column of ones - acts as an
         intercept term in a linear model).
 
+    Examples
+    --------
+    >>> X = np.arange(6).reshape(3, 2)
+    >>> X
+    array([[0, 1],
+           [2, 3],
+           [4, 5]])
+    >>> poly = PolynomialFeatures(2)
+    >>> poly.fit_transform(X)
+    array([[ 1,  1,  1,  0,  0,  0],
+           [ 1,  3,  9,  2,  6,  4],
+           [ 1,  5, 25,  4, 20, 16]])
+
     Notes
     -----
     This estimator is stateless (besides constructor parameters), the
@@ -477,7 +490,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     See also
     --------
     :func:`sklearn.preprocessing.polynomial_features` equivalent function
-    without the object oriented API  
+    without the object oriented API.
     """
     def __init__(self, degree=2, include_bias=True):
         self.degree = degree

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -23,7 +23,7 @@ from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler
 from sklearn.preprocessing.data import add_dummy_feature
-from sklearn.preprocessing.data import PolynomialFeatures, polynomial_features
+from sklearn.preprocessing.data import PolynomialFeatures
 
 from sklearn import datasets
 
@@ -48,8 +48,8 @@ def test_polynomial_features():
     x2 = X2[:, 1:]
     P2 = np.hstack([x1 ** 0 * x2 ** 0,
                     x1 ** 1 * x2 ** 0,
-                    x1 ** 2 * x2 ** 0,
                     x1 ** 0 * x2 ** 1,
+                    x1 ** 2 * x2 ** 0,
                     x1 ** 1 * x2 ** 1,
                     x1 ** 0 * x2 ** 2])
     deg2 = 2
@@ -58,12 +58,8 @@ def test_polynomial_features():
         print deg, X.shape, P.shape
         P_test = PolynomialFeatures(deg, include_bias=True).fit_transform(X)
         assert_array_almost_equal(P_test, P)
-        P_test = polynomial_features(X, deg, include_bias=True)
-        assert_array_almost_equal(P_test, P)
 
         P_test = PolynomialFeatures(deg, include_bias=False).fit_transform(X)
-        assert_array_almost_equal(P_test, P[:, 1:])
-        P_test = polynomial_features(X, deg, include_bias=False)
         assert_array_almost_equal(P_test, P[:, 1:])
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -61,7 +61,7 @@ def test_polynomial_features():
 
         P_test = PolynomialFeatures(deg, include_bias=False).fit_transform(X)
         assert_array_almost_equal(P_test, P[:, 1:])
-                               
+
 
 def test_scaler_1d():
     """Test scaling of dataset along single axis"""

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -55,7 +55,6 @@ def test_polynomial_features():
     deg2 = 2
 
     for (deg, X, P) in [(deg1, X1, P1), (deg2, X2, P2)]:
-        print deg, X.shape, P.shape
         P_test = PolynomialFeatures(deg, include_bias=True).fit_transform(X)
         assert_array_almost_equal(P_test, P)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -23,7 +23,7 @@ from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler
 from sklearn.preprocessing.data import add_dummy_feature
-from sklearn.preprocessing.data import PolynomialFeatures
+from sklearn.preprocessing.data import PolynomialFeatures, polynomial_features
 
 from sklearn import datasets
 
@@ -47,19 +47,23 @@ def test_polynomial_features():
     x1 = X2[:, :1]
     x2 = X2[:, 1:]
     P2 = np.hstack([x1 ** 0 * x2 ** 0,
-                    x1 ** 0 * x2 ** 1,
-                    x1 ** 0 * x2 ** 2,
                     x1 ** 1 * x2 ** 0,
+                    x1 ** 2 * x2 ** 0,
+                    x1 ** 0 * x2 ** 1,
                     x1 ** 1 * x2 ** 1,
-                    x1 ** 2 * x2 ** 0])
+                    x1 ** 0 * x2 ** 2])
     deg2 = 2
 
     for (deg, X, P) in [(deg1, X1, P1), (deg2, X2, P2)]:
         print deg, X.shape, P.shape
         P_test = PolynomialFeatures(deg, include_bias=True).fit_transform(X)
         assert_array_almost_equal(P_test, P)
+        P_test = polynomial_features(X, deg, include_bias=True)
+        assert_array_almost_equal(P_test, P)
 
         P_test = PolynomialFeatures(deg, include_bias=False).fit_transform(X)
+        assert_array_almost_equal(P_test, P[:, 1:])
+        P_test = polynomial_features(X, deg, include_bias=False)
         assert_array_almost_equal(P_test, P[:, 1:])
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -23,6 +23,7 @@ from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler
 from sklearn.preprocessing.data import add_dummy_feature
+from sklearn.preprocessing.data import PolynomialFeatures
 
 from sklearn import datasets
 
@@ -34,6 +35,33 @@ def toarray(a):
         a = a.toarray()
     return a
 
+
+def test_polynomial_features():
+    """Test Polynomial Features"""
+    X1 = np.arange(6)[:, np.newaxis]
+    P1 = np.hstack([np.ones_like(X1),
+                    X1, X1 ** 2, X1 ** 3])
+    deg1 = 3
+
+    X2 = np.arange(6).reshape((3, 2))
+    x1 = X2[:, :1]
+    x2 = X2[:, 1:]
+    P2 = np.hstack([x1 ** 0 * x2 ** 0,
+                    x1 ** 0 * x2 ** 1,
+                    x1 ** 0 * x2 ** 2,
+                    x1 ** 1 * x2 ** 0,
+                    x1 ** 1 * x2 ** 1,
+                    x1 ** 2 * x2 ** 0])
+    deg2 = 2
+
+    for (deg, X, P) in [(deg1, X1, P1), (deg2, X2, P2)]:
+        print deg, X.shape, P.shape
+        P_test = PolynomialFeatures(deg, include_bias=True).fit_transform(X)
+        assert_array_almost_equal(P_test, P)
+
+        P_test = PolynomialFeatures(deg, include_bias=False).fit_transform(X)
+        assert_array_almost_equal(P_test, P[:, 1:])
+                               
 
 def test_scaler_1d():
     """Test scaling of dataset along single axis"""

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -49,7 +49,7 @@ dont_test = ['SparseCoder', 'EllipticEnvelope', 'EllipticEnvelop',
              'DictVectorizer', 'LabelBinarizer', 'LabelEncoder',
              'TfidfTransformer', 'IsotonicRegression', 'OneHotEncoder',
              'RandomTreesEmbedding', 'FeatureHasher', 'DummyClassifier',
-             'DummyRegressor', 'TruncatedSVD']
+             'DummyRegressor', 'TruncatedSVD', 'PolynomialFeatures']
 
 
 def test_all_estimators():


### PR DESCRIPTION
This is a simple pre-processor that creates mixed polynomial features of any given degree. This is something I use often in tutorials, and this will make the process much more streamlined.

What this PR contains:
- A new `sklearn.preprocessing.PolynomialFeatures` transformer class
- A `sklearn.preprocessing.polynomial_features` function
- Tests of the new functionality
- A modified polynomial interpolation example which uses this in a pipeline rather than using `np.vander` to construct the features by hand.

Note that full polynomial features are more general than `np.vander`, because they'll work for more than one-dimensional input (see the docstring for an example).

This doesn't support sparse yet: we'll have to think about how to most efficiently implement that.
