### PR TITLE
fix Cythonize on Python 3.4

### DIFF
--- a/sklearn/datasets/_svmlight_format.pyx
+++ b/sklearn/datasets/_svmlight_format.pyx
@@ -54,7 +54,8 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
     for line in f:
         # skip comments
         line_cstr = line
-        hash_ptr = strchr(line_cstr, '#')
+        # byte-value 35 is the ascii-code for # (hash)
+        hash_ptr = strchr(line_cstr, 35)
         if hash_ptr != NULL:
             line = line[:hash_ptr - line_cstr]
 


### PR DESCRIPTION
- byte-value 35 is the ascii-code for # (hash)
