### PR TITLE
FIX TfidfVectorizer exports idf_ attribute

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -877,3 +877,9 @@ def test_tfidfvectorizer_binary():
     assert_array_equal(X.ravel(), [1, 1, 1, 0])
     X2 = v.transform(['hello world', 'hello hello']).toarray()
     assert_array_equal(X2.ravel(), [1, 1, 1, 0])
+
+
+def test_tfidfvectorizer_export_idf():
+    vect = TfidfVectorizer(use_idf=True)
+    vect.fit(JUNK_FOOD_DOCS)
+    assert_array_almost_equal(vect.idf_, vect._tfidf.idf_)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1145,6 +1145,12 @@ class TfidfVectorizer(CountVectorizer):
     sublinear_tf : boolean, optional
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
+    Attributes
+    ----------
+    ``idf_`` : array, shape = [n_features], or None
+        The learned idf vector (global term weights)
+        when ``use_idf`` is set to True, None otherwise.
+
     See also
     --------
     CountVectorizer
@@ -1215,6 +1221,10 @@ class TfidfVectorizer(CountVectorizer):
     @sublinear_tf.setter
     def sublinear_tf(self, value):
         self._tfidf.sublinear_tf = value
+
+    @property
+    def idf_(self):
+        return self._tfidf.idf_
 
     def fit(self, raw_documents, y=None):
         """Learn a conversion law from documents to array data"""


### PR DESCRIPTION
This fixes #3179 by adding an attribute `idf_` to `TfidfVectorizer`.
