### PR TITLE
Handling out-of-bounds in IsotonicRegression (clean PR #3147)

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -293,21 +293,23 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if len(T.shape) != 1:
             raise ValueError("X should be a vector")
 
-        # Only raise exception on out-of-bounds data if requested.
+        # Handle the out_of_bounds argument by setting bounds_error and T
         if self.out_of_bounds == "raise":
             f = interpolate.interp1d(self.X_, self.y_, kind='linear',
                                      bounds_error=True)
-        else:
+        elif self.out_of_bounds == "nan":
             f = interpolate.interp1d(self.X_, self.y_, kind='linear',
                                      bounds_error=False)
-
-        # Clip out-of-bounds values if requested.
-        if self.out_of_bounds == "clip":
-            T_final = np.clip(T, self.X_min_, self.X_max_)
+        elif self.out_of_bounds == "clip":
+            f = interpolate.interp1d(self.X_, self.y_, kind='linear',
+                                     bounds_error=False)
+            T = np.clip(T, self.X_min_, self.X_max_)
         else:
-            T_final = T
+            raise ValueError("The argument ``out_of_bounds`` must be in "
+                             "'nan', 'clip', 'raise'; got {0}"\
+                             .format(self.out_of_bounds))
 
-        return f(T_final)
+        return f(T)
 
     def fit_transform(self, X, y, sample_weight=None, weight=None):
         """Fit model and transform y by linear interpolation.

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -183,6 +183,13 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         increase or decrease based on the Spearman correlation estimate's
         sign.
 
+    out_of_bounds : string, optional, default: "nan"
+        The ``out_of_bounds`` parameter handles how x-values outside of the
+        training domain are handled.  When set to "nan", predicted y-values
+        will be NaN.  When set to "clip", predicted y-values will be
+        set to the value corresponding to the nearest train interval endpoint.
+        When set to "raise", allow ``interp1d`` to throw ValueError.
+
 
     Attributes
     ----------
@@ -192,6 +199,12 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     `y_` : ndarray (n_samples, )
         Isotonic fit of y.
 
+    `X_min_` : float
+        Minimum value of input array X_ for left bound.
+
+    `X_max_` : float
+        Maximum value of input array X_ for right bound.
+
     References
     ----------
     Isotonic Median Regression: A Linear Programming Approach
@@ -199,10 +212,12 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     Mathematics of Operations Research
     Vol. 14, No. 2 (May, 1989), pp. 303-308
     """
-    def __init__(self, y_min=None, y_max=None, increasing=True):
+    def __init__(self, y_min=None, y_max=None, increasing=True,
+                 out_of_bounds='nan'):
         self.y_min = y_min
         self.y_max = y_max
         self.increasing = increasing
+        self.out_of_bounds = out_of_bounds
 
     def _check_fit_data(self, X, y, sample_weight=None):
         if len(X.shape) != 1:
@@ -254,6 +269,11 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         self.X_ = as_float_array(X[order], copy=False)
         self.y_ = isotonic_regression(y[order], sample_weight, self.y_min,
                                       self.y_max, increasing=self.increasing_)
+
+        # Handle the left and right bounds on X
+        self.X_min_ = np.min(self.X_)
+        self.X_max_ = np.max(self.X_)
+
         return self
 
     def transform(self, T):
@@ -273,9 +293,21 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         if len(T.shape) != 1:
             raise ValueError("X should be a vector")
 
-        f = interpolate.interp1d(self.X_, self.y_, kind='linear',
-                                 bounds_error=True)
-        return f(T)
+        # Only raise exception on out-of-bounds data if requested.
+        if self.out_of_bounds == "raise":
+            f = interpolate.interp1d(self.X_, self.y_, kind='linear',
+                                     bounds_error=True)
+        else:
+            f = interpolate.interp1d(self.X_, self.y_, kind='linear',
+                                     bounds_error=False)
+
+        # Clip out-of-bounds values if requested.
+        if self.out_of_bounds == "clip":
+            T_final = np.clip(T, self.X_min_, self.X_max_)
+        else:
+            T_final = T
+
+        return f(T_final)
 
     def fit_transform(self, X, y, sample_weight=None, weight=None):
         """Fit model and transform y by linear interpolation.
@@ -325,6 +357,11 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         self.X_ = as_float_array(X[order], copy=False)
         self.y_ = isotonic_regression(y[order], sample_weight, self.y_min,
                                       self.y_max, increasing=self.increasing_)
+
+        # Handle the left and right bounds on X
+        self.X_min_ = np.min(self.X_)
+        self.X_max_ = np.max(self.X_)
+
         return self.y_[order_inv]
 
     def predict(self, T):

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -306,7 +306,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             T = np.clip(T, self.X_min_, self.X_max_)
         else:
             raise ValueError("The argument ``out_of_bounds`` must be in "
-                             "'nan', 'clip', 'raise'; got {0}"\
+                             "'nan', 'clip', 'raise'; got {0}"
                              .format(self.out_of_bounds))
 
         return f(T)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -204,6 +204,20 @@ def test_isotonic_regression_oob_nan():
     y1 = ir.predict([min(x)-10, max(x)+10])
     assert_equal(sum(np.isnan(y1)), 2)
 
+
+def test_isotonic_regression_oob_bad():
+    # Set y and x
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression(increasing='auto', out_of_bounds="xyz")
+    ir.fit(x, y)
+
+    # Make sure that we throw an error for bad out_of_bounds value
+    assert_raises(ValueError, ir.predict, [min(x)-10, max(x)+10])
+
+
 if __name__ == "__main__":
     import nose
     nose.run(argv=['', __file__])

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -4,7 +4,7 @@ from sklearn.isotonic import check_increasing, isotonic_regression,\
     IsotonicRegression
 
 from sklearn.utils.testing import assert_raises, assert_array_equal,\
-    assert_true, assert_false
+    assert_true, assert_false, assert_equal
 
 from sklearn.utils.testing import assert_warns_message, assert_no_warnings
 
@@ -161,6 +161,48 @@ def test_isotonic_sample_weight():
 
     assert_array_equal(expected_y, received_y)
 
+
+def test_isotonic_regression_oob_raise():
+    # Set y and x
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression(increasing='auto', out_of_bounds="raise")
+    ir.fit(x, y)
+
+    # Check that an exception is thrown
+    assert_raises(ValueError, ir.predict, [min(x)-10, max(x)+10])
+
+
+def test_isotonic_regression_oob_clip():
+    # Set y and x
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression(increasing='auto', out_of_bounds="clip")
+    ir.fit(x, y)
+
+    # Predict from  training and test x and check that min/max match.
+    y1 = ir.predict([min(x) - 10, max(x) + 10])
+    y2 = ir.predict(x)
+    assert_equal(max(y1), max(y2))
+    assert_equal(min(y1), min(y2))
+
+
+def test_isotonic_regression_oob_nan():
+    # Set y and x
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression(increasing='auto', out_of_bounds="nan")
+    ir.fit(x, y)
+
+    # Predict from  training and test x and check that we have two NaNs.
+    y1 = ir.predict([min(x)-10, max(x)+10])
+    assert_equal(sum(np.isnan(y1)), 2)
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Here's a clean, follow-up PR based on the other Isotonic merges today and conversation from PR #3147.
- Added argument `out_of_bounds`
- Added test for each value case below
- Changed default behavior from "raise", i.e., ValueError, to "nan"

**Argument behavior**
- "nan": x-values not in training domain -> y-values = NaN
- "clip": x-values not in training domain -> y-values = y-value for nearest training x
- "raise": x-values not in training domain -> ValueError exception

Let me know if you want to see L296-310 differently.  I'd like to clean up `fit` vs. `fit_transform` and some of the matrix/vector notation mismatch in the module anyway.

(My interpretation is also that there is no need for `f` to be created anew on each call to `transform`.)
