### PR TITLE
Sphinx formatting issue for Coclustering and Biclustering

### DIFF
--- a/sklearn/cluster/bicluster/spectral.py
+++ b/sklearn/cluster/bicluster/spectral.py
@@ -237,8 +237,8 @@ class SpectralCoclustering(BaseSpectral):
     Attributes
     ----------
     `rows_` : array-like, shape (n_row_clusters, n_rows)
-        Results of the clustering. `rows[i, r]` is True if cluster `i`
-        contains row `r`. Available only after calling ``fit``.
+        Results of the clustering. `rows[i, r]` is True if
+        cluster `i` contains row `r`. Available only after calling ``fit``.
 
     `columns_` : array-like, shape (n_column_clusters, n_columns)
         Results of the clustering, like `rows`.
@@ -365,8 +365,8 @@ class SpectralBiclustering(BaseSpectral):
     Attributes
     ----------
     `rows_` : array-like, shape (n_row_clusters, n_rows)
-        Results of the clustering. `rows[i, r]` is True if cluster `i`
-        contains row `r`. Available only after calling ``fit``.
+        Results of the clustering. `rows[i, r]` is True if
+        cluster `i` contains row `r`. Available only after calling ``fit``.
 
     `columns_` : array-like, shape (n_column_clusters, n_columns)
         Results of the clustering, like `rows`.


### PR DESCRIPTION
I'm not entirely sure why this solved the problem, but sphinx was failing if the second line was longer than the first line for the Attributes comment section. This should resolve Issue #2483
