### PR TITLE
removed the type checking for the customer defined distance metric.

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -883,8 +883,6 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
         else:
             return _parallel_pairwise(X, Y, func, n_jobs, **kwds)
     elif callable(metric):
-        # Check matrices first (this is usually done by the metric).
-        X, Y = check_pairwise_arrays(X, Y)
         n_x, n_y = X.shape[0], Y.shape[0]
         # Calculate distance for each element in X and Y.
         # FIXME: can use n_jobs here too


### PR DESCRIPTION
I asked question in stackoverflow about How to use a customer distance metric for KNeighboursRegressor,
link: http://stackoverflow.com/q/20655287/807695

Scikit's builtin metrics don't support mixture types of dataset,so I have to write a customer metric function. But even I'm using my defined metric function, I still cann't use the KNeighboursRegressor because these two lines codes it force the input dataset to be pure float type,  I think this is kind of bug, so I removed these two lines.
