### PR TITLE
[MRG] check for ndim exceeding two in utils.check_arrays 

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -77,6 +77,7 @@ def test_check_arrays_exceptions():
     assert_raises(TypeError, check_arrays, [0], 0)
     assert_raises(TypeError, check_arrays, [0, 1], [0, 1], meaning_of_life=42)
     assert_raises(ValueError, check_arrays, [0], [0], sparse_format='fake')
+    assert_raises(ValueError, check_arrays, np.zeros((2, 3, 4)), [0])
 
 
 def test_np_matrix():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -250,7 +250,7 @@ def check_arrays(*arrays, **options):
                     array = np.asarray(array, dtype=dtype)
                 _assert_all_finite(array)
 
-            if array.ndim > 2:
+            if array.ndim >= 3:
                 raise ValueError("Found array with dim %d. Expected <= 2" %
                                  array.ndim)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -249,6 +249,11 @@ def check_arrays(*arrays, **options):
                 else:
                     array = np.asarray(array, dtype=dtype)
                 _assert_all_finite(array)
+            n_dim = array.ndim
+
+            if n_dim > 2:
+                raise ValueError("Found array with n_dim %d. Expected <= 2" %
+                                (n_dim))
 
         if copy and array is array_orig:
             array = array.copy()

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -249,11 +249,10 @@ def check_arrays(*arrays, **options):
                 else:
                     array = np.asarray(array, dtype=dtype)
                 _assert_all_finite(array)
-            n_dim = array.ndim
 
-            if n_dim > 2:
-                raise ValueError("Found array with n_dim %d. Expected <= 2" %
-                                (n_dim))
+            if array.ndim > 2:
+                raise ValueError("Found array with dim %d. Expected <= 2" %
+                                 array.ndim)
 
         if copy and array is array_orig:
             array = array.copy()


### PR DESCRIPTION
PR for issue #1597.

The check has been added in utils.check_arrays, and the unit tests in utils/test/test_validation.py were expanded to include a raise assert when check_arrays is called with an array of dimension three.

Pep8 returns no outputs for utils/validation.py and utils/test/test_validation.py.

The make returns the following

---

Ran 35 tests in 35.188s

OK (SKIP=2)
