### PR TITLE
[MRG+1] Ensure delegated ducktyping in MetaEstimators

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -19,7 +19,7 @@ from ..metrics.scorer import check_scoring
 from .base import SelectorMixin
 
 
-iff_estimator_has_method = make_delegation_decorator('estimator_')
+iff_estimator_has_method = make_delegation_decorator('estimator')
 
 
 class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
@@ -216,6 +216,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     @iff_estimator_has_method
     def predict_proba(self, X):
         return self.estimator_.predict_proba(self.transform(X))
+
+    @iff_estimator_has_method
+    def predict_log_proba(self, X):
+        return self.estimator_.predict_log_proba(self.transform(X))
 
 
 class RFECV(RFE, MetaEstimatorMixin):

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -8,14 +8,18 @@
 
 import numpy as np
 from ..utils import check_X_y, safe_sqr
+from ..utils.metaestimators import make_delegation_decorator
 from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..base import clone
 from ..base import is_classifier
 from ..cross_validation import _check_cv as check_cv
 from ..cross_validation import _safe_split, _score
-from .base import SelectorMixin
 from ..metrics.scorer import check_scoring
+from .base import SelectorMixin
+
+
+iff_estimator_has_method = make_delegation_decorator('estimator_')
 
 
 class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
@@ -170,6 +174,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
         return self
 
+    @iff_estimator_has_method
     def predict(self, X):
         """Reduce X to the selected features and then predict using the
            underlying estimator.
@@ -186,6 +191,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         """
         return self.estimator_.predict(self.transform(X))
 
+    @iff_estimator_has_method
     def score(self, X, y):
         """Reduce X to the selected features and then return the score of the
            underlying estimator.
@@ -203,9 +209,11 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     def _get_support_mask(self):
         return self.support_
 
+    @iff_estimator_has_method
     def decision_function(self, X):
         return self.estimator_.decision_function(self.transform(X))
 
+    @iff_estimator_has_method
     def predict_proba(self, X):
         return self.estimator_.predict_proba(self.transform(X))
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -27,6 +27,7 @@ from .externals.joblib import Parallel, delayed
 from .externals import six
 from .utils import check_random_state
 from .utils.validation import _num_samples, indexable
+from .utils.metaestimators import make_delegation_decorator
 from .metrics.scorer import check_scoring
 
 
@@ -282,6 +283,9 @@ class ChangedBehaviorWarning(UserWarning):
     pass
 
 
+iff_best_estimator_has_method = make_delegation_decorator('best_estimator_')
+
+
 class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                       MetaEstimatorMixin)):
     """Base class for hyper parameter search with cross-validation."""
@@ -342,21 +346,25 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                           ChangedBehaviorWarning)
         return self.scorer_(self.best_estimator_, X, y)
 
-    @property
-    def predict(self):
-        return self.best_estimator_.predict
+    @iff_best_estimator_has_method
+    def predict(self, X):
+        return self.best_estimator_.predict(X)
 
-    @property
-    def predict_proba(self):
-        return self.best_estimator_.predict_proba
+    @iff_best_estimator_has_method
+    def predict_proba(self, X):
+        return self.best_estimator_.predict_proba(X)
 
-    @property
-    def decision_function(self):
-        return self.best_estimator_.decision_function
+    @iff_best_estimator_has_method
+    def decision_function(self, X):
+        return self.best_estimator_.decision_function(X)
 
-    @property
-    def transform(self):
-        return self.best_estimator_.transform
+    @iff_best_estimator_has_method
+    def transform(self, X):
+        return self.best_estimator_.transform(X)
+
+    @iff_best_estimator_has_method
+    def inverse_transform(self, Xt):
+        return self.best_estimator_.transform(Xt)
 
     def _fit(self, X, y, parameter_iterable):
         """Actual fitting,  performing the search over parameters."""

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -283,7 +283,7 @@ class ChangedBehaviorWarning(UserWarning):
     pass
 
 
-iff_best_estimator_has_method = make_delegation_decorator('best_estimator_')
+iff_estimator_has_method = make_delegation_decorator('estimator')
 
 
 class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
@@ -346,23 +346,27 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                           ChangedBehaviorWarning)
         return self.scorer_(self.best_estimator_, X, y)
 
-    @iff_best_estimator_has_method
+    @iff_estimator_has_method
     def predict(self, X):
         return self.best_estimator_.predict(X)
 
-    @iff_best_estimator_has_method
+    @iff_estimator_has_method
     def predict_proba(self, X):
         return self.best_estimator_.predict_proba(X)
 
-    @iff_best_estimator_has_method
+    @iff_estimator_has_method
+    def predict_log_proba(self, X):
+        return self.best_estimator_.predict_log_proba(X)
+
+    @iff_estimator_has_method
     def decision_function(self, X):
         return self.best_estimator_.decision_function(X)
 
-    @iff_best_estimator_has_method
+    @iff_estimator_has_method
     def transform(self, X):
         return self.best_estimator_.transform(X)
 
-    @iff_best_estimator_has_method
+    @iff_estimator_has_method
     def inverse_transform(self, Xt):
         return self.best_estimator_.transform(Xt)
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -18,13 +18,14 @@ from .base import BaseEstimator, TransformerMixin
 from .externals.joblib import Parallel, delayed
 from .externals import six
 from .utils import tosequence
+from .utils.metaestimators import make_delegation_decorator
 from .externals.six import iteritems
 
 __all__ = ['Pipeline', 'FeatureUnion']
 
 
-# One round of beers on me if someone finds out why the backslash
-# is needed in the Attributes section so as not to upset sphinx.
+iff_final_estimator_has_method = make_delegation_decorator('_final_estimator')
+
 
 class Pipeline(BaseEstimator):
     """Pipeline of transforms with a final estimator.
