### PR TITLE
ENH: issue #3171

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -351,6 +351,10 @@ def test_max_features():
         est.fit(iris.data, iris.target)
         assert_equal(est.max_features_, 3)
 
+        est = TreeEstimator(max_features=0.01)
+        est.fit(iris.data, iris.target)
+        assert_equal(est.max_features_, 1)
+
         est = TreeEstimator(max_features=0.5)
         est.fit(iris.data, iris.target)
         assert_equal(est.max_features_,

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -194,7 +194,10 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         elif isinstance(self.max_features, (numbers.Integral, np.integer)):
             max_features = self.max_features
         else:  # float
-            max_features = int(self.max_features * self.n_features_)
+            if self.max_features > 0.0:
+                max_features = max(1, int(self.max_features * self.n_features_))
+            else:
+                max_features = 0
 
         self.max_features_ = max_features
 


### PR DESCRIPTION
Trees do no longer fail if `int(max_features*n_features) == 0`, but use
`max_features=1` if the max_features paramater was larger than 0.0
