### PR TITLE
[MRG+1] deprecate sequences of sequences multilabel support

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -244,7 +244,7 @@ Multiclass and multilabel utility function
   a classification output is in label indicator matrix format.
 
 - :func:`multiclass.unique_labels`: Helper function to extract an ordered
-  array of unique labels from a list of labels.
+  array of unique labels from different formats of target.
 
 
 Helper Functions

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1058,6 +1058,7 @@ Pairwise metrics
    preprocessing.KernelCenterer
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder
+   preprocessing.MultiLabelBinarizer
    preprocessing.MinMaxScaler
    preprocessing.Normalizer
    preprocessing.OneHotEncoder

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -259,15 +259,10 @@ where :math:`1(x)` is the `indicator function
   >>> accuracy_score(y_true, y_pred, normalize=False)
   2
 
-In the multilabel case with binary indicator format:
+In the multilabel case with binary label indicators:
 
   >>> accuracy_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
   0.5
-
-and with a list of labels format:
-
-  >>> accuracy_score([(1,), (3,)], [(1, 2), tuple()])
-  0.0
 
 .. topic:: Example:
 
@@ -377,15 +372,10 @@ where :math:`1(x)` is the `indicator function
   >>> hamming_loss(y_true, y_pred)
   0.25
 
-In the multilabel case with binary indicator format: ::
+In the multilabel case with binary label indicators: ::
 
   >>> hamming_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.zeros((2, 2)))
   0.75
-
-and with a list of labels format: ::
-
-  >>> hamming_loss([(1, 2), (3,)], [(1, 2), tuple()])  # doctest: +ELLIPSIS
-  0.166...
 
 .. note::
 
@@ -434,16 +424,10 @@ score is equal to the classification accuracy.
   >>> jaccard_similarity_score(y_true, y_pred, normalize=False)
   2
 
-In the multilabel case with binary indicator format:
+In the multilabel case with binary label indicators:
 
   >>> jaccard_similarity_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
   0.75
-
-and with a list of labels format:
-
-  >>> jaccard_similarity_score([(1,), (3,)], [(1, 2), tuple()])
-  0.25
-
 
 .. _precision_recall_f_measure_metrics:
 
@@ -897,15 +881,10 @@ where :math:`1(x)` is the `indicator function
   >>> zero_one_loss(y_true, y_pred, normalize=False)
   1
 
-In the multilabel case with binary indicator format:
+In the multilabel case with binary label indicators: ::
 
   >>> zero_one_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
   0.5
-
-and with a list of labels format:
-
-  >>> zero_one_loss([(1,), (3,)], [(1, 2), tuple()])
-  1.0
 
 
 .. topic:: Example:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -259,7 +259,7 @@ where :math:`1(x)` is the `indicator function
   >>> accuracy_score(y_true, y_pred, normalize=False)
   2
 
-In the multilabel case with binary label indicators:
+In the multilabel case with binary label indicators: ::
 
   >>> accuracy_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
   0.5
@@ -424,7 +424,7 @@ score is equal to the classification accuracy.
   >>> jaccard_similarity_score(y_true, y_pred, normalize=False)
   2
 
-In the multilabel case with binary label indicators:
+In the multilabel case with binary label indicators: ::
 
   >>> jaccard_similarity_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
   0.75

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -77,42 +77,30 @@ tasks :ref:`Decision Trees <tree>`, :ref:`Random Forests <forest>`,
 Multilabel classification format
 ================================
 
-In multilabel learning, the joint set of binary classification tasks
-is expressed with either a sequence of sequences or a label binary indicator
-array.
+In multilabel learning, the joint set of binary classification tasks is
+expressed with label binary indicator array: each sample is one row of a 2d
+array of shape (n_samples, n_classes) with binary values: the one, i.e. the non
+zero elements, corresponds to the subset of labels. An array such as
+``np.array([[1, 0, 0], [0, 1, 1], [0, 0, 0]])`` represents label 0 in the first
+sample, labels 1 and 2 in the second sample, and no labels in the third sample.
 
