### PR TITLE
[MRG] ENH remove unnecessary CSR->CSC transform in text feature extractors

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -25,6 +25,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
+from ..utils.fixes import bincount
 from ..externals.six.moves import xrange
 from ..preprocessing import normalize
 from .hashing import FeatureHasher
@@ -455,8 +456,11 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
 
 
 def _document_frequency(X):
-    """Count the number of non-zero values for each feature in csc_matrix X."""
-    return np.diff(X.indptr)
+    """Count the number of non-zero values for each feature in sparse X."""
+    if sp.isspmatrix_csr(X):
+        return bincount(X.indices, minlength=X.shape[1])
+    else:
+        return np.diff(sp.csc_matrix(X, copy=False).indptr)
 
 
 class CountVectorizer(BaseEstimator, VectorizerMixin):
@@ -663,7 +667,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.binary = binary
         self.dtype = dtype
 
-    def _sort_features(self, cscmatrix, vocabulary):
+    def _sort_features(self, X, vocabulary):
         """Sort features by name
 
         Returns a reordered matrix and modifies the vocabulary in place
@@ -673,9 +677,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         for new_val, (term, old_val) in enumerate(sorted_features):
             map_index[new_val] = old_val
             vocabulary[term] = new_val
-        return cscmatrix[:, map_index]
+        return X[:, map_index]
 
-    def _limit_features(self, cscmatrix, vocabulary, high=None, low=None,
+    def _limit_features(self, X, vocabulary, high=None, low=None,
                         limit=None):
         """Remove too rare or too common features.
 
@@ -686,11 +690,11 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         This does not prune samples with zero features.
         """
         if high is None and low is None and limit is None:
-            return cscmatrix, set()
+            return X, set()
 
         # Calculate a mask based on document frequencies
-        dfs = _document_frequency(cscmatrix)
-        tfs = np.asarray(cscmatrix.sum(axis=0)).ravel()
+        dfs = _document_frequency(X)
+        tfs = np.asarray(X.sum(axis=0)).ravel()
         mask = np.ones(len(dfs), dtype=bool)
         if high is not None:
             mask &= dfs <= high
@@ -714,7 +718,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         if len(kept_indices) == 0:
             raise ValueError("After pruning, no terms remain. Try a lower"
                              " min_df or a higher max_df.")
-        return cscmatrix[:, kept_indices], removed_terms
+        return X[:, kept_indices], removed_terms
 
     def _count_vocab(self, raw_documents, fixed_vocab):
         """Create sparse feature matrix, and vocabulary where fixed_vocab=False
@@ -797,7 +801,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         max_features = self.max_features
 
         vocabulary, X = self._count_vocab(raw_documents, self.fixed_vocabulary)
-        X = X.tocsc()
 
         if self.binary:
             X.data.fill(1)
@@ -950,7 +953,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         X : sparse matrix, [n_samples, n_features]
             a matrix of term/token counts
         """
-        if not sp.isspmatrix_csc(X):
+        if not sp.issparse(X):
             X = sp.csc_matrix(X)
         if self.use_idf:
             n_samples, n_features = X.shape


### PR DESCRIPTION
A small change to avoid a copy/transformation of sparse matrices in text feature extraction.
