### PR TITLE
DOC: disambiguate General[ized] Linear Models

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -630,7 +630,7 @@ From text
 
 .. _linear_model_ref:
 
-:mod:`sklearn.linear_model`: Generalized Linear Models
+:mod:`sklearn.linear_model`: General Linear Models
 ======================================================
 
 .. automodule:: sklearn.linear_model

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1,7 +1,7 @@
 .. _linear_model:
 
 =========================
-Generalized Linear Models
+General Linear Models
 =========================
 
 .. currentmodule:: sklearn.linear_model

--- a/examples/linear_model/README.txt
+++ b/examples/linear_model/README.txt
@@ -1,6 +1,6 @@
 .. _linear_examples:
 
-Generalized Linear Models
+General Linear Models
 -------------------------
 
 Examples concerning the :mod:`sklearn.linear_model` package.

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -38,7 +38,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         must correspond to high absolute values in the `coef_` array.
 
         For instance, this is the case for most supervised learning
-        algorithms such as Support Vector Classifiers and Generalized
+        algorithms such as Support Vector Classifiers and General
         Linear Models from the `svm` and `linear_model` modules.
 
     n_features_to_select : int or None (default=None)
@@ -221,7 +221,7 @@ class RFECV(RFE, MetaEstimatorMixin):
         must correspond to high absolute values in the `coef_` array.
 
         For instance, this is the case for most supervised learning
-        algorithms such as Support Vector Classifiers and Generalized
+        algorithms such as Support Vector Classifiers and General
         Linear Models from the `svm` and `linear_model` modules.
 
     step : int or float, optional (default=1)

--- a/sklearn/linear_model/__init__.py
+++ b/sklearn/linear_model/__init__.py
@@ -1,5 +1,5 @@
 """
-The :mod:`sklearn.linear_model` module implements generalized linear models. It
+The :mod:`sklearn.linear_model` module implements general linear models. It
 includes Ridge regression, Bayesian Regression, Lasso and Elastic Net
 estimators computed with Least Angle Regression and coordinate descent. It also
 implements Stochastic Gradient Descent related algorithms.

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -1,5 +1,5 @@
 """
-Generalized Linear models.
+General Linear models.
 """
 
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1,6 +1,6 @@
 """
 Least Angle Regression algorithm. See the documentation on the
-Generalized Linear Model for a complete discussion.
+General Linear Model for a complete discussion.
 """
 from __future__ import print_function
 


### PR DESCRIPTION
The documentation refers to "Generalized Linear Models" for the collection including OLS, ridge regression, etc. This is not "Generalized Linear Models" as usually understood by statisticians - see https://en.wikipedia.org/wiki/Generalized_linear_models - so the use of this term is potentially confusing for people hoping to use GLM in Python.

A better term is "General Linear Models" - see https://en.wikipedia.org/wiki/General_linear_model - so this PR updates the documentation to say that. I hope this is not a controversial suggestion, I merely hope to disambiguate!
