### PR TITLE
[Proof of concept] Syntactic sugar for pipelines

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -262,12 +262,22 @@ class BaseEstimator(object):
         class_name = self.__class__.__name__
         return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),
                                                offset=len(class_name),),)
-
     def __str__(self):
         class_name = self.__class__.__name__
         return '%s(%s)' % (class_name,
                            _pprint(self.get_params(deep=True),
                                    offset=len(class_name), printer=str,),)
+
+    def __or__(self, estimator):
+        from sklearn.pipeline import Pipeline
+        if isinstance(self, Pipeline):
+            name = estimator.__class__.__name__
+            steps = self.steps + [(name, estimator)]
+        else:
+            name1 = self.__class__.__name__
+            name2 = estimator.__class__.__name__
+            steps = [(name1, self), (name2, estimator)]
+        return Pipeline(steps)
 
 
 ###############################################################################

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -195,6 +195,26 @@ def test_pipeline_methods_preprocessing_svm():
         pipe.score(X, y)
 
 
+def test_pipeline_syntactic_sugar():
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    pipeline = StandardScaler() | PCA(n_components=2) | SVC(random_state=0)
+    assert_true(isinstance(pipeline, Pipeline))
+
+    assert_equal(pipeline.steps[0][0], "StandardScaler")
+    assert_true(isinstance(pipeline.steps[0][1], StandardScaler))
+
+    assert_equal(pipeline.steps[1][0], "PCA")
+    assert_true(isinstance(pipeline.steps[1][1], PCA))
+
+    assert_equal(pipeline.steps[2][0], "SVC")
+    assert_true(isinstance(pipeline.steps[2][1], SVC))
+
+    y_pred = pipeline.fit(X, y).predict(X)
+    assert_equal(np.mean(y == y_pred), 0.92)
+
+
 def test_feature_union():
     # basic sanity check for feature union
     iris = load_iris()


### PR DESCRIPTION
Inspired by https://github.com/aht/stream.py by @aht

This PR adds a simple syntactic sugar for easily creating pipelines.

```
>>> iris = load_iris()
>>> X, y = iris.data, iris.target
>>> pipeline = StandardScaler() | PCA(n_components=2) | SVC(random_state=0)
>>> pipeline.__class__
<class 'sklearn.pipeline.Pipeline'>
>>> y_pred = pipeline.fit(X, y).predict(X)
>>> np.mean(y == y_pred)
0.92000000000000004
```

I used the bitwise or operator because of the similarity between pipelines and UNIX pipes but the right shift operator could be nice too (easier to read and convey the idea of direction):

```
>>> pipeline = StandardScaler() >> PCA(n_components=2) >> SVC(random_state=0)
```
