### PR TITLE
[MRG+1] DOC more complete coverage of API linking in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ inplace:
 
 test-code: in
 	$(NOSETESTS) -s -v sklearn
+test-sphinxext:
+	$(NOSETESTS) -s -v doc/sphinxext/
 test-doc:
 	$(NOSETESTS) -s -v doc/ doc/modules/ doc/datasets/ \
 	doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
@@ -31,7 +33,7 @@ test-coverage:
 	rm -rf coverage .coverage
 	$(NOSETESTS) -s -v --with-coverage sklearn
 
-test: test-code test-doc
+test: test-code test-sphinxext test-doc
 
 trailing-spaces:
 	find sklearn -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -16,4 +16,4 @@ if [[ "$COVERAGE" == "true" ]]; then
 else
     make test-code
 fi
-make test-doc
+make test-doc test-sphinxext

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -48,14 +48,6 @@ try:
 except NameError:
     basestring = str
 
-try:
-    from PIL import Image
-except ImportError:
-    import Image
-
-import matplotlib
-matplotlib.use('Agg')
-
 import token
 import tokenize
 import numpy as np
@@ -747,6 +739,11 @@ def make_thumbnail(in_fname, out_fname, width, height):
     """Make a thumbnail with the same aspect ratio centered in an
        image with a given width and height
     """
+    # local import to avoid testing dependency on PIL:
+    try:
+        from PIL import Image
+    except ImportError:
+        import Image
     img = Image.open(in_fname)
     width_in, height_in = img.size
     scale_w = width / float(width_in)
@@ -922,6 +919,8 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
             # We need to execute the code
             print('plotting %s' % fname)
             t0 = time()
+            import matplotlib
+            matplotlib.use('Agg')
             import matplotlib.pyplot as plt
             plt.close('all')
             cwd = os.getcwd()

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -1151,3 +1151,8 @@ def setup(app):
         for filename in filelist:
             if filename.endswith('png'):
                 os.remove(os.path.join(build_image_dir, filename))
+
+
+def setup_module():
+    # HACK: Stop nosetests running setup() above
+    pass

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -7,7 +7,7 @@ example files.
 Files that generate images should start with 'plot'
 
 """
-from __future__ import division
+from __future__ import division, print_function
 from time import time
 import ast
 import os
@@ -839,8 +839,20 @@ class NameFinder(ast.NodeVisitor):
                 yield name, full_name
 
 
-def identify_names(example_file):
-    code = open(example_file).read()
+def identify_names(code):
+    """Builds a codeobj summary by identifying and resovles used names
+
+    >>> code = '''
+    ... from a.b import c
+    ... import d as e
+    ... print(c)
+    ... e.HelloWorld().f.g
+    ... '''
+    >>> for name, o in sorted(identify_names(code).items()):
+    ...     print(name, o['name'], o['module'], o['module_short'])
+    c c a.b a.b
+    e.HelloWorld HelloWorld d d
+    """
     finder = NameFinder()
     finder.visit(ast.parse(code))
 
@@ -1016,7 +1028,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
     f.flush()
 
     # save variables so we can later add links to the documentation
-    example_code_obj = identify_names(example_file)
+    example_code_obj = identify_names(open(example_file).read())
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle'
         with open(codeobj_fname, 'wb') as fid:

--- a/doc/sphinxext/numpy_ext/docscrape_sphinx.py
+++ b/doc/sphinxext/numpy_ext/docscrape_sphinx.py
@@ -2,7 +2,6 @@ import re
 import inspect
 import textwrap
 import pydoc
-import sphinx
 from .docscrape import NumpyDocString
 from .docscrape import FunctionDoc
 from .docscrape import ClassDoc
@@ -156,6 +155,7 @@ class SphinxDocString(NumpyDocString):
             out += ['']
             # Latex collects all references to a separate bibliography,
             # so we need to insert links to it
+            import sphinx  # local import to avoid test dependency
             if sphinx.__version__ >= "0.6":
                 out += ['.. only:: latex', '']
             else:

--- a/doc/sphinxext/numpy_ext/numpydoc.py
+++ b/doc/sphinxext/numpy_ext/numpydoc.py
@@ -25,7 +25,6 @@ import re
 import pydoc
 from .docscrape_sphinx import get_doc_object
 from .docscrape_sphinx import SphinxDocString
-from sphinx.util.compat import Directive
 import inspect
 
 
@@ -123,9 +122,13 @@ def setup(app, get_doc_object_=get_doc_object):
 # Docstring-mangling domains
 #-----------------------------------------------------------------------------
 
-from docutils.statemachine import ViewList
-from sphinx.domains.c import CDomain
-from sphinx.domains.python import PythonDomain
+try:
+    import sphinx  # lazy to avoid test dependency
+except ImportError:
+    CDomain = PythonDomain = object
+else:
+    from sphinx.domains.c import CDomain
+    from sphinx.domains.python import PythonDomain
 
 
 class ManglingDomainBase(object):
@@ -180,6 +183,8 @@ def wrap_mangling_directive(base_directive, objtype):
 
             lines = list(self.content)
             mangle_docstrings(env.app, objtype, name, None, None, lines)
+            # local import to avoid testing dependency
+            from docutils.statemachine import ViewList
             self.content = ViewList(lines, self.content.parent)
 
             return base_directive.run(self)


### PR DESCRIPTION
Examples in the documentation currently hyperlink to the API reference where a particular class or function is used. The current implementation has a few flaws, which this PR fixes:
- only plot examples currently have hyperlinks added (for example, [feature_selection_pipeline](http://scikit-learn.org/dev/auto_examples/feature_selection_pipeline.html))
- hyperlink determination currently involves ad-hoc regular expressions, rather than AST traversal
- it also runs the code and uses the resulting `locals` which, I think, is responsible for the spurious linking of `estimator` in [plot_learning_curve](http://scikit-learn.org/dev/auto_examples/plot_learning_curve.html)
- matching of hyperlink text was non-greedy, so that e.g. `plt` rather than `plt.xlabel` is linked in [plot_learning_curve](http://scikit-learn.org/dev/auto_examples/plot_learning_curve.html)
- etc.
