### PR TITLE
FIX remove confusing BaseEstimator.__str__

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -263,12 +263,6 @@ class BaseEstimator(object):
         return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),
                                                offset=len(class_name),),)
 
-    def __str__(self):
-        class_name = self.__class__.__name__
-        return '%s(%s)' % (class_name,
-                           _pprint(self.get_params(deep=True),
-                                   offset=len(class_name), printer=str,),)
-
 
 ###############################################################################
 class ClassifierMixin(object):


### PR DESCRIPTION
I propose that `str(some_estimator)` and `repr(some_estimator)` should produce the same string.

Examples of their difference:

``` python
>>> from sklearn.cluster import SpectralClustering
>>> from sklearn.pipeline import make_pipeline
>>> make_pipeline(SpectralClustering())
Pipeline(steps=[('spectralclustering', SpectralClustering(affinity='rbf', assign_labels='kmeans', coef0=1, degree=3,
          eigen_solver=None, eigen_tol=0.0, gamma=1.0, kernel_params=None,
          n_clusters=8, n_init=10, n_neighbors=10, random_state=None))])
>>> print(make_pipeline(SpectralClustering()))
Pipeline(spectralclustering=SpectralClustering(affinity=rbf, assign_labels=kmeans, coef0=1, degree=3,
          eigen_solver=None, eigen_tol=0.0, gamma=1.0, kernel_params=None,
          n_clusters=8, n_init=10, n_neighbors=10, random_state=None),
     spectralclustering__affinity=rbf,
     spectralclustering__assign_labels=kmeans, spectralclustering__coef0=1,
     spectralclustering__degree=3, spectralclustering__eigen_solver=None,
     spectralclustering__eigen_tol=0.0, spectralclustering__gamma=1.0,
     spectralclustering__kernel_params=None,
     spectralclustering__n_clusters=8, spectralclustering__n_init=10,
     spectralclustering__n_neighbors=10,
     spectralclustering__random_state=None)
```

Note that `str` (i.e. `print`):
- includes "deep" parameter settings, which is redundant where the name of the sub-estimator is clear and it also inherits from `BaseEstimator`; however, these are not valid constructor parameters
- removes quotes from around string-valued parameters (e.g. `affinity=rbf`), making it almost-but-not-quite valid construction code.
- If a parameter is a numpy array, there are more substantial differences due to the differences in numpy's (and scipy.sparse's) `__str__` and `__repr__` implementations.

I think that at a minimum, we should use `repr` for string parameters, but I'm not altogether convinced that there should be a difference between `str` and `repr` at all for estimators. 
