### PR TITLE
[ENH] ward_tree: return distances

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,10 @@ New features
 Enhancements
 ............
 
+   - Add option ``return_distance`` in :func:`hierarchical.ward_tree`
+     to return distances between nodes for both structured and unstructured
+     versions of the algorithm. By `Matteo Visconti di Oleggio Castello`_.
+
    - Add support for sample weights in scorer objects.  Metrics with sample
      weight support will automatically benefit from it. By `Noel Dawe`_ and
      `Vlad Niculae`_.

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -286,7 +286,7 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
 
     if return_distance:
         # 2 is scaling factor to compare w/ unstructured version
-        distances = (np.array(distances) * 2) ** 0.5
+        distances = np.sqrt(np.array(distances) * 2)
         return children, n_components, n_leaves, parent, distances
     else:
         return children, n_components, n_leaves, parent

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -226,7 +226,8 @@ def ward_tree(X, connectivity=None, n_components=None, copy=None,
         parent[i], parent[j] = k, k
         children.append((i, j))
         used_node[i] = used_node[j] = False
-        heights.append(inert**0.5)
+        # store inertia value
+        heights.append(inert)
 
         # update the moments
         moments_1[k] = moments_1[i] + moments_1[j]
@@ -259,9 +260,9 @@ def ward_tree(X, connectivity=None, n_components=None, copy=None,
     # sort children to get consistent output with unstructured version
     children = [c[::-1] for c in children]
     children = np.array(children)  # return numpy array for efficient caching
-    heights = np.array(heights)
 
     if return_height:
+        heights = (np.array(heights) * 2) ** 0.5  # scaling factor to compare w/ unstructured version
         return children, n_components, n_leaves, parent, heights
     else:
         return children, n_components, n_leaves, parent

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -261,9 +261,6 @@ def ward_tree(X, connectivity=None, n_components=None, copy=None,
     children = [c[::-1] for c in children]
     children = np.array(children)  # return numpy array for efficient caching
 
-    # sort children to get consistent output with unstructured version
-    children = [np.sort(c) for c in children]
-
     if return_distance:
         # 2 is scaling factor to compare w/ unstructured version
         distances = (np.array(distances) * 2) ** 0.5

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -87,8 +87,8 @@ def _fix_connectivity(X, connectivity, n_components=None,
 ###############################################################################
 # Hierarchical tree building functions
 
-def ward_tree(X, connectivity=None, n_components=None, copy=None,
-              n_clusters=None, return_distance=False):
+def ward_tree(X, connectivity=None, n_components=None, n_clusters=None, 
+              return_distance=False):
     """Ward clustering based on a Feature matrix.
 
     Recursively merges the pair of clusters that minimally increases

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -286,7 +286,7 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
 
     if return_distance:
         # 2 is scaling factor to compare w/ unstructured version
-        distances = np.sqrt(np.array(distances) * 2)
+        distances = np.sqrt(2. * np.array(distances))
         return children, n_components, n_leaves, parent, distances
     else:
         return children, n_components, n_leaves, parent

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -234,7 +234,8 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
     parent = np.arange(n_nodes, dtype=np.intp)
     used_node = np.ones(n_nodes, dtype=bool)
     children = []
-    distances = []
+    if return_distance:
+        distances = []
 
     not_visited = np.empty(n_nodes, dtype=np.int8, order='C')
 
@@ -248,8 +249,8 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
         parent[i], parent[j] = k, k
         children.append((i, j))
         used_node[i] = used_node[j] = False
-        # store inertia value
-        distances.append(inert)
+        if return_distance:  # store inertia value
+            distances.append(inert)
 
         # update the moments
         moments_1[k] = moments_1[i] + moments_1[j]

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -143,12 +143,30 @@ def ward_tree(X, connectivity=None, n_components=None, copy=None,
         is specified, elsewhere 'None' is returned.
 
     distances : 1D array, shape (n_nodes, )
-        The distances between the centers of the nodes. For example,
-        `distances[i]` corresponds to a weighted euclidean distance between
+        Only returned if return_distance is set to True (for compatibility).
+        The distances between the centers of the nodes. `distances[i]`
+        corresponds to a weighted euclidean distance between
         the nodes `children[i, 1]` and `children[i, 2]`. If the nodes refer to
         leaves of the tree, then `distances[i]` is their unweighted euclidean
-        distance.
-        Only returned if return_distance is set to True (for compatibility).
+        distance. Distances are updated in the following way
+        (from scipy.hierarchy.linkage):
+
+        The new entry :math:`d(u,v)` is computed as follows,
+
+        .. math::
+
+           d(u,v) = \\sqrt{\\frac{|v|+|s|}
+                               {T}d(v,s)^2
+                        + \\frac{|v|+|t|}
+                               {T}d(v,t)^2
+                        - \\frac{|v|}
+                               {T}d(s,t)^2}
+
+        where :math:`u` is the newly joined cluster consisting of
+        clusters :math:`s` and :math:`t`, :math:`v` is an unused
+        cluster in the forest, :math:`T=|v|+|s|+|t|`, and
+        :math:`|*|` is the cardinality of its argument. This is also
+        known as the incremental algorithm.
     """
     X = np.asarray(X)
     if X.ndim == 1:

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -143,8 +143,12 @@ def ward_tree(X, connectivity=None, n_components=None, copy=None,
         is specified, elsewhere 'None' is returned.
 
     distances : 1D array, shape (n_nodes, )
-        The distance between the clusters. Only returned if return_distance is
-        set to True (for compatibility).
+        The distances between the centers of the nodes. For example,
+        `distances[i]` corresponds to a weighted euclidean distance between
+        the nodes `children[i, 1]` and `children[i, 2]`. If the nodes refer to
+        leaves of the tree, then `distances[i]` is their unweighted euclidean
+        distance.
+        Only returned if return_distance is set to True (for compatibility).
     """
     X = np.asarray(X)
     if X.ndim == 1:

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -17,10 +17,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-<<<<<<< HEAD
 from sklearn.utils.testing import clean_warning_registry, ignore_warnings
-=======
->>>>>>> TST, test ward_tree_distance on known dataset
 
 from sklearn.cluster import Ward, WardAgglomeration, ward_tree
 from sklearn.cluster import AgglomerativeClustering, FeatureAgglomeration
@@ -291,16 +288,16 @@ def test_ward_tree_children_order():
 
     # test on five random datasets
     n, p = 10, 5
-    rnd = np.random.RandomState(0)
+    rng = np.random.RandomState(0)
 
     connectivity = np.ones((n, n))
     for i in range(5):
-        X = .1 * rnd.normal(size=(n, p))
-        X -= 4 * np.arange(n)[:, np.newaxis]
+        X = .1 * rng.normal(size=(n, p))
+        X -= 4. * np.arange(n)[:, np.newaxis]
         X -= X.mean(axis=1)[:, np.newaxis]
 
         out_unstructured = ward_tree(X)
-        out_structured = ward_tree(X, connectivity)
+        out_structured = ward_tree(X, connectivity=connectivity)
 
         assert_array_equal(out_unstructured[0], out_structured[0])
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -283,6 +283,28 @@ def test_connectivity_propagation():
     ward.fit(X)
 
 
+def test_ward_tree_children_order():
+    """
+    Check that children are ordered in the same way for both structured and
+    unstructured versions of ward_tree.
+    """
+
+    # test on five random datasets
+    n, p = 10, 5
+    rnd = np.random.RandomState(0)
+
+    connectivity = np.ones((n, n))
+    for i in range(5):
+        X = .1 * rnd.normal(size=(n, p))
+        X -= 4 * np.arange(n)[:, np.newaxis]
+        X -= X.mean(axis=1)[:, np.newaxis]
+
+        out_unstructured = ward_tree(X)
+        out_structured = ward_tree(X, connectivity)
+
+        assert_array_equal(out_unstructured[0], out_structured[0])
+
+
 def test_ward_tree_distance():
     """
     Check that children are ordered in the same way for both structured and
@@ -306,19 +328,17 @@ def test_ward_tree_distance():
         out_unstructured = ward_tree(X, return_distance=True)
         out_structured = ward_tree(X, connectivity, return_distance=True)
 
-        # sort labels
-        merge_unstructured = np.asanyarray([np.sort(m)
-                                            for m in out_unstructured[0]])
-        merge_structured = np.asanyarray([np.sort(m)
-                                          for m in out_structured[0]])
+        # get children
+        children_unstructured = out_unstructured[0]
+        children_structured = out_structured[0]
 
         # sort clusters according to the same criterion
-        idx_unstructured = argsort(merge_unstructured, key=max)
-        idx_structured = argsort(merge_structured, key=max)
+        idx_unstructured = argsort(children_unstructured, key=max)
+        idx_structured = argsort(children_structured, key=max)
 
         # check if we got the same clusters
-        assert_array_equal(merge_unstructured[idx_unstructured],
-                           merge_structured[idx_structured])
+        assert_array_equal(children_unstructured[idx_unstructured],
+                           children_structured[idx_structured])
 
         # check if the distances are the same
         dist_unstructured = out_unstructured[-1]

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -32,7 +32,6 @@ from sklearn.utils.fast_dict import IntFloatDict
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns
 
-
 def test_linkage_misc():
     # Misc tests on linkage
     rng = np.random.RandomState(42)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -285,7 +285,9 @@ def test_ward_tree_children_order():
     unstructured versions of ward_tree.
     """
 
-    # test on five random datasets
+    def argsort(x, key, **kwargs):
+        return sorted(range(len(x)), key=lambda e: key(x.__getitem__(e)), **kwargs)
+
     n, p = 10, 5
     rng = np.random.RandomState(0)
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -326,7 +326,8 @@ def test_ward_tree_distance():
         X -= X.mean(axis=1)[:, np.newaxis]
 
         out_unstructured = ward_tree(X, return_distance=True)
-        out_structured = ward_tree(X, connectivity, return_distance=True)
+        out_structured = ward_tree(X, connectivity=connectivity,
+                                   return_distance=True)
 
         # get children
         children_unstructured = out_unstructured[0]
@@ -365,7 +366,8 @@ def test_ward_tree_distance():
     connectivity_X = np.ones((n_samples, n_samples))
 
     out_X_unstructured = ward_tree(X, return_distance=True)
-    out_X_structured = ward_tree(X, connectivity_X, return_distance=True)
+    out_X_structured = ward_tree(X, connectivity=connectivity_X,
+                                 return_distance=True)
 
     # check that the labels are the same
     assert_array_equal(linkage_X_ward[:, :2], out_X_unstructured[0])

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -307,11 +307,6 @@ def test_ward_tree_distance():
     Check that children are ordered in the same way for both structured and
     unstructured versions of ward_tree.
     """
-
-    def argsort(x, key, **kwargs):
-        return sorted(range(len(x)),
-                      key=lambda e: key(x.__getitem__(e)), **kwargs)
-
     # test on five random datasets
     n, p = 10, 5
     rng = np.random.RandomState(0)
@@ -330,13 +325,8 @@ def test_ward_tree_distance():
         children_unstructured = out_unstructured[0]
         children_structured = out_structured[0]
 
-        # sort clusters according to the same criterion
-        idx_unstructured = argsort(children_unstructured, key=max)
-        idx_structured = argsort(children_structured, key=max)
-
         # check if we got the same clusters
-        assert_array_equal(children_unstructured[idx_unstructured],
-                           children_structured[idx_structured])
+        assert_array_equal(children_unstructured, children_structured)
 
         # check if the distances are the same
         dist_unstructured = out_unstructured[-1]


### PR DESCRIPTION
Modified `ward_tree` to return distances for both the structured and unstructured versions,
useful to have when plotting the dendrogram with scipy.
