### PR TITLE
DOC use hyperlink colour when in tt

### DIFF
--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -484,6 +484,10 @@ tt {
     font-family: monospace;
 }
 
+a tt {
+	color: inherit;
+}
+
 .viewcode-back {
     font-family: Arial, sans-serif;
 }


### PR DESCRIPTION
This is a fix for #3002. I haven't checked how nicely this works in all context where it applies, but I agree with @thomasahle that API reference links are easy to miss at the moment.
