### PR TITLE
[MRG+1] MAINT Refactor  univariate_selection module

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -66,20 +66,19 @@ as objects that implement the `transform` method:
     selection with a configurable strategy. This allows to select the best
     univariate selection strategy with hyper-parameter search estimator.
 
-Using the boolean-feature example given above,
-we can perform a :math:`\chi^2` test to the samples
+For instance, we can perform a :math:`\chi^2` test to the samples
 to retrieve only the two best features as follows:
 
-  >>> from sklearn.feature_selection import VarianceThreshold
-  >>> X = [[0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 1], [0, 1, 0], [0, 1, 1]]
-  >>> sel = VarianceThreshold(threshold=(.8 * (1 - .8)))
-  >>> sel.fit_transform(X)
-  array([[0, 1],
-         [1, 0],
-         [0, 0],
-         [1, 1],
-         [1, 0],
-         [1, 1]])
+  >>> from sklearn.datasets import load_iris
+  >>> from sklearn.feature_selection import SelectKBest
+  >>> from sklearn.feature_selection import chi2
+  >>> iris = load_iris()
+  >>> X, y = iris.data, iris.target
+  >>> X.shape
+  (150, 4)
+  >>> X_new = SelectKBest(chi2, k=2).fit_transform(X, y)
+  >>> X_new.shape
+  (150, 2)
 
 These objects take as input a scoring function that returns
 univariate p-values:

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -235,6 +235,7 @@ def test_select_kbest_all():
     X_r = univariate_filter.fit(X, y).transform(X)
     assert_array_equal(X, X_r)
 
+
 def test_select_kbest_zero():
     """
     Test whether k=0 correctly returns no features.
@@ -245,8 +246,9 @@ def test_select_kbest_zero():
     univariate_filter = SelectKBest(f_classif, k=0)
     univariate_filter.fit(X, y).transform(X)
     support = univariate_filter.get_support()
-    gtruth= np.zeros(10, dtype=bool)
+    gtruth = np.zeros(10, dtype=bool)
     assert_array_equal(support, gtruth)
+
 
 def test_select_fpr_classif():
     """
@@ -375,7 +377,11 @@ def test_select_percentile_regression_full():
 
 
 def test_invalid_percentile():
-    assert_raises(ValueError, SelectPercentile, percentile=101)
+    X, y = make_regression(n_samples=10, n_features=20,
+                           n_informative=2, shuffle=False, random_state=0)
+
+    assert_raises(ValueError, SelectPercentile(percentile=101).fit, X, y)
+    assert_raises(ValueError, SelectPercentile(percentile=-1).fit, X, y)
 
 
 def test_select_kbest_regression():
@@ -544,5 +550,10 @@ def test_nans():
 
 
 def test_score_func_error():
+    X = [[0, 1, 0],
+         [0, -1, -1],
+         [0, .5, .5]]
+    y = [1, 0, 1]
+
     # test that score-func needs to be a callable
-    assert_raises(TypeError, SelectKBest, score_func=10)
+    assert_raises(TypeError, SelectKBest(score_func=10).fit, X, y)

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -380,8 +380,12 @@ def test_invalid_percentile():
     X, y = make_regression(n_samples=10, n_features=20,
                            n_informative=2, shuffle=False, random_state=0)
 
-    assert_raises(ValueError, SelectPercentile(percentile=101).fit, X, y)
     assert_raises(ValueError, SelectPercentile(percentile=-1).fit, X, y)
+    assert_raises(ValueError, SelectPercentile(percentile=101).fit, X, y)
+    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
+                                                      param=-1).fit, X, y)
+    assert_raises(ValueError, GenericUnivariateSelect(mode='percentile',
+                                                      param=101).fit, X, y)
 
 
 def test_select_kbest_regression():
@@ -538,9 +542,7 @@ def test_nans():
     """Assert that SelectKBest and SelectPercentile can handle NaNs."""
     # First feature has zero variance to confuse f_classif (ANOVA) and
     # make it return a NaN.
