### PR TITLE
[MRG+1] allow y to be a list in GridSearchCV, cross_val_score and train_test_split

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -12,6 +12,8 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 
 from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
 
+from sklearn.cross_validation import train_test_split
+from sklearn.cross_validation import cross_val_score
 from sklearn.grid_search import GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
@@ -704,15 +706,13 @@ def test_vectorizer_inverse_transform():
 def test_count_vectorizer_pipeline_grid_selection():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
-    # simulate iterables
-    train_data = iter(data[1:-1])
-    test_data = iter([data[0], data[-1]])
 
     # label junk food as -1, the others as +1
-    y = np.ones(len(data))
-    y[:6] = -1
-    y_train = y[1:-1]
-    y_test = np.array([y[0], y[-1]])
+    target = [-1] * len(JUNK_FOOD_DOCS) + [1] * len(NOTJUNK_FOOD_DOCS)
+
+    # split the dataset for model development and final evaluation
+    train_data, test_data, target_train, target_test = train_test_split(
+        data, target, test_size=.2, random_state=0)
 
     pipeline = Pipeline([('vect', CountVectorizer()),
                          ('svc', LinearSVC())])
@@ -726,10 +726,10 @@ def test_count_vectorizer_pipeline_grid_selection():
     # classifier
     grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
 
-    # cross-validation doesn't work if the length of the data is not known,
-    # hence use lists instead of iterators
-    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
-    assert_array_equal(pred, y_test)
+    # Check that the best model found by grid search is 100% correct on the
+    # held out evaluation set.
+    pred = grid_search.fit(train_data, target_train).predict(test_data)
+    assert_array_equal(pred, target_test)
 
     # on this toy dataset bigram representation which is used in the last of
     # the grid_search is considered the best estimator since they all converge
@@ -742,15 +742,13 @@ def test_count_vectorizer_pipeline_grid_selection():
 def test_vectorizer_pipeline_grid_selection():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
-    # simulate iterables
-    train_data = iter(data[1:-1])
-    test_data = iter([data[0], data[-1]])
 
     # label junk food as -1, the others as +1
-    y = np.ones(len(data))
-    y[:6] = -1
-    y_train = y[1:-1]
-    y_test = np.array([y[0], y[-1]])
+    target = [-1] * len(JUNK_FOOD_DOCS) + [1] * len(NOTJUNK_FOOD_DOCS)
+
+    # split the dataset for model development and final evaluation
+    train_data, test_data, target_train, target_test = train_test_split(
+        data, target, test_size=.1, random_state=0)
 
     pipeline = Pipeline([('vect', TfidfVectorizer()),
                          ('svc', LinearSVC())])
@@ -765,10 +763,10 @@ def test_vectorizer_pipeline_grid_selection():
     # classifier
     grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
 
-    # cross-validation doesn't work if the length of the data is not known,
-    # hence use lists instead of iterators
-    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
-    assert_array_equal(pred, y_test)
+    # Check that the best model found by grid search is 100% correct on the
+    # held out evaluation set.
+    pred = grid_search.fit(train_data, target_train).predict(test_data)
+    assert_array_equal(pred, target_test)
 
     # on this toy dataset bigram representation which is used in the last of
     # the grid_search is considered the best estimator since they all converge
@@ -778,6 +776,21 @@ def test_vectorizer_pipeline_grid_selection():
     assert_equal(best_vectorizer.ngram_range, (1, 1))
     assert_equal(best_vectorizer.norm, 'l2')
     assert_false(best_vectorizer.fixed_vocabulary)
+
+
+def test_vectorizer_pipeline_cross_validation():
+    # raw documents
+    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
+
+    # label junk food as -1, the others as +1
+    target = [-1] * len(JUNK_FOOD_DOCS) + [1] * len(NOTJUNK_FOOD_DOCS)
+
+
+    pipeline = Pipeline([('vect', TfidfVectorizer()),
+                         ('svc', LinearSVC())])
+
+    cv_scores = cross_val_score(pipeline, data, target, cv=3)
+    assert_array_equal(cv_scores, [1., 1., 1.])
 
 
 def test_vectorizer_unicode():

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -355,7 +355,6 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                 raise ValueError('Target variable (y) has a different number '
                                  'of samples (%i) than data (X: %i samples)'
                                  % (len(y), n_samples))
-            y = np.asarray(y)
         cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
 
         if self.verbose > 0:

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -534,6 +534,18 @@ def test_cross_val_score():
     assert_raises(ValueError, cval.cross_val_score, clf, X_3d, y)
 
 
