### PR TITLE
Updated K-means clustering for Nystroem

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -36,9 +36,9 @@ The Nystroem method, as implemented in :class:`Nystroem` is a general method
 for low-rank approximations of kernels. It achieves this by essentially subsampling
 the data on which the kernel is evaluated.
 The subsampling methodology used to generate the approximate kernel is specified by
-the parameter ``basis_method`` which can either be ``random`` or ``clustered``.
+the parameter ``basis_sampling`` which can either be ``random`` or ``kmeans``.
 If the ``random`` method is specified randomly selected data will be utilized in
-the approximation while the ``clustered`` method uses the cluster centers found via
+the approximation while the ``kmeans`` method uses the cluster centers found via
 k-means clustering. Further details concerning the subsampling methods can be found
 in [ZK2010]_.
 By default :class:`Nystroem` uses the ``rbf`` kernel, but it can use any

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -35,9 +35,15 @@ Nystroem Method for Kernel Approximation
 The Nystroem method, as implemented in :class:`Nystroem` is a general method
 for low-rank approximations of kernels. It achieves this by essentially subsampling
 the data on which the kernel is evaluated.
+The subsampling methodology used to generate the approximate kernel is specified by
+the parameter ``basis_method`` which can either be ``random`` or ``clustered``.
+If the ``random`` method is specified randomly selected data will be utilized in
+the approximation while the ``clustered`` method uses the cluster centers found via
+k-means clustering. Further details concerning the subsampling methods can be found
+in [ZK2010]_.
 By default :class:`Nystroem` uses the ``rbf`` kernel, but it can use any
 kernel function or a precomputed kernel matrix.
-The number of samples used - which is also the dimensionality of the features computed -
+The number of bases used - which is also the dimensionality of the features computed -
 is given by the parameter ``n_components``.
 
 
@@ -197,3 +203,6 @@ or store training examples.
     .. [VVZ2010] `"Generalized RBF feature maps for Efficient Detection"
       <http://eprints.pascal-network.org/archive/00007024/01/inproceedings.pdf.8a865c2a5421e40d.537265656b616e7468313047656e6572616c697a65642e706466.pdf>`_
       Vempati, S. and Vedaldi, A. and Zisserman, A. and Jawahar, CV - 2010
+    .. [ZK2010] `"Clustered Nystroem method for large scale manifold learning and dimension reduction"
+      <http://www.cs.ust.hk/~jamesk/papers/tnn10b.pdf>`_
+      Zhang, K. and Kwok, J.T. - Neural Networks, IEEE Transactions on 21, no. 10 2010

--- a/examples/plot_kernel_approximation.py
+++ b/examples/plot_kernel_approximation.py
@@ -85,8 +85,8 @@ linear_svm = svm.LinearSVC()
 # create pipeline from kernel approximation
 # and linear svm
 feature_map_fourier = RBFSampler(gamma=kernel_gamma, random_state=0)
-feature_map_random_nystroem = Nystroem(gamma=kernel_gamma, random_state=0, basis_method='random')
-feature_map_clusted_nystroem_ = Nystroem(gamma=kernel_gamma, random_state=0, basis_method='clustered')
+feature_map_random_nystroem = Nystroem(gamma=kernel_gamma, random_state=0, basis_sampling='random')
+feature_map_clusted_nystroem_ = Nystroem(gamma=kernel_gamma, random_state=0, basis_sampling='kmeans')
 
 fourier_approx_svm = pipeline.Pipeline([("feature_map", feature_map_fourier),
                                         ("svm", svm.LinearSVC())])