-    X = [[0, 1, 0],
-         [0, -1, -1],
-         [0, .5, .5]]
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
     y = [1, 0, 1]
 
     for select in (SelectKBest(f_classif, 2),
@@ -550,10 +552,21 @@ def test_nans():
 
 
 def test_score_func_error():
-    X = [[0, 1, 0],
-         [0, -1, -1],
-         [0, .5, .5]]
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
     y = [1, 0, 1]
 
-    # test that score-func needs to be a callable
-    assert_raises(TypeError, SelectKBest(score_func=10).fit, X, y)
+    for SelectFeatures in [SelectKBest, SelectPercentile, SelectFwe,
+                           SelectFdr, SelectFpr, GenericUnivariateSelect]:
+        assert_raises(TypeError, SelectFeatures(score_func=10).fit, X, y)
+
+
+def test_invalid_k():
+    X = [[0, 1, 0], [0, -1, -1], [0, .5, .5]]
+    y = [1, 0, 1]
+
+    assert_raises(ValueError, SelectKBest(k=-1).fit, X, y)
+    assert_raises(ValueError, SelectKBest(k=4).fit, X, y)
+    assert_raises(ValueError,
+                  GenericUnivariateSelect(mode='k_best', param=-1).fit, X, y)
+    assert_raises(ValueError,
+                  GenericUnivariateSelect(mode='k_best', param=4).fit, X, y)

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -6,12 +6,17 @@ import itertools
 import numpy as np
 from scipy import stats, sparse
 
-from nose.tools import (assert_equal, assert_almost_equal, assert_raises,
-                        assert_true)
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from sklearn.utils.testing import assert_not_in, ignore_warnings
-
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_not_in
+from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import ignore_warnings
 from sklearn.utils import safe_mask
+
 from sklearn.datasets.samples_generator import (make_classification,
                                                 make_regression)
 from sklearn.feature_selection import (chi2, f_classif, f_oneway, f_regression,
@@ -60,11 +65,11 @@ def test_f_classif():
 
     F, pv = f_classif(X, y)
     F_sparse,  pv_sparse = f_classif(sparse.csr_matrix(X), y)
-    assert(F > 0).all()
-    assert(pv > 0).all()
-    assert(pv < 1).all()
-    assert(pv[:5] < 0.05).all()
-    assert(pv[5:] > 1.e-4).all()
+    assert_true((F > 0).all())
+    assert_true((pv > 0).all())
+    assert_true((pv < 1).all())
+    assert_true((pv[:5] < 0.05).all())
+    assert_true((pv[5:] > 1.e-4).all())
     assert_array_almost_equal(F_sparse, F)
     assert_array_almost_equal(pv_sparse, pv)
 
@@ -78,11 +83,11 @@ def test_f_regression():
                            shuffle=False, random_state=0)
 
     F, pv = f_regression(X, y)
-    assert(F > 0).all()
-    assert(pv > 0).all()
-    assert(pv < 1).all()
-    assert(pv[:5] < 0.05).all()
-    assert(pv[5:] > 1.e-4).all()
+    assert_true((F > 0).all())
+    assert_true((pv > 0).all())
+    assert_true((pv < 1).all())
+    assert_true((pv[:5] < 0.05).all())
+    assert_true((pv[5:] > 1.e-4).all())
 
     # again without centering, compare with sparse
     F, pv = f_regression(X, y, center=False)
@@ -137,11 +142,11 @@ def test_f_classif_multi_class():
                                class_sep=10, shuffle=False, random_state=0)
 
     F, pv = f_classif(X, y)
-    assert(F > 0).all()
-    assert(pv > 0).all()
-    assert(pv < 1).all()
-    assert(pv[:5] < 0.05).all()
-    assert(pv[5:] > 1.e-5).all()
+    assert_true((F > 0).all())
+    assert_true((pv > 0).all())
+    assert_true((pv < 1).all())
+    assert_true((pv[:5] < 0.05).all())
+    assert_true((pv[5:] > 1.e-4).all())
 
 
 def test_select_percentile_classif():
