### PR TITLE
[MRG] replace 'f1' scorer by explicit variants

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -737,6 +737,8 @@ details.
    :template: function.rst
 
    metrics.make_scorer
+   metrics.list_scorers
+   metrics.get_scorer
 
 Classification metrics
 ----------------------

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -120,7 +120,7 @@ scoring parameter::
 
   >>> from sklearn import metrics
   >>> scores = cross_validation.cross_val_score(clf, iris.data, iris.target,
-  ...     cv=5, scoring='f1')
+  ...     cv=5, scoring='f1_weighted')
   >>> scores                                              # doctest: +ELLIPSIS
   array([ 0.96...,  1.  ...,  0.96...,  0.96...,  1.        ])
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -47,15 +47,18 @@ Common cases: predefined values
 For the most common usecases, you can simply provide a string as the
 ``scoring`` parameter. Possible values are:
 
-======================     =================================================
+======================     ===================================================
 Scoring                    Function
-======================     =================================================
+======================     ===================================================
 **Classification**
 'accuracy'                 :func:`sklearn.metrics.accuracy_score`
 'average_precision'        :func:`sklearn.metrics.average_precision_score`
-'f1'                       :func:`sklearn.metrics.f1_score`
-'precision'                :func:`sklearn.metrics.precision_score`
-'recall'                   :func:`sklearn.metrics.recall_score`
+'f1_binary'                :func:`sklearn.metrics.f1_score` with `pos_label=1`
+'f1_micro'                 :func:`sklearn.metrics.f1_score` micro-averaged
+'f1_macro'                 :func:`sklearn.metrics.f1_score` macro-averaged
+'f1_weighted'              :func:`sklearn.metrics.f1_score` weighted average
+'precision_...'            :func:`sklearn.metrics.precision_score` likewise
+'recall_...'               :func:`sklearn.metrics.recall_score` likewise
 'roc_auc'                  :func:`sklearn.metrics.roc_auc_score`
 
 **Clustering**
@@ -64,10 +67,10 @@ Scoring                    Function
 **Regression**
 'mean_squared_error'       :func:`sklearn.metrics.mean_squared_error`
 'r2'                       :func:`sklearn.metrics.r2_score`
-======================     =================================================
+======================     ===================================================
 
-Setting the ``scoring`` parameter to a wrong value should give you a list
-of acceptable values::
+A list of acceptable values is available from ``sklearn.metrics.list_scorers``,
+and is shown if ``scoring`` is set to an unknown string::
 
     >>> from sklearn import svm, cross_validation, datasets
     >>> iris = datasets.load_iris()
@@ -75,12 +78,12 @@ of acceptable values::
     >>> model = svm.SVC()
     >>> cross_validation.cross_val_score(model, X, y, scoring='wrong_choice')
     Traceback (most recent call last):
-    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'f1', 'log_loss', 'mean_squared_error', 'precision', 'r2', 'recall', 'roc_auc']
+    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'f1_binary', 'f1_macro', 'f1_micro', 'f1_weighted', 'log_loss', 'mean_squared_error', 'precision_binary', 'precision_macro', 'precision_micro', 'precision_weighted', 'r2', 'recall_binary', 'recall_macro', 'recall_micro', 'recall_weighted', 'roc_auc']
 
 .. note::
 
-    The corresponding scorer objects are stored in the dictionary
-    ``sklearn.metrics.SCORERS``.
+    The corresponding scorer objects may be retrieved with
+    ``sklearn.metrics.get_scorer``.
 
 The above choices correspond to error-metric functions that can be applied to
 predicted values. These are detailed below, in the next sections.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -47,9 +47,9 @@ Common cases: predefined values
 For the most common usecases, you can simply provide a string as the
 ``scoring`` parameter. Possible values are:
 
-======================     ===================================================
+======================     =====================================================
 Scoring                    Function
-======================     ===================================================
+======================     =====================================================
 **Classification**
 'accuracy'                 :func:`sklearn.metrics.accuracy_score`
 'average_precision'        :func:`sklearn.metrics.average_precision_score`
@@ -57,6 +57,7 @@ Scoring                    Function
 'f1_micro'                 :func:`sklearn.metrics.f1_score` micro-averaged
 'f1_macro'                 :func:`sklearn.metrics.f1_score` macro-averaged
 'f1_weighted'              :func:`sklearn.metrics.f1_score` weighted average
