### PR TITLE
[MRG+1] Fix not used pos_label parameter in metrics.precision_recall_curve

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -799,6 +799,7 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
 
     """
     fps, tps, thresholds = _binary_clf_curve(y_true, probas_pred,
+                                             pos_label=pos_label,
                                              sample_weight=sample_weight)
 
     precision = tps / (tps + fps)

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1113,12 +1113,15 @@ def test_precision_recall_curve():
 
 def test_precision_recall_curve_pos_label():
     y_true, _, probas_pred = make_prediction(binary=False)
+    pos_label = 2
     p, r, thresholds = precision_recall_curve(y_true,
-                                              probas_pred[:, 1],
-                                              pos_label=1)
-    precision_recall_auc = auc(r, p)
-    assert_array_almost_equal(precision_recall_auc, 0.44, 2)
-
+                                              probas_pred[:, pos_label],
+                                              pos_label=pos_label)
+    p2, r2, thresholds2 = precision_recall_curve(y_true == pos_label,
+                                                 probas_pred[:, pos_label])
+    assert_array_almost_equal(p, p2)
+    assert_array_almost_equal(r, r2)
+    assert_array_almost_equal(thresholds, thresholds2)
     assert_equal(p.size, r.size)
     assert_equal(p.size, thresholds.size + 1)
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -1111,6 +1111,18 @@ def test_precision_recall_curve():
     assert_equal(p.size, t.size + 1)
 
 
+def test_precision_recall_curve_pos_label():
+    y_true, _, probas_pred = make_prediction(binary=False)
+    p, r, thresholds = precision_recall_curve(y_true,
+                                              probas_pred[:, 1],
+                                              pos_label=1)
+    precision_recall_auc = auc(r, p)
+    assert_array_almost_equal(precision_recall_auc, 0.44, 2)
+
+    assert_equal(p.size, r.size)
+    assert_equal(p.size, thresholds.size + 1)
+
+
 def _test_precision_recall_curve(y_true, probas_pred):
     """Test Precision-Recall and aread under PR curve"""
     p, r, thresholds = precision_recall_curve(y_true, probas_pred)


### PR DESCRIPTION
It seems like the parameter pos_label were not used in the precision_recall_curve.
