### PR TITLE
Update the install documentation to add a paragraph about installing a binary release in Fedora

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -251,6 +251,20 @@ scikit-learn is available via `pkgsrc-wip <http://pkgsrc-wip.sourceforge.net/>`_
 
     http://pkgsrc.se/wip/py-scikit_learn
 
+Fedora
+------
+
+The Fedora package is called `python-scikit-learn` for the Python 2 version
+and `python3-scikit-learn` for the Python 3 version. Both versions can
+be installed using `yum`::
+
+    $ sudo yum install python-scikit-learn
+
+or::
+
+    $ sudo yum install python3-scikit-learn
+
+
 .. _install_bleeding_edge:
 
 Bleeding Edge


### PR DESCRIPTION
Fedora 20 ships binary packages of scikit-learn for python 2.7 and python 3.3 
This added paragraph explains how to install them