@@ -316,7 +321,7 @@ def test_select_fwe_classif():
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
     gtruth[:5] = 1
-    assert(np.sum(np.abs(support - gtruth)) < 2)
+    assert_array_almost_equal(support, gtruth)
 
 
 ##############################################################################
@@ -426,8 +431,8 @@ def test_select_fpr_regression():
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
     gtruth[:5] = 1
-    assert(support[:5] == 1).all()
-    assert(np.sum(support[5:] == 1) < 3)
+    assert_array_equal(support[:5], np.ones((5, ), dtype=np.bool))
+    assert_less(np.sum(support[5:] == 1), 3)
 
 
 def test_select_fdr_regression():
@@ -467,8 +472,8 @@ def test_select_fwe_regression():
     support = univariate_filter.get_support()
     gtruth = np.zeros(20)
     gtruth[:5] = 1
-    assert(support[:5] == 1).all()
-    assert(np.sum(support[5:] == 1) < 2)
+    assert_array_equal(support[:5], np.ones((5, ), dtype=np.bool))
+    assert_less(np.sum(support[5:] == 1), 2)
 
 
 def test_selectkbest_tiebreaking():

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -411,9 +411,6 @@ class SelectKBest(_BaseFilter):
             return np.zeros(self.scores_.shape, dtype=bool)
         else:
             scores = _clean_nans(self.scores_)
-            # XXX This should be refactored; we're getting an array of indices
-            # from argsort, which we transform to a mask, which we probably
-            # transform back to indices later.
             mask = np.zeros(scores.shape, dtype=bool)
 
             # Request a stable sort. Mergesort takes more memory (~40MB per

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -261,7 +261,7 @@ def f_regression(X, y, center=True):
 # Base classes
 
 class _BaseFilter(BaseEstimator, SelectorMixin):
-    """ Initialize the univariate feature selection.
+    """Initialize the univariate feature selection.
 
     Parameters
     ----------

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 """Univariate features selection."""
 
 # Authors: V. Michel, B. Thirion, G. Varoquaux, A. Gramfort, E. Duchesnay.
-#          L. Buitinck
+#          L. Buitinck, A. Joly
 # License: BSD 3 clause
 
-
-from abc import ABCMeta, abstractmethod
 
 import numpy as np
 from scipy import special, stats
@@ -18,7 +15,6 @@ from ..utils import (array2d, as_float_array,
                      atleast2d_or_csr, check_arrays, safe_sqr,
                      safe_mask)
 from ..utils.extmath import norm, safe_sparse_dot
-from ..externals import six
 from .base import SelectorMixin
 
 
@@ -147,7 +143,7 @@ def _chisquare(f_obs, f_exp):
     f_obs = np.asarray(f_obs, dtype=np.float64)
 
     k = len(f_obs)
-    # Reuse f_obs for χ² statistics
+    # Reuse f_obs for chi-squared statistics
     chisq = f_obs
     chisq -= f_exp
     chisq **= 2
@@ -264,59 +260,58 @@ def f_regression(X, y, center=True):
 ######################################################################
 # Base classes
 
-class _BaseFilter(six.with_metaclass(ABCMeta, BaseEstimator,
-                                     SelectorMixin)):
+class _BaseFilter(BaseEstimator, SelectorMixin):
+    """ Initialize the univariate feature selection.
+
+    Parameters
+    ----------
+    score_func : callable
+        Function taking two arrays X and y, and returning a pair of arrays
+        (scores, pvalues).
+    """
 
     def __init__(self, score_func):
-        """ Initialize the univariate feature selection.
+        self.score_func = score_func
+
+    def fit(self, X, y):
+        """Run score function on (X, y) and get the appropriate features.
 
         Parameters
         ----------
