### PR TITLE
fix defaultdict call

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -726,7 +726,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             vocabulary = self.vocabulary_
         else:
             # Add a new value when a new vocabulary item is seen
-            vocabulary = defaultdict(None)
+            vocabulary = defaultdict()
             vocabulary.default_factory = vocabulary.__len__
 
         analyze = self.build_analyzer()


### PR DESCRIPTION
In Python 2.7, the current version fails with:

$ python -c 'from collections import defaultdict; defaultdict(None)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: first argument must be callable
