### PR TITLE
Fix OOB score calculation for non-contiguous targets

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -345,7 +345,6 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
 
     def _set_oob_score(self, X, y):
         n_classes_ = self.n_classes_
-        classes_ = self.classes_
         n_samples = y.shape[0]
 
         oob_decision_function = []
@@ -376,8 +375,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
             decision = (predictions[k] /
                         predictions[k].sum(axis=1)[:, np.newaxis])
             oob_decision_function.append(decision)
-            oob_score += np.mean((y[:, k] == classes_[k].take(
-                np.argmax(predictions[k], axis=1), axis=0)))
+            oob_score += np.mean(y[:, k] ==
+                                 np.argmax(predictions[k], axis=1), axis=0)
 
         if self.n_outputs_ == 1:
             self.oob_decision_function_ = oob_decision_function[0]

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -219,6 +219,19 @@ def test_oob_score_classification():
     assert_less(abs(test_score - clf.oob_score_), 0.1)
 
 
+def test_oob_score_classification_for_non_contiguous_target():
+    """Check that oob prediction is a good estimation of the generalization
+    error for non-contiguous targets."""
+    iris_target = iris.target * 2 + 1
+    clf = RandomForestClassifier(n_estimators=50,
+                                 oob_score=True, random_state=rng)
+    n_samples = iris.data.shape[0]
+    clf.fit(iris.data[:n_samples / 2, :], iris_target[:n_samples / 2])
+    test_score = clf.score(iris.data[n_samples / 2:, :],
+                           iris_target[n_samples / 2:])
+    assert_less(abs(test_score - clf.oob_score_), 0.1)
+
+
 def test_oob_score_regression():
     """Check that oob prediction is pessimistic estimate.
     Not really a good test that prediction is independent."""


### PR DESCRIPTION
OOB scores of RandomForestClassifier are incorrectly calculated
because of confusion between predicted labels and indices of a target.
For example, when you label the `digits` dataset from 1 or greater
number but 0, OOB score becomes nearly zero.
This patch will fix this error, and a test is added in order to avoid
regression.