-In the sequence of sequences format, each set of labels is represented as
-a sequence of integer, e.g. ``[0]``, ``[1, 2]``. An empty set of labels is
-then expressed as ``[]``, and a set of samples as ``[[0], [1, 2], []]``.
-In the label indicator format, each sample is one row of a 2d array of
-shape (n_samples, n_classes) with binary values: the one, i.e. the non zero
-elements, corresponds to the subset of labels. Our previous example is
-therefore expressed as ``np.array([[1, 0, 0], [0, 1, 1], [0, 0, 0])``
-and an empty set of labels would be represented by a row of zero elements.
-
-
-In the preprocessing module, the transformer
-:class:`sklearn.preprocessing.label_binarize` and the function
-:func:`sklearn.preprocessing.LabelBinarizer`
-can help you to convert the sequence of sequences format to the label
-indicator format.
+Producing multilabel data as a list of sets of labels may be more intuitive.
+The transformer :class:`MultiLabelBinarizer <preprocessing.MultiLabelBinarizer>`
+will convert between a collection of collections of labels and the indicator
+format.
 
   >>> from sklearn.datasets import make_multilabel_classification
-  >>> from sklearn.preprocessing import LabelBinarizer
-  >>> X, Y = make_multilabel_classification(n_samples=5, random_state=0)
+  >>> from sklearn.preprocessing import MultiLabelBinarizer
+  >>> X, Y = make_multilabel_classification(n_samples=5, random_state=0,
+  ...                                       return_indicator=False)
   >>> Y
   ([0, 1, 2], [4, 1, 0, 2], [4, 0, 1], [1, 0], [3, 2])
-  >>> LabelBinarizer().fit_transform(Y)
+  >>> MultiLabelBinarizer().fit_transform(Y)
   array([[1, 1, 1, 0, 0],
          [1, 1, 1, 0, 1],
          [1, 1, 0, 0, 1],
          [1, 1, 0, 0, 0],
          [0, 0, 1, 1, 0]])
-
-.. warning::
-
-    - The sequence of sequences format will disappear in a near future.
-    - Most estimators and functions support both multilabel format.
 
 
 One-Vs-The-Rest

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -139,8 +139,8 @@ Multilabel learning
 -------------------
 
 :class:`OneVsRestClassifier` also supports multilabel classification.
-To use this feature, feed the classifier a list of tuples containing
-target labels, like in the example below.
+To use this feature, feed the classifier an indicator matrix, in which cell
+[i, j] indicates the presence of label j in sample i.
 
 
 .. figure:: ../auto_examples/images/plot_multilabel_1.png

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -377,8 +377,9 @@ matrix from a list of multi-class labels::
     array([[1, 0, 0, 0],
            [0, 0, 0, 1]])
 
-:class:`LabelBinarizer` also supports multiple labels per instance::
+For multiple labels per instance, use :class:`MultiLabelBinarizer`::
 
+    >>> lb = preprocessing.MultiLabelBinarizer()
     >>> lb.fit_transform([(1, 2), (3,)])
     array([[1, 1, 0],
            [0, 0, 1]])

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -175,6 +175,12 @@ API changes summary
    - :class:`cluster.WardClustering` is deprecated. Use
    - :class:`cluster.AgglomerativeClustering` instead.
 
+   - Direct support for the sequence of sequences (or list of lists) multilabel
+     format is deprecated. To convert to and from the supported binary
+     indicator matrix format, use
+     :class:`MultiLabelBinarizer <preprocessing.MultiLabelBinarizer>`.
+     By `Joel Nothman`_.
+
    - Add score method to :class:`PCA <decomposition.PCA>` following the model of
      probabilistic PCA and deprecate
      :class:`ProbabilisticPCA <decomposition.ProbabilisticPCA>` model whose

--- a/examples/plot_multilabel.py
+++ b/examples/plot_multilabel.py
@@ -72,7 +72,7 @@ def plot_subfigure(X, Y, subplot, title, transform):
     pl.title(title)
 
     zero_class = np.where(Y[:, 0])
-    one_class = np.where(Y[:, 0])
+    one_class = np.where(Y[:, 1])
     pl.scatter(X[:, 0], X[:, 1], s=40, c='gray')
     pl.scatter(X[zero_class, 0], X[zero_class, 1], s=160, edgecolors='b',
                facecolors='none', linewidths=2, label='Class 1')

--- a/examples/plot_multilabel.py
+++ b/examples/plot_multilabel.py
@@ -55,9 +55,7 @@ def plot_subfigure(X, Y, subplot, title, transform):
     if transform == "pca":
         X = PCA(n_components=2).fit_transform(X)
     elif transform == "cca":
-        # Convert list of tuples to a class indicator matrix first
-        Y_indicator = LabelBinarizer().fit(Y).transform(Y)
-        X = CCA(n_components=2).fit(X, Y_indicator).transform(X)
+        X = CCA(n_components=2).fit(X, Y).transform(X)
     else:
         raise ValueError
 
@@ -73,8 +71,8 @@ def plot_subfigure(X, Y, subplot, title, transform):
     pl.subplot(2, 2, subplot)
     pl.title(title)
 
-    zero_class = np.where([0 in y for y in Y])
-    one_class = np.where([1 in y for y in Y])
+    zero_class = np.where(Y[:, 0])
+    one_class = np.where(Y[:, 0])
     pl.scatter(X[:, 0], X[:, 1], s=40, c='gray')
     pl.scatter(X[zero_class, 0], X[zero_class, 1], s=160, edgecolors='b',
                facecolors='none', linewidths=2, label='Class 1')
@@ -100,6 +98,7 @@ pl.figure(figsize=(8, 6))
 
 X, Y = make_multilabel_classification(n_classes=2, n_labels=1,
                                       allow_unlabeled=True,
+                                      return_indicator=True,
                                       random_state=1)
 
 plot_subfigure(X, Y, 1, "With unlabeled samples + CCA", "cca")
@@ -107,6 +106,7 @@ plot_subfigure(X, Y, 2, "With unlabeled samples + PCA", "pca")
 
 X, Y = make_multilabel_classification(n_classes=2, n_labels=1,
                                       allow_unlabeled=False,
+                                      return_indicator=True,
                                       random_state=1)
 
 plot_subfigure(X, Y, 3, "Without unlabeled samples + CCA", "cca")

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -7,10 +7,11 @@ Generate samples of synthetic data sets.
 # License: BSD 3 clause
 
 import numbers
+import warnings
 import numpy as np
 from scipy import linalg
 
-from ..preprocessing import LabelBinarizer
+from ..preprocessing import MultiLabelBinarizer
 from ..utils import array2d, check_random_state
 from ..utils import shuffle as util_shuffle
 from ..utils.random import sample_without_replacement
@@ -336,8 +337,15 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     X, Y = zip(*[sample_example() for i in range(n_samples)])
 
     if return_indicator:
-        lb = LabelBinarizer()
+        lb = MultiLabelBinarizer()
         Y = lb.fit([range(n_classes)]).transform(Y)
+    else:
+        warnings.warn('Support for the sequence of sequences multilabel '
+                      'representation is being deprecated and replaced with '
+                      'a sparse indicator matrix. '
+                      'return_indicator wil default to True from version '
+                      '0.17.',
+                      DeprecationWarning)
 
     return np.array(X, dtype=np.float64), Y
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns
 
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_multilabel_classification
@@ -131,11 +132,11 @@ def test_make_classification_informative_features():
                   n_clusters_per_class=2)
 
 
-def test_make_multilabel_classification():
+def test_make_multilabel_classification_return_sequences():
     for allow_unlabeled, min_length in zip((True, False), (0, 1)):
-        X, Y = make_multilabel_classification(n_samples=100, n_features=20,
-                                              n_classes=3, random_state=0,
-                                              allow_unlabeled=allow_unlabeled)
+        X, Y = assert_warns(DeprecationWarning, make_multilabel_classification,
+                            n_samples=100, n_features=20, n_classes=3,
+                            random_state=0, allow_unlabeled=allow_unlabeled)
         assert_equal(X.shape, (100, 20), "X shape mismatch")
         if not allow_unlabeled:
             assert_equal(max([max(y) for y in Y]), 2)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1199,7 +1199,6 @@ def accuracy_score(y_true, y_pred, normalize=True):
     2
 
     In the multilabel case with binary label indicators:
-
     >>> accuracy_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
     0.5
     """

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -289,7 +289,7 @@ def average_precision_score(y_true, y_score, average="macro"):
 
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels in binary indicator format.
+        True binary labels in binary label indicators.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
@@ -397,7 +397,7 @@ def _average_binary_score(binary_metric, y_true, y_score, average):
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels in binary indicator format.
+        True binary labels in binary label indicators.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
@@ -481,7 +481,7 @@ def roc_auc_score(y_true, y_score, average="macro"):
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
-        True binary labels in binary indicator format.
+        True binary labels in binary label indicators.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
@@ -912,10 +912,10 @@ def zero_one_loss(y_true, y_pred, normalize=True):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -948,17 +948,10 @@ def zero_one_loss(y_true, y_pred, normalize=True):
     >>> zero_one_loss(y_true, y_pred, normalize=False)
     1
 
-    In the multilabel case with binary indicator format:
+    In the multilabel case with binary label indicators:
 
-    >>> zero_one_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
+    >>> zero_one_loss(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
     0.5
-
-    and with a list of labels format:
-
-    >>> zero_one_loss([(1, ), (3, )], [(1, 2), tuple()])
-    1.0
-
-
     """
     score = accuracy_score(y_true, y_pred,
                            normalize=normalize)
