### PR TITLE
[MRG] AdaBoost Sparse Input Support

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -6,15 +6,18 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_equal
 from nose.tools import assert_raises
 
+from sklearn.cross_validation import train_test_split
 from sklearn.grid_search import GridSearchCV
 from sklearn.ensemble import AdaBoostClassifier
 from sklearn.ensemble import AdaBoostRegressor
-from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from scipy.sparse import csc_matrix
+from scipy.sparse import csr_matrix
+from scipy.sparse import coo_matrix
+from scipy.sparse import dok_matrix
+from scipy.sparse import lil_matrix
 from sklearn.svm import SVC, SVR
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import shuffle
-from sklearn.cross_validation import train_test_split
-from scipy.sparse import csc_matrix, csr_matrix, coo_matrix, dok_matrix, \
-    lil_matrix
 from sklearn import datasets
 
 
@@ -253,7 +256,10 @@ def test_sparse_classification():
             self.data_type_ = type(X)
             return self
 
-    X, y = datasets.make_classification()
+    X, y = datasets.make_multilabel_classification(n_classes=1,
+                                                   return_indicator=True)
+    # Flatten y to a 1d array
+    y = np.ravel(y)
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
@@ -297,7 +303,9 @@ def test_sparse_regression():
             self.data_type_ = type(X)
             return self
 
-    X, y = datasets.make_regression()
+    X, y = datasets.make_multilabel_classification(n_classes=20,
+                                                   return_indicator=True)
+    y = y.sum(axis=1)
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -249,7 +249,7 @@ def test_base_estimator():
 
 
 def test_sparse_classification():
-    """Check classification on sparse input."""
+    """Check classification with sparse input."""
     class CustomSVC(SVC):
 
         """SVC variant that records the nature of the training set."""
@@ -347,7 +347,7 @@ def test_sparse_classification():
 
 
 def test_sparse_regression():
-    """Check regression on sparse input."""
+    """Check regression with sparse input."""
     class CustomSVR(SVR):
 
         """SVR variant that records the nature of the training set."""

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -308,8 +308,8 @@ def test_sparse_classification():
         assert_array_equal(sparse_results, dense_results)
 
         # score
-        sparse_results = sparse_classifier.score(X_test_sparse, sparse_y_pred)
-        dense_results = dense_classifier.score(X_test, dense_y_pred)
+        sparse_results = sparse_classifier.score(X_test_sparse, y_test)
+        dense_results = dense_classifier.score(X_test, y_test)
         assert_array_equal(sparse_results, dense_results)
 
         # staged_decision_function
@@ -333,8 +333,8 @@ def test_sparse_classification():
 
         # staged_score
         sparse_results = sparse_classifier.staged_score(X_test_sparse,
-                                                        sparse_y_pred)
-        dense_results = dense_classifier.staged_score(X_test, dense_y_pred)
+                                                        y_test)
+        dense_results = dense_classifier.staged_score(X_test, y_test)
         for sprase_res, dense_res in zip(sparse_results, dense_results):
             assert_array_equal(sprase_res, dense_res)
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -220,6 +220,10 @@ def test_error():
                   AdaBoostClassifier(algorithm="foo").fit,
                   X, y_class)
 
+    assert_raises(ValueError,
+                  AdaBoostClassifier().fit,
+                  X, y_class, sample_weight=np.asarray([-1]))
+
 
 def test_base_estimator():
     """Test different base estimators."""

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -13,8 +13,8 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.svm import SVC, SVR
 from sklearn.utils import shuffle
 from sklearn.cross_validation import train_test_split
-from scipy.sparse import csc_matrix, csr_matrix, coo_matrix, dok_matrix
-from scipy.sparse import lil_matrix
+from scipy.sparse import csc_matrix, csr_matrix, coo_matrix, dok_matrix, \
+    lil_matrix
 from sklearn import datasets
 
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -281,7 +281,6 @@ def test_sparse_classification():
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 
         assert_array_equal(sparse_results, dense_results)
-        print(types)
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
 
@@ -324,7 +323,6 @@ def test_sparse_regression():
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 
         assert_array_equal(sparse_results, dense_results)
-        print(types)
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -270,23 +270,74 @@ def test_sparse_classification():
 
         # Trained on sparse format
         sparse_classifier = AdaBoostClassifier(
-            base_estimator=CustomSVC(),
+            base_estimator=CustomSVC(probability=True),
             random_state=1,
             algorithm="SAMME"
         ).fit(X_train_sparse, y_train)
