### PR TITLE
FIX Bounds in anisotropic GP hyperparameter optimization

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -708,9 +708,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             constraints = []
             for i in range(self.theta0.size):
-                constraints.append(lambda log10t:
+                constraints.append(lambda log10t, i=i:
                                    log10t[i] - np.log10(self.thetaL[0, i]))
-                constraints.append(lambda log10t:
+                constraints.append(lambda log10t, i=i:
                                    np.log10(self.thetaU[0, i]) - log10t[i])
 
             for k in range(self.random_start):

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -58,14 +58,20 @@ def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
                   [-2.87600388, 6.74310541],
                   [5.21301203, 4.26386883]])
     y = g(X).ravel()
+
+    thetaL = [1e-4] * 2
+    thetaU = [1e-1] * 2
     gp = GaussianProcess(regr=regr, corr=corr, beta0=beta0,
-                         theta0=[1e-2] * 2, thetaL=[1e-4] * 2,
-                         thetaU=[1e-1] * 2,
+                         theta0=[1e-2] * 2, thetaL=thetaL,
+                         thetaU=thetaU,
                          random_start=random_start, verbose=False)
     gp.fit(X, y)
     y_pred, MSE = gp.predict(X, eval_MSE=True)
 
     assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.))
+
+    assert_true(np.all(gp.theta_ >= thetaL)) # Lower bounds of hyperparameters
+    assert_true(np.all(gp.theta_ <= thetaU)) # Upper bounds of hyperparameters
 
 
 def test_2d_2d(regr=regression.constant, corr=correlation.squared_exponential,


### PR DESCRIPTION
Currently, if multi-dimensional thetaU and thetaL are given as bounds for anisotropic GP hyperparameter optimization, only the bounds in the last dimensions are obeyed (see added unittest). This pull request fixes this bug. The bug was related to https://stackoverflow.com/questions/10452770/python-lambdas-binding-to-local-values
