### PR TITLE
[MRG+2] MAINT warn of future behaviour change proposed in #2610

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1631,6 +1631,13 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ### Select labels to keep ###
 
     if y_type == 'binary' and average is not None and pos_label is not None:
+        if label_order is not None and len(label_order) == 2:
+            warnings.warn('In the future, providing two `labels` values, as '
+                          'well as `average` will average over those '
+                          'labels. For now, please use `labels=None` with '
+                          '`pos_label` to evaluate precision, recall and '
+                          'F-score for the positive label only.',
+                          FutureWarning)
         if pos_label not in labels:
             if len(labels) == 1:
                 # Only negative labels


### PR DESCRIPTION
Assuming my proposal in #2610 to make PRF's `labels` parameter more functional and deprecate `pos_label` goes through at some future point, it will create a compatibility issue in the case where all of the following apply:
- `y_true` and `y_pred` contain at most two labels
- `labels` specifies exactly two labels
- `pos_label` is not None (default)
- `average` is not None (generally default).

I expect this case is rare atm, but since behaviour would change with #2610 or similar (unless `labels` changed its name), we can warn in this release (0.15) and change behaviour in 0.16 or 0.17.
