### PR TITLE
[MRG] ENH fast make_multilabel classification with sparse output support

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -7,8 +7,10 @@ Generate samples of synthetic data sets.
 # License: BSD 3 clause
 
 import numbers
+import array
 import numpy as np
 from scipy import linalg
+import scipy.sparse as sp
 
 from ..preprocessing import LabelBinarizer
 from ..utils import array2d, check_random_state
@@ -238,7 +240,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
 def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
                                    n_labels=2, length=50, allow_unlabeled=True,
-                                   return_indicator=False, random_state=None):
+                                   sparse=False, return_indicator=False,
+                                   random_state=None):
     """Generate a random multilabel classification problem.
 
     For each sample, the generative process is:
@@ -272,6 +275,9 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     allow_unlabeled : bool, optional (default=True)
         If ``True``, some instances might not belong to any class.
 
+    sparse : bool, optional (default=False)
+        If ``True``, return a sparse matrix
+
     return_indicator : bool, optional (default=False),
         If ``True``, return ``Y`` in the binary indicator format, else
         return a tuple of lists of labels.
@@ -284,7 +290,7 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
 
     Returns
     -------
-    X : array of shape [n_samples, n_features]
+    X : array or sparse matrix of shape [n_samples, n_features]
         The generated samples.
 
     Y : tuple of lists or array of shape [n_samples, n_classes]
@@ -294,8 +300,10 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     generator = check_random_state(random_state)
     p_c = generator.rand(n_classes)
     p_c /= p_c.sum()
+    cumulative_p_c = np.cumsum(p_c)
     p_w_c = generator.rand(n_features, n_classes)
     p_w_c /= np.sum(p_w_c, axis=0)
+    cumulative_p_w_c = np.cumsum(p_w_c, axis=0)
 
     def sample_example():
         _, n_classes = p_w_c.shape
@@ -309,7 +317,7 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         y = []
         while len(y) != n:
             # pick a class with probability P(c)
-            c = generator.multinomial(1, p_c).argmax()
+            c = np.searchsorted(cumulative_p_c, generator.rand())
 
             if not c in y:
                 y.append(c)
@@ -320,26 +328,39 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
             k = generator.poisson(length)
 
         # generate a document of length k words
-        x = np.zeros(n_features, dtype=int)
+        if len(y) == 0:
+            # if sample does not belong to any class, generate noise word
+            words = generator.randint(n_features, size=k)
+            return words, y
+
+        words = array.array('i')
         for i in range(k):
-            if len(y) == 0:
-                # if sample does not belong to any class, generate noise word
-                w = generator.randint(n_features)
-            else:
-                # pick a class and generate an appropriate word
-                c = y[generator.randint(len(y))]
-                w = generator.multinomial(1, p_w_c[:, c]).argmax()
-            x[w] += 1
+            # pick a class and generate an appropriate word
+            c = y[generator.randint(len(y))]
+            words.append(np.searchsorted(cumulative_p_w_c[:, c],
+                                         generator.rand()))
+        return words, y
 
-        return x, y
-
-    X, Y = zip(*[sample_example() for i in range(n_samples)])
+    X_indices = array.array('i')
+    X_indptr = array.array('i', [0])
+    Y = []
+    for i in range(n_samples):
+        words, y = sample_example()
+        X_indices.extend(words)
+        X_indptr.append(len(X_indices))
+        Y.append(y)
+    X_data = np.ones(len(X_indices), dtype=np.float64)
+    X = sp.csr_matrix((X_data, X_indices, X_indptr),
+                      shape=(n_samples, n_features))
+    X.sum_duplicates()
+    if not sparse:
+        X = X.toarray()
 
     if return_indicator:
         lb = LabelBinarizer()
         Y = lb.fit([range(n_classes)]).transform(Y)
 
-    return np.array(X, dtype=np.float64), Y
+    return X, Y
 
 
 def make_hastie_10_2(n_samples=12000, random_state=None):

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -321,8 +321,11 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
 
     # pick a (nonzero) number of labels per document by rejection sampling
     sample_n_labels = generator.poisson(n_labels, size=n_samples)
-    while 0 in sample_n_labels or np.max(sample_n_labels) > n_classes:
-        mask = np.logical_or(sample_n_labels == 0, sample_n_labels > n_classes)
+    while ((not allow_unlabeled and 0 in sample_n_labels) or
+           np.max(sample_n_labels) > n_classes):
+        mask = sample_n_labels > n_classes
+        if not allow_unlabeled:
+            mask = np.logical_or(mask, sample_n_labels == 0, out=mask)
         sample_n_labels[mask] = generator.poisson(n_labels, size=mask.sum())
 
     # pick a non-zero length per document by rejection sampling

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -341,17 +341,16 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         if len(y) == 0:
             # if sample does not belong to any class, generate noise words
             words = generator.randint(n_features, size=sample_length[i])
-            return words, y
-
-        # sample words without replacement from selected classes
-        p_w_sample = p_w_c[:, y].sum(axis=1)
-        p_w_sample /= p_w_sample.sum()
-        words = np.searchsorted(np.cumsum(p_w_sample),
-                                generator.rand(sample_length[i]))
+        else:
+            # sample words without replacement from selected classes
+            p_w_sample = p_w_c[:, y].sum(axis=1)
+            p_w_sample /= p_w_sample.sum()
+            words = np.searchsorted(np.cumsum(p_w_sample),
+                                    generator.rand(sample_length[i]))
 
         X_indices.extend(words)
         X_indptr.append(len(X_indices))
-        Y.append(y)
+        Y.append(list(y))
     X_data = np.ones(len(X_indices), dtype=np.float64)
     X = sp.csr_matrix((X_data, X_indices, X_indptr),
                       shape=(n_samples, n_features))
@@ -362,6 +361,8 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     if return_indicator:
         lb = LabelBinarizer()
         Y = lb.fit([range(n_classes)]).transform(Y)
+    else:
+        Y = tuple(Y)
 
     return X, Y
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -143,6 +143,17 @@ def test_make_multilabel_classification():
         assert_true(max([len(y) for y in Y]) <= 3)
 
 
+def test_make_multilabel_classification_sparse():
+    X1, Y1 = make_multilabel_classification(n_samples=100, n_features=20,
+                                            n_classes=3, random_state=0,
+                                            sparse=False)
+    X2, Y2 = make_multilabel_classification(n_samples=100, n_features=20,
+                                            n_classes=3, random_state=0,
+                                            sparse=True)
+    assert_array_equal(Y1, Y2)
+    assert_array_equal(X1, X2.toarray())
+
+
 def test_make_multilabel_classification_return_indicator():
     for allow_unlabeled, min_length in zip((True, False), (0, 1)):
         X, Y = make_multilabel_classification(n_samples=25, n_features=20,

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1053,12 +1053,12 @@ def test_multilabel_classification_report():
     expected_report = """\
              precision    recall  f1-score   support
 
