### PR TITLE
Bugfixes in gaussian_process subpackage

### DIFF
--- a/examples/gaussian_process/gp_diabetes_dataset.py
+++ b/examples/gaussian_process/gp_diabetes_dataset.py
@@ -40,7 +40,7 @@ gp = GaussianProcess(regr='constant', corr='absolute_exponential',
 gp.fit(X, y)
 
 # Deactivate maximum likelihood estimation for the cross-validation loop
-gp.theta0 = gp.theta  # Given correlation parameter = MLE
+gp.theta0 = gp.theta_  # Given correlation parameter = MLE
 gp.thetaL, gp.thetaU = None, None  # None bounds deactivate MLE
 
 # Perform a cross-validation estimate of the coefficient of determination using

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -736,9 +736,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     raise ve
 
                 optimal_theta = 10. ** log10_optimal_theta
-                optimal_minus_rlf_value, optimal_par = \
+                optimal_rlf_value, optimal_par = \
                     self.reduced_likelihood_function(theta=optimal_theta)
-                optimal_rlf_value = - optimal_minus_rlf_value
 
                 # Compare the new optimizer to the best previous one
                 if k > 0:


### PR DESCRIPTION
Hi list,

It's been a while... ;-)

I've been told the `random_start` feature of the GaussianProcess estimator was making it worse rather than making it better.
It was indeed due to a bad handling of sign in the randomly restarted maximization of the reduced likelihood function (implemented as the minimization of the opposite reduced likelihood function with `fmin_cobyla`).

While running GP tests and examples, I spotted another mistake in the `gp_diabetes_dataset` example which appeared when the optimized `theta` value stored in the estimator was made "private" by renaming it to `theta_`.

Cheers!
