### PR TITLE
Updating copyright year to 2014, and changing 'striving' to 'thriving'

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,7 +14,7 @@ this project as part of his thesis.
 In 2010 Fabian Pedregosa, Gael Varoquaux, Alexandre Gramfort and Vincent
 Michel of INRIA took leadership of the project and made the first public
 release, February the 1st 2010. Since then, several releases have appeared
-following a ~3 month cycle, and a striving international community has
+following a ~3 month cycle, and a thriving international community has
 been leading the development.
 
 People

--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 New BSD License
 
-Copyright (c) 2007–2013 The scikit-learn developers.
+Copyright (c) 2007–2014 The scikit-learn developers.
 All rights reserved.
 
 


### PR DESCRIPTION
Updating copyright year to 2014, and changing 'striving' to 'thriving'.
