### PR TITLE
[WIP] FIX normalize to unit variance in [sparse_]center_data

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -56,8 +56,6 @@ def sparse_center_data(X, y, fit_intercept, normalize=False):
         X_mean, X_var = mean_variance_axis0(X)
         if normalize:
             # transform variance to std in-place
-            # XXX: currently scaled to variance=n_samples to match center_data
-            X_var *= X.shape[0]
             X_std = np.sqrt(X_var, X_var)
             del X_var
             X_std[X_std == 0] = 1
@@ -94,8 +92,7 @@ def center_data(X, y, fit_intercept, normalize=False, copy=True,
             X_mean = np.average(X, axis=0, weights=sample_weight)
             X -= X_mean
             if normalize:
-                # XXX: currently scaled to variance=n_samples
-                X_std = np.sqrt(np.sum(X ** 2, axis=0))
+                X_std = np.sqrt(np.sum(X ** 2, axis=0) / X.shape[0])
                 X_std[X_std == 0] = 1
                 X /= X_std
             else:

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -120,8 +120,7 @@ def test_center_data():
     X = rng.rand(n_samples, n_features)
     y = rng.rand(n_samples)
     expected_X_mean = np.mean(X, axis=0)
-    # XXX: currently scaled to variance=n_samples
-    expected_X_std = np.std(X, axis=0) * np.sqrt(X.shape[0])
+    expected_X_std = np.std(X, axis=0)
     expected_y_mean = np.mean(y, axis=0)
 
     Xt, yt, X_mean, y_mean, X_std = center_data(X, y, fit_intercept=False,
@@ -188,9 +187,7 @@ def test_center_data_weighted():
 
     # XXX: if normalize=True, should we expect a weighted standard deviation?
     #      Currently not weighted, but calculated with respect to weighted mean
-    # XXX: currently scaled to variance=n_samples
-    expected_X_std = (np.sqrt(X.shape[0]) *
-                      np.mean((X - expected_X_mean) ** 2, axis=0) ** .5)
+    expected_X_std = np.mean((X - expected_X_mean) ** 2, axis=0) ** .5
 
     Xt, yt, X_mean, y_mean, X_std = center_data(X, y, fit_intercept=True,
                                                 normalize=False,
@@ -220,8 +217,7 @@ def test_sparse_center_data():
     X = X.tolil()
     y = rng.rand(n_samples)
     XA = X.toarray()
-    # XXX: currently scaled to variance=n_samples
-    expected_X_std = np.std(XA, axis=0) * np.sqrt(X.shape[0])
+    expected_X_std = np.std(XA, axis=0)
 
     Xt, yt, X_mean, y_mean, X_std = sparse_center_data(X, y,
                                                        fit_intercept=False,


### PR DESCRIPTION
It appears `center_data` had been normalizing to variance=`n_samples` since https://github.com/scikit-learn/scikit-learn/commit/295dc3c#diff-7b11510996b18ecc1e4bfd4f4ec850b4R67

At master:

``` python
>>> X1 = np.random.normal(size=(1000, 1))
>>> X2 = np.random.normal(size=(10000, 1))
>>> center_data(X1, np.zeros(X1.shape[0]), True, True)[0].std()
0.031622776601683784
>>> center_data(X2, np.zeros(X1.shape[0]), True, True)[0].std()
0.0099999999999999794
```

This also deletes `sparse_std`, cleans up and tests the centering code.
