### PR TITLE
BF: load_boston() returns 13 features, but 14 feature names

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -431,7 +431,8 @@ def load_boston():
 
     return Bunch(data=data,
                  target=target,
-                 feature_names=feature_names,
+                 # last column is target value
+                 feature_names=feature_names[:-1],
                  DESCR=fdescr.read())
 
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -181,5 +181,5 @@ def test_load_boston():
     res = load_boston()
     assert_equal(res.data.shape, (506, 13))
     assert_equal(res.target.size, 506)
-    assert_equal(res.feature_names.size, 14)
+    assert_equal(res.feature_names.size, 13)
     assert_true(res.DESCR)


### PR DESCRIPTION
Last column has the target value, hence only report first 13 names.

It could be argued that it would be useful to report the name of the target as well, but a better and different name than "feature_names" would avoid confusion.
