### PR TITLE
[MRG] Determine IsotonicRegression ``increasing`` by Pearson or Spearman corr rho

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -569,6 +569,12 @@ From text
 
    isotonic.isotonic_regression
 
+.. autosummary::
+   :toctree: generated
+   :template: function.rst
+
+   isotonic.check_increasing
+
 .. _kernel_approximation_ref:
 
 :mod:`sklearn.kernel_approximation` Kernel Approximation

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -568,11 +568,6 @@ From text
    :template: function.rst
 
    isotonic.isotonic_regression
-
-.. autosummary::
-   :toctree: generated
-   :template: function.rst
-
    isotonic.check_increasing
 
 .. _kernel_approximation_ref:

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -115,13 +115,13 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         If not None, set the highest value of the fit to y_max.
 
     increasing : optional, boolean or string, default : True
-        If boolean, whether or not to fit the isotonic regression with y 
+        If boolean, whether or not to fit the isotonic regression with y
         increasing or decreasing.
 
         If string and "pearson" or "spearman," determine whether y should
         increase or decrease based on the Pearson or Spearman rho estimate
         sign, respectively.
-        
+
 
     Attributes
     ----------
@@ -152,7 +152,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         Set the proper value of increasing based on the constructor
         parameter and the data.
         '''
-        # Determine the direction of increasing if Spearman or Pearson requested
+        # Determine increasing if Spearman or Pearson requested
         increasing_bool = self.increasing
 
         if self.increasing == 'pearson':
@@ -171,8 +171,6 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
                 increasing_bool = False
 
         return increasing_bool
-
-
 
     def fit(self, X, y, sample_weight=None, weight=None):
         """Fit the model using X, y as training data.
@@ -210,7 +208,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         y = as_float_array(y)
         self._check_fit_data(X, y, sample_weight)
 
-        # Determine the direction of increasing if Spearman or Pearson requested
+        # Determine increasing if Spearman or Pearson requested
         increasing_bool = self._check_increasing(X, y)
 
         order = np.argsort(X)
@@ -277,7 +275,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         y = as_float_array(y)
         self._check_fit_data(X, y, sample_weight)
 
-        # Determine the direction of increasing if Spearman or Pearson requested
+        # Determine increasing if Spearman or Pearson requested
         increasing_bool = self._check_increasing(X, y)
 
         order = np.lexsort((y, X))

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -172,8 +172,11 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             # Run Fisher transform to get the rho CI
             F = 0.5 * np.log((1 + rho) / (1 - rho))
             F_se = 1 / np.sqrt(len(X) - 3)
-            rho_0 = np.tanh(F - 2.0 * F_se)
-            rho_1 = np.tanh(F + 2.0 * F_se)
+            
+            # Use a 95% CI, i.e., +/-1.96 S.E.
+            # http://en.wikipedia.org/wiki/Fisher_transformation
+            rho_0 = np.tanh(F - 1.96 * F_se)
+            rho_1 = np.tanh(F + 1.96 * F_se)
 
             # Warn if the CI spans zero.
             if np.sign(rho_0) != np.sign(rho_1):

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -10,6 +10,7 @@ from .base import BaseEstimator, TransformerMixin, RegressorMixin
 from .utils import as_float_array, check_arrays
 from ._isotonic import _isotonic_regression
 import warnings
+import math
 
 
 def check_increasing(x, y):
@@ -54,13 +55,13 @@ def check_increasing(x, y):
 
     # Run Fisher transform to get the rho CI, but handle rho=+/-1
     if rho not in [-1.0, 1.0]:
-        F = 0.5 * np.log((1 + rho) / (1 - rho))
-        F_se = 1 / np.sqrt(len(x) - 3)
+        F = 0.5 * math.log((1. + rho) / (1. - rho))
+        F_se = 1 / math.sqrt(len(x) - 3)
 
         # Use a 95% CI, i.e., +/-1.96 S.E.
         # http://en.wikipedia.org/wiki/Fisher_transformation
-        rho_0 = np.tanh(F - 1.96 * F_se)
-        rho_1 = np.tanh(F + 1.96 * F_se)
+        rho_0 = math.tanh(F - 1.96 * F_se)
+        rho_1 = math.tanh(F + 1.96 * F_se)
 
         # Warn if the CI spans zero.
         if np.sign(rho_0) != np.sign(rho_1):

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -147,6 +147,33 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if len(X.shape) != 1:
             raise ValueError("X should be a vector")
 
+    def _check_increasing(self, X, y):
+        '''
+        Set the proper value of increasing based on the constructor
+        parameter and the data.
+        '''
+        # Determine the direction of increasing if Spearman or Pearson requested
+        increasing_bool = self.increasing
+
+        if self.increasing == 'pearson':
+            # Calculate Pearson rho estimate and set accordingly
+            rho, _ = pearsonr(X, y)
+            if rho >= 0:
+                increasing_bool = True
+            else:
+                increasing_bool = False
+        elif self.increasing == 'spearman':
+            # Calculate Spearman rho estimate and set accordingly
+            rho, _ = spearmanr(X, y)
+            if rho >= 0:
+                increasing_bool = True
+            else:
+                increasing_bool = False
+
+        return increasing_bool
+
+
+
     def fit(self, X, y, sample_weight=None, weight=None):
         """Fit the model using X, y as training data.
 
@@ -184,22 +211,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         self._check_fit_data(X, y, sample_weight)
 
         # Determine the direction of increasing if Spearman or Pearson requested
-        increasing_bool = self.increasing
-
-        if self.increasing == 'pearson':
-            # Calculate Pearson rho estimate and set accordingly
-            rho, p_val = pearsonr(X, y)
-            if rho >= 0:
-                increasing_bool = True
-            else:
-                increasing_bool = False
-        elif self.increasing == 'spearman':
-            # Calculate Spearman rho estimate and set accordingly
-            rho, p_val = spearmanr(X, y)
-            if rho >= 0:
-                increasing_bool = True
-            else:
-                increasing_bool = False
+        increasing_bool = self._check_increasing(X, y)
 
         order = np.argsort(X)
         self.X_ = as_float_array(X[order], copy=False)
@@ -266,22 +278,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         self._check_fit_data(X, y, sample_weight)
 
         # Determine the direction of increasing if Spearman or Pearson requested
-        increasing_bool = self.increasing
-
-        if self.increasing == 'pearson':
-            # Calculate Pearson rho estimate and set accordingly
-            rho, p_val = pearsonr(X, y)
-            if rho >= 0:
-                increasing_bool = True
-            else:
-                increasing_bool = False
-        elif self.increasing == 'spearman':
-            # Calculate Spearman rho estimate and set accordingly
-            rho, p_val = spearmanr(X, y)
-            if rho >= 0:
-                increasing_bool = True
-            else:
-                increasing_bool = False
+        increasing_bool = self._check_increasing(X, y)
 
         order = np.lexsort((y, X))
         order_inv = np.argsort(order)

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -118,7 +118,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         If boolean, whether or not to fit the isotonic regression with y
         increasing or decreasing.
 
-        If string and set to "auto," determine whether y should
+        The string value "auto" determines whether y should
         increase or decrease based on the Spearman correlation estimate's
         sign.
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -120,7 +120,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         If string and set to "auto," determine whether y should
         increase or decrease based on the Spearman correlation estimate's
-        sign, respectively.
+        sign.
 
 
     Attributes
@@ -155,7 +155,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         The Spearman correlation coefficent is estimated from the data,
         and the sign of the resulting estiamte is used to set ``increasing``.
 
-        In the event that the confidence interval based on Fisher transform
+        In the event that the 95% confidence interval based on Fisher transform
         spans zero, a warning is raised.
         """
         # Determine increasing if Spearman requested
@@ -172,8 +172,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             # Run Fisher transform to get the rho CI
             F = 0.5 * np.log((1 + rho) / (1 - rho))
             F_se = 1 / np.sqrt(len(X) - 3)
-            rho_0 = np.tanh(F - F_se)
-            rho_1 = np.tanh(F + F_se)
+            rho_0 = np.tanh(F - 2.0 * F_se)
+            rho_1 = np.tanh(F + 2.0 * F_se)
 
             # Warn if the CI spans zero.
             if np.sign(rho_0) != np.sign(rho_1):

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -174,7 +174,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     y_max : optional, default: None
         If not None, set the highest value of the fit to y_max.
 
-    increasing : boolean or string, optional, default : 'auto'
+    increasing : boolean or string, optional, default: True
         If boolean, whether or not to fit the isotonic regression with y
         increasing or decreasing.
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -114,7 +114,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     y_max : optional, default: None
         If not None, set the highest value of the fit to y_max.
 
-    increasing : optional, boolean or string, default : True
+    increasing : boolean or string, optional, default : True
         If boolean, whether or not to fit the isotonic regression with y
         increasing or decreasing.
 
@@ -148,10 +148,10 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             raise ValueError("X should be a vector")
 
     def _check_increasing(self, X, y):
-        '''
+        """
         Set the proper value of increasing based on the constructor
         parameter and the data.
-        '''
+        """
         # Determine increasing if Spearman or Pearson requested
         increasing_bool = self.increasing
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -153,7 +153,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         parameter and the data.
 
         The Spearman correlation coefficent is estimated from the data,
