### PR TITLE
DOC: Remove dead link

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,3 +1,5 @@
+.. _installation-instructions:
+
 =========================
 Installing `scikit-learn`
 =========================

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -30,7 +30,7 @@ To get started with this tutorial, you firstly must have the
 Please refer to the `scikit-learn install`_ page for more information
 and for per-system instructions.
 
-.. _`scikit-learn install`: http://scikit-learn.sourceforge.net/install.html
+.. _`scikit-learn install`: http://scikit-learn.org/stable/install.html
 
 The source of this tutorial can be found within your
 scikit-learn folder::

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -27,10 +27,8 @@ Tutorial setup
 To get started with this tutorial, you firstly must have the
 *scikit-learn* and all of its required dependencies installed.
 
-Please refer to the `scikit-learn install`_ page for more information
-and for per-system instructions.
-
-.. _`scikit-learn install`: http://scikit-learn.org/stable/install.html
+Please refer to the :ref:`installation instructions <installation-instructions>`
+page for more information and for per-system instructions.
 
 The source of this tutorial can be found within your
 scikit-learn folder::


### PR DESCRIPTION
Link to installation instructions was pointed to a non-existant location.
