### PR TITLE
[MRG+2] Require explicit average arg for multiclass/label P/R/F metrics and scorers

### DIFF
--- a/benchmarks/bench_multilabel_metrics.py
+++ b/benchmarks/bench_multilabel_metrics.py
@@ -22,7 +22,7 @@ from sklearn.utils.testing import ignore_warnings
 
 
 METRICS = {
-    'f1': f1_score,
+    'f1': partial(f1_score, average='micro'),
     'f1-by-sample': partial(f1_score, average='samples'),
     'accuracy': accuracy_score,
     'hamming': hamming_loss,

--- a/doc/datasets/twenty_newsgroups.rst
+++ b/doc/datasets/twenty_newsgroups.rst
@@ -131,7 +131,7 @@ which is fast to train and achieves a decent F-score::
   >>> clf = MultinomialNB(alpha=.01)
   >>> clf.fit(vectors, newsgroups_train.target)
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(newsgroups_test.target, pred)
+  >>> metrics.f1_score(newsgroups_test.target, pred, average='weighted')
   0.88251152461278892
 
 (The example :ref:`example_text_document_classification_20newsgroups.py` shuffles
@@ -181,7 +181,7 @@ blocks, and quotation blocks respectively.
   ...                                      categories=categories)
   >>> vectors_test = vectorizer.transform(newsgroups_test.data)
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(pred, newsgroups_test.target)
+  >>> metrics.f1_score(pred, newsgroups_test.target, average='weighted')
   0.78409163025839435
 
 This classifier lost over a lot of its F-score, just because we removed
@@ -196,7 +196,7 @@ It loses even more if we also strip this metadata from the training data:
   >>> clf.fit(vectors, newsgroups_train.target)
   >>> vectors_test = vectorizer.transform(newsgroups_test.data)
   >>> pred = clf.predict(vectors_test)
-  >>> metrics.f1_score(newsgroups_test.target, pred)
+  >>> metrics.f1_score(newsgroups_test.target, pred, average='weighted')
   0.73160869205141166
 
 Some other classifiers cope better with this harder version of the task. Try

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -732,6 +732,7 @@ details.
    :template: function.rst
 
    metrics.make_scorer
+   metrics.get_scorer
 
 Classification metrics
 ----------------------

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -120,7 +120,7 @@ scoring parameter::
 
   >>> from sklearn import metrics
   >>> scores = cross_validation.cross_val_score(clf, iris.data, iris.target,
-  ...     cv=5, scoring='f1')
+  ...     cv=5, scoring='f1_weighted')
   >>> scores                                              # doctest: +ELLIPSIS
   array([ 0.96...,  1.  ...,  0.96...,  0.96...,  1.        ])
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -234,6 +234,17 @@ API changes summary
       :func:`linear_model.enet_path` which constrains coefficients to be
       positive. By `Manoj Kumar`_.
 
+    - Users should now supply an explicit ``average`` parameter to
+      :func:`sklearn.metrics.f1_score`, :func:`sklearn.metrics.fbeta_score`,
+      :func:`sklearn.metrics.recall_score` and
+      :func:`sklearn.metrics.precision_score` when performing multiclass
+      or multilabel (i.e. not binary) classification. By `Joel Nothman`_.
+
+    - `scoring` parameter for cross validation now accepts `'f1_micro'`,
+      `'f1_macro'` or `'f1_weighted'`. `'f1'` is now for binary classification
+      only. Similar changes apply to `'precision'` and `'recall'`.
+      By `Joel Nothman`_.
+
 .. _changes_0_15_2:
 
 0.15.2
@@ -274,7 +285,7 @@ Bug fixes
     running the tests. By `Joel Nothman`_.
 
   - Many documentation and website fixes by `Joel Nothman`_, `Lars Buitinck`_
-    and others.
+    `Matt Pico`_, and others.
 
 .. _changes_0_15_1:
 

--- a/examples/model_selection/grid_search_digits.py
+++ b/examples/model_selection/grid_search_digits.py
@@ -50,7 +50,8 @@ for score in scores:
     print("# Tuning hyper-parameters for %s" % score)
     print()
 
