### PR TITLE
Changed assert_array_equal() in Line 45 and 46 to assert_array_almost_equal...

### DIFF
--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -42,8 +42,8 @@ def test_f_oneway_ints():
 
     # test that is gives the same result as with float
     f, p = f_oneway(X.astype(np.float), y)
-    assert_array_equal(f, fint)
-    assert_array_equal(p, pint)
+    assert_array_almost_equal(f, fint, decimal=5)
+    assert_array_almost_equal(p, pint, decimal=5)
 
 
 def test_f_classif():


### PR DESCRIPTION
Changed assert_array_equal() in Line 45 and 46 to assert_array_almost_equal(,,decimal=5). This has fixed the AssertionError, which occurs during the installation test.

This is related to issue #2741
