### PR TITLE
[MRG+1] MacOS X testing improvements

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import if_not_mac_os
 
 from sklearn.utils.extmath import row_norms
 from sklearn.metrics.cluster import v_measure_score
@@ -195,25 +196,13 @@ def test_k_means_new_centers():
         np.testing.assert_array_equal(this_labels, labels)
 
 
-def _is_mac_os_version(versions):
-    """
-    Return True if OS is Mac OS X and its major
-    version is one of the ``versions``.
-    """
-    import platform
-    mac_version, _, _ = platform.mac_ver()
-    return '.'.join(mac_version.split('.')[:2]) in versions
-
-
 def _has_blas_lib(libname):
     from numpy.distutils.system_info import get_info
     return libname in get_info('blas_opt').get('libraries', [])
 
 
+@if_not_mac_os()
 def test_k_means_plus_plus_init_2_jobs():
-    if _is_mac_os_version(['10.7', '10.8', '10.9']):
-        raise SkipTest('Multi-process bug in Mac OS X >= 10.7 (see issue #636)')
-
     if _has_blas_lib('openblas'):
         raise SkipTest('Multi-process bug with OpenBLAS (see issue #636)')
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -195,11 +195,14 @@ def test_k_means_new_centers():
         np.testing.assert_array_equal(this_labels, labels)
 
 
-def _is_mac_os_version(version):
-    """Returns True iff Mac OS X and newer than specified version."""
+def _is_mac_os_version(versions):
+    """
+    Return True if OS is Mac OS X and its major
+    version is one of the ``versions``.
+    """
     import platform
     mac_version, _, _ = platform.mac_ver()
-    return mac_version.split('.')[:2] == version.split('.')[:2]
+    return '.'.join(mac_version.split('.')[:2]) in versions
 
 
 def _has_blas_lib(libname):
@@ -208,8 +211,8 @@ def _has_blas_lib(libname):
 
 
 def test_k_means_plus_plus_init_2_jobs():
-    if _is_mac_os_version('10.7') or _is_mac_os_version('10.8'):
-        raise SkipTest('Multi-process bug in Mac OS X Lion (see issue #636)')
+    if _is_mac_os_version(['10.7', '10.8', '10.9']):
+        raise SkipTest('Multi-process bug in Mac OS X >= 10.7 (see issue #636)')
 
     if _has_blas_lib('openblas'):
         raise SkipTest('Multi-process bug with OpenBLAS (see issue #636)')

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -338,7 +338,7 @@ def test_parallel():
 
     for n_jobs in [-1, 3]:
         ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                    n_jobs=3,
+                                    n_jobs=n_jobs,
                                     random_state=0).fit(X_train, y_train)
 
         ensemble.set_params(n_jobs=1)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -285,8 +285,8 @@ def test_error():
                   BaggingClassifier(base).fit(X, y).decision_function, X)
 
 
-def test_parallel():
-    """Check parallel computations."""
+def test_parallel_classification():
+    """Check parallel classification."""
     rng = check_random_state(0)
 
     # Classification
@@ -294,65 +294,67 @@ def test_parallel():
                                                         iris.target,
                                                         random_state=rng)
 
-    for n_jobs in [-1, 3]:
-        ensemble = BaggingClassifier(DecisionTreeClassifier(),
-                                     n_jobs=n_jobs,
-                                     random_state=0).fit(X_train, y_train)
+    ensemble = BaggingClassifier(DecisionTreeClassifier(),
+                                 n_jobs=3,
+                                 random_state=0).fit(X_train, y_train)
 
-        # predict_proba
-        ensemble.set_params(n_jobs=1)
-        y1 = ensemble.predict_proba(X_test)
-        ensemble.set_params(n_jobs=2)
-        y2 = ensemble.predict_proba(X_test)
-        assert_array_almost_equal(y1, y2)
+    # predict_proba
+    ensemble.set_params(n_jobs=1)
+    y1 = ensemble.predict_proba(X_test)
+    ensemble.set_params(n_jobs=2)
+    y2 = ensemble.predict_proba(X_test)
+    assert_array_almost_equal(y1, y2)
 
-        ensemble = BaggingClassifier(DecisionTreeClassifier(),
-                                     n_jobs=1,
-                                     random_state=0).fit(X_train, y_train)
+    ensemble = BaggingClassifier(DecisionTreeClassifier(),
+                                 n_jobs=1,
+                                 random_state=0).fit(X_train, y_train)
 
-        y3 = ensemble.predict_proba(X_test)
-        assert_array_almost_equal(y1, y3)
+    y3 = ensemble.predict_proba(X_test)
+    assert_array_almost_equal(y1, y3)
 
-        # decision_function
-        ensemble = BaggingClassifier(SVC(),
-                                     n_jobs=n_jobs,
-                                     random_state=0).fit(X_train, y_train)
+    # decision_function
+    ensemble = BaggingClassifier(SVC(),
+                                 n_jobs=3,
+                                 random_state=0).fit(X_train, y_train)
 