+def test_cross_val_score_mask():
+    # test that cross_val_score works with boolean masks
+    svm = SVC(kernel="linear")
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    cv_indices = cval.KFold(len(y), 5, indices=True)
+    scores_indices = cval.cross_val_score(svm, X, y, cv=cv_indices)
+    cv_masks = cval.KFold(len(y), 5, indices=False)
+    scores_masks = cval.cross_val_score(svm, X, y, cv=cv_masks)
+    assert_array_equal(scores_indices, scores_masks)
+
+
 def test_cross_val_score_precomputed():
     # test for svm with precomputed kernel
     svm = SVC(kernel="precomputed")

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -44,16 +44,16 @@ class MockListClassifier(BaseEstimator):
 
     Checks that GridSearchCV didn't convert X or Y to array.
     """
-    def __init__(self, foo_param=0, check_y=False, check_X=True):
+    def __init__(self, foo_param=0, check_y_is_list=False, check_X_is_list=True):
         self.foo_param = foo_param
-        self.check_y = check_y
-        self.check_X = check_X
+        self.check_y_is_list = check_y_is_list
+        self.check_X_is_list = check_X_is_list
 
     def fit(self, X, Y):
         assert_true(len(X) == len(Y))
-        if self.check_X:
+        if self.check_X_is_list:
             assert_true(isinstance(X, list))
-        if self.check_y:
+        if self.check_y_is_list:
             assert_true(isinstance(Y, list))
 
         return self
@@ -519,7 +519,7 @@ def test_cross_val_score():
     clf = MockListClassifier()
     scores = cval.cross_val_score(clf, X.tolist(), y.tolist())
 
-    clf = MockListClassifier(check_X=False, check_y=True)
+    clf = MockListClassifier(check_X_is_list=False, check_y_is_list=True)
     scores = cval.cross_val_score(clf, X, y.tolist())
 
     assert_raises(ValueError, cval.cross_val_score, clf, X, y,

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -81,16 +81,17 @@ class MockListClassifier(object):
 
     Checks that GridSearchCV didn't convert X (or y) to array.
     """
-    def __init__(self, foo_param=0, check_y=False, check_X=True):
+    def __init__(self, foo_param=0, check_y_is_list=False,
+                 check_X_is_list=True):
         self.foo_param = foo_param
-        self.check_y = check_y
-        self.check_X = check_X
+        self.check_y_is_list = check_y_is_list
+        self.check_X_is_list = check_X_is_list
 
     def fit(self, X, Y):
         assert_true(len(X) == len(Y))
-        if self.check_X:
+        if self.check_X_is_list:
             assert_true(isinstance(X, list))
-        if self.check_y:
+        if self.check_y_is_list:
             assert_true(isinstance(Y, list))
 
         return self
@@ -106,15 +107,15 @@ class MockListClassifier(object):
         return score
 
     def get_params(self, deep=False):
-        return {'foo_param': self.foo_param, 'check_X': self.check_X,
-                'check_y': self.check_y}
+        return {'foo_param': self.foo_param, 'check_X_is_list': self.check_X_is_list,
+                'check_y_is_list': self.check_y_is_list}
 
     def set_params(self, **params):
         self.foo_param = params['foo_param']
-        if "check_y" in params:
-            self.check_y = params["check_y"]
-        if "check_X" in params:
-            self.check_X = params["check_X"]
+        if "check_y_is_list" in params:
+            self.check_y = params["check_y_is_list"]
+        if "check_X_is_list" in params:
+            self.check_X = params["check_X_is_list"]
         return self
 
 
@@ -494,7 +495,7 @@ def test_y_as_list():
     X = np.arange(100).reshape(10, 10)
     y = np.array([0] * 5 + [1] * 5)
 
-    clf = MockListClassifier(check_X=False, check_y=True)
+    clf = MockListClassifier(check_X_is_list=False, check_y_is_list=True)
     cv = KFold(n=len(X), n_folds=3)
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, cv=cv)
     grid_search.fit(X, y.tolist()).score(X, y)

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -79,14 +79,20 @@ class MockClassifier(object):
 class MockListClassifier(object):
     """Dummy classifier to test the cross-validation.
 
-    Checks that GridSearchCV didn't convert X to array.
+    Checks that GridSearchCV didn't convert X (or y) to array.
     """
-    def __init__(self, foo_param=0):
+    def __init__(self, foo_param=0, check_y=False, check_X=True):
         self.foo_param = foo_param
