### PR TITLE
PCA inverse_transform now computes the exact inverse operation as transform

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -406,10 +406,8 @@ class PCA(BaseEstimator, TransformerMixin):
 
         Notes
         -----
-        If whitening is enabled, inverse_transform does not compute the
-        exact inverse operation as transform.
         """
-        return fast_dot(X, self.components_) + self.mean_
+        return fast_dot(X, self.components_ if not self.whiten else self.explained_variance_[:, np.newaxis] * self.components_) + self.mean_
 
     def score_samples(self, X):
         """Return the log-likelihood of each sample


### PR DESCRIPTION
If there is no specific reason, why PCA.inverse_transfrom(PCA.transform(X)) should not be as close to X as possible, this fixes the issue (these changes make one of the tests fail, as it expects relative delta of PCA.inverse_transfrom(PCA.transform(X) be greater).

P.S. Sorry if there actually is a reason for such behavior which I just failed to find, and am now bothering you for no reason.
