### PR TITLE
[MRG+1] ENH Parallelize CountVectorizer

### DIFF
--- a/benchmarks/bench_vectorizer_parallel.py
+++ b/benchmarks/bench_vectorizer_parallel.py
@@ -1,5 +1,32 @@
 # Author: Aldrian Obaja <aldrian_math@yahoo.co.id>
 # License: BSD 3 clause
+#
+# Benchmark the performance of Parallel version of CountVectorizer
+#
+# This will run the test on Brown corpus, containing 500 docs and
+# 1,161,192 words.
+#
+# The result should be something like the following:
+#
+# $ python bench_vectorizer_parallel.py
+# Testing one-core... Done in 38.760s
+# Testing multi-core... Done in 22.352s
+# Testing one-core... Done in 22.559s
+# Testing multi-core... Done in 37.539s
+# Testing one-core... Done in 0.009s
+# Testing multi-core... Done in 0.138s
+# Testing one-core... Done in 0.025s
+# Testing multi-core... Done in 0.141s
+#
+# The first two do the benchmark on Brown corpus with heavy analyzer,
+# which include stemming.
+#
+# The next two do the benchmark on Brown corpus repeated 7 times with
+# light analyzer, which is the default when using analyzer='word'
+#
+# The next two do the benchmark on small dataset containing 35 docs
+#
+# The last two do the benchmark on small dataset containing 101 docs
 import time
 
 import os
@@ -7,10 +34,12 @@ import pylab as pl
 import nltk
 
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.utils import check_random_state
 
 import sys
+
+
 class Unbuffered():
+
     def __init__(self, stream):
         self.stream = stream
 
@@ -24,14 +53,21 @@ sys.stdout = Unbuffered(sys.stdout)
 
 stemmer = nltk.stem.porter.PorterStemmer()
 
+
 def filename_analyzer(filename):
-    with open(filename,'r') as infile:
-        return [stemmer.stem(word.lower()) for word in nltk.wordpunct_tokenize(infile.read())]
+    with open(filename, 'r') as infile:
+        return [stemmer.stem(word.lower())
+                for word in nltk.wordpunct_tokenize(infile.read())]
+
 
 def string_analyzer(content):
-    return [stemmer.stem(word.lower()) for word in nltk.wordpunct_tokenize(content)]
+    return [stemmer.stem(word.lower())
+            for word in nltk.wordpunct_tokenize(content)]
 
-def plot(Vectorizer, corpora, analyzers):
+
+def plot(Vectorizer, corpora, analyzers,
+         title='Parallel test at %s' % time.time(),
+         xlabel='X-axis'):
     one_core = []
     multi_core = []
 
@@ -43,26 +79,38 @@ def plot(Vectorizer, corpora, analyzers):
         one_core.append(time.time() - start)
         print 'Done in %.3fs' % one_core[-1]
 
-        vectorizer = Vectorizer(analyzer=analyzer, n_jobs=-1)
+        vectorizer = Vectorizer(analyzer=analyzer, n_jobs=2)
         print 'Testing multi-core...',
         start = time.time()
         vectorizer.fit_transform(corpus)
         multi_core.append(time.time() - start)
         print 'Done in %.3fs' % multi_core[-1]
 
-    pl.figure('scikit-learn parallel %s benchmark results' % Vectorizer.__name__)
-    pl.plot([0,1], one_core, label="one core")
-    pl.plot([0,1], multi_core, label="multi core")
-    pl.xlabel('With/Without file loading')
+    pl.figure(title)
+    pl.plot(range(len(corpora)), one_core, label="one core")
+    pl.plot(range(len(corpora)), multi_core, label="multi core")
+    pl.xlabel(xlabel)
     pl.ylabel('Time (s)')
     pl.title('Parallel %s' % Vectorizer.__name__)
     pl.legend()
 
-list_of_filenames = [os.path.join(nltk.corpus.brown.root,fileid) for fileid in nltk.corpus.brown.fileids()]
+list_of_filenames = [os.path.join(nltk.corpus.brown.root, fileid)
+                     for fileid in nltk.corpus.brown.fileids()]
 list_of_contents = []
 for filename in list_of_filenames:
-    with open(filename,'r') as infile:
+    with open(filename, 'r') as infile:
         list_of_contents.append(infile.read())
-plot(CountVectorizer, [list_of_filenames, list_of_contents], [filename_analyzer, string_analyzer])
+plot(CountVectorizer,
+     [list_of_filenames, list_of_contents * 7],
+     [filename_analyzer, 'word'],
+     title='CountVectorizer parallel benchmark on heavy/light analyzers',
+     xlabel='Heavy Analyzer (500 docs) - Light Analyzer (3500 docs)')
+
+plot(CountVectorizer,
+     [['This is a very small document'] * 35,
+         ['This is another small set of document'] * 101],
+     [string_analyzer, string_analyzer],
+     title='CountVectorizer parallel benchmark on small dataset',
+     xlabel='35 small documents - 101 small documents')
 
 pl.show()

--- a/benchmarks/bench_vectorizer_parallel.py
+++ b/benchmarks/bench_vectorizer_parallel.py
@@ -1,0 +1,68 @@
+# Author: Aldrian Obaja <aldrian_math@yahoo.co.id>
+# License: BSD 3 clause
+import time
+
+import os
+import pylab as pl
+import nltk
+
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.utils import check_random_state
+
+import sys
+class Unbuffered():
+    def __init__(self, stream):
+        self.stream = stream
+
+    def write(self, data):
+        self.stream.write(data)
+        self.stream.flush()
+
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)
+sys.stdout = Unbuffered(sys.stdout)
+
+stemmer = nltk.stem.porter.PorterStemmer()
+
+def filename_analyzer(filename):
+    with open(filename,'r') as infile:
+        return [stemmer.stem(word.lower()) for word in nltk.wordpunct_tokenize(infile.read())]
+
+def string_analyzer(content):
+    return [stemmer.stem(word.lower()) for word in nltk.wordpunct_tokenize(content)]
+
+def plot(Vectorizer, corpora, analyzers):
+    one_core = []
+    multi_core = []
+
+    for corpus, analyzer in zip(corpora, analyzers):
+        vectorizer = Vectorizer(analyzer=analyzer)
+        print 'Testing one-core...',
+        start = time.time()
+        vectorizer.fit_transform(corpus)
+        one_core.append(time.time() - start)
+        print 'Done in %.3fs' % one_core[-1]
+
+        vectorizer = Vectorizer(analyzer=analyzer, n_jobs=-1)
+        print 'Testing multi-core...',
+        start = time.time()
+        vectorizer.fit_transform(corpus)
+        multi_core.append(time.time() - start)
+        print 'Done in %.3fs' % multi_core[-1]
+
+    pl.figure('scikit-learn parallel %s benchmark results' % Vectorizer.__name__)
+    pl.plot([0,1], one_core, label="one core")
+    pl.plot([0,1], multi_core, label="multi core")
+    pl.xlabel('With/Without file loading')
+    pl.ylabel('Time (s)')
+    pl.title('Parallel %s' % Vectorizer.__name__)
+    pl.legend()
+
+list_of_filenames = [os.path.join(nltk.corpus.brown.root,fileid) for fileid in nltk.corpus.brown.fileids()]
+list_of_contents = []
+for filename in list_of_filenames:
+    with open(filename,'r') as infile:
+        list_of_contents.append(infile.read())
+plot(CountVectorizer, [list_of_filenames, list_of_contents], [filename_analyzer, string_analyzer])
+
+pl.show()

--- a/benchmarks/bench_vectorizer_parallel.py
+++ b/benchmarks/bench_vectorizer_parallel.py
@@ -38,19 +38,6 @@ from sklearn.feature_extraction.text import CountVectorizer
 import sys
 
 
-class Unbuffered(object):
-
-    def __init__(self, stream):
-        self.stream = stream
-
-    def write(self, data):
-        self.stream.write(data)
-        self.stream.flush()
-
-    def __getattr__(self, attr):
-        return getattr(self.stream, attr)
-sys.stdout = Unbuffered(sys.stdout)
-
 stemmer = nltk.stem.porter.PorterStemmer()
 
 
@@ -74,6 +61,7 @@ def plot(Vectorizer, corpora, analyzers,
     for corpus, analyzer in zip(corpora, analyzers):
         vectorizer = Vectorizer(analyzer=analyzer)
         print 'Testing one-core...',
+        sys.stdout.flush()
         start = time.time()
         vectorizer.fit_transform(corpus)
         one_core.append(time.time() - start)
@@ -81,6 +69,7 @@ def plot(Vectorizer, corpora, analyzers,
 
         vectorizer = Vectorizer(analyzer=analyzer, n_jobs=2)
         print 'Testing multi-core...',
+        sys.stdout.flush()
         start = time.time()
         vectorizer.fit_transform(corpus)
         multi_core.append(time.time() - start)

--- a/benchmarks/bench_vectorizer_parallel.py
+++ b/benchmarks/bench_vectorizer_parallel.py
@@ -38,7 +38,7 @@ from sklearn.feature_extraction.text import CountVectorizer
 import sys
 
 
-class Unbuffered():
+class Unbuffered(object):
 
     def __init__(self, stream):
         self.stream = stream

--- a/doc/datasets/mldata.rst
+++ b/doc/datasets/mldata.rst
@@ -3,6 +3,8 @@
 
     >>> import numpy as np
     >>> import os
+    >>> custom_data_home = os.path.join(os.environ['HOME'],
+    ...     'scikit_learn_data')
 
 .. _mldata:
 
@@ -35,7 +37,8 @@ specified by the ``data_home`` keyword argument, which defaults to
 ``~/scikit_learn_data/``::
 
   >>> os.listdir(os.path.join(custom_data_home, 'mldata'))
-  ['mnist-original.mat']
+  ... #doctest: +ELLIPSIS
+  [...'mnist-original.mat'...]
 
 Data sets in `mldata.org <http://mldata.org>`_ do not adhere to a strict
 naming or formatting convention. ``fetch_mldata`` is able to make sense

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -293,7 +293,7 @@ reasonable (please see  the :ref:`reference documentation
   CountVectorizer(analyzer=...'word', binary=False, charset=None,
           charset_error=None, decode_error=...'strict',
           dtype=<... 'numpy.int64'>, encoding=...'utf-8', input=...'content',
-          lowercase=True, max_df=1.0, max_features=None, min_df=1,
+          lowercase=True, max_df=1.0, max_features=None, min_df=1, n_jobs=1,
           ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=...'(?u)\\b\\w\\w+\\b',
           tokenizer=None, vocabulary=None)

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -293,7 +293,7 @@ reasonable (please see  the :ref:`reference documentation
   CountVectorizer(analyzer=...'word', binary=False, charset=None,
           charset_error=None, decode_error=...'strict',
           dtype=<... 'numpy.int64'>, encoding=...'utf-8', input=...'content',
-          lowercase=True, max_df=1.0, max_features=None, min_df=1, n_jobs=1,
+          lowercase=True, max_df=1.0, max_features=None, min_df=1,
           ngram_range=(1, 1), preprocessor=None, stop_words=None,
           strip_accents=None, token_pattern=...'(?u)\\b\\w\\w+\\b',
           tokenizer=None, vocabulary=None)

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -111,6 +111,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         # sort the feature names to define the mapping
         feature_names = sorted(feature_names)
         self.vocabulary_ = dict((f, i) for i, f in enumerate(feature_names))
+        if not self.vocabulary_:
+            raise ValueError('empty vocabulary; no feature was passed to fit')
         self.feature_names_ = feature_names
 
         return self

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -7,7 +7,8 @@ import scipy.sparse as sp
 
 from numpy.testing import assert_array_equal
 from sklearn.utils.testing import (assert_equal, assert_in,
-                                   assert_false, assert_true)
+                                   assert_false, assert_true,
+                                   assert_raise_message)
 
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.feature_selection import SelectKBest, chi2
@@ -83,10 +84,8 @@ def test_unseen_or_no_features():
             X = X.toarray()
         assert_array_equal(X, np.zeros((1, 2)))
 
-        try:
-            v.transform([])
-        except ValueError as e:
-            assert_in("empty", str(e))
+        if sparse:
+            assert_raise_message(ValueError, 'empty', v.transform, [])
 
 
 def test_deterministic_vocabulary():
@@ -106,14 +105,10 @@ def test_deterministic_vocabulary():
 
 def test_empty_vocabulary():
     d = DictVectorizer()
-    try:
-        d.fit([{}])
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
+    assert_raise_message(ValueError, 'empty vocabulary', d.fit, [{}])
+    assert_raise_message(ValueError, 'empty vocabulary', d.fit_transform, [{}])
 
-    try:
-        d.fit_transform([{}])
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
+if __name__ == '__main__':
+    for test in dir():
+        if test.startswith('test_'):
+            globals()[test]()

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -107,8 +107,3 @@ def test_empty_vocabulary():
     d = DictVectorizer()
     assert_raise_message(ValueError, 'empty vocabulary', d.fit, [{}])
     assert_raise_message(ValueError, 'empty vocabulary', d.fit_transform, [{}])
-
-if __name__ == '__main__':
-    for test in dir():
-        if test.startswith('test_'):
-            globals()[test]()

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -102,3 +102,18 @@ def test_deterministic_vocabulary():
     v_2 = DictVectorizer().fit([d_shuffled])
 
     assert_equal(v_1.vocabulary_, v_2.vocabulary_)
+
+
+def test_empty_vocabulary():
+    d = DictVectorizer()
+    try:
+        d.fit([{}])
+        assert False, "we shouldn't get here"
+    except ValueError as e:
+        assert_in("empty vocabulary", str(e).lower())
+
+    try:
+        d.fit_transform([{}])
+        assert False, "we shouldn't get here"
+    except ValueError as e:
+        assert_in("empty vocabulary", str(e).lower())

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -152,9 +152,58 @@ def test_word_analyzer_unigrams():
         assert_equal(wa(text), expected)
 
 
+def test_word_analyzer_unigram_multiprocess():
+    wa = CountVectorizer(strip_accents='ascii', n_jobs=-1).build_analyzer()
+    text = ("J'ai mang\xe9 du kangourou  ce midi, "
+            "c'\xe9tait pas tr\xeas bon.")
+    expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
+                'etait', 'pas', 'tres', 'bon']
+    assert_equal(wa(text), expected)
+
+    text = "This is a test, really.\n\n I met Harry yesterday."
+    expected = ['this', 'is', 'test', 'really', 'met', 'harry',
+                'yesterday']
+    assert_equal(wa(text), expected)
+
+    wa = CountVectorizer(input='file', n_jobs=-1).build_analyzer()
+    text = StringIO("This is a test with a file-like object!")
+    expected = ['this', 'is', 'test', 'with', 'file', 'like',
+                'object']
+    assert_equal(wa(text), expected)
+
+    # with custom preprocessor
+    wa = CountVectorizer(preprocessor=uppercase, n_jobs=-1).build_analyzer()
+    text = ("J'ai mang\xe9 du kangourou  ce midi, "
+            " c'\xe9tait pas tr\xeas bon.")
+    expected = ['AI', 'MANGE', 'DU', 'KANGOUROU', 'CE', 'MIDI',
+                'ETAIT', 'PAS', 'TRES', 'BON']
+    assert_equal(wa(text), expected)
+
+    # with custom tokenizer
+    wa = CountVectorizer(tokenizer=split_tokenize,
+                         strip_accents='ascii', n_jobs=-1).build_analyzer()
+    text = ("J'ai mang\xe9 du kangourou  ce midi, "
+            "c'\xe9tait pas tr\xeas bon.")
+    expected = ["j'ai", 'mange', 'du', 'kangourou', 'ce', 'midi,',
+                "c'etait", 'pas', 'tres', 'bon.']
+    assert_equal(wa(text), expected)
+
+
 def test_word_analyzer_unigrams_and_bigrams():
     wa = CountVectorizer(analyzer="word", strip_accents='unicode',
                          ngram_range=(1, 2)).build_analyzer()
+
+    text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
+    expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
+                'etait', 'pas', 'tres', 'bon', 'ai mange', 'mange du',
+                'du kangourou', 'kangourou ce', 'ce midi', 'midi etait',
+                'etait pas', 'pas tres', 'tres bon']
+    assert_equal(wa(text), expected)
+
+
+def test_word_analyzer_unigrams_and_bigrams_multiprocess():
+    wa = CountVectorizer(analyzer="word", strip_accents='unicode',
+                         ngram_range=(1, 2), n_jobs=-1).build_analyzer()
 
     text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
     expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
