### PR TITLE
[DOC] Make _fit_and_score return value docstring consistent with code.

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1159,11 +1159,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose, parameters,
 
     Returns
     -------
+    train_score : float, optional
+        Score on training set, returned only if `return_train_score` is `True`. 
+        
     test_score : float
         Score on test set.
-
-    train_score : float, optional
-        Score on training set.
 
     n_test_samples : int
         Number of test samples.


### PR DESCRIPTION
The order of the return values currently listed in the cross_validation._fit_and_score docstring does not match the actual order of the return values when the kwarg `return_train_score=True`. In the code, this option causes the train_score to be the first return value, but in the docstring it's implied that it's the second.

This PR changes the docstring to be in sync with the code.
