### PR TITLE
[MRG+2] make_multilabel_classification for large n_features: faster and sparse output support

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -308,34 +308,34 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
         _, n_classes = p_w_c.shape
 
         # pick a nonzero number of labels per document by rejection sampling
-        n = n_classes + 1
-        while (not allow_unlabeled and n == 0) or n > n_classes:
-            n = generator.poisson(n_labels)
+        y_size = n_classes + 1
+        while (not allow_unlabeled and y_size == 0) or y_size > n_classes:
+            y_size = generator.poisson(n_labels)
 
         # pick n classes
-        y = []
-        while len(y) != n:
+        y = set()
+        while len(y) != y_size:
             # pick a class with probability P(c)
-            c = np.searchsorted(cumulative_p_c, generator.rand())
-
-            if not c in y:
-                y.append(c)
+            c = np.searchsorted(cumulative_p_c,
+                                generator.rand(y_size - len(y)))
+            y.update(c)
+        y = list(y)
 
         # pick a non-zero document length by rejection sampling
-        k = 0
-        while k == 0:
-            k = generator.poisson(length)
+        n_words = 0
+        while n_words == 0:
+            n_words = generator.poisson(length)
 
-        # generate a document of length k words
+        # generate a document of length n_words
         if len(y) == 0:
             # if sample does not belong to any class, generate noise word
-            words = generator.randint(n_features, size=k)
+            words = generator.randint(n_features, size=n_words)
             return words, y
 
         # sample words with replacement from selected classes
-        cumulative_p_w_sample = np.cumsum(p_w_c[:, y].sum(axis=1))
+        cumulative_p_w_sample = p_w_c.take(y, axis=1).sum(axis=1).cumsum()
         cumulative_p_w_sample /= cumulative_p_w_sample[-1]
-        words = np.searchsorted(cumulative_p_w_sample, generator.rand(k))
+        words = np.searchsorted(cumulative_p_w_sample, generator.rand(n_words))
         return words, y
 
     X_indices = array.array('i')

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1053,12 +1053,12 @@ def test_multilabel_classification_report():
     expected_report = """\
              precision    recall  f1-score   support
 
-          0       0.39      0.73      0.51        15
-          1       0.57      0.75      0.65        28
-          2       0.33      0.11      0.17        18
-          3       0.44      0.50      0.47        24
+          0       0.50      0.67      0.57        24
+          1       0.51      0.74      0.61        27
+          2       0.29      0.08      0.12        26
+          3       0.52      0.56      0.54        27
 
-avg / total       0.45      0.54      0.47        85
+avg / total       0.45      0.51      0.46       104
 """
 
     lb = LabelBinarizer()

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -107,7 +107,7 @@ def test_ovr_fit_predict_svc():
 
 def test_ovr_multilabel_dataset():
     base_clf = MultinomialNB(alpha=1)
-    for au, prec, recall in zip((True, False), (0.65, 0.74), (0.72, 0.84)):
+    for au, prec, recall in zip((True, False), (0.51, 0.66), (0.51, 0.80)):
         X, Y = datasets.make_multilabel_classification(n_samples=100,
                                                        n_features=20,
                                                        n_classes=5,


### PR DESCRIPTION
This is a more focussed #2773.

`make_multilabel_classification` is currently very slow for large `n_features`, and only outputs dense matrices although it effectively generates a sparse structure.

Although this function can certainly be more optimised, the per-sample Python iteration will slow it down I don't think there's much value in further optimisation.