@@ -212,9 +261,51 @@ def test_char_ngram_analyzer():
     assert_equal(cnga(text)[:5], expected)
 
 
+def test_char_ngram_analyzer_multiprocess():
+    cnga = CountVectorizer(analyzer='char', strip_accents='unicode',
+                           ngram_range=(3, 6), n_jobs=-1).build_analyzer()
+
+    text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon"
+    expected = ["j'a", "'ai", 'ai ', 'i m', ' ma']
+    assert_equal(cnga(text)[:5], expected)
+    expected = ['s tres', ' tres ', 'tres b', 'res bo', 'es bon']
+    assert_equal(cnga(text)[-5:], expected)
+
+    text = "This \n\tis a test, really.\n\n I met Harry yesterday"
+    expected = ['thi', 'his', 'is ', 's i', ' is']
+    assert_equal(cnga(text)[:5], expected)
+
+    expected = [' yeste', 'yester', 'esterd', 'sterda', 'terday']
+    assert_equal(cnga(text)[-5:], expected)
+
+    cnga = CountVectorizer(input='file', analyzer='char',
+                           ngram_range=(3, 6)).build_analyzer()
+    text = StringIO("This is a test with a file-like object!")
+    expected = ['thi', 'his', 'is ', 's i', ' is']
+    assert_equal(cnga(text)[:5], expected)
+
+
 def test_char_wb_ngram_analyzer():
     cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
                            ngram_range=(3, 6)).build_analyzer()
+
+    text = "This \n\tis a test, really.\n\n I met Harry yesterday"
+    expected = [' th', 'thi', 'his', 'is ', ' thi']
+    assert_equal(cnga(text)[:5], expected)
+
+    expected = ['yester', 'esterd', 'sterda', 'terday', 'erday ']
+    assert_equal(cnga(text)[-5:], expected)
+
+    cnga = CountVectorizer(input='file', analyzer='char_wb',
+                           ngram_range=(3, 6)).build_analyzer()
+    text = StringIO("A test with a file-like object!")
+    expected = [' a ', ' te', 'tes', 'est', 'st ', ' tes']
+    assert_equal(cnga(text)[:6], expected)
+
+
+def test_char_wb_ngram_analyzer_multiprocess():
+    cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
+                           ngram_range=(3, 6), n_jobs=-1).build_analyzer()
 
     text = "This \n\tis a test, really.\n\n I met Harry yesterday"
     expected = [' th', 'thi', 'his', 'is ', ' thi']
@@ -247,6 +338,23 @@ def test_countvectorizer_custom_vocabulary():
         assert_equal(X.shape[1], len(terms))
 
 
