### PR TITLE
Fix ValueError: Buffer dtype mismatch, expected 'INTP' but got 'long' on win-amd64

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -405,7 +405,7 @@ def linkage_tree(X, connectivity=None, n_components=None,
     heapify(inertia)
 
     # prepare the main fields
-    parent = np.arange(n_nodes, dtype=np.int)
+    parent = np.arange(n_nodes, dtype=np.intp)
     used_node = np.ones(n_nodes, dtype=np.intp)
     children = []
 


### PR DESCRIPTION
This fixes the following test failure. See also issue #3008.

```
======================================================================
ERROR: Check that we obtain the correct number of clusters with
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\sklearn\cluster\tests\test_hierarchical.py", line 149, in test_agglomerative_clustering
    clustering.fit(X)
  File "X:\Python27-x64\lib\site-packages\sklearn\cluster\hierarchical.py", line 656, in fit
    labels = _hierarchical.hc_get_heads(parents, copy=False)
  File "_hierarchical.pyx", line 106, in sklearn.cluster._hierarchical.hc_get_heads (sklearn\cluster\_hierarchical.cpp:2810)
ValueError: Buffer dtype mismatch, expected 'INTP' but got 'long'
```
