### PR TITLE
DOC Fix wrong confidence interval

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_quantile.py
+++ b/examples/ensemble/plot_gradient_boosting_quantile.py
@@ -61,7 +61,7 @@ clf.fit(X, y)
 # Make the prediction on the meshed x-axis
 y_pred = clf.predict(xx)
 
-# Plot the function, the prediction and the 95% confidence interval based on
+# Plot the function, the prediction and the 90% confidence interval based on
 # the MSE
 fig = plt.figure()
 plt.plot(xx, f(xx), 'g:', label=u'$f(x) = x\,\sin(x)$')
@@ -71,7 +71,7 @@ plt.plot(xx, y_upper, 'k-')
 plt.plot(xx, y_lower, 'k-')
 plt.fill(np.concatenate([xx, xx[::-1]]),
          np.concatenate([y_upper, y_lower[::-1]]),
-         alpha=.5, fc='b', ec='None', label='95% prediction interval')
+         alpha=.5, fc='b', ec='None', label='90% prediction interval')
 plt.xlabel('$x$')
 plt.ylabel('$f(x)$')
 plt.ylim(-10, 20)


### PR DESCRIPTION
The confidence interval should be 90% instead of 95%. Running the code below will give you 0.8997%.

```
import numpy as np
from sklearn.ensemble import GradientBoostingRegressor

np.random.seed(1)

def f(x):
    return x * np.sin(x)

X = np.atleast_2d(np.random.uniform(0, 10.0, size=10000)).T
X = X.astype(np.float32)

y = f(X).ravel()

dy = 1.5 + 1.0 * np.random.random(y.shape)
noise = np.random.normal(0, dy)
y += noise
y = y.astype(np.float32)

alpha = 0.95
clf = GradientBoostingRegressor(loss='quantile', alpha=alpha,
                                n_estimators=250, max_depth=3,
                                learning_rate=.1, min_samples_leaf=9,
                                min_samples_split=9)

clf.fit(X, y)
y_upper = clf.predict(X)
clf.set_params(alpha=1.0 - alpha)
clf.fit(X, y)
y_lower = clf.predict(X)

interval = np.sum((y < y_upper) == (y > y_lower)) / float(10000)
print("{}% confidence interval".format(interval))
```
