### PR TITLE
fix numpy bug in imputation example

### DIFF
--- a/examples/imputation.py
+++ b/examples/imputation.py
@@ -12,8 +12,8 @@ value using the ``strategy`` hyper-parameter.
 Script output:
 
   Score with the entire dataset = 0.56
-  Score without the samples containing missing values = 0.48
-  Score after imputation of the missing values = 0.55
+  Score without the samples containing missing values = 0.49
+  Score after imputation of the missing values = 0.57
 
 """
 import numpy as np
@@ -48,7 +48,7 @@ missing_features = rng.randint(0, n_features, n_missing_samples)
 
 # Estimate the score without the lines containing missing values
 X_filtered = X_full[~missing_samples, :]
-y_filtered = y_full[~missing_samples, :]
+y_filtered = y_full[~missing_samples]
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_filtered, y_filtered).mean()
 print("Score without the samples containing missing values = %.2f" % score)


### PR DESCRIPTION
fixes issue Imputation Training Example Err #2934 I filed. Using numpy version 1.8.0 on Python 2.7.6 |Anaconda 1.8.0 (x86_64)| (default, Jan 10 2014, 11:23:15).
