### PR TITLE
Improve Naive Bayes test coverage

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -315,10 +315,6 @@ class BaseDiscreteNB(BaseNB):
         if Y.shape[1] == 1:
             Y = np.concatenate((1 - Y, Y), axis=1)
 
-        if X.shape[0] != Y.shape[0]:
-            msg = "X.shape[0]=%d and y.shape[0]=%d are incompatible."
-            raise ValueError(msg % (X.shape[0], y.shape[0]))
-
         # convert to float to support sample weight consistently
         Y = Y.astype(np.float64)
         if sample_weight is not None:

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -534,8 +534,14 @@ class BernoulliNB(BaseDiscreteNB):
         """Count and smooth feature occurrences."""
         if self.binarize is None:
             #ensure data is binary
-            if not set(np.unique(X)).issubset({0, 1}):
-                raise ValueError("Expected binary input, got non-binary input")
+            if issparse(X):
+                if not (X.data == 1).all():
+                    raise ValueError("Expected binary input, \
+                                    got non-binary input")
+            else:
+                if not np.logical_or(X == 1, X == 0).all():
+                    raise ValueError("Expected binary input, \
+                                    got non-binary input")
         else:
             X = binarize(X, threshold=self.binarize)
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -534,11 +534,14 @@ class BernoulliNB(BaseDiscreteNB):
         """check if data is binary and binarize if necessary"""
         if self.binarize is None:
             # ensure data is binary
-            non_binary = np.setdiff1d(X.data if issparse(X) else X, [0, 1])
-            if (non_binary.size > 0):
-                raise ValueError('Expected binary input, but there are %d'
-                                 ' non-binary value(s) in input'
-                                 % non_binary.size)
+            if issparse(X):
+                if not (X.data == 1).all():
+                    raise ValueError("Expected binary input, "
+                                     "got non-binary input")
+            else:
+                if not np.logical_or(X == 1, X == 0).all():
+                    raise ValueError("Expected binary input, "
+                                     "got non-binary input")
         else:
             X = binarize(X, threshold=self.binarize)
         return X

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -533,7 +533,7 @@ class BernoulliNB(BaseDiscreteNB):
     def _binarize(self, X):
         """check if data is binary and binarize if necessary"""
         if self.binarize is None:
-            #ensure data is binary
+            # ensure data is binary
             non_binary = np.setdiff1d(X.data if issparse(X) else X, [0, 1])
             if (non_binary.size > 0):
                 raise ValueError('Expected binary input, but there are %d'

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -536,8 +536,13 @@ class BernoulliNB(BaseDiscreteNB):
 
     def _count(self, X, Y):
         """Count and smooth feature occurrences."""
-        if self.binarize is not None:
+        if self.binarize is None:
+            #ensure data is binary
+            if not set(np.unique(X)).issubset({0, 1}):
+                raise ValueError("Expected binary input, got non-binary input")
+        else:
             X = binarize(X, threshold=self.binarize)
+
         self.feature_count_ += safe_sparse_dot(Y.T, X)
         self.class_count_ += Y.sum(axis=0)
 
@@ -555,9 +560,12 @@ class BernoulliNB(BaseDiscreteNB):
 
         X = atleast2d_or_csr(X)
 
-        if self.binarize is not None:
+        if self.binarize is None:
+            #ensure data is binary
+            if not set(np.unique(X)).issubset({0, 1}):
+                raise ValueError("Expected binary input, got non-binary input")
+        else:
             X = binarize(X, threshold=self.binarize)
-
         n_classes, n_features = self.feature_log_prob_.shape
         n_samples, n_features_X = X.shape
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -115,22 +115,24 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_proba3, y_pred_proba)
         assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
+
 def test_bnb():
     """Test Bernoulli Naive Bayes classification.
     """
     clf = BernoulliNB(binarize=None)
 
-    #fit should raise an error when using 
+    #fit should raise an error when using
     # non-binary data with binarize=None
-    assert_raises(ValueError,clf.fit, [[0, 0], [0, 1], [0, 2]], [0, 1, 1])
+    assert_raises(ValueError, clf.fit, [[0, 0], [0, 1], [0, 2]], [0, 1, 1])
 
     clf.fit([[0, 0], [0, 1], [0, 1]], [0, 1, 1])
 
