### PR TITLE
Fix deprecation warning in Python 3

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -550,8 +550,8 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     X = np.vstack((np.append(outer_circ_x, inner_circ_x),
                    np.append(outer_circ_y, inner_circ_y))).T
-    y = np.hstack([np.zeros(n_samples / 2, dtype=np.intp),
-                   np.ones(n_samples / 2, dtype=np.intp)])
+    y = np.hstack([np.zeros(n_samples // 2, dtype=np.intp),
+                   np.ones(n_samples // 2, dtype=np.intp)])
     if shuffle:
         X, y = util_shuffle(X, y, random_state=generator)
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -213,9 +213,9 @@ def test_oob_score_classification():
     error."""
     clf = RandomForestClassifier(oob_score=True, random_state=rng)
     n_samples = iris.data.shape[0]
-    clf.fit(iris.data[:n_samples / 2, :], iris.target[:n_samples / 2])
-    test_score = clf.score(iris.data[n_samples / 2:, :],
-                           iris.target[n_samples / 2:])
+    clf.fit(iris.data[:n_samples // 2, :], iris.target[:n_samples // 2])
+    test_score = clf.score(iris.data[n_samples // 2:, :],
+                           iris.target[n_samples // 2:])
     assert_less(abs(test_score - clf.oob_score_), 0.1)
 
 
@@ -226,9 +226,9 @@ def test_oob_score_classification_for_non_contiguous_target():
     clf = RandomForestClassifier(n_estimators=50,
                                  oob_score=True, random_state=rng)
     n_samples = iris.data.shape[0]
-    clf.fit(iris.data[:n_samples / 2, :], iris_target[:n_samples / 2])
-    test_score = clf.score(iris.data[n_samples / 2:, :],
-                           iris_target[n_samples / 2:])
+    clf.fit(iris.data[:n_samples // 2, :], iris_target[:n_samples // 2])
+    test_score = clf.score(iris.data[n_samples // 2:, :],
+                           iris_target[n_samples // 2:])
     assert_less(abs(test_score - clf.oob_score_), 0.1)
 
 
@@ -238,9 +238,9 @@ def test_oob_score_regression():
     clf = RandomForestRegressor(n_estimators=50, oob_score=True,
                                 random_state=rng)
     n_samples = boston.data.shape[0]
-    clf.fit(boston.data[:n_samples / 2, :], boston.target[:n_samples / 2])
-    test_score = clf.score(boston.data[n_samples / 2:, :],
-                           boston.target[n_samples / 2:])
+    clf.fit(boston.data[:n_samples // 2, :], boston.target[:n_samples // 2])
+    test_score = clf.score(boston.data[n_samples // 2:, :],
+                           boston.target[n_samples // 2:])
     assert_greater(test_score, clf.oob_score_)
     assert_greater(clf.oob_score_, .8)
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -325,7 +325,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         z_pos = arrayfuncs.min_pos(z)
         if z_pos < gamma_:
             # some coefficients have changed sign
-            idx = np.where(z == z_pos)[0]
+            idx = np.where(z == z_pos)[0][::-1]
 
             # update the sign, important for LAR
             sign_active[idx] = -sign_active[idx]
@@ -365,14 +365,16 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
             n_active -= 1
             m, n = idx, n_active
-            drop_idx = active.pop(idx[0])
+            # handle the case when idx is not length of 1
+            drop_idx = [active.pop(ii) for ii in idx]
 
             if Gram is None:
                 # propagate dropped variable
-                for i in range(idx[0], n_active):
-                    X.T[i], X.T[i + 1] = swap(X.T[i], X.T[i + 1])
-                    # yeah this is stupid
-                    indices[i], indices[i + 1] = indices[i + 1], indices[i]
+                for ii in idx:
+                    for i in range(ii, n_active):
+                        X.T[i], X.T[i + 1] = swap(X.T[i], X.T[i + 1])
+                        # yeah this is stupid
+                        indices[i], indices[i + 1] = indices[i + 1], indices[i]
 
                 # TODO: this could be updated
                 residual = y - np.dot(X[:, :n_active], coef[active])
@@ -380,11 +382,12 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
                 Cov = np.r_[temp, Cov]
             else:
-                for i in range(idx[0], n_active):
-                    indices[i], indices[i + 1] = indices[i + 1], indices[i]
-                    Gram[i], Gram[i + 1] = swap(Gram[i], Gram[i + 1])
-                    Gram[:, i], Gram[:, i + 1] = swap(Gram[:, i],
-                                                      Gram[:, i + 1])
+                for ii in idx:
+                    for i in range(ii, n_active):
+                        indices[i], indices[i + 1] = indices[i + 1], indices[i]
+                        Gram[i], Gram[i + 1] = swap(Gram[i], Gram[i+1])
+                        Gram[:, i], Gram[:, i + 1] = swap(Gram[:, i],
+                                                          Gram[:, i + 1])
 
                 # Cov_n = Cov_j + x_j * X + increment(betas) TODO:
                 # will this still work with multiple drops ?

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -365,11 +365,11 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
             n_active -= 1
             m, n = idx, n_active
-            drop_idx = active.pop(idx)
+            drop_idx = active.pop(idx[0])
 
             if Gram is None:
                 # propagate dropped variable
-                for i in range(idx, n_active):
+                for i in range(idx[0], n_active):
                     X.T[i], X.T[i + 1] = swap(X.T[i], X.T[i + 1])
                     # yeah this is stupid
                     indices[i], indices[i + 1] = indices[i + 1], indices[i]
@@ -380,7 +380,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
                 Cov = np.r_[temp, Cov]
             else:
-                for i in range(idx, n_active):
+                for i in range(idx[0], n_active):
                     indices[i], indices[i + 1] = indices[i + 1], indices[i]
                     Gram[i], Gram[i + 1] = swap(Gram[i], Gram[i + 1])
                     Gram[:, i], Gram[:, i + 1] = swap(Gram[:, i],

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -361,7 +361,9 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
         # See if any coefficient has changed sign
         if drop and method == 'lasso':
 
-            arrayfuncs.cholesky_delete(L[:n_active, :n_active], idx)
+            # handle the case when idx is not length of 1
+            [arrayfuncs.cholesky_delete(L[:n_active, :n_active], ii) for ii in
+                idx]
 
             n_active -= 1
             m, n = idx, n_active


### PR DESCRIPTION
This PR fixed the second failed test case in #2737. The following line caused the failure,

```
drop_idx = active.pop(idx)
```

type of `idx` is `numpy.ndarray`, and `pop` operation raised 

```
DeprecationWarning: converting an array with ndim > 0 to an index will result in an error in the future
```

To fix it, just using `active.pop(idx[0])`.

This PR also changed `floating point division` to `floor division`. `Floating point division` caused `numpy` warning, 

```
DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future 
```

in `Python 3`
