### PR TITLE
open iris files with 'with' statement to avoid ResourceWarning

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -249,22 +249,25 @@ def load_iris():
     ['setosa', 'versicolor', 'virginica']
     """
     module_path = dirname(__file__)
-    data_file = csv.reader(open(join(module_path, 'data', 'iris.csv')))
-    fdescr = open(join(module_path, 'descr', 'iris.rst'))
-    temp = next(data_file)
-    n_samples = int(temp[0])
-    n_features = int(temp[1])
-    target_names = np.array(temp[2:])
-    data = np.empty((n_samples, n_features))
-    target = np.empty((n_samples,), dtype=np.int)
+    with open(join(module_path, 'data', 'iris.csv')) as csv_file:
+        data_file = csv.reader(csv_file)
+        temp = next(data_file)
+        n_samples = int(temp[0])
+        n_features = int(temp[1])
+        target_names = np.array(temp[2:])
+        data = np.empty((n_samples, n_features))
+        target = np.empty((n_samples,), dtype=np.int)
 
-    for i, ir in enumerate(data_file):
-        data[i] = np.asarray(ir[:-1], dtype=np.float)
-        target[i] = np.asarray(ir[-1], dtype=np.int)
+        for i, ir in enumerate(data_file):
+            data[i] = np.asarray(ir[:-1], dtype=np.float)
+            target[i] = np.asarray(ir[-1], dtype=np.int)
+
+    with open(join(module_path, 'descr', 'iris.rst')) as rst_file:
+        fdescr = rst_file.read()
 
     return Bunch(data=data, target=target,
                  target_names=target_names,
-                 DESCR=fdescr.read(),
+                 DESCR=fdescr,
                  feature_names=['sepal length (cm)', 'sepal width (cm)',
                                 'petal length (cm)', 'petal width (cm)'])
 


### PR DESCRIPTION
I was occasionally getting "ResourceWarning: unclosed file" warnings when running load_iris(). Moved file reading into 'with' blocks to handle IO stuff.