+def test_countvectorizer_custom_vocabulary_multiprocess():
+    vocab = {"pizza": 0, "beer": 1}
+    terms = set(vocab.keys())
+
+    # Try a few of the supported types.
+    for typ in [dict, list, iter, partial(defaultdict, int)]:
+        v = typ(vocab)
+        vect = CountVectorizer(vocabulary=v, n_jobs=-1)
+        vect.fit(JUNK_FOOD_DOCS)
+        if isinstance(v, Mapping):
+            assert_equal(vect.vocabulary_, vocab)
+        else:
+            assert_equal(set(vect.vocabulary_), terms)
+        X = vect.transform(JUNK_FOOD_DOCS)
+        assert_equal(X.shape[1], len(terms))
+
+
 def test_countvectorizer_custom_vocabulary_pipeline():
     what_we_like = ["pizza", "beer"]
     pipe = Pipeline([
@@ -258,10 +366,29 @@ def test_countvectorizer_custom_vocabulary_pipeline():
     assert_equal(X.shape[1], len(what_we_like))
 
 
-def test_countvectorizer_custom_vocabulary_repeated_indeces():
+def test_countvectorizer_custom_vocabulary_pipeline_multiprocess():
+    what_we_like = ["pizza", "beer"]
+    pipe = Pipeline([
+        ('count', CountVectorizer(vocabulary=what_we_like, n_jobs=-1)),
+        ('tfidf', TfidfTransformer())])
+    X = pipe.fit_transform(ALL_FOOD_DOCS)
+    assert_equal(set(pipe.named_steps['count'].vocabulary_),
+                 set(what_we_like))
+    assert_equal(X.shape[1], len(what_we_like))
+
+
+def test_countvectorizer_custom_vocabulary_repeated_indices():
     vocab = {"pizza": 0, "beer": 0}
     try:
         CountVectorizer(vocabulary=vocab)
+    except ValueError as e:
+        assert_in("vocabulary contains repeated indices", str(e).lower())
+
+
+def test_countvectorizer_custom_vocabulary_repeated_indices_multiprocess():
+    vocab = {"pizza": 0, "beer": 0}
+    try:
+        CountVectorizer(vocabulary=vocab, n_jobs=-1)
     except ValueError as e:
         assert_in("vocabulary contains repeated indices", str(e).lower())
 
@@ -274,8 +401,29 @@ def test_countvectorizer_custom_vocabulary_gap_index():
         assert_in("doesn't contain index", str(e).lower())
 
 
+def test_countvectorizer_custom_vocabulary_gap_index_multiprocess():
+    vocab = {"pizza": 1, "beer": 2}
+    try:
+        CountVectorizer(vocabulary=vocab, n_jobs=-1)
+    except ValueError as e:
+        assert_in("doesn't contain index", str(e).lower())
+
+
 def test_countvectorizer_stop_words():
     cv = CountVectorizer()
+    cv.set_params(stop_words='english')
+    assert_equal(cv.get_stop_words(), ENGLISH_STOP_WORDS)
+    cv.set_params(stop_words='_bad_str_stop_')
+    assert_raises(ValueError, cv.get_stop_words)
+    cv.set_params(stop_words='_bad_unicode_stop_')
+    assert_raises(ValueError, cv.get_stop_words)
+    stoplist = ['some', 'other', 'words']
+    cv.set_params(stop_words=stoplist)
+    assert_equal(cv.get_stop_words(), stoplist)
+
+
+def test_countvectorizer_stop_words_multiprocess():
+    cv = CountVectorizer(n_jobs=-1)
     cv.set_params(stop_words='english')
     assert_equal(cv.get_stop_words(), ENGLISH_STOP_WORDS)
     cv.set_params(stop_words='_bad_str_stop_')
@@ -303,8 +451,31 @@ def test_countvectorizer_empty_vocabulary():
         assert_in("empty vocabulary", str(e).lower())
 
 
+def test_countvectorizer_empty_vocabulary_multiprocess():
+    try:
+        CountVectorizer(vocabulary=[], n_jobs=-1)
+        assert False, "we shouldn't get here"
+    except ValueError as e:
+        assert_in("empty vocabulary", str(e).lower())
+
+    try:
+        v = CountVectorizer(max_df=1.0, stop_words="english", n_jobs=-1)
+        # fit on stopwords only
+        v.fit(["to be or not to be", "and me too", "and so do you"])
+        assert False, "we shouldn't get here"
+    except ValueError as e:
+        assert_in("empty vocabulary", str(e).lower())
+
+
 def test_fit_countvectorizer_twice():
     cv = CountVectorizer()
+    X1 = cv.fit_transform(ALL_FOOD_DOCS[:5])
+    X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
+    assert_not_equal(X1.shape[1], X2.shape[1])
+
+
+def test_fit_countvectorizer_twice_multiprocess():
+    cv = CountVectorizer(n_jobs=-1)
     X1 = cv.fit_transform(ALL_FOOD_DOCS[:5])
     X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
     assert_not_equal(X1.shape[1], X2.shape[1])
@@ -348,6 +519,7 @@ def test_tfidf_no_smoothing():
          [1, 0, 0]]
     tr = TfidfTransformer(smooth_idf=False, norm='l2')
 
+    # First we need to verify that numpy here provides div 0 warnings
     with warnings.catch_warnings(record=True) as w:
         1. / np.array([0.])
         numpy_provides_div0_warning = len(w) == 1
@@ -473,6 +645,109 @@ def test_vectorizer():
     assert_raises(ValueError, v3.build_analyzer)
 
 
+def test_vectorizer_multiprocess():
+    # raw documents as an iterator
+    train_data = iter(ALL_FOOD_DOCS[:-1])
+    test_data = [ALL_FOOD_DOCS[-1]]
+    n_train = len(ALL_FOOD_DOCS) - 1
+
+    # test without vocabulary
+    v1 = CountVectorizer(max_df=0.5, n_jobs=-1)
+    counts_train = v1.fit_transform(train_data)
+    if hasattr(counts_train, 'tocsr'):
+        counts_train = counts_train.tocsr()
+    assert_equal(counts_train[0, v1.vocabulary_["pizza"]], 2)
+
+    # build a vectorizer v1 with the same vocabulary as the one fitted by v1
+    v2 = CountVectorizer(vocabulary=v1.vocabulary_, n_jobs=-1)
+
+    # compare that the two vectorizer give the same output on the test sample
+    for v in (v1, v2):
+        counts_test = v.transform(test_data)
+        if hasattr(counts_test, 'tocsr'):
+            counts_test = counts_test.tocsr()
+
+        vocabulary = v.vocabulary_
+        assert_equal(counts_test[0, vocabulary["salad"]], 1)
+        assert_equal(counts_test[0, vocabulary["tomato"]], 1)
+        assert_equal(counts_test[0, vocabulary["water"]], 1)
+
+        # stop word from the fixed list
+        assert_false("the" in vocabulary)
+
+        # stop word found automatically by the vectorizer DF thresholding
+        # words that are high frequent across the complete corpus are likely
+        # to be not informative (either real stop words of extraction
+        # artifacts)
+        assert_false("copyright" in vocabulary)
+
+        # not present in the sample
+        assert_equal(counts_test[0, vocabulary["coke"]], 0)
+        assert_equal(counts_test[0, vocabulary["burger"]], 0)
+        assert_equal(counts_test[0, vocabulary["beer"]], 0)
+        assert_equal(counts_test[0, vocabulary["pizza"]], 0)
+
+    # test tf-idf
+    t1 = TfidfTransformer(norm='l1')
+    tfidf = t1.fit(counts_train).transform(counts_train).toarray()
+    assert_equal(len(t1.idf_), len(v1.vocabulary_))
+    assert_equal(tfidf.shape, (n_train, len(v1.vocabulary_)))
+
+    # test tf-idf with new data
+    tfidf_test = t1.transform(counts_test).toarray()
+    assert_equal(tfidf_test.shape, (len(test_data), len(v1.vocabulary_)))
+
+    # test tf alone
+    t2 = TfidfTransformer(norm='l1', use_idf=False)
+    tf = t2.fit(counts_train).transform(counts_train).toarray()
+    assert_equal(t2.idf_, None)
+
+    # test idf transform with unlearned idf vector
+    t3 = TfidfTransformer(use_idf=True)
+    assert_raises(ValueError, t3.transform, counts_train)
+
+    # test idf transform with incompatible n_features
+    X = [[1, 1, 5],
+         [1, 1, 0]]
+    t3.fit(X)
+    X_incompt = [[1, 3],
+                 [1, 3]]
+    assert_raises(ValueError, t3.transform, X_incompt)
+
+    # L1-normalized term frequencies sum to one
+    assert_array_almost_equal(np.sum(tf, axis=1), [1.0] * n_train)
+
+    # test the direct tfidf vectorizer
+    # (equivalent to term count vectorizer + tfidf transformer)
+    train_data = iter(ALL_FOOD_DOCS[:-1])
+    tv = TfidfVectorizer(norm='l1', n_jobs=-1)
+    assert_false(tv.fixed_vocabulary)
+
+    tv.max_df = v1.max_df
+    tfidf2 = tv.fit_transform(train_data).toarray()
+    assert_array_almost_equal(tfidf, tfidf2)
+
+    # test the direct tfidf vectorizer with new data
+    tfidf_test2 = tv.transform(test_data).toarray()
+    assert_array_almost_equal(tfidf_test, tfidf_test2)
+
+    # test transform on unfitted vectorizer with empty vocabulary
+    v3 = CountVectorizer(vocabulary=None, n_jobs=-1)
+    assert_raises(ValueError, v3.transform, train_data)
+
+    # ascii preprocessor?
+    v3.set_params(strip_accents='ascii', lowercase=False)
+    assert_equal(v3.build_preprocessor(), strip_accents_ascii)
+
+    # error on bad strip_accents param
+    v3.set_params(strip_accents='_gabbledegook_', preprocessor=None)
+    assert_raises(ValueError, v3.build_preprocessor)
+
+    # error with bad analyzer type
+    v3.set_params = '_invalid_analyzer_type_'
+    assert_raises(ValueError, v3.build_analyzer)
+
+
 def test_tfidf_vectorizer_setters():
     tv = TfidfVectorizer(norm='l2', use_idf=False, smooth_idf=False,
                          sublinear_tf=False)
@@ -544,6 +819,26 @@ def test_feature_names():
         assert_equal(idx, cv.vocabulary_.get(name))
 
 
+def test_feature_names_multiprocess():
+    cv = CountVectorizer(max_df=0.5, n_jobs=-1)
+
+    # test for Value error on unfitted/empty vocabulary
+    assert_raises(ValueError, cv.get_feature_names)
+
+    X = cv.fit_transform(ALL_FOOD_DOCS)
+    n_samples, n_features = X.shape
+    assert_equal(len(cv.vocabulary_), n_features)
+
+    feature_names = cv.get_feature_names()
+    assert_equal(len(feature_names), n_features)
+    assert_array_equal(['beer', 'burger', 'celeri', 'coke', 'pizza',
+                        'salad', 'sparkling', 'tomato', 'water'],
+                       feature_names)
+
+    for idx, name in enumerate(feature_names):
+        assert_equal(idx, cv.vocabulary_.get(name))
+
+
 def test_vectorizer_max_features():
     vec_factories = (
         CountVectorizer,
@@ -562,12 +857,56 @@ def test_vectorizer_max_features():
         assert_equal(vectorizer.stop_words_, expected_stop_words)
 
 
+def test_vectorizer_max_features_multiprocess():
+    vec_factories = (
+        CountVectorizer,
+        TfidfVectorizer,
+    )
+
+    expected_vocabulary = set(['burger', 'beer', 'salad', 'pizza'])
+    expected_stop_words = set([u'celeri', u'tomato', u'copyright', u'coke',
+                               u'sparkling', u'water', u'the'])
+
+    for vec_factory in vec_factories:
+        # test bounded number of extracted features
+        vectorizer = vec_factory(max_df=0.6, max_features=4, n_jobs=-1)
+        vectorizer.fit(ALL_FOOD_DOCS)
+        assert_equal(set(vectorizer.vocabulary_), expected_vocabulary)
+        assert_equal(vectorizer.stop_words_, expected_stop_words)
+
+
 def test_count_vectorizer_max_features():
     """Regression test: max_features didn't work correctly in 0.14."""
 
     cv_1 = CountVectorizer(max_features=1)
     cv_3 = CountVectorizer(max_features=3)
     cv_None = CountVectorizer(max_features=None)
+
+    counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+
+    features_1 = cv_1.get_feature_names()
+    features_3 = cv_3.get_feature_names()
+    features_None = cv_None.get_feature_names()
+
+    # The most common feature is "the", with frequency 7.
+    assert_equal(7, counts_1.max())
+    assert_equal(7, counts_3.max())
+    assert_equal(7, counts_None.max())
+
+    # The most common feature should be the same
+    assert_equal("the", features_1[np.argmax(counts_1)])
+    assert_equal("the", features_3[np.argmax(counts_3)])
+    assert_equal("the", features_None[np.argmax(counts_None)])
+
+
+def test_count_vectorizer_max_features_multiprocess():
+    """Regression test: max_features didn't work correctly in 0.14."""
+
+    cv_1 = CountVectorizer(max_features=1, n_jobs=-1)
+    cv_3 = CountVectorizer(max_features=3, n_jobs=-1)
+    cv_None = CountVectorizer(max_features=None, n_jobs=-1)
 
     counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
     counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
@@ -611,6 +950,29 @@ def test_vectorizer_max_df():
     assert_equal(len(vect.stop_words_), 2)
 
 
+def test_vectorizer_max_df_multiprocess():
+    test_data = ['abc', 'dea', 'eat']
+    vect = CountVectorizer(analyzer='char', max_df=1.0, n_jobs=-1)
+    vect.fit(test_data)
+    assert_true('a' in vect.vocabulary_.keys())
+    assert_equal(len(vect.vocabulary_.keys()), 6)
+    assert_equal(len(vect.stop_words_), 0)
+
+    vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
+    vect.fit(test_data)
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_true('a' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 2)
+
+    vect.max_df = 1
+    vect.fit(test_data)
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_true('a' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 2)
+
+
 def test_vectorizer_min_df():
     test_data = ['abc', 'dea', 'eat']
     vect = CountVectorizer(analyzer='char', min_df=1)
@@ -632,6 +994,29 @@ def test_vectorizer_min_df():
     assert_equal(len(vect.vocabulary_.keys()), 1)    # {a} remains
     assert_true('c' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 5)
+
+
+def test_vectorizer_min_df_multiprocess():
+    test_data = ['abc', 'dea', 'eat']  # the letter a occurs in both strings
+    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1, n_jobs=-1)
+    vect.fit(test_data)
+    assert_true('a' in vect.vocabulary_.keys())
+    assert_equal(len(vect.vocabulary_.keys()), 6)
+    assert_equal(len(vect.stop_words_), 0)
+
+    vect.min_df = 2
+    vect.fit(test_data)
+    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
+    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+    assert_true('c' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 4)
+
+    vect.min_df = .5
+    vect.fit(test_data)
+    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
+    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
+    assert_true('c' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 4)
 
 
 def test_count_binary_occurrences():
@@ -701,6 +1086,25 @@ def test_vectorizer_inverse_transform():
             assert_array_equal(np.sort(terms), np.sort(terms2))
 
 
+def test_vectorizer_inverse_transform_multiprocess():
+    # raw documents
+    data = ALL_FOOD_DOCS
+    for vectorizer in (TfidfVectorizer(n_jobs=-1), CountVectorizer(n_jobs=-1)):
+        transformed_data = vectorizer.fit_transform(data)
+        inversed_data = vectorizer.inverse_transform(transformed_data)
+        analyze = vectorizer.build_analyzer()
+        for doc, inversed_terms in zip(data, inversed_data):
+            terms = np.sort(np.unique(analyze(doc)))
+            inversed_terms = np.sort(np.unique(inversed_terms))
+            assert_array_equal(terms, inversed_terms)
+
+        # Test that inverse_transform also works with numpy arrays
+        transformed_data = transformed_data.toarray()
+        inversed_data2 = vectorizer.inverse_transform(transformed_data)
+        for terms, terms2 in zip(inversed_data, inversed_data2):
+            assert_array_equal(np.sort(terms), np.sort(terms2))
+
+
 def test_count_vectorizer_pipeline_grid_selection():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
@@ -715,6 +1119,44 @@ def test_count_vectorizer_pipeline_grid_selection():
     y_test = np.array([y[0], y[-1]])
 
     pipeline = Pipeline([('vect', CountVectorizer()),
+                         ('svc', LinearSVC())])
+
+    parameters = {
+        'vect__ngram_range': [(1, 1), (1, 2)],
+        'svc__loss': ('l1', 'l2')
+    }
+
+    # find the best parameters for both the feature extraction and the
+    # classifier
+    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
+
+    # cross-validation doesn't work if the length of the data is not known,
+    # hence use lists instead of iterators
+    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
+    assert_array_equal(pred, y_test)
+
+    # on this toy dataset bigram representation which is used in the last of
+    # the grid_search is considered the best estimator since they all converge
+    # to 100% accuracy models
+    assert_equal(grid_search.best_score_, 1.0)
+    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
+    assert_equal(best_vectorizer.ngram_range, (1, 1))
+
+
+def test_count_vectorizer_pipeline_grid_selection_multiprocess():
+    # raw documents
+    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
+    # simulate iterables
+    train_data = iter(data[1:-1])
+    test_data = iter([data[0], data[-1]])
+
+    # label junk food as -1, the others as +1
+    y = np.ones(len(data))
+    y[:6] = -1
+    y_train = y[1:-1]
+    y_test = np.array([y[0], y[-1]])
+
+    pipeline = Pipeline([('vect', CountVectorizer(n_jobs=-1)),
                          ('svc', LinearSVC())])
 
     parameters = {
@@ -780,6 +1222,47 @@ def test_vectorizer_pipeline_grid_selection():
     assert_false(best_vectorizer.fixed_vocabulary)
 
 
+def test_vectorizer_pipeline_grid_selection_multiprocess():
+    # raw documents
+    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
+    # simulate iterables
+    train_data = iter(data[1:-1])
+    test_data = iter([data[0], data[-1]])
+
+    # label junk food as -1, the others as +1
+    y = np.ones(len(data))
+    y[:6] = -1
+    y_train = y[1:-1]
+    y_test = np.array([y[0], y[-1]])
+
+    pipeline = Pipeline([('vect', TfidfVectorizer(n_jobs=-1)),
+                         ('svc', LinearSVC())])
+
+    parameters = {
+        'vect__ngram_range': [(1, 1), (1, 2)],
+        'vect__norm': ('l1', 'l2'),
+        'svc__loss': ('l1', 'l2'),
+    }
+
+    # find the best parameters for both the feature extraction and the
+    # classifier
+    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
+
+    # cross-validation doesn't work if the length of the data is not known,
+    # hence use lists instead of iterators
+    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
+    assert_array_equal(pred, y_test)
+
+    # on this toy dataset bigram representation which is used in the last of
+    # the grid_search is considered the best estimator since they all converge
+    # to 100% accuracy models
+    assert_equal(grid_search.best_score_, 1.0)
+    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
+    assert_equal(best_vectorizer.ngram_range, (1, 1))
+    assert_equal(best_vectorizer.norm, 'l2')
+    assert_false(best_vectorizer.fixed_vocabulary)
+
+
 def test_vectorizer_unicode():
     # tests that the count vectorizer works with cyrillic.
     document = (
@@ -815,6 +1298,41 @@ def test_vectorizer_unicode():
     assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
 
 
+def test_vectorizer_unicode_multiprocess():
+    # tests that the count vectorizer works with cyrillic.
+    document = (
+        "\xd0\x9c\xd0\xb0\xd1\x88\xd0\xb8\xd0\xbd\xd0\xbd\xd0\xbe\xd0"
+        "\xb5 \xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0"
+        "\xb5 \xe2\x80\x94 \xd0\xbe\xd0\xb1\xd1\x88\xd0\xb8\xd1\x80\xd0\xbd"
+        "\xd1\x8b\xd0\xb9 \xd0\xbf\xd0\xbe\xd0\xb4\xd1\x80\xd0\xb0\xd0\xb7"
+        "\xd0\xb4\xd0\xb5\xd0\xbb \xd0\xb8\xd1\x81\xd0\xba\xd1\x83\xd1\x81"
+        "\xd1\x81\xd1\x82\xd0\xb2\xd0\xb5\xd0\xbd\xd0\xbd\xd0\xbe\xd0\xb3"
+        "\xd0\xbe \xd0\xb8\xd0\xbd\xd1\x82\xd0\xb5\xd0\xbb\xd0\xbb\xd0"
+        "\xb5\xd0\xba\xd1\x82\xd0\xb0, \xd0\xb8\xd0\xb7\xd1\x83\xd1\x87"
+        "\xd0\xb0\xd1\x8e\xd1\x89\xd0\xb8\xd0\xb9 \xd0\xbc\xd0\xb5\xd1\x82"
+        "\xd0\xbe\xd0\xb4\xd1\x8b \xd0\xbf\xd0\xbe\xd1\x81\xd1\x82\xd1\x80"
+        "\xd0\xbe\xd0\xb5\xd0\xbd\xd0\xb8\xd1\x8f \xd0\xb0\xd0\xbb\xd0\xb3"
+        "\xd0\xbe\xd1\x80\xd0\xb8\xd1\x82\xd0\xbc\xd0\xbe\xd0\xb2, \xd1\x81"
+        "\xd0\xbf\xd0\xbe\xd1\x81\xd0\xbe\xd0\xb1\xd0\xbd\xd1\x8b\xd1\x85 "
+        "\xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb0\xd1\x82\xd1\x8c\xd1\x81\xd1"
+        "\x8f.")
+
+    vect = CountVectorizer(n_jobs=-1)
+    X_counted = vect.fit_transform([document])
+    assert_equal(X_counted.shape, (1, 15))
+
+    vect = HashingVectorizer(norm=None, non_negative=True)
+    X_hashed = vect.transform([document])
+    assert_equal(X_hashed.shape, (1, 2 ** 20))
+
+    # No collisions on such a small dataset
+    assert_equal(X_counted.nnz, X_hashed.nnz)
+
+    # When norm is None and non_negative, the tokens are counted up to
+    # collisions
+    assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
+
+
 def test_tfidf_vectorizer_with_fixed_vocabulary():
     # non regression smoke test for inheritance issues
     vocabulary = ['pizza', 'celeri']
@@ -833,6 +1351,7 @@ def test_pickling_vectorizer():
         HashingVectorizer(binary=True),
         HashingVectorizer(ngram_range=(1, 2)),
         CountVectorizer(),
+        CountVectorizer(n_jobs=-1),
         CountVectorizer(preprocessor=strip_tags),
         CountVectorizer(analyzer=lazy_analyze),
         CountVectorizer(preprocessor=strip_tags).fit(JUNK_FOOD_DOCS),

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -409,8 +409,6 @@ def _test_vectorizer(n):
     # test without vocabulary
     v1 = CountVectorizer(max_df=0.5, n_jobs=n)
     counts_train = v1.fit_transform(train_data)
-    if hasattr(counts_train, 'tocsr'):
-        counts_train = counts_train.tocsr()
     assert_equal(counts_train[0, v1.vocabulary_["pizza"]], 2)
 
     # build a vectorizer v1 with the same vocabulary as the one fitted by v1
@@ -419,8 +417,6 @@ def _test_vectorizer(n):
     # compare that the two vectorizer give the same output on the test sample
     for v in (v1, v2):
         counts_test = v.transform(test_data)
-        if hasattr(counts_test, 'tocsr'):
-            counts_test = counts_test.tocsr()
 
         vocabulary = v.vocabulary_
         assert_equal(counts_test[0, vocabulary["salad"]], 1)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -28,7 +28,7 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_raises
 from sklearn.utils.testing import (assert_in, assert_less, assert_greater,
-                                   assert_warns_message)
+                                   assert_warns_message, assert_raise_message)
 
 from collections import defaultdict, Mapping
 from functools import partial
@@ -230,164 +230,113 @@ def test_char_wb_ngram_analyzer():
     assert_equal(cnga(text)[:6], expected)
 
 
+def _test_countvectorizer_custom_vocabulary(n):
+    vocab = {"pizza": 0, "beer": 1}
+    terms = set(vocab.keys())
+
+    # Try a few of the supported types.
+    for typ in [dict, list, iter, partial(defaultdict, int)]:
+        v = typ(vocab)
+        vect = CountVectorizer(vocabulary=v, n_jobs=n)
+        vect.fit(JUNK_FOOD_DOCS)
+        if isinstance(v, Mapping):
+            assert_equal(vect.vocabulary_, vocab)
+        else:
+            assert_equal(set(vect.vocabulary_), terms)
+        X = vect.transform(JUNK_FOOD_DOCS)
+        assert_equal(X.shape[1], len(terms))
+
+
 def test_countvectorizer_custom_vocabulary():
-    vocab = {"pizza": 0, "beer": 1}
-    terms = set(vocab.keys())
-
-    # Try a few of the supported types.
-    for typ in [dict, list, iter, partial(defaultdict, int)]:
-        v = typ(vocab)
-        vect = CountVectorizer(vocabulary=v)
-        vect.fit(JUNK_FOOD_DOCS)
-        if isinstance(v, Mapping):
-            assert_equal(vect.vocabulary_, vocab)
-        else:
-            assert_equal(set(vect.vocabulary_), terms)
-        X = vect.transform(JUNK_FOOD_DOCS)
-        assert_equal(X.shape[1], len(terms))
+    _test_countvectorizer_custom_vocabulary(1)
+    _test_countvectorizer_custom_vocabulary(2)
 
 
-def test_countvectorizer_custom_vocabulary_multiprocess():
-    vocab = {"pizza": 0, "beer": 1}
-    terms = set(vocab.keys())
-
-    # Try a few of the supported types.
-    for typ in [dict, list, iter, partial(defaultdict, int)]:
-        v = typ(vocab)
-        vect = CountVectorizer(vocabulary=v, n_jobs=2)
-        vect.fit(JUNK_FOOD_DOCS)
-        if isinstance(v, Mapping):
-            assert_equal(vect.vocabulary_, vocab)
-        else:
-            assert_equal(set(vect.vocabulary_), terms)
-        X = vect.transform(JUNK_FOOD_DOCS)
-        assert_equal(X.shape[1], len(terms))
+def _test_countvectorizer_custom_vocabulary_pipeline(n):
+    what_we_like = ["pizza", "beer"]
+    pipe = Pipeline([
+        ('count', CountVectorizer(vocabulary=what_we_like, n_jobs=n)),
+        ('tfidf', TfidfTransformer())])
+    X = pipe.fit_transform(ALL_FOOD_DOCS)
+    assert_equal(set(pipe.named_steps['count'].vocabulary_),
+                 set(what_we_like))
+    assert_equal(X.shape[1], len(what_we_like))
 
 
 def test_countvectorizer_custom_vocabulary_pipeline():
-    what_we_like = ["pizza", "beer"]
-    pipe = Pipeline([
-        ('count', CountVectorizer(vocabulary=what_we_like)),
-        ('tfidf', TfidfTransformer())])
-    X = pipe.fit_transform(ALL_FOOD_DOCS)
-    assert_equal(set(pipe.named_steps['count'].vocabulary_),
-                 set(what_we_like))
-    assert_equal(X.shape[1], len(what_we_like))
+    _test_countvectorizer_custom_vocabulary_pipeline(1)
+    _test_countvectorizer_custom_vocabulary_pipeline(2)
 
 
-def test_countvectorizer_custom_vocabulary_pipeline_multiprocess():
-    what_we_like = ["pizza", "beer"]
-    pipe = Pipeline([
-        ('count', CountVectorizer(vocabulary=what_we_like, n_jobs=2)),
-        ('tfidf', TfidfTransformer())])
-    X = pipe.fit_transform(ALL_FOOD_DOCS)
-    assert_equal(set(pipe.named_steps['count'].vocabulary_),
-                 set(what_we_like))
-    assert_equal(X.shape[1], len(what_we_like))
+def _test_countvectorizer_custom_vocabulary_repeated_indices(n):
+    vocab = {"pizza": 0, "beer": 0}
+    try:
+        CountVectorizer(vocabulary=vocab, n_jobs=n)
+    except ValueError as e:
+        assert_in("vocabulary contains repeated indices", str(e).lower())
 
 
 def test_countvectorizer_custom_vocabulary_repeated_indices():
-    vocab = {"pizza": 0, "beer": 0}
-    try:
-        CountVectorizer(vocabulary=vocab)
-    except ValueError as e:
-        assert_in("vocabulary contains repeated indices", str(e).lower())
+    _test_countvectorizer_custom_vocabulary_repeated_indices(1)
+    _test_countvectorizer_custom_vocabulary_repeated_indices(2)
 
 
-def test_countvectorizer_custom_vocabulary_repeated_indices_multiprocess():
-    vocab = {"pizza": 0, "beer": 0}
+def _test_countvectorizer_custom_vocabulary_gap_index(n):
+    vocab = {"pizza": 1, "beer": 2}
     try:
-        CountVectorizer(vocabulary=vocab, n_jobs=2)
+        CountVectorizer(vocabulary=vocab, n_jobs=n)
     except ValueError as e:
-        assert_in("vocabulary contains repeated indices", str(e).lower())
+        assert_in("doesn't contain index", str(e).lower())
 
 
 def test_countvectorizer_custom_vocabulary_gap_index():
-    vocab = {"pizza": 1, "beer": 2}
-    try:
-        CountVectorizer(vocabulary=vocab)
-    except ValueError as e:
-        assert_in("doesn't contain index", str(e).lower())
+    _test_countvectorizer_custom_vocabulary_gap_index(1)
+    _test_countvectorizer_custom_vocabulary_gap_index(2)
 
 
-def test_countvectorizer_custom_vocabulary_gap_index_multiprocess():
-    vocab = {"pizza": 1, "beer": 2}
-    try:
-        CountVectorizer(vocabulary=vocab, n_jobs=2)
-    except ValueError as e:
-        assert_in("doesn't contain index", str(e).lower())
+def _test_countvectorizer_stop_words(n):
+    cv = CountVectorizer(n_jobs=n)
+    cv.set_params(stop_words='english')
+    assert_equal(cv.get_stop_words(), ENGLISH_STOP_WORDS)
+    cv.set_params(stop_words='_bad_str_stop_')
+    assert_raises(ValueError, cv.get_stop_words)
+    cv.set_params(stop_words='_bad_unicode_stop_')
+    assert_raises(ValueError, cv.get_stop_words)
+    stoplist = ['some', 'other', 'words']
+    cv.set_params(stop_words=stoplist)
+    assert_equal(cv.get_stop_words(), stoplist)
 
 
 def test_countvectorizer_stop_words():
-    cv = CountVectorizer()
-    cv.set_params(stop_words='english')
-    assert_equal(cv.get_stop_words(), ENGLISH_STOP_WORDS)
-    cv.set_params(stop_words='_bad_str_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
-    cv.set_params(stop_words='_bad_unicode_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
-    stoplist = ['some', 'other', 'words']
-    cv.set_params(stop_words=stoplist)
-    assert_equal(cv.get_stop_words(), stoplist)
+    _test_countvectorizer_stop_words(1)
+    _test_countvectorizer_stop_words(2)
 
 
-def test_countvectorizer_stop_words_multiprocess():
-    cv = CountVectorizer(n_jobs=2)
-    cv.set_params(stop_words='english')
-    assert_equal(cv.get_stop_words(), ENGLISH_STOP_WORDS)
-    cv.set_params(stop_words='_bad_str_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
-    cv.set_params(stop_words='_bad_unicode_stop_')
-    assert_raises(ValueError, cv.get_stop_words)
-    stoplist = ['some', 'other', 'words']
-    cv.set_params(stop_words=stoplist)
-    assert_equal(cv.get_stop_words(), stoplist)
+def _test_countvectorizer_empty_vocabulary(n):
+    assert_raise_message(ValueError, 'empty vocabulary',
+                         CountVectorizer, vocabulary=[], n_jobs=n)
+    v = CountVectorizer(max_df=1.0, stop_words='english', n_jobs=n)
+    assert_raise_message(ValueError, 'empty vocabulary',
+                         v.fit, ['to be or not to be',
+                                 'and me too',
+                                 'and so do you'])
 
 
 def test_countvectorizer_empty_vocabulary():
-    try:
-        CountVectorizer(vocabulary=[])
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
-
-    try:
-        v = CountVectorizer(max_df=1.0, stop_words="english")
-        # fit on stopwords only
-        v.fit(["to be or not to be", "and me too", "and so do you"])
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
+    _test_countvectorizer_empty_vocabulary(1)
+    _test_countvectorizer_empty_vocabulary(2)
 
 
-def test_countvectorizer_empty_vocabulary_multiprocess():
-    try:
-        CountVectorizer(vocabulary=[], n_jobs=2)
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
-
-    try:
-        v = CountVectorizer(max_df=1.0, stop_words="english", n_jobs=2)
-        # fit on stopwords only
-        v.fit(["to be or not to be", "and me too", "and so do you"])
-        assert False, "we shouldn't get here"
-    except ValueError as e:
-        assert_in("empty vocabulary", str(e).lower())
+def _test_fit_countvectorizer_twice(n):
+    cv = CountVectorizer(n_jobs=n)
+    X1 = cv.fit_transform(ALL_FOOD_DOCS[:5])
+    X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
+    assert_not_equal(X1.shape[1], X2.shape[1])
 
 
 def test_fit_countvectorizer_twice():
-    cv = CountVectorizer()
-    X1 = cv.fit_transform(ALL_FOOD_DOCS[:5])
-    X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
-    assert_not_equal(X1.shape[1], X2.shape[1])
-
-
-def test_fit_countvectorizer_twice_multiprocess():
-    cv = CountVectorizer(n_jobs=2)
-    X1 = cv.fit_transform(ALL_FOOD_DOCS[:5])
-    X2 = cv.fit_transform(ALL_FOOD_DOCS[5:])
-    assert_not_equal(X1.shape[1], X2.shape[1])
+    _test_fit_countvectorizer_twice(1)
+    _test_fit_countvectorizer_twice(2)
 
 
 def test_tf_idf_smoothing():
@@ -451,21 +400,21 @@ def test_sublinear_tf():
     assert_less(tfidf[2], 3)
 
 
-def test_vectorizer():
+def _test_vectorizer(n):
     # raw documents as an iterator
     train_data = iter(ALL_FOOD_DOCS[:-1])
     test_data = [ALL_FOOD_DOCS[-1]]
     n_train = len(ALL_FOOD_DOCS) - 1
 
     # test without vocabulary
-    v1 = CountVectorizer(max_df=0.5)
+    v1 = CountVectorizer(max_df=0.5, n_jobs=n)
     counts_train = v1.fit_transform(train_data)
     if hasattr(counts_train, 'tocsr'):
         counts_train = counts_train.tocsr()
     assert_equal(counts_train[0, v1.vocabulary_["pizza"]], 2)
 
     # build a vectorizer v1 with the same vocabulary as the one fitted by v1
-    v2 = CountVectorizer(vocabulary=v1.vocabulary_)
+    v2 = CountVectorizer(vocabulary=v1.vocabulary_, n_jobs=n)
 
     # compare that the two vectorizer give the same output on the test sample
     for v in (v1, v2):
@@ -538,7 +487,7 @@ def test_vectorizer():
     assert_array_almost_equal(tfidf_test, tfidf_test2)
 
     # test transform on unfitted vectorizer with empty vocabulary
-    v3 = CountVectorizer(vocabulary=None)
+    v3 = CountVectorizer(vocabulary=None, n_jobs=n)
     assert_raises(ValueError, v3.transform, train_data)
 
     # ascii preprocessor?
@@ -554,107 +503,9 @@ def test_vectorizer():
     assert_raises(ValueError, v3.build_analyzer)
 
 
-def test_vectorizer_multiprocess():
-    # raw documents as an iterator
-    train_data = iter(ALL_FOOD_DOCS[:-1])
-    test_data = [ALL_FOOD_DOCS[-1]]
-    n_train = len(ALL_FOOD_DOCS) - 1
-
-    # test without vocabulary
-    v1 = CountVectorizer(max_df=0.5, n_jobs=2)
-    counts_train = v1.fit_transform(train_data)
-    if hasattr(counts_train, 'tocsr'):
-        counts_train = counts_train.tocsr()
-    assert_equal(counts_train[0, v1.vocabulary_["pizza"]], 2)
-
-    # build a vectorizer v1 with the same vocabulary as the one fitted by v1
-    v2 = CountVectorizer(vocabulary=v1.vocabulary_, n_jobs=2)
-
-    # compare that the two vectorizer give the same output on the test sample
-    for v in (v1, v2):
-        counts_test = v.transform(test_data)
-        if hasattr(counts_test, 'tocsr'):
-            counts_test = counts_test.tocsr()
-
-        vocabulary = v.vocabulary_
-        assert_equal(counts_test[0, vocabulary["salad"]], 1)
-        assert_equal(counts_test[0, vocabulary["tomato"]], 1)
-        assert_equal(counts_test[0, vocabulary["water"]], 1)
-
-        # stop word from the fixed list
-        assert_false("the" in vocabulary)
-
-        # stop word found automatically by the vectorizer DF thresholding
-        # words that are high frequent across the complete corpus are likely
-        # to be not informative (either real stop words of extraction
-        # artifacts)
-        assert_false("copyright" in vocabulary)
-
-        # not present in the sample
-        assert_equal(counts_test[0, vocabulary["coke"]], 0)
-        assert_equal(counts_test[0, vocabulary["burger"]], 0)
-        assert_equal(counts_test[0, vocabulary["beer"]], 0)
-        assert_equal(counts_test[0, vocabulary["pizza"]], 0)
-
-    # test tf-idf
-    t1 = TfidfTransformer(norm='l1')
-    tfidf = t1.fit(counts_train).transform(counts_train).toarray()
-    assert_equal(len(t1.idf_), len(v1.vocabulary_))
-    assert_equal(tfidf.shape, (n_train, len(v1.vocabulary_)))
-
-    # test tf-idf with new data
-    tfidf_test = t1.transform(counts_test).toarray()
-    assert_equal(tfidf_test.shape, (len(test_data), len(v1.vocabulary_)))
-
-    # test tf alone
-    t2 = TfidfTransformer(norm='l1', use_idf=False)
-    tf = t2.fit(counts_train).transform(counts_train).toarray()
-    assert_equal(t2.idf_, None)
-
-    # test idf transform with unlearned idf vector
-    t3 = TfidfTransformer(use_idf=True)
-    assert_raises(ValueError, t3.transform, counts_train)
-
-    # test idf transform with incompatible n_features
-    X = [[1, 1, 5],
-         [1, 1, 0]]
-    t3.fit(X)
-    X_incompt = [[1, 3],
-                 [1, 3]]
-    assert_raises(ValueError, t3.transform, X_incompt)
-
-    # L1-normalized term frequencies sum to one
-    assert_array_almost_equal(np.sum(tf, axis=1), [1.0] * n_train)
-
-    # test the direct tfidf vectorizer
-    # (equivalent to term count vectorizer + tfidf transformer)
-    train_data = iter(ALL_FOOD_DOCS[:-1])
-    tv = TfidfVectorizer(norm='l1', n_jobs=2)
-    assert_false(tv.fixed_vocabulary)
-
-    tv.max_df = v1.max_df
-    tfidf2 = tv.fit_transform(train_data).toarray()
-    assert_array_almost_equal(tfidf, tfidf2)
-
-    # test the direct tfidf vectorizer with new data
-    tfidf_test2 = tv.transform(test_data).toarray()
-    assert_array_almost_equal(tfidf_test, tfidf_test2)
-
-    # test transform on unfitted vectorizer with empty vocabulary
-    v3 = CountVectorizer(vocabulary=None, n_jobs=2)
-    assert_raises(ValueError, v3.transform, train_data)
-
-    # ascii preprocessor?
-    v3.set_params(strip_accents='ascii', lowercase=False)
-    assert_equal(v3.build_preprocessor(), strip_accents_ascii)
-
-    # error on bad strip_accents param
-    v3.set_params(strip_accents='_gabbledegook_', preprocessor=None)
-    assert_raises(ValueError, v3.build_preprocessor)
-
-    # error with bad analyzer type
-    v3.set_params = '_invalid_analyzer_type_'
-    assert_raises(ValueError, v3.build_analyzer)
+def test_vectorizer():
+    _test_vectorizer(1)
+    _test_vectorizer(2)
 
 
 def test_tfidf_vectorizer_setters():
@@ -708,183 +559,116 @@ def test_hashing_vectorizer():
         assert_almost_equal(np.linalg.norm(X[0].data, 1), 1.0)
 
 
+def _test_feature_names(n):
+    cv = CountVectorizer(max_df=0.5, n_jobs=n)
+
+    # test for Value error on unfitted/empty vocabulary
+    assert_raises(ValueError, cv.get_feature_names)
+
+    X = cv.fit_transform(ALL_FOOD_DOCS)
+    n_samples, n_features = X.shape
+    assert_equal(len(cv.vocabulary_), n_features)
+
+    feature_names = cv.get_feature_names()
+    assert_equal(len(feature_names), n_features)
+    assert_array_equal(['beer', 'burger', 'celeri', 'coke', 'pizza',
+                        'salad', 'sparkling', 'tomato', 'water'],
+                       feature_names)
+
+    for idx, name in enumerate(feature_names):
+        assert_equal(idx, cv.vocabulary_.get(name))
+
+
 def test_feature_names():
-    cv = CountVectorizer(max_df=0.5)
-
-    # test for Value error on unfitted/empty vocabulary
-    assert_raises(ValueError, cv.get_feature_names)
-
-    X = cv.fit_transform(ALL_FOOD_DOCS)
-    n_samples, n_features = X.shape
-    assert_equal(len(cv.vocabulary_), n_features)
-
-    feature_names = cv.get_feature_names()
-    assert_equal(len(feature_names), n_features)
-    assert_array_equal(['beer', 'burger', 'celeri', 'coke', 'pizza',
-                        'salad', 'sparkling', 'tomato', 'water'],
-                       feature_names)
-
-    for idx, name in enumerate(feature_names):
-        assert_equal(idx, cv.vocabulary_.get(name))
+    _test_feature_names(1)
+    _test_feature_names(2)
 
 
-def test_feature_names_multiprocess():
-    cv = CountVectorizer(max_df=0.5, n_jobs=2)
+def _test_vectorizer_max_features(n):
+    vec_factories = (
+        CountVectorizer,
+        TfidfVectorizer,
+    )
 
-    # test for Value error on unfitted/empty vocabulary
-    assert_raises(ValueError, cv.get_feature_names)
+    expected_vocabulary = set(['burger', 'beer', 'salad', 'pizza'])
+    expected_stop_words = set([u'celeri', u'tomato', u'copyright', u'coke',
+                               u'sparkling', u'water', u'the'])
 
-    X = cv.fit_transform(ALL_FOOD_DOCS)
-    n_samples, n_features = X.shape
-    assert_equal(len(cv.vocabulary_), n_features)
-
-    feature_names = cv.get_feature_names()
-    assert_equal(len(feature_names), n_features)
-    assert_array_equal(['beer', 'burger', 'celeri', 'coke', 'pizza',
-                        'salad', 'sparkling', 'tomato', 'water'],
-                       feature_names)
-
-    for idx, name in enumerate(feature_names):
-        assert_equal(idx, cv.vocabulary_.get(name))
+    for vec_factory in vec_factories:
+        # test bounded number of extracted features
+        vectorizer = vec_factory(max_df=0.6, max_features=4, n_jobs=n)
+        vectorizer.fit(ALL_FOOD_DOCS)
+        assert_equal(set(vectorizer.vocabulary_), expected_vocabulary)
+        assert_equal(vectorizer.stop_words_, expected_stop_words)
 
 
 def test_vectorizer_max_features():
-    vec_factories = (
-        CountVectorizer,
-        TfidfVectorizer,
-    )
-
-    expected_vocabulary = set(['burger', 'beer', 'salad', 'pizza'])
-    expected_stop_words = set([u'celeri', u'tomato', u'copyright', u'coke',
-                               u'sparkling', u'water', u'the'])
-
-    for vec_factory in vec_factories:
-        # test bounded number of extracted features
-        vectorizer = vec_factory(max_df=0.6, max_features=4)
-        vectorizer.fit(ALL_FOOD_DOCS)
-        assert_equal(set(vectorizer.vocabulary_), expected_vocabulary)
-        assert_equal(vectorizer.stop_words_, expected_stop_words)
+    _test_vectorizer_max_features(1)
+    _test_vectorizer_max_features(2)
 
 
-def test_vectorizer_max_features_multiprocess():
-    vec_factories = (
-        CountVectorizer,
-        TfidfVectorizer,
-    )
+def _test_count_vectorizer_max_features(n):
+    """Regression test: max_features didn't work correctly in 0.14."""
 
-    expected_vocabulary = set(['burger', 'beer', 'salad', 'pizza'])
-    expected_stop_words = set([u'celeri', u'tomato', u'copyright', u'coke',
-                               u'sparkling', u'water', u'the'])
+    cv_1 = CountVectorizer(max_features=1, n_jobs=n)
+    cv_3 = CountVectorizer(max_features=3, n_jobs=n)
+    cv_None = CountVectorizer(max_features=None, n_jobs=n)
 
-    for vec_factory in vec_factories:
-        # test bounded number of extracted features
-        vectorizer = vec_factory(max_df=0.6, max_features=4, n_jobs=2)
-        vectorizer.fit(ALL_FOOD_DOCS)
-        assert_equal(set(vectorizer.vocabulary_), expected_vocabulary)
-        assert_equal(vectorizer.stop_words_, expected_stop_words)
+    counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
+
+    features_1 = cv_1.get_feature_names()
+    features_3 = cv_3.get_feature_names()
+    features_None = cv_None.get_feature_names()
+
+    # The most common feature is "the", with frequency 7.
+    assert_equal(7, counts_1.max())
+    assert_equal(7, counts_3.max())
+    assert_equal(7, counts_None.max())
+
+    # The most common feature should be the same
+    assert_equal("the", features_1[np.argmax(counts_1)])
+    assert_equal("the", features_3[np.argmax(counts_3)])
+    assert_equal("the", features_None[np.argmax(counts_None)])
 
 
 def test_count_vectorizer_max_features():
-    """Regression test: max_features didn't work correctly in 0.14."""
-
-    cv_1 = CountVectorizer(max_features=1)
-    cv_3 = CountVectorizer(max_features=3)
-    cv_None = CountVectorizer(max_features=None)
-
-    counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-    counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-
-    features_1 = cv_1.get_feature_names()
-    features_3 = cv_3.get_feature_names()
-    features_None = cv_None.get_feature_names()
-
-    # The most common feature is "the", with frequency 7.
-    assert_equal(7, counts_1.max())
-    assert_equal(7, counts_3.max())
-    assert_equal(7, counts_None.max())
-
-    # The most common feature should be the same
-    assert_equal("the", features_1[np.argmax(counts_1)])
-    assert_equal("the", features_3[np.argmax(counts_3)])
-    assert_equal("the", features_None[np.argmax(counts_None)])
+    _test_count_vectorizer_max_features(1)
+    _test_count_vectorizer_max_features(2)
 
 
-def test_count_vectorizer_max_features_multiprocess():
-    """Regression test: max_features didn't work correctly in 0.14."""
+def _test_vectorizer_max_df(n):
+    test_data = ['abc', 'dea', 'eat']
+    vect = CountVectorizer(analyzer='char', max_df=1.0, n_jobs=n)
+    vect.fit(test_data)
+    assert_true('a' in vect.vocabulary_.keys())
+    assert_equal(len(vect.vocabulary_.keys()), 6)
+    assert_equal(len(vect.stop_words_), 0)
 
-    cv_1 = CountVectorizer(max_features=1, n_jobs=2)
-    cv_3 = CountVectorizer(max_features=3, n_jobs=2)
-    cv_None = CountVectorizer(max_features=None, n_jobs=2)
+    vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
+    vect.fit(test_data)
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_true('a' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 2)
 
-    counts_1 = cv_1.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-    counts_3 = cv_3.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-    counts_None = cv_None.fit_transform(JUNK_FOOD_DOCS).sum(axis=0)
-
-    features_1 = cv_1.get_feature_names()
-    features_3 = cv_3.get_feature_names()
-    features_None = cv_None.get_feature_names()
-
-    # The most common feature is "the", with frequency 7.
-    assert_equal(7, counts_1.max())
-    assert_equal(7, counts_3.max())
-    assert_equal(7, counts_None.max())
-
-    # The most common feature should be the same
-    assert_equal("the", features_1[np.argmax(counts_1)])
-    assert_equal("the", features_3[np.argmax(counts_3)])
-    assert_equal("the", features_None[np.argmax(counts_None)])
+    vect.max_df = 1
+    vect.fit(test_data)
+    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
+    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_true('a' in vect.stop_words_)
+    assert_equal(len(vect.stop_words_), 2)
 
 
 def test_vectorizer_max_df():
+    _test_vectorizer_max_df(1)
+    _test_vectorizer_max_df(2)
+
+
+def _test_vectorizer_min_df(n):
     test_data = ['abc', 'dea', 'eat']
-    vect = CountVectorizer(analyzer='char', max_df=1.0)
-    vect.fit(test_data)
-    assert_true('a' in vect.vocabulary_.keys())
-    assert_equal(len(vect.vocabulary_.keys()), 6)
-    assert_equal(len(vect.stop_words_), 0)
-
-    vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
-    vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
-    assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 2)
-
-    vect.max_df = 1
-    vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
-    assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 2)
-
-
-def test_vectorizer_max_df_multiprocess():
-    test_data = ['abc', 'dea', 'eat']
-    vect = CountVectorizer(analyzer='char', max_df=1.0, n_jobs=2)
-    vect.fit(test_data)
-    assert_true('a' in vect.vocabulary_.keys())
-    assert_equal(len(vect.vocabulary_.keys()), 6)
-    assert_equal(len(vect.stop_words_), 0)
-
-    vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
-    vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
-    assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 2)
-
-    vect.max_df = 1
-    vect.fit(test_data)
-    assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
-    assert_true('a' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 2)
-
-
-def test_vectorizer_min_df():
-    test_data = ['abc', 'dea', 'eat']
-    vect = CountVectorizer(analyzer='char', min_df=1)
+    vect = CountVectorizer(analyzer='char', min_df=1, n_jobs=n)
     vect.fit(test_data)
     assert_true('a' in vect.vocabulary_.keys())
     assert_equal(len(vect.vocabulary_.keys()), 6)
@@ -905,27 +689,9 @@ def test_vectorizer_min_df():
     assert_equal(len(vect.stop_words_), 5)
 
 
-def test_vectorizer_min_df_multiprocess():
-    test_data = ['abc', 'dea', 'eat']  # the letter a occurs in both strings
-    vect = CountVectorizer(analyzer='char', max_df=1.0, min_df=1, n_jobs=2)
-    vect.fit(test_data)
-    assert_true('a' in vect.vocabulary_.keys())
-    assert_equal(len(vect.vocabulary_.keys()), 6)
-    assert_equal(len(vect.stop_words_), 0)
-
-    vect.min_df = 2
-    vect.fit(test_data)
-    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
-    assert_true('c' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 4)
-
-    vect.min_df = .5
-    vect.fit(test_data)
-    assert_true('c' not in vect.vocabulary_.keys())  # 'c' is ignored
-    assert_equal(len(vect.vocabulary_.keys()), 2)  # only e, a remain
-    assert_true('c' in vect.stop_words_)
-    assert_equal(len(vect.stop_words_), 4)
+def test_vectorizer_min_df():
+    _test_vectorizer_min_df(1)
+    _test_vectorizer_min_df(2)
 
 
 def test_count_binary_occurrences():
@@ -976,118 +742,71 @@ def test_hashed_binary_occurrences():
     assert_equal(X.dtype, np.float64)
 
 
+def _test_vectorizer_inverse_transform(n):
+    # raw documents
+    data = ALL_FOOD_DOCS
+    for vectorizer in (TfidfVectorizer(), CountVectorizer(n_jobs=n)):
+        transformed_data = vectorizer.fit_transform(data)
+        inversed_data = vectorizer.inverse_transform(transformed_data)
+        analyze = vectorizer.build_analyzer()
+        for doc, inversed_terms in zip(data, inversed_data):
+            terms = np.sort(np.unique(analyze(doc)))
+            inversed_terms = np.sort(np.unique(inversed_terms))
+            assert_array_equal(terms, inversed_terms)
+
+        # Test that inverse_transform also works with numpy arrays
+        transformed_data = transformed_data.toarray()
+        inversed_data2 = vectorizer.inverse_transform(transformed_data)
+        for terms, terms2 in zip(inversed_data, inversed_data2):
+            assert_array_equal(np.sort(terms), np.sort(terms2))
+
+
 def test_vectorizer_inverse_transform():
+    _test_vectorizer_inverse_transform(1)
+    _test_vectorizer_inverse_transform(2)
+
+
+def _test_count_vectorizer_pipeline_grid_selection(n):
     # raw documents
-    data = ALL_FOOD_DOCS
-    for vectorizer in (TfidfVectorizer(), CountVectorizer()):
-        transformed_data = vectorizer.fit_transform(data)
-        inversed_data = vectorizer.inverse_transform(transformed_data)
-        analyze = vectorizer.build_analyzer()
-        for doc, inversed_terms in zip(data, inversed_data):
-            terms = np.sort(np.unique(analyze(doc)))
-            inversed_terms = np.sort(np.unique(inversed_terms))
-            assert_array_equal(terms, inversed_terms)
+    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
+    # simulate iterables
+    train_data = iter(data[1:-1])
+    test_data = iter([data[0], data[-1]])
 
-        # Test that inverse_transform also works with numpy arrays
-        transformed_data = transformed_data.toarray()
-        inversed_data2 = vectorizer.inverse_transform(transformed_data)
-        for terms, terms2 in zip(inversed_data, inversed_data2):
-            assert_array_equal(np.sort(terms), np.sort(terms2))
+    # label junk food as -1, the others as +1
+    y = np.ones(len(data))
+    y[:6] = -1
+    y_train = y[1:-1]
+    y_test = np.array([y[0], y[-1]])
 
+    pipeline = Pipeline([('vect', CountVectorizer(n_jobs=n)),
+                         ('svc', LinearSVC())])
 
-def test_vectorizer_inverse_transform_multiprocess():
-    # raw documents
-    data = ALL_FOOD_DOCS
-    for vectorizer in (TfidfVectorizer(n_jobs=2), CountVectorizer(n_jobs=2)):
-        transformed_data = vectorizer.fit_transform(data)
-        inversed_data = vectorizer.inverse_transform(transformed_data)
-        analyze = vectorizer.build_analyzer()
-        for doc, inversed_terms in zip(data, inversed_data):
-            terms = np.sort(np.unique(analyze(doc)))
-            inversed_terms = np.sort(np.unique(inversed_terms))
-            assert_array_equal(terms, inversed_terms)
+    parameters = {
+        'vect__ngram_range': [(1, 1), (1, 2)],
+        'svc__loss': ('l1', 'l2')
+    }
 
-        # Test that inverse_transform also works with numpy arrays
-        transformed_data = transformed_data.toarray()
-        inversed_data2 = vectorizer.inverse_transform(transformed_data)
-        for terms, terms2 in zip(inversed_data, inversed_data2):
-            assert_array_equal(np.sort(terms), np.sort(terms2))
+    # find the best parameters for both the feature extraction and the
+    # classifier
+    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
+
+    # cross-validation doesn't work if the length of the data is not known,
+    # hence use lists instead of iterators
+    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
+    assert_array_equal(pred, y_test)
+
+    # on this toy dataset bigram representation which is used in the last of
+    # the grid_search is considered the best estimator since they all converge
+    # to 100% accuracy models
+    assert_equal(grid_search.best_score_, 1.0)
+    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
+    assert_equal(best_vectorizer.ngram_range, (1, 1))
 
 
 def test_count_vectorizer_pipeline_grid_selection():
-    # raw documents
-    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
-    # simulate iterables
-    train_data = iter(data[1:-1])
-    test_data = iter([data[0], data[-1]])
-
-    # label junk food as -1, the others as +1
-    y = np.ones(len(data))
-    y[:6] = -1
-    y_train = y[1:-1]
-    y_test = np.array([y[0], y[-1]])
-
-    pipeline = Pipeline([('vect', CountVectorizer()),
-                         ('svc', LinearSVC())])
-
-    parameters = {
-        'vect__ngram_range': [(1, 1), (1, 2)],
-        'svc__loss': ('l1', 'l2')
-    }
-
-    # find the best parameters for both the feature extraction and the
-    # classifier
-    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
-
-    # cross-validation doesn't work if the length of the data is not known,
-    # hence use lists instead of iterators
-    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
-    assert_array_equal(pred, y_test)
-
-    # on this toy dataset bigram representation which is used in the last of
-    # the grid_search is considered the best estimator since they all converge
-    # to 100% accuracy models
-    assert_equal(grid_search.best_score_, 1.0)
-    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
-    assert_equal(best_vectorizer.ngram_range, (1, 1))
-
-
-def test_count_vectorizer_pipeline_grid_selection_multiprocess():
-    # raw documents
-    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
-    # simulate iterables
-    train_data = iter(data[1:-1])
-    test_data = iter([data[0], data[-1]])
-
-    # label junk food as -1, the others as +1
-    y = np.ones(len(data))
-    y[:6] = -1
-    y_train = y[1:-1]
-    y_test = np.array([y[0], y[-1]])
-
-    pipeline = Pipeline([('vect', CountVectorizer(n_jobs=2)),
-                         ('svc', LinearSVC())])
-
-    parameters = {
-        'vect__ngram_range': [(1, 1), (1, 2)],
-        'svc__loss': ('l1', 'l2')
-    }
-
-    # find the best parameters for both the feature extraction and the
-    # classifier
-    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
-
-    # cross-validation doesn't work if the length of the data is not known,
-    # hence use lists instead of iterators
-    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
-    assert_array_equal(pred, y_test)
-
-    # on this toy dataset bigram representation which is used in the last of
-    # the grid_search is considered the best estimator since they all converge
-    # to 100% accuracy models
-    assert_equal(grid_search.best_score_, 1.0)
-    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
-    assert_equal(best_vectorizer.ngram_range, (1, 1))
+    _test_count_vectorizer_pipeline_grid_selection(1)
+    _test_count_vectorizer_pipeline_grid_selection(2)
 
 
 def test_vectorizer_pipeline_grid_selection():
@@ -1131,115 +850,44 @@ def test_vectorizer_pipeline_grid_selection():
     assert_false(best_vectorizer.fixed_vocabulary)
 
 
-def test_vectorizer_pipeline_grid_selection_multiprocess():
-    # raw documents
-    data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
-    # simulate iterables
-    train_data = iter(data[1:-1])
-    test_data = iter([data[0], data[-1]])
+def _test_vectorizer_unicode(n):
+    # tests that the count vectorizer works with cyrillic.
+    document = (
+        "\xd0\x9c\xd0\xb0\xd1\x88\xd0\xb8\xd0\xbd\xd0\xbd\xd0\xbe\xd0"
+        "\xb5 \xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0"
+        "\xb5 \xe2\x80\x94 \xd0\xbe\xd0\xb1\xd1\x88\xd0\xb8\xd1\x80\xd0\xbd"
+        "\xd1\x8b\xd0\xb9 \xd0\xbf\xd0\xbe\xd0\xb4\xd1\x80\xd0\xb0\xd0\xb7"
+        "\xd0\xb4\xd0\xb5\xd0\xbb \xd0\xb8\xd1\x81\xd0\xba\xd1\x83\xd1\x81"
+        "\xd1\x81\xd1\x82\xd0\xb2\xd0\xb5\xd0\xbd\xd0\xbd\xd0\xbe\xd0\xb3"
+        "\xd0\xbe \xd0\xb8\xd0\xbd\xd1\x82\xd0\xb5\xd0\xbb\xd0\xbb\xd0"
+        "\xb5\xd0\xba\xd1\x82\xd0\xb0, \xd0\xb8\xd0\xb7\xd1\x83\xd1\x87"
+        "\xd0\xb0\xd1\x8e\xd1\x89\xd0\xb8\xd0\xb9 \xd0\xbc\xd0\xb5\xd1\x82"
+        "\xd0\xbe\xd0\xb4\xd1\x8b \xd0\xbf\xd0\xbe\xd1\x81\xd1\x82\xd1\x80"
+        "\xd0\xbe\xd0\xb5\xd0\xbd\xd0\xb8\xd1\x8f \xd0\xb0\xd0\xbb\xd0\xb3"
+        "\xd0\xbe\xd1\x80\xd0\xb8\xd1\x82\xd0\xbc\xd0\xbe\xd0\xb2, \xd1\x81"
+        "\xd0\xbf\xd0\xbe\xd1\x81\xd0\xbe\xd0\xb1\xd0\xbd\xd1\x8b\xd1\x85 "
+        "\xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb0\xd1\x82\xd1\x8c\xd1\x81\xd1"
+        "\x8f.")
 
-    # label junk food as -1, the others as +1
-    y = np.ones(len(data))
-    y[:6] = -1
-    y_train = y[1:-1]
-    y_test = np.array([y[0], y[-1]])
+    vect = CountVectorizer(n_jobs=n)
+    X_counted = vect.fit_transform([document])
+    assert_equal(X_counted.shape, (1, 15))
 
-    pipeline = Pipeline([('vect', TfidfVectorizer(n_jobs=2)),
-                         ('svc', LinearSVC())])
+    vect = HashingVectorizer(norm=None, non_negative=True)
+    X_hashed = vect.transform([document])
+    assert_equal(X_hashed.shape, (1, 2 ** 20))
 
-    parameters = {
-        'vect__ngram_range': [(1, 1), (1, 2)],
-        'vect__norm': ('l1', 'l2'),
-        'svc__loss': ('l1', 'l2'),
-    }
+    # No collisions on such a small dataset
+    assert_equal(X_counted.nnz, X_hashed.nnz)
 
-    # find the best parameters for both the feature extraction and the
-    # classifier
-    grid_search = GridSearchCV(pipeline, parameters, n_jobs=1)
-
-    # cross-validation doesn't work if the length of the data is not known,
-    # hence use lists instead of iterators
-    pred = grid_search.fit(list(train_data), y_train).predict(list(test_data))
-    assert_array_equal(pred, y_test)
-
-    # on this toy dataset bigram representation which is used in the last of
-    # the grid_search is considered the best estimator since they all converge
-    # to 100% accuracy models
-    assert_equal(grid_search.best_score_, 1.0)
-    best_vectorizer = grid_search.best_estimator_.named_steps['vect']
-    assert_equal(best_vectorizer.ngram_range, (1, 1))
-    assert_equal(best_vectorizer.norm, 'l2')
-    assert_false(best_vectorizer.fixed_vocabulary)
+    # When norm is None and non_negative, the tokens are counted up to
+    # collisions
+    assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
 
 
 def test_vectorizer_unicode():
-    # tests that the count vectorizer works with cyrillic.
-    document = (
-        "\xd0\x9c\xd0\xb0\xd1\x88\xd0\xb8\xd0\xbd\xd0\xbd\xd0\xbe\xd0"
-        "\xb5 \xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0"
-        "\xb5 \xe2\x80\x94 \xd0\xbe\xd0\xb1\xd1\x88\xd0\xb8\xd1\x80\xd0\xbd"
-        "\xd1\x8b\xd0\xb9 \xd0\xbf\xd0\xbe\xd0\xb4\xd1\x80\xd0\xb0\xd0\xb7"
-        "\xd0\xb4\xd0\xb5\xd0\xbb \xd0\xb8\xd1\x81\xd0\xba\xd1\x83\xd1\x81"
-        "\xd1\x81\xd1\x82\xd0\xb2\xd0\xb5\xd0\xbd\xd0\xbd\xd0\xbe\xd0\xb3"
-        "\xd0\xbe \xd0\xb8\xd0\xbd\xd1\x82\xd0\xb5\xd0\xbb\xd0\xbb\xd0"
-        "\xb5\xd0\xba\xd1\x82\xd0\xb0, \xd0\xb8\xd0\xb7\xd1\x83\xd1\x87"
-        "\xd0\xb0\xd1\x8e\xd1\x89\xd0\xb8\xd0\xb9 \xd0\xbc\xd0\xb5\xd1\x82"
-        "\xd0\xbe\xd0\xb4\xd1\x8b \xd0\xbf\xd0\xbe\xd1\x81\xd1\x82\xd1\x80"
-        "\xd0\xbe\xd0\xb5\xd0\xbd\xd0\xb8\xd1\x8f \xd0\xb0\xd0\xbb\xd0\xb3"
-        "\xd0\xbe\xd1\x80\xd0\xb8\xd1\x82\xd0\xbc\xd0\xbe\xd0\xb2, \xd1\x81"
-        "\xd0\xbf\xd0\xbe\xd1\x81\xd0\xbe\xd0\xb1\xd0\xbd\xd1\x8b\xd1\x85 "
-        "\xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb0\xd1\x82\xd1\x8c\xd1\x81\xd1"
-        "\x8f.")
-
-    vect = CountVectorizer()
-    X_counted = vect.fit_transform([document])
-    assert_equal(X_counted.shape, (1, 15))
-
-    vect = HashingVectorizer(norm=None, non_negative=True)
-    X_hashed = vect.transform([document])
-    assert_equal(X_hashed.shape, (1, 2 ** 20))
-
-    # No collisions on such a small dataset
-    assert_equal(X_counted.nnz, X_hashed.nnz)
-
-    # When norm is None and non_negative, the tokens are counted up to
-    # collisions
-    assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
-
-
-def test_vectorizer_unicode_multiprocess():
-    # tests that the count vectorizer works with cyrillic.
-    document = (
-        "\xd0\x9c\xd0\xb0\xd1\x88\xd0\xb8\xd0\xbd\xd0\xbd\xd0\xbe\xd0"
-        "\xb5 \xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0"
-        "\xb5 \xe2\x80\x94 \xd0\xbe\xd0\xb1\xd1\x88\xd0\xb8\xd1\x80\xd0\xbd"
-        "\xd1\x8b\xd0\xb9 \xd0\xbf\xd0\xbe\xd0\xb4\xd1\x80\xd0\xb0\xd0\xb7"
-        "\xd0\xb4\xd0\xb5\xd0\xbb \xd0\xb8\xd1\x81\xd0\xba\xd1\x83\xd1\x81"
-        "\xd1\x81\xd1\x82\xd0\xb2\xd0\xb5\xd0\xbd\xd0\xbd\xd0\xbe\xd0\xb3"
-        "\xd0\xbe \xd0\xb8\xd0\xbd\xd1\x82\xd0\xb5\xd0\xbb\xd0\xbb\xd0"
-        "\xb5\xd0\xba\xd1\x82\xd0\xb0, \xd0\xb8\xd0\xb7\xd1\x83\xd1\x87"
-        "\xd0\xb0\xd1\x8e\xd1\x89\xd0\xb8\xd0\xb9 \xd0\xbc\xd0\xb5\xd1\x82"
-        "\xd0\xbe\xd0\xb4\xd1\x8b \xd0\xbf\xd0\xbe\xd1\x81\xd1\x82\xd1\x80"
-        "\xd0\xbe\xd0\xb5\xd0\xbd\xd0\xb8\xd1\x8f \xd0\xb0\xd0\xbb\xd0\xb3"
-        "\xd0\xbe\xd1\x80\xd0\xb8\xd1\x82\xd0\xbc\xd0\xbe\xd0\xb2, \xd1\x81"
-        "\xd0\xbf\xd0\xbe\xd1\x81\xd0\xbe\xd0\xb1\xd0\xbd\xd1\x8b\xd1\x85 "
-        "\xd0\xbe\xd0\xb1\xd1\x83\xd1\x87\xd0\xb0\xd1\x82\xd1\x8c\xd1\x81\xd1"
-        "\x8f.")
-
-    vect = CountVectorizer(n_jobs=2)
-    X_counted = vect.fit_transform([document])
-    assert_equal(X_counted.shape, (1, 15))
-
-    vect = HashingVectorizer(norm=None, non_negative=True)
-    X_hashed = vect.transform([document])
-    assert_equal(X_hashed.shape, (1, 2 ** 20))
-
-    # No collisions on such a small dataset
-    assert_equal(X_counted.nnz, X_hashed.nnz)
-
-    # When norm is None and non_negative, the tokens are counted up to
-    # collisions
-    assert_array_equal(np.sort(X_counted.data), np.sort(X_hashed.data))
+    _test_vectorizer_unicode(1)
+    _test_vectorizer_unicode(2)
 
 
 def test_tfidf_vectorizer_with_fixed_vocabulary():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -152,58 +152,9 @@ def test_word_analyzer_unigrams():
         assert_equal(wa(text), expected)
 
 
-def test_word_analyzer_unigram_multiprocess():
-    wa = CountVectorizer(strip_accents='ascii', n_jobs=-1).build_analyzer()
-    text = ("J'ai mang\xe9 du kangourou  ce midi, "
-            "c'\xe9tait pas tr\xeas bon.")
-    expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
-                'etait', 'pas', 'tres', 'bon']
-    assert_equal(wa(text), expected)
-
-    text = "This is a test, really.\n\n I met Harry yesterday."
-    expected = ['this', 'is', 'test', 'really', 'met', 'harry',
-                'yesterday']
-    assert_equal(wa(text), expected)
-
-    wa = CountVectorizer(input='file', n_jobs=-1).build_analyzer()
-    text = StringIO("This is a test with a file-like object!")
-    expected = ['this', 'is', 'test', 'with', 'file', 'like',
-                'object']
-    assert_equal(wa(text), expected)
-
-    # with custom preprocessor
-    wa = CountVectorizer(preprocessor=uppercase, n_jobs=-1).build_analyzer()
-    text = ("J'ai mang\xe9 du kangourou  ce midi, "
-            " c'\xe9tait pas tr\xeas bon.")
-    expected = ['AI', 'MANGE', 'DU', 'KANGOUROU', 'CE', 'MIDI',
-                'ETAIT', 'PAS', 'TRES', 'BON']
-    assert_equal(wa(text), expected)
-
-    # with custom tokenizer
-    wa = CountVectorizer(tokenizer=split_tokenize,
-                         strip_accents='ascii', n_jobs=-1).build_analyzer()
-    text = ("J'ai mang\xe9 du kangourou  ce midi, "
-            "c'\xe9tait pas tr\xeas bon.")
-    expected = ["j'ai", 'mange', 'du', 'kangourou', 'ce', 'midi,',
-                "c'etait", 'pas', 'tres', 'bon.']
-    assert_equal(wa(text), expected)
-
-
 def test_word_analyzer_unigrams_and_bigrams():
     wa = CountVectorizer(analyzer="word", strip_accents='unicode',
                          ngram_range=(1, 2)).build_analyzer()
-
-    text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
-    expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
-                'etait', 'pas', 'tres', 'bon', 'ai mange', 'mange du',
-                'du kangourou', 'kangourou ce', 'ce midi', 'midi etait',
-                'etait pas', 'pas tres', 'tres bon']
-    assert_equal(wa(text), expected)
-
-
-def test_word_analyzer_unigrams_and_bigrams_multiprocess():
-    wa = CountVectorizer(analyzer="word", strip_accents='unicode',
-                         ngram_range=(1, 2), n_jobs=-1).build_analyzer()
 
     text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon."
     expected = ['ai', 'mange', 'du', 'kangourou', 'ce', 'midi',
@@ -261,51 +212,9 @@ def test_char_ngram_analyzer():
     assert_equal(cnga(text)[:5], expected)
 
 
-def test_char_ngram_analyzer_multiprocess():
-    cnga = CountVectorizer(analyzer='char', strip_accents='unicode',
-                           ngram_range=(3, 6), n_jobs=-1).build_analyzer()
-
-    text = "J'ai mang\xe9 du kangourou  ce midi, c'\xe9tait pas tr\xeas bon"
-    expected = ["j'a", "'ai", 'ai ', 'i m', ' ma']
-    assert_equal(cnga(text)[:5], expected)
-    expected = ['s tres', ' tres ', 'tres b', 'res bo', 'es bon']
-    assert_equal(cnga(text)[-5:], expected)
-
-    text = "This \n\tis a test, really.\n\n I met Harry yesterday"
-    expected = ['thi', 'his', 'is ', 's i', ' is']
-    assert_equal(cnga(text)[:5], expected)
-
-    expected = [' yeste', 'yester', 'esterd', 'sterda', 'terday']
-    assert_equal(cnga(text)[-5:], expected)
-
-    cnga = CountVectorizer(input='file', analyzer='char',
-                           ngram_range=(3, 6)).build_analyzer()
-    text = StringIO("This is a test with a file-like object!")
-    expected = ['thi', 'his', 'is ', 's i', ' is']
-    assert_equal(cnga(text)[:5], expected)
-
-
 def test_char_wb_ngram_analyzer():
     cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
                            ngram_range=(3, 6)).build_analyzer()
