### PR TITLE
[MRG+1] Feature or Bug? Whitened PCA does not inverse_transform properly and is even document that way

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,11 @@ Documentation improvements
 Bug fixes
 .........
 
+    - The :class:`decomposition.PCA` now undoes whitening in its 
+     ``inverse_transform``. Also, its ``components_`` now always have unit
+     length. By Michael Eickenberg.
+
+
 API changes summary
 -------------------
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -403,13 +403,14 @@ class PCA(BaseEstimator, TransformerMixin):
         Returns
         -------
         X_original array-like, shape (n_samples, n_features)
-
-        Notes
-        -----
-        If whitening is enabled, inverse_transform does not compute the
-        exact inverse operation as transform.
         """
-        return fast_dot(X, self.components_) + self.mean_
+        if self.whiten:
+            return fast_dot(X,
+                            self.explained_variance_[:, np.newaxis] *
+                            self.components_) + self.mean_
+        else:
+            return fast_dot(X, self.components_) + self.mean_
+
 
     def score_samples(self, X):
         """Return the log-likelihood of each sample

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -5,6 +5,7 @@
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Mathieu Blondel <mathieu@mblondel.org>
 #         Denis A. Engemann <d.engemann@fz-juelich.de>
+#         Michael Eickenberg <michael.eickenberg@inria.fr>
 #
 # License: BSD 3 clause
 
@@ -271,10 +272,7 @@ class PCA(BaseEstimator, TransformerMixin):
         explained_variance_ratio_ = (explained_variance_ /
                                      explained_variance_.sum())
 
-        if self.whiten:
-            components_ = V / (S[:, np.newaxis] / sqrt(n_samples))
-        else:
-            components_ = V
+        components_ = V
 
         n_components = self.n_components
         if n_components is None:
@@ -356,8 +354,6 @@ class PCA(BaseEstimator, TransformerMixin):
         # Get precision using matrix inversion lemma
         components_ = self.components_
         exp_var = self.explained_variance_
-        if self.whiten:
-            components_ = components_ * np.sqrt(exp_var[:, np.newaxis])
         exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
         precision = np.dot(components_, components_.T) / self.noise_variance_
         precision.flat[::len(precision) + 1] += 1. / exp_var_diff
@@ -388,6 +384,8 @@ class PCA(BaseEstimator, TransformerMixin):
         if self.mean_ is not None:
             X = X - self.mean_
         X_transformed = fast_dot(X, self.components_.T)
+        if self.whiten:
+            X_transformed /= np.sqrt(self.explained_variance_)
         return X_transformed
 
     def inverse_transform(self, X):
@@ -405,9 +403,10 @@ class PCA(BaseEstimator, TransformerMixin):
         X_original array-like, shape (n_samples, n_features)
         """
         if self.whiten:
-            return fast_dot(X,
-                            self.explained_variance_[:, np.newaxis] *
-                            self.components_) + self.mean_
+            return fast_dot(
+                X,
+                np.sqrt(self.explained_variance_[:, np.newaxis]) *
+                self.components_) + self.mean_
         else:
             return fast_dot(X, self.components_) + self.mean_
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -151,8 +151,7 @@ def test_pca_inverse():
     pca.fit(X)
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
-    relative_max_delta = (np.abs(X - Y_inverse) / np.abs(X).mean()).max()
-    assert_almost_equal(relative_max_delta, 0.11, decimal=2)
+    assert_almost_equal(X, Y_inverse, decimal=3)
 
 
 def test_pca_validation():


### PR DESCRIPTION
The `PCA.inverse_transform` docstring even explicitly states that the inverse transform after whitening is inexact, because the necessary rescaling to fall back into the right space is not done. Is there a specific reason for this? One would think that the expected behaviour of an `inverse_transform` should be that it maps to the closest possible point in input space given the incurred information loss. Since with (full rank) PCA one can keep all the information, the inverse transform should be the true inverse.

Any opinions on this?

My main concern for changing this is that this behaviour is documented and thus possibly expected by some users.
Making the `PCA` object do a true inverse is as easy as adding 2 lines to the `inverse_transform` as visible in the diff.
