### PR TITLE
TST: Switch from python 3.3 to 3.4 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ env:
   matrix:
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
       COVERAGE="true"
+    # This environment tests the oldest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.6" INSTALL_MKL="false"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
-    - DISTRIB="conda" PYTHON_VERSION="3.3" INSTALL_MKL="true"
+    # This environment tests the newest supported anaconda env
+    - DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="true"
       NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.13.3"
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,10 @@ Important links
 Dependencies
 ============
 
-scikit-learn is tested to work under Python 2.6+ and Python 3.3+
-(using the same codebase thanks to an embedded copy of `six <http://pythonhosted.org/six/>`_).
+scikit-learn is tested to work under Python 2.6, Python 2.7, and Python 3.4.
+(using the same codebase thanks to an embedded copy of
+`six <http://pythonhosted.org/six/>`_). It should also work against Python
+3.3.
 
 The required dependencies to build the software NumPy >= 1.6.1, SciPy >= 0.9
 and a working C/C++ compiler.

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ def setup_package():
                                  'Programming Language :: Python :: 2.7',
                                  'Programming Language :: Python :: 3',
                                  'Programming Language :: Python :: 3.3',
+                                 'Programming Language :: Python :: 3.4',
                                  ],
                     cmdclass={'clean': CleanCommand},
                     **extra_setuptools_args)


### PR DESCRIPTION
Python 3.4 is supported by anaconda now so we can update travis-ci to use 3.4 instead of 3.3
