### PR TITLE
CLN: Fix PEP8 warnings in linear_model

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -16,7 +16,7 @@ from ..utils.extmath import fast_logdet, pinvh
 from ..utils import check_arrays
 
 
-###############################################################################
+#################
 # BayesianRidge regression
 
 class BayesianRidge(LinearModel, RegressorMixin):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -25,7 +25,7 @@ from ..utils.extmath import safe_sparse_dot
 from . import cd_fast
 
 
-###############################################################################
+#
 # Paths functions
 
 def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
@@ -94,7 +94,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
         if normalize:
             Xy /= X_std[:, np.newaxis]
     alpha_max = np.sqrt(np.sum(Xy ** 2, axis=1)).max() / (
-                            n_samples * l1_ratio)
+        n_samples * l1_ratio)
     alphas = np.logspace(np.log10(alpha_max * eps), np.log10(alpha_max),
                          num=n_alphas)[::-1]
     return alphas
@@ -450,7 +450,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         coefs = np.empty((n_features, n_alphas), dtype=np.float64)
     else:
         coefs = np.empty((n_outputs, n_features, n_alphas),
-                          dtype=np.float64)
+                         dtype=np.float64)
 
     if coef_init is None:
         coef_ = np.asfortranarray(np.zeros(coefs.shape[:-1]))
@@ -463,18 +463,18 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         if not multi_output and sparse.isspmatrix(X):
             coef_, dual_gap_, eps_ = (
                 cd_fast.sparse_enet_coordinate_descent(
-                coef_, l1_reg, l2_reg, X.data, X.indices,
-                X.indptr, y, X_sparse_scaling,
-                max_iter, tol, positive)
-                )
+                    coef_, l1_reg, l2_reg, X.data, X.indices,
+                    X.indptr, y, X_sparse_scaling,
+                    max_iter, tol, positive)
+            )
         elif not multi_output:
             coef_, dual_gap_, eps_ = cd_fast.enet_coordinate_descent(
                 coef_, l1_reg, l2_reg, X, y, max_iter, tol, positive)
         else:
             coef_, dual_gap_, eps_ = (
                 cd_fast.enet_coordinate_descent_multi_task(
-                coef_, l1_reg, l2_reg, X, y, max_iter, tol)
-                )
+                    coef_, l1_reg, l2_reg, X, y, max_iter, tol)
+            )
         coefs[..., i] = coef_
         dual_gaps[i] = dual_gap_
         if dual_gap_ > eps_:
@@ -513,11 +513,12 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         return alphas, coefs, dual_gaps
 
 
-###############################################################################
+#
 # ElasticNet model
 
 
 class ElasticNet(LinearModel, RegressorMixin):
+
     """Linear Model trained with L1 and L2 prior as regularizer
 
     Minimizes the objective function::
@@ -668,7 +669,7 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if not self.warm_start or self.coef_ is None:
             coef_ = np.zeros((n_targets, n_features), dtype=np.float64,
-                                  order='F')
+                             order='F')
         else:
             coef_ = self.coef_
             if coef_.ndim == 1:
@@ -723,10 +724,11 @@ class ElasticNet(LinearModel, RegressorMixin):
             return super(ElasticNet, self).decision_function(X)
 
 
-###############################################################################
+#
 # Lasso model
 
 class Lasso(ElasticNet):
+
     """Linear Model trained with L1 prior as regularizer (aka the Lasso)
 
     The optimization objective for Lasso is::
@@ -831,7 +833,7 @@ class Lasso(ElasticNet):
             positive=positive)
 
 
-###############################################################################
+#
 # Functions for CV with paths functions
 
 def _path_residuals(X, y, train, test, path, path_params, alphas=None,
@@ -925,7 +927,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
         coefs_feature_major = np.rollaxis(coefs, 1)
         feature_2d = np.reshape(coefs_feature_major, (n_features, -1))
         X_test_coefs = safe_sparse_dot(X_test, feature_2d).reshape(
-                                     X_test.shape[0], n_order, -1)
+            X_test.shape[0], n_order, -1)
     else:
         X_test_coefs = safe_sparse_dot(X_test, coefs)
     residues = X_test_coefs - y_test[:, :, np.newaxis]
@@ -936,6 +938,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
 
 
 class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
+
     """Base class for iterative model fitting along a regularization path"""
 
     @abstractmethod
@@ -1052,7 +1055,7 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
                         eps=self.eps, n_alphas=self.n_alphas,
                         normalize=self.normalize,
                         copy_X=self.copy_X)
-                    )
+                )
         else:
             # Making sure alphas is properly ordered.
             alphas = np.tile(np.sort(alphas)[::-1], (n_l1_ratio, 1))
