### PR TITLE
[MRG+1] some clean-up in Imputer, particularly in calculation of sparse median

### DIFF
--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -43,7 +43,6 @@ def _get_median(data, n_zeros):
         return np.nan
     n_negative = np.count_nonzero(data < 0)
     middle, is_odd = divmod(n_elems, 2)
-    assert middle == n_elems // 2
 
     if is_odd:
         ind = _partition_ind_for_rank(middle, data, n_negative, n_zeros)


### PR DESCRIPTION
This:
- tests some edge cases in calculating a sparse median in `Imputer`
- reimplements that functionality for simpler computation
- leaves behaviour with NaNs in the array undefined, since `np.ma.median` is buggy (see #2918)
- silences some numpy warnings.