@@ -106,6 +107,10 @@ class Pipeline(BaseEstimator):
                     out['%s__%s' % (name, key)] = value
             return out
 
+    @property
+    def _final_estimator(self):
+        return self.steps[-1][1]
+
     # Estimator interface
 
     def _pre_transform(self, X, y=None, **fit_params):
@@ -140,6 +145,7 @@ class Pipeline(BaseEstimator):
         else:
             return self.steps[-1][-1].fit(Xt, y, **fit_params).transform(Xt)
 
+    @iff_final_estimator_has_method
     def predict(self, X):
         """Applies transforms to the data, and the predict method of the
         final estimator. Valid only if the final estimator implements
@@ -149,6 +155,7 @@ class Pipeline(BaseEstimator):
             Xt = transform.transform(Xt)
         return self.steps[-1][-1].predict(Xt)
 
+    @iff_final_estimator_has_method
     def predict_proba(self, X):
         """Applies transforms to the data, and the predict_proba method of the
         final estimator. Valid only if the final estimator implements
@@ -158,6 +165,7 @@ class Pipeline(BaseEstimator):
             Xt = transform.transform(Xt)
         return self.steps[-1][-1].predict_proba(Xt)
 
+    @iff_final_estimator_has_method
     def decision_function(self, X):
         """Applies transforms to the data, and the decision_function method of
         the final estimator. Valid only if the final estimator implements
@@ -167,12 +175,14 @@ class Pipeline(BaseEstimator):
             Xt = transform.transform(Xt)
         return self.steps[-1][-1].decision_function(Xt)
 
+    @iff_final_estimator_has_method
     def predict_log_proba(self, X):
         Xt = X
         for name, transform in self.steps[:-1]:
             Xt = transform.transform(Xt)
         return self.steps[-1][-1].predict_log_proba(Xt)
 
+    @iff_final_estimator_has_method
     def transform(self, X):
         """Applies transforms to the data, and the transform method of the
         final estimator. Valid only if the final estimator implements
@@ -182,6 +192,7 @@ class Pipeline(BaseEstimator):
             Xt = transform.transform(Xt)
         return Xt
 
+    @iff_final_estimator_has_method
     def inverse_transform(self, X):
         if X.ndim == 1:
             X = X[None, :]
@@ -190,6 +201,7 @@ class Pipeline(BaseEstimator):
             Xt = step.inverse_transform(Xt)
         return Xt
 