@@ -1087,7 +1090,7 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
         mean_mse = np.mean(mse_paths, axis=1)
         self.mse_path_ = np.squeeze(np.rollaxis(mse_paths, 2, 1))
         for l1_ratio, l1_alphas, mse_alphas in zip(
-            l1_ratios, alphas, mean_mse):
+                l1_ratios, alphas, mean_mse):
             i_best_alpha = np.argmin(mse_alphas)
             this_best_mse = mse_alphas[i_best_alpha]
             if this_best_mse < best_mse:
@@ -1123,6 +1126,7 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
 
 
 class LassoCV(LinearModelCV, RegressorMixin):
+
     """Lasso linear model with iterative fitting along a regularization path
 
     The best model is selected by cross-validation.
@@ -1226,6 +1230,7 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
 
 class ElasticNetCV(LinearModelCV, RegressorMixin):
+
     """Elastic Net model with iterative fitting along a regularization path
 
     The best model is selected by cross-validation.
@@ -1361,10 +1366,11 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
         self.positive = positive
 
 
-###############################################################################
+#
 # Multi Task ElasticNet and Lasso models (with joint feature selection)
 
 class MultiTaskElasticNet(Lasso):
+
     """Multi-task ElasticNet model trained with L1/L2 mixed-norm as regularizer
 
     The optimization objective for MultiTaskElasticNet is::
@@ -1449,6 +1455,7 @@ class MultiTaskElasticNet(Lasso):
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
     """
+
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
                  normalize=False, copy_X=True, max_iter=1000, tol=1e-4,
                  warm_start=False):
@@ -1524,6 +1531,7 @@ class MultiTaskElasticNet(Lasso):
 
 
 class MultiTaskLasso(MultiTaskElasticNet):
+
     """Multi-task Lasso model trained with L1/L2 mixed-norm as regularizer
 
     The optimization objective for Lasso is::
@@ -1597,6 +1605,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=1000, tol=1e-4, warm_start=False):
         self.alpha = alpha
@@ -1611,6 +1620,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
 
 class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
+
     """Multi-task L1/L2 ElasticNet with built-in cross-validation.
 
     The optimization objective for MultiTaskElasticNet is::
@@ -1756,6 +1766,7 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
 
 
 class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
+
     """Multi-task L1/L2 Lasso with built-in cross-validation.
 
     The optimization objective for MultiTaskLasso is::

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -24,7 +24,7 @@ from .least_angle import lars_path, LassoLarsIC
 from .logistic import LogisticRegression
 
 
-###############################################################################
+#
 # Randomized linear model: feature selection
 
 def _resample_model(estimator_func, X, y, scaling=.5, n_resampling=200,
@@ -57,6 +57,7 @@ def _resample_model(estimator_func, X, y, scaling=.5, n_resampling=200,
 
 class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
                                                    TransformerMixin)):
+
     """Base class to implement randomized linear models for feature selection
 
     This implements the strategy by Meinshausen and Buhlman:
@@ -101,15 +102,15 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
 
         scores_ = memory.cache(
             _resample_model, ignore=['verbose', 'n_jobs', 'pre_dispatch'])(
-                estimator_func, X, y,
-                scaling=self.scaling,
-                n_resampling=self.n_resampling,
-                n_jobs=self.n_jobs,
-                verbose=self.verbose,
-                pre_dispatch=self.pre_dispatch,
-                random_state=self.random_state,
-                sample_fraction=self.sample_fraction,
-                **params)
+            estimator_func, X, y,
+            scaling=self.scaling,
+            n_resampling=self.n_resampling,
+            n_jobs=self.n_jobs,
+            verbose=self.verbose,
+            pre_dispatch=self.pre_dispatch,
+            random_state=self.random_state,
+            sample_fraction=self.sample_fraction,
+            **params)
 
         if scores_.ndim == 1:
             scores_ = scores_[:, np.newaxis]
@@ -145,7 +146,7 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
         return Xt
 
 
