### PR TITLE
DOC: Fixed roc_curve docstring

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -755,7 +755,7 @@ def roc_curve(y_true, y_score, pos_label=None):
 
     y_score : array, shape = [n_samples]
         Target scores, can either be probability estimates of the positive
-        class, confidence values, or binary decisions.
+        class or confidence values.
 
     pos_label : int
         Label considered as positive and others are considered negative.


### PR DESCRIPTION
It does not make sense for y_score of roc_curve to be binary.