-        sparse_results = sparse_classifier.predict(X_test_sparse)
 
         # Trained on dense format
-        dense_results = AdaBoostClassifier(
-            base_estimator=CustomSVC(),
+        dense_classifier = AdaBoostClassifier(
+            base_estimator=CustomSVC(probability=True),
             random_state=1,
             algorithm="SAMME"
-        ).fit(X_train, y_train).predict(X_test)
+        ).fit(X_train, y_train)
 
+        # predict
+        sparse_results = sparse_classifier.predict(X_test_sparse)
+        dense_results = dense_classifier.predict(X_test)
+        assert_array_equal(sparse_results, dense_results)
+        sparse_y_pred, dense_y_pred = sparse_results, dense_results
+
+        # decision_function
+        sparse_results = sparse_classifier.decision_function(X_test_sparse)
+        dense_results = dense_classifier.decision_function(X_test)
+        assert_array_equal(sparse_results, dense_results)
+
+        # predict_log_proba
+        sparse_results = sparse_classifier.predict_log_proba(X_test_sparse)
+        dense_results = dense_classifier.predict_log_proba(X_test)
+        assert_array_equal(sparse_results, dense_results)
+
+        # predict_proba
+        sparse_results = sparse_classifier.predict_proba(X_test_sparse)
+        dense_results = dense_classifier.predict_proba(X_test)
+        assert_array_equal(sparse_results, dense_results)
+
+        # score
+        sparse_results = sparse_classifier.score(X_test_sparse, sparse_y_pred)
+        dense_results = dense_classifier.score(X_test, dense_y_pred)
+        assert_array_equal(sparse_results, dense_results)
+
+        # staged_decision_function
+        sparse_results = sparse_classifier.staged_decision_function(
+            X_test_sparse)
+        dense_results = dense_classifier.staged_decision_function(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # staged_predict
+        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
+        dense_results = dense_classifier.staged_predict(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # staged_predict_proba
+        sparse_results = sparse_classifier.staged_predict_proba(X_test_sparse)
+        dense_results = dense_classifier.staged_predict_proba(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # staged_score
+        sparse_results = sparse_classifier.staged_score(X_test_sparse,
+                                                        sparse_y_pred)
+        dense_results = dense_classifier.staged_score(X_test, dense_y_pred)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
+
+        # Verify sparsity of data is maintained during training
         sparse_type = type(X_train_sparse)
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 
-        assert_array_equal(sparse_results, dense_results)
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
 
@@ -316,21 +367,30 @@ def test_sparse_regression():
 
         # Trained on sparse format
         sparse_classifier = AdaBoostRegressor(
-            base_estimator=CustomSVR(),
+            base_estimator=CustomSVR(probability=True),
             random_state=1
         ).fit(X_train_sparse, y_train)
-        sparse_results = sparse_classifier.predict(X_test_sparse)
 
         # Trained on dense format
-        dense_results = AdaBoostRegressor(
-            base_estimator=CustomSVR(),
+        dense_classifier = dense_results = AdaBoostRegressor(
+            base_estimator=CustomSVR(probability=True),
             random_state=1
-        ).fit(X_train, y_train).predict(X_test)
+        ).fit(X_train, y_train)
+
+        # predict
+        sparse_results = sparse_classifier.predict(X_test_sparse)
+        dense_results = dense_classifier.predict(X_test)
+        assert_array_equal(sparse_results, dense_results)
+
+        # staged_predict
+        sparse_results = sparse_classifier.staged_predict(X_test_sparse)
+        dense_results = dense_classifier.staged_predict(X_test)
+        for sprase_res, dense_res in zip(sparse_results, dense_results):
+            assert_array_equal(sprase_res, dense_res)
 
         sparse_type = type(X_train_sparse)
         types = [i.data_type_ for i in sparse_classifier.estimators_]
 
-        assert_array_equal(sparse_results, dense_results)
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -19,6 +19,7 @@ from sklearn.svm import SVC, SVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import shuffle
 from sklearn import datasets
+import time
 
 
 # Common random state
@@ -250,8 +251,8 @@ def test_base_estimator():
 
 def test_sparse_classification():
     """Check classification with sparse input."""
-    class CustomSVC(SVC):
 
+    class CustomSVC(SVC):
         """SVC variant that records the nature of the training set."""
 
         def fit(self, X, y, sample_weight=None):
@@ -260,8 +261,10 @@ def test_sparse_classification():
             self.data_type_ = type(X)
             return self
 
-    X, y = datasets.make_multilabel_classification(n_classes=1,
-                                                   return_indicator=True)
+    X, y = datasets.make_multilabel_classification(n_classes=1, n_samples=100,
+                                                   n_features=50,
+                                                   return_indicator=True,
+                                                   random_state=42)
     # Flatten y to a 1d array
     y = np.ravel(y)
 
@@ -348,8 +351,8 @@ def test_sparse_classification():
 
 def test_sparse_regression():
     """Check regression with sparse input."""
-    class CustomSVR(SVR):
 
+    class CustomSVR(SVR):
         """SVR variant that records the nature of the training set."""
 
         def fit(self, X, y, sample_weight=None):
@@ -358,9 +361,8 @@ def test_sparse_regression():
             self.data_type_ = type(X)
             return self
 
-    X, y = datasets.make_multilabel_classification(n_classes=20,
-                                                   return_indicator=True)
-    y = y.sum(axis=1)
+    X, y = datasets.make_regression(n_samples=100, n_features=50, n_targets=1,
+                                    random_state=42)
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
@@ -397,6 +399,7 @@ def test_sparse_regression():
 
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
+
 
 if __name__ == "__main__":
     import nose

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -76,7 +76,9 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. coo, dok, and lil are converted to csr. The dtype is 
+            forced to DTYPE from tree._tree if the base classifier of this 
+            ensemble weighted boosting classifier is a tree or forest.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -32,7 +32,9 @@ from .base import BaseEnsemble
 from ..base import ClassifierMixin, RegressorMixin
 from ..externals import six
 from ..externals.six.moves import xrange, zip
+from forest import BaseForest
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
+from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE
 from ..utils import array2d, check_arrays, check_random_state, column_or_1d
 from ..utils import safe_asarray
@@ -101,7 +103,9 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         if (X.ndim != 2 and not issparse(X)):
             X = array2d(X)
 
-        X, = check_arrays(X, dtype=DTYPE)
+        if(self.base_estimator is None or
+           isinstance(self.base_estimator, (BaseDecisionTree, BaseForest))):
+            X, = check_arrays(X, dtype=DTYPE)
         X, y = check_arrays(X, y, check_ccontiguous=True)
 
         y = column_or_1d(y, warn=True)

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -71,7 +71,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -95,7 +96,9 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             X = X.tocsr()
         X = safe_asarray(X)
 
+        X, = check_arrays(X, dtype=DTYPE)
         X, y = check_arrays(X, y, check_ccontiguous=True)
+
         y = column_or_1d(y, warn=True)
 
         if sample_weight is None:
@@ -166,7 +169,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -199,8 +203,9 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
-            Training set.
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -358,7 +363,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -408,7 +414,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -556,7 +563,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -608,7 +616,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -651,7 +660,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -704,7 +714,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -747,7 +758,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -791,7 +803,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -886,7 +899,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -925,7 +939,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -1034,7 +1049,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------
@@ -1059,7 +1075,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The input samples.
+            The training input samples. Sparse matrix can be csc, csr, coo,
+            dok, or lil. coo, dok, and lil are converted to csr.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -25,6 +25,9 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from numpy.core.umath_tests import inner1d
 
+from scipy.sparse import coo_matrix
+from scipy.sparse import issparse
+
 from .base import BaseEnsemble
 from ..base import ClassifierMixin, RegressorMixin
 from ..externals import six
@@ -34,7 +37,6 @@ from ..tree._tree import DTYPE
 from ..utils import array2d, check_arrays, check_random_state, column_or_1d
 from ..utils import safe_asarray
 from ..metrics import accuracy_score, r2_score
-from scipy.sparse import coo_matrix
 
 __all__ = [
     'AdaBoostClassifier',
@@ -95,6 +97,9 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         if isinstance(X, coo_matrix):
             X = X.tocsr()
         X = safe_asarray(X)
+
+        if (X.ndim != 2 and not issparse(X)):
+            X = array2d(X)
 
         X, = check_arrays(X, dtype=DTYPE)
         X, y = check_arrays(X, y, check_ccontiguous=True)
@@ -205,7 +210,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -364,7 +369,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -415,7 +420,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -564,7 +569,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -617,7 +622,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -661,7 +666,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -715,7 +720,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -759,7 +764,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -804,7 +809,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -900,7 +905,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -940,7 +945,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -1050,7 +1055,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------
@@ -1076,7 +1081,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            dok, or lil. dok, and lil are converted to csr.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -217,7 +217,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -376,7 +376,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -427,7 +427,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -576,7 +576,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -629,7 +629,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -673,7 +673,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -727,7 +727,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -771,7 +771,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -816,7 +816,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -912,7 +912,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -952,7 +952,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -1062,7 +1062,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------
@@ -1088,7 +1088,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be CSC, CSR, COO,
-            DOK, or LIL. DOK, and LIL are converted to CSR.
+            DOK, or LIL. DOK and LIL are converted to CSR.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -100,7 +100,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Check data
         if isinstance(X, coo_matrix):
-            X = X.toCSR()
+            X = X.tocsr()
         X = safe_asarray(X)
 
         if (X.ndim != 2 and not issparse(X)):

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -18,6 +18,7 @@ The module structure is the following:
 
 # Authors: Noel Dawe <noel@dawe.me>
 #          Gilles Louppe <g.louppe@gmail.com>
+#          Hamzeh Alsalhi <ha258@cornell.edu>
 # Licence: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod
@@ -76,8 +77,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr. The dtype is 
-            forced to DTYPE from tree._tree if the base classifier of this 
+            dok, or lil. coo, dok, and lil are converted to csr. The dtype is
+            forced to DTYPE from tree._tree if the base classifier of this
             ensemble weighted boosting classifier is a tree or forest.
 
         y : array-like of shape = [n_samples]

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -70,7 +70,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -165,7 +165,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         iboost : int
             The index of the current boost iteration.
 
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -199,7 +199,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Training set.
 
         y : array-like, shape = [n_samples]
@@ -357,7 +357,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -407,7 +407,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         iboost : int
             The index of the current boost iteration.
 
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -555,7 +555,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -607,7 +607,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -650,7 +650,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -703,7 +703,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -746,7 +746,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -790,7 +790,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -885,7 +885,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -924,7 +924,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         iboost : int
             The index of the current boost iteration.
 
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The training input samples.
 
         y : array-like of shape = [n_samples]
@@ -1033,7 +1033,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns
@@ -1058,7 +1058,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
         Parameters
         ----------
-        X : array-like of shape = [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape = [n_samples, n_features]
             The input samples.
 
         Returns

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -76,8 +76,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr. The dtype is
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR. The dtype is
             forced to DTYPE from tree._tree if the base classifier of this
             ensemble weighted boosting classifier is a tree or forest.
 
@@ -100,7 +100,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Check data
         if isinstance(X, coo_matrix):
-            X = X.tocsr()
+            X = X.toCSR()
         X = safe_asarray(X)
 
         if (X.ndim != 2 and not issparse(X)):
@@ -181,8 +181,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. coo, dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -216,8 +216,8 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         y : array-like, shape = [n_samples]
             Labels for X.
@@ -375,8 +375,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -426,8 +426,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels).
@@ -575,8 +575,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -628,8 +628,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -672,8 +672,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -726,8 +726,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -770,8 +770,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -815,8 +815,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -911,8 +911,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (real numbers).
@@ -951,8 +951,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
             The index of the current boost iteration.
 
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         y : array-like of shape = [n_samples]
             The target values (class labels in classification, real numbers in
@@ -1061,8 +1061,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------
@@ -1087,8 +1087,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape = [n_samples, n_features]
-            The training input samples. Sparse matrix can be csc, csr, coo,
-            dok, or lil. dok, and lil are converted to csr.
+            The training input samples. Sparse matrix can be CSC, CSR, COO,
+            DOK, or LIL. DOK, and LIL are converted to CSR.
 
         Returns
         -------

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -32,7 +32,7 @@ from .base import BaseEnsemble
 from ..base import ClassifierMixin, RegressorMixin
 from ..externals import six
 from ..externals.six.moves import xrange, zip
-from forest import BaseForest
+from .forest import BaseForest
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE


### PR DESCRIPTION
This is a PR for issue #2581, this includes both updates to the AdaBoost classifier in ensemble/weighted_boosting.py and updates to the tests in ensemble/tests/test_weighted_boosting.py

The testing code is based off of the code written to test the sparse support in the bagging classifier (PR #3076) it was only modified slightly to work as test code for the AdaBoost classifier and regressor. Like the bagging method this is showing that the results on the sparse and dense classifiers match exactly.

Two specific parts to be reviewed is the choice of parameter_sets in the testing code, and also the exclusion of a np.ascontiguousarray in the base class for the AdaBoost code.
- [X] Remove AdaBoost densification calls - with testing 
- [X] Convert non CSC, CSR to COO in `init()` and predict functions
- [x] Finalize Bugs Found
