### PR TITLE
[MRG] make_pipeline utility function

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1024,6 +1024,13 @@ Pairwise metrics
    pipeline.Pipeline
    pipeline.FeatureUnion
 
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   pipeline.make_pipeline
+   pipeline.make_union
+
 
 .. _preprocessing_ref:
 

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -17,9 +17,9 @@ and classification. :class:`Pipeline` serves two purposes here:
     **Joint parameter selection**: You can :ref:`grid search <grid_search>`
     over parameters of all estimators in the pipeline at once.
 
-For estimators to be usable within a pipeline, all except the last one need to have
-a ``transform`` function. Otherwise, the dataset can not be passed through this
-estimator.
+All estimators in a pipeline, except the last one, must be transformers
+(i.e. must have a ``transform`` method).
+The last estimator may be any type (transformer, classifier, etc.).
 
 
 Usage
@@ -41,7 +41,21 @@ is an estimator object::
         probability=False, random_state=None, shrinking=True, tol=0.001,
         verbose=False))])
 
-The estimators of the pipeline are stored as a list in the ``steps`` attribute::
+The utility function :func:`make_pipeline` is a shorthand
+for constructing pipelines;
+it takes a variable number of estimators and returns a pipeline,
+filling in the names automatically::
+
+    >>> from sklearn.pipeline import make_pipeline
+    >>> from sklearn.naive_bayes import MultinomialNB
+    >>> from sklearn.preprocessing import Binarizer
+    >>> make_pipeline(Binarizer(), MultinomialNB()) # doctest: +NORMALIZE_WHITESPACE
+    Pipeline(steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
+                    ('multinomialnb', MultinomialNB(alpha=1.0,
+                                                    class_prior=None,
+                                                    fit_prior=True))])
+
+The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 
     >>> clf.steps[0]
     ('reduce_dim', PCA(copy=True, n_components=None, whiten=False))
@@ -137,6 +151,8 @@ and ``value`` is an estimator object::
         n_components=None, remove_zero_eig=False, tol=0))],
         transformer_weights=None)
 
+Like pipelines, feature unions have a shorthand constructor called
+:func:`make_union` that does require manual naming of the components.
 
                                                                        
 .. topic:: Examples:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,9 @@ Changelog
    - Fixed bug in :class:`linear_model.stochastic_gradient` :
      ``l1_ratio`` was used as ``(1.0 - l1_ratio)`` .
 
+   - Shorthand constructors :func:`pipeline.make_pipeline` and
+     :func:`pipeline.make_union` were added by `Lars Buitinck`_.
+
 API changes summary
 -------------------
 

--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -57,7 +57,7 @@ from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer
-from sklearn.pipeline import Pipeline
+from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import Normalizer
 from sklearn import metrics
 
@@ -137,10 +137,7 @@ if opts.use_hashing:
         hasher = HashingVectorizer(n_features=opts.n_features,
                                    stop_words='english', non_negative=True,
                                    norm=None, binary=False)
