### PR TITLE
Mention that train_test_split returns a random split

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -420,10 +420,10 @@ If the data ordering is not arbitrary (e.g. samples with the same label are cont
 
 Some cross validation iterators, such as :class:`KFold`, have an inbuilt option to shuffle the data indices before splitting them. Note that:
 
-  * This consumes less memory than shuffling the data directly.
-  * By default no shuffling occurs, including for the (stratified) K fold cross-validation performed by specifying ``cv=some_integer`` to :func:`cross_val_score`, grid search, etc.
-  * The ``random_state`` parameter defaults to ``None``, meaning that the shuffling will be different every time ``KFold(..., shuffle=True)`` is iterated. However, ``GridSearchCV`` will use the same shuffling for each set of parameters validated by a single call to its ``fit`` method.
-  * To ensure results are repeatable (*on the same platform*), use a fixed value for ``random_state``.
+* This consumes less memory than shuffling the data directly.
+* By default no shuffling occurs, including for the (stratified) K fold cross-validation performed by specifying ``cv=some_integer`` to :func:`cross_val_score`, grid search, etc. Keep in mind that :func:`train_test_split` still returns a random split.
+* The ``random_state`` parameter defaults to ``None``, meaning that the shuffling will be different every time ``KFold(..., shuffle=True)`` is iterated. However, ``GridSearchCV`` will use the same shuffling for each set of parameters validated by a single call to its ``fit`` method.
+* To ensure results are repeatable (*on the same platform*), use a fixed value for ``random_state``.
 
 Cross validation and model selection
 ====================================


### PR DESCRIPTION
I saw https://github.com/scikit-learn/scikit-learn/commit/17bca23b455f45c0b28d3ff04b05252317c76552 - cudos for adding this note! Shuffling always bothered me, and it is an issue not only for cross-validation, but also for `train_test_split` (which shuffles by default) - maybe mention it as well?

Sorry for a bad diff; I've removed improper indentation. What is changed is "Keep in mind that :func:`train_test_split` still returns a random split." sentence added to the second point.