-
-    text = "This \n\tis a test, really.\n\n I met Harry yesterday"
-    expected = [' th', 'thi', 'his', 'is ', ' thi']
-    assert_equal(cnga(text)[:5], expected)
-
-    expected = ['yester', 'esterd', 'sterda', 'terday', 'erday ']
-    assert_equal(cnga(text)[-5:], expected)
-
-    cnga = CountVectorizer(input='file', analyzer='char_wb',
-                           ngram_range=(3, 6)).build_analyzer()
-    text = StringIO("A test with a file-like object!")
-    expected = [' a ', ' te', 'tes', 'est', 'st ', ' tes']
-    assert_equal(cnga(text)[:6], expected)
-
-
-def test_char_wb_ngram_analyzer_multiprocess():
-    cnga = CountVectorizer(analyzer='char_wb', strip_accents='unicode',
-                           ngram_range=(3, 6), n_jobs=-1).build_analyzer()
 
     text = "This \n\tis a test, really.\n\n I met Harry yesterday"
     expected = [' th', 'thi', 'his', 'is ', ' thi']
@@ -524,11 +433,11 @@ def test_tfidf_no_smoothing():
         1. / np.array([0.])
         numpy_provides_div0_warning = len(w) == 1
 
+    if not numpy_provides_div0_warning:
+        raise SkipTest("Numpy does not provide div 0 warnings.")
     in_warning_message = 'divide by zero'
     tfidf = assert_warns_message(RuntimeWarning, in_warning_message,
                                  tr.fit_transform, X).toarray()
