### PR TITLE
ENH: use partial sort for kneighbors selection

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -18,6 +18,7 @@ from ..base import BaseEstimator
 from ..metrics import pairwise_distances
 from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from ..utils import safe_asarray, atleast2d_or_csr, check_arrays
+from ..utils.fixes import argpartition
 from ..utils.validation import DataConversionWarning
 from ..externals import six
 
@@ -293,11 +294,7 @@ class KNeighborsMixin(object):
                                           self.effective_metric_,
                                           **self.effective_metric_kwds_)
 
-            # numpy 1.8+ includes a partial sort
-            if hasattr(np, 'argpartition'):
-                neigh_ind = np.argpartition(dist, n_neighbors - 1, axis=1)
-            else:
-                neigh_ind = dist.argsort(axis=1)
+            neigh_ind = argpartition(dist, n_neighbors - 1, axis=1)
             neigh_ind = neigh_ind[:, :n_neighbors]
             if return_distance:
                 j = np.arange(neigh_ind.shape[0])[:, None]

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -293,8 +293,11 @@ class KNeighborsMixin(object):
                                           self.effective_metric_,
                                           **self.effective_metric_kwds_)
 
-            # XXX: should be implemented with a partial sort
-            neigh_ind = dist.argsort(axis=1)
+            # numpy 1.8+ includes a partial sort
+            if hasattr(np, 'argpartition'):
+                neigh_ind = np.argpartition(dist, n_neighbors - 1, axis=1)
+            else:
+                neigh_ind = dist.argsort(axis=1)
             neigh_ind = neigh_ind[:, :n_neighbors]
             if return_distance:
                 j = np.arange(neigh_ind.shape[0])[:, None]

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -296,8 +296,10 @@ class KNeighborsMixin(object):
 
             neigh_ind = argpartition(dist, n_neighbors - 1, axis=1)
             neigh_ind = neigh_ind[:, :n_neighbors]
+            # argpartition doesn't guarantee sorted order, so we sort again
+            j = np.arange(neigh_ind.shape[0])[:, None]
+            neigh_ind = neigh_ind[j, np.argsort(dist[j, neigh_ind])]
             if return_distance:
-                j = np.arange(neigh_ind.shape[0])[:, None]
                 if self.effective_metric_ == 'euclidean':
                     return np.sqrt(dist[j, neigh_ind]), neigh_ind
                 else:

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -164,3 +164,13 @@ else:
     def sparse_min_max(X, axis):
         return (X.min(axis=axis).toarray().ravel(),
                 X.max(axis=axis).toarray().ravel())
+
+try:
+    from numpy import argpartition
+except ImportError:
+    # numpy.argpartition was introduced in v 1.8.0
+    def argpartition(a, kth, axis=-1, kind='introselect', order=None):
+        return np.argsort(a, axis=axis, order=order)
+else:
+    def argpartition(a, kth, axis=-1, kind='introselect', order=None):
+        return np.argpartition(a, kth, axis=axis, kind=kind, order=order)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -171,6 +171,3 @@ except ImportError:
     # numpy.argpartition was introduced in v 1.8.0
     def argpartition(a, kth, axis=-1, kind='introselect', order=None):
         return np.argsort(a, axis=axis, order=order)
-else:
-    def argpartition(a, kth, axis=-1, kind='introselect', order=None):
-        return np.argpartition(a, kth, axis=axis, kind=kind, order=order)


### PR DESCRIPTION
This produces a considerable speedup with Numpy >= 1.8. Faster implementations of `argpartition` exist (see [bottleneck's argpartsort](http://berkeleyanalytics.com/bottleneck/reference.html#bottleneck.argpartsort), but that would involve adding dependencies.

Is this sort of on-demand feature checking acceptable, or should I make a shim for `argpartition`?

Also note that this has the side-effect of leaving the selected indices unsorted. I don't think any downstream code relies on this, but I haven't checked.
