### PR TITLE
[WIP] Do not import the sklearn package from setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ benchmarks/bench_covertype_data/
 *.prefs
 .pydevproject
 .idea
+
+# Generated when running setup.py
+sklearn/version.py

--- a/setup.py
+++ b/setup.py
@@ -8,17 +8,9 @@ descr = """A set of python modules for machine learning and data mining"""
 import sys
 import os
 import shutil
+import subprocess
 from distutils.command.clean import clean as Clean
 
-if sys.version_info[0] < 3:
-    import __builtin__ as builtins
-else:
-    import builtins
-
-# This is a bit (!) hackish: we are setting a global variable so that the main
-# sklearn __init__ can detect if it is being loaded by the setup routine, to
-# avoid attempting to load components that aren't built yet.
-builtins.__SKLEARN_SETUP__ = True
 
 DISTNAME = 'scikit-learn'
 DESCRIPTION = 'A set of python modules for machine learning and data mining'
@@ -29,11 +21,78 @@ URL = 'http://scikit-learn.org'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'http://sourceforge.net/projects/scikit-learn/files/'
 
-# We can actually import a restricted version of sklearn that
-# does not need the compiled code
-import sklearn
+MAJOR               = 0
+MINOR               = 15
+MICRO               = 0
+ISRELEASED          = False
+VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-VERSION = sklearn.__version__
+
+# Return the git revision as a string
+def git_version():
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for k in ['SYSTEMROOT', 'PATH']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.Popen(cmd, stdout = subprocess.PIPE,
+                               env=env).communicate()[0]
+        return out
+
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        GIT_REVISION = out.strip().decode('ascii')
+    except OSError:
+        GIT_REVISION = "Unknown"
+
+    return GIT_REVISION
+
+
+def get_version_info():
+    FULLVERSION = VERSION
+    if os.path.exists('.git'):
+        GIT_REVISION = git_version()
+    else:
+        GIT_REVISION = "Unknown"
+
+    if not ISRELEASED:
+        FULLVERSION += '.dev-' + GIT_REVISION[:7]
+
+    return FULLVERSION, GIT_REVISION
+
+
+def write_version_py(filename='sklearn/version.py'):
+    content = """
+# THIS FILE IS GENERATED FROM SETUP.PY
+short_version = '%(version)s'
+version = '%(version)s'
+full_version = '%(full_version)s'
+git_revision = '%(git_revision)s'
+release = %(isrelease)s
+
+if not release:
+    version = full_version
+"""
+    FULLVERSION, GIT_REVISION = get_version_info()
+
+    a = open(filename, 'w')
+    try:
+        a.write(content % {'version': VERSION,
+                           'full_version' : FULLVERSION,
+                           'git_revision' : GIT_REVISION,
+                           'isrelease': str(ISRELEASED)})
+    finally:
+        a.close()
+    return FULLVERSION
+
+FULLVERSION = write_version_py()
+
 
 ###############################################################################
 # Optional setuptools features
@@ -101,7 +160,7 @@ def setup_package():
                     description=DESCRIPTION,
                     license=LICENSE,
                     url=URL,
