### PR TITLE
Fix scoring function string

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -62,7 +62,7 @@ Scoring                    Function
 'adjusted_rand_score'      :func:`sklearn.metrics.adjusted_rand_score`
 
 **Regression**
-'mean_squared_error'       :func:`sklearn.metrics.mean_squared_error`
+'mse'                      :func:`sklearn.metrics.mean_squared_error`
 'r2'                       :func:`sklearn.metrics.r2_score`
 ======================     =================================================
 


### PR DESCRIPTION
Change it to the correct key from the sklearn.metrics.SCORERS dict
