### PR TITLE
[MRG] Set travis to test old versions of numpy and scipy too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,16 @@
 language: python
-env:
-    - COVERAGE=--with-coverage
-python:
-    - "2.7"
-    - "2.6"
-    - "3.3"
 virtualenv:
   system_site_packages: true
-before_install:
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then chmod +x miniconda.sh ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then ./miniconda.sh -b ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then export PATH=/home/travis/anaconda/bin:$PATH ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then conda update --yes conda ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then conda update --yes conda ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then source activate testenv ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION != '2.7' ]]; then conda install --yes numpy scipy nose ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo apt-get update -qq ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo apt-get install -qq python-scipy python-nose python-pip ; fi
-install:
-    - python setup.py build_ext --inplace
-    - if [ "${COVERAGE}" == "--with-coverage" ]; then sudo pip install coverage; fi
-    - if [ "${COVERAGE}" == "--with-coverage" ]; then sudo pip install coveralls; fi
-script:
-    - if [ "${COVERAGE}" == "--with-coverage" ]; then
-    -   make test-coverage;
-    - else
-    -   make test;
-    - fi
+env:
+  matrix:
+    - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
+      COVERAGE="true"
+    - DISTRIB="conda" PYTHON_VERSION="2.6" INSTALL_MKL="false"
+      NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
+    - DISTRIB="conda" PYTHON_VERSION="3.3" INSTALL_MKL="true"
+      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.13.3"
+install: source continuous_integration/install.sh
+script: bash continuous_integration/test_script.sh
 after_success:
-    - if [ "${COVERAGE}" == "--with-coverage" ]; then coveralls; fi
-
+    - if [[ "$COVERAGE" == "true" ]]; then coveralls; fi
+cache: apt

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update -qq
+if [[ "$INSTALL_ATLAS" == "true" ]]; then
+    sudo apt-get install -qq libatlas3gf-base libatlas-dev
+fi
+
+if [[ "$DISTRIB" == "conda" ]]; then
+    # Deactivate the travis-provided virtual environment and setup a
+    # conda-based environment instead
+    deactivate
+
+    # Use the miniconda installer for faster download / install of conda
+    # itself
+    wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh \
+        -O miniconda.sh
+    chmod +x miniconda.sh && ./miniconda.sh -b
+    export PATH=/home/travis/anaconda/bin:$PATH
+    conda update --yes conda
+
+    # Configure the conda environment and put it in the path using the
+    # provided versions
+    conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
+    source activate testenv
+
+    if [[ "$INSTALL_MKL" == "true" ]]; then
+        # Make sure that MKL is used
+        conda install --yes mkl
+    else
+        # Make sure that MKL is not used
+        conda remove --yes --features mkl || echo "MKL not installed"
+    fi
+
+elif [[ "$DISTRIB" == "ubuntu" ]]; then
+    # Use standard ubuntu packages in their default version
+    sudo apt-get install -qq python-scipy python-nose python-pip
+fi
+
+if [[ "$COVERAGE" == "true" ]]; then
+    pip install coverage coveralls
+fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This script is meant to be called by the "install" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+# The behavior of the script is controlled by environment variabled defined
+# in the .travis.yml in the top level folder of the project.
 
 set -e
 

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This script is meant to be called by the "script" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+# The behavior of the script is controlled by environment variabled defined
+# in the .travis.yml in the top level folder of the project.
 
 set -e
 

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+python --version
+python -c "import numpy; print('numpy %s' % numpy.__version__)"
+python -c "import scipy; print('scipy %s' % scipy.__version__)"
+python setup.py build_ext --inplace
+
+if [[ "$COVERAGE" == "true" ]]; then
+    export WITH_COVERAGE="--with-coverage"
+else
+    export WITH_COVERAGE=""
+fi
+nosetests -s -v $WITH_COVERAGE sklearn


### PR DESCRIPTION
This is a tentative PR (to check travis build) to improve the travis config by: 
- use cleaner multiline scripts in separate files
- test old versions of numpy and scipy with python 2.6
- use the travis managed apt cache
