### PR TITLE
[MRG+2] TruncatedSVD: Calculate explained variance.

### DIFF
--- a/examples/document_clustering.py
+++ b/examples/document_clustering.py
@@ -159,11 +159,17 @@ if opts.n_components:
     # Vectorizer results are normalized, which makes KMeans behave as
     # spherical k-means for better results. Since LSA/SVD results are
     # not normalized, we have to redo the normalization.
-    lsa = make_pipeline(TruncatedSVD(opts.n_components),
-                        Normalizer(copy=False))
+    svd = TruncatedSVD(opts.n_components)
+    lsa = make_pipeline(svd, Normalizer(copy=False))
+
     X = lsa.fit_transform(X)
 
     print("done in %fs" % (time() - t0))
+
+    explained_variance = svd.explained_variance_ratio_.sum()
+    print("Explained variance of the SVD step: {}%".format(
+        int(explained_variance * 100)))
+
     print()
 
 
@@ -197,7 +203,7 @@ if not (opts.n_components or opts.use_hashing):
     print("Top terms per cluster:")
     order_centroids = km.cluster_centers_.argsort()[:, ::-1]
     terms = vectorizer.get_feature_names()
-    for i in xrange(true_k):
+    for i in range(true_k):
         print("Cluster %d:" % i, end='')
         for ind in order_centroids[i, :10]:
             print(' %s' % terms[ind], end='')

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -6,7 +6,8 @@ import scipy.sparse as sp
 from sklearn.decomposition import TruncatedSVD
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
-                                   assert_raises)
+                                   assert_raises, assert_almost_equal,
+                                   assert_greater, assert_array_less)
 
 
 # Make an X that looks somewhat like a small tf-idf matrix.
@@ -74,3 +75,90 @@ def test_integers():
     tsvd = TruncatedSVD(n_components=6)
     Xtrans = tsvd.fit_transform(Xint)
     assert_equal(Xtrans.shape, (n_samples, tsvd.n_components))
+
+
+def test_explained_variance():
+    # Test sparse data
+    svd_a_10_sp = TruncatedSVD(10, algorithm="arpack")
+    svd_r_10_sp = TruncatedSVD(10, algorithm="randomized", random_state=42)
+    svd_a_20_sp = TruncatedSVD(20, algorithm="arpack")
+    svd_r_20_sp = TruncatedSVD(20, algorithm="randomized", random_state=42)
+    X_trans_a_10_sp = svd_a_10_sp.fit_transform(X)
+    X_trans_r_10_sp = svd_r_10_sp.fit_transform(X)
+    X_trans_a_20_sp = svd_a_20_sp.fit_transform(X)
+    X_trans_r_20_sp = svd_r_20_sp.fit_transform(X)
+
+    # Test dense data
+    svd_a_10_de = TruncatedSVD(10, algorithm="arpack")
+    svd_r_10_de = TruncatedSVD(10, algorithm="randomized", random_state=42)
+    svd_a_20_de = TruncatedSVD(20, algorithm="arpack")
+    svd_r_20_de = TruncatedSVD(20, algorithm="randomized", random_state=42)
+    X_trans_a_10_de = svd_a_10_de.fit_transform(X.toarray())
+    X_trans_r_10_de = svd_r_10_de.fit_transform(X.toarray())
+    X_trans_a_20_de = svd_a_20_de.fit_transform(X.toarray())
+    X_trans_r_20_de = svd_r_20_de.fit_transform(X.toarray())
+
+    # helper arrays for tests below
+    svds = (svd_a_10_sp, svd_r_10_sp, svd_a_20_sp, svd_r_20_sp, svd_a_10_de,
+            svd_r_10_de, svd_a_20_de, svd_r_20_de)
+    svds_trans = (
+        (svd_a_10_sp, X_trans_a_10_sp),
+        (svd_r_10_sp, X_trans_r_10_sp),
+        (svd_a_20_sp, X_trans_a_20_sp),
+        (svd_r_20_sp, X_trans_r_20_sp),
+        (svd_a_10_de, X_trans_a_10_de),
+        (svd_r_10_de, X_trans_r_10_de),
+        (svd_a_20_de, X_trans_a_20_de),
+        (svd_r_20_de, X_trans_r_20_de),
+    )
+    svds_10_v_20 = (
+        (svd_a_10_sp, svd_a_20_sp),
+        (svd_r_10_sp, svd_r_20_sp),
+        (svd_a_10_de, svd_a_20_de),
+        (svd_r_10_de, svd_r_20_de),
+    )
+    svds_sparse_v_dense = (
+        (svd_a_10_sp, svd_a_10_de),
+        (svd_a_20_sp, svd_a_20_de),
+        (svd_r_10_sp, svd_r_10_de),
+        (svd_r_20_sp, svd_r_20_de),
+    )
+
+    # Assert the 1st component is equal
+    for svd_10, svd_20 in svds_10_v_20:
+        assert_array_almost_equal(
+            svd_10.explained_variance_ratio_,
+            svd_20.explained_variance_ratio_[:10],
+            decimal=5,
+        )
+
+    # Assert that 20 components has higher explained variance than 10
+    for svd_10, svd_20 in svds_10_v_20:
+        assert_greater(
+            svd_20.explained_variance_ratio_.sum(),
+            svd_10.explained_variance_ratio_.sum(),
+        )
+
+    # Assert that all the values are greater than 0
+    for svd in svds:
+        assert_array_less(0.0, svd.explained_variance_ratio_)
+
+    # Assert that total explained variance is less than 1
+    for svd in svds:
+        assert_array_less(svd.explained_variance_ratio_.sum(), 1.0)
+
+    # Compare sparse vs. dense
+    for svd_sparse, svd_dense in svds_sparse_v_dense:
+        assert_array_almost_equal(svd_sparse.explained_variance_ratio_,
+                svd_dense.explained_variance_ratio_)
+
+    # Test that explained_variance is correct
+    for svd, transformed in svds_trans:
+        total_variance = np.var(X.toarray(), axis=0).sum()
+        variances = np.var(transformed, axis=0)
+        true_explained_variance_ratio = variances / total_variance
+
+        assert_array_almost_equal(
+            svd.explained_variance_ratio_,
+            true_explained_variance_ratio,
+        )

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -7,6 +7,7 @@
 import warnings
 
 import numpy as np
