### PR TITLE
ENH: Raise explicitly on non-unique vocab.

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -860,3 +860,7 @@ def test_pickling_transformer():
     assert_array_equal(
         copy.fit_transform(X).toarray(),
         orig.fit_transform(X).toarray())
+
+def test_non_unique_vocab():
+    vocab = ['a', 'b', 'c', 'a', 'a']
+    vectorizer = assert_raises(ValueError, CountVectorizer, vocabulary=vocab)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -638,16 +638,23 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.ngram_range = ngram_range
         if vocabulary is not None:
             if not isinstance(vocabulary, Mapping):
-                vocabulary = dict((t, i) for i, t in enumerate(vocabulary))
+                vocab = {}
+                for i, t in enumerate(vocabulary):
+                    if vocab.setdefault(t, i) != i:
+                        msg = "Duplicate term in vocabulary: %r" % t
+                        raise ValueError(msg)
+                vocabulary = vocab
+            else:
+                indices = set(six.itervalues(vocabulary))
+                if len(indices) != len(vocabulary):
+                    raise ValueError("Vocabulary contains repeated indices.")
+                for i in xrange(len(vocabulary)):
+                    if i not in indices:
+                        msg = ("Vocabulary of size %d doesn't contain index "
+                                "%d." % (len(vocabulary), i))
+                        raise ValueError(msg)
             if not vocabulary:
                 raise ValueError("empty vocabulary passed to fit")
-            indices = set(six.itervalues(vocabulary))
-            if len(indices) != len(vocabulary):
-                raise ValueError("Vocabulary contains repeated indices.")
-            for i in xrange(len(vocabulary)):
-                if i not in indices:
-                    msg = "Vocabulary of size %d doesn't contain index %d."
-                    raise ValueError(msg % (len(vocabulary), i))
             self.fixed_vocabulary = True
             self.vocabulary_ = dict(vocabulary)
         else:


### PR DESCRIPTION
A little better error message in this case. It's a bit ugly, but AFAICT there's not a better way since the user may give an object without a `__len__`.

Incidentally, what are the thoughts on just handling non-unique vocabularies? Something like 

```
vocabulary = list(set(vocabulary))
```

This won't work because things like this that are actually mappings would get clobbered by the current check for a mapping.

```
vocab = {"vocab" : 0, "beer" : 1}

from collections import Mapping

isinstance(iter(vocab), Mapping)
```

But it seems like it would be nice to just do this, if possible. Maybe raise a warning that the feature names of the vectorizer are now different than the given vocabulary. Thoughts?
