### PR TITLE
[MRG] make hasattr(clf, "predict_proba") work with probabilities disabled

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -127,7 +127,7 @@ def _parallel_predict_proba(estimators, estimators_features, X, n_classes):
     proba = np.zeros((n_samples, n_classes))
 
     for estimator, features in zip(estimators, estimators_features):
-        try:
+        if hasattr(estimator, "predict_proba"):
             proba_estimator = estimator.predict_proba(X[:, features])
 
             if n_classes == len(estimator.classes_):
@@ -137,7 +137,7 @@ def _parallel_predict_proba(estimators, estimators_features, X, n_classes):
                 proba[:, estimator.classes_] += \
                     proba_estimator[:, range(len(estimator.classes_))]
 
-        except (AttributeError, NotImplementedError):
+        else:
             # Resort to voting
             predictions = estimator.predict(X[:, features])
 
@@ -463,11 +463,11 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
             mask = np.ones(n_samples, dtype=np.bool)
             mask[samples] = False
 
-            try:
+            if hasattr(estimator, "predict_proba"):
                 predictions[mask, :] += estimator.predict_proba(
                     (X[mask, :])[:, features])
 
-            except (AttributeError, NotImplementedError):
+            else:
                 p = estimator.predict((X[mask, :])[:, features])
                 j = 0
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -164,10 +164,7 @@ def check_regressors_classifiers_sparse_data(name, Estimator, X, y):
         estimator.fit(X, y)
         estimator.predict(X)
         if hasattr(estimator, 'predict_proba'):
-            try:
-                estimator.predict_proba(X)
-            except NotImplementedError:
-                pass
+            estimator.predict_proba(X)
     except TypeError as e:
         if not 'sparse' in repr(e):
             print("Estimator %s doesn't seem to fail gracefully on "
@@ -623,20 +620,16 @@ def check_classifiers_train(name, Classifier, X, y):
         except NotImplementedError:
             pass
     if hasattr(classifier, "predict_proba"):
-        try:
-            # predict_proba agrees with predict:
-            y_prob = classifier.predict_proba(X)
-            assert_equal(y_prob.shape, (n_samples, n_classes))
-            assert_array_equal(np.argmax(y_prob, axis=1), y_pred)
-            # check that probas for all classes sum to one
-            assert_array_almost_equal(
-                np.sum(y_prob, axis=1), np.ones(n_samples))
-            # raises error on malformed input
-            assert_raises(ValueError, classifier.predict_proba, X.T)
-            # raises error on malformed input for predict_proba
-            assert_raises(ValueError, classifier.predict_proba, X.T)
-        except NotImplementedError:
-            pass
+        # predict_proba agrees with predict:
+        y_prob = classifier.predict_proba(X)
+        assert_equal(y_prob.shape, (n_samples, n_classes))
+        assert_array_equal(np.argmax(y_prob, axis=1), y_pred)
+        # check that probas for all classes sum to one
+        assert_array_almost_equal(np.sum(y_prob, axis=1), np.ones(n_samples))
+        # raises error on malformed input
+        assert_raises(ValueError, classifier.predict_proba, X.T)
+        # raises error on malformed input for predict_proba
+        assert_raises(ValueError, classifier.predict_proba, X.T)
 
 
 def test_classifiers_classes():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -17,7 +17,7 @@ import scipy.sparse as sp
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_false, assert_true
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -644,3 +644,12 @@ def test_grid_search_with_multioutput_data():
                 correct_score = est.score(X[test], y[test])
                 assert_almost_equal(correct_score,
                                     cv_validation_scores[i])
+
+
+def test_predict_proba_disabled():
+    """Test predict_proba when disabled on estimator."""
+    X = np.arange(20).reshape(5, -1)
+    y = [0, 0, 1, 1, 1]
+    clf = SVC(probability=False)
+    gs = GridSearchCV(clf, {}, cv=2).fit(X, y)
+    assert_false(hasattr(gs, "predict_proba"))

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -146,6 +146,11 @@ def test_ovr_multilabel_predict_proba():
         decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
         assert_raises(AttributeError, decision_only.predict_proba, X_test)
 
+        # Estimator with predict_proba disabled, depending on parameters.
+        decision_only = OneVsRestClassifier(svm.SVC(probability=False))
+        decision_only.fit(X_train, Y_train)
+        assert_raises(AttributeError, decision_only.predict_proba, X_test)
+
         Y_pred = clf.predict(X_test)
         Y_proba = clf.predict_proba(X_test)
 


### PR DESCRIPTION
Here's a trick with `property` that @mblondel suggested earlier to make `hasattr(clf, "predict_proba")` work with `SVC(probability=False)` and `SGDClassifier(loss="hinge")`: models that define the method, but where it doesn't actually work.

This is a bit of a hack, so I don't suggest using it in new code (see comment in `SVC`), but it simplifies other code such as bagging and the smoke tests, i.e. it localizes the problem that these exceptional estimators have instead of spreading it across the codebase. There might be more places where the code can be simplified.

The documentation comes out almost right, despite the property:

![predict_proba](https://f.cloud.github.com/assets/335383/2287207/46037cde-9fea-11e3-9128-54e5df18e5ff.png)

(The "returns X" is there in `master` too, I'll change it in a minute.)

Ping @jnothman, @GaelVaroquaux, @agramfort, @ogrisel.
