### PR TITLE
[MRG] FIX: more robust skip of implicit constructor

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -163,27 +163,26 @@ class BaseEstimator(object):
     @classmethod
     def _get_param_names(cls):
         """Get parameter names for the estimator"""
-        try:
-            # fetch the constructor or the original constructor before
-            # deprecation wrapping if any
-            init = getattr(cls.__init__, 'deprecated_original', cls.__init__)
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, 'deprecated_original', cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
 
-            # introspect the constructor arguments to find the model parameters
-            # to represent
-            args, varargs, kw, default = inspect.getargspec(init)
-            if not varargs is None:
-                raise RuntimeError("scikit-learn estimators should always "
-                                   "specify their parameters in the signature"
-                                   " of their __init__ (no varargs)."
-                                   " %s doesn't follow this convention."
-                                   % (cls, ))
-            # Remove 'self'
-            # XXX: This is going to fail if the init is a staticmethod, but
-            # who would do this?
-            args.pop(0)
-        except TypeError:
-            # No explicit __init__
-            args = []
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        args, varargs, kw, default = inspect.getargspec(init)
+        if varargs is not None:
+            raise RuntimeError("scikit-learn estimators should always "
+                               "specify their parameters in the signature"
+                               " of their __init__ (no varargs)."
+                               " %s doesn't follow this convention."
+                               % (cls, ))
+        # Remove 'self'
+        # XXX: This is going to fail if the init is a staticmethod, but
+        # who would do this?
+        args.pop(0)
         args.sort()
         return args
 


### PR DESCRIPTION
Parameter introspection requires introspecting the keyword arguments of the
constructor of Python classes deriving from BaseEstimator.

This can be problematic for classes that do not override the default
constructor. Introspecting the implicit constructor used to raise a TypeError
but this is no longer the case in Python 3.4+. Hence with use an explicit check
for the implicit constructor prior to using inspection.