-###############################################################################
+#
 # Randomized lasso: regression settings
 
 def _randomized_lasso(X, y, weights, mask, alpha=1., verbose=False,
@@ -180,6 +181,7 @@ def _randomized_lasso(X, y, weights, mask, alpha=1., verbose=False,
 
 
 class RandomizedLasso(BaseRandomizedLinearModel):
+
     """Randomized Lasso.
 
     Randomized Lasso works by resampling the train data and computing
@@ -295,6 +297,7 @@ class RandomizedLasso(BaseRandomizedLinearModel):
     --------
     RandomizedLogisticRegression, LogisticRegression
     """
+
     def __init__(self, alpha='aic', scaling=.5, sample_fraction=.75,
                  n_resampling=200, selection_threshold=.25,
                  fit_intercept=True, verbose=False,
@@ -334,7 +337,7 @@ class RandomizedLasso(BaseRandomizedLinearModel):
                                        precompute=self.precompute)
 
 
-###############################################################################
+#
 # Randomized logistic: classification settings
 
 def _randomized_logistic(X, y, weights, mask, C=1., verbose=False,
@@ -362,6 +365,7 @@ def _randomized_logistic(X, y, weights, mask, C=1., verbose=False,
 
 
 class RandomizedLogisticRegression(BaseRandomizedLinearModel):
+
     """Randomized Logistic Regression
 
     Randomized Regression works by resampling the train data and computing
@@ -463,6 +467,7 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
     --------
     RandomizedLasso, Lasso, ElasticNet
     """
+
     def __init__(self, C=1, scaling=.5, sample_fraction=.75,
                  n_resampling=200,
                  selection_threshold=.25, tol=1e-3,
@@ -497,7 +502,7 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
         return X, y, Xmean, y, X_std
 
 
-###############################################################################
+#
 # Stability paths
 def _lasso_stability_path(X, y, mask, weights, eps):
     "Inner loop of lasso_stability_path"

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -342,6 +342,7 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
 
 
 class Ridge(_BaseRidge, RegressorMixin):
+
     """Linear least squares with l2 regularization.
 
     This model solves a regression model where the loss function is
@@ -423,6 +424,7 @@ class Ridge(_BaseRidge, RegressorMixin):
     Ridge(alpha=1.0, copy_X=True, fit_intercept=True, max_iter=None,
           normalize=False, solver='auto', tol=0.001)
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto"):
         super(Ridge, self).__init__(alpha=alpha, fit_intercept=fit_intercept,
@@ -451,6 +453,7 @@ class Ridge(_BaseRidge, RegressorMixin):
 
 
 class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
+
     """Classifier using Ridge regression.
 
     Parameters
@@ -509,6 +512,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
     a one-versus-all approach. Concretely, this is implemented by taking
     advantage of the multi-variate response support in Ridge.
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, class_weight=None,
                  solver="auto"):
@@ -554,6 +558,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
 
 class _RidgeGCV(LinearModel):
+
     """Ridge regression with built-in Generalized Cross-Validation
 
     It allows efficient Leave-One-Out cross-validation.
@@ -730,8 +735,9 @@ class _RidgeGCV(LinearModel):
         C = []
 
         scorer = check_scoring(self, scoring=self.scoring, allow_none=True,
-            loss_func=self.loss_func, score_func=self.score_func,
-            score_overrides_loss=True)
+                               loss_func=self.loss_func,
+                               score_func=self.score_func,
+                               score_overrides_loss=True)
         error = scorer is None
 
         for i, alpha in enumerate(self.alphas):
@@ -774,6 +780,7 @@ class _RidgeGCV(LinearModel):
 
 
 class _BaseRidgeCV(LinearModel):
+
     def __init__(self, alphas=np.array([0.1, 1.0, 10.0]),
                  fit_intercept=True, normalize=False, scoring=None,
                  score_func=None, loss_func=None, cv=None, gcv_mode=None,
@@ -826,7 +833,7 @@ class _BaseRidgeCV(LinearModel):
             parameters = {'alpha': self.alphas}
             # FIXME: sample_weight must be split into training/validation data
             #        too!
-            #fit_params = {'sample_weight' : sample_weight}
+            # fit_params = {'sample_weight' : sample_weight}
             fit_params = {}
             gs = GridSearchCV(Ridge(fit_intercept=self.fit_intercept),
                               parameters, fit_params=fit_params, cv=self.cv)
@@ -841,6 +848,7 @@ class _BaseRidgeCV(LinearModel):
 
 
 class RidgeCV(_BaseRidgeCV, RegressorMixin):
+
     """Ridge regression with built-in cross-validation.
 
     By default, it performs Generalized Cross-Validation, which is a form of
@@ -921,6 +929,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
 
 class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
+
     """Ridge classifier with built-in cross-validation.
 
     By default, it performs Generalized Cross-Validation, which is a form of
@@ -985,6 +994,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     a one-versus-all approach. Concretely, this is implemented by taking
     advantage of the multi-variate response support in Ridge.
     """
+
     def __init__(self, alphas=np.array([0.1, 1.0, 10.0]), fit_intercept=True,
                  normalize=False, score_func=None, loss_func=None, cv=None,
                  class_weight=None):


### PR DESCRIPTION
Ran autopep8 on each file in the folder, then fixed remaining warnings manually. Tests still pass locally.

Fixes for bayes.py were not added because of technical issues on my side.