-    #predict should raise an error when using 
+    #predict should raise an error when using
     # non-binary data with binarize=None
-    assert_raises(ValueError,clf.predict,[0,2])
+    assert_raises(ValueError, clf.predict, [0, 2])
 
-    assert_equal(clf.predict([0,1]),1)
+    assert_equal(clf.predict([0, 1]), 1)
+
 
 def check_partial_fit(cls):
     clf1 = cls()

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -121,19 +121,19 @@ def test_bnb():
     """
     clf = BernoulliNB(binarize=None)
 
-    #fit should raise an error when using
+    # fit should raise an error when using
     # non-binary data with binarize=None
     X = np.array([[0, 0], [0, 1], [0, 2]])
-    sX = scipy.sparse.csr_matrix(X)
+    X_sparse = scipy.sparse.csr_matrix(X)
     assert_raises(ValueError, clf.fit, X, [0, 1, 1])
-    assert_raises(ValueError, clf.fit, sX, [0, 1, 1])
+    assert_raises(ValueError, clf.fit, X_sparse, [0, 1, 1])
 
     X2 = np.array([[0, 0], [0, 1], [0, 1]])
-    sX2 = scipy.sparse.csr_matrix(X2)
+    X2_sparse = scipy.sparse.csr_matrix(X2)
     clf.fit(X2, [0, 1, 1])
-    clf.fit(sX2, [0, 1, 1])
+    clf.fit(X2_sparse, [0, 1, 1])
 
-    #predict should raise an error when using
+    # predict should raise an error when using
     # non-binary data with binarize=None
     assert_raises(ValueError, clf.predict, [0, 2])
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -115,6 +115,22 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_proba3, y_pred_proba)
         assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
+def test_bnb():
+    """Test Bernoulli Naive Bayes classification.
+    """
+    clf = BernoulliNB(binarize=None)
+
+    #fit should raise an error when using 
+    # non-binary data with binarize=None
+    assert_raises(ValueError,clf.fit, [[0, 0], [0, 1], [0, 2]], [0, 1, 1])
+
+    clf.fit([[0, 0], [0, 1], [0, 1]], [0, 1, 1])
+
+    #predict should raise an error when using 
+    # non-binary data with binarize=None
+    assert_raises(ValueError,clf.predict,[0,2])
+
+    assert_equal(clf.predict([0,1]),1)
 
 def check_partial_fit(cls):
     clf1 = cls()

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -123,9 +123,15 @@ def test_bnb():
 
     #fit should raise an error when using
     # non-binary data with binarize=None
-    assert_raises(ValueError, clf.fit, [[0, 0], [0, 1], [0, 2]], [0, 1, 1])
+    X = np.array([[0, 0], [0, 1], [0, 2]])
+    sX = scipy.sparse.csr_matrix(X)
+    assert_raises(ValueError, clf.fit, X, [0, 1, 1])
+    assert_raises(ValueError, clf.fit, sX, [0, 1, 1])
 
-    clf.fit([[0, 0], [0, 1], [0, 1]], [0, 1, 1])
+    X2 = np.array([[0, 0], [0, 1], [0, 1]])
+    sX2 = scipy.sparse.csr_matrix(X2)
+    clf.fit(X2, [0, 1, 1])
+    clf.fit(sX2, [0, 1, 1])
 
     #predict should raise an error when using
     # non-binary data with binarize=None


### PR DESCRIPTION
This PR adds tests for the binarize=None option in BernoulliNB. If binarize=None, and non-binary data is used, an error should be raised (which is now the case.)

Test coverage has been improved in f6bf82f, by removing a conditional that was always true (the check_arrays call above serves the same purpose.)

Coverage is now 99% for naive_bayes.py. it should be 100%, but the @abstractmethod decorator on line 39 is incorrectly counted as a missing branch due to a bug in coverage.py (see https://bitbucket.org/ned/coveragepy/issue/129/misleading-branch-coverage-of-empty for details.)