+'f1_samples'               :func:`sklearn.metrics.f1_score` by multilabel sample
 'precision_...'            :func:`sklearn.metrics.precision_score` likewise
 'recall_...'               :func:`sklearn.metrics.recall_score` likewise
 'roc_auc'                  :func:`sklearn.metrics.roc_auc_score`
@@ -67,9 +68,9 @@ Scoring                    Function
 **Regression**
 'mean_squared_error'       :func:`sklearn.metrics.mean_squared_error`
 'r2'                       :func:`sklearn.metrics.r2_score`
-======================     ===================================================
+======================     =====================================================
 
-A list of acceptable values is available from ``sklearn.metrics.list_scorers``,
+A list of acceptable values is available from :func:`sklearn.metrics.list_scorers`,
 and is shown if ``scoring`` is set to an unknown string::
 
     >>> from sklearn import svm, cross_validation, datasets
@@ -78,12 +79,12 @@ and is shown if ``scoring`` is set to an unknown string::
     >>> model = svm.SVC()
     >>> cross_validation.cross_val_score(model, X, y, scoring='wrong_choice')
     Traceback (most recent call last):
-    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'f1_binary', 'f1_macro', 'f1_micro', 'f1_weighted', 'log_loss', 'mean_squared_error', 'precision_binary', 'precision_macro', 'precision_micro', 'precision_weighted', 'r2', 'recall_binary', 'recall_macro', 'recall_micro', 'recall_weighted', 'roc_auc']
+    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'f1_binary', 'f1_macro', 'f1_micro', 'f1_samples', 'f1_weighted', 'log_loss', 'mean_squared_error', 'precision_binary', 'precision_macro', 'precision_micro', 'precision_weighted', 'r2', 'recall_binary', 'recall_macro', 'recall_micro', 'recall_weighted', 'roc_auc']
 
 .. note::
 
     The corresponding scorer objects may be retrieved with
-    ``sklearn.metrics.get_scorer``.
+    :func:`sklearn.metrics.get_scorer`.
 
 The above choices correspond to error-metric functions that can be applied to
 predicted values. These are detailed below, in the next sections.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -114,6 +114,11 @@ API changes summary
      :class:`RandomizedPCA <decomposition.RandomizedPCA>`.
      By `Alexandre Gramfort`_.
 
+   - `scoring` parameter for cross validatiokn now accepts `'f1_binary'`,
+     `'f1_micro'`, `'f1_macro'` or `'f1_weighted'`, deprecating the generic
+     `'f1'`. Similarly, `'precision'` and `'recall'` are deprecated.
+     By `Joel Nothman`_.
+
 .. _changes_0_14:
 
 0.14

--- a/examples/grid_search_digits.py
+++ b/examples/grid_search_digits.py
@@ -51,7 +51,8 @@ for score in scores:
     print("# Tuning hyper-parameters for %s" % score)
     print()
 
-    clf = GridSearchCV(SVC(C=1), tuned_parameters, cv=5, scoring=score)
+    clf = GridSearchCV(SVC(C=1), tuned_parameters, cv=5,
+                       scoring='%_weighted' % score)
     clf.fit(X_train, y_train)
 
     print("Best parameters set found on development set:")

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -14,7 +14,7 @@ from sklearn.svm import SVC
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
 
-from sklearn.metrics.scorer import SCORERS
+from sklearn.metrics.scorer import get_scorer
 
 def test_rfe_set_params():
     generator = check_random_state(0)
@@ -94,7 +94,7 @@ def test_rfecv():
     assert_array_equal(X_r, iris.data)
 
     # Test using a scorer
