### PR TITLE
TST: Fix ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long' on win-amd64

### DIFF
--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -37,10 +37,11 @@ def test_densify_rows():
                        [0, 0, 0],
                        [9, 8, 7],
                        [4, 0, 5]], dtype=np.float64)
-    rows = np.array([0, 2, 3], dtype=np.int)
+    rows = np.array([0, 2, 3], dtype=np.intp)
     out = np.ones((rows.shape[0], X.shape[1]), dtype=np.float64)
 
-    assign_rows_csr(X, rows, np.arange(out.shape[0])[::-1], out)
+    assign_rows_csr(X, rows, 
+                    np.arange(out.shape[0], dtype=np.intp)[::-1], out)
     assert_array_equal(out, X[rows].toarray()[::-1])
 
 


### PR DESCRIPTION
This fixes the following test error on win-amd64. See also issue #3008.

```
======================================================================
ERROR: sklearn.utils.tests.test_sparsefuncs.test_densify_rows
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\sklearn\utils\tests\test_sparsefuncs.py", line 43, in test_densify_rows
    assign_rows_csr(X, rows, np.arange(out.shape[0], dtype=np.intp)[::-1], out)
  File "sparsefuncs_fast.pyx", line 313, in sklearn.utils.sparsefuncs_fast.assign_rows_csr (sklearn\utils\sparsefuncs_fast.c:4235)
ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long'

```
