### PR TITLE
Add user option to use SVD for orthogonalizing the mixing matrix in FastICA

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -43,13 +43,12 @@ def _gs_decorrelation(w, W, j):
 
 
 def _sym_decorrelation(W):
-    """ Symmetric decorrelation
+    """ Symmetric decorrelation using SVD
     i.e. W <- (W * W.T) ^{-1/2} * W
     """
-    s, u = linalg.eigh(np.dot(W, W.T))
-    # u (resp. s) contains the eigenvectors (resp. square roots of
-    # the eigenvalues) of W * W.T
-    return np.dot(np.dot(u * (1. / np.sqrt(s)), u.T), W)
+    U, _, Vt = linalg.svd(W, full_matrices=False)
+    W = np.dot(U, Vt)
+    return W
 
 
 def _ica_def(X, tol, g, fun_args, max_iter, w_init):


### PR DESCRIPTION
It seems that the current eigendecomposition-based method for orthogonalizing the mixing matrix in `sklearn.decomp.fastica` is less numerically stable and produces a less orthogonal output than using a different SVD-based strategy. In some cases, the original method yields NaNs in the result, resulting in a `ValueError` exception that does not occur with the new SVD-based method. However, there seems to be a trade-off between speed and quality, as the new method is not quite as fast as the original - see the extended discussion in #2735.

I've added another boolean keyword argument to `fastica` and to the `FastICA` class to enable the use of the SVD-based method rather than the original eigendecomposition-based method.
## Quality

![ortho_closeness](https://f.cloud.github.com/assets/2284074/1894446/c927898c-7ae9-11e3-8f5f-790f6c2f9e5a.png)
## Speed

![ortho_bench](https://f.cloud.github.com/assets/2284074/1894443/9c1fc6d4-7ae9-11e3-9a7a-d116f0d8c030.png)
