### PR TITLE
[MRG+1] FIX: Cleaning up compute_class_weight for 'auto'

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -217,6 +217,9 @@ API changes summary
      performance, you should modify the value of `max_features`.
      By `Arnaud Joly`_.
 
+   - Fix :func:`utils.compute_class_weight` when class_weight is "auto".
+     Previously it was broken for input of non-int dtype and the weighted
+     array that was returned was wrong. By `Manoj Kumar`_.
 
 .. _changes_0_14:
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -22,7 +22,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils import safe_asarray
 from ..utils import compute_class_weight
 from ..utils import column_or_1d
-from ..preprocessing import LabelBinarizer
+from ..preprocessing import LabelBinarizer, LabelEncoder
 from ..grid_search import GridSearchCV
 from ..externals import six
 from ..metrics.scorer import check_scoring
@@ -538,8 +538,11 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
             y = column_or_1d(y, warn=True)
 
         if self.class_weight:
+            # compute_class_weight cannot handle negative values
+            # hence transform to positive integers.
+            lby = LabelEncoder().fit_transform(y)
             cw = compute_class_weight(self.class_weight,
-                                      self.classes_, Y)
+                                      self.classes_, lby)
             # get the class weight corresponding to each sample
             sample_weight = cw[np.searchsorted(self.classes_, y)]
         else:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -22,7 +22,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils import safe_asarray
 from ..utils import compute_class_weight
 from ..utils import column_or_1d
-from ..preprocessing import LabelBinarizer, LabelEncoder
+from ..preprocessing import LabelBinarizer
 from ..grid_search import GridSearchCV
 from ..externals import six
 from ..metrics.scorer import check_scoring
@@ -538,11 +538,8 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
             y = column_or_1d(y, warn=True)
 
         if self.class_weight:
-            # compute_class_weight cannot handle negative values
-            # hence transform to positive integers.
-            lby = LabelEncoder().fit_transform(y)
             cw = compute_class_weight(self.class_weight,
-                                      self.classes_, lby)
+                                      self.classes_, y)
             # get the class weight corresponding to each sample
             sample_weight = cw[np.searchsorted(self.classes_, y)]
         else:

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -466,6 +466,18 @@ def test_class_weights():
     # the prediction on this point should shift
     assert_array_equal(clf.predict([[0.2, -1.0]]), np.array([-1]))
 
+    # class_weight = 'auto', and class_weight = None should return
+    # same values when y has equal number of all labels
+    X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0], [1.0, 1.0]])
+    y = [1, 1, -1, -1]
+    clf = RidgeClassifier(class_weight=None)
+    clf.fit(X, y)
+    clfa = RidgeClassifier(class_weight='auto')
+    clfa.fit(X, y)
+    assert_equal(len(clfa.classes_), 2)
+    assert_array_almost_equal(clf.coef_, clfa.coef_)
+    assert_array_almost_equal(clf.intercept_, clfa.intercept_)
+
 
 def test_class_weights_cv():
     """

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -466,6 +466,11 @@ def test_class_weights():
     # the prediction on this point should shift
     assert_array_equal(clf.predict([[0.2, -1.0]]), np.array([-1]))
 
+    # check if class_weight = 'auto' can handle negative labels.
+    clf = RidgeClassifier(class_weight='auto')
+    clf.fit(X, y)
+    assert_array_equal(clf.predict([[0.2, -1.0]]), np.array([1]))
+
     # class_weight = 'auto', and class_weight = None should return
     # same values when y has equal number of all labels
     X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0], [1.0, 1.0]])

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -436,9 +436,9 @@ class BaseSVC(BaseLibSVM, ClassifierMixin):
     """ABC for LibSVM-based classifiers."""
 
     def _validate_targets(self, y):
-        y = column_or_1d(y, warn=True)
-        cls, y = unique(y, return_inverse=True)
-        self.class_weight_ = compute_class_weight(self.class_weight, cls, y)
+        y_ = column_or_1d(y, warn=True)
+        cls, y = unique(y_, return_inverse=True)
+        self.class_weight_ = compute_class_weight(self.class_weight, cls, y_)
         if len(cls) < 2:
             raise ValueError(
                 "The number of classes has to be greater than one; got %d"
@@ -655,7 +655,7 @@ class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
             Returns self.
         """
         self._enc = LabelEncoder()
-        y = self._enc.fit_transform(y)
+        y_ind = self._enc.fit_transform(y)
         if len(self.classes_) < 2:
             raise ValueError("The number of classes has to be greater than"
                              " one.")
@@ -665,7 +665,7 @@ class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.class_weight_ = compute_class_weight(self.class_weight,
                                                   self.classes_, y)
 
-        if X.shape[0] != y.shape[0]:
+        if X.shape[0] != y_ind.shape[0]:
             raise ValueError("X and y have incompatible shapes.\n"
                              "X has %s samples, but y has %s." %
                              (X.shape[0], y.shape[0]))