@@ -983,7 +976,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) labels for n_samples samples.
 
     y_pred : array-like of float, shape = (n_samples, n_classes)
@@ -1058,10 +1051,10 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -1106,17 +1099,11 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True):
     >>> jaccard_similarity_score(y_true, y_pred, normalize=False)
     2
 
-    In the multilabel case with binary indicator format:
+    In the multilabel case with binary label indicators:
 
-    >>> jaccard_similarity_score(np.array([[0.0, 1.0], [1.0, 1.0]]),\
+    >>> jaccard_similarity_score(np.array([[0, 1], [1, 1]]),\
         np.ones((2, 2)))
     0.75
-
-    and with a list of labels format:
-
-    >>> jaccard_similarity_score([(1, ), (3, )], [(1, 2), tuple()])
-    0.25
-
     """
 
     # Compute accuracy for each possible representation
@@ -1171,10 +1158,10 @@ def accuracy_score(y_true, y_pred, normalize=True):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -1211,16 +1198,10 @@ def accuracy_score(y_true, y_pred, normalize=True):
     >>> accuracy_score(y_true, y_pred, normalize=False)
     2
 
-    In the multilabel case with binary indicator format:
+    In the multilabel case with binary label indicators:
 
-    >>> accuracy_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
+    >>> accuracy_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
     0.5
-
-    and with a list of labels format:
-
-    >>> accuracy_score([(1, ), (3, )], [(1, 2), tuple()])
-    0.0
-
     """
 
     # Compute accuracy for each possible representation
@@ -1254,10 +1235,10 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -1334,10 +1315,10 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     beta: float
@@ -1488,10 +1469,10 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     beta : float, 1.0 by default
@@ -1702,10 +1683,10 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -1779,10 +1760,10 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted'):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -1849,10 +1830,10 @@ def classification_report(y_true, y_pred, labels=None, target_names=None):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Estimated targets as returned by a classifier.
 
     labels : array, shape = [n_labels]
@@ -1939,10 +1920,10 @@ def hamming_loss(y_true, y_pred, classes=None):
 
     Parameters
     ----------
-    y_true : array-like or list of labels or label indicator matrix
+    y_true : array-like or label indicator matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or list of labels or label indicator matrix
+    y_pred : array-like or label indicator matrix
         Predicted labels, as returned by a classifier.
 
     classes : array, shape = [n_labels], optional
@@ -1990,16 +1971,10 @@ def hamming_loss(y_true, y_pred, classes=None):
     >>> hamming_loss(y_true, y_pred)
     0.25
 
-    In the multilabel case with binary indicator format:
+    In the multilabel case with binary label indicators:
 
-    >>> hamming_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.zeros((2, 2)))
+    >>> hamming_loss(np.array([[0, 1], [1, 1]]), np.zeros((2, 2)))
     0.75
-
-    and with a list of labels format:
-
-    >>> hamming_loss([(1, 2), (3, )], [(1, 2), tuple()])  # doctest: +ELLIPSIS
-    0.166...
-
     """
     y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -100,9 +100,9 @@ def _check_clf_targets(y_true, y_pred):
         The type of the true target data, as output by
         ``utils.multiclass.type_of_target``
 
-    y_true : array or indicator matrix or sequence of sequences
+    y_true : array or indicator matrix
 
-    y_pred : array or indicator matrix or sequence of sequences
+    y_pred : array or indicator matrix
     """
     y_true, y_pred = check_arrays(y_true, y_pred, allow_lists=True)
     type_true = type_of_target(y_true)

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -8,7 +8,7 @@ import warnings
 from sklearn import datasets
 from sklearn import svm
 
-from sklearn.preprocessing import LabelBinarizer
+from sklearn.preprocessing import LabelBinarizer, MultiLabelBinarizer
 from sklearn.datasets import make_multilabel_classification
 from sklearn.utils import check_random_state, shuffle
 from sklearn.utils.multiclass import unique_labels
@@ -1041,14 +1041,12 @@ def test_multilabel_classification_report():
 
     n_classes = 4
     n_samples = 50
-    _, y_true_ll = make_multilabel_classification(n_features=1,
-                                                  n_classes=n_classes,
-                                                  random_state=0,
-                                                  n_samples=n_samples)
-    _, y_pred_ll = make_multilabel_classification(n_features=1,
-                                                  n_classes=n_classes,
-                                                  random_state=1,
-                                                  n_samples=n_samples)
+    # using sequence of sequences is deprecated, but still tested
+    make_ml = ignore_warnings(make_multilabel_classification)
+    _, y_true_ll = make_ml(n_features=1, n_classes=n_classes, random_state=0,
+                           n_samples=n_samples)
+    _, y_pred_ll = make_ml(n_features=1, n_classes=n_classes, random_state=1,
+                           n_samples=n_samples)
 
     expected_report = """\
              precision    recall  f1-score   support
@@ -1061,7 +1059,7 @@ def test_multilabel_classification_report():
 avg / total       0.45      0.54      0.47        85
 """
 
-    lb = LabelBinarizer()
+    lb = MultiLabelBinarizer()
     lb.fit([range(4)])
     y_true_bi = lb.transform(y_true_ll)
     y_pred_bi = lb.transform(y_pred_ll)
@@ -1617,10 +1615,12 @@ def test_multilabel_representation_invariance():
     # Generate some data
     n_classes = 4
     n_samples = 50
-    _, y1 = make_multilabel_classification(n_features=1, n_classes=n_classes,
-                                           random_state=0, n_samples=n_samples)
-    _, y2 = make_multilabel_classification(n_features=1, n_classes=n_classes,
-                                           random_state=1, n_samples=n_samples)
+    # using sequence of sequences is deprecated, but still tested
+    make_ml = ignore_warnings(make_multilabel_classification)
+    _, y1 = make_ml(n_features=1, n_classes=n_classes, random_state=0,
+                    n_samples=n_samples)
+    _, y2 = make_ml(n_features=1, n_classes=n_classes, random_state=1,
+                    n_samples=n_samples)
 
     # Be sure to have at least one empty label
     y1 += ([], )
