### PR TITLE
[MRG] speed up RBM training with scipy.special.expit

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -14,7 +14,7 @@ from scipy import linalg
 from scipy.sparse import issparse
 from distutils.version import LooseVersion
 
-from . import check_random_state
+from . import check_random_state, deprecated
 from .fixes import qr_economic
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from ..externals.six.moves import xrange
@@ -565,6 +565,15 @@ def svd_flip(u, v):
     u *= signs
     v *= signs[:, np.newaxis]
     return u, v
+
+
+@deprecated('to be removed in 0.17; use scipy.special.expit or log_logistic')
+def logistic_sigmoid(X, log=False, out=None):
+    """Logistic function, ``1 / (1 + e ** (-x))``, or its log."""
+    from .fixes import expit
+    fn = log_logistic if log else expit
+    return fn(X, out)
+
 
 
 def log_logistic(X, out=None):

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -567,28 +567,21 @@ def svd_flip(u, v):
     return u, v
 
 
-def logistic_sigmoid(X, log=False, out=None):
-    """
-    Implements the logistic function, ``1 / (1 + e ** -x)`` and its log.
+def log_logistic(X, out=None):
+    """Compute the log of the logistic function, ``log(1 / (1 + e ** -x))``.
 
-    This implementation is more stable by splitting on positive and negative
-    values and computing::
+    This implementation is numerically stable because it splits positive and
+    negative values::
 
-        1 / (1 + exp(-x_i)) if x_i > 0
-        exp(x_i) / (1 + exp(x_i)) if x_i <= 0
-
-    The log is computed using::
-
-        -log(1 + exp(-x_i)) if x_i > 0
+        -log(1 + exp(-x_i))     if x_i > 0
         x_i - log(1 + exp(x_i)) if x_i <= 0
+
+    For the ordinary logistic function, use ``sklearn.utils.fixes.expit``.
 
     Parameters
     ----------
     X: array-like, shape (M, N)
         Argument to the logistic function
-
-    log: boolean, default: False
-        Whether to compute the logarithm of the logistic function.
 
     out: array-like, shape: (M, N), optional:
         Preallocated output array.
@@ -596,7 +589,7 @@ def logistic_sigmoid(X, log=False, out=None):
     Returns
     -------
     out: array, shape (M, N)
-        Value of the logistic function evaluated at every point in x
+        Log of the logistic function evaluated at every point in x
 
     Notes
     -----
@@ -611,15 +604,7 @@ def logistic_sigmoid(X, log=False, out=None):
     if out is None:
         out = np.empty_like(X)
 
-    if log:
-        _log_logistic_sigmoid(n_samples, n_features, X, out)
-    else:
-        # logistic(x) = (1 + tanh(x / 2)) / 2
-        out[:] = X
-        out *= .5
-        np.tanh(out, out)
-        out += 1
-        out *= .5
+    _log_logistic_sigmoid(n_samples, n_features, X, out)
 
     if is_1d:
         return np.squeeze(out)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -6,6 +6,7 @@ at which the fixe is no longer needed.
 # Authors: Emmanuelle Gouillart <emmanuelle.gouillart@normalesup.org>
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Fabian Pedregosa <fpedregosa@acm.org>
+#          Lars Buitinck
 #
 # License: BSD 3 clause
 
@@ -107,6 +108,27 @@ if np_version[:2] < (1, 4):
     logaddexp = _logaddexp
 else:
     logaddexp = np.logaddexp
+
+
+try:
+    from scipy.special import expit     # SciPy >= 0.10
+except ImportError:
+    def expit(x, out=None):
+        """Logistic sigmoid function, ``1 / (1 + exp(-x))``.
+
+        See sklearn.utils.extmath.log_logistic for the log of this function.
+        """
+        if out is None:
+            out = np.copy(x)
+
+        # 1 / (1 + exp(-x)) = (1 + tanh(x / 2)) / 2
+        # This way of computing the logistic is both fast and stable.
+        out *= .5
+        np.tanh(out, out)
+        out += 1
+        out *= .5
+
+        return out
 
 
 def _bincount(X, weights=None, minlength=None):

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -3,6 +3,8 @@
 #          Denis Engemann <d.engemann@fz-juelich.de>
 #
 # License: BSD 3 clause
+import warnings
+
 import numpy as np
 from scipy import sparse
 from scipy import linalg
@@ -22,7 +24,7 @@ from sklearn.utils.extmath import randomized_svd
 from sklearn.utils.extmath import row_norms
 from sklearn.utils.extmath import weighted_mode
 from sklearn.utils.extmath import cartesian
