### PR TITLE
[MRG+2] Sample weights for gradient boosting

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -434,7 +434,7 @@ Classification
 ---------------
 
 :class:`GradientBoostingClassifier` supports both binary and multi-class
-classification via the deviance loss function (``loss='deviance'``).
+classification.
 The following example shows how to fit a gradient boosting classifier
 with 100 decision stumps as weak learners::
 
@@ -649,6 +649,10 @@ the parameter ``loss``:
       prior probability of each class. At each iteration ``n_classes``
       regression trees have to be constructed which makes GBRT rather
       inefficient for data sets with a large number of classes.
+    * Exponential loss (``'exponential'``): The same loss function
+      as :class:`AdaBoostClassifier`. Less robust to mislabeled
+      examples than ``'deviance'``; cannot provide probability
+      estimates and can only be used for binary classification.
 
 Regularization
 ----------------

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -651,8 +651,8 @@ the parameter ``loss``:
       inefficient for data sets with a large number of classes.
     * Exponential loss (``'exponential'``): The same loss function
       as :class:`AdaBoostClassifier`. Less robust to mislabeled
-      examples than ``'deviance'``; cannot provide probability
-      estimates and can only be used for binary classification.
+      examples than ``'deviance'``; can only be used for binary
+      classification.
 
 Regularization
 ----------------
@@ -892,4 +892,3 @@ averaged.
  .. [HTF2009] T. Hastie, R. Tibshirani and J. Friedman, "Elements of Statistical Learning Ed. 2", Springer, 2009.
 
  .. [R2007] G. Ridgeway, "Generalized Boosted Models: A guide to the gbm package", 2007
-

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,10 @@ New features
      trained forest model to grow additional trees incrementally. By
      `Laurent Direr`_.
 
+   - Add ``sample_weight`` support to :class:`ensemble.GradientBoostingClassifier` and
+     :class:`ensemble.GradientBoostingRegressor`. By
+     `Peter Prettenhofer`_.
+
 
 Enhancements
 ............

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -536,7 +536,7 @@ class MultinomialDeviance(ClassificationLossFunction):
             return np.sum(-1 * sample_weight * (Y * pred).sum(axis=1) +
                           logsumexp(pred, axis=1))
 
-    def negative_gradient(self, y, pred, k=0):
+    def negative_gradient(self, y, pred, k=0, **kwargs):
         """Compute negative gradient for the ``k``-th class. """
         return y - np.nan_to_num(np.exp(pred[:, k] -
                                         logsumexp(pred, axis=1)))

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -299,7 +299,15 @@ class LeastAbsoluteError(RegressionLossFunction):
 
 
 class HuberLossFunction(RegressionLossFunction):
-    """Loss function for least absolute deviation (LAD) regression. """
+    """Huber loss function forrobust regression.
+
+    M-Regression proposed in Friedman 2001.
+
+    See
+    ---
+    J. Friedman, Greedy Function Approximation: A Gradient Boosting
+    Machine, The Annals of Statistics, Vol. 29, No. 5, 2001.
+    """
 
     def __init__(self, n_classes, alpha=0.9):
         super(HuberLossFunction, self).__init__(n_classes)
@@ -333,7 +341,6 @@ class HuberLossFunction(RegressionLossFunction):
 
     def _update_terminal_region(self, tree, terminal_regions, leaf, X, y,
                                 residual, pred, sample_weight):
