### PR TITLE
Small documentation fix: from CMS to VCS

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -2242,7 +2242,7 @@ Major changes in this release include:
 
     - feature_selection module redesign.
 
-    - Migration to GIT as content management system.
+    - Migration to GIT as version control system.
 
     - Removal of obsolete attrselect module.
 


### PR DESCRIPTION
GIT is better defined as a "version control system" rather than a "content management system".
