### PR TITLE
Test and fix regression in CountVectorizer handling of float min_df/max_df

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -596,32 +596,31 @@ def test_count_vectorizer_max_features():
 
 
 def test_vectorizer_max_df():
-    test_data = ['abc', 'dea']  # the letter a occurs in both strings
+    test_data = ['abc', 'dea', 'eat']
     vect = CountVectorizer(analyzer='char', max_df=1.0)
     vect.fit(test_data)
     assert_true('a' in vect.vocabulary_.keys())
-    assert_equal(len(vect.vocabulary_.keys()), 5)
+    assert_equal(len(vect.vocabulary_.keys()), 6)
     assert_equal(len(vect.stop_words_), 0)
 
-    vect.max_df = 0.5
+    vect.max_df = 0.5  # 0.5 * 3 documents -> max_df == 1.5
     vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # 'a' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)  # the others remain
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
     assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 1)
+    assert_equal(len(vect.stop_words_), 2)
 
-    # absolute count: if in more than one
     vect.max_df = 1
     vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # 'a' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)  # the others remain
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
     assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 1)
+    assert_equal(len(vect.stop_words_), 2)
 
 
 def test_vectorizer_min_df():
-    test_data = ['abc', 'dea', 'eat']  # the letter a occurs in both strings
-    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1)
+    test_data = ['abc', 'dea', 'eat']
+    vect = CountVectorizer(analyzer='char', min_df=1)
     vect.fit(test_data)
     assert_true('a' in vect.vocabulary_.keys())
     assert_equal(len(vect.vocabulary_.keys()), 6)
@@ -629,17 +628,17 @@ def test_vectorizer_min_df():
 
     vect.min_df = 2
     vect.fit(test_data)
-    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+    assert_true('c' not in vect.vocabulary_.keys())  # {bcdt} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 2)    # {ae} remain
     assert_true('c' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 4)
 
-    vect.min_df = .5
+    vect.min_df = 0.8  # 0.8 * 3 documents -> min_df == 2.4
     vect.fit(test_data)
-    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+    assert_true('c' not in vect.vocabulary_.keys())  # {bcdet} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 1)    # {a} remain
     assert_true('c' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 4)
+    assert_equal(len(vect.stop_words_), 5)
 
 
 def test_count_binary_occurrences():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -797,10 +797,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             n_doc = X.shape[0]
             max_doc_count = (max_df
                              if isinstance(max_df, numbers.Integral)
-                             else int(round(max_df * n_doc)))
+                             else max_df * n_doc)
             min_doc_count = (min_df
                              if isinstance(min_df, numbers.Integral)
-                             else int(round(min_df * n_doc)))
+                             else min_df * n_doc)
             if max_doc_count < min_doc_count:
                 raise ValueError(
                     "max_df corresponds to < documents than min_df")


### PR DESCRIPTION
This updated test used to pass on 0.13.1, broken in newer versions.