-    clf = GridSearchCV(SVC(C=1), tuned_parameters, cv=5, scoring=score)
+    clf = GridSearchCV(SVC(C=1), tuned_parameters, cv=5,
+                       scoring='%_weighted' % score)
     clf.fit(X_train, y_train)
 
     print("Best parameters set found on development set:")

--- a/examples/text/document_classification_20newsgroups.py
+++ b/examples/text/document_classification_20newsgroups.py
@@ -140,7 +140,7 @@ print()
 # split a training set and a test set
 y_train, y_test = data_train.target, data_test.target
 
-print("Extracting features from the training dataset using a sparse vectorizer")
+print("Extracting features from the training data using a sparse vectorizer")
 t0 = time()
 if opts.use_hashing:
     vectorizer = HashingVectorizer(stop_words='english', non_negative=True,
@@ -155,7 +155,7 @@ print("done in %fs at %0.3fMB/s" % (duration, data_train_size_mb / duration))
 print("n_samples: %d, n_features: %d" % X_train.shape)
 print()
 
-print("Extracting features from the test dataset using the same vectorizer")
+print("Extracting features from the test data using the same vectorizer")
 t0 = time()
 X_test = vectorizer.transform(data_test.data)
 duration = time() - t0
@@ -208,8 +208,8 @@ def benchmark(clf):
     test_time = time() - t0
     print("test time:  %0.3fs" % test_time)
 
-    score = metrics.f1_score(y_test, pred)
-    print("f1-score:   %0.3f" % score)
+    score = metrics.accuracy_score(y_test, pred, average='micro')
+    print("accuracy:   %0.3f" % score)
 
     if hasattr(clf, 'coef_'):
         print("dimensionality: %d" % clf.coef_.shape[1])

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -14,8 +14,8 @@ from sklearn.svm import SVC, SVR
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
 
-from sklearn.metrics.scorer import SCORERS
 from sklearn.metrics import make_scorer
+from sklearn.metrics import get_scorer
 
 
 def test_rfe_set_params():
@@ -97,7 +97,7 @@ def test_rfecv():
     assert_array_equal(X_r, iris.data)
 
     # Test using a scorer
-    scorer = SCORERS['accuracy']
+    scorer = get_scorer('accuracy')
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, cv=5,
                   scoring=scorer)
     rfecv.fit(X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -15,8 +15,8 @@ from sklearn.utils.testing import ignore_warnings
 
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
-from sklearn.metrics.scorer import SCORERS
 from sklearn.metrics import make_scorer
+from sklearn.metrics import get_scorer
 
 from sklearn.linear_model.base import LinearRegression
 from sklearn.linear_model.ridge import ridge_regression
@@ -336,7 +336,7 @@ def _test_ridge_loo(filter_):
     assert_equal(ridge_gcv3.alpha_, alpha_)
 
     # check that we get same best alpha with a scorer
-    scorer = SCORERS['mean_squared_error']
+    scorer = get_scorer('mean_squared_error')
     ridge_gcv4 = RidgeCV(fit_intercept=False, scoring=scorer)
     ridge_gcv4.fit(filter_(X_diabetes), y_diabetes)
     assert_equal(ridge_gcv4.alpha_, alpha_)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -610,14 +610,16 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         y = y[idx]
         clf = self.factory(alpha=0.0001, n_iter=1000,
                            class_weight=None).fit(X, y)
-        assert_almost_equal(metrics.f1_score(y, clf.predict(X)), 0.96,
-                            decimal=1)
+        assert_almost_equal(metrics.f1_score(y, clf.predict(X),
+                                             average='weighted'),
+                            0.96, decimal=1)
 
         # make the same prediction using automated class_weight
         clf_auto = self.factory(alpha=0.0001, n_iter=1000,
                                 class_weight="auto").fit(X, y)
-        assert_almost_equal(metrics.f1_score(y, clf_auto.predict(X)), 0.96,
-                            decimal=1)
+        assert_almost_equal(metrics.f1_score(y, clf_auto.predict(X),
+                                             average='weighted'),
+                            0.96, decimal=1)
 
         # Make sure that in the balanced case it does not change anything
         # to use "auto"
@@ -634,19 +636,19 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         clf = self.factory(n_iter=1000, class_weight=None)
         clf.fit(X_imbalanced, y_imbalanced)
         y_pred = clf.predict(X)
-        assert_less(metrics.f1_score(y, y_pred), 0.96)
+        assert_less(metrics.f1_score(y, y_pred, average='weighted'), 0.96)
 
         # fit a model with auto class_weight enabled
         clf = self.factory(n_iter=1000, class_weight="auto")
         clf.fit(X_imbalanced, y_imbalanced)
         y_pred = clf.predict(X)
-        assert_greater(metrics.f1_score(y, y_pred), 0.96)
+        assert_greater(metrics.f1_score(y, y_pred, average='weighted'), 0.96)
 
         # fit another using a fit parameter override
         clf = self.factory(n_iter=1000, class_weight="auto")
         clf.fit(X_imbalanced, y_imbalanced)
         y_pred = clf.predict(X)
-        assert_greater(metrics.f1_score(y, y_pred), 0.96)
+        assert_greater(metrics.f1_score(y, y_pred, average='weighted'), 0.96)
 
     def test_sample_weights(self):
         """Test weights on individual samples"""

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -53,6 +53,7 @@ from .regression import r2_score
 
 from .scorer import make_scorer
 from .scorer import SCORERS
+from .scorer import get_scorer
 
 # Deprecated in 0.16
 from .ranking import auc_score
@@ -73,6 +74,7 @@ __all__ = [
     'explained_variance_score',
     'f1_score',
     'fbeta_score',
+    'get_scorer',
     'hamming_loss',
     'hinge_loss',
     'homogeneity_completeness_v_measure',

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -475,7 +475,7 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
         return n_samples - score
 
 
-def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
+def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
              sample_weight=None):
     """Compute the F1 score, also known as balanced F-score or F-measure
 
@@ -504,7 +504,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
-    average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
+    average : one of [None, 'micro', 'macro', 'samples', 'weighted']
+        This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise,
         unless ``pos_label`` is given in binary classification, this
         determines the type of averaging performed on the data:
@@ -561,7 +562,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
 
 
 def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
-                average='weighted', sample_weight=None):
+                average='binary', sample_weight=None):
     """Compute the F-beta score
 
     The F-beta score is the weighted harmonic mean of precision and recall,
@@ -590,7 +591,8 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
-    average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
+    average : one of [None, 'micro', 'macro', 'samples', 'weighted']
+        This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise,
         unless ``pos_label`` is given in binary classification, this
         determines the type of averaging performed on the data:
@@ -822,13 +824,24 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     """
     average_options = (None, 'micro', 'macro', 'weighted', 'samples')
-    if average not in average_options:
+    if average not in average_options and average != 'binary':
         raise ValueError('average has to be one of ' +
                          str(average_options))
     if beta <= 0:
         raise ValueError("beta should be >0 in the F-beta score")
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+
+    if average == 'binary' and y_type != 'binary':
+        warnings.warn('The default `weighted` averaging is deprecated, '
+                      'and from version 0.18, use of precision, recall or '
+                      'F-score with multiclass or multilabel data will result '
+                      'in an exception. '
+                      'Please set an explicit value for `average`, one of '
+                      '%s. In cross validation use, for instance, '
+                      'scoring="f1_weighted" instead of scoring="f1".'
+                      % str(average_options), DeprecationWarning, stacklevel=2)
+        average = 'weighted'
 
     label_order = labels  # save this for later
     if labels is None:
@@ -852,7 +865,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     elif average == 'samples':
         raise ValueError("Sample-based precision, recall, fscore is "
-                         "not meaningful outside multilabel"
+                         "not meaningful outside multilabel "
                          "classification. See the accuracy_score instead.")
     else:
         lb = LabelEncoder()
@@ -885,11 +898,12 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ### Select labels to keep ###
 
     if y_type == 'binary' and average is not None and pos_label is not None:
-        if label_order is not None and len(label_order) == 2:
+        if average != 'binary' and label_order is not None \
+           and len(label_order) == 2:
             warnings.warn('In the future, providing two `labels` values, as '
-                          'well as `average` will average over those '
-                          'labels. For now, please use `labels=None` with '
-                          '`pos_label` to evaluate precision, recall and '
+                          'well as `average!=`binary`` will average over '
+                          'those labels. For now, please use `labels=None` '
+                          'with `pos_label` to evaluate precision, recall and '
                           'F-score for the positive label only.',
                           FutureWarning)
         if pos_label not in labels:
@@ -954,7 +968,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
 
 def precision_score(y_true, y_pred, labels=None, pos_label=1,
-                    average='weighted', sample_weight=None):
+                    average='binary', sample_weight=None):
     """Compute the precision
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
@@ -979,7 +993,8 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
-    average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
+    average : one of [None, 'micro', 'macro', 'samples', 'weighted']
+        This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise,
         unless ``pos_label`` is given in binary classification, this
         determines the type of averaging performed on the data:
@@ -1036,7 +1051,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
     return p
 
 
-def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
+def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
                  sample_weight=None):
     """Compute the recall
 
@@ -1061,7 +1076,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
         If ``average`` is not ``None`` and the classification target is binary,
         only this class's scores will be returned.
 
-    average : string, [None, 'micro', 'macro', 'samples', 'weighted' (default)]
+    average : one of [None, 'micro', 'macro', 'samples', 'weighted']
+        This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise,
         unless ``pos_label`` is given in binary classification, this
         determines the type of averaging performed on the data:

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,6 +19,7 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta, abstractmethod
+from functools import partial
 
 import numpy as np
 
@@ -342,8 +343,15 @@ SCORERS = dict(r2=r2_scorer,
                median_absolute_error=median_absolute_error_scorer,
                mean_absolute_error=mean_absolute_error_scorer,
                mean_squared_error=mean_squared_error_scorer,
-               accuracy=accuracy_scorer, f1=f1_scorer, roc_auc=roc_auc_scorer,
+               accuracy=accuracy_scorer, roc_auc=roc_auc_scorer,
                average_precision=average_precision_scorer,
-               precision=precision_scorer, recall=recall_scorer,
                log_loss=log_loss_scorer,
                adjusted_rand_score=adjusted_rand_scorer)
+
+for name, metric in [('precision', precision_score),
+                     ('recall', recall_score), ('f1', f1_score)]:
+    SCORERS[name] = make_scorer(metric)
+    for average in ['macro', 'micro', 'samples', 'weighted']:
+        qualified_name = '{0}_{1}'.format(name, average)
+        SCORERS[qualified_name] = make_scorer(partial(metric, pos_label=None,
+                                                      average=average))

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -991,6 +991,24 @@ def test_fscore_warnings():
                          'being set to 0.0 due to no true samples.')
 
 
+def test_prf_average_compat():
+    """Ensure warning if f1_score et al.'s average is implicit for multiclass
+    """
+    y_true = [1, 2, 3, 3]
+    y_pred = [1, 2, 3, 1]
+
+    for metric in [precision_score, recall_score, f1_score,
+                   partial(fbeta_score, beta=2)]:
+        score = assert_warns(DeprecationWarning, metric, y_true, y_pred)
+        score_weighted = assert_no_warnings(metric, y_true, y_pred,
+                                            average='weighted')
+        assert_equal(score, score_weighted,
+                     'average does not act like "weighted" by default')
+
+        # check binary passes without warning
+        assert_no_warnings(metric, [0, 1, 1], [0, 1, 0])
+
+
 @ignore_warnings  # sequence of sequences is deprecated
 def test__check_targets():
     """Check that _check_targets correctly merges target types, squeezes

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -107,6 +107,7 @@ CLASSIFICATION_METRICS = {
     "zero_one_loss": zero_one_loss,
     "unnormalized_zero_one_loss": partial(zero_one_loss, normalize=False),
 
+    # These are needed to test averaging
     "precision_score": precision_score,
     "recall_score": recall_score,
     "f1_score": f1_score,
@@ -336,6 +337,7 @@ METRICS_WITHOUT_SAMPLE_WEIGHT = [
 ]
 
 
+@ignore_warnings
 def test_symmetry():
     """Test the symmetry of score and loss functions"""
     random_state = check_random_state(0)
@@ -366,6 +368,7 @@ def test_symmetry():
                     msg="%s seems to be symmetric" % name)
 
 
