### PR TITLE
[WIP] enhance `labels` and deprecate `pos_label` in PRF metrics

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1541,7 +1541,7 @@ def _prf_divide(numerator, denominator, metric, modifier, average, warn_for):
 
 
 def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
-                                    pos_label=1, average=None,
+                                    pos_label='!deprecated', average=None,
                                     warn_for=('precision', 'recall',
                                               'f-score'),
                                     sample_weight=None):
@@ -1580,17 +1580,15 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     beta : float, 1.0 by default
         The strength of recall versus precision in the F-score.
 
-    labels : array
-        Integer array of labels.
-
-    pos_label : str or int, 1 by default
-        If ``average`` is not ``None`` and the classification target is binary,
-        only this class's scores will be returned.
+    labels : array-like of integers or strings (optional)
+        Specifies the order of results returned if `average` is `None`, and
+        otherwise the set of labels to take into account when averaging.
+        By default, all labels in `y_true` and `y_pred` are used in sorted
+        order.
 
     average : string, [None (default), 'micro', 'macro', 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
-        unless ``pos_label`` is given in binary classification, this
-        determines the type of averaging performed on the data:
+        this determines the type of averaging performed on the data:
 
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
@@ -1618,16 +1616,16 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     Returns
     -------
     precision: float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+        len(labels)
 
     recall: float (if average is not None) or array of float, , shape =\
-        [n_unique_labels]
+        len(labels)
 
     fbeta_score: float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+        len(labels)
 
     support: int (if average is not None) or array of int, shape =\
-        [n_unique_labels]
+        len(labels)
         The number of occurrences of each label in ``y_true``.
 
     References

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1582,7 +1582,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels='compat',
         When `labels` is None, all labels in `y_true` and `y_pred` are used in
         sorted order. By default, binary classification is handled specially
         for backwards compatibility, but this feature will be removed in
-        version 0.16.
+        release 0.16.
 
     average : string, [None (default), 'micro', 'macro', 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
@@ -1665,9 +1665,19 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels='compat',
     y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
     present_labels = unique_labels(y_true, y_pred)
 
+    if pos_label != '!deprecated':
+        warnings.warn('The `pos_label` parameter to precision, recall and '
+                      'F-score is deprecated, and will be removed in release '
+                      '0.16. The `labels` parameter may be used instead.',
+                      DeprecationWarning)
+
     if not isinstance(labels, np.ndarray) and labels == 'compat':
         if y_type == 'binary' and (average is not None and
                                    pos_label is not None):
+            warnings.warn('From release 0.16, binary classification will not '
+                          'be handled specially for precision, recall and '
+                          'F-score. Instead, specify a single positive label '
+                          'with the `labels` parameter.', FutureWarning)
 
             if pos_label == '!deprecated':
                 pos_label = 1
@@ -1685,6 +1695,14 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels='compat',
     else:
         n_labels = len(labels)
         labels = np.hstack([labels, np.setdiff1d(present_labels, labels)])
+        if n_labels == 2 and len(labels) == 2 and (pos_label is not None and
+                                                   average is not None):
+            warnings.warn('Precision, recall and F-score behaviour has '
+                          'changed: providing two classes to the `labels` '
+                          'parameter no longer returns results only for the '
+                          'positive label. Use `labels=[positive_label]` for '
+                          'former behaviour, or `labels=None` for all labels '
+                          'present in the data to be considered equally.')
 
     ### Calculate tp_sum, pred_sum, true_sum ###
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1335,17 +1335,17 @@ def f1_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
     y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
-
-    pos_label : str or int, 1 by default
-        If ``average`` is not ``None`` and the classification target is binary,
-        only this class's scores will be returned.
+    labels : array-like of integers or strings (optional)
+        Specifies the order of results returned if `average` is `None`, and
+        otherwise the set of labels to take into account when averaging.
+        When `labels` is None, all labels in `y_true` and `y_pred` are used in
+        sorted order. By default, binary classification is handled specially
+        for backwards compatibility, but this feature will be removed in
+        release 0.17.
 
     average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
         If ``None``, the scores for each class are returned. Otherwise,
-        unless ``pos_label`` is given in binary classification, this
-        determines the type of averaging performed on the data:
+        this determines the type of averaging performed on the data:
 
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
@@ -1368,7 +1368,7 @@ def f1_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
 
     Returns
     -------
-    f1_score : float or array of float, shape = [n_unique_labels]
+    f1_score : float or array of float, shape = [len(labels)]
         F1 score of the positive class in binary classification or weighted
         average of the F1 scores of each class for the multiclass task.
 
@@ -1421,17 +1421,17 @@ def fbeta_score(y_true, y_pred, beta, labels='compat', pos_label='!deprecated',
     beta: float
         Weight of precision in harmonic mean.
 
-    labels : array
-        Integer array of labels.
-
-    pos_label : str or int, 1 by default
-        If ``average`` is not ``None`` and the classification target is binary,
-        only this class's scores will be returned.
+    labels : array-like of integers or strings (optional)
+        Specifies the order of results returned if `average` is `None`, and
+        otherwise the set of labels to take into account when averaging.
+        When `labels` is None, all labels in `y_true` and `y_pred` are used in
+        sorted order. By default, binary classification is handled specially
+        for backwards compatibility, but this feature will be removed in
+        release 0.17.
 
     average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
         If ``None``, the scores for each class are returned. Otherwise,
-        unless ``pos_label`` is given in binary classification, this
-        determines the type of averaging performed on the data:
+        this determines the type of averaging performed on the data:
 
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
@@ -1455,7 +1455,7 @@ def fbeta_score(y_true, y_pred, beta, labels='compat', pos_label='!deprecated',
     Returns
     -------
     fbeta_score : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+        [len(labels)]
         F-beta score of the positive class in binary classification or weighted
         average of the F-beta score of each class for the multiclass task.
 
@@ -1582,7 +1582,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels='compat',
         When `labels` is None, all labels in `y_true` and `y_pred` are used in
         sorted order. By default, binary classification is handled specially
         for backwards compatibility, but this feature will be removed in
-        release 0.16.
+        release 0.17.
 
     average : string, [None (default), 'micro', 'macro', 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
@@ -1614,16 +1614,16 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels='compat',
     Returns
     -------
     precision: float (if average is not None) or array of float, shape =\
-        len(labels)
+        [len(labels)]
 
     recall: float (if average is not None) or array of float, , shape =\
-        len(labels)
+        [len(labels)]
 
     fbeta_score: float (if average is not None) or array of float, shape =\
-        len(labels)
+        [len(labels)]
 
     support: int (if average is not None) or array of int, shape =\
-        len(labels)
+        [len(labels)]
         The number of occurrences of each label in ``y_true``.
 
     References
@@ -1838,17 +1838,17 @@ def precision_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
     y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
-
-    pos_label : str or int, 1 by default
-        If ``average`` is not ``None`` and the classification target is binary,
-        only this class's scores will be returned.
+    labels : array-like of integers or strings (optional)
+        Specifies the order of results returned if `average` is `None`, and
+        otherwise the set of labels to take into account when averaging.
+        When `labels` is None, all labels in `y_true` and `y_pred` are used in
+        sorted order. By default, binary classification is handled specially
+        for backwards compatibility, but this feature will be removed in
+        release 0.17.
 
     average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
         If ``None``, the scores for each class are returned. Otherwise,
-        unless ``pos_label`` is given in binary classification, this
-        determines the type of averaging performed on the data:
+        this determines the type of averaging performed on the data:
 
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
@@ -1872,7 +1872,7 @@ def precision_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
     Returns
     -------
     precision : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+        [len(labels)]
         Precision of the positive class in binary classification or weighted
         average of the precision of each class for the multiclass task.
 
@@ -1920,17 +1920,17 @@ def recall_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
     y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
-    labels : array
-        Integer array of labels.
-
-    pos_label : str or int, 1 by default
-        If ``average`` is not ``None`` and the classification target is binary,
-        only this class's scores will be returned.
+    labels : array-like of integers or strings (optional)
+        Specifies the order of results returned if `average` is `None`, and
+        otherwise the set of labels to take into account when averaging.
+        When `labels` is None, all labels in `y_true` and `y_pred` are used in
+        sorted order. By default, binary classification is handled specially
+        for backwards compatibility, but this feature will be removed in
+        release 0.17.
 
     average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
         If ``None``, the scores for each class are returned. Otherwise,
-        unless ``pos_label`` is given in binary classification, this
-        determines the type of averaging performed on the data:
+        this determines the type of averaging performed on the data:
 
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
@@ -1954,7 +1954,7 @@ def recall_score(y_true, y_pred, labels='compat', pos_label='!deprecated',
     Returns
     -------
     recall : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+        [len(labels)]
         Recall of the positive class in binary classification or weighted
         average of the recall of each class for the multiclass task.
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1419,11 +1419,6 @@ def test_losses_at_limits():
     assert_almost_equal(r2_score([0., 1], [0., 1]), 1.00, 2)
 
 
-def test_r2_one_case_error():
-    # test whether r2_score raises error given one point
-    assert_raises(ValueError, r2_score, [0], [0])
-
-
 @ignore_warnings
 def test_symmetry():
     """Test the symmetry of score and loss functions"""
@@ -2314,11 +2309,11 @@ def test_prf_warnings():
         # single postive label
         msg = ('Precision and F-score are ill-defined and '
                'being set to 0.0 due to no predicted samples.')
-        my_assert(w, msg, f, [1, 1], [-1, -1], average='macro')
+        my_assert(w, msg, f, [1, 1], [-1, -1], labels=[1], average='macro')
 
         msg = ('Recall and F-score are ill-defined and '
                'being set to 0.0 due to no true samples.')
-        my_assert(w, msg, f, [-1, -1], [1, 1], average='macro')
+        my_assert(w, msg, f, [-1, -1], [1, 1], labels=[1], average='macro')
 
 
 def test_recall_warnings():


### PR DESCRIPTION
This intends to make the parameter `labels` clearly defined for the `precision_recall_fscore_support` family of metrics. This amounts to a (partial) fix for #1983, #1989, #2029, #2094, #3122. As implied by the comment I have committed, labels will:
- determine the sort order when returning a result for each class
- determine which labels will be included in an average (allowing one or more negative/ignored classes in multiclass classification)
- by default, all labels are used, with no special handling of binary -the current special handling of binary classification is preserved, but `pos_label` is determined implicitly.-

There are some potential issues in the deprecation process, and in making binary classifier metrics available as Scorers...
- [x] Define and document intended behaviour
- [x] Tests for new `labels` functionality
- [x] Implement new `labels` functionality
- [x] Ensure `labels` is set correctly for legacy functionality
- [x] Deprecation warnings for `pos_label`
- [ ] Some solution for scorers, at least handling the binary case
- [x] Copy documentation to derived functions
- [ ] Update narrative documentation
- [ ] Update what's new
- [ ] Open issue for similar behaviour in `average_precision_score`, `roc_auc_score` and any other binary-averaged metrics.

**This should not be merged until after the 0.15 release to allow at least one release with the warning merged from #2952**