-from sklearn.utils.extmath import log_logistic
+from sklearn.utils.extmath import log_logistic, logistic_sigmoid
 from sklearn.utils.extmath import fast_dot, _fast_dot
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
@@ -273,9 +275,12 @@ def test_cartesian():
 
 def test_logistic_sigmoid():
     """Check correctness and robustness of logistic sigmoid implementation"""
-    naive_log_logistic = lambda x: np.log(1 / (1 + np.exp(-x)))
+    naive_logistic = lambda x: 1 / (1 + np.exp(-x))
+    naive_log_logistic = lambda x: np.log(naive_logistic(x))
 
     x = np.linspace(-2, 2, 50)
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(logistic_sigmoid(x), naive_logistic(x))
     assert_array_almost_equal(log_logistic(x), naive_log_logistic(x))
 
     extreme_x = np.array([-100., 100.])

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -22,7 +22,7 @@ from sklearn.utils.extmath import randomized_svd
 from sklearn.utils.extmath import row_norms
 from sklearn.utils.extmath import weighted_mode
 from sklearn.utils.extmath import cartesian
-from sklearn.utils.extmath import logistic_sigmoid
+from sklearn.utils.extmath import log_logistic
 from sklearn.utils.extmath import fast_dot, _fast_dot
 from sklearn.datasets.samples_generator import make_low_rank_matrix
 
@@ -273,32 +273,13 @@ def test_cartesian():
 
 def test_logistic_sigmoid():
     """Check correctness and robustness of logistic sigmoid implementation"""
-    naive_logsig = lambda x: 1 / (1 + np.exp(-x))
-    naive_log_logsig = lambda x: np.log(naive_logsig(x))
-
-    # Simulate the previous Cython implementations of logistic_sigmoid based on
-    #http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression
-    def stable_logsig(x):
-        out = np.zeros_like(x)
-        positive = x > 0
-        negative = x <= 0
-        out[positive] = 1. / (1 + np.exp(-x[positive]))
-        out[negative] = np.exp(x[negative]) / (1. + np.exp(x[negative]))
-        return out
+    naive_log_logistic = lambda x: np.log(1 / (1 + np.exp(-x)))
 
     x = np.linspace(-2, 2, 50)
-    assert_array_almost_equal(logistic_sigmoid(x), naive_logsig(x))
-    assert_array_almost_equal(logistic_sigmoid(x, log=True),
-                              naive_log_logsig(x))
-    assert_array_almost_equal(logistic_sigmoid(x), stable_logsig(x),
-                              decimal=16)
+    assert_array_almost_equal(log_logistic(x), naive_log_logistic(x))
 
-    extreme_x = np.array([-100, 100], dtype=np.float)
-    assert_array_almost_equal(logistic_sigmoid(extreme_x), [0, 1])
-    assert_array_almost_equal(logistic_sigmoid(extreme_x, log=True), [-100, 0])
-    assert_array_almost_equal(logistic_sigmoid(extreme_x),
-                              stable_logsig(extreme_x),
-                              decimal=16)
+    extreme_x = np.array([-100., 100.])
+    assert_array_almost_equal(log_logistic(extreme_x), [-100, 0])
 
 
 def test_fast_dot():

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -5,15 +5,25 @@
 import numpy as np
 
 from nose.tools import assert_equal
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 
-from ..fixes import _in1d, _copysign, divide
+from ..fixes import _in1d, _copysign, divide, expit
 
 
 def test_in1d():
     a = np.arange(10)
     b = a[a % 2 == 0]
     assert_equal(_in1d(a, b).sum(), 5)
+
+
+def test_expit():
+    """Check numerical stability of expit (logistic function)."""
+
+    # Simulate our previous Cython implementation, based on
+    #http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression
+    assert_almost_equal(expit(100.), 1. / (1. + np.exp(-100.)), decimal=16)
+    assert_almost_equal(expit(-100.), np.exp(-100.) / (1. + np.exp(-100.)),
+                        decimal=16)
 
 
 def test_divide():


### PR DESCRIPTION
SciPy 0.10 already has an implementation of the logistic function called `scipy.special.expit`. Moved our `logistic_sigmoid` to `fixes.expit`, keeping its log-of-logistic functionality as `log_logistic` (should that be `log_expit`? I don't like the name `expit` at all.)

Using this makes RBM training 12% faster, as measured by observing the time per iteration as reported by the `plot_rbm_logistic_classification.py` example, disregarding the first iteration as an outlier (it's consistently faster than the rest, not sure why). The speedup is in the `expit` function, not the inplace operations; those are there to make benchmarking easier, but they certainly won't hurt.
