### PR TITLE
Update plot_rfe_with_cross_validation.py

### DIFF
--- a/examples/plot_rfe_with_cross_validation.py
+++ b/examples/plot_rfe_with_cross_validation.py
@@ -22,7 +22,7 @@ X, y = make_classification(n_samples=1000, n_features=25, n_informative=3,
 # Create the RFE object and compute a cross-validated score.
 svc = SVC(kernel="linear")
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(y, 2),
-              scoring='accuracy')
+              scoring=zero_one_loss)
 rfecv.fit(X, y)
 
 print("Optimal number of features : %d" % rfecv.n_features_)


### PR DESCRIPTION
Line 34 says "nb of misclassifications" but 'accuracy' was used as the scoring parameter. Noticed `zero_one_loss` was imported but not used so assumed this is what was intended (?)
