### PR TITLE
Fixed incredibly minor spelling mistake

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -483,7 +483,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     solver : {'auto', 'svd', 'dense_cholesky', 'lsqr', 'sparse_cg'}
         Solver to use in the computational
-        routines. 'svd' will use a Sinvular value decomposition to obtain
+        routines. 'svd' will use a Singular value decomposition to obtain
         the solution, 'dense_cholesky' will use the standard
         scipy.linalg.solve function, 'sparse_cg' will use the
         conjugate gradient solver as found in


### PR DESCRIPTION
I happened to be browsing the documentation online at 

http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifier.html#sklearn.linear_model.RidgeClassifier

When I happened to note that Singular was spelled incorrectly as Sinvular. This is just a correction of that mis-spelled word.