-          0       0.69      0.67      0.68        30
-          1       0.44      0.65      0.53        23
-          2       0.75      0.12      0.21        24
-          3       0.38      0.59      0.47        17
+          0       0.30      0.50      0.37        16
+          1       0.46      0.62      0.53        21
+          2       0.60      0.11      0.19        27
+          3       0.40      0.42      0.41        19
 
-avg / total       0.59      0.51      0.48        94
+avg / total       0.46      0.39      0.36        83
 """
 
     lb = LabelBinarizer()
@@ -1503,8 +1503,8 @@ def test_invariance_string_vs_numbers_labels():
             measure_with_number = metric(y1, y2)
             measure_with_str = metric(y1_str, y2)
             assert_array_equal(measure_with_number, measure_with_str,
-                               err_msg="{0} failed string vs number invariance "
-                                       "test".format(name))
+                               err_msg="{0} failed string vs number "
+                                       "invariance test".format(name))
 
             measure_with_strobj = metric(y1_str.astype('O'), y2)
             assert_array_equal(measure_with_number, measure_with_strobj,
@@ -2472,7 +2472,7 @@ def test_averaging_multilabel():
     n_classes = 5
     n_samples = 40
     _, y = make_multilabel_classification(n_features=1, n_classes=n_classes,
-                                          random_state=0, n_samples=n_samples,
+                                          random_state=3, n_samples=n_samples,
                                           return_indicator=True,
                                           allow_unlabeled=False)
     y_true = y[:20]

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1053,12 +1053,12 @@ def test_multilabel_classification_report():
     expected_report = """\
              precision    recall  f1-score   support
 
-          0       0.39      0.73      0.51        15
-          1       0.57      0.75      0.65        28
-          2       0.33      0.11      0.17        18
-          3       0.44      0.50      0.47        24
+          0       0.69      0.67      0.68        30
+          1       0.44      0.65      0.53        23
+          2       0.75      0.12      0.21        24
+          3       0.38      0.59      0.47        17
 
-avg / total       0.45      0.54      0.47        85
+avg / total       0.59      0.51      0.48        94
 """
 
     lb = LabelBinarizer()
@@ -2472,7 +2472,7 @@ def test_averaging_multilabel():
     n_classes = 5
     n_samples = 40
     _, y = make_multilabel_classification(n_features=1, n_classes=n_classes,
-                                          random_state=5, n_samples=n_samples,
+                                          random_state=0, n_samples=n_samples,
                                           return_indicator=True,
                                           allow_unlabeled=False)
     y_true = y[:20]

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -107,7 +107,7 @@ def test_ovr_fit_predict_svc():
 
 def test_ovr_multilabel_dataset():
     base_clf = MultinomialNB(alpha=1)
-    for au, prec, recall in zip((True, False), (0.65, 0.78), (0.71, 0.76)):
+    for au, prec, recall in zip((True, False), (0.76, 0.77), (0.61, 0.79)):
         X, Y = datasets.make_multilabel_classification(n_samples=100,
                                                        n_features=20,
                                                        n_classes=5,

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -107,7 +107,7 @@ def test_ovr_fit_predict_svc():
 
 def test_ovr_multilabel_dataset():
     base_clf = MultinomialNB(alpha=1)
-    for au, prec, recall in zip((True, False), (0.65, 0.74), (0.72, 0.84)):
+    for au, prec, recall in zip((True, False), (0.65, 0.78), (0.71, 0.76)):
         X, Y = datasets.make_multilabel_classification(n_samples=100,
                                                        n_features=20,
                                                        n_classes=5,


### PR DESCRIPTION
I wanted sparse output from `make_multilabel_classification`, but in setting `n_features` high, I discovered quite how inefficient `generator.multinomial(1, ...).argmax()` is.
