### PR TITLE
python 3 compatibility fix

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -48,7 +48,7 @@ def l1_cross_distances(X):
     """
     X = array2d(X)
     n_samples, n_features = X.shape
-    n_nonzero_cross_dist = n_samples * (n_samples - 1) / 2
+    n_nonzero_cross_dist = n_samples * (n_samples - 1) // 2
     ij = np.zeros((n_nonzero_cross_dist, 2), dtype=np.int)
     D = np.zeros((n_nonzero_cross_dist, n_features))
     ll_1 = 0


### PR DESCRIPTION
This fixes a warning in python 3: 
gaussian_process.py:53: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
