### PR TITLE
[MRG] faster convergence reporting in RBMs

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -223,11 +223,6 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
 
         rng : RandomState
             Random number generator to use for sampling.
-
-        Returns
-        -------
-        pseudo_likelihood : array-like, shape (n_samples,)
-            If verbose=True, pseudo-likelihood estimate for this batch.
         """
         h_pos = self._mean_hiddens(v_pos)
         v_neg = self._sample_visibles(self.h_samples_, rng)

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -51,9 +51,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         during training.
 
     verbose : int, optional
-        The verbosity level. Enabling it (with a non-zero value) will compute 
-        the log-likelihood of each mini-batch and hence cause a runtime overhead
-        in the order of 10%.
+        The verbosity level. The default, zero, means silent mode.
 
     random_state : integer or numpy.RandomState, optional
         A random number generator instance to define the state of the
@@ -81,7 +79,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
     >>> model = BernoulliRBM(n_components=2)
     >>> model.fit(X)
     BernoulliRBM(batch_size=10, learning_rate=0.1, n_components=2, n_iter=10,
-           random_state=None, verbose=False)
+           random_state=None, verbose=0)
 
     References
     ----------
@@ -95,7 +93,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         on Machine Learning (ICML) 2008
     """
     def __init__(self, n_components=256, learning_rate=0.1, batch_size=10,
-                 n_iter=10, verbose=False, random_state=None):
+                 n_iter=10, verbose=0, random_state=None):
         self.n_components = n_components
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -311,21 +309,17 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         batch_slices = list(gen_even_slices(n_batches * self.batch_size,
                                             n_batches, n_samples))
         verbose = self.verbose
-        for iteration in xrange(self.n_iter):
-            pl = 0.
-            if verbose:
-                begin = time.time()
-
+        begin = time.time()
+        for iteration in xrange(1, self.n_iter + 1):
             for batch_slice in batch_slices:
-                pl_batch = self._fit(X[batch_slice], rng)
-
-                if verbose:
-                    pl += pl_batch.sum()
+                self._fit(X[batch_slice], rng)
 
             if verbose:
-                pl /= n_samples
                 end = time.time()
-                print("Iteration %d, pseudo-likelihood = %.2f, time = %.2fs"
-                      % (iteration, pl, end - begin))
+                print("[%s] Iteration %d, pseudo-likelihood = %.2f,"
+                      " time = %.2fs"
+                      % (type(self).__name__, iteration,
+                         self.score_samples(X).mean(), end - begin))
+                begin = end
 
         return self

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -9,11 +9,12 @@
 import time
 
 import numpy as np
+import scipy.sparse as sp
 
 from ..base import BaseEstimator
 from ..base import TransformerMixin
 from ..externals.six.moves import xrange
-from ..utils import check_arrays
+from ..utils import atleast2d_or_csr, check_arrays
 from ..utils import check_random_state
 from ..utils import gen_even_slices
 from ..utils import issparse
@@ -189,8 +190,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
             The value of the free energy.
         """
         return (- safe_sparse_dot(v, self.intercept_visible_)
-                - np.log(1. + np.exp(safe_sparse_dot(v, self.components_.T)
-                            + self.intercept_hidden_)).sum(axis=1))
+                - np.log1p(np.exp(safe_sparse_dot(v, self.components_.T)
+                                  + self.intercept_hidden_)).sum(axis=1))
 
     def gibbs(self, v):
         """Perform one Gibbs sampling step.
@@ -246,33 +247,40 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         h_neg[rng.uniform(size=h_neg.shape) < h_neg] = 1.0  # sample binomial
         self.h_samples_ = np.floor(h_neg, h_neg)
 
-        if self.verbose:
-            return self.score_samples(v_pos)
-
-    def score_samples(self, v):
-        """Compute the pseudo-likelihood of v.
+    def score_samples(self, X):
+        """Compute the pseudo-likelihood of X.
 
         Parameters
         ----------
-        v : {array-like, sparse matrix} shape (n_samples, n_features)
-            Values of the visible layer.
+        X : {array-like, sparse matrix} shape (n_samples, n_features)
+            Values of the visible layer. Must be all-boolean (not checked).
 
         Returns
         -------
         pseudo_likelihood : array-like, shape (n_samples,)
