### PR TITLE
Remove superfluous AdaBoostRegressor call.

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -52,7 +52,6 @@ def test_classification_toy():
 def test_regression_toy():
     """Check classification on a toy dataset."""
     clf = AdaBoostRegressor(random_state=0)
-    clf = AdaBoostRegressor()
     clf.fit(X, y_regr)
     assert_array_equal(clf.predict(T), y_t_regr)
 


### PR DESCRIPTION
I get this test failure occasionally.

```
======================================================================
FAIL: Check classification on a toy dataset.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File ".../scikit-learn/sklearn/ensemble/tests/test_weight_boosting.py", line 59, in test_regression_toy
    assert_array_equal(clf.predict(T), y_t_regr)
  File "/usr/lib64/python2.7/site-packages/numpy/testing/utils.py", line 718, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "/usr/lib64/python2.7/site-packages/numpy/testing/utils.py", line 644, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal

(mismatch 33.3333333333%)
 x: array([ 1.,  1.,  1.])
 y: array([-1,  1,  1])
```

Using the regressor with `random_state=0` seems to solve the problem for me, although I'm not sure if this is hinting at a deeper problem.

This [commit](https://github.com/scikit-learn/scikit-learn/commit/10ee464177be4b931197e46ba735a52488edbfad#diff-e9f9c11c51c9b39b67f2a0dd9928adbdR56) introduced the additional regressor but I'm not sure why.
