### PR TITLE
FIX ValueError was not being raised

### DIFF
--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -233,10 +233,9 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
                 indptr.append(len(indices))
 
-            if len(indptr) == 0:
+            if len(indices) == 0:
                 raise ValueError("Sample sequence X is empty.")
-
-            if len(indices) > 0:
+            else:
                 # workaround for bug in older NumPy:
                 # http://projects.scipy.org/numpy/ticket/1943
                 indices = np.frombuffer(indices, dtype=np.intc)


### PR DESCRIPTION
len(indptr) is always greater that 0 because its initialized with non-empty list.
Because of that this branch is never taken and the ValueError never raised.

Aditionaly, (as VirgileFritsch) suggested the next "if" was subsumed in the "else" of the first.
