### PR TITLE
[MRG] FIX #1565: fix race condition in parallel pre-dispatch by upgrading joblib

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -139,6 +139,10 @@ Changelog
      :class:`ElasticNetCV <linear_model.ElasticNetCV>`.
      By Brian Wignall and `Alexandre Gramfort`_.
 
+   - Fixed a race condition in parallel processing with
+     ``pre_dispatch != "all"`` (for instance in ``cross_val_score``).
+     By `Olivier Grisel`_.
+
 
 
 API changes summary

--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -102,7 +102,7 @@ Main features
 
 """
 
-__version__ = '0.8.0a2'
+__version__ = '0.8.0a3'
 
 
 from .memory import Memory

--- a/sklearn/externals/joblib/memory.py
+++ b/sklearn/externals/joblib/memory.py
@@ -333,7 +333,7 @@ class MemorizedFunc(Logger):
             print(self.format_call(*args, **kwargs))
         output = self.func(*args, **kwargs)
         self._persist_output(output, output_dir)
-        self._persist_input(output_dir, *args, **kwargs)
+        self._persist_input(output_dir, args, kwargs)
         duration = time.time() - start_time
         if self._verbose:
             _, name = get_func_name(self.func)
@@ -394,7 +394,7 @@ class MemorizedFunc(Logger):
         except OSError:
             " Race condition in the creation of the directory "
 
-    def _persist_input(self, output_dir, *args, **kwargs):
+    def _persist_input(self, output_dir, args, kwargs):
         """ Save a small summary of the call using json format in the
             output directory.
         """

--- a/sklearn/externals/joblib/pool.py
+++ b/sklearn/externals/joblib/pool.py
@@ -414,7 +414,7 @@ class MemmapingPool(PicklingPool):
     suprocesses will have access to the same shared memory in the
     original mode except for the 'w+' mode that is automatically
     transformed as 'r+' to avoid zeroing the original data upon
-    instanciation.
+    instantiation.
 
     Furthermore large arrays from the parent process are automatically
     dumped to a temporary folder on the filesystem such as child

--- a/sklearn/externals/joblib/test/test_memory.py
+++ b/sklearn/externals/joblib/test/test_memory.py
@@ -497,3 +497,16 @@ def test_format_signature():
 def test_format_signature_numpy():
     """ Test the format signature formatting with numpy.
     """
+
+
+def test_persist_with_output_dir_keyword_arg():
+    """Test that "output_dir" keyword argument can be persisted (issue #72)"""
+
+    def f(output_dir="thing"):
+        return output_dir
+
+    mem = Memory(cachedir=env['dir'])
+    first_result = mem.cache(f)(output_dir="other/thing")
+    cached_result = mem.cache(f)(output_dir="other/thing")
+    nose.tools.assert_equal(first_result, "other/thing")
+    nose.tools.assert_equal(cached_result, "other/thing")

--- a/sklearn/externals/joblib/test/test_parallel.py
+++ b/sklearn/externals/joblib/test/test_parallel.py
@@ -320,3 +320,13 @@ def test_joblib_exception():
 def test_safe_function():
     safe_division = SafeFunction(division)
     nose.tools.assert_raises(JoblibException, safe_division, 1, 0)
+
+
+def test_pre_dispatch_race_condition():
+    # Check that using pre-dispatch does not yield a race condition on the
+    # iterable generator that is not thread-safe natively.
+    # this is a non-regression test for the "Pool seems closed" class of error
+    for n_tasks in [2, 10, 20]:
+        for n_jobs in [2, 4, 8, 16]:
+            Parallel(n_jobs=n_jobs, pre_dispatch="2 * n_jobs")(
+                delayed(square)(i) for i in range(n_tasks))


### PR DESCRIPTION
I fixed a race condition upstream in joblib . This should fix potential crash of `cross_val_score` and `GridSearchCV` with the "[Parallel] pool seems closed" and `ValueError: generator already executing` error messages as reported in #1565.

If no one objects, I will merge this fix as soon as travis is green.