@@ -677,8 +677,8 @@ class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
             print('[LibLinear]', end='')
 
         # LibLinear wants targets as doubles, even for classification
-        y = np.asarray(y, dtype=np.float64).ravel()
-        self.raw_coef_ = liblinear.train_wrap(X, y,
+        y_ind = np.asarray(y_ind, dtype=np.float64).ravel()
+        self.raw_coef_ = liblinear.train_wrap(X, y_ind,
                                               sp.isspmatrix(X),
                                               self._get_solver_type(),
                                               self.tol, self._get_bias(),

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -358,8 +358,8 @@ def test_auto_weight():
     X, y = iris.data[:, :2], iris.target + 1
     unbalanced = np.delete(np.arange(y.size), np.where(y > 2)[0][::2])
 
-    classes, y_ind = unique(y[unbalanced], return_inverse=True)
-    class_weights = compute_class_weight('auto', classes, y_ind)
+    classes = unique(y[unbalanced])
+    class_weights = compute_class_weight('auto', classes, y[unbalanced])
     assert_true(np.argmax(class_weights) == 2)
 
     for clf in (svm.SVC(kernel='linear'), svm.LinearSVC(random_state=0),

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -6,7 +6,7 @@ import numpy as np
 from .fixes import bincount
 
 
-def compute_class_weight(class_weight, classes, y_ind):
+def compute_class_weight(class_weight, classes, y):
     """Estimate class weights for unbalanced datasets.
 
     Parameters
@@ -22,7 +22,7 @@ def compute_class_weight(class_weight, classes, y_ind):
         Array of the classes occurring in the data, as given by
         ``np.unique(y_org)`` with ``y_org`` the original class labels.
 
-    y_ind : array-like, shape (n_samples,)
+    y : array-like, shape (n_samples,)
         Array of original class labels per sample;
 
     Returns
@@ -39,7 +39,7 @@ def compute_class_weight(class_weight, classes, y_ind):
     elif class_weight == 'auto':
         le = LabelEncoder()
         # inversely proportional to the number of samples in the class
-        counts = bincount(le.fit_transform(y_ind), minlength=len(classes))
+        counts = bincount(le.fit_transform(y), minlength=len(classes))
         counts = np.maximum(counts, 1)
         weight = 1. / counts
         weight *= classes.shape[0] / np.sum(weight)

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -22,22 +22,24 @@ def compute_class_weight(class_weight, classes, y_ind):
         Array of the classes occurring in the data, as given by
         ``np.unique(y_org)`` with ``y_org`` the original class labels.
 
-    y_ind : array-like, shape=(n_samples,), dtype=int
-        Array of class indices per sample;
-        0 <= y_ind[i] < n_classes for i in range(n_samples).
+    y_ind : array-like, shape (n_samples,)
+        Array of original class labels per sample;
 
     Returns
     -------
-    class_weight_vect : ndarray, shape=(n_classes,)
+    class_weight_vect : ndarray, shape (n_classes,)
         Array with class_weight_vect[i] the weight for i-th class
         (as determined by sorting).
     """
+    from ..preprocessing import LabelEncoder
+
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'auto':
+        le = LabelEncoder()
         # inversely proportional to the number of samples in the class
-        counts = bincount(y_ind, minlength=len(classes))
+        counts = bincount(le.fit_transform(y_ind), minlength=len(classes))
         counts = np.maximum(counts, 1)
         weight = 1. / counts
         weight *= classes.shape[0] / np.sum(weight)

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -29,8 +29,8 @@ def compute_class_weight(class_weight, classes, y):
     -------
     class_weight_vect : ndarray, shape (n_classes,)
         Array with class_weight_vect[i] the weight for i-th class
-        (as determined by sorting).
     """
+    # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder
 
     if class_weight is None or len(class_weight) == 0:
@@ -38,16 +38,14 @@ def compute_class_weight(class_weight, classes, y):
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'auto':
         # Find the weight of each class as present in y.
-        y_classes = np.unique(y)
-        if not all(np.in1d(classes, y)):
+        le = LabelEncoder()
+        y_ind = le.fit_transform(y)
+        if not all(np.in1d(classes, le.classes_)):
             raise ValueError("classes should have valid labels that are in y")
 
-        le = LabelEncoder()
         # inversely proportional to the number of samples in the class
-        counts = bincount(le.fit_transform(y))
-        weighted_array = 1. / counts
-        weights = y_classes.shape[0] / np.sum(weighted_array)
-        weight = weighted_array[le.transform(classes)] * weights
+        recip_freq = 1. / bincount(y_ind)
+        weight = recip_freq[le.transform(classes)] / np.mean(recip_freq)
     else:
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -37,12 +37,17 @@ def compute_class_weight(class_weight, classes, y):
         # uniform class weights
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
     elif class_weight == 'auto':
+        # Find the weight of each class as present in y.
+        y_classes = np.unique(y)
+        if not all(np.in1d(classes, y)):
+            raise ValueError("classes should have valid labels that are in y")
+
         le = LabelEncoder()
         # inversely proportional to the number of samples in the class
-        counts = bincount(le.fit_transform(y), minlength=len(classes))
-        counts = np.maximum(counts, 1)
-        weight = 1. / counts
-        weight *= classes.shape[0] / np.sum(weight)
+        counts = bincount(le.fit_transform(y))
+        weighted_array = 1. / counts
+        weights = y_classes.shape[0] / np.sum(weighted_array)
+        weight = weighted_array[le.transform(classes)] * weights
     else:
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.fixes import unique
 
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
@@ -24,3 +25,13 @@ def test_compute_class_weight_not_present():
     assert_almost_equal(cw.sum(), classes.shape)
     assert_equal(len(cw), len(classes))
     assert_true(cw[0] < cw[1] < cw[2] <= cw[3])
+
+
+def test_compute_class_weight_auto_negative():
+    """Test compute_class_weight when labels are negative"""
+    classes = -np.arange(3)
+    y = np.asarray([-1, -1, 0, 0, -2, -2])
+    cw = compute_class_weight("auto", classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([1., 1., 1.]))

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -29,9 +29,17 @@ def test_compute_class_weight_not_present():
 
 def test_compute_class_weight_auto_negative():
     """Test compute_class_weight when labels are negative"""
+    # Test with balanced class labels.
     classes = -np.arange(3)
     y = np.asarray([-1, -1, 0, 0, -2, -2])
     cw = compute_class_weight("auto", classes, y)
     assert_almost_equal(cw.sum(), classes.shape)
     assert_equal(len(cw), len(classes))
     assert_array_almost_equal(cw, np.array([1., 1., 1.]))
+
+    # Test with unbalanced class labels.
+    y = np.asarray([-1, 0, 0, -2, -2, -2])
+    cw = compute_class_weight("auto", classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([0.545, 1.636, 0.818]), decimal=3)

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -5,32 +5,31 @@ from sklearn.utils.fixes import unique
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 
 
 def test_compute_class_weight():
     """Test (and demo) compute_class_weight."""
-    classes, y = unique(np.asarray([2, 2, 2, 3, 3, 4]), return_inverse=True)
+    y = np.asarray([2, 2, 2, 3, 3, 4])
+    classes = unique(y)
     cw = compute_class_weight("auto", classes, y)
     assert_almost_equal(cw.sum(), classes.shape)
     assert_true(cw[0] < cw[1] < cw[2])
 
 
 def test_compute_class_weight_not_present():
-    """Test compute_class_weight in case y doesn't contain all classes."""
+    """Raise error when y does not contain all class labels"""
     classes = np.arange(4)
     y = np.asarray([0, 0, 0, 1, 1, 2])
-    cw = compute_class_weight("auto", classes, y)
-    assert_almost_equal(cw.sum(), classes.shape)
-    assert_equal(len(cw), len(classes))
-    assert_true(cw[0] < cw[1] < cw[2] <= cw[3])
+    assert_raises(ValueError, compute_class_weight, "auto", classes, y)
 
 
 def test_compute_class_weight_auto_negative():
     """Test compute_class_weight when labels are negative"""
     # Test with balanced class labels.
-    classes = -np.arange(3)
+    classes = np.array([-2, -1, 0])
     y = np.asarray([-1, -1, 0, 0, -2, -2])
     cw = compute_class_weight("auto", classes, y)
     assert_almost_equal(cw.sum(), classes.shape)
@@ -43,3 +42,13 @@ def test_compute_class_weight_auto_negative():
     assert_almost_equal(cw.sum(), classes.shape)
     assert_equal(len(cw), len(classes))
     assert_array_almost_equal(cw, np.array([0.545, 1.636, 0.818]), decimal=3)
+
+
+def test_compute_class_weight_auto_unordered():
+    """Test compute_class_weight when classes are unordered"""
+    classes = np.array([1, 0, 3])
+    y = np.asarray([1, 0, 0, 3, 3, 3])
+    cw = compute_class_weight("auto", classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([1.636, 0.818, 0.545]), decimal=3)


### PR DESCRIPTION
Nothing great, I came across this bug, while playing with the class_weights option . I don't know if there is an issue already for this.

In master

```
 X = np.array([[-1.0, -1.0], [-1.0, 0], [-.8, -1.0], [1.0, 1.0]])
 y = np.array([1, 1, -1, -1])
 clfa = RidgeClassifier(class_weight='auto')
 clfa.fit(X, y)
 ValueError: object too deep for desired array
```

This fixes this.