+@ignore_warnings
 def test_sample_order_invariance():
     random_state = check_random_state(0)
     y_true = random_state.randint(0, 2, size=(20, ))
@@ -382,6 +385,7 @@ def test_sample_order_invariance():
                                     % name)
 
 
+@ignore_warnings
 def test_sample_order_invariance_multilabel_and_multioutput():
     random_state = check_random_state(0)
 
@@ -421,6 +425,7 @@ def test_sample_order_invariance_multilabel_and_multioutput():
                                     % name)
 
 
+@ignore_warnings
 def test_format_invariance_with_1d_vectors():
     random_state = check_random_state(0)
     y1 = random_state.randint(0, 2, size=(20, ))
@@ -499,6 +504,7 @@ def test_format_invariance_with_1d_vectors():
             assert_raises(ValueError, metric, y1_row, y2_row)
 
 
+@ignore_warnings
 def test_invariance_string_vs_numbers_labels():
     """Ensure that classification metrics with string labels"""
     random_state = check_random_state(0)
@@ -627,6 +633,7 @@ def test_multioutput_regression_invariance_to_dimension_shuffling():
                                         "invariant" % name)
 
 
+@ignore_warnings
 def test_multilabel_representation_invariance():
     # Generate some data
     n_classes = 4

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -10,10 +10,10 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_not_equal
 
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
-                             log_loss)
+                             log_loss, precision_score, recall_score)
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.metrics.scorer import check_scoring
-from sklearn.metrics import make_scorer, SCORERS
+from sklearn.metrics import make_scorer, get_scorer, SCORERS
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
 from sklearn.dummy import DummyRegressor