@@ -147,9 +147,9 @@ accuracy.plot(sample_sizes, random_scores, label="Random Nystroem approx. kernel
 timescale.plot(sample_sizes, random_times, '--',
                label='Random Nystroem approx. kernel')
 
-accuracy.plot(sample_sizes, clustered_scores, label="Clustered Nystroem approx. kernel")
+accuracy.plot(sample_sizes, clustered_scores, label="K-means Nystroem approx. kernel")
 timescale.plot(sample_sizes, clustered_times, '--',
-               label='Clustered Nystroem approx. kernel')
+               label='K-means Nystroem approx. kernel')
 
 accuracy.plot(sample_sizes, fourier_scores, label="Fourier approx. kernel")
 timescale.plot(sample_sizes, fourier_times, '--',
@@ -204,7 +204,7 @@ titles = ['SVC with rbf kernel',
           'SVC with linear kernel',
           'SVC (linear kernel)\n with Fourier rbf approx\n'
           'n_components={}'.format(n_components_to_plot),
-          'SVC (linear kernel)\n with clustered Nystroem rbf approx\n'
+          'SVC (linear kernel)\n with K-means Nystroem rbf approx\n'
           'n_components={}'.format(n_components_to_plot)]
 
 plt.tight_layout()

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -469,7 +469,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
             basis_inds = None
 
         else:
-            raise NameError('{} is not a supported basis_method'.format(self.basis_method))
+            raise NameError('{0} is not a supported basis_method'.format(self.basis_method))
 
         basis_kernel = pairwise_kernels(basis, metric=self.kernel,
                                         filter_params=True,

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -377,7 +377,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         If int, random_state is the seed used by the random number generator;
         if RandomState instance, random_state is the random number generator.
 
-    basis_method : string "random" or "clustered"
+    basis_sampling : string "random" or "kmeans"
         Form approximation using randomly sampled columns or k-means
         cluster centers to construct the Nystrom Approximation
 
@@ -420,7 +420,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
     """
     def __init__(self, kernel="rbf", gamma=None, coef0=1, degree=3,
                  kernel_params=None, n_components=100, random_state=None,
-                 basis_method="random"):
+                 basis_sampling="random"):
         self.kernel = kernel
         self.gamma = gamma
         self.coef0 = coef0
@@ -428,7 +428,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         self.kernel_params = kernel_params
         self.n_components = n_components
         self.random_state = random_state
-        self.basis_method = basis_method
+        self.basis_sampling = basis_sampling
 
     def fit(self, X, y=None):
         """Fit estimator to data.
@@ -458,18 +458,17 @@ class Nystroem(BaseEstimator, TransformerMixin):
         else:
             n_components = self.n_components
 
-        if self.basis_method == "random":
+        if self.basis_sampling == "random":
             inds = rnd.permutation(n_samples)
             basis_inds = inds[:n_components]
             basis = X[basis_inds]
-        elif self.basis_method == "clustered":
+        elif self.basis_sampling == "kmeans":
             # Zhang and Kwok use 5 in their paper so lets do that
             basis, _, _ = k_means(X, n_components, init='random', max_iter=5, n_init=1, random_state=rnd)
             #If we are using k_means centers as input, cannot record basis_inds
             basis_inds = None
-
         else:
-            raise NameError('{0} is not a supported basis_method'.format(self.basis_method))
+            raise NameError('{0} is not a supported basis_sampling method'.format(self.basis_sampling))
 
         basis_kernel = pairwise_kernels(basis, metric=self.kernel,
                                         filter_params=True,

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -138,32 +138,106 @@ def test_input_validation():
     RBFSampler().fit(X).transform(X)
 
 
-def test_nystroem_approximation():
+def test_nystroem_approximation_with_number_samples_is_exact():
     # some basic tests
     rnd = np.random.RandomState(0)
     X = rnd.uniform(size=(10, 4))
 
     # With n_components = n_samples this is exact
-    X_transformed = Nystroem(n_components=X.shape[0]).fit_transform(X)
+    ny_random = Nystroem(n_components=X.shape[0], basis_method='random')
+    X_transformed_random = ny_random.fit_transform(X)
     K = rbf_kernel(X)
+    assert_array_equal(np.sort(ny_random.component_indices_), np.arange(X.shape[0]))
+    assert_array_almost_equal(np.dot(X_transformed_random, X_transformed_random.T), K)
+
+    ny_clustered = Nystroem(n_components=X.shape[0], basis_method='clustered')
+    X_transformed_clustered = ny_clustered.fit_transform(X)
+    K = rbf_kernel(X)
+    # No component indicies to report for k-means
+    assert_equal(ny_clustered.component_indices_, None)
+    assert_array_almost_equal(np.dot(X_transformed_clustered, X_transformed_clustered.T), K)
+
+
+def test_nystroem_approximation_returns_appropriate_indices():
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 4))
+
+    ny_random = Nystroem(n_components=2, basis_method='random')
+    X_transformed = ny_random.fit_transform(X)
+    assert_equal(X_transformed.shape, (X.shape[0], 2))
+    assert_equal(len(ny_random.component_indices_), 2)
+    assert_array_almost_equal(ny_random.components_, X[ny_random.component_indices_])
+
+    ny_clustered = Nystroem(n_components=2, basis_method='clustered')
+    ny_clustered.fit_transform(X)
+    # No component indicies to report for k-means
+    assert_equal(ny_clustered.component_indices_, None)
+
+
+def test_nystroem_approximation_with_singular_kernel_matrix():
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 4))
+    X = np.concatenate((X, X[-2:, :]), axis=0)
+
+    K = rbf_kernel(X)
+    assert_equal(np.linalg.matrix_rank(K), 10)
+
+    ny_random = Nystroem(n_components=X.shape[0], basis_method='random')
+    X_transformed = ny_random.fit_transform(X)
+    assert_equal(X_transformed.shape, (X.shape[0], 12))
     assert_array_almost_equal(np.dot(X_transformed, X_transformed.T), K)
 
