### PR TITLE
[MRG+1] Bad default arguments in gmm.py

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -556,7 +556,7 @@ class GMM(BaseEstimator):
 #########################################################################
 
 
-def _log_multivariate_normal_density_diag(X, means=0.0, covars=1.0):
+def _log_multivariate_normal_density_diag(X, means, covars):
     """Compute Gaussian log-density at X for a diagonal model"""
     n_samples, n_dim = X.shape
     lpr = -0.5 * (n_dim * np.log(2 * np.pi) + np.sum(np.log(covars), 1)
@@ -566,7 +566,7 @@ def _log_multivariate_normal_density_diag(X, means=0.0, covars=1.0):
     return lpr
 
 
-def _log_multivariate_normal_density_spherical(X, means=0.0, covars=1.0):
+def _log_multivariate_normal_density_spherical(X, means, covars):
     """Compute Gaussian log-density at X for a spherical model"""
     cv = covars.copy()
     if covars.ndim == 1:

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -98,7 +98,6 @@ def sample_gaussian(mean, covar, covariance_type='diag', n_samples=1,
         rand = np.dot(np.diag(np.sqrt(covar)), rand)
     else:
         s, U = linalg.eigh(covar)
-        sqrtS = np.sqrt(s)
         sqrt_covar = U * np.sqrt(s)
         rand = np.dot(sqrt_covar, rand)
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -97,9 +97,9 @@ def sample_gaussian(mean, covar, covariance_type='diag', n_samples=1,
     elif covariance_type == 'diag':
         rand = np.dot(np.diag(np.sqrt(covar)), rand)
     else:
-        U, s, V = linalg.svd(covar)
-        sqrtS = np.diag(np.sqrt(s))
-        sqrt_covar = np.dot(U, np.dot(sqrtS, V))
+        s, U = linalg.eigh(covar)
+        sqrtS = np.sqrt(s)
+        sqrt_covar = U * np.sqrt(s)
         rand = np.dot(sqrt_covar, rand)
 
     return (rand.T + mean).T

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -97,7 +97,6 @@ def sample_gaussian(mean, covar, covariance_type='diag', n_samples=1,
     elif covariance_type == 'diag':
         rand = np.dot(np.diag(np.sqrt(covar)), rand)
     else:
-        from scipy import linalg
         U, s, V = linalg.svd(covar)
         sqrtS = np.diag(np.sqrt(s))
         sqrt_covar = np.dot(U, np.dot(sqrtS, V))


### PR DESCRIPTION
Removed default values for 'mean' and 'covars' arguments. The did not have the excepted format causing the function to fail when called with default arguments.
