### PR TITLE
[MRG+1] adding conditional import to lfw.py for python3 support

### DIFF
--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -28,7 +28,11 @@ from os.path import join, exists, isdir
 
 import logging
 import numpy as np
-import urllib
+
+try:
+    import urllib.request as urllib #for backwards compatibility 
+except ImportError:
+    import urllib
 
 from .base import get_data_home, Bunch
 from ..externals.joblib import Memory


### PR DESCRIPTION
I tried to run this command from python 3.4:
`lfw_people = datasets.fetch_lfw_people(min_faces_per_person=70, resize=0.4, data_home='datasets')`

I got the following error:

```
/usr/local/lib/python3.4/site-packages/sklearn/datasets/lfw.py in check_fetch_lfw(data_home, funneled, download_if_missing)
     85                 url = BASE_URL + target_filename
     86                 logger.warn("Downloading LFW metadata: %s", url)
---> 87                 urllib.urlretrieve(url, target_filepath)
     88             else:
     89                 raise IOError("%s is missing" % target_filepath)

AttributeError: 'module' object has no attribute 'urlretrieve'
```

Urllib in Python3 no longer supports urllib.urlretrieve.  It is now under urllib.request.