-        """LAD updates terminal regions to median estimates. """
         terminal_region = np.where(terminal_regions == leaf)[0]
         gamma = self.gamma
         diff = (y.take(terminal_region, axis=0)
@@ -378,7 +385,6 @@ class QuantileLossFunction(RegressionLossFunction):
 
     def _update_terminal_region(self, tree, terminal_regions, leaf, X, y,
                                 residual, pred, sample_weight):
-        """LAD updates terminal regions to median estimates. """
         terminal_region = np.where(terminal_regions == leaf)[0]
         diff = (y.take(terminal_region, axis=0)
                 - pred.take(terminal_region, axis=0))
@@ -905,6 +911,9 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
             sample_weight = np.ones(n_samples, dtype=np.float32)
         else:
             sample_weight = column_or_1d(sample_weight, warn=True)
+            if self.loss in ('lad', 'huber', 'quantile'):
+                raise ValueError('sample_weight not supported for loss=%r' %
+                                 self.loss)
 
         if y.shape[0] != n_samples:
             raise ValueError('Shape mismatch of X and y: %d != %d' %

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -903,6 +903,16 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         n_samples, n_features = X.shape
         if sample_weight is None:
             sample_weight = np.ones(n_samples, dtype=np.float32)
+        else:
+            sample_weight = column_or_1d(sample_weight, warn=True)
+
+        if y.shape[0] != n_samples:
+            raise ValueError('Shape mismatch of X and y: %d != %d' %
+                             (n_samples, y.shape[0]))
+        if n_samples != sample_weight.shape[0]:
+            raise ValueError('Shape mismatch of sample_weight: %d != %d' %
+                             (sample_weight.shape[0], n_samples))
+
         self.n_features = n_features
         random_state = check_random_state(self.random_state)
         self._check_params()
@@ -1239,6 +1249,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     See also
     --------
     sklearn.tree.DecisionTreeClassifier, RandomForestClassifier
+    AdaBoostClassifier
 
     References
     ----------

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -117,13 +117,8 @@ class PriorProbabilityEstimator(BaseEstimator):
             class_counts = np.bincount(y)
             priors = class_counts / float(y.shape[0])
         else:
-            classes = np.unique(y)
-            n_classes = classes.shape[0]
-            priors = np.zeros(n_classes, dtype=np.float64)
-            for c in classes:
-                mask = y == c
-                priors[c] = np.sum(sample_weight[mask])
-            priors /= priors.sum()
+            weighted_class_counts = np.bincount(y, weights=sample_weight)
+            priors = weighted_class_counts / sample_weight.sum()
         self.priors = priors
 
     def predict(self, X):

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -291,7 +291,7 @@ class LeastAbsoluteError(RegressionLossFunction):
 
 
 class HuberLossFunction(RegressionLossFunction):
-    """Huber loss function forrobust regression.
+    """Huber loss function for robust regression.
 
     M-Regression proposed in Friedman 2001.
 
@@ -392,7 +392,7 @@ class ClassificationLossFunction(six.with_metaclass(ABCMeta, LossFunction)):
 
         If the loss does not support probabilites raises AttributeError.
         """
-        raise AttributeError('Loss does not support predict_proba')
+        raise TypeError('%s does not support predict_proba' % type(self).__name__)
 
     @abstractmethod
     def _score_to_decision(self, score):
@@ -425,8 +425,8 @@ class BinomialDeviance(ClassificationLossFunction):
         if sample_weight is None:
             return -2.0 * np.mean((y * pred) - np.logaddexp(0.0, pred))
         else:
-            return (-2.0 / sample_weight.sum()) * \
-              np.sum(sample_weight * ((y * pred) - np.logaddexp(0.0, pred)))
+            return (-2.0 / sample_weight.sum() *
+                    np.sum(sample_weight * ((y * pred) - np.logaddexp(0.0, pred))))
 
     def negative_gradient(self, y, pred, **kargs):
         """Compute the residual (= negative gradient). """
@@ -904,8 +904,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         else:
             sample_weight = column_or_1d(sample_weight, warn=True)
             if self.loss in ('lad', 'huber', 'quantile'):
-                raise ValueError('sample_weight not supported for loss=%r' %
-                                 self.loss)
+                raise NotImplementedError('sample_weight not supported for loss=%r' %
+                                          self.loss)
 
         if y.shape[0] != n_samples:
             raise ValueError('Shape mismatch of X and y: %d != %d' %

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -114,12 +114,9 @@ class PriorProbabilityEstimator(BaseEstimator):
     """
     def fit(self, X, y, sample_weight=None):
         if sample_weight is None:
-            class_counts = np.bincount(y)
-            priors = class_counts / float(y.shape[0])
-        else:
-            weighted_class_counts = np.bincount(y, weights=sample_weight)
-            priors = weighted_class_counts / sample_weight.sum()
-        self.priors = priors
+            sample_weight = np.ones_like(y, dtype=np.float)
+        class_counts = np.bincount(y, weights=sample_weight)
+        self.priors = class_counts / class_counts.sum()
 
     def predict(self, X):
         y = np.empty((X.shape[0], self.priors.shape[0]), dtype=np.float64)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -367,7 +367,6 @@ class HuberLossFunction(RegressionLossFunction):
         diff = (y.take(terminal_region, axis=0)
                 - pred.take(terminal_region, axis=0))
         median = _weighted_percentile(diff, sample_weight, percentile=50)
-        #median = np.median(diff)
         diff_minus_median = diff - median
         tree.value[leaf, 0] = median + np.mean(
             np.sign(diff_minus_median) *

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -339,11 +339,13 @@ class HuberLossFunction(RegressionLossFunction):
         if sample_weight is None:
             sq_loss = np.sum(0.5 * diff[gamma_mask] ** 2.0)
             lin_loss = np.sum(gamma * (np.abs(diff[~gamma_mask]) - gamma / 2.0))
+            loss = (sq_loss + lin_loss) / y.shape[0]
         else:
             sq_loss = np.sum(0.5 * sample_weight[gamma_mask] * diff[gamma_mask] ** 2.0)
             lin_loss = np.sum(gamma * sample_weight[~gamma_mask] *
                               (np.abs(diff[~gamma_mask]) - gamma / 2.0))
-        return (sq_loss + lin_loss) / sample_weight.sum()
+            loss = (sq_loss + lin_loss) / sample_weight.sum()
+        return loss
 
     def negative_gradient(self, y, pred, sample_weight=None, **kargs):
         pred = pred.ravel()
@@ -370,7 +372,6 @@ class HuberLossFunction(RegressionLossFunction):
         diff_minus_median = diff - median
         tree.value[leaf, 0] = median + np.mean(
             np.sign(diff_minus_median) *
-            sample_weight *
             np.minimum(np.abs(diff_minus_median), gamma))
 
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -617,6 +617,12 @@ class ExponentialLoss(ClassificationLossFunction):
         else:
             tree.value[leaf, 0, 0] = numerator / denominator
 
+    def _score_to_proba(self, score):
+        proba = np.ones((score.shape[0], 2), dtype=np.float64)
+        proba[:, 1] = 1.0 / (1.0 + np.exp(-2.0 * score.ravel()))
+        proba[:, 0] -= proba[:, 1]
+        return proba
+
     def _score_to_decision(self, score):
         return (score.ravel() >= 0.0).astype(np.int)
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -50,16 +50,16 @@ from ._gradient_boosting import predict_stage
 from ._gradient_boosting import _random_sample_mask
 
 
-def _weighted_percentile(arr, sample_weight, percentile=50):
-    """Compute the weighted ``percentile`` of ``arr`` with ``sample_weight``. """
-    sorted_idx = np.argsort(arr)
+def _weighted_percentile(array, sample_weight, percentile=50):
+    """Compute the weighted ``percentile`` of ``array`` with ``sample_weight``. """
+    sorted_idx = np.argsort(array)
 
     # Find index of median prediction for each sample
     weight_cdf = sample_weight[sorted_idx].cumsum()
     percentile_or_above = weight_cdf >= (percentile / 100.0) * weight_cdf[-1]
     percentile_idx = percentile_or_above.argmax()
 
-    return arr[sorted_idx[percentile_idx]]
+    return array[sorted_idx[percentile_idx]]
 
 
 class QuantileEstimator(BaseEstimator):

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -162,9 +162,8 @@ def test_classification_synthetic():
                                           random_state=0)
         gbrt.fit(X_train, y_train)
         error_rate = (1.0 - gbrt.score(X_test, y_test))
-        assert error_rate < 0.08, \
-            "Stochastic GB(loss={} failed with error {}".format(loss,
-                                                                error_rate)
+        assert error_rate < 0.08, ("Stochastic GradientBoostingClassifier(loss={}) "
+                                   "failed with error {}".format(loss, error_rate))
 
 
 def test_boston():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -172,7 +172,6 @@ def test_boston():
     for loss in ("ls", "lad", "huber"):
         for subsample in (1.0, 0.5):
             for sample_weight in (None, np.ones(len(boston.target))):
-
                 clf = GradientBoostingRegressor(n_estimators=100, loss=loss,
                                                 max_depth=4, subsample=subsample,
                                                 min_samples_split=1,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -172,9 +172,6 @@ def test_boston():
     for loss in ("ls", "lad", "huber"):
         for subsample in (1.0, 0.5):
             for sample_weight in (None, np.ones(len(boston.target))):
-                if sample_weight is not None and loss != 'ls':
-                    # 'lad' and 'huber' don't support sample_weights
-                    continue
 
                 clf = GradientBoostingRegressor(n_estimators=100, loss=loss,
                                                 max_depth=4, subsample=subsample,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -959,15 +959,6 @@ def test_probability_exponential():
     assert_raises(TypeError, lambda : next(clf.staged_predict_proba(T)))
 
 
-def test_sample_weight_robust():
-    """Test that robost regression loss raise ValueError. """
-    sample_weight = np.ones(len(boston.target))
-    for loss in ('lad', 'huber', 'quantile'):
-        est = GradientBoostingRegressor(n_estimators=1, loss=loss)
-        assert_raises(NotImplementedError, est.fit, boston.data, boston.target,
-                      sample_weight=sample_weight)
-
-
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -173,6 +173,10 @@ def test_boston():
     for loss in ("ls", "lad", "huber"):
         for subsample in (1.0, 0.5):
             for sample_weight in (None, np.ones(len(boston.target))):
+                if sample_weight is not None and loss != 'ls':
+                    # 'lad' and 'huber' don't support sample_weights
+                    continue
+
                 clf = GradientBoostingRegressor(n_estimators=100, loss=loss,
                                                 max_depth=4, subsample=subsample,
                                                 min_samples_split=1,
@@ -954,6 +958,15 @@ def test_probability_exponential():
     assert_array_equal(clf.predict(T), true_result)
     assert_raises(AttributeError, clf.predict_proba, T)
     assert_raises(AttributeError, lambda : next(clf.staged_predict_proba(T)))
+
+
+def test_sample_weight_robust():
+    """Test that robost regression loss raise ValueError. """
+    sample_weight = np.ones(len(boston.target))
+    for loss in ('lad', 'huber', 'quantile'):
+        est = GradientBoostingRegressor(n_estimators=1, loss=loss)
+        assert_raises(ValueError, est.fit, boston.data, boston.target,
+                      sample_weight=sample_weight)
 
 
 if __name__ == "__main__":

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -289,6 +289,10 @@ def test_check_inputs():
     clf = GradientBoostingClassifier().fit(X, y)
     assert_raises(TypeError, clf.predict, X_sparse)
 
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1)
+    assert_raises(ValueError, clf.fit, X, y,
+                  sample_weight=([1] * len(y)) + [0, 1])
+
 
 def test_check_inputs_predict():
     """X has wrong shape """
@@ -949,7 +953,7 @@ def test_probability_exponential():
     clf.fit(X, y)
     assert_array_equal(clf.predict(T), true_result)
     assert_raises(AttributeError, clf.predict_proba, T)
-    assert_raises(AttributeError, clf.staged_predict_proba, T)
+    assert_raises(AttributeError, lambda : next(clf.staged_predict_proba(T)))
 
 
 if __name__ == "__main__":

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -955,8 +955,8 @@ def test_probability_exponential():
 
     clf.fit(X, y)
     assert_array_equal(clf.predict(T), true_result)
-    assert_raises(AttributeError, clf.predict_proba, T)
-    assert_raises(AttributeError, lambda : next(clf.staged_predict_proba(T)))
+    assert_raises(TypeError, clf.predict_proba, T)
+    assert_raises(TypeError, lambda : next(clf.staged_predict_proba(T)))
 
 
 def test_sample_weight_robust():
@@ -964,7 +964,7 @@ def test_sample_weight_robust():
     sample_weight = np.ones(len(boston.target))
     for loss in ('lad', 'huber', 'quantile'):
         est = GradientBoostingRegressor(n_estimators=1, loss=loss)
-        assert_raises(ValueError, est.fit, boston.data, boston.target,
+        assert_raises(NotImplementedError, est.fit, boston.data, boston.target,
                       sample_weight=sample_weight)
 
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -965,7 +965,7 @@ def test_probability_exponential():
     assert_raises(TypeError, lambda : next(clf.staged_predict_proba(T)))
 
 
-def test_non_uniform_weights_toy_edge_case():
+def test_non_uniform_weights_toy_edge_case_reg():
     X = [[1, 0],
          [1, 0],
          [1, 0],
@@ -974,9 +974,25 @@ def test_non_uniform_weights_toy_edge_case():
     y = [0, 0, 1, 0]
     # ignore the first 2 training samples by setting their weight to 0
     sample_weight = [0, 0, 1, 1]
-    gb = GradientBoostingClassifier(n_estimators=5)
-    gb.fit(X, y, sample_weight=sample_weight)
-    assert_array_equal(gb.predict([[1, 0]]), [1])
+    for loss in ('ls', 'huber', 'lad', 'quantile'):
+        gb = GradientBoostingRegressor(n_estimators=5)
+        gb.fit(X, y, sample_weight=sample_weight)
+        assert_true(gb.predict([[1, 0]])[0] > 0.5)
+
+
+def test_non_uniform_weights_toy_edge_case_clf():
+    X = [[1, 0],
+         [1, 0],
+         [1, 0],
+         [0, 1],
+        ]
+    y = [0, 0, 1, 0]
+    # ignore the first 2 training samples by setting their weight to 0
+    sample_weight = [0, 0, 1, 1]
+    for loss in ('deviance', 'exponential'):
+        gb = GradientBoostingClassifier(n_estimators=5)
+        gb.fit(X, y, sample_weight=sample_weight)
+        assert_array_equal(gb.predict([[1, 0]]), [1])
 
 
 if __name__ == "__main__":

--- a/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
@@ -9,9 +9,12 @@ from numpy.testing import assert_equal
 
 from nose.tools import assert_raises
 
-
+from sklearn.utils import check_random_state
 from sklearn.ensemble.gradient_boosting import BinomialDeviance
 from sklearn.ensemble.gradient_boosting import LogOddsEstimator
+from sklearn.ensemble.gradient_boosting import LeastSquaresError
+from sklearn.ensemble.gradient_boosting import RegressionLossFunction
+from sklearn.ensemble.gradient_boosting import LOSS_FUNCTIONS
 
 
 def test_binomial_deviance():
@@ -59,3 +62,54 @@ def test_log_odds_estimator():
     assert_equal(est.prior, 0.0)
     assert_array_equal(est.predict(np.array([[1.0], [1.0]])),
                        np.array([[0.0], [0.0]]))
+
+
+def test_sample_weight_smoke():
+    rng = check_random_state(13)
+    y = rng.rand(100)
+    pred = rng.rand(100)
+
+    # least squares
+    loss = LeastSquaresError(1)
+    loss_wo_sw = loss(y, pred)
+    loss_w_sw = loss(y, pred, np.ones(pred.shape[0], dtype=np.float32))
+    assert_almost_equal(loss_wo_sw, loss_w_sw)
+
+
+def test_sample_weight_init_estimators():
+    """Smoke test for init estimators with sample weights. """
+    rng = check_random_state(13)
+    X = rng.rand(100, 2)
+    sample_weight = np.ones(100)
+    reg_y = rng.rand(100)
+    #reg_pred = rng.rand(100)
+
+    clf_y = rng.randint(0, 2, size=100)
+    #clf_pred = rng.randint(0, 1, size=100)
+
+    for Loss in LOSS_FUNCTIONS.values():
+        if Loss is None:
+            continue
+        if issubclass(Loss, RegressionLossFunction):
+            k = 1
+            y = reg_y
+        else:
+            k = 2
+            y = clf_y
+            if Loss.is_multi_class:
+                # skip multiclass
+                continue
+
+        loss = Loss(k)
+        init_est = loss.init_estimator()
+        init_est.fit(X, y)
+        out = init_est.predict(X)
+        assert_equal(out.shape, (y.shape[0], 1))
+
+        sw_init_est = loss.init_estimator()
+        sw_init_est.fit(X, y, sample_weight=sample_weight)
+        sw_out = init_est.predict(X)
+        assert_equal(sw_out.shape, (y.shape[0], 1))
+
+        # check if predictions match
+        assert_array_equal(out, sw_out)

--- a/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
@@ -15,6 +15,7 @@ from sklearn.ensemble.gradient_boosting import LogOddsEstimator
 from sklearn.ensemble.gradient_boosting import LeastSquaresError
 from sklearn.ensemble.gradient_boosting import RegressionLossFunction
 from sklearn.ensemble.gradient_boosting import LOSS_FUNCTIONS
+from sklearn.ensemble.gradient_boosting import _weighted_percentile
 
 
 def test_binomial_deviance():
@@ -111,3 +112,33 @@ def test_sample_weight_init_estimators():
 
         # check if predictions match
         assert_array_equal(out, sw_out)
+
+
+def test_weighted_percentile():
+    y = np.empty(102, dtype=np.float)
+    y[:50] = 0
+    y[-51:] = 2
+    y[-1] = 100000
+    y[50] = 1
+    sw = np.ones(102, dtype=np.float)
+    sw[-1] = 0.0
+    score = _weighted_percentile(y, sw, 50)
+    assert score == 1
+
+
+def test_weighted_percentile_equal():
+    y = np.empty(102, dtype=np.float)
+    y.fill(0.0)
+    sw = np.ones(102, dtype=np.float)
+    sw[-1] = 0.0
+    score = _weighted_percentile(y, sw, 50)
+    assert score == 0
+
+
+def test_weighted_percentile_zero_weight():
+    y = np.empty(102, dtype=np.float)
+    y.fill(1.0)
+    sw = np.ones(102, dtype=np.float)
+    sw.fill(0.0)
+    score = _weighted_percentile(y, sw, 50)
+    assert score == 1.0

--- a/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
@@ -82,10 +82,8 @@ def test_sample_weight_init_estimators():
     X = rng.rand(100, 2)
     sample_weight = np.ones(100)
     reg_y = rng.rand(100)
-    #reg_pred = rng.rand(100)
 
     clf_y = rng.randint(0, 2, size=100)
-    #clf_pred = rng.randint(0, 1, size=100)
 
     for Loss in LOSS_FUNCTIONS.values():
         if Loss is None:


### PR DESCRIPTION
and piggy-packed `'exponential'` loss for binary classification (= AdaBoost).

~~I didn't implement sample weights for `'lad'`, `'huber'`, and `'quantile'` since it would require weighted median / percentiles. I will either raise a warning or exception in this case: what do you prefer?~~

cc @glouppe

TODO: ~~benchmark benchmark and some regression tests~~
