### PR TITLE
[MRG] DOC add link to module reference from class/function pages

### DIFF
--- a/doc/templates/class.rst
+++ b/doc/templates/class.rst
@@ -1,4 +1,4 @@
-{{ fullname }}
+:mod:`{{module}}`.{{objname}}
 {{ underline }}
 
 .. currentmodule:: {{ module }}

--- a/doc/templates/class_with_call.rst
+++ b/doc/templates/class_with_call.rst
@@ -1,4 +1,4 @@
-{{ fullname }}
+:mod:`{{module}}`.{{objname}}
 {{ underline }}
 
 .. currentmodule:: {{ module }}

--- a/doc/templates/function.rst
+++ b/doc/templates/function.rst
@@ -1,4 +1,4 @@
-{{ fullname }}
+:mod:`{{module}}`.{{objname}}
 {{ underline }}
 
 .. currentmodule:: {{ module }}


### PR DESCRIPTION
Another fix for a documentation peeve. This links the module in the title of autogenerated pages to the relevant section of reference. The "Up" link on the left takes you back to the top of the reference page, rather than the module's section, and I don't know of a nice way to fix that. So this helps instead.

Ping @jaquesgrobler
