### PR TITLE
ENH support multiclass targets of dtype=object strings

### DIFF
--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1496,10 +1496,22 @@ def test_invariance_string_vs_numbers_labels():
                            err_msg="{0} failed string vs number invariance "
                                    "test".format(name))
 
+        measure_with_strobj = metric_str(y1_str.astype('O'),
+                                         y2_str.astype('O'))
+        assert_array_equal(measure_with_number, measure_with_strobj,
+                           err_msg="{0} failed string object vs number "
+                                   "invariance test".format(name))
+
         if name in METRICS_WITH_LABELS:
             metric_str = partial(metric_str, labels=labels_str)
             measure_with_str = metric_str(y1_str, y2_str)
             assert_array_equal(measure_with_number, measure_with_str,
+                               err_msg="{0} failed string vs number  "
+                                       "invariance test".format(name))
+
+            measure_with_strobj = metric_str(y1_str.astype('O'),
+                                             y2_str.astype('O'))
+            assert_array_equal(measure_with_number, measure_with_strobj,
                                err_msg="{0} failed string vs number  "
                                        "invariance test".format(name))
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -620,41 +620,43 @@ def test_classifiers_classes():
     X, y = shuffle(X, y, random_state=1)
     X = StandardScaler().fit_transform(X)
     y_names = iris.target_names[y]
-    for name, Classifier in classifiers:
-        if name in dont_test:
-            continue
-        if name in ['MultinomialNB', 'BernoulliNB']:
-            # TODO also test these!
-            continue
-        if name in ["LabelPropagation", "LabelSpreading"]:
-            # TODO some complication with -1 label
-            y_ = y
-        else:
-            y_ = y_names
+    for y_names in [y_names, y_names.astype('O')]:
+        for name, Classifier in classifiers:
+            if name in dont_test:
+                continue
+            if name in ['MultinomialNB', 'BernoulliNB']:
+                # TODO also test these!
+                continue
+            if name in ["LabelPropagation", "LabelSpreading"]:
+                # TODO some complication with -1 label
+                y_ = y
+            else:
+                y_ = y_names
 
-        classes = np.unique(y_)
-        # catch deprecation warnings
-        with warnings.catch_warnings(record=True):
-            classifier = Classifier()
-        # fit
-        try:
-            classifier.fit(X, y_)
-        except Exception as e:
-            print(e)
+            classes = np.unique(y_)
+            # catch deprecation warnings
+            with warnings.catch_warnings(record=True):
+                classifier = Classifier()
+            # fit
+            try:
+                classifier.fit(X, y_)
+            except Exception as e:
+                print(e)
 
-        y_pred = classifier.predict(X)
-        # training set performance
-        assert_array_equal(np.unique(y_), np.unique(y_pred))
-        accuracy = accuracy_score(y_, y_pred)
-        assert_greater(accuracy, 0.78,
-                       "accuracy %f of %s not greater than 0.78"
-                       % (accuracy, name))
-        #assert_array_equal(
-            #clf.classes_, classes,
-            #"Unexpected classes_ attribute for %r" % clf)
-        if np.any(classifier.classes_ != classes):
-            print("Unexpected classes_ attribute for %r: expected %s, got %s" %
-                  (classifier, classes, classifier.classes_))
+            y_pred = classifier.predict(X)
+            # training set performance
+            assert_array_equal(np.unique(y_), np.unique(y_pred))
+            accuracy = accuracy_score(y_, y_pred)
+            assert_greater(accuracy, 0.78,
+                           "accuracy %f of %s not greater than 0.78"
+                           % (accuracy, name))
+            #assert_array_equal(
+                #clf.classes_, classes,
+                #"Unexpected classes_ attribute for %r" % clf)
+            if np.any(classifier.classes_ != classes):
+                print("Unexpected classes_ attribute for %r: "
+                      "expected %s, got %s" %
+                      (classifier, classes, classifier.classes_))
 
 
 def test_classifiers_input_shapes():

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -290,7 +290,8 @@ def type_of_target(y):
     except ValueError:
         # known to fail in numpy 1.3 for array of arrays
         return 'unknown'
-    if y.ndim > 2 or y.dtype == object:
+    if y.ndim > 2 or (y.dtype == object and len(y) and
+                      not isinstance(y.flat[0], string_types)):
         return 'unknown'
     if y.ndim == 2 and y.shape[1] == 0:
         return 'unknown'

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -51,6 +51,8 @@ EXAMPLES = {
         [0, 1, 2],
         ['a', 'b', 'c'],
         np.array([u'a', u'b', u'c']),
+        np.array([u'a', u'b', u'c'], dtype=object),
+        np.array(['a', 'b', 'c'], dtype=object),
     ],
     'multiclass-multioutput': [
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]]),
@@ -60,6 +62,7 @@ EXAMPLES = {
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.float32),
         np.array([['a', 'b'], ['c', 'd']]),
         np.array([[u'a', u'b'], [u'c', u'd']]),
+        np.array([[u'a', u'b'], [u'c', u'd']], dtype=object),
         np.array([[1, 0, 2]]),
     ],
     'binary': [
@@ -79,7 +82,9 @@ EXAMPLES = {
         ['a'],
         ['a', 'b'],
         ['abc', 'def'],
+        np.array(['abc', 'def']),
         [u'a', u'b'],
+        np.array(['abc', 'def'], dtype=object),
     ],
     'continuous': [
         [1e-5],


### PR DESCRIPTION
Here's a first hack at fixing #2374, #2618. I think we should get this into the next release, since it seems it was a regression of 0.14 relative to 0.13 (or so says @samuela).

There are probably more parts of the code to test, but I thought the main invariance tests were low-hanging fruit. Feel free to offer further commits to the patch.
