### PR TITLE
[BUG?] safe_asarray fails for dok_matrix and lil_matrix

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -37,6 +37,23 @@ def test_safe_asarray():
     assert_equal(Y.dtype, np.int)
 
 
+def test_safe_asarray_with_dok_and_lil():
+    """Make sure dok and lil sparse matrices are handled"""
+
+    X = np.ones([4, 5])
+    X_dok = sp.dok_matrix(X)
+    X_lil = sp.lil_matrix(X)
+
+    # Test fails on X_dok due to non-exposure of .data (it is .values)
+    # Test fails on X_lil because .data is an array of dtype object
+    # containing a list of lists of not necessarily the same length
+
+    safe_X_dok = safe_asarray(X_dok)
+    safe_X_lil = safe_asarray(X_lil, X.dtype)
+
+    # Later one could check the type of output, e.g. coo_matrix
+
+
 def test_as_float_array():
     """Test function for as_float_array"""
     X = np.ones((3, 10), dtype=np.int32)


### PR DESCRIPTION
safe_asarray doesn't like dok_matrix or lil_matrix, because dok_matrix does not expose .data and lil_matrix exposes .data weirdly (array of dtype object, list of not necessarily equally sized lists).