-        score_func : callable
-            Function taking two arrays X and y, and returning a pair of arrays
-            (scores, pvalues).
+        X : array-like, shape = [n_samples, n_features]
+            The training input samples.
+
+        y : array-like, shape = [n_samples]
+            The target values (class labels in classification, real numbers in
+            regression).
+
+        Returns
+        -------
+        self : object
+            Returns self.
         """
-        if not callable(score_func):
-            raise TypeError(
-                "The score function should be a callable, %s (%s) "
-                "was passed." % (score_func, type(score_func)))
-        self.score_func = score_func
+        X, y = check_arrays(X, y)
 
-    @abstractmethod
-    def fit(self, X, y):
-        """Run score function on (X, y) and get the appropriate features."""
+        if not callable(self.score_func):
+            raise TypeError("The score function should be a callable, %s (%s) "
+                            "was passed."
+                            % (self.score_func, type(self.score_func)))
 
+        self._check_params(X, y)
 
-class _PvalueFilter(_BaseFilter):
-    def fit(self, X, y):
-        """Evaluate the score function on samples X with outputs y.
-
-        Records and selects features according to the p-values output by the
-        score function.
-        """
         self.scores_, self.pvalues_ = self.score_func(X, y)
         self.scores_ = np.asarray(self.scores_)
         self.pvalues_ = np.asarray(self.pvalues_)
         return self
 
-
-class _ScoreFilter(_BaseFilter):
-    def fit(self, X, y):
-        """Evaluate the score function on samples X with outputs y.
-
-        Records and selects features according to their scores.
-        """
-        self.scores_, self.pvalues_ = self.score_func(X, y)
-        self.scores_ = np.asarray(self.scores_)
-        self.pvalues_ = np.asarray(self.pvalues_)
-        return self
+    def _check_params(self, X, y):
+        pass
 
 
 ######################################################################
 # Specific filters
 ######################################################################
-
-class SelectPercentile(_ScoreFilter):
+class SelectPercentile(_BaseFilter):
     """Select features according to a percentile of the highest scores.
 
     Parameters
@@ -344,35 +339,34 @@ class SelectPercentile(_ScoreFilter):
     """
 
     def __init__(self, score_func=f_classif, percentile=10):
-        if not 0 <= percentile <= 100:
-            raise ValueError("percentile should be >=0, <=100; got %r"
-                             % percentile)
-        self.percentile = percentile
         super(SelectPercentile, self).__init__(score_func)
+        self.percentile = percentile
+
+    def _check_params(self, X, y):
+        if not 0 <= self.percentile <= 100:
+            raise ValueError("percentile should be >=0, <=100; got %r"
+                             % self.percentile)
 
     def _get_support_mask(self):
-        percentile = self.percentile
-        if percentile > 100:
-            raise ValueError("percentile should be between 0 and 100"
-                             " (%f given)" % (percentile))
         # Cater for NaNs
-        if percentile == 100:
+        if self.percentile == 100:
             return np.ones(len(self.scores_), dtype=np.bool)
-        elif percentile == 0:
+        elif self.percentile == 0:
             return np.zeros(len(self.scores_), dtype=np.bool)
-        scores = _clean_nans(self.scores_)
 
-        alpha = stats.scoreatpercentile(scores, 100 - percentile)
-        mask = scores > alpha
-        ties = np.where(scores == alpha)[0]
+        scores = _clean_nans(self.scores_)
+        treshold = stats.scoreatpercentile(scores,
+                                           100 - self.percentile)
+        mask = scores > treshold
+        ties = np.where(scores == treshold)[0]
         if len(ties):
-            max_feats = len(scores) * percentile // 100
+            max_feats = len(scores) * self.percentile // 100
             kept_ties = ties[:max_feats - mask.sum()]
             mask[kept_ties] = True
         return mask
 
 
-class SelectKBest(_ScoreFilter):
+class SelectKBest(_BaseFilter):
     """Select features according to the k highest scores.
 
     Parameters