+        self.check_y = check_y
+        self.check_X = check_X
 
     def fit(self, X, Y):
         assert_true(len(X) == len(Y))
-        assert_true(isinstance(X, list))
+        if self.check_X:
+            assert_true(isinstance(X, list))
+        if self.check_y:
+            assert_true(isinstance(Y, list))
+
         return self
 
     def predict(self, T):
@@ -100,10 +106,15 @@ class MockListClassifier(object):
         return score
 
     def get_params(self, deep=False):
-        return {'foo_param': self.foo_param}
+        return {'foo_param': self.foo_param, 'check_X': self.check_X,
+                'check_y': self.check_y}
 
     def set_params(self, **params):
         self.foo_param = params['foo_param']
+        if "check_y" in params:
+            self.check_y = params["check_y"]
+        if "check_X" in params:
+            self.check_X = params["check_X"]
         return self
 
 
@@ -475,6 +486,18 @@ def test_X_as_list():
     cv = KFold(n=len(X), n_folds=3)
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, cv=cv)
     grid_search.fit(X.tolist(), y).score(X, y)
+    assert_true(hasattr(grid_search, "grid_scores_"))
+
+
+def test_y_as_list():
+    """Pass y as list in GridSearchCV"""
+    X = np.arange(100).reshape(10, 10)
+    y = np.array([0] * 5 + [1] * 5)
+
+    clf = MockListClassifier(check_X=False, check_y=True)
+    cv = KFold(n=len(X), n_folds=3)
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, cv=cv)
+    grid_search.fit(X, y.tolist()).score(X, y)
     assert_true(hasattr(grid_search, "grid_scores_"))
 
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -18,8 +18,12 @@ from sklearn.utils.sparsetools import minimum_spanning_tree
 
 __all__ = ["murmurhash3_32", "as_float_array", "check_arrays", "safe_asarray",
            "assert_all_finite", "array2d", "atleast2d_or_csc",
-           "atleast2d_or_csr", "warn_if_not_float", "check_random_state",
-           "compute_class_weight", "minimum_spanning_tree", "column_or_1d"]
+           "atleast2d_or_csr",
+           "warn_if_not_float",
+           "check_random_state",
+           "compute_class_weight",
+           "minimum_spanning_tree",
+           "column_or_1d", "safe_indexing"]
 
 
 class deprecated(object):
@@ -127,6 +131,25 @@ def safe_mask(X, mask):
         ind = np.arange(mask.shape[0])
         mask = ind[mask]
     return mask
+
+
+def safe_indexing(X, indices):
+    """Return items or rows from X using indices.
+
+    Allows simple indexing of lists or arrays.
+
+    Parameters
+    ----------
+    X : array-like, sparse-matrix, list.
+        Data from which to sample rows or items.
+
+    indices : array-like, list
+        Indices according to which X will be subsampled.
+    """
+    if hasattr(X, "shape"):
+        return X[indices]
+    else:
+        return [X[idx] for idx in indices]
 
 
 def resample(*arrays, **options):

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -12,6 +12,7 @@ from sklearn.utils import deprecated
 from sklearn.utils import resample
 from sklearn.utils import safe_mask
 from sklearn.utils import column_or_1d
+from sklearn.utils import safe_indexing
 from sklearn.utils.extmath import pinvh
 
 
@@ -141,3 +142,12 @@ def test_column_or_1d():
             assert_array_equal(column_or_1d(y), np.ravel(y))
         else:
             assert_raises(ValueError, column_or_1d, y)
+
+
+def test_safe_indexing():
+    X = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    inds = np.array([1, 2])
+    X_inds = safe_indexing(X, inds)
+    X_arrays = safe_indexing(np.array(X), inds)
+    assert_array_equal(np.array(X_inds), X_arrays)
+    assert_array_equal(np.array(X_inds), np.array(X)[inds])


### PR DESCRIPTION
Fixes #2508.

This makes input validation consistent across the three cross-validating functions and less intrusive.

I am not entirely sure this is the right thing to do, as it has some slight backward-incompatibilities. When `X` or `y` was given as a list to `train_test_split`, it was converted to an array before, but is no longer. In the case of `X` this could be considered a bug-fix (for lists of strings). There is an off-chance that this breaks someone's code, though. `GridSearchCV` now passes `y` though as a list, without converting. I think that is fine and very unlikely to break anyone's code (as I think an estimator should handle exactly the same kind of input GridSearchCV gets).
