### PR TITLE
remove EllipticEnvelop deprecation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,10 @@
 Changelog
 ---------
 
+   - Use of :class:`covariance.EllipticEnvelop` has now been removed after
+     deprecation.
+     Please use :class:`covariance.EllipticEnvelope` instead.
+
    - Added :class:`ensemble.BaggingClassifier` and
      :class:`ensemble.BaggingRegressor` meta-estimators for ensembling
      any kind of base estimator. See the :ref:`Bagging <bagging>` section of

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -13,11 +13,10 @@ from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
     LedoitWolf, oas, OAS
 from .robust_covariance import fast_mcd, MinCovDet
 from .graph_lasso_ import graph_lasso, GraphLasso, GraphLassoCV
-from .outlier_detection import EllipticEnvelope, EllipticEnvelop
+from .outlier_detection import EllipticEnvelope
 
 
-__all__ = ['EllipticEnvelop',
-           'EllipticEnvelope',
+__all__ = ['EllipticEnvelope',
            'EmpiricalCovariance',
            'GraphLasso',
            'GraphLassoCV',

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -15,7 +15,6 @@ covariance estimator (the Minimum Covariance Determinant).
 import numpy as np
 import scipy as sp
 from . import MinCovDet
-from ..utils import deprecated
 from ..base import ClassifierMixin
 
 
@@ -184,8 +183,3 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
 
         return self
 
-
-# Deprecated classes
-@deprecated("Use EllipticEnvelope instead. To be removed in 0.13.")
-class EllipticEnvelop(EllipticEnvelope):
-    pass

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -45,9 +45,9 @@ from sklearn.svm.base import BaseLibSVM
 from sklearn.cross_validation import train_test_split
 from sklearn.utils.validation import DataConversionWarning
 
-dont_test = ['SparseCoder', 'EllipticEnvelope', 'EllipticEnvelop',
-             'DictVectorizer', 'LabelBinarizer', 'LabelEncoder',
-             'TfidfTransformer', 'IsotonicRegression', 'OneHotEncoder',
+dont_test = ['SparseCoder', 'EllipticEnvelope', 'DictVectorizer',
+             'LabelBinarizer', 'LabelEncoder', 'TfidfTransformer',
+             'IsotonicRegression', 'OneHotEncoder',
              'RandomTreesEmbedding', 'FeatureHasher', 'DummyClassifier',
              'DummyRegressor', 'TruncatedSVD', 'PolynomialFeatures']
 


### PR DESCRIPTION
Remove the support for '`EllipticEnvelop`' since it's been deprecated for quite a while.
Leave only `EllipticEnvelope`