@@ -401,33 +395,34 @@ class SelectKBest(_ScoreFilter):
     """
 
     def __init__(self, score_func=f_classif, k=10):
-        self.k = k
         super(SelectKBest, self).__init__(score_func)
+        self.k = k
+
+    def _check_params(self, X, y):
+        if not (0 <= self.k <= X.shape[1] or self.k == "all"):
+            raise ValueError("k should be >=0, <= n_features; got %r."
+                             "Use k='all' to return all features."
+                             % self.k)
 
     def _get_support_mask(self):
-        k = self.k
-        if k == 'all':
+        if self.k == 'all':
             return np.ones(self.scores_.shape, dtype=bool)
-        elif k == 0:
+        elif self.k == 0:
             return np.zeros(self.scores_.shape, dtype=bool)
-        if k > len(self.scores_):
-            raise ValueError("Cannot select %d features among %d. "
-                             "Use k='all' to return all features."
-                             % (k, len(self.scores_)))
+        else:
+            scores = _clean_nans(self.scores_)
+            # XXX This should be refactored; we're getting an array of indices
+            # from argsort, which we transform to a mask, which we probably
+            # transform back to indices later.
+            mask = np.zeros(scores.shape, dtype=bool)
 
-        scores = _clean_nans(self.scores_)
-        # XXX This should be refactored; we're getting an array of indices
-        # from argsort, which we transform to a mask, which we probably
-        # transform back to indices later.
-        mask = np.zeros(scores.shape, dtype=bool)
-
-        # Request a stable sort. Mergesort takes more memory (~40MB per
-        # megafeature on x86-64).
-        mask[np.argsort(scores, kind="mergesort")[-k:]] = 1
-        return mask
+            # Request a stable sort. Mergesort takes more memory (~40MB per
+            # megafeature on x86-64).
+            mask[np.argsort(scores, kind="mergesort")[-self.k:]] = 1
+            return mask
 
 
-class SelectFpr(_PvalueFilter):
+class SelectFpr(_BaseFilter):
     """Filter: Select the pvalues below alpha based on a FPR test.
 
     FPR test stands for False Positive Rate test. It controls the total
@@ -452,15 +447,14 @@ class SelectFpr(_PvalueFilter):
     """
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
         super(SelectFpr, self).__init__(score_func)
+        self.alpha = alpha
 
     def _get_support_mask(self):
-        alpha = self.alpha
-        return self.pvalues_ < alpha
+        return self.pvalues_ < self.alpha
 
 
-class SelectFdr(_PvalueFilter):
+class SelectFdr(_BaseFilter):
     """Filter: Select the p-values for an estimated false discovery rate
 
     This uses the Benjamini-Hochberg procedure. ``alpha`` is the target false
@@ -486,8 +480,8 @@ class SelectFdr(_PvalueFilter):
     """
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
         super(SelectFdr, self).__init__(score_func)
+        self.alpha = alpha
 
     def _get_support_mask(self):
         alpha = self.alpha
@@ -496,7 +490,7 @@ class SelectFdr(_PvalueFilter):
         return self.pvalues_ <= threshold
 
 
-class SelectFwe(_PvalueFilter):
+class SelectFwe(_BaseFilter):
     """Filter: Select the p-values corresponding to Family-wise error rate
 
     Parameters
@@ -518,12 +512,11 @@ class SelectFwe(_PvalueFilter):
     """
 
     def __init__(self, score_func=f_classif, alpha=5e-2):
-        self.alpha = alpha
         super(SelectFwe, self).__init__(score_func)
+        self.alpha = alpha
 
     def _get_support_mask(self):
-        alpha = self.alpha
-        return (self.pvalues_ < alpha / len(self.pvalues_))
+        return (self.pvalues_ < self.alpha / len(self.pvalues_))
 
 
 ######################################################################
@@ -532,7 +525,7 @@ class SelectFwe(_PvalueFilter):
 
 # TODO this class should fit on either p-values or scores,
 # depending on the mode.
-class GenericUnivariateSelect(_PvalueFilter):
+class GenericUnivariateSelect(_BaseFilter):
     """Univariate feature selector with configurable strategy.
 
     Parameters
