### PR TITLE
[MRG+1] Silhouette score crashed if wrong number of labels

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -5,7 +5,7 @@ from .... import datasets
 from ..unsupervised import silhouette_score
 from ... import pairwise_distances
 from sklearn.utils.testing import assert_false, assert_almost_equal
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regexp
 
 
 def test_silhouette():
@@ -59,8 +59,16 @@ def test_correct_labelsize():
 
     # n_labels = n_samples
     y = np.arange(X.shape[0])
-    assert_raises(ValueError, silhouette_score, X, y)
+    assert_raises_regexp(ValueError,
+                         "Number of labels is %d "
+                         "but should be more than 2"
+                         "and less than n_samples - 1" % len(np.unique(y)),
+                         silhouette_score, X, y)
 
     # n_labels = 1
     y = np.zeros(X.shape[0])
-    assert_raises(ValueError, silhouette_score, X, y)
+    assert_raises_regexp(ValueError,
+                         "Number of labels is %d "
+                         "but should be more than 2"
+                         "and less than n_samples - 1" % len(np.unique(y)),
+                         silhouette_score, X, y)

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -4,7 +4,8 @@ from scipy.sparse import csr_matrix
 from .... import datasets
 from ..unsupervised import silhouette_score
 from ... import pairwise_distances
-from nose.tools import assert_false, assert_almost_equal
+from sklearn.utils.testing import assert_false, assert_almost_equal
+from sklearn.utils.testing import assert_raises
 
 
 def test_silhouette():
@@ -49,3 +50,17 @@ def test_no_nan():
     D = np.random.RandomState(0).rand(len(labels), len(labels))
     silhouette = silhouette_score(D, labels, metric='precomputed')
     assert_false(np.isnan(silhouette))
+
+
+def test_correct_labelsize():
+    """ Assert 2 <= n_labels <= nsample -1 """
+    dataset = datasets.load_iris()
+    X = dataset.data
+
+    # n_labels = n_samples
+    y = np.arange(X.shape[0])
+    assert_raises(ValueError, silhouette_score, X, y)
+
+    # n_labels = 1
+    y = np.zeros(X.shape[0])
+    assert_raises(ValueError, silhouette_score, X, y)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -79,8 +79,9 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     n_labels = len(np.unique(labels))
     n_samples = X.shape[0]
     if not 2 <= n_labels <= n_samples-1:
-        raise ValueError("Number of labels should be more than 2 \
-                         and less than n_samples - 1")
+        raise ValueError("Number of labels is %d "
+                         "but should be more than 2"
+                         "and less than n_samples - 1" % n_labels)
 
     if sample_size is not None:
         random_state = check_random_state(random_state)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -19,6 +19,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     sample.  The Silhouette Coefficient for a sample is ``(b - a) / max(a,
     b)``.  To clarify, ``b`` is the distance between a sample and the nearest
     cluster that the sample is not a part of.
+    Note that Silhouette Coefficent is only defined if number of labels
+    is 2 <= n_labels <= n_samples - 1.
 
     This function returns the mean Silhouette Coefficient over all samples.
     To obtain the values for each sample, use :func:`silhouette_samples`.
@@ -74,6 +76,12 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <http://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
+    n_labels = len(np.unique(labels))
+    n_samples = X.shape[0]
+    if not 2 <= n_labels <= n_samples-1:
+        raise ValueError("Number of labels should be more than 2 \
+                         and less than n_samples - 1")
+
     if sample_size is not None:
         random_state = check_random_state(random_state)
         indices = random_state.permutation(X.shape[0])[:sample_size]
@@ -97,6 +105,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     distance (``a``) and the mean nearest-cluster distance (``b``) for each
     sample.  The Silhouette Coefficient for a sample is ``(b - a) / max(a,
     b)``.
+    Note that Silhouette Coefficent is only defined if number of labels
+    is 2 <= n_labels <= n_samples - 1.
 
     This function returns the Silhouette Coefficient for each sample.
 


### PR DESCRIPTION
Silhouette score is only defined if `2 <= n_labels <= n_samples -1`
but before this fix silhouette_score crashed if `n_labels <= 2` with 
`ValueError: zero-size array to reduction operation minimum which has no identity`
and returned 0 if `n_labels == n_samples`

I thought raising a ValueError was the most appropriate solution, what do you think?
I added test to it, if necessary, and changed such that all tests depends on `sklearn.testing`.

This fix makes it behave like silhouette {cluster} in R.
https://stat.ethz.ch/R-manual/R-devel/library/cluster/html/silhouette.html

Example:

```
dataset = load_iris()
X = dataset.data
y = np.arange(X.shape[0]) # n_labels == n_samples
cluster.silhouette_score(X,y)
Out[39]: 0.0
```

```
dataset = load_iris()
X = dataset.data
y = np.zeros(X.shape[0]) # n_labels == 1
cluster.silhouette_score(X,y)

ValueError: zero-size array to reduction operation minimum which has no identity
```
