### PR TITLE
[MRG] MAINT: run tests on files with the exec bit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,12 @@
 test = nosetests
 
 [nosetests]
-#with-coverage = 1
+# nosetests skips test files with the executable bit by default
+# which can silently hide failing tests.
+# There are no executable scripts within the scikit-learn project
+# so let's turn the --exe flag on to avoid skipping tests by
+# mistake.
+exe = 1
 cover-html = 1
 cover-html-dir = coverage
 cover-package = sklearn


### PR DESCRIPTION
`nosetests` skips test files with the executable bit by default which can silently hide failing tests. There are no executable scripts within the scikit-learn project so let's turn the `--exe` flag on to avoid skipping tests by mistake.