-                    version=VERSION,
+                    version=FULLVERSION,
                     download_url=DOWNLOAD_URL,
                     long_description=LONG_DESCRIPTION,
                     classifiers=['Intended Audience :: Science/Research',
@@ -138,7 +197,7 @@ def setup_package():
         except ImportError:
             from distutils.core import setup
 
-        metadata['version'] = VERSION
+        metadata['version'] = FULLVERSION
     else:
         from numpy.distutils.core import setup
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,16 @@ ISRELEASED          = False
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+# This is a bit (!) hackish: we are setting a global variable so that the main
+# sklearn __init__ can detect if it is being loaded by the setup routine, to
+# avoid attempting to load components that aren't built yet.
+builtins.__SKLEARN_SETUP__ = True
+
 # Return the git revision as a string
 def git_version():
     def _minimal_ext_cmd(cmd):

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -15,33 +15,20 @@ See http://scikit-learn.org for complete documentation.
 import sys
 import re
 import warnings
-__version__ = '0.15-git'
+from . import __check_build
+from .base import clone
+from .version import full_version as __version__
 
 # Make sure that DeprecationWarning within this package always gets printed
 warnings.filterwarnings('always', category=DeprecationWarning,
                         module='^{0}\.'.format(re.escape(__name__)))
 
-try:
-    # This variable is injected in the __builtins__ by the build
-    # process. It used to enable importing subpackages of sklearn when
-    # the binaries are not built
-    __SKLEARN_SETUP__
-except NameError:
-    __SKLEARN_SETUP__ = False
 
-if __SKLEARN_SETUP__:
-    sys.stderr.write('Partial import of sklearn during the build process.\n')
-    # We are not importing the rest of the scikit during the build
-    # process, as it may not be compiled yet
-else:
-    from . import __check_build
-    from .base import clone
-
-    def test(*args, **kwargs):
-        import warnings
-        # Not using a DeprecationWarning, as they are turned off by
-        # default
-        warnings.warn("""sklearn.test() is no longer supported to run the
+def test(*args, **kwargs):
+    import warnings
+    # Not using a DeprecationWarning, as they are turned off by
+    # default
+    warnings.warn("""sklearn.test() is no longer supported to run the
 scikit-learn test suite.
 
 After installation, you can launch the test suite from outside the
@@ -56,18 +43,18 @@ This function, `sklearn.test()` does not do anything. It does not run
 the tests and will be removed in release 0.16.
 """, stacklevel=2)
 
-    # The following line is useful so that nosetests doesn't consider
-    # "test" as a test function
-    test.__test__ = False
+# The following line is useful so that nosetests doesn't consider
+# "test" as a test function
+test.__test__ = False
 
-    __all__ = ['cross_validation', 'cluster', 'covariance',
-               'datasets', 'decomposition', 'feature_extraction',
-               'feature_selection', 'semi_supervised',
-               'gaussian_process', 'grid_search', 'hmm', 'lda', 'linear_model',
-               'metrics', 'mixture', 'naive_bayes', 'neighbors', 'pipeline',
-               'preprocessing', 'qda', 'svm', 'clone',
-               'cross_decomposition',
-               'isotonic', 'pls']
+__all__ = ['cross_validation', 'cluster', 'covariance',
+           'datasets', 'decomposition', 'feature_extraction',
+           'feature_selection', 'semi_supervised',
+           'gaussian_process', 'grid_search', 'hmm', 'lda', 'linear_model',
+           'metrics', 'mixture', 'naive_bayes', 'neighbors', 'pipeline',
+           'preprocessing', 'qda', 'svm', 'clone',
+           'cross_decomposition',
+           'isotonic', 'pls']
 
 
 def setup_module(module):

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -15,20 +15,30 @@ See http://scikit-learn.org for complete documentation.
 import sys
 import re
 import warnings
-from . import __check_build
-from .base import clone
-from .version import full_version as __version__
 
 # Make sure that DeprecationWarning within this package always gets printed
 warnings.filterwarnings('always', category=DeprecationWarning,
                         module='^{0}\.'.format(re.escape(__name__)))
 
+try:
+    # This builtins variable is defined by setup.py when building the project.
+    in_setup = __SKLEARN_SETUP__
+except NameError:
+    in_setup = False
 
-def test(*args, **kwargs):
-    import warnings
-    # Not using a DeprecationWarning, as they are turned off by
-    # default
-    warnings.warn("""sklearn.test() is no longer supported to run the
+if not in_setup:
+    # Trigger the build check only when run once the build is actually
+    # complete.
+    from . import __check_build
+    from .base import clone
+    from .version import full_version as __version__
+
+
+    def test(*args, **kwargs):
+        import warnings
+        # Not using a DeprecationWarning, as they are turned off by
+        # default
+        warnings.warn("""sklearn.test() is no longer supported to run the
 scikit-learn test suite.
 
 After installation, you can launch the test suite from outside the
@@ -43,18 +53,18 @@ This function, `sklearn.test()` does not do anything. It does not run
 the tests and will be removed in release 0.16.
 """, stacklevel=2)
 
-# The following line is useful so that nosetests doesn't consider
-# "test" as a test function
-test.__test__ = False
+    # The following line is useful so that nosetests doesn't consider
+    # "test" as a test function
+    test.__test__ = False
 
-__all__ = ['cross_validation', 'cluster', 'covariance',
-           'datasets', 'decomposition', 'feature_extraction',
-           'feature_selection', 'semi_supervised',
-           'gaussian_process', 'grid_search', 'hmm', 'lda', 'linear_model',
-           'metrics', 'mixture', 'naive_bayes', 'neighbors', 'pipeline',
-           'preprocessing', 'qda', 'svm', 'clone',
-           'cross_decomposition',
-           'isotonic', 'pls']
+    __all__ = ['cross_validation', 'cluster', 'covariance',
+               'datasets', 'decomposition', 'feature_extraction',
+               'feature_selection', 'semi_supervised',
+               'gaussian_process', 'grid_search', 'hmm', 'lda', 'linear_model',
+               'metrics', 'mixture', 'naive_bayes', 'neighbors', 'pipeline',
+               'preprocessing', 'qda', 'svm', 'clone',
+               'cross_decomposition',
+               'isotonic', 'pls']
 
 
 def setup_module(module):


### PR DESCRIPTION
The execution of setup.py never imports the sklearn package to avoid cyclid dependencies.

The sklearn/version.py file is now generated each time setup.py is executed. If the version is not a release version, a '.dev_aaaaaaa' suffix is appended where 'aaaaaaa' is the 7 first digits of the hexdigest of the last git commit in the local repo.

I find this solution less hackish and more informative than the previous stateful builtins-based hack.
