### PR TITLE
Fix citation in TfidfTransformer

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -933,9 +933,9 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     .. [Yates2011] `R. Baeza-Yates and B. Ribeiro-Neto (2011). Modern
                    Information Retrieval. Addison Wesley, pp. 68-74.`
 
-    .. [MSR2008] `C.D. Manning, H. Schuetze and P. Raghavan (2008).
+    .. [MRS2008] `C.D. Manning, P. Raghavan and H. Schuetze  (2008).
                    Introduction to Information Retrieval. Cambridge University
-                   Press, pp. 121-125.`
+                   Press, pp. 118-120.`
     """
 
     def __init__(self, norm='l2', use_idf=True, smooth_idf=True,


### PR DESCRIPTION
Corrected names order for tf-idf citation. Should be
C.D. Manning, P. Raghavan and H. Schuetze 
instead of
C.D. Manning, H. Schuetze and P. Raghavan

Corrected pages numbers. See: http://nlp.stanford.edu/IR-book/pdf/irbookprint.pdf
