### PR TITLE
DOC Fix ``copy_X `` default in documentation

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -573,7 +573,7 @@ class ElasticNet(LinearModel, RegressorMixin):
     max_iter : int, optional
         The maximum number of iterations
 
-    copy_X : boolean, optional, default False
+    copy_X : boolean, optional, default True
         If ``True``, X will be copied; else, it may be overwritten.
 
     tol: float, optional


### PR DESCRIPTION
The code uses `True` as the default, but the documentation incorrectly
stated that `False` was the default.