-    scorer = SCORERS['accuracy']
+    scorer = get_scorer('accuracy')
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, cv=5,
                   scoring=scorer)
     rfecv.fit(X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -12,7 +12,7 @@ from sklearn.utils.testing import ignore_warnings
 
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
-from sklearn.metrics.scorer import SCORERS
+from sklearn.metrics.scorer import get_scorer
 
 from sklearn.linear_model.base import LinearRegression
 from sklearn.linear_model.ridge import ridge_regression
@@ -291,7 +291,7 @@ def _test_ridge_loo(filter_):
     assert_equal(ridge_gcv3.alpha_, alpha_)
 
     # check that we get same best alpha with a scorer
-    scorer = SCORERS['mean_squared_error']
+    scorer = get_scorer('mean_squared_error')
     ridge_gcv4 = RidgeCV(fit_intercept=False, scoring=scorer)
     ridge_gcv4.fit(filter_(X_diabetes), y_diabetes)
     assert_equal(ridge_gcv4.alpha_, alpha_)

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -31,7 +31,7 @@ from .metrics import (accuracy_score,
 # Deprecated in 0.16
 from .metrics import auc_score
 
-from .scorer import make_scorer, SCORERS
+from .scorer import make_scorer, get_scorer, list_scorers, SCORERS
 
 from . import cluster
 from .cluster import (adjusted_rand_score,
@@ -93,5 +93,7 @@ __all__ = ['accuracy_score',
            'v_measure_score',
            'consensus_score',
            'zero_one_loss',
+           'get_scorer',
+           'list_scorers',
            'make_scorer',
            'SCORERS']

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -16,9 +16,11 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # Authors: Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
+#          Joel Nothman <joel.nothman@gmail.com>
 # License: Simplified BSD
 
 from abc import ABCMeta, abstractmethod
+from functools import partial
 from warnings import warn
 
 import numpy as np
@@ -179,17 +181,35 @@ def _deprecate_loss_and_score_funcs(
                  category=DeprecationWarning, stacklevel=2)
             if loss_func is None or score_overrides_loss:
                 scorer = make_scorer(score_func)
-
-    elif isinstance(scoring, six.string_types):
-        try:
-            scorer = SCORERS[scoring]
-        except KeyError:
-            raise ValueError('%r is not a valid scoring value. '
-                             'Valid options are %s' % (scoring,
-                             sorted(SCORERS.keys())))
     else:
-        scorer = scoring
+        scorer = get_scorer(scoring)
+
     return scorer
+
+
+def get_scorer(scoring=None):
+    """Get a scorer by its name
+
+    Parameters
+    ----------
+    scoring : string or callable
+
+    Returns
+    -------
+    scorer : callable
+        Returns the scorer of the given name if scoring is a string, and
+        otherwise the object passed in.
+    """
+    if isinstance(scoring, six.string_types):
+        if scoring in SCORER_DEPRECATION:
+            warn(SCORER_DEPRECATION[scoring], DeprecationWarning)
+        try:
+            return SCORERS[scoring]
+        except KeyError:
+            raise ValueError('%r is not a valid scoring name. '
+                             'Valid options are %s' % (scoring,
+                             list_scorers()))
+    return scoring
 
 
 def make_scorer(score_func, greater_is_better=True, needs_proba=False,
@@ -256,6 +276,17 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
     return cls(score_func, sign, kwargs)
 
 
+def list_scorers():
+    """Lists the names of known scorers
+
+    Returns
+    -------
+    scorer_names : list of strings
+    """
+    return sorted(set(SCORERS) - set(SCORER_DEPRECATION))
+
+
+
 # Standard regression scores
 r2_scorer = make_scorer(r2_score)
 mean_squared_error_scorer = make_scorer(mean_squared_error,
@@ -280,6 +311,7 @@ log_loss_scorer = make_scorer(log_loss, greater_is_better=False,
 # Clustering scores
 adjusted_rand_scorer = make_scorer(adjusted_rand_score)
 
+SCORER_DEPRECATION = {}
 SCORERS = dict(r2=r2_scorer,
                mean_squared_error=mean_squared_error_scorer,
                accuracy=accuracy_scorer, f1=f1_scorer, roc_auc=roc_auc_scorer,
@@ -287,3 +319,21 @@ SCORERS = dict(r2=r2_scorer,
                precision=precision_scorer, recall=recall_scorer,
                log_loss=log_loss_scorer,
                adjusted_rand_score=adjusted_rand_scorer)
+
+msg = ("The {0!r} scorer has been deprecated and will be removed in version "
+       "0.17. Please choose one of '{0}_binary' or '{0}_weighted' depending "
+       "on your data; '{0}_macro' and '{0}_micro' provide alternative "
+       "multiclass/multilabel averaging.")
+for name, metric in [('precision', precision_score),
+                       ('recall', recall_score), ('f1', f1_score)]:
+    SCORERS.update({
+        name: make_scorer(metric),
+        '{0}_binary'.format(name): make_scorer(partial(metric)),
+        '{0}_macro'.format(name): make_scorer(partial(metric, pos_label=None,
+                                                     average='macro')),
+        '{0}_micro'.format(name): make_scorer(partial(metric, pos_label=None,
+                                                     average='micro')),
+        '{0}_weighted'.format(name): make_scorer(partial(metric, pos_label=None,
+                                                        average='weighted')),
+    })
+    SCORER_DEPRECATION[name] = (msg.format(name))

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -322,8 +322,8 @@ SCORERS = dict(r2=r2_scorer,
 
 msg = ("The {0!r} scorer has been deprecated and will be removed in version "
        "0.17. Please choose one of '{0}_binary' or '{0}_weighted' depending "
-       "on your data; '{0}_macro' and '{0}_micro' provide alternative "
-       "multiclass/multilabel averaging.")
+       "on your data; '{0}_macro', '{0}_micro' and '{0}_samples' provide "
+       "alternative multiclass/multilabel averaging.")
 for name, metric in [('precision', precision_score),
                        ('recall', recall_score), ('f1', f1_score)]:
     SCORERS.update({
@@ -333,6 +333,8 @@ for name, metric in [('precision', precision_score),
                                                      average='macro')),
         '{0}_micro'.format(name): make_scorer(partial(metric, pos_label=None,
                                                      average='micro')),
+        '{0}_samples'.format(name): make_scorer(partial(metric, pos_label=None,
+                                                        average='samples')),
         '{0}_weighted'.format(name): make_scorer(partial(metric, pos_label=None,
                                                         average='weighted')),
     })

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -538,7 +538,7 @@ def test_cross_val_score_with_score_func_classification():
     # F1 score (class are balanced so f1_score should be equal to zero/one
     # score
     f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                     scoring="f1", cv=5)
+                                     scoring="f1_weighted", cv=5)
     assert_array_almost_equal(f1_scores, [0.97, 1., 0.97, 0.97, 1.], 2)
     # also test deprecated old way
     with warnings.catch_warnings(record=True):

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -319,14 +319,14 @@ def test_grid_search_sparse_scoring():
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
     clf = LinearSVC()
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1")
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1_binary")
     cv.fit(X_[:180], y_[:180])
     y_pred = cv.predict(X_[180:])
     C = cv.best_estimator_.C
 
     X_ = sp.csr_matrix(X_)
     clf = LinearSVC()
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1")
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1_binary")
     cv.fit(X_[:180], y_[:180])
     y_pred2 = cv.predict(X_[180:])
     C2 = cv.best_estimator_.C
@@ -355,7 +355,7 @@ def test_deprecated_score_func():
     # supported
     X, y = make_classification(n_samples=200, n_features=100, random_state=0)
     clf = LinearSVC(random_state=0)
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1")
+    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1_binary")
     cv.fit(X[:180], y[:180])
     y_pred = cv.predict(X[180:])
     C = cv.best_estimator_.C
@@ -458,7 +458,7 @@ def test_refit():
     y = np.array([0] * 5 + [1] * 5)
 
     clf = GridSearchCV(BrokenClassifier(), [{'parameter': [0, 1]}],
-                       scoring="precision", refit=True)
+                       scoring="precision_binary", refit=True)
     clf.fit(X, y)
 
 
@@ -560,7 +560,7 @@ def test_grid_search_score_consistency():
     clf = LinearSVC(random_state=0)
     X, y = make_blobs(random_state=0, centers=2)
     Cs = [.1, 1, 10]
-    for score in ['f1', 'roc_auc']:
+    for score in ['f1_binary', 'roc_auc']:
         grid_search = GridSearchCV(clf, {'C': Cs}, scoring=score)
         grid_search.fit(X, y)
         cv = StratifiedKFold(n_folds=3, y=y)
@@ -570,7 +570,7 @@ def test_grid_search_score_consistency():
             i = 0
             for train, test in cv:
                 clf.fit(X[train], y[train])
-                if score == "f1":
+                if score == "f1_binary":
                     correct_score = f1_score(y[test], clf.predict(X[test]))
                 elif score == "roc_auc":
                     correct_score = roc_auc_score(y[test],


### PR DESCRIPTION
This makes the averaging options for P/R/F scorers clearer for users, and avoids users getting binary behaviour when they shouldn't (cf. #2094 where `scoring` isn't used). I think this is extra important because "weighted" F1 isn't especially common in the literature, and having people report it without realising that's what it is is unhelpful to the applied ML community. This helps, IMO, towards a more explicit and robust API for binary classification metrics (cf. #2610).

It also entails a deprecation procedure for scorers, and more API there: `get_scorer` and `list_scorers`
