### PR TITLE
[MRG] Check error message with regex

### DIFF
--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 
@@ -58,7 +58,9 @@ class EstimatorWithFitAndPredict(object):
 def test_check_scoring():
     """Test all branches of check_scoring"""
     estimator = EstimatorWithoutFit()
-    assert_raise_message(TypeError, "'fit' method", check_scoring, estimator)
+    assert_raises_regexp(TypeError,
+        r"estimator should a be an estimator implementing 'fit' method, .* "
+        "was passed", check_scoring, estimator)
 
     estimator = EstimatorWithFitAndScore()
     estimator.fit([[1]], [1])
@@ -67,14 +69,17 @@ def test_check_scoring():
 
     estimator = EstimatorWithFitAndPredict()
     estimator.fit([[1]], [1])
-    assert_raise_message(TypeError, "no scoring", check_scoring, estimator)
+    assert_raises_regexp(TypeError,
+        r"If no scoring is specified, the estimator passed should have a "
+        "'score' method\. The estimator .* does not.", check_scoring, estimator)
 
     scorer = check_scoring(estimator, "accuracy")
     assert_almost_equal(scorer(estimator, [[1]], [1]), 1.0)
 
     estimator = EstimatorWithFit()
-    assert_raise_message(TypeError, "'score' or a 'predict'", check_scoring,
-                         estimator, "accuracy")
+    assert_raises_regexp(TypeError,
+        r"The estimator passed should have a 'score' or a 'predict' method. "
+        "The estimator .* does not.", check_scoring, estimator, "accuracy")
 
     estimator = EstimatorWithFit()
     scorer = check_scoring(estimator, allow_none=True)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -34,6 +34,7 @@ from nose.tools import assert_not_equal
 from nose.tools import assert_true
 from nose.tools import assert_false
 from nose.tools import assert_raises
+from nose.tools import assert_raises_regexp
 from nose.tools import raises
 from nose import SkipTest
 from nose import with_setup
@@ -47,10 +48,10 @@ import numpy as np
 from sklearn.base import (ClassifierMixin, RegressorMixin, TransformerMixin,
                           ClusterMixin)
 
-__all__ = ["assert_equal", "assert_not_equal", "assert_raises", "raises",
-           "with_setup", "assert_true", "assert_false", "assert_almost_equal",
-           "assert_array_equal", "assert_array_almost_equal",
-           "assert_array_less"]
+__all__ = ["assert_equal", "assert_not_equal", "assert_raises",
+           "assert_raises_regexp", "raises", "with_setup", "assert_true",
+           "assert_false", "assert_almost_equal", "assert_array_equal",
+           "assert_array_almost_equal", "assert_array_less"]
 
 
 try:


### PR DESCRIPTION
Use `nose.tools.assert_raises_regexp` as suggested by @ogrisel [here](https://github.com/scikit-learn/scikit-learn/pull/2736/files#r8889008).

On the one hand we should not check for the exact error message, on the other hand checking for small substrings might not be accurate enough. Checking for patterns seems to be a good compromise.