@@ -1638,7 +1638,7 @@ def test_multilabel_representation_invariance():
     y2_redundant = [x * rng.randint(1, 4) for x in y2]
 
     # Binary indicator matrix format
-    lb = LabelBinarizer().fit([range(n_classes)])
+    lb = MultiLabelBinarizer().fit([range(n_classes)])
     y1_binary_indicator = lb.transform(y1)
     y2_binary_indicator = lb.transform(y2)
 
@@ -1843,21 +1843,19 @@ def test_normalize_option_multilabel_classification():
     # Test in the multilabel case
     n_classes = 4
     n_samples = 100
-    _, y_true = make_multilabel_classification(n_features=1,
-                                               n_classes=n_classes,
-                                               random_state=0,
-                                               n_samples=n_samples)
-    _, y_pred = make_multilabel_classification(n_features=1,
-                                               n_classes=n_classes,
-                                               random_state=1,
-                                               n_samples=n_samples)
+    # using sequence of sequences is deprecated, but still tested
+    make_ml = ignore_warnings(make_multilabel_classification)
+    _, y_true = make_ml(n_features=1, n_classes=n_classes,
+                        random_state=0, n_samples=n_samples)
+    _, y_pred = make_ml(n_features=1, n_classes=n_classes,
+                        random_state=1, n_samples=n_samples)
 
     # Be sure to have at least one empty label
     y_true += ([], )
     y_pred += ([], )
     n_samples += 1
 
-    lb = LabelBinarizer().fit([range(n_classes)])
+    lb = MultiLabelBinarizer().fit([range(n_classes)])
     y_true_binary_indicator = lb.transform(y_true)
     y_pred_binary_indicator = lb.transform(y_pred)
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1652,8 +1652,9 @@ def test_multilabel_representation_invariance():
         if isinstance(metric, partial):
             metric.__module__ = 'tmp'
             metric.__name__ = name
-        metric = ignore_warnings(metric)
+        # Check warning for sequence of sequences
         measure = assert_warns(DeprecationWarning, metric, y1, y2)
