### PR TITLE
Fix MSVC error C2036: 'void *' : unknown size

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -2397,8 +2397,8 @@ cdef class Tree:
 
         # value memory is initialised to 0 to enable classifier argmax
         if capacity > self.capacity:
-            memset((<void*> self.value) + self.capacity *
-                   self.value_stride * sizeof(double), 0,
+            memset(<void*>((<char*> self.value) + self.capacity *
+                   self.value_stride * sizeof(double)), 0,
                    (capacity - self.capacity) * self.value_stride *
                    sizeof(double))
 


### PR DESCRIPTION
`sklearn\tree\_tree.c(19094) : error C2036: 'void *' : unknown size`
