### PR TITLE
BUG: FeatureAgglomeration: error for n_samples = 0

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -174,6 +174,10 @@ Changelog
      models: it now uses threads, not separate processes, when ``n_jobs>1``.
      By `Lars Buitinck`_.
 
+   - Raise error in :class:`cluster.FeatureAgglomeration` and
+     :class:`cluster.WardAgglomeration` when no samples are given,
+     rather than returning meaningless clustering.
+
 
 API changes summary
 -------------------

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -19,7 +19,7 @@ from ..base import BaseEstimator, ClusterMixin
 from ..externals.joblib import Memory
 from ..externals import six
 from ..metrics.pairwise import paired_distances, pairwise_distances
-from ..utils import array2d
+from ..utils import array2d, safe_asarray
 from ..utils.sparsetools import connected_components
 
 from . import _hierarchical
@@ -674,6 +674,11 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         -------
         self
         """
+        X = safe_asarray(X)
+        if not (len(X.shape) == 2 and X.shape[0] > 0):
+            raise ValueError('At least one sample is required to fit the '
+                'model. A data matrix of shape %s was given.'
+                % (X.shape, ))
         return AgglomerativeClustering.fit(self, X.T, **params)
 
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -80,6 +80,9 @@ def test_structured_linkage_tree():
         # of the wrong shape
         assert_raises(ValueError,
                       tree_builder, X.T, np.ones((4, 4)))
+        # Check that fitting with no samples raises an error
+        assert_raises(ValueError,
+                      tree_builder, X.T[:0], connectivity)
 
 
 def test_unstructured_linkage_tree():
@@ -221,6 +224,9 @@ def test_ward_agglomeration():
     X_full = agglo.inverse_transform(X_red)
     assert_true(np.unique(X_full[0]).size == 5)
     assert_array_almost_equal(agglo.transform(X_full), X_red)
+
+    # Check that fitting with no samples raises a ValueError
+    assert_raises(ValueError, agglo.fit, X[:0])
 
 
 def assess_same_labelling(cut1, cut2):


### PR DESCRIPTION
Trivial fix for trivial bug. Can I haz review, plz.

Currently, the FeatureAgglomeration code does not raises an error when it is given no samples (a matrix of dimensions (0, n_features), but creates a meaningless clustering that only reflects the connectivity matrix.

@schwarty has a nasty bug in his codebase because of that.