@@ -30,10 +30,16 @@ from sklearn.multiclass import OneVsRestClassifier
 
 REGRESSION_SCORERS = ['r2', 'mean_absolute_error', 'mean_squared_error',
                       'median_absolute_error']
-CLF_SCORERS = ['accuracy', 'f1', 'roc_auc', 'average_precision', 'precision',
-               'recall', 'log_loss',
+
+CLF_SCORERS = ['accuracy', 'f1', 'f1_weighted', 'f1_macro', 'f1_micro',
+               'roc_auc', 'average_precision', 'precision',
+               'precision_weighted', 'precision_macro', 'precision_micro',
+               'recall', 'recall_weighted', 'recall_macro', 'recall_micro',
+               'log_loss',
                'adjusted_rand_score'  # not really, but works
                ]
+
+MULTILABEL_ONLY_SCORERS = ['precision_samples', 'recall_samples', 'f1_samples']
 
 
 class EstimatorWithoutFit(object):
@@ -107,18 +113,38 @@ def test_make_scorer():
 
 def test_classification_scores():
     """Test classification scorers."""
-    X, y = make_blobs(random_state=0)
+    X, y = make_blobs(random_state=0, centers=2)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = LinearSVC(random_state=0)
     clf.fit(X_train, y_train)
-    score1 = SCORERS['f1'](clf, X_test, y_test)
-    score2 = f1_score(y_test, clf.predict(X_test))
-    assert_almost_equal(score1, score2)
+
+    for prefix, metric in [('f1', f1_score), ('precision', precision_score),
+                           ('recall', recall_score)]:
+
+        score1 = get_scorer('%s_weighted' % prefix)(clf, X_test, y_test)
+        score2 = metric(y_test, clf.predict(X_test), pos_label=None,
+                        average='weighted')
+        assert_almost_equal(score1, score2)
+
+        score1 = get_scorer('%s_macro' % prefix)(clf, X_test, y_test)
+        score2 = metric(y_test, clf.predict(X_test), pos_label=None,
+                        average='macro')
+        assert_almost_equal(score1, score2)
+
+        score1 = get_scorer('%s_micro' % prefix)(clf, X_test, y_test)
+        score2 = metric(y_test, clf.predict(X_test), pos_label=None,
+                        average='micro')
+        assert_almost_equal(score1, score2)
+
+        score1 = get_scorer('%s' % prefix)(clf, X_test, y_test)
+        score2 = metric(y_test, clf.predict(X_test), pos_label=1)
+        assert_almost_equal(score1, score2)
 
     # test fbeta score that takes an argument
     scorer = make_scorer(fbeta_score, beta=2)
     score1 = scorer(clf, X_test, y_test)
-    score2 = fbeta_score(y_test, clf.predict(X_test), beta=2)
+    score2 = fbeta_score(y_test, clf.predict(X_test), beta=2,
+                         average='weighted')
     assert_almost_equal(score1, score2)
 
     # test that custom scorer can be pickled
@@ -137,7 +163,7 @@ def test_regression_scorers():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = Ridge()
     clf.fit(X_train, y_train)
-    score1 = SCORERS['r2'](clf, X_test, y_test)
+    score1 = get_scorer('r2')(clf, X_test, y_test)
     score2 = r2_score(y_test, clf.predict(X_test))
     assert_almost_equal(score1, score2)
 
@@ -148,20 +174,20 @@ def test_thresholded_scorers():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf = LogisticRegression(random_state=0)
     clf.fit(X_train, y_train)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, clf.decision_function(X_test))
     score3 = roc_auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
     assert_almost_equal(score1, score3)
 
