### PR TITLE
[WIP] FIX: MiniBatchKMeans fails no more if there are too many clusters to reassign, #3039

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -840,7 +840,7 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
         # Reassign clusters that have very low counts
         to_reassign = np.logical_or(
             (counts <= 1), counts <= reassignment_ratio * counts.max())
-        n_reassigns = min(to_reassign.sum(), X.shape[0])
+        n_reassigns = to_reassign.sum()
         if n_reassigns:
             # Pick new clusters amongst observations with probability
             # proportional to their closeness to their center.

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -360,14 +360,18 @@ def test_minibatch_reassign():
 def test_minibatch_with_many_reassignments():
     # Test for the case that the number of clusters to reassign is bigger
     # than the batch_size
-    X = np.random.rand(500, 250)
+    n_samples = 550
+    rnd = np.random.RandomState(42)
+    X = rnd.uniform(size=(n_samples, 10))
     # Check that the fit works if n_clusters is bigger than the batch_size.
-    # Run the test multiple times with different values for n_clusters
-    # to ensure that at least in one case we need to reassign enough clusters
-    for n_clusters in [200, 250, 300]:
-        MiniBatchKMeans(n_clusters=n_clusters,
-                        batch_size=100,
-                        init_size=500).fit(X)
+    # Run the test with 550 clusters and 550 samples, because it turned out
+    # that this values ensure that the number of clusters to reassign
+    # is always bigger than the batch_size
+    n_clusters = 550
+    MiniBatchKMeans(n_clusters=n_clusters,
+                    batch_size=100,
+                    init_size=n_samples,
+                    random_state=42).fit(X)
 
 
 def test_sparse_mb_k_means_callable_init():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -357,6 +357,19 @@ def test_minibatch_reassign():
                          reassignment_ratio=1e-15)
 
 
+def test_minibatch_with_many_reassignments():
+    # Test for the case that the number of clusters to reassign is bigger
+    # than the batch_size
+    X = np.random.rand(500, 250)
+    # Check that the fit works if n_clusters is bigger than the batch_size.
+    # Run the test multiple times with different values for n_clusters
+    # to ensure that at least in one case we need to reassign enough clusters
+    for n_clusters in [200, 250, 300]:
+        MiniBatchKMeans(n_clusters=n_clusters,
+                        batch_size=100,
+                        init_size=500).fit(X)
+
+
 def test_sparse_mb_k_means_callable_init():
 
     def test_init(X, k, random_state):


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/issues/3039#issuecomment-40409814
