### PR TITLE
BF: Correct degrees of freedom in f_regression + test.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -150,6 +150,10 @@ Changelog
    - Added :class:`linear_model.MultiTaskElasticNetCV` and
      :class:`linear_model.MultiTaskLassoCV`. By `Manoj Kumar`_.
 
+   - Fixed incorrect estimation of the degrees of freedom in
+     :func:`feature_selection.f_regression` when variates are not centered.
+     By `VirgileFritsch`_.
+
 
 API changes summary
 -------------------

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -122,7 +122,7 @@ def test_f_regression_center():
     F1, _ = f_regression(X, Y, center=True)
     F2, _ = f_regression(X, Y, center=False)
     assert_array_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
-    assert_array_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
+    assert_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
 
 
 def test_f_classif_multi_class():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -6,7 +6,8 @@ import itertools
 import numpy as np
 from scipy import stats, sparse
 
-from nose.tools import assert_equal, assert_raises, assert_true
+from nose.tools import (assert_equal, assert_almost_equal, assert_raises,
+                        assert_true)
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from sklearn.utils.testing import assert_not_in, ignore_warnings
 
@@ -103,6 +104,25 @@ def test_f_regression_input_dtype():
     F2, pv2 = f_regression(X, y.astype(np.float))
     assert_array_almost_equal(F1, F2, 5)
     assert_array_almost_equal(pv1, pv2, 5)
+
+
+def test_f_regression_center():
+    """Test whether f_regression preserves dof according to 'center' argument
+
+    We use two centered variates so we have a simple relationship between
+    F-score with variates centering and F-score without variates centering.
+    """
+    # Create toy example
+    X = np.arange(-5, 6)  # X has zero mean
+    n_samples = X.size
+    Y = np.ones(n_samples)
+    Y[::2] *= -1.
+    Y[0] = 0.  # have Y mean being null
+
+    F1, _ = f_regression(X, Y, center=True)
+    F2, _ = f_regression(X, Y, center=False)
+    assert_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
+    assert_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
 
 
 def test_f_classif_multi_class():

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -121,8 +121,8 @@ def test_f_regression_center():
 
     F1, _ = f_regression(X, Y, center=True)
     F2, _ = f_regression(X, Y, center=False)
-    assert_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
-    assert_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
+    assert_array_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
+    assert_array_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
 
 
 def test_f_classif_multi_class():

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -255,9 +255,9 @@ def f_regression(X, y, center=True):
     corr /= norm(y)
 
     # convert to p-value
-    dof = y.size - 1 - int(center)  # one more lost dof if 'center' is True
-    F = corr ** 2 / (1 - corr ** 2) * dof
-    pv = stats.f.sf(F, 1, dof)
+    degrees_of_freedom = y.size - (2 if center else 1)
+    F = corr ** 2 / (1 - corr ** 2) * degrees_of_freedom
+    pv = stats.f.sf(F, 1, degrees_of_freedom)
     return F, pv
 
 

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -255,7 +255,7 @@ def f_regression(X, y, center=True):
     corr /= norm(y)
 
     # convert to p-value
-    dof = y.size - 2
+    dof = y.size - 1 - int(center)  # one more lost dof if 'center' is True
     F = corr ** 2 / (1 - corr ** 2) * dof
     pv = stats.f.sf(F, 1, dof)
     return F, pv


### PR DESCRIPTION
Degrees of freedom are equal to 'n - 2' only if we center the variates. Otherwise it should be 'n - 1'.
I use the syntax `... - int(center)` because it is concise but using a `if center: ... else ...` statement instead would afford checking that we actually test it through code coverage.
