### PR TITLE
FIX: make K-Means accept 1D vectors

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -652,6 +652,11 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     def _check_fit_data(self, X):
         """Verify that the number of samples given is larger than k"""
+        try:
+            if X.ndim == 1:
+                X = X[:, np.newaxis]
+        except AttributeError:
+            pass
         X = atleast2d_or_csr(X, dtype=np.float64)
         if X.shape[0] < self.n_clusters:
             raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
@@ -659,6 +664,11 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         return X
 
     def _check_test_data(self, X):
+        try:
+            if X.ndim == 1:
+                X = X[:, np.newaxis]
+        except AttributeError:
+            pass
         X = atleast2d_or_csr(X)
         n_samples, n_features = X.shape
         expected_n_features = self.cluster_centers_.shape[1]


### PR DESCRIPTION
Other unsupervised learning implementations, such as GMM accept 1D vectors as input. K-Means, however, expects a 2D array, because 1D vectors are mangled by atleast2d_or_csr(). I think that this should be fixed for consistency: either all should _not_ accept 1D vectors, or all should accept them.

I'm not sure what is the best way to do this, but here is my take: I copy-pasted the check from GMM, but wrapped it into a try / except statement, because apparently it's not a good idea to run asarray() on the array_like, since atleast2d_or_csr() is used as an input check. So I check from the ndim == 1, if there is no such attribute, then this check is a nop.

Hope this helps!
