### PR TITLE
BUG: avoid NaNs throwing off class probabilities

### DIFF
--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -214,7 +214,9 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
             # normalize 'votes' into real [0,1] probabilities
             normalizer = proba_k.sum(axis=1)[:, np.newaxis]
             normalizer[normalizer == 0.0] = 1.0
-            proba_k /= normalizer
+            with np.errstate(divide='ignore'):
+                proba_k /= normalizer
+            proba_k[np.isnan(proba_k)] = 1.0
 
             probabilities.append(proba_k)
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -214,7 +214,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
             # normalize 'votes' into real [0,1] probabilities
             normalizer = proba_k.sum(axis=1)[:, np.newaxis]
             normalizer[normalizer == 0.0] = 1.0
-            with np.errstate(divide='ignore'):
+            with np.errstate(invalid='ignore'):
                 proba_k /= normalizer
             proba_k[np.isnan(proba_k)] = 1.0
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -201,6 +201,13 @@ def test_kneighbors_classifier_predict_proba():
     cls.fit(X, y.astype(str))
     y_prob = cls.predict_proba(X)
     assert_array_equal(real_prob, y_prob)
+    # Check that it works with weights='distance'
+    cls = neighbors.KNeighborsClassifier(n_neighbors=2, p=1, weights='distance')
+    cls.fit(X, y)
+    y_prob = cls.predict_proba(np.array([[0,2,0],[2,2,2]]))
+    real_prob = np.array([[0,1,0],[0,0.4,0.6]])
+    assert_array_almost_equal(real_prob, y_prob)
+
 
 
 def test_radius_neighbors_classifier(n_samples=40,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -202,10 +202,11 @@ def test_kneighbors_classifier_predict_proba():
     y_prob = cls.predict_proba(X)
     assert_array_equal(real_prob, y_prob)
     # Check that it works with weights='distance'
-    cls = neighbors.KNeighborsClassifier(n_neighbors=2, p=1, weights='distance')
+    cls = neighbors.KNeighborsClassifier(
+        n_neighbors=2, p=1, weights='distance')
     cls.fit(X, y)
-    y_prob = cls.predict_proba(np.array([[0,2,0],[2,2,2]]))
-    real_prob = np.array([[0,1,0],[0,0.4,0.6]])
+    y_prob = cls.predict_proba(np.array([[0, 2, 0], [2, 2, 2]]))
+    real_prob = np.array([[0, 1, 0], [0, 0.4, 0.6]])
     assert_array_almost_equal(real_prob, y_prob)
 
 


### PR DESCRIPTION
In the case where `neigh_dist` includes at least one zero and `self.weights` is 'distance', some values of `weights` may be infinite.
This is ok, except for when normalizing `proba_k`, when it creates some pernicious NaN values.