-    logscore = SCORERS['log_loss'](clf, X_test, y_test)
+    logscore = get_scorer('log_loss')(clf, X_test, y_test)
     logloss = log_loss(y_test, clf.predict_proba(X_test))
     assert_almost_equal(-logscore, logloss)
 
     # same for an estimator without decision_function
     clf = DecisionTreeClassifier()
     clf.fit(X_train, y_train)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, clf.predict_proba(X_test)[:, 1])
     assert_almost_equal(score1, score2)
 
@@ -169,7 +195,7 @@ def test_thresholded_scorers():
     X, y = make_blobs(random_state=0, centers=3)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     clf.fit(X_train, y_train)
-    assert_raises(ValueError, SCORERS['roc_auc'], clf, X_test, y_test)
+    assert_raises(ValueError, get_scorer('roc_auc'), clf, X_test, y_test)
 
 
 def test_thresholded_scorers_multilabel_indicator_data():
@@ -185,7 +211,7 @@ def test_thresholded_scorers_multilabel_indicator_data():
     clf = DecisionTreeClassifier()
     clf.fit(X_train, y_train)
     y_proba = clf.predict_proba(X_test)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, np.vstack(p[:, -1] for p in y_proba).T)
     assert_almost_equal(score1, score2)
 
@@ -198,21 +224,21 @@ def test_thresholded_scorers_multilabel_indicator_data():
     clf.decision_function = lambda X: [p[:, 1] for p in clf._predict_proba(X)]
 
     y_proba = clf.decision_function(X_test)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, np.vstack(p for p in y_proba).T)
     assert_almost_equal(score1, score2)
 
     # Multilabel predict_proba
     clf = OneVsRestClassifier(DecisionTreeClassifier())
     clf.fit(X_train, y_train)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, clf.predict_proba(X_test))
     assert_almost_equal(score1, score2)
 
     # Multilabel decision function
     clf = OneVsRestClassifier(LinearSVC(random_state=0))
     clf.fit(X_train, y_train)
