### PR TITLE
DOC: typo in binary_tree docs

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -1240,7 +1240,7 @@ cdef class BinaryTree:
         query(X, k=1, return_distance=True,
               dualtree=False, breadth_first=False)
 
-        query the treeree for the k nearest neighbors
+        query the tree for the k nearest neighbors
 
         Parameters
         ----------


### PR DESCRIPTION
Small typo in the Binary Tree cython source.

I'm doing a PR rather than just pushing the fix because I'm not sure if I should re-generate the C code for this minor change, or wait until a more major change happens.
