### PR TITLE
CI: make travis run the doctests

### DIFF
--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -12,8 +12,8 @@ python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python setup.py build_ext --inplace
 
 if [[ "$COVERAGE" == "true" ]]; then
-    export WITH_COVERAGE="--with-coverage"
+    make test-coverage
 else
-    export WITH_COVERAGE=""
+    make test-code
 fi
-nosetests -s -v $WITH_COVERAGE sklearn
+make test-doc


### PR DESCRIPTION
Reuse the Makefile to avoid duplication of the list of documentation folders to test. Unfortunately there is no simple way to make nose recursively introspect non-package folders.