+        metric = ignore_warnings(metric)
 
         # Check representation invariance
         assert_almost_equal(metric(y1_binary_indicator,

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1653,7 +1653,7 @@ def test_multilabel_representation_invariance():
             metric.__module__ = 'tmp'
             metric.__name__ = name
         metric = ignore_warnings(metric)
-        measure = metric(y1, y2)
+        measure = assert_warns(DeprecationWarning, metric, y1, y2)
 
         # Check representation invariance
         assert_almost_equal(metric(y1_binary_indicator,
@@ -1865,7 +1865,8 @@ def test_normalize_option_multilabel_classification():
         metrics = ALL_METRICS[name]
 
         # List of list of labels
-        measure = metrics(y_true, y_pred, normalize=True)
+        measure = assert_warns(DeprecationWarning, metrics, y_true, y_pred,
+                               normalize=True)
         assert_greater(measure, 0,
                        msg="We failed to test correctly the normalize option")
         assert_almost_equal(metrics(y_true, y_pred, normalize=False)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -143,9 +143,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     This strategy can also be used for multilabel learning, where a classifier
     is used to predict multiple labels for instance, by fitting on a 2-d matrix
-    in which cell [i, j] is 1 sample i has label j and 0 otherwise.
-    For multilabel learning, the number of classes must be at
-    least three, since otherwise OvR reduces to binary classification.
+    in which cell [i, j] is 1 if sample i has label j and 0 otherwise.
 
     In the multilabel learning literature, OvR is also known as the binary
     relevance method.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -142,9 +142,9 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     multiclass classification and is a fair default choice.
 
     This strategy can also be used for multilabel learning, where a classifier
-    is used to predict multiple labels for instance, by fitting on a sequence
-    of sequences of labels (e.g., a list of tuples) rather than a single
-    target vector. For multilabel learning, the number of classes must be at
+    is used to predict multiple labels for instance, by fitting on a 2-d matrix
+    in which cell [i, j] is 1 sample i has label j and 0 otherwise.
+    For multilabel learning, the number of classes must be at
     least three, since otherwise OvR reduces to binary classification.
 
     In the multilabel learning literature, OvR is also known as the binary
@@ -188,9 +188,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data.
 
-        y : array-like, shape = [n_samples]
-         or sequence of sequences, len = n_samples
-            Multi-class targets. A sequence of sequences turns on multilabel
+        y : array-like, shape = [n_samples] or [n_samples, n_classes]
+            Multi-class targets. An indicator matrix turns on multilabel
             classification.
 
         Returns

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -20,6 +20,7 @@ from .data import PolynomialFeatures
 from .label import label_binarize
 from .label import LabelBinarizer
 from .label import LabelEncoder
+from .label import MultiLabelBinarizer
 
 from .imputation import Imputer
 from ._weights import balance_weights
@@ -30,6 +31,7 @@ __all__ = [
     'KernelCenterer',
     'LabelBinarizer',
     'LabelEncoder',
+    'MultiLabelBinarizer',
     'MinMaxScaler',
     'Normalizer',
     'OneHotEncoder',

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -557,7 +557,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         indices = array.array('i')
         indptr = array.array('i', [0])
         for labels in y:
-            indices.extend(class_mapping[label] for label in labels)
+            indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
         return sp.csr_matrix((data, indices, indptr),

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -340,8 +340,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                 return Y
             else:
                 # Lists of tuples format
-                return [tuple(self.classes_[np.flatnonzero(Y[i])])
-                        for i in range(Y.shape[0])]
+                mlb = MultiLabelBinarizer(classes=self.classes_).fit([])
+                return mlb.inverse_transform(Y)
 
         if len(Y.shape) == 1 or Y.shape[1] == 1:
             y = np.array(Y.ravel() > threshold, dtype=int)
@@ -418,14 +418,7 @@ def label_binarize(y, classes, multilabel=False, neg_label=0, pos_label=1):
             Y[y == 1] = pos_label
             return Y
         elif y_type == "multilabel-sequences":
-            # inverse map: label => column index
-            imap = dict((v, k) for k, v in enumerate(classes))
-
-            for i, label_tuple in enumerate(y):
-                for label in label_tuple:
-                    Y[i, imap[label]] = pos_label
-
-            return Y
+            return MultiLabelBinarizer(classes=classes).fit_transform(y)
         else:
             raise ValueError("y should be in a multilabel format, "
                              "got %r" % (y,))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -10,7 +10,6 @@ import itertools
 import array
 
 import numpy as np
-from numpy.lib.stride_tricks import as_strided
 import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
@@ -552,14 +551,26 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         return yt.toarray()
 
     def _transform(self, y, class_mapping):
+        """Transforms the label sets with a given mapping
+
+        Parameters
+        ----------
+        y : iterable of iterables
+        class_mapping : Mapping
+            Maps from label to column index in label indicator matrix
+
+        Returns
+        -------
+        y_indicator : sparse CSR matrix, shape (n_samples, n_classes)
+            Label indicator matrix
+        """
         indices = array.array('i')
         indptr = array.array('i', [0])
         for labels in y:
             indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
         # virtual array of len(indices) 1s:
-        data = as_strided(np.array([1], dtype=int), strides=(0,),
-                          shape=(len(indices),))
+        data = np.ones(len(indices), dtype=int)
         return sp.csr_matrix((data, indices, indptr),
                              shape=(len(indptr) - 1, len(class_mapping)))
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -248,9 +248,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array of shape (n_samples,) or sequence of sequences
-            Target values. In the multilabel case the nested sequences can
-            have variable lengths.
+        y : numpy array of shape (n_samples,) or (n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1,
+            represents multilabel classification, and is returned unchanged
+            by LabelBinarizer.
 
         Returns
         -------
@@ -273,9 +274,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array of shape [n_samples] or sequence of sequences
-            Target values. In the multilabel case the nested sequences can
-            have variable lengths.
+        y : numpy array of shape (n_samples,) or (n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1,
+            represents multilabel classification, and is returned unchanged
+            by LabelBinarizer.
 
         Returns
         -------
@@ -315,9 +317,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        y : numpy array of shape [n_samples] or sequence of sequences
-            Target values. In the multilabel case the nested sequences can
-            have variable lengths.
+        y : numpy array of shape (n_samples,) or (n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1,
+            represents multilabel classification, and is returned unchanged
+            by LabelBinarizer.
 
         Notes
         -----

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -249,8 +249,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         ----------
         y : numpy array of shape (n_samples,) or (n_samples, n_classes)
             Target values. The 2-d matrix should only contain 0 and 1,
-            represents multilabel classification, and is returned unchanged
-            by LabelBinarizer.
+            represents multilabel classification.
 
         Returns
         -------
@@ -275,8 +274,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         ----------
         y : numpy array of shape (n_samples,) or (n_samples, n_classes)
             Target values. The 2-d matrix should only contain 0 and 1,
-            represents multilabel classification, and is returned unchanged
-            by LabelBinarizer.
+            represents multilabel classification.
 
         Returns
         -------
@@ -318,8 +316,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         -------
         y : numpy array of shape (n_samples,) or (n_samples, n_classes)
             Target values. The 2-d matrix should only contain 0 and 1,
-            represents multilabel classification, and is returned unchanged
-            by LabelBinarizer.
+            represents multilabel classification.
 
         Notes
         -----
@@ -569,8 +566,8 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         for labels in y:
             indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
-        # virtual array of len(indices) 1s:
         data = np.ones(len(indices), dtype=int)
+
         return sp.csr_matrix((data, indices, indptr),
                              shape=(len(indptr) - 1, len(class_mapping)))
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -509,7 +509,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        y_indicator : matrix of shape (n_samples, n_classes)
+        y_indicator : array, shape (n_samples, n_classes)
             A matrix such that `y_indicator[i, j] = 1` iff `classes_[j]` is in
             `y[i]`, and 0 otherwise.
         """
@@ -542,7 +542,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        y_indicator : matrix of shape (n_samples, n_classes)
+        y_indicator : array, shape (n_samples, n_classes)
             A matrix such that `y_indicator[i, j] = 1` iff `classes_[j]` is in
             `y[i]`, and 0 otherwise.
         """
@@ -579,7 +579,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        yt : matrix of shape (n_samples, n_classes)
+        yt : array of shape (n_samples, n_classes)
             A matrix containing only 1s ands 0s.
 
         Returns
@@ -588,4 +588,13 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
             The set of labels for each sample such that `y[i]` consists of
             `classes_[j]` for each `yt[i, j] == 1`.
         """
+        yt = np.asarray(yt)
+        if yt.shape[1] != len(self.classes_):
+            raise ValueError('Expected indicator for {0} classes, but got {1}'
+                             .format(len(self.classes_), yt.shape[1]))
+        unexpected = np.setdiff1d(yt, [0, 1])
+        if len(unexpected) > 0:
+            raise ValueError('Expected only 0s and 1s in label indicator. '
+                             'Also got {0}'.format(unexpected))
+
         return [tuple(self.classes_.compress(indicators)) for indicators in yt]

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -468,7 +468,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
            [0, 0, 1]])
     >>> mlb.classes_          # doctest: +ELLIPSIS
     array([1, 2, 3]...)
-    >>> mlb.fit_transform([{1, 2}, {3,}])
+    >>> mlb.fit_transform([set([1, 2]), set([3])])
     array([[1, 1, 0],
            [0, 0, 1]])
     """

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -10,6 +10,7 @@ import itertools
 import array
 
 import numpy as np
+from numpy.lib.stride_tricks import as_strided
 import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
@@ -552,7 +553,9 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         for labels in y:
             indices.extend(set(class_mapping[label] for label in labels))
             indptr.append(len(indices))
-        data = np.ones(len(indices), dtype=int)
+        # virtual array of len(indices) 1s:
+        data = as_strided(np.array([1], dtype=int), strides=(0,),
+                          shape=(len(indices),))
         return sp.csr_matrix((data, indices, indptr),
                              shape=(len(indptr) - 1, len(class_mapping)))
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -547,7 +547,8 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
             A matrix such that `y_indicator[i, j] = 1` iff `classes_[j]` is in
             `y[i]`, and 0 otherwise.
         """
-        yt = self._transform(y, {k: i for i, k in enumerate(self.classes_)})
+        class_to_index = dict(zip(self.classes_, range(len(self.classes_))))
+        yt = self._transform(y, class_to_index)
         return yt.toarray()
 
     def _transform(self, y, class_mapping):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -459,13 +459,13 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         A copy of the `classes` parameter where provided, or otherwise, the
         sorted set of classes found when fitting.
 
-    >>> lsb = MultiLabelBinarizer()
-    >>> lsb.fit_transform([(1, 2), (3,)])
+    >>> mlb = MultiLabelBinarizer()
+    >>> mlb.fit_transform([(1, 2), (3,)])
     array([[1, 1, 0],
            [0, 0, 1]])
-    >>> lsb.classes_          # doctest: +ELLIPSIS
+    >>> mlb.classes_          # doctest: +ELLIPSIS
     array([1, 2, 3]...)
-    >>> lsb.fit_transform([{1, 2}, {3,}])
+    >>> mlb.fit_transform([{1, 2}, {3,}])
     array([[1, 1, 0],
            [0, 0, 1]])
     """

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -351,6 +351,7 @@ def test_mutlilabel_binarizer_non_integer_labels():
     tuple_classes[:] = [(1,), (2,), (3,)]
     inputs = [
         ([('2', '3'), ('1',), ('1', '2')], ['1', '2', '3']),
+        ([('b', 'c'), ('a',), ('a', 'b')], ['a', 'b', 'c']),
         ([((2,), (3,)), ((1,),), ((1,), (2,))], tuple_classes),
     ]
     indicator_mat = np.array([[0, 1, 1],

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -371,3 +371,12 @@ def test_mutlilabel_binarizer_non_integer_labels():
 
     lsb = MultiLabelBinarizer()
     assert_raises(TypeError, lsb.fit_transform, [({}), ({}, {'a': 'b'})])
+
+
+def test_mutlilabel_binarizer_non_unique():
+    inp = [(1, 1, 1, 0)]
+    indicator_mat = np.array([[1, 1]])
+    lsb = MultiLabelBinarizer()
+    assert_array_equal(lsb.fit_transform(inp), indicator_mat)
+
+    assert_array_equal(lsb.inverse_transform(np.array([[1, 3]])), [(0, 1,)])

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import ignore_warnings
 
 from sklearn.preprocessing.label import LabelBinarizer
 from sklearn.preprocessing.label import MultiLabelBinarizer
@@ -51,6 +53,7 @@ def test_label_binarizer():
     assert_array_equal(lb.inverse_transform(got), inp)
 
 
+@ignore_warnings
 def test_label_binarizer_column_y():
     # first for binary classification vs multi-label with 1 possible class
     # lists are multi-label, array is multi-class :-/
@@ -125,7 +128,7 @@ def test_label_binarizer_multilabel():
     indicator_mat = np.array([[0, 1, 1],
                               [1, 0, 0],
                               [1, 1, 0]])
-    got = lb.fit_transform(inp)
+    got = assert_warns(DeprecationWarning, lb.fit_transform, inp)
     assert_true(lb.multilabel_)
     assert_array_equal(indicator_mat, got)
     assert_equal(lb.inverse_transform(got), inp)
@@ -142,7 +145,7 @@ def test_label_binarizer_multilabel():
                          [1, 0],
                          [0, 1],
                          [1, 1]])
-    got = lb.fit_transform(inp)
+    got = assert_warns(DeprecationWarning, lb.fit_transform, inp)
     assert_true(lb.multilabel_)
     assert_array_equal(expected, got)
     assert_equal([set(x) for x in lb.inverse_transform(got)],
@@ -155,7 +158,7 @@ def test_label_binarizer_errors():
     lb = LabelBinarizer().fit(one_class)
     assert_false(lb.multilabel_)
 
-    multi_label = [(2, 3), (0,), (0, 2)]
+    multi_label = np.array([[0, 0, 1, 0], [1, 0, 1, 0]])
     assert_raises(ValueError, lb.transform, multi_label)
 
     lb = LabelBinarizer()
@@ -229,7 +232,8 @@ def test_label_binarizer_multilabel_unlabeled():
     Y = np.array([[1, 1],
                   [1, 0],
                   [0, 0]])
-    assert_array_equal(lb.fit_transform(y), Y)
+    assert_array_equal(assert_warns(DeprecationWarning,
+                                    lb.fit_transform, y), Y)
 
 
 def test_label_binarize_with_multilabel_indicator():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -379,4 +379,18 @@ def test_mutlilabel_binarizer_non_unique():
     mlb = MultiLabelBinarizer()
     assert_array_equal(mlb.fit_transform(inp), indicator_mat)
 
-    assert_array_equal(mlb.inverse_transform(np.array([[1, 3]])), [(0, 1,)])
+
+def test_multilabel_binarizer_inverse_validation():
+    inp = [(1, 1, 1, 0)]
+    mlb = MultiLabelBinarizer()
+    mlb.fit_transform(inp)
+    # Not binary
+    assert_raises(ValueError, mlb.inverse_transform, np.array([[1, 3]]))
+    # The following binary cases are fine, however
+    mlb.inverse_transform(np.array([[0, 0]]))
+    mlb.inverse_transform(np.array([[1, 1]]))
+    mlb.inverse_transform(np.array([[1, 0]]))
+
+    # Wrong shape
+    assert_raises(ValueError, mlb.inverse_transform, np.array([[1]]))
+    assert_raises(ValueError, mlb.inverse_transform, np.array([[1, 1, 1]]))

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -260,8 +260,8 @@ def test_mutlilabel_binarizer():
     # test input as iterable of iterables
     inputs = [
         lambda: [(2, 3), (1,), (1, 2)],
-        lambda: ({2, 3}, {1}, {1, 2}),
-        lambda: iter([iter((2, 3)), iter((1,)), {1, 2}]),
+        lambda: (set([2, 3]), set([1]), set([1, 2])),
+        lambda: iter([iter((2, 3)), iter((1,)), set([1, 2])]),
     ]
     indicator_mat = np.array([[0, 1, 1],
                               [1, 0, 0],

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -269,36 +269,36 @@ def test_mutlilabel_binarizer():
     inverse = inputs[0]()
     for inp in inputs:
         # With fit_tranform
-        lsb = MultiLabelBinarizer()
-        got = lsb.fit_transform(inp())
+        mlb = MultiLabelBinarizer()
+        got = mlb.fit_transform(inp())
         assert_array_equal(indicator_mat, got)
-        assert_array_equal([1, 2, 3], lsb.classes_)
-        assert_equal(lsb.inverse_transform(got), inverse)
+        assert_array_equal([1, 2, 3], mlb.classes_)
+        assert_equal(mlb.inverse_transform(got), inverse)
 
         # With fit
-        lsb = MultiLabelBinarizer()
-        got = lsb.fit(inp()).transform(inp())
+        mlb = MultiLabelBinarizer()
+        got = mlb.fit(inp()).transform(inp())
         assert_array_equal(indicator_mat, got)
-        assert_array_equal([1, 2, 3], lsb.classes_)
-        assert_equal(lsb.inverse_transform(got), inverse)
+        assert_array_equal([1, 2, 3], mlb.classes_)
+        assert_equal(mlb.inverse_transform(got), inverse)
 
 
 def test_mutlilabel_binarizer_empty_sample():
-    lsb = MultiLabelBinarizer()
+    mlb = MultiLabelBinarizer()
     y = [[1, 2], [1], []]
     Y = np.array([[1, 1],
                   [1, 0],
                   [0, 0]])
-    assert_array_equal(lsb.fit_transform(y), Y)
+    assert_array_equal(mlb.fit_transform(y), Y)
 
 
 def test_mutlilabel_binarizer_unknown_class():
-    lsb = MultiLabelBinarizer()
+    mlb = MultiLabelBinarizer()
     y = [[1, 2]]
-    assert_raises(KeyError, lsb.fit(y).transform, [[0]])
+    assert_raises(KeyError, mlb.fit(y).transform, [[0]])
 
-    lsb = MultiLabelBinarizer(classes=[1, 2])
-    assert_raises(KeyError, lsb.fit_transform, [[0]])
+    mlb = MultiLabelBinarizer(classes=[1, 2])
+    assert_raises(KeyError, mlb.fit_transform, [[0]])
 
 
 def test_mutlilabel_binarizer_given_classes():
@@ -307,25 +307,25 @@ def test_mutlilabel_binarizer_given_classes():
                               [1, 0, 0],
                               [1, 0, 1]])
     # fit_transform()
-    lsb = MultiLabelBinarizer(classes=[1, 3, 2])
-    assert_array_equal(lsb.fit_transform(inp), indicator_mat)
-    assert_array_equal(lsb.classes_, [1, 3, 2])
+    mlb = MultiLabelBinarizer(classes=[1, 3, 2])
+    assert_array_equal(mlb.fit_transform(inp), indicator_mat)
+    assert_array_equal(mlb.classes_, [1, 3, 2])
 
     # fit().transform()
-    lsb = MultiLabelBinarizer(classes=[1, 3, 2])
-    assert_array_equal(lsb.fit(inp).transform(inp), indicator_mat)
-    assert_array_equal(lsb.classes_, [1, 3, 2])
+    mlb = MultiLabelBinarizer(classes=[1, 3, 2])
+    assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
+    assert_array_equal(mlb.classes_, [1, 3, 2])
 
     # ensure works with extra class
-    lsb = MultiLabelBinarizer(classes=[4, 1, 3, 2])
-    assert_array_equal(lsb.fit_transform(inp),
+    mlb = MultiLabelBinarizer(classes=[4, 1, 3, 2])
+    assert_array_equal(mlb.fit_transform(inp),
                        np.hstack(([[0], [0], [0]], indicator_mat)))
-    assert_array_equal(lsb.classes_, [4, 1, 3, 2])
+    assert_array_equal(mlb.classes_, [4, 1, 3, 2])
 
     # ensure fit is no-op as iterable is not consumed
     inp = iter(inp)
-    lsb = MultiLabelBinarizer(classes=[1, 3, 2])
-    assert_array_equal(lsb.fit(inp).transform(inp), indicator_mat)
+    mlb = MultiLabelBinarizer(classes=[1, 3, 2])
+    assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
 
 
 def test_mutlilabel_binarizer_same_length_sequence():
@@ -336,14 +336,14 @@ def test_mutlilabel_binarizer_same_length_sequence():
                               [1, 0, 0],
                               [0, 0, 1]])
     # fit_transform()
-    lsb = MultiLabelBinarizer()
-    assert_array_equal(lsb.fit_transform(inp), indicator_mat)
-    assert_array_equal(lsb.inverse_transform(indicator_mat), inp)
+    mlb = MultiLabelBinarizer()
+    assert_array_equal(mlb.fit_transform(inp), indicator_mat)
+    assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
 
     # fit().transform()
-    lsb = MultiLabelBinarizer()
-    assert_array_equal(lsb.fit(inp).transform(inp), indicator_mat)
-    assert_array_equal(lsb.inverse_transform(indicator_mat), inp)
+    mlb = MultiLabelBinarizer()
+    assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
+    assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
 
 
 def test_mutlilabel_binarizer_non_integer_labels():
@@ -358,25 +358,25 @@ def test_mutlilabel_binarizer_non_integer_labels():
                               [1, 1, 0]])
     for inp, classes in inputs:
         # fit_transform()
-        lsb = MultiLabelBinarizer()
-        assert_array_equal(lsb.fit_transform(inp), indicator_mat)
-        assert_array_equal(lsb.classes_, classes)
-        assert_array_equal(lsb.inverse_transform(indicator_mat), inp)
+        mlb = MultiLabelBinarizer()
+        assert_array_equal(mlb.fit_transform(inp), indicator_mat)
+        assert_array_equal(mlb.classes_, classes)
+        assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
 
         # fit().transform()
-        lsb = MultiLabelBinarizer()
-        assert_array_equal(lsb.fit(inp).transform(inp), indicator_mat)
-        assert_array_equal(lsb.classes_, classes)
-        assert_array_equal(lsb.inverse_transform(indicator_mat), inp)
+        mlb = MultiLabelBinarizer()
+        assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
+        assert_array_equal(mlb.classes_, classes)
+        assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
 
-    lsb = MultiLabelBinarizer()
-    assert_raises(TypeError, lsb.fit_transform, [({}), ({}, {'a': 'b'})])
+    mlb = MultiLabelBinarizer()
+    assert_raises(TypeError, mlb.fit_transform, [({}), ({}, {'a': 'b'})])
 
 
 def test_mutlilabel_binarizer_non_unique():
     inp = [(1, 1, 1, 0)]
     indicator_mat = np.array([[1, 1]])
-    lsb = MultiLabelBinarizer()
-    assert_array_equal(lsb.fit_transform(inp), indicator_mat)
+    mlb = MultiLabelBinarizer()
+    assert_array_equal(mlb.fit_transform(inp), indicator_mat)
 
-    assert_array_equal(lsb.inverse_transform(np.array([[1, 3]])), [(0, 1,)])
+    assert_array_equal(mlb.inverse_transform(np.array([[1, 3]])), [(0, 1,)])

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -48,8 +48,8 @@ from sklearn.cross_validation import train_test_split
 from sklearn.utils.validation import DataConversionWarning
 
 dont_test = ['SparseCoder', 'EllipticEnvelope', 'DictVectorizer',
-             'LabelBinarizer', 'LabelEncoder', 'TfidfTransformer',
-             'IsotonicRegression', 'OneHotEncoder',
+             'LabelBinarizer', 'LabelEncoder', 'MultiLabelBinarizer',
+             'TfidfTransformer', 'IsotonicRegression', 'OneHotEncoder',
              'RandomTreesEmbedding', 'FeatureHasher', 'DummyClassifier',
              'DummyRegressor', 'TruncatedSVD', 'PolynomialFeatures']
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns
 
 from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
@@ -86,7 +87,9 @@ def test_ovr_multilabel():
                      LinearRegression(), Ridge(),
                      ElasticNet(), Lasso(alpha=0.5)):
         # test input as lists of tuples
-        clf = OneVsRestClassifier(base_clf).fit(X, y)
+        clf = assert_warns(DeprecationWarning,
+                           OneVsRestClassifier(base_clf).fit,
+                           X, y)
         assert_equal(set(clf.classes_), classes)
         y_pred = clf.predict([[0, 4, 4]])[0]
         assert_equal(set(y_pred), set(["spam", "eggs"]))
@@ -115,6 +118,7 @@ def test_ovr_multilabel_dataset():
                                                        n_labels=2,
                                                        length=50,
                                                        allow_unlabeled=au,
+                                                       return_indicator=True,
                                                        random_state=0)
         X_train, Y_train = X[:80], Y[:80]
         X_test, Y_test = X[80:], Y[80:]
@@ -138,6 +142,7 @@ def test_ovr_multilabel_predict_proba():
                                                        n_labels=3,
                                                        length=50,
                                                        allow_unlabeled=au,
+                                                       return_indicator=True,
                                                        random_state=0)
         X_train, Y_train = X[:80], Y[:80]
         X_test, Y_test = X[80:], Y[80:]
@@ -157,8 +162,8 @@ def test_ovr_multilabel_predict_proba():
 
         # predict assigns a label if the probability that the
         # sample has the label is greater than 0.5.
-        pred = [tuple(l.nonzero()[0]) for l in (Y_proba > 0.5)]
-        assert_equal(pred, Y_pred)
+        pred = Y_proba > .5
+        assert_array_equal(pred, Y_pred)
 
 
 def test_ovr_single_label_predict_proba():
@@ -189,12 +194,13 @@ def test_ovr_multilabel_decision_function():
                                                    n_labels=3,
                                                    length=50,
                                                    allow_unlabeled=True,
+                                                   return_indicator=True,
                                                    random_state=0)
     X_train, Y_train = X[:80], Y[:80]
     X_test, Y_test = X[80:], Y[80:]
     clf = OneVsRestClassifier(svm.SVC()).fit(X_train, Y_train)
-    assert_array_equal((clf.decision_function(X_test) > 0).nonzero()[1],
-                       np.hstack(clf.predict(X_test)))
+    assert_array_equal((clf.decision_function(X_test) > 0).astype(int),
+                       clf.predict(X_test))
 
 
 def test_ovr_single_label_decision_function():

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -68,11 +68,6 @@ def unique_labels(*ys):
     array([1, 2, 3, 4])
     >>> unique_labels([1, 2, 10], [5, 11])
     array([ 1,  2,  5, 10, 11])
-    >>> unique_labels(np.array([[0.0, 1.0], [1.0, 1.0]]), np.zeros((2, 2)))
-    array([0, 1])
-    >>> unique_labels([(1, 2), (3,)], [(1, 2), tuple()])
-    array([1, 2, 3])
-
     """
     if not ys:
         raise ValueError('No argument has been passed.')
@@ -152,6 +147,8 @@ def is_label_indicator_matrix(y):
 def is_sequence_of_sequences(y):
     """ Check if ``y`` is in the sequence of sequences format (multilabel).
 
+    This format is DEPRECATED.
+
     Parameters
     ----------
     y : sequence or array.
@@ -160,22 +157,6 @@ def is_sequence_of_sequences(y):
     -------
     out : bool,
         Return ``True``, if ``y`` is a sequence of sequences else ``False``.
-
-    >>> import numpy as np
-    >>> is_sequence_of_sequences([0, 1, 0, 1])
-    False
-    >>> is_sequence_of_sequences([[1], [0, 2], []])
-    True
-    >>> is_sequence_of_sequences(np.array([[1], [0, 2], []], dtype=object))
-    True
-    >>> is_sequence_of_sequences([(1,), (0, 2), ()])
-    True
-    >>> is_sequence_of_sequences(np.array([[1, 0], [0, 0]]))
-    False
-    >>> is_sequence_of_sequences(np.array([[1], [0], [0]]))
-    False
-    >>> is_sequence_of_sequences(np.array([[1, 0, 0]]))
-    False
     """
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
@@ -213,8 +194,6 @@ def is_multilabel(y):
     >>> from sklearn.utils.multiclass import is_multilabel
     >>> is_multilabel([0, 1, 0, 1])
     False
-    >>> is_multilabel([[1], [0, 2], []])
-    True
     >>> is_multilabel(np.array([[1, 0], [0, 0]]))
     True
     >>> is_multilabel(np.array([[1], [0], [0]]))
@@ -273,10 +252,6 @@ def type_of_target(y):
     'multiclass-multioutput'
     >>> type_of_target(np.array([[1.5, 2.0], [3.0, 1.6]]))
     'continuous-multioutput'
-    >>> type_of_target([['a', 'b'], ['c'], []])
-    'multilabel-sequences'
-    >>> type_of_target([[]])
-    'multilabel-sequences'
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -8,6 +8,7 @@ Multi-class / multi-label utility function
 """
 from collections import Sequence
 from itertools import chain
+import warnings
 
 import numpy as np
 
@@ -179,10 +180,17 @@ def is_sequence_of_sequences(y):
     # the explicit check for ndarray is for forward compatibility; future
     # versions of Numpy might want to register ndarray as a Sequence
     try:
-        return (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence)
-                and not isinstance(y[0], string_types))
+        out = (not isinstance(y[0], np.ndarray) and isinstance(y[0], Sequence)
+               and not isinstance(y[0], string_types))
     except IndexError:
         return False
+    if out:
+        warnings.warn('Direct support for sequence of sequences multilabel '
+                      'representation will be unavailable from version 0.17. '
+                      'Use sklearn.preprocessing.MultiLabelBinarizer to '
+                      'convert to a label indicator representation.',
+                      DeprecationWarning)
+    return out
 
 
 def is_multilabel(y):


### PR DESCRIPTION
Towards #2270
- add warnings: most uses of the deprecated format are through `type_of_target`. Its helper, `is_sequence_of_sequences` triggers the warning. A further warning applies to `make_multilabel_classification`.
- provide alternative binarizer, `sklearn.preprocessing.MultiLabelBinarizer`
- fix documentation

This will require a bit of updating once the alternative sparse matrix support in is incorporated from #2458 and https://github.com/jnothman/scikit-learn/tree/sparse_multi_metrics ... or vice-versa.