-    trans = Nystroem(n_components=2, random_state=rnd)
-    X_transformed = trans.fit(X).transform(X)
-    assert_equal(X_transformed.shape, (X.shape[0], 2))
 
-    # test callable kernel
-    linear_kernel = lambda X, Y: np.dot(X, Y.T)
-    trans = Nystroem(n_components=2, kernel=linear_kernel, random_state=rnd)
-    X_transformed = trans.fit(X).transform(X)
-    assert_equal(X_transformed.shape, (X.shape[0], 2))
+def test_nystroem_approximation_for_multiple_kernels():
+    """test that Nystroem approximates kernel on random data"""
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 4))
+    trans_not_valid = Nystroem(n_components=2, random_state=rnd,
+                               basis_method="not_a_valid_basis_method")
+    assert_raises(NameError, trans_not_valid.fit, X)
 
-    # test that available kernels fit and transform
-    kernels_available = kernel_metrics()
-    for kern in kernels_available:
-        trans = Nystroem(n_components=2, kernel=kern, random_state=rnd)
-        X_transformed = trans.fit(X).transform(X)
-        assert_equal(X_transformed.shape, (X.shape[0], 2))
+    # Kernel tests to perform with each basis method used
+    def test_nystroem_approximation_with_basis(tested_basis):
+         # Test default kernel
+        trans = Nystroem(n_components=2, random_state=rnd, basis_method=tested_basis)
+        transformed = trans.fit(X).transform(X)
+        assert_equal(transformed.shape, (X.shape[0], 2))
+
+        # test callable kernel
+        linear_kernel = lambda X, Y: np.dot(X, Y.T)
+        trans = Nystroem(n_components=2, kernel=linear_kernel, random_state=rnd, basis_method=tested_basis)
+        transformed = trans.fit(X).transform(X)
+        assert_equal(transformed.shape, (X.shape[0], 2))
+
+        # test that available kernels fit and transform
+        kernels_available = kernel_metrics()
+        for kern in kernels_available:
+            trans = Nystroem(n_components=2, kernel=kern, random_state=rnd, basis_method=tested_basis)
+            transformed = trans.fit(X).transform(X)
+            assert_equal(transformed.shape, (X.shape[0], 2))
+
+        # Test default kernel
+        trans = Nystroem(n_components=2, random_state=rnd, basis_method=tested_basis)
+        transformed = trans.fit(X).transform(X)
+        assert_equal(transformed.shape, (X.shape[0], 2))
+
+        # test callable kernel
+        linear_kernel = lambda X, Y: np.dot(X, Y.T)
+        trans = Nystroem(n_components=2, kernel=linear_kernel, random_state=rnd, basis_method=tested_basis)
+        transformed = trans.fit(X).transform(X)
+        assert_equal(transformed.shape, (X.shape[0], 2))
+
+        # test that available kernels fit and transform
+        kernels_available = kernel_metrics()
+        for kern in kernels_available:
+            trans = Nystroem(n_components=2, kernel=kern, random_state=rnd, basis_method=tested_basis)
+            transformed = trans.fit(X).transform(X)
+            assert_equal(transformed.shape, (X.shape[0], 2))
+
+    # Go through all the kernels with each basis_method
+    basis_methods = ("random", "clustered")
+    for current_basis in basis_methods:
+        yield test_nystroem_approximation_with_basis, current_basis
 
 
 def test_nystroem_poly_kernel_params():