-        and the sign of the resulting estiamte is used to set ``increasing``.
+        and the sign of the resulting estimate is used to set ``increasing``.
 
         In the event that the 95% confidence interval based on Fisher transform
         spans zero, a warning is raised.

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -12,19 +12,41 @@ from ._isotonic import _isotonic_regression
 import warnings
 
 
-def check_increasing(X, y):
-    """
-    Determine whether the relationship between X and y appears to be
+def check_increasing(x, y):
+    """Determine whether the relationship between x and y appears to be
+    increasing or decreasing based on Spearman correlation.
+
+    Parameters
+    ----------
+    x : array-like, shape=(n_samples,)
+            Training data.
+
+    y : array-like, shape=(n_samples,)
+        Training target.
+
+    Returns
+    -------
+    `increasing_bool` : boolean
+        Whether the relationship is increasing or decreasing.
+
+    Notes
+    -----
+    Determine whether the relationship between x and y appears to be
     increasing or decreasing.  The Spearman correlation coefficient is
     estimated from the data, and the sign of the resulting estimate
     is used as the result.
 
     In the event that the 95% confidence interval based on Fisher transform
     spans zero, a warning is raised.
+
+    References
+    ----------
+    Fisher transformation. Wikipedia.
+    http://en.wikipedia.org/w/index.php?title=Fisher_transformation
     """
 
     # Calculate Spearman rho estimate and set return accordingly.
-    rho, _ = spearmanr(X, y)
+    rho, _ = spearmanr(x, y)
     if rho >= 0:
         increasing_bool = True
     else:
@@ -33,7 +55,7 @@ def check_increasing(X, y):
     # Run Fisher transform to get the rho CI, but handle rho=+/-1
     if rho not in [-1.0, 1.0]:
         F = 0.5 * np.log((1 + rho) / (1 - rho))
-        F_se = 1 / np.sqrt(len(X) - 3)
+        F_se = 1 / np.sqrt(len(x) - 3)
 
         # Use a 95% CI, i.e., +/-1.96 S.E.
         # http://en.wikipedia.org/wiki/Fisher_transformation

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -3,8 +3,8 @@ import numpy as np
 from sklearn.isotonic import check_increasing, isotonic_regression,\
     IsotonicRegression
 
-from sklearn.utils.testing import assert_raises, assert_equal, \
-    assert_array_equal, assert_true, assert_false
+from sklearn.utils.testing import assert_raises, assert_array_equal,\
+    assert_true, assert_false
 
 from sklearn.utils.testing import assert_warns_message, assert_no_warnings
 
@@ -96,7 +96,7 @@ def test_isotonic_regression_auto_decreasing():
         x, y)
 
     is_increasing = y_[0] < y_[-1]
-    assert_equal(is_increasing, False)
+    assert_false(is_increasing)
 
 
 def test_isotonic_regression_auto_increasing():
@@ -108,7 +108,7 @@ def test_isotonic_regression_auto_increasing():
         x, y)
 
     is_increasing = y_[0] < y_[-1]
-    assert_equal(is_increasing, True)
+    assert_true(is_increasing)
 
 
 def test_assert_raises_exceptions():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -36,6 +36,7 @@ def test_isotonic_regression_reversed():
         np.arange(len(y)), y)
     assert_array_equal(np.ones(y_[:-1].shape), ((y_[:-1] - y_[1:]) >= 0))
 
+
 def test_isotonic_regression_pearson_decreasing():
     # Set y and x for decreasing
     y = np.array([10, 9, 10, 7, 6, 6.1, 5])
@@ -46,6 +47,7 @@ def test_isotonic_regression_pearson_decreasing():
 
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, False)
+
 
 def test_isotonic_regression_pearson_increasing():
     # Set y and x for decreasing
@@ -58,6 +60,7 @@ def test_isotonic_regression_pearson_increasing():
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, True)
 
+
 def test_isotonic_regression_spearman_decreasing():
     # Set y and x for decreasing
     y = np.array([10, 9, 10, 7, 6, 6.1, 5])
@@ -68,6 +71,7 @@ def test_isotonic_regression_spearman_decreasing():
 
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, False)
+
 
 def test_isotonic_regression_spearman_increasing():
     # Set y and x for decreasing

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -1,12 +1,56 @@
 import numpy as np
 
-from sklearn.isotonic import isotonic_regression, IsotonicRegression
+from sklearn.isotonic import check_increasing, isotonic_regression,\
+    IsotonicRegression
 
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 
 import warnings
+
+
+def test_check_increasing_up():
+    X = [0, 1, 2, 3, 4, 5]
+    y = [0, 1, 2, 3, 4, 5]
+
+    # Check that we got increasing=True and no warnings
+    with warnings.catch_warnings(record=True) as w:
+        # Trigger all warnings
+        warnings.simplefilter("always")
+
+        is_increasing = check_increasing(X, y)
+        assert_equal(is_increasing, True)
+        assert_equal(len(w), 0)
+
+
+def test_check_increasing_down():
+    X = [0, 1, 2, 3, 4, 5]
+    y = [0, -1, -2, -3, -4, -5]
+
+    # Check that we got increasing=False and no warnings
+    with warnings.catch_warnings(record=True) as w:
+        # Trigger all warnings
+        warnings.simplefilter("always")
+
+        is_increasing = check_increasing(X, y)
+        assert_equal(is_increasing, False)
+        assert_equal(len(w), 0)
+
+
+def test_check_increasing_ci():
+    X = [0, 1, 2, 3, 4, 5]
+    y = [0, -1, 2, -3, 4, -5]
+
+    # Check that we got increasing=False and CI warning
+    with warnings.catch_warnings(record=True) as w:
+        # Trigger all warnings
+        warnings.simplefilter("always")
+
+        is_increasing = check_increasing(X, y)
+        assert_equal(is_increasing, False)
+        assert_equal(len(w), 1)
+        assert_equal(True, "interval" in str(w[-1].message))
 
 
 def test_isotonic_regression():
@@ -59,39 +103,8 @@ def test_isotonic_regression_auto_increasing():
     y_ = IsotonicRegression(increasing='auto').fit_transform(
         x, y)
 
-    # Check that a warning is NOT thrown
-    with warnings.catch_warnings(record=True) as w:
-        # Trigger all warnings
-        warnings.simplefilter("always")
-
-        # Fit and transform
-        y_ = IsotonicRegression(increasing='auto').fit_transform(
-            x, y)
-
-        # Ensure that we got no warning
-        assert_equal(len(w), 0)
-
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, True)
-
-
-def test_isotonic_regression_auto_ci_check():
-    # Set y and x for decreasing
-    y = np.array([-5, 6.1, -6, 7, -10, 9, -10])
-    x = np.arange(len(y))
-
-    # Check that a warning is thrown
-    with warnings.catch_warnings(record=True) as w:
-        # Trigger all warnings
-        warnings.simplefilter("always")
-
-        # Fit and transform
-        y_ = IsotonicRegression(increasing='auto').fit_transform(
-            x, y)
-
-        # Ensure that we got a warning
-        assert_equal(len(w), 1)
-        assert_equal(True, "interval" in str(w[-1].message))
 
 
 def test_assert_raises_exceptions():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 
+import warnings
+
 
 def test_isotonic_regression():
     y = np.array([3, 7, 5, 9, 8, 7, 10])
@@ -37,52 +39,47 @@ def test_isotonic_regression_reversed():
     assert_array_equal(np.ones(y_[:-1].shape), ((y_[:-1] - y_[1:]) >= 0))
 
 
-def test_isotonic_regression_pearson_decreasing():
+def test_isotonic_regression_auto_decreasing():
     # Set y and x for decreasing
     y = np.array([10, 9, 10, 7, 6, 6.1, 5])
     x = np.arange(len(y))
 
-    y_ = IsotonicRegression(increasing='pearson').fit_transform(
+    y_ = IsotonicRegression(increasing='auto').fit_transform(
         x, y)
 
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, False)
 
 
-def test_isotonic_regression_pearson_increasing():
+def test_isotonic_regression_auto_increasing():
     # Set y and x for decreasing
     y = np.array([5, 6.1, 6, 7, 10, 9, 10])
     x = np.arange(len(y))
 
-    y_ = IsotonicRegression(increasing='pearson').fit_transform(
+    y_ = IsotonicRegression(increasing='auto').fit_transform(
         x, y)
 
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, True)
 
 
-def test_isotonic_regression_spearman_decreasing():
+def test_isotonic_regression_auto_ci_check():
     # Set y and x for decreasing
-    y = np.array([10, 9, 10, 7, 6, 6.1, 5])
+    y = np.array([-5, 6.1, -6, 7, -10, 9, -10])
     x = np.arange(len(y))
 
-    y_ = IsotonicRegression(increasing='spearman').fit_transform(
-        x, y)
+    # Check that a warning is thrown
+    with warnings.catch_warnings(record=True) as w:
+        # Trigger all warnings
+        warnings.simplefilter("always")
 
-    is_increasing = y_[0] < y_[-1]
-    assert_equal(is_increasing, False)
+        # Fit and transform
+        y_ = IsotonicRegression(increasing='auto').fit_transform(
+            x, y)
 
-
-def test_isotonic_regression_spearman_increasing():
-    # Set y and x for decreasing
-    y = np.array([5, 6.1, 6, 7, 10, 9, 10])
-    x = np.arange(len(y))
-
-    y_ = IsotonicRegression(increasing='spearman').fit_transform(
-        x, y)
-
-    is_increasing = y_[0] < y_[-1]
-    assert_equal(is_increasing, True)
+        # Ensure that we got a warning
+        assert_equal(len(w), 1)
+        assert_equal(True, "interval" in str(w[-1].message))
 
 
 def test_assert_raises_exceptions():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -68,7 +68,7 @@ def test_isotonic_regression_auto_increasing():
         y_ = IsotonicRegression(increasing='auto').fit_transform(
             x, y)
 
-        # Ensure that we got a warning
+        # Ensure that we got no warning
         assert_equal(len(w), 0)
 
     is_increasing = y_[0] < y_[-1]

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.isotonic import isotonic_regression, IsotonicRegression
 
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 
 
@@ -34,6 +35,50 @@ def test_isotonic_regression_reversed():
     y_ = IsotonicRegression(increasing=False).fit_transform(
         np.arange(len(y)), y)
     assert_array_equal(np.ones(y_[:-1].shape), ((y_[:-1] - y_[1:]) >= 0))
+
+def test_isotonic_regression_pearson_decreasing():
+    # Set y and x for decreasing
+    y = np.array([10, 9, 10, 7, 6, 6.1, 5])
+    x = np.arange(len(y))
+
+    y_ = IsotonicRegression(increasing='pearson').fit_transform(
+        x, y)
+
+    is_increasing = y_[0] < y_[-1]
+    assert_equal(is_increasing, False)
+
+def test_isotonic_regression_pearson_increasing():
+    # Set y and x for decreasing
+    y = np.array([5, 6.1, 6, 7, 10, 9, 10])
+    x = np.arange(len(y))
+
+    y_ = IsotonicRegression(increasing='pearson').fit_transform(
+        x, y)
+
+    is_increasing = y_[0] < y_[-1]
+    assert_equal(is_increasing, True)
+
+def test_isotonic_regression_spearman_decreasing():
+    # Set y and x for decreasing
+    y = np.array([10, 9, 10, 7, 6, 6.1, 5])
+    x = np.arange(len(y))
+
+    y_ = IsotonicRegression(increasing='spearman').fit_transform(
+        x, y)
+
+    is_increasing = y_[0] < y_[-1]
+    assert_equal(is_increasing, False)
+
+def test_isotonic_regression_spearman_increasing():
+    # Set y and x for decreasing
+    y = np.array([5, 6.1, 6, 7, 10, 9, 10])
+    x = np.arange(len(y))
+
+    y_ = IsotonicRegression(increasing='spearman').fit_transform(
+        x, y)
+
+    is_increasing = y_[0] < y_[-1]
+    assert_equal(is_increasing, True)
 
 
 def test_assert_raises_exceptions():

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -92,9 +92,11 @@ def test_isotonic_regression_auto_decreasing():
     y = np.array([10, 9, 10, 7, 6, 6.1, 5])
     x = np.arange(len(y))
 
-    y_ = IsotonicRegression(increasing='auto').fit_transform(
-        x, y)
+    # Create model and fit_transform
+    ir = IsotonicRegression(increasing='auto')
+    y_ = assert_no_warnings(ir.fit_transform, x, y)
 
+    # Check that relationship decreases
     is_increasing = y_[0] < y_[-1]
     assert_false(is_increasing)
 
@@ -104,9 +106,11 @@ def test_isotonic_regression_auto_increasing():
     y = np.array([5, 6.1, 6, 7, 10, 9, 10])
     x = np.arange(len(y))
 
-    y_ = IsotonicRegression(increasing='auto').fit_transform(
-        x, y)
+    # Create model and fit_transform
+    ir = IsotonicRegression(increasing='auto')
+    y_ = assert_no_warnings(ir.fit_transform, x, y)
 
+    # Check that relationship increases
     is_increasing = y_[0] < y_[-1]
     assert_true(is_increasing)
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -59,6 +59,18 @@ def test_isotonic_regression_auto_increasing():
     y_ = IsotonicRegression(increasing='auto').fit_transform(
         x, y)
 
+    # Check that a warning is NOT thrown
+    with warnings.catch_warnings(record=True) as w:
+        # Trigger all warnings
+        warnings.simplefilter("always")
+
+        # Fit and transform
+        y_ = IsotonicRegression(increasing='auto').fit_transform(
+            x, y)
+
+        # Ensure that we got a warning
+        assert_equal(len(w), 0)
+
     is_increasing = y_[0] < y_[-1]
     assert_equal(is_increasing, True)
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -3,54 +3,58 @@ import numpy as np
 from sklearn.isotonic import check_increasing, isotonic_regression,\
     IsotonicRegression
 
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises, assert_equal, \
+    assert_array_equal, assert_true, assert_false
 
-import warnings
+from sklearn.utils.testing import assert_warns_message, assert_no_warnings
 
 
 def test_check_increasing_up():
-    X = [0, 1, 2, 3, 4, 5]
+    x = [0, 1, 2, 3, 4, 5]
+    y = [0, 1.5, 2.77, 8.99, 8.99, 50]
+
+    # Check that we got increasing=True and no warnings
+    is_increasing = assert_no_warnings(check_increasing, x, y)
+    assert_true(is_increasing)
+
+
+def test_check_increasing_up_extreme():
+    x = [0, 1, 2, 3, 4, 5]
     y = [0, 1, 2, 3, 4, 5]
 
     # Check that we got increasing=True and no warnings
-    with warnings.catch_warnings(record=True) as w:
-        # Trigger all warnings
-        warnings.simplefilter("always")
-
-        is_increasing = check_increasing(X, y)
-        assert_equal(is_increasing, True)
-        assert_equal(len(w), 0)
+    is_increasing = assert_no_warnings(check_increasing, x, y)
+    assert_true(is_increasing)
 
 
 def test_check_increasing_down():
-    X = [0, 1, 2, 3, 4, 5]
+    x = [0, 1, 2, 3, 4, 5]
+    y = [0, -1.5, -2.77, -8.99, -8.99, -50]
+
+    # Check that we got increasing=False and no warnings
+    is_increasing = assert_no_warnings(check_increasing, x, y)
+    assert_false(is_increasing)
+
+
+def test_check_increasing_down_extreme():
+    x = [0, 1, 2, 3, 4, 5]
     y = [0, -1, -2, -3, -4, -5]
 
     # Check that we got increasing=False and no warnings
-    with warnings.catch_warnings(record=True) as w:
-        # Trigger all warnings
-        warnings.simplefilter("always")
-
-        is_increasing = check_increasing(X, y)
-        assert_equal(is_increasing, False)
-        assert_equal(len(w), 0)
+    is_increasing = assert_no_warnings(check_increasing, x, y)
+    assert_false(is_increasing)
 
 
-def test_check_increasing_ci():
-    X = [0, 1, 2, 3, 4, 5]
+def test_check_ci_warn():
+    x = [0, 1, 2, 3, 4, 5]
     y = [0, -1, 2, -3, 4, -5]
 
-    # Check that we got increasing=False and CI warning
-    with warnings.catch_warnings(record=True) as w:
-        # Trigger all warnings
-        warnings.simplefilter("always")
+    # Check that we got increasing=False and CI interval warning
+    is_increasing = assert_warns_message(UserWarning, "interval",
+                                         check_increasing,
+                                         x, y)
 
-        is_increasing = check_increasing(X, y)
-        assert_equal(is_increasing, False)
-        assert_equal(len(w), 1)
-        assert_equal(True, "interval" in str(w[-1].message))
+    assert_false(is_increasing)
 
 
 def test_isotonic_regression():


### PR DESCRIPTION
Sorry to mix a bit of docstring fix with a real PR, but:
1. Adding the missing `increasing` docstring to IsotonicRegression.  Missing here: http://scikit-learn.org/stable/modules/generated/sklearn.isotonic.IsotonicRegression.html#sklearn.isotonic.IsotonicRegression
2. Adding the option to use either `scipy.stats.pearsonr` or `scipy.stats.spearmanr` to estimate whether increasing should be True or False.  Tests included and passing for isotonic, though there appears to be an issue with `sklearn.utils.tests.test_sparsefuncs.test_mean_variance_axis0` for me at the moment when I merged to upstream earlier this morning.
