### PR TITLE
Fixed gaussian process parameter optimization not respecting optimization limits.

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -707,9 +707,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             constraints = []
             for i in range(self.theta0.size):
-                constraints.append(lambda log10t:
+                constraints.append(lambda log10t, i=i:
                                    log10t[i] - np.log10(self.thetaL[0, i]))
-                constraints.append(lambda log10t:
+                constraints.append(lambda log10t, i=i:
                                    np.log10(self.thetaU[0, i]) - log10t[i])
 
             for k in range(self.random_start):

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -135,3 +135,22 @@ def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
     y_pred = gp.predict(X)
     assert_true(np.allclose(y_pred, y))
+    
+    
+def test_hyperparam_optimization_limits():
+    """
+    Regression test for parameter optimization constraints.
+    """
+    testX = X.repeat(2,axis=1)
+    theta_init = np.array([1e-1,1e-1])
+    theta_lower = np.array([1e-2,1e-2])
+    theta_upper = np.array([2e-1,2e-1])
+    gp = GaussianProcess(corr='squared_exponential',theta0=theta_init,thetaL=theta_lower,thetaU=theta_upper,random_start=50)
+    gp.fit(testX,y)
+    # Check the upper bound
+    assert_true( (gp.theta_ <= theta_upper).all() or np.allclose(gp.theta_,theta_upper) )
+    # Check the lower bound
+    assert_true( (gp.theta_ >= theta_lower).all() or np.allclose(gp.theta_,theta_lower) )
+    
+    
+    


### PR DESCRIPTION
There's a bug in gaussian_process.py that causes the parameter optimization via random starts to not respect optimization limits when there is more than one parameter to optimize (i.e. len(theta) > 1).  The problem is that the optimization constraints are enforced by lambda functions that are constructed inside a loop and that depend on the loop counter; when the lambda is later evaluated, only the last value of the loop counter is remembered, not the value at the time the lambda was created.  The solution to this is to save the value of the loop counter as a named parameter.

I also added a simple unit test that checks that the theta bounds are being respected.  It fails without this fix.
