### PR TITLE
PR re: issue 3167 to eradicate .todense()

### DIFF
--- a/examples/applications/plot_model_complexity_influence.py
+++ b/examples/applications/plot_model_complexity_influence.py
@@ -119,7 +119,7 @@ def plot_influence(conf, mse_values, prediction_times, complexities):
 
 
 def _count_nonzero_coefficients(estimator):
-    a = estimator.coef_.todense()
+    a = estimator.coef_.toarray()
     return np.count_nonzero(a)
 
 ###############################################################################

--- a/examples/linear_model/lasso_dense_vs_sparse_data.py
+++ b/examples/linear_model/lasso_dense_vs_sparse_data.py
@@ -59,7 +59,7 @@ sparse_lasso.fit(Xs, y)
 print("Sparse Lasso done in %fs" % (time() - t0))
 
 t0 = time()
-dense_lasso.fit(Xs.todense(), y)
+dense_lasso.fit(Xs.toarray(), y)
 print("Dense Lasso done in %fs" % (time() - t0))
 
 print("Distance between coefficients : %s"

--- a/sklearn/cluster/bicluster/tests/test_utils.py
+++ b/sklearn/cluster/bicluster/tests/test_utils.py
@@ -35,11 +35,11 @@ def test_get_submatrix():
     for X in (data, csr_matrix(data)):
         submatrix = get_submatrix(rows, cols, X)
         if issparse(submatrix):
-            submatrix = submatrix.todense()
+            submatrix = submatrix.toarray()
         assert_array_equal(submatrix, [[2, 3],
                                        [6, 7],
                                        [18, 19]])
         submatrix[:] = -1
         if issparse(X):
-            X = X.todense()
+            X = X.toarray()
         assert_true(np.all(X != -1))

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -167,7 +167,7 @@ def test_agglomerative_clustering():
         clustering = AgglomerativeClustering(
             n_clusters=10,
             connectivity=sparse.lil_matrix(
-                connectivity.todense()[:10, :10]),
+                connectivity.toarray()[:10, :10]),
             linkage=linkage)
         assert_raises(ValueError, clustering.fit, X)
 
@@ -175,7 +175,7 @@ def test_agglomerative_clustering():
     # exception
     clustering = AgglomerativeClustering(
         n_clusters=10,
-        connectivity=connectivity.todense(),
+        connectivity=connectivity.toarray(),
         affinity="manhattan",
         linkage="ward")
     assert_raises(ValueError, clustering.fit, X)

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -188,7 +188,7 @@ def test_discretize(seed=8):
                                              y_true)),
                                             shape=(n_samples,
                                                    n_class + 1))