-        vectorizer = Pipeline((
-            ('hasher', hasher),
-            ('tf_idf', TfidfTransformer())
-        ))
+        vectorizer = make_pipeline(hasher, TfidfTransformer())
     else:
         vectorizer = HashingVectorizer(n_features=opts.n_features,
                                        stop_words='english',
@@ -158,12 +155,12 @@ print()
 if opts.n_components:
     print("Performing dimensionality reduction using LSA")
     t0 = time()
-    lsa = TruncatedSVD(opts.n_components)
-    X = lsa.fit_transform(X)
     # Vectorizer results are normalized, which makes KMeans behave as
     # spherical k-means for better results. Since LSA/SVD results are
     # not normalized, we have to redo the normalization.
-    X = Normalizer(copy=False).fit_transform(X)
+    lsa = make_pipeline(TruncatedSVD(opts.n_components),
+                        Normalizer(copy=False))
+    X = lsa.fit_transform(X)
 
     print("done in %fs" % (time() - t0))
     print()

--- a/examples/feature_selection_pipeline.py
+++ b/examples/feature_selection_pipeline.py
@@ -11,7 +11,7 @@ print(__doc__)
 from sklearn import svm
 from sklearn.datasets import samples_generator
 from sklearn.feature_selection import SelectKBest, f_regression
-from sklearn.pipeline import Pipeline
+from sklearn.pipeline import make_pipeline
 
 # import some data to play with
 X, y = samples_generator.make_classification(
@@ -24,6 +24,6 @@ anova_filter = SelectKBest(f_regression, k=3)
 # 2) svm
 clf = svm.SVC(kernel='linear')
 
-anova_svm = Pipeline([('anova', anova_filter), ('svm', clf)])
+anova_svm = make_pipeline(anova_filter, clf)
 anova_svm.fit(X, y)
 anova_svm.predict(X)

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -32,12 +32,13 @@ import matplotlib.pyplot as plt
 
 from sklearn.linear_model import Ridge
 from sklearn.preprocessing import PolynomialFeatures
-from sklearn.pipeline import Pipeline
+from sklearn.pipeline import make_pipeline
 
 
 def f(x):
     """ function to approximate by polynomial interpolation"""
     return x * np.sin(x)
+
 
 # generate points used to plot
 x_plot = np.linspace(0, 10, 100)
@@ -57,8 +58,7 @@ plt.plot(x_plot, f(x_plot), label="ground truth")
 plt.scatter(x, y, label="training points")
 
 for degree in [3, 4, 5]:
-    model = Pipeline([('poly', PolynomialFeatures(degree)),
-                      ('ridge', Ridge())])
+    model = make_pipeline(PolynomialFeatures(degree), Ridge())
     model.fit(X, y)
     y_plot = model.predict(X_plot)
     plt.plot(x_plot, y_plot, label="degree %d" % degree)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -6,7 +6,10 @@ estimator, as a chain of transforms and estimators.
 #         Gael Varoquaux
 #         Virgile Fritsch
 #         Alexandre Gramfort
+#         Lars Buitinck
 # Licence: BSD
+
+from collections import defaultdict
 
 import numpy as np
 from scipy import sparse
@@ -206,6 +209,50 @@ class Pipeline(BaseEstimator):
         return getattr(self.steps[0][1], '_pairwise', False)
 
 
+def _name_estimators(estimators):
+    """Generate names for estimators."""
+
+    names = [type(estimator).__name__.lower() for estimator in estimators]
+    namecount = defaultdict(int)
+    for est, name in zip(estimators, names):
+        namecount[name] += 1
+
+    for k, v in list(six.iteritems(namecount)):
+        if v == 1:
+            del namecount[k]
+
+    for i in reversed(range(len(estimators))):
+        name = names[i]
+        if name in namecount:
+            names[i] += "-%d" % namecount[name]
+            namecount[name] -= 1
+
+    return list(zip(names, estimators))
+
+
+def make_pipeline(*steps):
+    """Construct a Pipeline from the given estimators.
+
+    This is a shorthand for the Pipeline constructor; it does not require, and
+    does not permit, naming the estimators. Instead, they will be given names
+    automatically based on their types.
+
+    Examples
+    --------
+    >>> from sklearn.naive_bayes import GaussianNB
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> make_pipeline(StandardScaler(), GaussianNB())    # doctest: +NORMALIZE_WHITESPACE
+    Pipeline(steps=[('standardscaler',
+                     StandardScaler(copy=True, with_mean=True, with_std=True)),
+                    ('gaussiannb', GaussianNB())])
+
+    Returns
+    -------
+    p : Pipeline
+    """
+    return Pipeline(_name_estimators(steps))
+
+
 def _fit_one_transformer(transformer, X, y):
     return transformer.fit(X, y)
 
@@ -359,3 +406,31 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
             for ((name, old), new) in zip(self.transformer_list, transformers)
         ]
 
+
+# XXX it would be nice to have a keyword-only n_jobs argument to this function,
+# but that's not allowed in Python 2.x.
+def make_union(*transformers):
+    """Construct a FeatureUnion from the given transformers.
+
+    This is a shorthand for the FeatureUnion constructor; it does not require,
+    and does not permit, naming the transformers. Instead, they will be given
+    names automatically based on their types. It also does not allow weighting.
+
+    Examples
+    --------
+    >>> from sklearn.decomposition import PCA, TruncatedSVD
+    >>> make_union(PCA(), TruncatedSVD())    # doctest: +NORMALIZE_WHITESPACE
+    FeatureUnion(n_jobs=1,
+                 transformer_list=[('pca', PCA(copy=True, n_components=None,
+                                               whiten=False)),
+                                   ('truncatedsvd',
+                                    TruncatedSVD(algorithm='randomized',
+                                                 n_components=2, n_iter=5,
+                                                 random_state=None, tol=0.0))],
+                 transformer_weights=None)
+
+    Returns
+    -------
+    f : FeatureUnion
+    """
+    return FeatureUnion(_name_estimators(transformers))

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -12,7 +12,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.base import BaseEstimator, clone
-from sklearn.pipeline import Pipeline, FeatureUnion
+from sklearn.pipeline import Pipeline, FeatureUnion, make_pipeline, make_union
 from sklearn.svm import SVC
 from sklearn.linear_model import LogisticRegression
 from sklearn.feature_selection import SelectKBest, f_classif
@@ -230,6 +230,15 @@ def test_feature_union():
     assert_equal(X_transformed.shape, (X.shape[0], 8))
 
 
+def test_make_union():
+    pca = PCA()
+    mock = TransfT()
+    fu = make_union(pca, mock)
+    names, transformers = zip(*fu.transformer_list)
+    assert_equal(names, ("pca", "transft"))
+    assert_equal(transformers, (pca, mock))
+
+
 def test_pipeline_transform():
     # Test whether pipeline works with a transformer at the end.
     # Also test pipeline.transform and pipeline.inverse_transform
@@ -262,6 +271,22 @@ def test_pipeline_fit_transform():
     X_trans = pipeline.fit_transform(X, y)
     X_trans2 = transft.fit(X, y).transform(X)
     assert_array_almost_equal(X_trans, X_trans2)
+
+
+def test_make_pipeline():
+    t1 = TransfT()
+    t2 = TransfT()
+
+    pipe = make_pipeline(t1, t2)
+    assert_true(isinstance(pipe, Pipeline))
+    assert_equal(pipe.steps[0][0], "transft-1")
+    assert_equal(pipe.steps[1][0], "transft-2")
+
+    pipe = make_pipeline(t1, t2, FitParamT())
+    assert_true(isinstance(pipe, Pipeline))
+    assert_equal(pipe.steps[0][0], "transft-1")
+    assert_equal(pipe.steps[1][0], "transft-2")
+    assert_equal(pipe.steps[2][0], "fitparamt")
 
 
 def test_feature_union_weights():


### PR DESCRIPTION
Shorthand for the `Pipeline` constructor with automatic naming of steps.

Examples and tutorial may need to be changed to show this syntax.