-    score1 = SCORERS['roc_auc'](clf, X_test, y_test)
+    score1 = get_scorer('roc_auc')(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, clf.decision_function(X_test))
     assert_almost_equal(score1, score2)
 
@@ -224,7 +250,7 @@ def test_unsupervised_scorers():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
     km = KMeans(n_clusters=3)
     km.fit(X_train)
-    score1 = SCORERS['adjusted_rand_score'](km, X_test, y_test)
+    score1 = get_scorer('adjusted_rand_score')(km, X_test, y_test)
     score2 = adjusted_rand_score(y_test, km.predict(X_test))
     assert_almost_equal(score1, score2)
 
@@ -242,6 +268,7 @@ def test_raises_on_score_list():
     assert_raises(ValueError, grid_search.fit, X, y)
 
 
+@ignore_warnings
 def test_scorer_sample_weight():
     """Test that scorers support sample_weight or raise sensible errors"""
 
@@ -249,7 +276,12 @@ def test_scorer_sample_weight():
     # to ensure that, on the classifier output, weighted and unweighted
     # scores really should be unequal.
     X, y = make_classification(random_state=0)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    _, y_ml = make_multilabel_classification(n_samples=X.shape[0],
+                                             return_indicator=True,
+                                             random_state=0)
+    split = train_test_split(X, y, y_ml, random_state=0)
+    X_train, X_test, y_train, y_test, y_ml_train, y_ml_test = split
+
     sample_weight = np.ones_like(y_test)
     sample_weight[:10] = 0
 