@@ -560,27 +553,35 @@ class GenericUnivariateSelect(_PvalueFilter):
                         'k_best':       SelectKBest,
                         'fpr':          SelectFpr,
                         'fdr':          SelectFdr,
-                        'fwe':          SelectFwe,
-                        }
+                        'fwe':          SelectFwe}
 
     def __init__(self, score_func=f_classif, mode='percentile', param=1e-5):
-        if mode not in self._selection_modes:
-            raise ValueError(
-                "The mode passed should be one of %s, %r, (type %s) "
-                "was passed." % (
-                    self._selection_modes.keys(),
-                    mode, type(mode)))
         super(GenericUnivariateSelect, self).__init__(score_func)
         self.mode = mode
         self.param = param
 
-    def _get_support_mask(self):
-        selector = self._selection_modes[self.mode](lambda x: x)
-        selector.pvalues_ = self.pvalues_
-        selector.scores_ = self.scores_
+    def _make_selector(self):
+        selector = self._selection_modes[self.mode](score_func=self.score_func)
+
         # Now perform some acrobatics to set the right named parameter in
         # the selector
         possible_params = selector._get_param_names()
         possible_params.remove('score_func')
         selector.set_params(**{possible_params[0]: self.param})
+
+        return selector
+
+    def _check_params(self, X, y):
+        if self.mode not in self._selection_modes:
+            raise ValueError("The mode passed should be one of %s, %r,"
+                             " (type %s) was passed."
+                             % (self._selection_modes.keys(), self.mode,
+                                type(self.mode)))
+
+        self._make_selector()._check_params(X, y)
+
+    def _get_support_mask(self):
+        selector = self._make_selector()
+        selector.pvalues_ = self.pvalues_
+        selector.scores_ = self.scores_
         return selector._get_support_mask()

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -399,7 +399,7 @@ class SelectKBest(_BaseFilter):
         self.k = k
 
     def _check_params(self, X, y):
-        if not (0 <= self.k <= X.shape[1] or self.k == "all"):
+        if not (self.k == "all" or 0 <= self.k <= X.shape[1]):
             raise ValueError("k should be >=0, <= n_features; got %r."
                              "Use k='all' to return all features."
                              % self.k)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -359,6 +359,8 @@ def check_estimators_nan_inf(name, Estimator, X_train, X_train_finite, y):
             # than the number of features.
             # So we impose a smaller number (avoid "auto" mode)
             estimator = Estimator(n_components=1)
+        elif name == "SelectKBest":
+            estimator = Estimator(k=1)
 
         set_random_state(estimator, 1)
         # try to fit
@@ -1039,6 +1041,7 @@ def test_estimators_overwrite_params():
                 # FIXME!
                 # in particular GaussianProcess!
                 continue
+
             yield (check_estimators_overwrite_params, name, Estimator, X,
                    multioutput_estimator_convert_y_2d(name, y))
 
@@ -1061,6 +1064,8 @@ def check_estimators_overwrite_params(name, Estimator, X, y):
         # than the number of features.
         # So we impose a smaller number (avoid "auto" mode)
         estimator = Estimator(n_components=1)
+    elif name == "SelectKBest":
+        estimator = Estimator(k=1)
 
     set_random_state(estimator)
 


### PR DESCRIPTION
The refactoring : 
- simplifies the class hierachy of univariate feature selection transformer (_BaseFilter, _PvalueFilter, _ScoreFilter to only _BaseFilter)
- improves and performs all parameter checks during the fit,
- fix some pep8
- set the file to ascii only (instead of utf-8)
- fix issue #3132