-            Value of the pseudo-likelihood (proxy to likelihood).
-        """
-        rng = check_random_state(self.random_state)
-        fe = self._free_energy(v)
+            Value of the pseudo-likelihood (proxy for likelihood).
 
+        Notes
+        -----
+        This method is not deterministic: it computes a quantity called the
+        free energy on X, then on a randomly corrupted version of X, and
+        returns the log of the logistic function of the difference.
+        """
+        v = atleast2d_or_csr(X)
+        rng = check_random_state(self.random_state)
+
+        # Randomly corrupt one feature in each sample in v.
+        ind = (np.arange(v.shape[0]),
+               rng.randint(0, v.shape[1], v.shape[0]))
         if issparse(v):
-            v_ = v.toarray()
+            data = -2 * v[ind] + 1
+            v_ = v + sp.csr_matrix((data.A.ravel(), ind), shape=v.shape)
         else:
             v_ = v.copy()
-        i_ = rng.randint(0, v.shape[1], v.shape[0])
-        v_[np.arange(v.shape[0]), i_] = 1 - v_[np.arange(v.shape[0]), i_]
-        fe_ = self._free_energy(v_)
+            v_[ind] = 1 - v_[ind]
 
+        fe = self._free_energy(v)
+        fe_ = self._free_energy(v_)
         return v.shape[1] * logistic_sigmoid(fe_ - fe, log=True)
 
     def fit(self, X, y=None):

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -152,8 +152,10 @@ def test_sparse_and_verbose():
         rbm.fit(X)
         s = sys.stdout.getvalue()
         # make sure output is sound
-        assert(re.match(r"Iteration 0, pseudo-likelihood = -?(\d)+(\.\d+)?",
-                        s))
+        assert_true(re.match(r"\[BernoulliRBM\] Iteration 1,"
+                             r" pseudo-likelihood = -?(\d)+(\.\d+)?,"
+                             r" time = (\d|\.)+s",
+                             s))
     finally:
         sio = sys.stdout
         sys.stdout = old_stdout

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -2,8 +2,9 @@ import sys
 import re
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_equal
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, lil_matrix
+from sklearn.utils.testing import (assert_almost_equal, assert_array_equal,
+                                   assert_true)
 
 from sklearn.datasets import load_digits
 from sklearn.externals.six.moves import cStringIO as StringIO
@@ -108,16 +109,23 @@ def test_gibbs_smoke():
 
 
 def test_score_samples():
-    """Check that the pseudo likelihood is computed without clipping.
-
-    http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression/
-    """
+    """Test score_samples (pseudo-likelihood) method."""
+    # Assert that pseudo-likelihood is computed without clipping.
+    # http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression
     rng = np.random.RandomState(42)
     X = np.vstack([np.zeros(1000), np.ones(1000)])
     rbm1 = BernoulliRBM(n_components=10, batch_size=2,
                         n_iter=10, random_state=rng)
     rbm1.fit(X)
-    assert((rbm1.score_samples(X) < -300).all())
+    assert_true((rbm1.score_samples(X) < -300).all())
+
+    # Sparse vs. dense should not affect the output. Also test sparse input
+    # validation.
+    rbm1.random_state = 42
+    d_score = rbm1.score_samples(X)
+    rbm1.random_state = 42
+    s_score = rbm1.score_samples(lil_matrix(X))
+    assert_almost_equal(d_score, s_score)
 
 
 def test_rbm_verbose():


### PR DESCRIPTION
Our RBMs used to take about 45% of their time just computing convergence information. This PR brings that down to a few percent. Also, sparse matrices are no longer densified in `score_samples`, given a memory reduction of several orders of magnitude (for my typical data, that can be up to eight orders). Finally, the reported figures should be more realistic because they reflect the actual change that occurred during an iteration.

The downside is that the `fit` procedure requires a bit more memory now because it computes pseudo-likelihood for the entire input matrix.

Ping @vene, and maybe @IssamLaradji will find this interesting too.