@@ -258,17 +290,25 @@ def test_scorer_sample_weight():
     sensible_regr.fit(X_train, y_train)
     sensible_clf = DecisionTreeClassifier()
     sensible_clf.fit(X_train, y_train)
+    sensible_ml_clf = DecisionTreeClassifier()
+    sensible_ml_clf.fit(X_train, y_ml_train)
     estimator = dict([(name, sensible_regr)
                       for name in REGRESSION_SCORERS] +
                      [(name, sensible_clf)
-                      for name in CLF_SCORERS])
+                      for name in CLF_SCORERS] +
+                     [(name, sensible_ml_clf)
+                      for name in MULTILABEL_ONLY_SCORERS])
 
     for name, scorer in SCORERS.items():
+        if name in MULTILABEL_ONLY_SCORERS:
+            target = y_ml_test
+        else:
+            target = y_test
         try:
-            weighted = scorer(estimator[name], X_test, y_test,
+            weighted = scorer(estimator[name], X_test, target,
                               sample_weight=sample_weight)
-            ignored = scorer(estimator[name], X_test[10:], y_test[10:])
-            unweighted = scorer(estimator[name], X_test, y_test)
+            ignored = scorer(estimator[name], X_test[10:], target[10:])
+            unweighted = scorer(estimator[name], X_test, target)
             assert_not_equal(weighted, unweighted,
                              msg="scorer {0} behaves identically when "
                              "called with sample weights: {1} vs "

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -392,8 +392,9 @@ def test_auto_weight():
         y_pred = clf.fit(X[unbalanced], y[unbalanced]).predict(X)
         clf.set_params(class_weight='auto')
         y_pred_balanced = clf.fit(X[unbalanced], y[unbalanced],).predict(X)
-        assert_true(metrics.f1_score(y, y_pred)
-                    <= metrics.f1_score(y, y_pred_balanced))
+        assert_true(metrics.f1_score(y, y_pred, average='weighted')
+                    <= metrics.f1_score(y, y_pred_balanced,
+                                        average='weighted'))
 
 
 def test_bad_input():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -683,7 +683,7 @@ def test_cross_val_score_with_score_func_classification():
     # F1 score (class are balanced so f1_score should be equal to zero/one
     # score
     f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                     scoring="f1", cv=5)
+                                     scoring="f1_weighted", cv=5)
     assert_array_almost_equal(f1_scores, [0.97, 1., 0.97, 0.97, 1.], 2)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -742,8 +742,8 @@ def check_class_weight_auto_classifiers(name, Classifier, X_train, y_train,
     classifier.set_params(class_weight='auto')
     classifier.fit(X_train, y_train)
     y_pred_auto = classifier.predict(X_test)
-    assert_greater(f1_score(y_test, y_pred_auto),
-                   f1_score(y_test, y_pred))
+    assert_greater(f1_score(y_test, y_pred_auto, average='weighted'),
+                   f1_score(y_test, y_pred, average='weighted'))
 
 
 def check_class_weight_auto_linear_classifier(name, Classifier):


### PR DESCRIPTION
In order to avoid problems like #2094, and to avoid people unwittingly reporting weighted average, this goes towards making 'average' a required parameter for multiclass/multilabel precision, recall, f-score. Closely related to #2676.

After a deprecation cycle, we can turn the warning into an error, or make macro/micro default.

This PR also shards the builtin scorers to make the averaging explicit. This avoids users getting binary behaviour when they shouldn't (cf. #2094 where `scoring` isn't used). I think this is extra important because "weighted" F1 isn't especially common in the literature, and having people report it without realising that's what it is is unhelpful to the applied ML community. This helps, IMO, towards a more explicit and robust API for binary classification metrics (cf. #2610).

It also entails a deprecation procedure for scorers, and more API there: public `get_scorer` and `list_scorers`