+    @iff_final_estimator_has_method
     def score(self, X, y=None):
         """Applies transforms to the data, and the score method of the
         final estimator. Valid only if the final estimator implements

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -1,0 +1,116 @@
+"""Common tests for metaestimators"""
+
+import functools
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.externals.six import iterkeys
+from sklearn.datasets import make_classification
+from sklearn.utils.testing import assert_true, assert_false
+from sklearn.pipeline import Pipeline
+from sklearn.grid_search import GridSearchCV, RandomizedSearchCV
+from sklearn.feature_selection import RFE, RFECV
+
+
+class DelegatorData(object):
+    def __init__(self, name, construct, skip_methods=(),
+                 fit_args=make_classification()):
+        self.name = name
+        self.construct = construct
+        self.fit_args = fit_args
+        self.skip_methods = skip_methods
+
+
+DELEGATING_METAESTIMATORS = [
+    DelegatorData('Pipeline', lambda est: Pipeline([('est', est)])),
+    DelegatorData('GridSearchCV',
+                  lambda est: GridSearchCV(
+                      est, param_grid={'param': [5]}, cv=2),
+                  skip_methods=['score']),
+    DelegatorData('RandomizedSearchCV',
+                  lambda est: RandomizedSearchCV(
+                      est, param_distributions={'param': [5]}, cv=2),
+                  skip_methods=['score']),
+    DelegatorData('RFE', RFE,
+                  skip_methods=['transform', 'inverse_transform', 'score']),
+    DelegatorData('RFECV', RFECV,
+                  skip_methods=['transform', 'inverse_transform', 'score']),
+]
+
+
+def test_metaestimator_delegation():
+    """Ensures specified metaestimators have methods iff subestimator does"""
+    def hides(method):
+        @property
+        def wrapper(obj):
+            if obj.hidden_method == method.__name__:
+                raise AttributeError('%r is hidden' % obj.hidden_method)
+            return functools.partial(method, obj)
+        return wrapper
+
+    class SubEstimator(BaseEstimator):
+        def __init__(self, param=1, hidden_method=None):
+            self.param = param
+            self.hidden_method = hidden_method
+
+        def fit(self, X, y=None, *args, **kwargs):
+            self.coef_ = np.arange(X.shape[1])
+            return True
+
+        @hides
+        def inverse_transform(self, X, *args, **kwargs):
+            return X
+
+        @hides
+        def transform(self, X, *args, **kwargs):
+            return X
+
+        @hides
+        def predict(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def predict_proba(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def predict_log_proba(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def decision_function(self, X, *args, **kwargs):
+            return np.ones(X.shape[0])
+
+        @hides
+        def score(self, X, *args, **kwargs):
+            return 1.0
+
+    methods = [k for k in iterkeys(SubEstimator.__dict__)
+               if not k.startswith('_') and not k.startswith('fit')]
+    methods.sort()
+
+    for delegator_data in DELEGATING_METAESTIMATORS:
+        delegate = SubEstimator()
+        delegator = delegator_data.construct(delegate)
+        delegator.fit(*delegator_data.fit_args)
+        for method in methods:
+            if method in delegator_data.skip_methods:
+                continue
+            assert_true(hasattr(delegate, method))
+            assert_true(hasattr(delegator, method),
+                        msg="%s does not have method %r when its delegate does"
+                            % (delegator_data.name, method))
+            # smoke test delegation
+            getattr(delegator, method)(delegator_data.fit_args[0])
+
+        for method in methods:
+            if method in delegator_data.skip_methods:
+                continue
+            delegate = SubEstimator(hidden_method=method)
+            delegator = delegator_data.construct(delegate)
+            delegator.fit(*delegator_data.fit_args)
+            assert_false(hasattr(delegate, method))
+            assert_false(hasattr(delegator, method),
+                         msg="%s has method %r when its delegate does not"
+                             % (delegator_data.name, method))

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -93,7 +93,6 @@ def test_metaestimator_delegation():
     for delegator_data in DELEGATING_METAESTIMATORS:
         delegate = SubEstimator()
         delegator = delegator_data.construct(delegate)
-        delegator.fit(*delegator_data.fit_args)
         for method in methods:
             if method in delegator_data.skip_methods:
                 continue
@@ -101,6 +100,11 @@ def test_metaestimator_delegation():
             assert_true(hasattr(delegator, method),
                         msg="%s does not have method %r when its delegate does"
                             % (delegator_data.name, method))
+
+        delegator.fit(*delegator_data.fit_args)
+        for method in methods:
+            if method in delegator_data.skip_methods:
+                continue
             # smoke test delegation
             getattr(delegator, method)(delegator_data.fit_args[0])
 
@@ -109,7 +113,6 @@ def test_metaestimator_delegation():
                 continue
             delegate = SubEstimator(hidden_method=method)
             delegator = delegator_data.construct(delegate)
-            delegator.fit(*delegator_data.fit_args)
             assert_false(hasattr(delegate, method))
             assert_false(hasattr(delegator, method),
                          msg="%s has method %r when its delegate does not"

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -1,0 +1,66 @@
+"""Utilities for meta-estimators"""
+# Author: Joel Nothman
+# Licence: BSD
+
+from operator import attrgetter
+from functools import partial, update_wrapper
+
+
+__all__ = ['make_delegation_decorator']
+
+
+class _IffHasAttrDescriptor(object):
+    def __init__(self, fn, attr):
+        self.fn = fn
+        self.get_attr = attrgetter(attr)
+
+    def __get__(self, obj, type=None):
+        self.get_attr(obj)
+        # lambda, but not partial, allows help() to work with update_wrapper
+        out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
+        update_wrapper(out, self.fn)
+        return out
+
+
+def _iff_attr_has_method(prefix, fn, name=None):
+    if not callable(fn):
+        return partial(_iff_attr_has_method, prefix, name=fn)
+    if name is None:
+        name = fn.__name__
+    attr = '%s.%s' % (prefix, name)
+    out = _IffHasAttrDescriptor(fn, attr)
+    update_wrapper(out, fn)
+    return out
+
+
+def make_delegation_decorator(prefix):
+    """Create a decorator for methods that are delegated to a sub-estimator
+
+    This enables ducktyping by hasattr returning True according to the
+    sub-estimator.
+
+    >>> from sklearn.utils.metaestimators import make_delegation_decorator
+    >>>
+    >>> iff_sub_est_has_attr = make_delegation_decorator('sub_est')
+    >>>
+    >>> class MetaEst(object):
+    ...     def __init__(self, sub_est):
+    ...         self.sub_est = sub_est
+    ...
+    ...     @iff_sub_est_has_attr
+    ...     def predict(self, X):
+    ...         return self.sub_est.predict(X)
+    ...
+    >>> class HasPredict(object):
+    ...     def predict(self, X):
+    ...         return X.sum(axis=1)
+    ...
+    >>> class HasNoPredict(object):
+    ...     pass
+    ...
+    >>> hasattr(MetaEst(HasPredict()), 'predict')
+    True
+    >>> hasattr(MetaEst(HasNoPredict()), 'predict')
+    False
+    """
+    return partial(_iff_attr_has_method, prefix)


### PR DESCRIPTION
Supersedes #2019 to fix #1805, with a more readable (?) reimplementation, and an extension of the test to fix #2853.

This patch ensures that:
- `GridSearchCV`
- `RandomizedSearchCV`
- `Pipeline`
- `RFE` and
- `RFECV`

have  `hasattr(metaest, method) == True` iff the sub-estimator does for the set of standard methods:
- `inverse_transform`
- `transform`
- `predict`
- `predict_proba`
- `predict_log_proba`
- `decision_function`
- `score`

(with some exceptions where delegation doesn't apply).

To fix #2853, `hasattr` must be True before the metaestimator is `fit`, and if the delegating method is called before fit, an exception will be raised, as with other un-fit estimators.

Some alternatives are posed here and below:
- _(A)_ custom descriptor as in this PR (https://github.com/scikit-learn/scikit-learn/pull/2854/files#diff-589a953cf2ee991da252f7da86c1e5b9R176)
- _(B)_ property with access and nested function (https://github.com/scikit-learn/scikit-learn/pull/2854#issuecomment-35245852)
- _(C)_ property with `if hasattr` and nested function (https://github.com/scikit-learn/scikit-learn/pull/2854#issuecomment-35351774)
