### PR TITLE
Fixing MAE and MSE errors. should not be negative when used in cross_val

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -308,10 +308,8 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
 
 # Standard regression scores
 r2_scorer = make_scorer(r2_score)
-mean_squared_error_scorer = make_scorer(mean_squared_error,
-                                        greater_is_better=False)
-mean_absolute_error_scorer = make_scorer(mean_absolute_error,
-                                         greater_is_better=False)
+mean_squared_error_scorer = make_scorer(mean_squared_error)
+mean_absolute_error_scorer = make_scorer(mean_absolute_error)
 
 # Standard Classification Scores
 accuracy_scorer = make_scorer(accuracy_score)


### PR DESCRIPTION
Setting greater_is_better=True causes the sign in _PredictScorer to be negative.  This leads to negative values when using LinearRegression in cross_val_score

Alternatively, we could adjust the return statement in _PredictScorer.__call__
return self._sign \* self._score_func(y_true, y_pred, **self._kwargs)

Also, I found this mailthread on the issue: https://www.mail-archive.com/scikit-learn-general@lists.sourceforge.net/msg08945.html

That mailthread implies that this is not the correct fix, but I wanted to discuss how to correct this.
