### PR TITLE
[MRG] Fix #2697 - Copy parameter in Imputer

### DIFF
--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -10,7 +10,6 @@ from scipy import sparse
 from scipy import stats
 
 from ..base import BaseEstimator, TransformerMixin
-from ..utils import check_arrays
 from ..utils import array2d
 from ..utils import atleast2d_or_csr
 from ..utils import atleast2d_or_csc

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -128,10 +128,12 @@ class Imputer(BaseEstimator, TransformerMixin):
 
     copy : boolean, optional (default=True)
         If True, a copy of X will be created. If False, imputation will
-        be done in-place. Note that if X is sparse and `missing_values=0`, then
-        a new copy is made, even if copy=False. A copy is also always made
-        if `axis=0` and X is encoded as a CSR matrix, or if `axis=1` and X is
-        encoded as a CSC matrix.
+        be done in-place whenever possible. Note that, in the following cases,
+        a new copy will always be made, even if `copy=False`:
+            - If X is not an array of floating values;
+            - If X is sparse and `missing_values=0`;
+            - If `axis=0` and X is encoded as a CSR matrix;
+            - If `axis=1` and X is encoded as a CSC matrix.
 
     Attributes
     ----------
@@ -384,7 +386,7 @@ class Imputer(BaseEstimator, TransformerMixin):
         if sparse.issparse(X) and self.missing_values != 0:
             mask = _get_mask(X.data, self.missing_values)
             indexes = np.repeat(np.arange(len(X.indptr) - 1, dtype=np.int),
-                                X.indptr[1:] - X.indptr[:-1])[mask]
+                                np.diff(X.indptr))[mask]
 
             X.data[mask] = valid_statistics[indexes].astype(X.dtype)
         else:

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -255,36 +255,60 @@ def test_imputation_copy():
     """Test imputation with copy"""
     X_orig = sparse_random_matrix(5, 5, density=0.75, random_state=0)
 
-    # copy=True, dense
+    # copy=True, dense => copy
     X = X_orig.copy().todense()
     imputer = Imputer(missing_values=0, strategy="mean", copy=True)
     Xt = imputer.fit(X).transform(X)
     Xt[0, 0] = -1
     assert_false(np.all(X == Xt))
-    assert_not_equal(X.ctypes.data, Xt.ctypes.data)
 
-    # copy=True, sparse
+    # copy=True, sparse csr => copy
     X = X_orig.copy()
-    imputer = Imputer(missing_values=0, strategy="mean", copy=True)
-    X = X.todense()
+    imputer = Imputer(missing_values=X.data[0], strategy="mean", copy=True)
     Xt = imputer.fit(X).transform(X)
-    Xt[0, 0] = -1
-    assert_false(np.all(X == Xt))
-    assert_not_equal(X.ctypes.data, Xt.ctypes.data)
+    Xt.data[0] = -1
+    assert_false(np.all(X.data == Xt.data))
 
-    # copy=False, dense
+    # copy=False, dense => no copy
     X = X_orig.copy().todense()
     imputer = Imputer(missing_values=0, strategy="mean", copy=False)
     Xt = imputer.fit(X).transform(X)
     Xt[0, 0] = -1
     assert_true(np.all(X == Xt))
-    assert_equal(X.ctypes.data, Xt.ctypes.data)
 
-    # copy=False, sparse
+    # copy=False, sparse csr, axis=1 => no copy
     X = X_orig.copy()
     imputer = Imputer(missing_values=X.data[0], strategy="mean", copy=False, axis=1)
     Xt = imputer.fit(X).transform(X)
-    assert_true(np.all(X == Xt)) # Fail...
+    Xt.data[0] = -1
+    assert_true(np.all(X.data == Xt.data))
+
+    # copy=False, sparse csc, axis=0 => no copy
+    X = X_orig.copy().tocsc()
+    imputer = Imputer(missing_values=X.data[0], strategy="mean", copy=False, axis=0)
+    Xt = imputer.fit(X).transform(X)
+    Xt.data[0] = -1
+    assert_true(np.all(X.data == Xt.data))
+
+    # copy=False, sparse csr, axis=0 => copy
+    X = X_orig.copy()
+    imputer = Imputer(missing_values=X.data[0], strategy="mean", copy=False, axis=0)
+    Xt = imputer.fit(X).transform(X)
+    Xt.data[0] = -1
+    assert_false(np.all(X.data == Xt.data))
+
+    # copy=False, sparse csc, axis=1 => copy
+    X = X_orig.copy().tocsc()
+    imputer = Imputer(missing_values=X.data[0], strategy="mean", copy=False, axis=1)
+    Xt = imputer.fit(X).transform(X)
+    Xt.data[0] = -1
+    assert_false(np.all(X.data == Xt.data))
+
+    # copy=False, sparse csr, axis=1, missing_values=0 => copy
+    X = X_orig.copy()
+    imputer = Imputer(missing_values=0, strategy="mean", copy=False, axis=1)
+    Xt = imputer.fit(X).transform(X)
+    assert_false(sparse.issparse(Xt))
 
     # Note: If X is sparse and if missing_values=0, then a (dense) copy of X is
     # made, even if copy=False.


### PR DESCRIPTION
This PR fixes #2697. It ensures that the same buffers are used when `copy=False` and that data is indeed not dupplicated. The corresponding test has been rewritten to check for all cases. 

Ping @jnothman
