### PR TITLE
Add support for SVDD (one-class SVM) #2807

### DIFF
--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -1924,7 +1924,11 @@ static void solve_svdd(
 			obj -= QD[i]/2;
 			rho += QD[i]/2;
 			for(j=i+1;j<l;j++)
+#ifdef _DENSE_REP
 				rho += Kernel::k_function(prob->x+i, prob->x+j,*param);
+#else
+				rho += Kernel::k_function(prob->x[i], prob->x[j],*param);
+#endif
 		}
 		si->obj = (obj + rho/l)*sum;
 		si->rho = rho / (l*l);
@@ -1967,7 +1971,11 @@ static void solve_r2q(
 	for(i=0;i<l;i++)
 	{
         C[i] = INF;
+#ifdef _DENSE_REP
 		linear_term[i]=-0.5*(Kernel::k_function(prob->x+i,prob->x+i,*param) + 1.0/param->C);
+#else
+		linear_term[i]=-0.5*(Kernel::k_function(prob->x[i],prob->x[i],*param) + 1.0/param->C);
+#endif
 		ones[i] = 1;
 	}
 

--- a/sklearn/svm/src/libsvm/svm.h
+++ b/sklearn/svm/src/libsvm/svm.h
@@ -39,7 +39,7 @@ struct svm_csr_problem
 };
 
 
-enum { C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR };	/* svm_type */
+enum { C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR, SVDD, R2, R2q };	/* svm_type */
 enum { LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED }; /* kernel_type */
 
 struct svm_parameter


### PR DESCRIPTION
Support Vector Data Description (SVDD) could be a nice enhancement to OneClassSVM implementation.

A technical implementation is described in this paper:
http://www.csie.ntu.edu.tw/~cjlin/papers/svdd.pdf

Source code compatible with libsvm is available here:
http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/#libsvm_for_svdd_and_finding_the_smallest_sphere_containing_all_data

I have modified the sklearn/svm/src/libsvm/svm.h and svm.cpp files to add additional functionality of SVM.

-s 5 SVDD
-s 6 R^2 L1SVM
-s 7 R^2 L2SVM