+import scipy.sparse as sp
 
 try:
     from scipy.sparse.linalg import svds
@@ -17,6 +18,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import (array2d, as_float_array, atleast2d_or_csr,
                      check_random_state)
 from ..utils.extmath import randomized_svd, safe_sparse_dot, svd_flip
+from ..utils.sparsefuncs import mean_variance_axis0
 
 __all__ = ["TruncatedSVD"]
 
@@ -60,6 +62,27 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     `components_` : array, shape (n_components, n_features)
+
+    `explained_variance_` : array, [n_components]
+        The variance of the training samples transformed by a projection to
+        each component.
+
+    `explained_variance_ratio_` : array, [n_components]
+        Percentage of variance explained by each of the selected components.
+
+    Examples
+    --------
+    >>> from sklearn.decomposition import TruncatedSVD
+    >>> from sklearn.random_projection import sparse_random_matrix
+    >>> X = sparse_random_matrix(100, 100, density=0.01, random_state=42)
+    >>> svd = TruncatedSVD(n_components=5, random_state=42)
+    >>> svd.fit(X) # doctest: +NORMALIZE_WHITESPACE
+    TruncatedSVD(algorithm='randomized', n_components=5, n_iter=5,
+            random_state=42, tol=0.0)
+    >>> print(svd.explained_variance_ratio_) # doctest: +ELLIPSIS
+    [ 0.07825... 0.05528... 0.05445... 0.04997... 0.04134...]
+    >>> print(svd.explained_variance_ratio_.sum()) # doctest: +ELLIPSIS
+    0.27930...
 
     See also
     --------
@@ -105,7 +128,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         self : object
             Returns the transformer object.
         """
-        self._fit(X)
+        self.fit_transform(X)
         return self
 
     def fit_transform(self, X, y=None):
@@ -121,14 +144,12 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         X_new : array, shape (n_samples, n_components)
             Reduced version of X. This will always be a dense array.
         """
-        U, Sigma, VT = self._fit(X)
-        Sigma = np.diag(Sigma)
-
-        return np.dot(U, Sigma.T)
-
-    def _fit(self, X):
         X = as_float_array(X, copy=False)
         random_state = check_random_state(self.random_state)
+
+        # If sparse and not csr or csc, convert to csr
+        if sp.issparse(X) and X.getformat() not in ["csr", "csc"]:
+            X = X.tocsr()
 
         if self.algorithm == "arpack":
             U, Sigma, VT = svds(X, k=self.n_components, tol=self.tol)
@@ -150,7 +171,18 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
             raise ValueError("unknown algorithm %r" % self.algorithm)
 
         self.components_ = VT
-        return U, Sigma, VT
+
+        # Calculate explained variance & explained variance ratio
+        n_samples = X.shape[0]
+        X_transformed = np.dot(U, np.diag(Sigma))
+        self.explained_variance_ = exp_var = np.var(X_transformed, axis=0)
+        if sp.issparse(X):
+            _, full_var = mean_variance_axis0(X)
+            full_var = full_var.sum()
+        else:
+            full_var = np.var(X, axis=0).sum()
+        self.explained_variance_ratio_ = exp_var / full_var
+        return X_transformed
 
     def transform(self, X):
         """Perform dimensionality reduction on X.


### PR DESCRIPTION
Fixes #3047 

We tested this similar to in #2663 and determined that it makes sense to calculate explained variance as part of the fit method but then we merged the _fit method with the fit_transform method to avoid doing some duplicate work. This change will cause a minor performance regression in the case where fit is called by itself separate from transform (i.e. when calling on different inputs) which I believe is not the normal use case for this estimator.
