### PR TITLE
[RFC] make BaseEstimator.get_params and clone thread-safe by default

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -4,11 +4,11 @@
 
 import copy
 import inspect
-import warnings
 
 import numpy as np
 from scipy import sparse
 from .externals import six
+from .utils.safe_warnings import catch_warnings
 
 
 ###############################################################################
@@ -207,15 +207,11 @@ class BaseEstimator(object):
             # catch deprecated param values.
             # This is set in utils/__init__.py but it gets overwritten
             # when running under python3 somehow.
-            warnings.simplefilter("always", DeprecationWarning)
-            try:
-                with warnings.catch_warnings(record=True) as w:
-                    value = getattr(self, key, None)
-                if len(w) and w[0].category == DeprecationWarning:
-                # if the parameter is deprecated, don't show it
-                    continue
-            finally:
-                warnings.filters.pop(0)
+            with catch_warnings(record_category=DeprecationWarning) as w:
+                value = getattr(self, key, None)
+            if len(w) and w[0].category == DeprecationWarning:
+            # if the parameter is deprecated, don't show it
+                continue
 
             # XXX: should we rather test if instance of estimator?
             if deep and hasattr(value, 'get_params'):

--- a/sklearn/utils/safe_warnings.py
+++ b/sklearn/utils/safe_warnings.py
@@ -1,0 +1,52 @@
+"""Thread-safe implementation for warnings.catch_warnings
+
+The default implementation of warnings.catch_warnings is not thread-safe [1]
+which can cause issues in scikit-learn as we sometime need to customize the
+warnings behavior locally in the library rendering it thread-unsafe.
+
+[1] http://docs.python.org/2/library/warnings.html#available-context-managers
+
+"""
+# Author: Olivier Grisel <olivier.grisel@ensta.org>
+# License: BSD 3 clause
+
+import warnings
+from threading import RLock
+
+
+_lock = RLock()
+
+
+class catch_warnings(warnings.catch_warnings):
+    """Thread-safe wrapper for warnings.catch_warnings
+
+    If record_category is a warning class, all instances of that category
+    raised inside the context manager block are guaranteed to be recorded. The
+    filter configuration is restaured when exiting the block.
+
+    This implementation uses a threading.RLock which guarantees thread-safety
+    but can harm the concurrency performance of multi-threaded applications.
+
+    sklearn code should therefore avoid to use catch_warnings in multi-threaded
+    performance critical code sections.
+
+    """
+
+    def __init__(self, record=False, module=None, record_category=None):
+        if record_category is not None:
+            record = True
+        super(catch_warnings, self).__init__(record=record, module=module)
+        self.record_category = record_category
+
+    def __enter__(self):
+        _lock.acquire()
+        if self.record_category is not None:
+            self._module.simplefilter('always', self.record_category)
+        return super(catch_warnings, self).__enter__()
+
+    def __exit__(self, *exc_info):
+        out = super(catch_warnings, self).__exit__(*exc_info)
+        if self.record_category is not None:
+            self._module.filters.pop(0)
+        _lock.release()
+        return out

--- a/sklearn/utils/tests/test_warnings.py
+++ b/sklearn/utils/tests/test_warnings.py
@@ -1,0 +1,45 @@
+# Author: Olivier Grisel <olivier.grisel@ensta.org>
+# License: BSD 3 clause
+
+import warnings
+from multiprocessing.pool import ThreadPool
+from ..safe_warnings import catch_warnings
+
+
+class MyCustomWarning(Warning):
+    pass
+
+
+class MyOtherCustomWarning(Warning):
+    pass
+
+
+def check_caught_warning(iteration=0):
+    with catch_warnings(record_category=MyCustomWarning) as w:
+        warnings.warn(MyCustomWarning())
+    if len(w) != 1 or w[0].category != MyCustomWarning:
+        raise AssertionError(
+            "A MyCustomWarning should have been caught,"
+            " got %r" % list(w))
+
+
+def check_nested_caught_warnings(iteration=0):
+    with catch_warnings(record_category=MyOtherCustomWarning) as w:
+        check_caught_warning()
+        warnings.warn(MyOtherCustomWarning())
+    if len(w) != 1 or w[0].category != MyOtherCustomWarning:
+        raise AssertionError(
+            "A MyOtherCustomWarning should have been caught,"
+            " got %r" % list(w))
+
+
+def test_thread_safe_caught_warnings():
+    # check the sequential behavior first for easier debugging
+    check_caught_warning()
+    check_nested_caught_warnings()
+
+    # actual check for thread safety
+    p = ThreadPool(16)
+    p.map(check_caught_warning, range(5000))
+    p.map(check_nested_caught_warnings, range(5000))
+    p.close()


### PR DESCRIPTION
Modifying the configuration warnings filters of the Python standard library and using `warnings.catch_warnings` are unfortunately not thread-safe operations.

However our `get_params` implementation needs to record deprecation warning when introspecting estimator parameters to avoid including them in the model description rendering the `sklearn.base.clone` function thread-unsafe.

This problem has caused the recent random Jenkins failures reported in #2721 (since random forests now use threads internally when `n_jobs != 1`). The specific issue reported in #2721 has been fixed by making RF models call `clone` only in the sequential section of the code. However I think that `get_params` should be thread safe by default to avoid very confusing behaviors and other hard to debug crash to our users.

Here is a proposal to make this thread-safe by default by using a `threading.RLock`. I am not sure this is the best solution but I thought it would be more constructive to discuss this issue with a working possible solution.
