### PR TITLE
Update grid_search_digits.py

### DIFF
--- a/examples/grid_search_digits.py
+++ b/examples/grid_search_digits.py
@@ -1,9 +1,9 @@
 """
 =====================================================================
-Parameter estimation using grid search with a nested cross-validation
+Parameter estimation using grid search with cross-validation
 =====================================================================
 
-This examples shows how a classifier is optimized by "nested"
+This examples shows how a classifier is optimized by 
 cross-validation, which is done using the
 :class:`sklearn.grid_search.GridSearchCV` object on a development set
 that comprises only half of the available labeled data.


### PR DESCRIPTION
IMHO, this example does not use nested cross-validation. Proper nested cv is explained here: http://scikit-learn.org/stable/tutorial/statistical_inference/model_selection.html#grid-search. Calling the procedure "nested" cv (even in inverted commas) is confusing.