-    if not numpy_provides_div0_warning:
-        raise SkipTest("Numpy does not provide div 0 warnings.")
 
 
 def test_sublinear_tf():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -9,6 +9,7 @@ from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import _batch_iter
 
 from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
 
@@ -70,6 +71,24 @@ def split_tokenize(s):
 
 def lazy_analyze(s):
     return ['the_ultimate_feature']
+
+
+def test_batch_iter():
+    a_list = list(range(10))
+    an_iter = iter(range(10))
+    result = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+    assert_equal(list(_batch_iter(a_list, 3)), result)
+    assert_equal(list(_batch_iter(an_iter, 3)), result)
+
+    a_list = list(range(10))
+    an_iter = iter(range(10))
+    result = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+    assert_equal(list(_batch_iter(a_list, 5)), result)
+    assert_equal(list(_batch_iter(an_iter, 5)), result)
+
+    result = []
+    assert_equal(list(_batch_iter(list(), 5)), result)
+    assert_equal(list(_batch_iter(iter(list()), 5)), result)
 
 
 def test_strip_accents():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -605,11 +605,11 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
 
-    n_jobs : integer, optional
-        The number of CPUs to use to do the computation.
-        If n_jobs < 0, then the number of CPUs used is calculated according
-        to the formula cpu_used = number_of_cores + (n_jobs+1)
-        So putting n_jobs=-1 will use all available CPUs.
+    n_jobs : int, optional, 1 by default
+        The number of jobs to use for the computation. If -1 all CPUs
+        are used. If 1 is given, no parallel computing code is used
+        at all. For n_jobs below -1, (n_cpus + 1 + n_jobs) are used.
+        Thus for n_jobs = -2, all CPUs but one are used.
 
     Attributes
     ----------
