### PR TITLE
[MRG] update LibSVM to version 310

### DIFF
--- a/sklearn/svm/src/libsvm/libsvm_helper.c
+++ b/sklearn/svm/src/libsvm/libsvm_helper.c
@@ -392,11 +392,6 @@ int free_param(struct svm_parameter *param)
 }
 
 
-/* rely on built-in facility to control verbose output
- * in the versions of libsvm >= 2.89
- */
-#if LIBSVM_VERSION && LIBSVM_VERSION >= 289
-
 /* borrowed from original libsvm code */
 static void print_null(const char *s) {}
 
@@ -409,14 +404,7 @@ static void print_string_stdout(const char *s)
 /* provide convenience wrapper */
 void set_verbosity(int verbosity_flag){
 	if (verbosity_flag)
-# if LIBSVM_VERSION < 291
-		svm_print_string = &print_string_stdout;
-	else
-		svm_print_string = &print_null;
-# else
 		svm_set_print_string_function(&print_string_stdout);
 	else
 		svm_set_print_string_function(&print_null);
-# endif
 }
-#endif

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2928,32 +2928,52 @@ double PREFIX(predict_probability)(
 
 void PREFIX(free_model_content)(PREFIX(model)* model_ptr)
 {
-	if(model_ptr->free_sv && model_ptr->l > 0)
+	if(model_ptr->free_sv && model_ptr->l > 0 && model_ptr->SV != NULL)
 #ifdef _DENSE_REP
-	for (int i = 0; i < model_ptr->l; i++)
-		free (model_ptr->SV[i].values);
+		for (int i = 0; i < model_ptr->l; i++)
+			free(model_ptr->SV[i].values);
 #else
 		free((void *)(model_ptr->SV[0]));
 #endif
-	for(int i=0;i<model_ptr->nr_class-1;i++)
-		free(model_ptr->sv_coef[i]);
+
+	if(model_ptr->sv_coef)
+	{
+		for(int i=0;i<model_ptr->nr_class-1;i++)
+			free(model_ptr->sv_coef[i]);
+	}
+
 	free(model_ptr->SV);
+	model_ptr->SV = NULL;
+
 	free(model_ptr->sv_coef);
+	model_ptr->sv_coef = NULL;
+
 	free(model_ptr->sv_ind);
+	model_ptr->sv_ind = NULL;
+
 	free(model_ptr->rho);
+	model_ptr->rho = NULL;
+
 	free(model_ptr->label);
+	model_ptr->label= NULL;
+
 	free(model_ptr->probA);
+	model_ptr->probA = NULL;
+
 	free(model_ptr->probB);
+	model_ptr->probB= NULL;
+
 	free(model_ptr->nSV);
+	model_ptr->nSV = NULL;
 }
 
 void PREFIX(free_and_destroy_model)(PREFIX(model)** model_ptr_ptr)
 {
-	PREFIX(model)* model_ptr = *model_ptr_ptr;
-	if(model_ptr != NULL)
+	if(model_ptr_ptr != NULL && *model_ptr_ptr != NULL)
 	{
-		PREFIX(free_model_content)(model_ptr);
-		free(model_ptr);
+		PREFIX(free_model_content)(*model_ptr_ptr);
+		free(*model_ptr_ptr);
+		*model_ptr_ptr = NULL;
 	}
 }
 

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2787,14 +2787,13 @@ double PREFIX(get_svr_probability)(const PREFIX(model) *model)
 
 double PREFIX(predict_values)(const PREFIX(model) *model, const PREFIX(node) *x, double* dec_values)
 {
-        int i;
+	int i;
 	if(model->param.svm_type == ONE_CLASS ||
 	   model->param.svm_type == EPSILON_SVR ||
 	   model->param.svm_type == NU_SVR)
 	{
 		double *sv_coef = model->sv_coef[0];
 		double sum = 0;
-
 		
 		for(i=0;i<model->l;i++)
 #ifdef _DENSE_REP
@@ -2812,7 +2811,6 @@ double PREFIX(predict_values)(const PREFIX(model) *model, const PREFIX(node) *x,
 	}
 	else
 	{
-		int i;
 		int nr_class = model->nr_class;
 		int l = model->l;
 		

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2008,6 +2008,7 @@ static void sigmoid_train(
 static double sigmoid_predict(double decision_value, double A, double B)
 {
 	double fApB = decision_value*A+B;
+	// 1-p used later; avoid catastrophic cancellation
 	if (fApB >= 0)
 		return exp(-fApB)/(1.0+exp(-fApB));
 	else

--- a/sklearn/svm/src/libsvm/svm.h
+++ b/sklearn/svm/src/libsvm/svm.h
@@ -1,7 +1,7 @@
 #ifndef _LIBSVM_H
 #define _LIBSVM_H
 
-#define LIBSVM_VERSION 300
+#define LIBSVM_VERSION 310
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I cherry-picked the relevant patches from the [LibSVM GitHub repo](https://github.com/cjlin1/libsvm). I stopped at 310 because 311 introduces a `max_iter` that seems to work a bit differently from our own.
