### PR TITLE
[MRG+1] compute poly features directly

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -795,7 +795,7 @@ performance.
 
 .. _polynomial_regression:
 
-Polynomial Regression: Extending Linear Models with Basis Functions
+Polynomial regression: extending linear models with basis functions
 ===================================================================
 
 .. currentmodule:: sklearn.preprocessing
@@ -842,7 +842,7 @@ polynomial features of varying degrees:
 
 This figure is created using the :class:`PolynomialFeatures` preprocessor.
 This preprocessor transforms an input data matrix into a new data matrix
-of a given degree.  It can be used as follows:
+of a given degree.  It can be used as follows::
 
     >>> from sklearn.preprocessing import PolynomialFeatures
     >>> import numpy as np
@@ -863,7 +863,7 @@ any linear model.
 
 This sort of preprocessing can be streamlined with the
 :ref:`Pipeline <pipeline>` tools. A single object representing a simple
-polynomial regression can be created and used as follows:
+polynomial regression can be created and used as follows::
 
     >>> from sklearn.preprocessing import PolynomialFeatures
     >>> from sklearn.linear_model import LinearRegression
@@ -879,3 +879,28 @@ polynomial regression can be created and used as follows:
 
 The linear model trained on polynomial features is able to exactly recover
 the input polynomial coefficients.
+
+In some cases it's not necessary to include higher powers of any single feature,
+but only the so-called *interaction features*
+that multiply together at most :math:`d` distinct features.
+These can be gotten from :class:`PolynomialFeatures` with the setting
+``interaction_only=True``.
+
+For example, when dealing with boolean features,
+:math:`x_i^n = x_i` for all :math:`n` and is therefore useless;
+but :math:`x_i x_j` represents the conjunction of two booleans.
+This way, we can solve the XOR problem with a linear classifier::
+
+    >>> from sklearn.linear_model import Perceptron
+    >>> from sklearn.preprocessing import PolynomialFeatures
+    >>> X = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+    >>> y = X[:, 0] ^ X[:, 1]
+    >>> X = PolynomialFeatures(interaction_only=True).fit_transform(X)
+    >>> X
+    array([[1, 0, 0, 0],
+           [1, 0, 1, 0],
+           [1, 1, 0, 0],
+           [1, 1, 1, 1]])
+    >>> clf = Perceptron(fit_intercept=False, n_iter=10).fit(X, y)
+    >>> clf.score(X, y)
+    1.0

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -172,3 +172,27 @@ except ImportError:
     # numpy.argpartition was introduced in v 1.8.0
     def argpartition(a, kth, axis=-1, kind='introselect', order=None):
         return np.argsort(a, axis=axis, order=order)
+
+
+try:
+    from itertools import combinations_with_replacement
+except ImportError:
+    # Backport of itertools.combinations_with_replacement for Python 2.6,
+    # from Python 3.4 documentation (http://tinyurl.com/comb-w-r), copyright
+    # Python Software Foundation (https://docs.python.org/3/license.html)
+    def combinations_with_replacement(iterable, r):
+        # combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
+        pool = tuple(iterable)
+        n = len(pool)
+        if not n and r:
+            return
+        indices = [0] * r
+        yield tuple(pool[i] for i in indices)
+        while True:
+            for i in reversed(range(r)):
+                if indices[i] != n - 1:
+                    break
+            else:
+                return
+            indices[i:] = [indices[i] + 1] * (r - i)
+            yield tuple(pool[i] for i in indices)


### PR DESCRIPTION
Here's a much simpler alternative to #3194 for fixing #3191. `itertools` and NumPy have all the required functionality.

The great thing about this approach is that we can turn the actual polynomials (x², y²) off and get only the interaction terms (xy) by substituting `combinations` for `combinations_with_replacement`.