@@ -621,6 +621,28 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         they occurred in either too many
         (`max_df`) or in too few (`min_df`) documents.
         This is only available if no vocabulary was given.
+
+    Notes
+    -----
+
+    As it currently stands, the parallelism instantiated by n_jobs!=1 is
+    beneficial only if the analyzer is expected to run for a long time.
+    All the default analyzers (e.g., analyzer='word') provided here do not
+    benefit from the use of multiple cores, due to the overhead in inter
+    process communication, which involves pickling and unpickling of the
+    vocabulary.
+
+    For example, when n_jobs=2 and analyzer is set such that it will stem
+    the text (e.g., using nltk.stem.porter.PorterStemmer()), the vectorizer
+    is able to process Brown corpus (500 documents) faster (almost 2x)
+    compared to the n_jobs=1 version.
+
+    However, when analyzer='word' is used for the same dataset, the multi
+    process version runs almost two times slower compared to the n_jobs=1
+    version.
+
+    Therefore users are adviced to do your own benchmarks for your use case.
+    Run the benchmark scripts for more information.
 
     See also
     --------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -462,7 +462,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
 def _batch_iter(iterable, size):
     """Iterate an iterable in a group of 'size' as list"""
     c = count()
-    for k, g in groupby(iterable, lambda x: six.next(c)//size):
+    for k, g in groupby(iterable, lambda x: next(c)//size):
         yield list(g)  # To ensure the iterable is iterated in sequence
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -624,6 +624,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     Notes
     -----
+    When using n_jobs != 1 (that is, enabling multiprocessing), the analyzer
+    function should be pickleable. That means you can't pass lambda functions
+    as the analyzer if you want to use the multiprocessing feature.
 
     As it currently stands, the parallelism instantiated by n_jobs!=1 is
     beneficial only if the analyzer is expected to run for a long time.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -21,6 +21,7 @@ from operator import itemgetter
 import re
 import unicodedata
 import warnings
+from itertools import chain, count, groupby
 
 import numpy as np
 import scipy.sparse as sp
@@ -34,7 +35,6 @@ from .stop_words import ENGLISH_STOP_WORDS
 from sklearn.base import clone
 from sklearn.externals import six
 from sklearn.externals.joblib import Parallel, delayed
-from itertools import chain, count, groupby
 
 __all__ = ['CountVectorizer',
            'ENGLISH_STOP_WORDS',

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -767,7 +767,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         doc_list = Parallel(n_jobs=self.n_jobs)(
             delayed(_count_vocab_process)(docs, clone(self))
             for docs in _batch_iter(raw_documents, 10))
-        doc_list = list(chain(*doc_list))
+        doc_list = chain(*doc_list)
         dict_vectorizer = DictVectorizer(dtype=self.dtype, sparse=True)
         if fixed_vocab:
             vocabulary = self.vocabulary_
@@ -775,12 +775,11 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             dict_vectorizer.feature_names_ = set()
             X = dict_vectorizer.transform(doc_list)
         else:
-            dict_vectorizer = dict_vectorizer.fit(doc_list)
+            X = dict_vectorizer.fit_transform(doc_list)
             vocabulary = dict_vectorizer.vocabulary_
             if not vocabulary:
                 raise ValueError("empty vocabulary; perhaps the documents"
                                  " only contain stop words")
-            X = dict_vectorizer.transform(doc_list)
         return vocabulary, X
 
     def fit(self, raw_documents, y=None):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -620,7 +620,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     Notes
     -----
-    When using n_jobs != 1 in any of the transform function, the analyzer
+    When using n_jobs != 1 in any of the fit or transform method, the analyzer
     function should be pickleable. That means you can't pass lambda functions
     as the analyzer if you want to use the multiprocessing feature.
 
@@ -779,7 +779,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                                  " only contain stop words")
         return vocabulary, X
 
-    def fit(self, raw_documents, y=None):
+    def fit(self, raw_documents, y=None, n_jobs=1):
         """Learn a vocabulary dictionary of all tokens in the raw documents.
 
         Parameters
@@ -791,7 +791,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         -------
         self
         """
-        self.fit_transform(raw_documents)
+        self.fit_transform(raw_documents, n_jobs=n_jobs)
         return self
 
     def fit_transform(self, raw_documents, y=None, n_jobs=1):
@@ -876,7 +876,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             raise ValueError("Vocabulary wasn't fitted or is empty!")
 
         # use the same matrix-building strategy as fit_transform
-        _, X = self._count_vocab(raw_documents, fixed_vocab=True, n_jobs=n_jobs)
+        _, X = self._count_vocab(raw_documents, fixed_vocab=True,
+                                 n_jobs=n_jobs)
         if self.binary:
             X.data.fill(1)
         return X
@@ -1259,7 +1260,7 @@ class TfidfVectorizer(CountVectorizer):
     def idf_(self):
         return self._tfidf.idf_
 
-    def fit(self, raw_documents, y=None):
+    def fit(self, raw_documents, y=None, n_jobs=1):
         """Learn vocabulary and idf from training set.
 
         Parameters
@@ -1271,7 +1272,8 @@ class TfidfVectorizer(CountVectorizer):
         -------
         self : TfidfVectorizer
         """
-        X = super(TfidfVectorizer, self).fit_transform(raw_documents)
+        X = super(TfidfVectorizer, self).fit_transform(raw_documents,
+                                                       n_jobs=n_jobs)
         self._tfidf.fit(X)
         return self
 
@@ -1322,5 +1324,6 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
-        X = super(TfidfVectorizer, self).transform(raw_documents, n_jobs=n_jobs)
+        X = super(TfidfVectorizer, self).transform(raw_documents,
+                                                   n_jobs=n_jobs)
         return self._tfidf.transform(X, copy=False)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -462,7 +462,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
 def _batch_iter(iterable, size):
     """Iterate an iterable in a group of 'size' as list"""
     c = count()
-    for k, g in groupby(iterable, lambda x: c.next()//size):
+    for k, g in groupby(iterable, lambda x: six.next(c)//size):
         yield list(g)  # To ensure the iterable is iterated in sequence
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -789,7 +789,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 num_workers = multiprocessing.cpu_count() + num_workers + 1
             # Only support list for multiprocessing
             raw_documents = list(raw_documents)
-            batch_size = len(raw_documents)/num_workers
+            batch_size = len(raw_documents) // num_workers
             workers = []
             result_pipes = []
             for i in range(num_workers):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1176,6 +1176,13 @@ class TfidfVectorizer(CountVectorizer):
         The learned idf vector (global term weights)
         when ``use_idf`` is set to True, None otherwise.
 
+    ``n_jobs`` : int, optional, 1 by default
+        The number of jobs to use for the computation. If -1 all CPUs
+        are used. If 1 is given, no parallel computing code is used
+        at all. For n_jobs below -1, (n_cpus + 1 + n_jobs) are used.
+        Thus for n_jobs = -2, all CPUs but one are used.
+        See the notes in CountVectorizer for more information on this parameter
+
     See also
     --------
     CountVectorizer

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -767,7 +767,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         doc_list = Parallel(n_jobs=self.n_jobs)(
             delayed(_count_vocab_process)(docs, clone(self))
             for docs in _batch_iter(raw_documents, 10))
-        doc_list = chain(*doc_list)
+        doc_list = list(chain(*doc_list))
         dict_vectorizer = DictVectorizer(dtype=self.dtype, sparse=True)
         if fixed_vocab:
             vocabulary = self.vocabulary_
@@ -775,11 +775,12 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             dict_vectorizer.feature_names_ = set()
             X = dict_vectorizer.transform(doc_list)
         else:
-            X = dict_vectorizer.fit_transform(doc_list)
+            dict_vectorizer = dict_vectorizer.fit(doc_list)
             vocabulary = dict_vectorizer.vocabulary_
             if not vocabulary:
                 raise ValueError("empty vocabulary; perhaps the documents"
                                  " only contain stop words")
+            X = dict_vectorizer.transform(doc_list)
         return vocabulary, X
 
     def fit(self, raw_documents, y=None):


### PR DESCRIPTION
Add parameter n_jobs to CountVectorizer (also TfidfVectrizer, which uses CountVectorizer), similar to one in KMeans
Include timing benchmark on Brown corpus (using nltk)
Include unit tests for the multiprocessing version of CountVectorizer
Fix a few typos

Benchmark result on Brown corpus (500 documents, amounting to 1,161,192 words) shows that the one-core version finishes in 38s, while the multi-core version finishes in 12s on a four-core (2.66 GHz Intel Core i5) iMac running OSX 10.8.5, a three-fold speedup. On another personal test on different machine, the one-core version finishes in 155s, while the multi-core version finishes in 38s, a four-fold speedup. So the parallelization clearly improves the speed, even for Brown corpus, which is not very large.
The parallelization is very useful for very large data (like the one I'm building this one for, around 115k documents), which can mean the difference between a few days and a couple of hours.