-            y_true_noisy = (y_indicator.todense()
+            y_true_noisy = (y_indicator.toarray()
                             + 0.1 * random_state.randn(n_samples,
                                                        n_class + 1))
             y_pred = discretize(y_true_noisy, random_state)

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -165,13 +165,13 @@ def test_load_with_qid():
     7 qid:2 1:0.87 2:0.12""")
     X, y = load_svmlight_file(BytesIO(data), query_id=False)
     assert_array_equal(y, [3, 2, 7])
-    assert_array_equal(X.todense(), [[.53, .12], [.13, .1], [.87, .12]])
+    assert_array_equal(X.toarray(), [[.53, .12], [.13, .1], [.87, .12]])
     res1 = load_svmlight_files([BytesIO(data)], query_id=True)
     res2 = load_svmlight_file(BytesIO(data), query_id=True)
     for X, y, qid in (res1, res2):
         assert_array_equal(y, [3, 2, 7])
         assert_array_equal(qid, [1, 1, 2])
-        assert_array_equal(X.todense(), [[.53, .12], [.13, .1], [.87, .12]])
+        assert_array_equal(X.toarray(), [[.53, .12], [.13, .1], [.87, .12]])
 
 
 @raises(ValueError)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -248,7 +248,7 @@ def test_sparse_randomized_pca_inverse():
     Y = pca.transform(X)
 
     Y_inverse = pca.inverse_transform(Y)
-    assert_almost_equal(X.todense(), Y_inverse, decimal=2)
+    assert_almost_equal(X.toarray(), Y_inverse, decimal=2)
 
     # same as above with whitening (approximate reconstruction)
     pca = assert_warns(DeprecationWarning, RandomizedPCA(n_components=2,

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -124,7 +124,7 @@ def _to_graph(n_x, n_y, n_z, mask=None, img=None,
                               (n_voxels, n_voxels),
                               dtype=dtype)
     if return_as is np.ndarray:
-        return graph.todense()
+        return graph.toarray()
     return return_as(graph)
 
 

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -62,8 +62,8 @@ def test_transform_sparse():
     sel = StepSelector()
     Xt_actual = sel.fit(sparse(X)).transform(sparse(X))
     Xt_actual2 = sel.fit_transform(sparse(X))
-    assert_array_equal(Xt, Xt_actual.todense())
-    assert_array_equal(Xt, Xt_actual2.todense())
+    assert_array_equal(Xt, Xt_actual.toarray())
+    assert_array_equal(Xt, Xt_actual2.toarray())
 
     # Check dtype matches
     assert_equal(np.int32, sel.transform(sparse(X).astype(np.int32)).dtype)
@@ -96,7 +96,7 @@ def test_inverse_transform_sparse():
     sparse = sp.csc_matrix
     sel = StepSelector()
     Xinv_actual = sel.fit(sparse(X)).inverse_transform(sparse(Xt))
-    assert_array_equal(Xinv, Xinv_actual.todense())
+    assert_array_equal(Xinv, Xinv_actual.toarray())
 
     # Check dtype matches
     assert_equal(np.int32,

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -20,7 +20,7 @@ def test_sparse_coef():
     clf.coef_ = [1, 2, 3]
 
     assert_true(sp.isspmatrix(clf.sparse_coef_))
-    assert_equal(clf.sparse_coef_.todense().tolist()[0], clf.coef_)
+    assert_equal(clf.sparse_coef_.toarray().tolist()[0], clf.coef_)
 
 
 def test_normalize_option():
@@ -168,7 +168,7 @@ def _test_sparse_enet_not_as_toy_dataset(alpha, fit_intercept, positive):
     d_clf = ElasticNet(alpha=alpha, l1_ratio=0.8, fit_intercept=fit_intercept,
                        max_iter=max_iter, tol=1e-7, positive=positive,
                        warm_start=True)
-    d_clf.fit(X_train.todense(), y_train)
+    d_clf.fit(X_train.toarray(), y_train)
 
     assert_almost_equal(d_clf.dual_gap_, 0, 4)
     assert_greater(d_clf.score(X_test, y_test), 0.85)
@@ -207,7 +207,7 @@ def test_sparse_lasso_not_as_toy_dataset():
 
     # check the convergence is the same as the dense version
     d_clf = Lasso(alpha=0.1, fit_intercept=False, max_iter=max_iter, tol=1e-7)
-    d_clf.fit(X_train.todense(), y_train)
+    d_clf.fit(X_train.toarray(), y_train)
     assert_almost_equal(d_clf.dual_gap_, 0, 4)
     assert_greater(d_clf.score(X_test, y_test), 0.85)
 
@@ -254,7 +254,7 @@ def test_same_output_sparse_dense_lasso_and_enet_cv():
         clfs = ElasticNetCV(max_iter=100, cv=5, normalize=normalize)
         ignore_warnings(clfs.fit)(X, y)
         clfd = ElasticNetCV(max_iter=100, cv=5, normalize=normalize)
-        ignore_warnings(clfd.fit)(X.todense(), y)
+        ignore_warnings(clfd.fit)(X.toarray(), y)
         assert_almost_equal(clfs.alpha_, clfd.alpha_, 7)
         assert_almost_equal(clfs.intercept_, clfd.intercept_, 7)
         assert_array_almost_equal(clfs.mse_path_, clfd.mse_path_)
@@ -263,7 +263,7 @@ def test_same_output_sparse_dense_lasso_and_enet_cv():
         clfs = LassoCV(max_iter=100, cv=4, normalize=normalize)
         ignore_warnings(clfs.fit)(X, y)
         clfd = LassoCV(max_iter=100, cv=4, normalize=normalize)
-        ignore_warnings(clfd.fit)(X.todense(), y)
+        ignore_warnings(clfd.fit)(X.toarray(), y)
         assert_almost_equal(clfs.alpha_, clfd.alpha_, 7)
         assert_almost_equal(clfs.intercept_, clfd.intercept_, 7)
         assert_array_almost_equal(clfs.mse_path_, clfd.mse_path_)

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -288,7 +288,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
             # number of nodes
             # lobpcg will fallback to symeig, so we short circuit it
             if sparse.isspmatrix(laplacian):
-                laplacian = laplacian.todense()
+                laplacian = laplacian.toarray()
             lambdas, diffusion_map = symeig(laplacian)
             embedding = diffusion_map.T[:n_components] * dd
         else:

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -27,7 +27,7 @@ def test_barycenter_kneighbors_graph():
 
     A = barycenter_kneighbors_graph(X, 2)
     # check that columns sum to one
-    assert_array_almost_equal(np.sum(A.todense(), 1), np.ones((3, 1)))
+    assert_array_almost_equal(np.sum(A.toarray(), 1), np.ones(3))
     pred = np.dot(A.toarray(), X)
     assert_less(linalg.norm(pred - X) / X.shape[0], 1)
 

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -20,7 +20,7 @@ def test_barycenter_kneighbors_graph():
 
     A = barycenter_kneighbors_graph(X, 1)
     assert_array_almost_equal(
-        A.todense(),
+        A.toarray(),
         [[0.,  1.,  0.],
          [1.,  0.,  0.],
          [0.,  1.,  0.]])
@@ -28,7 +28,7 @@ def test_barycenter_kneighbors_graph():
     A = barycenter_kneighbors_graph(X, 2)
     # check that columns sum to one
     assert_array_almost_equal(np.sum(A.todense(), 1), np.ones((3, 1)))
-    pred = np.dot(A.todense(), X)
+    pred = np.dot(A.toarray(), X)
     assert_less(linalg.norm(pred - X) / X.shape[0], 1)
 
 
@@ -50,7 +50,7 @@ def test_lle_simple_grid():
                                           random_state=rng)
     tol = 0.1
 
-    N = barycenter_kneighbors_graph(X, clf.n_neighbors).todense()
+    N = barycenter_kneighbors_graph(X, clf.n_neighbors).toarray()
     reconstruction_error = linalg.norm(np.dot(N, X) - X, 'fro')
     assert_less(reconstruction_error, tol)
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -969,12 +969,9 @@ def confusion_matrix(y_true, y_pred, labels=None):
     y_pred = y_pred[ind]
     y_true = y_true[ind]
 
-    CM = np.asarray(
-        coo_matrix(
-            (np.ones(y_true.shape[0], dtype=np.int), (y_true, y_pred)),
-            shape=(n_labels, n_labels)
-        ).toarray()
-    )
+    CM = coo_matrix((np.ones(y_true.shape[0], dtype=np.int), (y_true, y_pred)),
+                    shape=(n_labels, n_labels)
+                    ).toarray()
 
     return CM
 

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -973,7 +973,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
         coo_matrix(
             (np.ones(y_true.shape[0], dtype=np.int), (y_true, y_pred)),
             shape=(n_labels, n_labels)
-        ).todense()
+        ).toarray()
     )
 
     return CM

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -35,8 +35,8 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity'):
     >>> X = [[0], [3], [1]]
     >>> from sklearn.neighbors import kneighbors_graph
     >>> A = kneighbors_graph(X, 2)
-    >>> A.todense()
-    matrix([[ 1.,  0.,  1.],
+    >>> A.toarray()
+    array([[ 1.,  0.,  1.],
             [ 0.,  1.,  1.],
             [ 1.,  0.,  1.]])
 
@@ -79,8 +79,8 @@ def radius_neighbors_graph(X, radius, mode='connectivity'):
     >>> X = [[0], [3], [1]]
     >>> from sklearn.neighbors import radius_neighbors_graph
     >>> A = radius_neighbors_graph(X, 1.5)
-    >>> A.todense()
-    matrix([[ 1.,  0.,  1.],
+    >>> A.toarray()
+    array([[ 1.,  0.,  1.],
             [ 0.,  1.,  0.],
             [ 1.,  0.,  1.]])
 

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -37,8 +37,8 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity'):
     >>> A = kneighbors_graph(X, 2)
     >>> A.toarray()
     array([[ 1.,  0.,  1.],
-            [ 0.,  1.,  1.],
-            [ 1.,  0.,  1.]])
+           [ 0.,  1.,  1.],
+           [ 1.,  0.,  1.]])
 
     See also
     --------
@@ -81,8 +81,8 @@ def radius_neighbors_graph(X, radius, mode='connectivity'):
     >>> A = radius_neighbors_graph(X, 1.5)
     >>> A.toarray()
     array([[ 1.,  0.,  1.],
-            [ 0.,  1.,  0.],
-            [ 1.,  0.,  1.]])
+           [ 0.,  1.,  0.],
+           [ 1.,  0.,  1.]])
 
     See also
     --------

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -256,7 +256,7 @@ def test_imputation_pipeline_grid_search():
 
     l = 100
     X = sparse_random_matrix(l, l, density=0.10)
-    Y = sparse_random_matrix(l, 1, density=0.10).todense()
+    Y = sparse_random_matrix(l, 1, density=0.10).toarray()
     gs = grid_search.GridSearchCV(pipeline, parameters)
     gs.fit(X, Y)
 
@@ -285,7 +285,7 @@ def test_imputation_copy():
     X_orig = sparse_random_matrix(5, 5, density=0.75, random_state=0)
 
     # copy=True, dense => copy
-    X = X_orig.copy().todense()
+    X = X_orig.copy().toarray()
     imputer = Imputer(missing_values=0, strategy="mean", copy=True)
     Xt = imputer.fit(X).transform(X)
     Xt[0, 0] = -1
@@ -299,7 +299,7 @@ def test_imputation_copy():
     assert_false(np.all(X.data == Xt.data))
 
     # copy=False, dense => no copy
-    X = X_orig.copy().todense()
+    X = X_orig.copy().toarray()
     imputer = Imputer(missing_values=0, strategy="mean", copy=False)
     Xt = imputer.fit(X).transform(X)
     Xt[0, 0] = -1

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -50,13 +50,13 @@ def test_svc():
 
     assert_true(sparse.issparse(sp_clf.support_vectors_))
     assert_array_almost_equal(clf.support_vectors_,
-                              sp_clf.support_vectors_.todense())
+                              sp_clf.support_vectors_.toarray())
 
     assert_true(sparse.issparse(sp_clf.dual_coef_))
-    assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.todense())
+    assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.toarray())
 
     assert_true(sparse.issparse(sp_clf.coef_))
-    assert_array_almost_equal(clf.coef_, sp_clf.coef_.todense())
+    assert_array_almost_equal(clf.coef_, sp_clf.coef_.toarray())
     assert_array_almost_equal(clf.support_, sp_clf.support_)
     assert_array_almost_equal(clf.predict(T), sp_clf.predict(T))
 
@@ -64,9 +64,9 @@ def test_svc():
     clf.fit(X2, Y2)
     sp_clf.fit(X2_sp, Y2)
     assert_array_almost_equal(clf.support_vectors_,
-                              sp_clf.support_vectors_.todense())
-    assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.todense())
-    assert_array_almost_equal(clf.coef_, sp_clf.coef_.todense())
+                              sp_clf.support_vectors_.toarray())
+    assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.toarray())
+    assert_array_almost_equal(clf.coef_, sp_clf.coef_.toarray())
     assert_array_almost_equal(clf.support_, sp_clf.support_)
     assert_array_almost_equal(clf.predict(T2), sp_clf.predict(T2))
     assert_array_almost_equal(clf.predict_proba(T2),
@@ -117,15 +117,15 @@ def test_svc_iris():
     """Test the sparse SVC with the iris dataset"""
     for k in ('linear', 'poly', 'rbf'):
         sp_clf = svm.SVC(kernel=k).fit(iris.data, iris.target)
-        clf = svm.SVC(kernel=k).fit(iris.data.todense(), iris.target)
+        clf = svm.SVC(kernel=k).fit(iris.data.toarray(), iris.target)
 
         assert_array_almost_equal(clf.support_vectors_,
-                                  sp_clf.support_vectors_.todense())
-        assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.todense())
+                                  sp_clf.support_vectors_.toarray())
+        assert_array_almost_equal(clf.dual_coef_, sp_clf.dual_coef_.toarray())
         assert_array_almost_equal(
-            clf.predict(iris.data.todense()), sp_clf.predict(iris.data))
+            clf.predict(iris.data.toarray()), sp_clf.predict(iris.data))
         if k == 'linear':
-            assert_array_almost_equal(clf.coef_, sp_clf.coef_.todense())
+            assert_array_almost_equal(clf.coef_, sp_clf.coef_.toarray())
 
 
 def test_error():
@@ -170,17 +170,17 @@ def test_linearsvc_iris():
     """Test the sparse LinearSVC with the iris dataset"""
 
     sp_clf = svm.LinearSVC(random_state=0).fit(iris.data, iris.target)
-    clf = svm.LinearSVC(random_state=0).fit(iris.data.todense(), iris.target)
+    clf = svm.LinearSVC(random_state=0).fit(iris.data.toarray(), iris.target)
 
     assert_equal(clf.fit_intercept, sp_clf.fit_intercept)
 
     assert_array_almost_equal(clf.raw_coef_, sp_clf.raw_coef_, decimal=1)
     assert_array_almost_equal(
-        clf.predict(iris.data.todense()), sp_clf.predict(iris.data))
+        clf.predict(iris.data.toarray()), sp_clf.predict(iris.data))
 
     # check decision_function
     pred = np.argmax(sp_clf.decision_function(iris.data), 1)
-    assert_array_almost_equal(pred, clf.predict(iris.data.todense()))
+    assert_array_almost_equal(pred, clf.predict(iris.data.toarray()))
 
     # sparsify the coefficients on both models and check that they still
     # produce the same results
@@ -252,11 +252,11 @@ def test_sparse_realdata():
          3.,  0.,  0.,  2.,  2.,  1.,  3.,  1.,  1.,  0.,  1.,  2.,  1.,
          1.,  3.])
 
-    clf = svm.SVC(kernel='linear').fit(X.todense(), y)
+    clf = svm.SVC(kernel='linear').fit(X.toarray(), y)
     sp_clf = svm.SVC(kernel='linear').fit(sparse.coo_matrix(X), y)
 
-    assert_array_equal(clf.support_vectors_, sp_clf.support_vectors_.todense())
-    assert_array_equal(clf.dual_coef_, sp_clf.dual_coef_.todense())
+    assert_array_equal(clf.support_vectors_, sp_clf.support_vectors_.toarray())
+    assert_array_equal(clf.dual_coef_, sp_clf.dual_coef_.toarray())
 
 
 def test_sparse_svc_clone_with_callable_kernel():

--- a/sklearn/utils/sparsetools/tests/test_spanning_tree.py
+++ b/sklearn/utils/sparsetools/tests/test_spanning_tree.py
@@ -28,16 +28,16 @@ def test_minimum_spanning_tree():
     # Ensure minimum spanning tree code gives this expected output.
     csgraph = csr_matrix(graph)
     mintree = minimum_spanning_tree(csgraph)
-    npt.assert_array_equal(mintree.todense(), expected,
+    npt.assert_array_equal(mintree.toarray(), expected,
                            'Incorrect spanning tree found.')
 
     # Ensure that the original graph was not modified.
-    npt.assert_array_equal(csgraph.todense(), graph,
+    npt.assert_array_equal(csgraph.toarray(), graph,
                            'Original graph was modified.')
 
     # Now let the algorithm modify the csgraph in place.
     mintree = minimum_spanning_tree(csgraph, overwrite=True)
-    npt.assert_array_equal(mintree.todense(), expected,
+    npt.assert_array_equal(mintree.toarray(), expected,
                            'Graph was not properly modified to contain MST.')
 
     np.random.seed(1234)
@@ -61,5 +61,5 @@ def test_minimum_spanning_tree():
         expected = np.zeros((N, N))
         expected[idx, idx + 1] = 1
 
-        npt.assert_array_equal(mintree.todense(), expected,
+        npt.assert_array_equal(mintree.toarray(), expected,
                                'Incorrect spanning tree found.')

--- a/sklearn/utils/tests/test_graph.py
+++ b/sklearn/utils/tests/test_graph.py
@@ -21,4 +21,4 @@ def test_graph_laplacian():
                                                      np.zeros(n_nodes))
             np.testing.assert_array_almost_equal(laplacian.T, laplacian)
             np.testing.assert_array_almost_equal(
-                laplacian, graph_laplacian(sp_mat, normed=normed).todense())
+                laplacian, graph_laplacian(sp_mat, normed=normed).toarray())

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -66,8 +66,8 @@ def test_as_float_array():
     # Test the copy parameter with some matrices
     matrices = [
         np.matrix(np.arange(5)),
-        sp.csc_matrix(np.arange(5)).todense(),
-        sparse_random_matrix(10, 10, density=0.10).todense()
+        sp.csc_matrix(np.arange(5)).toarray(),
+        sparse_random_matrix(10, 10, density=0.10).toarray()
     ]
     for M in matrices:
         N = as_float_array(M, copy=True)


### PR DESCRIPTION
As discussed in issue 3167 (https://github.com/scikit-learn/scikit-learn/issues/3167), replacing .todense() with .toarray().

Need to review in additional detail for any matrix-specific notation/operators/indexing, e.g., matrix mult or sums/means along axis.
