### PR TITLE
Improved documentation of the "estimator_params" argument for RFE and RF...

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -53,7 +53,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
     estimator_params : dict
         Parameters for the external estimator.
-        Useful for doing grid searches.
+        Useful for doing grid searches when an `RFE` object is passed as an
+        argument to, e.g., a `sklearn.grid_search.GridSearchCV` object.
 
     Attributes
     ----------
@@ -243,7 +244,8 @@ class RFECV(RFE, MetaEstimatorMixin):
 
     estimator_params : dict
         Parameters for the external estimator.
-        Useful for doing grid searches.
+        Useful for doing grid searches when an `RFE` object is passed as an
+        argument to, e.g., a `sklearn.grid_search.GridSearchCV` object.
 
     verbose : int, default=0
         Controls verbosity of output.


### PR DESCRIPTION
...ECV.

Changed the documentation for the "estimator_params" argument for both
RFE and RFECV to better indicate how it could be useful for doing a
grid search. Previously the documentation may have indicated that RFE
and RFECV would perform a grid search if "estimator_params" was passed
a grid of parameter values, which is not the actual behavior.
