### PR TITLE
Issue #2611: MiniBatchKmeans crashes

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -839,7 +839,7 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
         to_reassign = np.logical_or(
             (counts <= 1), counts <= reassignment_ratio * counts.max())
         n_reassigns = min(to_reassign.sum(), X.shape[0])
-				# Only keep first n_reassigns True values in to_reassign
+        # Only keep first n_reassigns True values in to_reassign
         if n_reassigns < to_reassign.sum():
             to_reassign = np.logical_and(
                 to_reassign, to_reassign.cumsum() <= n_reassigns)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -839,6 +839,10 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
         to_reassign = np.logical_or(
             (counts <= 1), counts <= reassignment_ratio * counts.max())
         n_reassigns = min(to_reassign.sum(), X.shape[0])
+				# Only keep first n_reassigns True values in to_reassign
+        if n_reassigns < to_reassign.sum():
+            to_reassign = np.logical_and(
+                to_reassign, to_reassign.cumsum() <= n_reassigns)
         if n_reassigns:
             # Pick new clusters amongst observations with probability
             # proportional to their closeness to their center.


### PR DESCRIPTION
Fixes [crash](https://github.com/scikit-learn/scikit-learn/issues/2611) by making sure arrays are the correct dimensions