@@ -172,10 +246,18 @@ def test_nystroem_poly_kernel_params():
     X = rnd.uniform(size=(10, 4))
 
     K = polynomial_kernel(X, degree=3.1, coef0=.1)
-    nystroem = Nystroem(kernel="polynomial", n_components=X.shape[0],
-                        degree=3.1, coef0=.1)
-    X_transformed = nystroem.fit_transform(X)
-    assert_array_almost_equal(np.dot(X_transformed, X_transformed.T), K)
+    nystroem_random = Nystroem(kernel="polynomial", n_components=X.shape[0],
+                               degree=3.1, coef0=.1, basis_method="random")
+    nystroem_k_means = Nystroem(kernel="polynomial", n_components=X.shape[0],
+                                degree=3.1, coef0=.1, basis_method="clustered")
+
+    transformed_k_means = nystroem_k_means.fit_transform(X)
+    transformed_random = nystroem_random.fit_transform(X)
+
+    assert_array_almost_equal(np.dot(transformed_k_means,
+                                     transformed_k_means.T), K)
+    assert_array_almost_equal(np.dot(transformed_random,
+                                     transformed_random.T), K)
 
 
 def test_nystroem_callable():
@@ -190,8 +272,15 @@ def test_nystroem_callable():
         return np.minimum(x, y).sum()
 
     kernel_log = []
-    X = list(X)     # test input validation
     Nystroem(kernel=logging_histogram_kernel,
              n_components=(n_samples - 1),
-             kernel_params={'log': kernel_log}).fit(X)
+             kernel_params={'log': kernel_log}, basis_method="clustered").fit(X)
+
+    assert_equal(len(kernel_log), n_samples * (n_samples - 1) / 2)
+
+    kernel_log = []
+    Nystroem(kernel=logging_histogram_kernel,
+             n_components=(n_samples - 1),
+             kernel_params={'log': kernel_log}, basis_method="random").fit(X)
+
     assert_equal(len(kernel_log), n_samples * (n_samples - 1) / 2)


### PR DESCRIPTION
Because I wanted to try K-means clustering as the basis for Nystroem approximation and it appeared as though pull request #2591 might be stalled I created a slightly modified version. I also tried to address @amueller comment about the effectiveness of the method by including it in the plot_kernel_approximation example and @dougalsutherland comment concerning the possible singularity of the sub-sampled kernel matrix using the same approach as scipy does in pinv2.

Since it is my first commit to the project (hopefully the first of many) any feedback or suggestions you have would be appreciated.
