### PR TITLE
Broken string value comparison method in Affinity Propagation

### DIFF
--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -249,7 +249,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
     @property
     def _pairwise(self):
-        return self.affinity is "precomputed"
+        return self.affinity == "precomputed"
 
     def fit(self, X):
         """ Create affinity matrix from negative euclidean distances, then
@@ -263,9 +263,9 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
             similarities / affinities.
         """
 
-        if self.affinity is "precomputed":
+        if self.affinity == "precomputed":
             self.affinity_matrix_ = X
-        elif self.affinity is "euclidean":
+        elif self.affinity == "euclidean":
             self.affinity_matrix_ = -euclidean_distances(X, squared=True)
         else:
             raise ValueError("Affinity must be 'precomputed' or "


### PR DESCRIPTION
The old code used 'is' instead of '==' to compare the user defined value of the 'affinity' parameter for the Affinity Propagation constructor. This causes problems when the input value is retrieved from an external source such as a file because the ID of the values will never be equivalent since they are stored in different locations in memory. '==' should be used to compare the string values instead of the string IDs.