-        ensemble.set_params(n_jobs=1)
-        decisions1 = ensemble.decision_function(X_test)
-        ensemble.set_params(n_jobs=2)
-        decisions2 = ensemble.decision_function(X_test)
-        assert_array_almost_equal(decisions1, decisions2)
+    ensemble.set_params(n_jobs=1)
+    decisions1 = ensemble.decision_function(X_test)
+    ensemble.set_params(n_jobs=2)
+    decisions2 = ensemble.decision_function(X_test)
+    assert_array_almost_equal(decisions1, decisions2)
 
-        ensemble = BaggingClassifier(SVC(),
-                                     n_jobs=1,
-                                     random_state=0).fit(X_train, y_train)
+    ensemble = BaggingClassifier(SVC(),
+                                 n_jobs=1,
+                                 random_state=0).fit(X_train, y_train)
 
-        decisions3 = ensemble.decision_function(X_test)
-        assert_array_almost_equal(decisions1, decisions3)
+    decisions3 = ensemble.decision_function(X_test)
+    assert_array_almost_equal(decisions1, decisions3)
 
-    # Regression
+
+def test_parallel_regression():
+    """Check parallel regression."""
+    rng = check_random_state(0)
+
     X_train, X_test, y_train, y_test = train_test_split(boston.data,
                                                         boston.target,
                                                         random_state=rng)
 
-    for n_jobs in [-1, 3]:
-        ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                    n_jobs=n_jobs,
-                                    random_state=0).fit(X_train, y_train)
+    ensemble = BaggingRegressor(DecisionTreeRegressor(),
+                                n_jobs=3,
+                                random_state=0).fit(X_train, y_train)
 
-        ensemble.set_params(n_jobs=1)
-        y1 = ensemble.predict(X_test)
-        ensemble.set_params(n_jobs=2)
-        y2 = ensemble.predict(X_test)
-        assert_array_almost_equal(y1, y2)
+    ensemble.set_params(n_jobs=1)
+    y1 = ensemble.predict(X_test)
+    ensemble.set_params(n_jobs=2)
+    y2 = ensemble.predict(X_test)
+    assert_array_almost_equal(y1, y2)
 
-        ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                    n_jobs=1,
-                                    random_state=0).fit(X_train, y_train)
+    ensemble = BaggingRegressor(DecisionTreeRegressor(),
+                                n_jobs=1,
+                                random_state=0).fit(X_train, y_train)
 
-        y3 = ensemble.predict(X_test)
-        assert_array_almost_equal(y1, y3)
+    y3 = ensemble.predict(X_test)
+    assert_array_almost_equal(y1, y3)
 
 
 def test_gridsearch():

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -302,10 +302,6 @@ def test_parallel():
     y2 = forest.predict(boston.data)
     assert_array_almost_equal(y1, y2, 3)
 
-    # Use all cores on the classification dataset
-    forest = RandomForestClassifier(n_jobs=-1)
-    forest.fit(iris.data, iris.target)
-
 
 def test_pickle():
     """Check pickability."""

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -123,11 +123,11 @@ def test_pairwise_parallel():
         Y = func(rng.random_sample((3, 4)))
 
         S = euclidean_distances(X)
-        S2 = _parallel_pairwise(X, None, euclidean_distances, n_jobs=-1)
+        S2 = _parallel_pairwise(X, None, euclidean_distances, n_jobs=3)
         assert_array_almost_equal(S, S2)
 
         S = euclidean_distances(X, Y)
-        S2 = _parallel_pairwise(X, Y, euclidean_distances, n_jobs=-1)
+        S2 = _parallel_pairwise(X, Y, euclidean_distances, n_jobs=3)
         assert_array_almost_equal(S, S2)
 
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -13,6 +13,7 @@ import pkgutil
 import warnings
 import sys
 import re
+import platform
 
 import scipy as sp
 import scipy.io
@@ -551,6 +552,23 @@ def if_matplotlib(func):
         else:
             return func(*args, **kwargs)
     return run_test
+
+
+def if_not_mac_os(versions=('10.7', '10.8', '10.9'),
+                  message='Multi-process bug in Mac OS X >= 10.7 '
+                          '(see issue #636)'):
+    """Test decorator that skips test if OS is Mac OS X and its
+    major version is one of ``versions``.
+    """
+    mac_version, _, _ = platform.mac_ver()
+    skip = '.'.join(mac_version.split('.')[:2]) in versions
+    def decorator(func):
+        if skip:
+            @wraps(func)
+            def func(*args, **kwargs):
+                raise SkipTest(message)
+        return func
+    return decorator
 
 
 def clean_warning_registry():


### PR DESCRIPTION
Hanging multiprocessing tests are skipped on Mac OS X 10.9 in this PR. See also: #636.

`test_k_means_plus_plus_init_2_jobs` doesn't fail for me on 10.9, but I've added skipping code anyways because it was intended to be skipped before, and failures could be non-deterministic.

Also, I'm not sure customization hooks in `if_not_mac_os` (versions and message arguments) worth keeping. But at least it is better than old `_is_mac_os_version` function which had incorrect docstring.

Not Mac specific: `BaggingRegressor` was untested with n_jobs=-1 (most likely because of a typo); this is also fixed.
