### PR TITLE
[WIP] Make LabelEncoder more friendly to new labels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27_64"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
 
@@ -21,9 +21,14 @@ environment:
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34_64"
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
+
+branches:
+  only:
+    - master
+    - 0.15.X
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
@@ -53,7 +58,7 @@ test_script:
 
   # Skip joblib tests that require multiprocessing as they are prone to random
   # slow down
-  - "python -c \"import nose; nose.main()\" -v -s sklearn"
+  - "python -c \"import nose; nose.main()\" -s sklearn"
 
 artifacts:
   # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -53,8 +53,8 @@ coming from the same population than the initial
 observations. Otherwise, if they lay outside the frontier, we can say
 that they are abnormal with a given confidence in our assessment.
 
-The One-Class SVM has been introduced in [1] for that purpose and
-implemented in the :ref:`svm` module in the
+The One-Class SVM has been introduced by Schölkopf et al. for that purpose 
+and implemented in the :ref:`svm` module in the
 :class:`svm.OneClassSVM` object. It requires the choice of a
 kernel and a scalar parameter to define a frontier.  The RBF kernel is
 usually chosen although there exists no exact formula or algorithm to
@@ -63,6 +63,12 @@ implementation. The :math:`\nu` parameter, also known as the margin of
 the One-Class SVM, corresponds to the probability of finding a new,
 but regular, observation outside the frontier.
 
+.. topic:: References:
+
+    * `Estimating the support of a high-dimensional distribution
+      <http://dl.acm.org/citation.cfm?id=1119749>`_ Schölkopf, 
+      Bernhard, et al. Neural computation 13.7 (2001): 1443-1471.
+      
 .. topic:: Examples:
 
    * See :ref:`example_svm_plot_oneclass.py` for visualizing the
@@ -73,7 +79,7 @@ but regular, observation outside the frontier.
    :target: ../auto_examples/svm/plot_oneclasse.html
    :align: center
    :scale: 75%
-
+   
 
 Outlier Detection
 =================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -418,6 +418,20 @@ hashable and comparable) to numerical labels::
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']
 
+By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
+labels are passed in ``transform`` that were not seen in ``fit``.  This
+behavior can be handled with the ``new_labels`` parameter, which supports
+``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
+handling new labels.  For example, the ``"label"`` strategy will assign
+the unseen values a label of ``-1``.
+
+    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
+    LabelEncoder(new_label_class=-1, new_labels='label')
+    >>> list(le.classes_)
+    ['amsterdam', 'paris', 'tokyo']
+    >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
+    array([ 2,  2,  1, -1])
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -396,7 +396,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -409,7 +409,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -417,6 +417,20 @@ hashable and comparable) to numerical labels::
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']
 
+By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
+labels are passed in ``transform`` that were not seen in ``fit``.  This
+behavior can be handled with the ``new_labels`` parameter, which supports
+``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
+handling new labels.  For example, the ``"label"`` strategy will assign
+the unseen values a label of ``-1``.
+
+    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
+    LabelEncoder(new_label_class=-1, new_labels='label')
+    >>> list(le.classes_)
+    ['amsterdam', 'paris', 'tokyo']
+    >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
+    array([ 2,  2,  1, -1])
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -396,7 +396,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -409,7 +409,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -468,7 +468,11 @@ def generate_example_rst(app):
         examples.
     """
     root_dir = os.path.join(app.builder.srcdir, 'auto_examples')
-    example_dir = os.path.abspath(app.builder.srcdir + '/../' + 'examples')
+    example_dir = os.path.abspath(os.path.join(app.builder.srcdir, '..',
+                                               'examples'))
+    generated_dir = os.path.abspath(os.path.join(app.builder.srcdir,
+                                                 'modules', 'generated'))
+
     try:
         plot_gallery = eval(app.builder.config.plot_gallery)
     except TypeError:
@@ -477,10 +481,12 @@ def generate_example_rst(app):
         os.makedirs(example_dir)
     if not os.path.exists(root_dir):
         os.makedirs(root_dir)
+    if not os.path.exists(generated_dir):
+        os.makedirs(generated_dir)
 
     # we create an index.rst with all examples
     fhindex = open(os.path.join(root_dir, 'index.rst'), 'w')
-    #Note: The sidebar button has been removed from the examples page for now
+    # Note: The sidebar button has been removed from the examples page for now
     #      due to how it messes up the layout. Will be fixed at a later point
     fhindex.write("""\
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -48,8 +48,8 @@ def test_f_oneway_ints():
 
     # test that is gives the same result as with float
     f, p = f_oneway(X.astype(np.float), y)
-    assert_array_almost_equal(f, fint, decimal=5)
-    assert_array_almost_equal(p, pint, decimal=5)
+    assert_array_almost_equal(f, fint, decimal=4)
+    assert_array_almost_equal(p, pint, decimal=4)
 
 
 def test_f_classif():

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -75,7 +75,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder(new_values='raise')
+    >>> le = preprocessing.LabelEncoder(new_labels='raise')
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder()
     >>> le.classes_
@@ -88,7 +88,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder(new_values='raise')
+    >>> le = preprocessing.LabelEncoder(new_labels='raise')
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder()
     >>> list(le.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -65,9 +65,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder(new_labels='raise')
+    >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -78,9 +78,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder(new_labels='raise')
+    >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -57,10 +57,13 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ----------
 
     new_labels : string, optional (default: "raise")
-        Determines how to handle newly seen labels, i.e., data
-        not seen in the fit domain.  If "raise", then raise ValueError;
-        if "map", then re-map the new labels to class N, where seen
-        classes are in {0, ..., N-1}.
+        Determines how to handle new labels, i.e., data
+        not seen in the training domain.
+        - If "raise", then raise ValueError.
+        - If "update", then re-map the new labels to classes
+          `[N, ..., N+m-1]`, where `m` is the number of new labels.
+        - If "nan", then re-map the new labels to numpy.nan.
+
 
     Attributes
     ----------
@@ -158,21 +161,30 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             diff = np.setdiff1d(classes, self.classes_)
 
             # If we are mapping new labels, get "new" ID and change in copy.
-            if self.new_labels == "map":
-                # Get new ID and append to class list
-                missing_id = len(self.classes_)
-                self.classes_ = np.append(self.classes_, missing_id)
-
-                # Reset the value in y_copy
-                missing_mask = np.in1d(y, diff)
-                y_copy = np.array(y)
-                y_copy[missing_mask] = missing_id
+            if self.new_labels == "update":
+                # Update the class list with new labels
+                self.classes_ = np.append(self.classes_, np.sort(diff))
 
                 # Return mapped encoding
-                return np.searchsorted(self.classes_, y_copy)
+                return np.searchsorted(self.classes_, y)
+            elif self.new_labels == "nan":
+                # Create copy of array and return
+                y_array = np.array(y)
+                z = np.zeros(y_array.shape)
+
+                # Find entries with new labels
+                missing_mask = np.in1d(y, diff)
+
+                # Populate return array properly and return
+                z[-missing_mask] = np.searchsorted(self.classes_,
+                                                   y_array[-missing_mask])
+                z[missing_mask] = np.nan
+                return z
             elif self.new_labels == "raise":
+                # Return ValueError, original behavior.
                 raise ValueError("y contains new labels: %s" % str(diff))
             else:
+                # Raise on invalid argument.
                 raise ValueError("Value of argument `new_labels`={0} "
                                  "is unknown.".format(self.new_labels))
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -167,7 +167,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             elif self.new_labels == "nan":
                 # Create copy of array and return
                 y_array = np.array(y)
-                z = np.zeros(y_array.shape)
+                z = np.zeros(y_array.shape, dtype=float)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)
@@ -180,7 +180,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             elif self.new_labels == "label":
                 # Create copy of array and return
                 y_array = np.array(y)
-                z = np.zeros(y_array.shape)
+                z = np.zeros(y_array.shape, dtype=int)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -75,9 +75,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder(new_labels='raise')
+    >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -88,9 +88,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder(new_labels='raise')
+    >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 import itertools
 import array
 import warnings
+import operator
 
 import numpy as np
 import scipy.sparse as sp
@@ -63,17 +64,18 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"raise"``, then raise ValueError.
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If ``"label"``, then use the value of ``new_label_class``.
-
-    new_label_class : integer, optional (default: -1)
-        If ``new_labels="label"``, then this value will be assigned to
-        as the class for any new labels that are encountered.
-
+        - If an integer value is passed, then use re-label with this value.
+          N.B. that default values are in [0, 1, ...], so caution should be
+          taken if a non-negative value is passed to not accidentally
+          intersect.
 
     Attributes
     ----------
     `classes_` : array of shape (n_class,)
         Holds the label for each class.
+
+    `new_label_mapping_` : dictionary
+        Stores the mapping for classes not seen during original ``fit``.
 
     Examples
     --------
@@ -105,14 +107,33 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, new_labels="raise", new_label_class=-1):
+    def __init__(self, new_labels="raise"):
         """Constructor"""
         self.new_labels = new_labels
-        self.new_label_class = new_label_class
+        self.new_label_mapping_ = {}
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
             raise ValueError("LabelEncoder was not fitted yet.")
+
+    def get_classes(self):
+        """Get classes that have been observed by the encoder.  Note that this
+        method returns classes seen both at original ``fit`` time (i.e.,
+        ``self.classes_``) and classes seen after ``fit`` (i.e.,
+        ``self.new_label_mapping_.keys()``) for applicable values of
+        ``new_labels``.
+
+        Returns
+        -------
+        classes : array-like of shape [n_classes]
+        """
+        # If we've seen updates, include them in the order they were added.
+        if len(self.new_label_mapping_) > 0:
+            sorted_new, _ = zip(*sorted(self.new_label_mapping_.iteritems(),
+                                        key=operator.itemgetter(1)))
+            return np.append(self.classes_, sorted_new)
+        else:
+            return self.classes_
 
     def fit(self, y):
         """Fit label encoder
@@ -127,10 +148,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "raise", "label"]:
+        if self.new_labels not in ["update", "raise"] and \
+                type(self.new_labels) not in [int]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
-                             "is unknown.".format(self.new_labels))
+                             "is unknown and not integer."
+                             .format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -150,10 +173,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "raise", "label"]:
+        if self.new_labels not in ["update", "raise"] and \
+                type(self.new_labels) not in [int]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
-                             "is unknown.".format(self.new_labels))
+                             "is unknown and not integer."
+                             .format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -176,47 +201,42 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         classes = np.unique(y)
         _check_numpy_unicode_bug(classes)
-        if len(np.intersect1d(classes, self.classes_)) < len(classes):
-            diff = np.setdiff1d(classes, self.classes_)
+        if len(np.intersect1d(classes, self.get_classes())) < len(classes):
+            # Get the new classes
+            diff_fit = np.setdiff1d(classes, self.classes_)
+            diff_new = np.setdiff1d(classes, self.get_classes())
+
             # Create copy of array and return
             y = np.array(y)
 
             # If we are mapping new labels, get "new" ID and change in copy.
             if self.new_labels == "update":
-                # Setup out
-                out = np.zeros(y.shape, dtype=int)
-
-                #  Find entries with new labels
-                missing_mask = np.in1d(y, diff)
-                new_class_values = np.sort(diff)
-
-                # Populate return array properly and return
-                out[~missing_mask] = np.searchsorted(self.classes_,
-                                                     y[~missing_mask])
-                out[missing_mask] = np.searchsorted(new_class_values,
-                                                    y[missing_mask]) + \
-                    len(self.classes_)
-
-                # Update the class list with new labels
-                self.classes_ = np.append(self.classes_, new_class_values)
-
-                # Return mapped encoding
-                return out
-            elif self.new_labels == "label":
-                # Setup out
-                out = np.zeros(y.shape, dtype=int)
+                # Update the new label mapping
+                next_label = len(self.get_classes())
+                self.new_label_mapping_.update(dict(zip(diff_new,
+                                                        range(next_label,
+                                                              next_label +
+                                                              len(diff_new)))))
 
                 # Find entries with new labels
-                missing_mask = np.in1d(y, diff)
+                missing_mask = np.in1d(y, diff_fit)
 
-                # Populate return array properly and return
-                out[~missing_mask] = np.searchsorted(self.classes_,
-                                                     y[~missing_mask])
-                out[missing_mask] = self.new_label_class
+                # Populate return array properly by mask and return
+                out = np.searchsorted(self.classes_, y)
+                out[missing_mask] = [self.new_label_mapping_[value]
+                                     for value in y[missing_mask]]
+                return out
+            elif type(self.new_labels) in [int]:
+                # Find entries with new labels
+                missing_mask = np.in1d(y, diff_fit)
+
+                # Populate return array properly by mask and return
+                out = np.searchsorted(self.classes_, y)
+                out[missing_mask] = self.new_labels
                 return out
             elif self.new_labels == "raise":
                 # Return ValueError, original behavior.
-                raise ValueError("y contains new labels: %s" % str(diff))
+                raise ValueError("y contains new labels: %s" % str(diff_fit))
             else:
                 # Raise on invalid argument.
                 raise ValueError("Value of argument `new_labels`={0} "

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -54,6 +54,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
         - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
+        - If ``"label"``, then use the value of ``new_label_class``.
+    
+    new_label_class : integer, optional (default: -1)
+        If ``new_labels="label"``, then this value will be assigned to
+        as the class for any new labels that are encountered.
 
 
     Attributes

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -116,6 +116,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         self : returns an instance of self.
         """
+        # Check new_labels parameter
+        if self.new_labels not in ["update", "nan", "raise", "label"]:
+            # Raise on invalid argument.
+                raise ValueError("Value of argument `new_labels`={0} "
+                                 "is unknown.".format(self.new_labels))
+
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
@@ -133,6 +139,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         y : array-like of shape [n_samples]
         """
+        # Check new_labels parameter
+        if self.new_labels not in ["update", "nan", "raise", "label"]:
+            # Raise on invalid argument.
+                raise ValueError("Value of argument `new_labels`={0} "
+                                 "is unknown.".format(self.new_labels))
+
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_, y = np.unique(y, return_inverse=True)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -53,7 +53,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"raise"``, then raise ValueError.
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
         - If ``"label"``, then use the value of ``new_label_class``.
 
     new_label_class : integer, optional (default: -1)
@@ -118,7 +117,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "nan", "raise", "label"]:
+        if self.new_labels not in ["update", "raise", "label"]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
                              "is unknown.".format(self.new_labels))
@@ -141,7 +140,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "nan", "raise", "label"]:
+        if self.new_labels not in ["update", "raise", "label"]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
                              "is unknown.".format(self.new_labels))
@@ -192,18 +191,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 self.classes_ = np.append(self.classes_, new_class_values)
 
                 # Return mapped encoding
-                return out
-            elif self.new_labels == "nan":
-                # Setup out
-                out = np.zeros(y.shape, dtype=float)
-
-                # Find entries with new labels
-                missing_mask = np.in1d(y, diff)
-
-                # Populate return array properly and return
-                out[~missing_mask] = np.searchsorted(self.classes_,
-                                                     y[~missing_mask])
-                out[missing_mask] = np.nan
                 return out
             elif self.new_labels == "label":
                 # Setup out

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -83,7 +83,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -96,7 +96,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -53,6 +53,15 @@ def _check_numpy_unicode_bug(labels):
 class LabelEncoder(BaseEstimator, TransformerMixin):
     """Encode labels with value between 0 and n_classes-1.
 
+    Parameters
+    ----------
+
+    new_labels : string, optional (default: "raise")
+        Determines how to handle newly seen labels, i.e., data
+        not seen in the fit domain.  If "raise", then raise ValueError;
+        if "map", then re-map the new labels to class N, where seen
+        classes are in {0, ..., N-1}.
+
     Attributes
     ----------
     `classes_` : array of shape (n_class,)
@@ -87,6 +96,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ['tokyo', 'tokyo', 'paris']
 
     """
+    def __init__(self, new_labels="raise"):
+        """Constructor"""
+        self.new_labels = new_labels
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
@@ -144,7 +156,27 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         _check_numpy_unicode_bug(classes)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
-            raise ValueError("y contains new labels: %s" % str(diff))
+
+            # If we are mapping new labels, get "new" ID and change in copy.
+            if self.new_labels == "map":
+                # Get new ID and append to class list
+                missing_id = len(self.classes_)
+                self.classes_.resize(len(self.classes_)+1)
+                self.classes_[-1] = missing_id
+
+                # Reset the value in y_copy
+                missing_mask = np.in1d(y, diff)
+                y_copy = np.array(y)
+                y_copy[missing_mask] = missing_id
+
+                # Return mapped encoding
+                return np.searchsorted(self.classes_, y_copy)
+            elif self.new_labels == "raise":
+                raise ValueError("y contains new labels: %s" % str(diff))
+            else:
+                raise ValueError("Value of argument `new_labels`={0} "
+                                 "is unknown.".format(self.new_labels))
+
         return np.searchsorted(self.classes_, y)
 
     def inverse_transform(self, y):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -100,9 +100,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ['tokyo', 'tokyo', 'paris']
 
     """
-    def __init__(self, new_labels="raise"):
+    def __init__(self, new_labels="raise", new_label_class=-1):
         """Constructor"""
         self.new_labels = new_labels
+        self.new_label_class = new_label_class
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
@@ -180,6 +181,19 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 z[-missing_mask] = np.searchsorted(self.classes_,
                                                    y_array[-missing_mask])
                 z[missing_mask] = np.nan
+                return z
+            elif self.new_labels == "label":
+                # Create copy of array and return
+                y_array = np.array(y)
+                z = np.zeros(y_array.shape)
+
+                # Find entries with new labels
+                missing_mask = np.in1d(y, diff)
+
+                # Populate return array properly and return
+                z[-missing_mask] = np.searchsorted(self.classes_,
+                                                   y_array[-missing_mask])
+                z[missing_mask] = self.new_label_class
                 return z
             elif self.new_labels == "raise":
                 # Return ValueError, original behavior.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -90,9 +90,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ['tokyo', 'tokyo', 'paris']
 
     """
-    def __init__(self, new_labels="raise"):
+    def __init__(self, new_labels="raise", new_label_class=-1):
         """Constructor"""
         self.new_labels = new_labels
+        self.new_label_class = new_label_class
 
     def _check_fitted(self):
         if not hasattr(self, "classes_"):
@@ -170,6 +171,19 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 z[-missing_mask] = np.searchsorted(self.classes_,
                                                    y_array[-missing_mask])
                 z[missing_mask] = np.nan
+                return z
+            elif self.new_labels == "label":
+                # Create copy of array and return
+                y_array = np.array(y)
+                z = np.zeros(y_array.shape)
+
+                # Find entries with new labels
+                missing_mask = np.in1d(y, diff)
+
+                # Populate return array properly and return
+                z[-missing_mask] = np.searchsorted(self.classes_,
+                                                   y_array[-missing_mask])
+                z[missing_mask] = self.new_label_class
                 return z
             elif self.new_labels == "raise":
                 # Return ValueError, original behavior.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -1,6 +1,6 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
-#          Mathieu Blondel <mathieu@mblondel.org>
-#          Olivier Grisel <olivier.grisel@ensta.org>
+# Mathieu Blondel <mathieu@mblondel.org>
+# Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Hamzeh Alsalhi <ha258@cornell.edu>
@@ -105,6 +105,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ['tokyo', 'tokyo', 'paris']
 
     """
+
     def __init__(self, new_labels="raise", new_label_class=-1):
         """Constructor"""
         self.new_labels = new_labels
@@ -129,8 +130,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # Check new_labels parameter
         if self.new_labels not in ["update", "nan", "raise", "label"]:
             # Raise on invalid argument.
-                raise ValueError("Value of argument `new_labels`={0} "
-                                 "is unknown.".format(self.new_labels))
+            raise ValueError("Value of argument `new_labels`={0} "
+                             "is unknown.".format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -152,8 +153,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # Check new_labels parameter
         if self.new_labels not in ["update", "nan", "raise", "label"]:
             # Raise on invalid argument.
-                raise ValueError("Value of argument `new_labels`={0} "
-                                 "is unknown.".format(self.new_labels))
+            raise ValueError("Value of argument `new_labels`={0} "
+                             "is unknown.".format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -192,9 +193,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = np.searchsorted(new_class_values,
-                                                   y[missing_mask]) + len(self.classes_)
+                                                    y[missing_mask]) + \
+                    len(self.classes_)
 
                 # Update the class list with new labels
                 self.classes_ = np.append(self.classes_, new_class_values)
@@ -210,7 +212,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = np.nan
                 return out
             elif self.new_labels == "label":
@@ -222,7 +224,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = self.new_label_class
                 return out
             elif self.new_labels == "raise":

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -177,7 +177,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             elif self.new_labels == "nan":
                 # Create copy of array and return
                 y_array = np.array(y)
-                z = np.zeros(y_array.shape)
+                z = np.zeros(y_array.shape, dtype=float)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)
@@ -190,7 +190,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             elif self.new_labels == "label":
                 # Create copy of array and return
                 y_array = np.array(y)
-                z = np.zeros(y_array.shape)
+                z = np.zeros(y_array.shape, dtype=int)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -65,7 +65,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder(new_values='raise')
+    >>> le = preprocessing.LabelEncoder(new_labels='raise')
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder()
     >>> le.classes_
@@ -78,7 +78,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder(new_values='raise')
+    >>> le = preprocessing.LabelEncoder(new_labels='raise')
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder()
     >>> list(le.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -151,8 +151,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             if self.new_labels == "map":
                 # Get new ID and append to class list
                 missing_id = len(self.classes_)
-                self.classes_.resize(len(self.classes_)+1)
-                self.classes_[-1] = missing_id
+                self.classes_ = np.append(self.classes_, missing_id)
 
                 # Reset the value in y_copy
                 missing_mask = np.in1d(y, diff)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -178,40 +178,53 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         _check_numpy_unicode_bug(classes)
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
+            # Create copy of array and return
+            y = np.array(y)
 
             # If we are mapping new labels, get "new" ID and change in copy.
             if self.new_labels == "update":
+                # Setup out
+                out = np.zeros(y.shape, dtype=int)
+
+                #  Find entries with new labels
+                missing_mask = np.in1d(y, diff)
+                new_class_values = np.sort(diff)
+
+                # Populate return array properly and return
+                out[~missing_mask] = np.searchsorted(self.classes_,
+                                                   y[~missing_mask])
+                out[missing_mask] = np.searchsorted(new_class_values,
+                                                   y[missing_mask]) + len(self.classes_)
+
                 # Update the class list with new labels
-                self.classes_ = np.append(self.classes_, np.sort(diff))
+                self.classes_ = np.append(self.classes_, new_class_values)
 
                 # Return mapped encoding
-                return np.searchsorted(self.classes_, y)
+                return out
             elif self.new_labels == "nan":
-                # Create copy of array and return
-                y_array = np.array(y)
-                z = np.zeros(y_array.shape, dtype=float)
+                # Setup out
+                out = np.zeros(y.shape, dtype=float)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)
 
                 # Populate return array properly and return
-                z[-missing_mask] = np.searchsorted(self.classes_,
-                                                   y_array[-missing_mask])
-                z[missing_mask] = np.nan
-                return z
+                out[~missing_mask] = np.searchsorted(self.classes_,
+                                                   y[~missing_mask])
+                out[missing_mask] = np.nan
+                return out
             elif self.new_labels == "label":
-                # Create copy of array and return
-                y_array = np.array(y)
-                z = np.zeros(y_array.shape, dtype=int)
+                # Setup out
+                out = np.zeros(y.shape, dtype=int)
 
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff)
 
                 # Populate return array properly and return
-                z[-missing_mask] = np.searchsorted(self.classes_,
-                                                   y_array[-missing_mask])
-                z[missing_mask] = self.new_label_class
-                return z
+                out[~missing_mask] = np.searchsorted(self.classes_,
+                                                   y[~missing_mask])
+                out[missing_mask] = self.new_label_class
+                return out
             elif self.new_labels == "raise":
                 # Return ValueError, original behavior.
                 raise ValueError("y contains new labels: %s" % str(diff))

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -75,7 +75,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder()
+    >>> le = preprocessing.LabelEncoder(new_values='raise')
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder()
     >>> le.classes_
@@ -88,7 +88,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder()
+    >>> le = preprocessing.LabelEncoder(new_values='raise')
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder()
     >>> list(le.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -63,7 +63,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"raise"``, then raise ValueError.
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
         - If ``"label"``, then use the value of ``new_label_class``.
 
     new_label_class : integer, optional (default: -1)
@@ -128,7 +127,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "nan", "raise", "label"]:
+        if self.new_labels not in ["update", "raise", "label"]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
                              "is unknown.".format(self.new_labels))
@@ -151,7 +150,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
         """
         # Check new_labels parameter
-        if self.new_labels not in ["update", "nan", "raise", "label"]:
+        if self.new_labels not in ["update", "raise", "label"]:
             # Raise on invalid argument.
             raise ValueError("Value of argument `new_labels`={0} "
                              "is unknown.".format(self.new_labels))
@@ -202,18 +201,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 self.classes_ = np.append(self.classes_, new_class_values)
 
                 # Return mapped encoding
-                return out
-            elif self.new_labels == "nan":
-                # Setup out
-                out = np.zeros(y.shape, dtype=float)
-
-                # Find entries with new labels
-                missing_mask = np.in1d(y, diff)
-
-                # Populate return array properly and return
-                out[~missing_mask] = np.searchsorted(self.classes_,
-                                                     y[~missing_mask])
-                out[missing_mask] = np.nan
                 return out
             elif self.new_labels == "label":
                 # Setup out

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -161,8 +161,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             if self.new_labels == "map":
                 # Get new ID and append to class list
                 missing_id = len(self.classes_)
-                self.classes_.resize(len(self.classes_)+1)
-                self.classes_[-1] = missing_id
+                self.classes_ = np.append(self.classes_, missing_id)
 
                 # Reset the value in y_copy
                 missing_mask = np.in1d(y, diff)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -73,7 +73,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -86,7 +86,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -1,6 +1,6 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
-#          Mathieu Blondel <mathieu@mblondel.org>
-#          Olivier Grisel <olivier.grisel@ensta.org>
+# Mathieu Blondel <mathieu@mblondel.org>
+# Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: BSD 3 clause
 
@@ -95,6 +95,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     ['tokyo', 'tokyo', 'paris']
 
     """
+
     def __init__(self, new_labels="raise", new_label_class=-1):
         """Constructor"""
         self.new_labels = new_labels
@@ -119,8 +120,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # Check new_labels parameter
         if self.new_labels not in ["update", "nan", "raise", "label"]:
             # Raise on invalid argument.
-                raise ValueError("Value of argument `new_labels`={0} "
-                                 "is unknown.".format(self.new_labels))
+            raise ValueError("Value of argument `new_labels`={0} "
+                             "is unknown.".format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -142,8 +143,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # Check new_labels parameter
         if self.new_labels not in ["update", "nan", "raise", "label"]:
             # Raise on invalid argument.
-                raise ValueError("Value of argument `new_labels`={0} "
-                                 "is unknown.".format(self.new_labels))
+            raise ValueError("Value of argument `new_labels`={0} "
+                             "is unknown.".format(self.new_labels))
 
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
@@ -182,9 +183,10 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = np.searchsorted(new_class_values,
-                                                   y[missing_mask]) + len(self.classes_)
+                                                    y[missing_mask]) + \
+                    len(self.classes_)
 
                 # Update the class list with new labels
                 self.classes_ = np.append(self.classes_, new_class_values)
@@ -200,7 +202,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = np.nan
                 return out
             elif self.new_labels == "label":
@@ -212,7 +214,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
                 # Populate return array properly and return
                 out[~missing_mask] = np.searchsorted(self.classes_,
-                                                   y[~missing_mask])
+                                                     y[~missing_mask])
                 out[missing_mask] = self.new_label_class
                 return out
             elif self.new_labels == "raise":

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -65,7 +65,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     `LabelEncoder` can be used to normalize labels.
 
     >>> from sklearn import preprocessing
-    >>> le = preprocessing.LabelEncoder()
+    >>> le = preprocessing.LabelEncoder(new_values='raise')
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder()
     >>> le.classes_
@@ -78,7 +78,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     It can also be used to transform non-numerical labels (as long as they are
     hashable and comparable) to numerical labels.
 
-    >>> le = preprocessing.LabelEncoder()
+    >>> le = preprocessing.LabelEncoder(new_values='raise')
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder()
     >>> list(le.classes_)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -126,6 +126,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         self : returns an instance of self.
         """
+        # Check new_labels parameter
+        if self.new_labels not in ["update", "nan", "raise", "label"]:
+            # Raise on invalid argument.
+                raise ValueError("Value of argument `new_labels`={0} "
+                                 "is unknown.".format(self.new_labels))
+
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
@@ -143,6 +149,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         -------
         y : array-like of shape [n_samples]
         """
+        # Check new_labels parameter
+        if self.new_labels not in ["update", "nan", "raise", "label"]:
+            # Raise on invalid argument.
+                raise ValueError("Value of argument `new_labels`={0} "
+                                 "is unknown.".format(self.new_labels))
+
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_, y = np.unique(y, return_inverse=True)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -65,7 +65,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
         - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
         - If ``"label"``, then use the value of ``new_label_class``.
-    
+
     new_label_class : integer, optional (default: -1)
         If ``new_labels="label"``, then this value will be assigned to
         as the class for any new labels that are encountered.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -55,7 +55,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
         - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
         - If ``"label"``, then use the value of ``new_label_class``.
-    
+
     new_label_class : integer, optional (default: -1)
         If ``new_labels="label"``, then this value will be assigned to
         as the class for any new labels that are encountered.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -59,10 +59,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     new_labels : string, optional (default: "raise")
         Determines how to handle new labels, i.e., data
         not seen in the training domain.
-        - If "raise", then raise ValueError.
-        - If "update", then re-map the new labels to classes
-          `[N, ..., N+m-1]`, where `m` is the number of new labels.
-        - If "nan", then re-map the new labels to numpy.nan.
+
+        - If ``"raise"``, then raise ValueError.
+        - If ``"update"``, then re-map the new labels to
+          classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
+        - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
 
 
     Attributes

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -49,10 +49,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     new_labels : string, optional (default: "raise")
         Determines how to handle new labels, i.e., data
         not seen in the training domain.
-        - If "raise", then raise ValueError.
-        - If "update", then re-map the new labels to classes
-          `[N, ..., N+m-1]`, where `m` is the number of new labels.
-        - If "nan", then re-map the new labels to numpy.nan.
+
+        - If ``"raise"``, then raise ValueError.
+        - If ``"update"``, then re-map the new labels to
+          classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
+        - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
 
 
     Attributes

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -64,6 +64,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
         - If ``"nan"``, then re-map the new labels to ``numpy.nan``.
+        - If ``"label"``, then use the value of ``new_label_class``.
+    
+    new_label_class : integer, optional (default: -1)
+        If ``new_labels="label"``, then this value will be assigned to
+        as the class for any new labels that are encountered.
 
 
     Attributes

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -228,19 +228,6 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
-def test_label_encoder_new_label_nan():
-    """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="nan")
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    assert_array_equal(le.transform(["_", "b", "c", "d"]),
-                       [np.nan, 1, 2, np.nan])
-
-
 def test_label_encoder_new_label_replace():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="label", new_label_class=-2)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -177,16 +177,30 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
-def test_label_encoder_new_label():
+def test_label_encoder_new_label_update():
     """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="map")
+    le = LabelEncoder(new_labels="update")
     le.fit(["a", "b", "b", "c"])
     assert_array_equal(le.classes_, ["a", "b", "c"])
     assert_array_equal(le.transform(["a", "a", "c"]),
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    le.transform(["b", "c", "d"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, 3])
+
+
+def test_label_encoder_new_label_nan():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="nan")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, np.nan])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -203,6 +203,19 @@ def test_label_encoder_new_label_nan():
                        [1, 2, np.nan])
 
 
+def test_label_encoder_new_label_replace():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="label", new_label_class=-2)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, -2])
+
+
 def test_label_encoder_new_label_arg():
     """Test LabelEncoder's  new_labels argument handling"""
     le = LabelEncoder(new_labels="xyz")

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -236,6 +236,19 @@ def test_label_encoder_new_label_nan():
                        [1, 2, np.nan])
 
 
+def test_label_encoder_new_label_replace():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="label", new_label_class=-2)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, -2])
+
+
 def test_label_encoder_new_label_arg():
     """Test LabelEncoder's  new_labels argument handling"""
     le = LabelEncoder(new_labels="xyz")

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,6 +210,17 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_get_classes():
+    """Test LabelEncoder's get_classes method."""
+    le = LabelEncoder(new_labels="update")
+    le.fit([1, 1, 4, 5, -1, 0])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.classes_, le.get_classes())
+    le.transform([10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+
+
 def test_label_encoder_new_label_update():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="update")
@@ -221,16 +232,14 @@ def test_label_encoder_new_label_update():
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "_"]),
                        [1, 2, 3])
-    assert_array_equal(le.classes_, ["a", "b", "c", "_"])
-    print(le.classes_)
+    assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
     assert_array_equal(le.transform(["_", "z", "a"]),
                        [3, 4, 0])
-    assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
 def test_label_encoder_new_label_replace():
     """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="label", new_label_class=-2)
+    le = LabelEncoder(new_labels=-99)
     le.fit(["a", "b", "b", "c"])
     assert_array_equal(le.classes_, ["a", "b", "c"])
     assert_array_equal(le.transform(["a", "a", "c"]),
@@ -238,7 +247,7 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, -2])
+                       [1, 2, -99])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,16 +210,30 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
-def test_label_encoder_new_label():
+def test_label_encoder_new_label_update():
     """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="map")
+    le = LabelEncoder(new_labels="update")
     le.fit(["a", "b", "b", "c"])
     assert_array_equal(le.classes_, ["a", "b", "c"])
     assert_array_equal(le.transform(["a", "a", "c"]),
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    le.transform(["b", "c", "d"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, 3])
+
+
+def test_label_encoder_new_label_nan():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="nan")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, np.nan])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -228,7 +228,6 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
-
 def test_label_encoder_new_label_nan():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="nan")

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -219,8 +219,8 @@ def test_label_encoder_new_label_update():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, 3])
+    assert_array_equal(le.transform(["_", "b", "c", "d"]),
+                       [3, 1, 2, 4])
 
 
 def test_label_encoder_new_label_nan():
@@ -232,8 +232,8 @@ def test_label_encoder_new_label_nan():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, np.nan])
+    assert_array_equal(le.transform(["_", "b", "c", "d"]),
+                       [np.nan, 1, 2, np.nan])
 
 
 def test_label_encoder_new_label_replace():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -177,6 +177,17 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_get_classes():
+    """Test LabelEncoder's get_classes method."""
+    le = LabelEncoder(new_labels="update")
+    le.fit([1, 1, 4, 5, -1, 0])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.classes_, le.get_classes())
+    le.transform([10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+
+
 def test_label_encoder_new_label_update():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="update")
@@ -188,16 +199,14 @@ def test_label_encoder_new_label_update():
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "_"]),
                        [1, 2, 3])
-    assert_array_equal(le.classes_, ["a", "b", "c", "_"])
-    print(le.classes_)
+    assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
     assert_array_equal(le.transform(["_", "z", "a"]),
                        [3, 4, 0])
-    assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
 def test_label_encoder_new_label_replace():
     """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="label", new_label_class=-2)
+    le = LabelEncoder(new_labels=-99)
     le.fit(["a", "b", "b", "c"])
     assert_array_equal(le.classes_, ["a", "b", "c"])
     assert_array_equal(le.transform(["a", "a", "c"]),
@@ -205,7 +214,7 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, -2])
+                       [1, 2, -99])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -186,8 +186,14 @@ def test_label_encoder_new_label_update():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["_", "b", "c", "d"]),
-                       [3, 1, 2, 4])
+    assert_array_equal(le.transform(["b", "c", "_"]),
+                       [1, 2, 3])
+    assert_array_equal(le.classes_, ["a", "b", "c", "_"])
+    print(le.classes_)
+    assert_array_equal(le.transform(["_", "z", "a"]),
+                       [3, 4, 0])
+    assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
+
 
 
 def test_label_encoder_new_label_nan():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -219,8 +219,14 @@ def test_label_encoder_new_label_update():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["_", "b", "c", "d"]),
-                       [3, 1, 2, 4])
+    assert_array_equal(le.transform(["b", "c", "_"]),
+                       [1, 2, 3])
+    assert_array_equal(le.classes_, ["a", "b", "c", "_"])
+    print(le.classes_)
+    assert_array_equal(le.transform(["_", "z", "a"]),
+                       [3, 4, 0])
+    assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
+
 
 
 def test_label_encoder_new_label_nan():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -195,19 +195,6 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
-def test_label_encoder_new_label_nan():
-    """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="nan")
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    assert_array_equal(le.transform(["_", "b", "c", "d"]),
-                       [np.nan, 1, 2, np.nan])
-
-
 def test_label_encoder_new_label_replace():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="label", new_label_class=-2)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -252,13 +252,7 @@ def test_label_encoder_new_label_replace():
 def test_label_encoder_new_label_arg():
     """Test LabelEncoder's  new_labels argument handling"""
     le = LabelEncoder(new_labels="xyz")
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    assert_raises(ValueError, le.transform, ["c", "d"])
+    assert_raises(ValueError, le.fit, ["a", "b", "b", "c"])
 
 
 def test_label_encoder_fit_transform():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -195,7 +195,6 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.classes_, ["a", "b", "c", "_", "z"])
 
 
-
 def test_label_encoder_new_label_nan():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="nan")

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,6 +210,30 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_new_label():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="map")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    le.transform(["b", "c", "d"])
+
+
+def test_label_encoder_new_label_arg():
+    """Test LabelEncoder's  new_labels argument handling"""
+    le = LabelEncoder(new_labels="xyz")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_raises(ValueError, le.transform, ["c", "d"])
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -177,6 +177,30 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_new_label():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="map")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    le.transform(["b", "c", "d"])
+
+
+def test_label_encoder_new_label_arg():
+    """Test LabelEncoder's  new_labels argument handling"""
+    le = LabelEncoder(new_labels="xyz")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_raises(ValueError, le.transform, ["c", "d"])
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -186,8 +186,8 @@ def test_label_encoder_new_label_update():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, 3])
+    assert_array_equal(le.transform(["_", "b", "c", "d"]),
+                       [3, 1, 2, 4])
 
 
 def test_label_encoder_new_label_nan():
@@ -199,8 +199,8 @@ def test_label_encoder_new_label_nan():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, np.nan])
+    assert_array_equal(le.transform(["_", "b", "c", "d"]),
+                       [np.nan, 1, 2, np.nan])
 
 
 def test_label_encoder_new_label_replace():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -219,13 +219,7 @@ def test_label_encoder_new_label_replace():
 def test_label_encoder_new_label_arg():
     """Test LabelEncoder's  new_labels argument handling"""
     le = LabelEncoder(new_labels="xyz")
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    assert_raises(ValueError, le.transform, ["c", "d"])
+    assert_raises(ValueError, le.fit, ["a", "b", "b", "c"])
 
 
 def test_label_encoder_fit_transform():

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -136,15 +136,6 @@ def check_regressors_classifiers_sparse_data(name, Estimator):
 
 
 def check_transformer(name, Transformer):
-    if name in ('CCA', 'LocallyLinearEmbedding', 'KernelPCA') and _is_32bit():
-        # Those transformers yield non-deterministic output when executed on
-        # a 32bit Python. The same transformers are stable on 64bit Python.
-        # FIXME: try to isolate a minimalistic reproduction case only depending
-        # on numpy & scipy and/or maybe generate a test dataset that does not
-        # cause such unstable behaviors.
-        msg = name + ' is non deterministic on 32bit Python'
-        raise SkipTest(msg)
-
     X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
                       random_state=0, n_features=2, cluster_std=0.1)
     X = StandardScaler().fit_transform(X)
@@ -166,6 +157,14 @@ def check_transformer_data_not_an_array(name, Transformer):
 
 
 def _check_transformer(name, Transformer, X, y):
+    if name in ('CCA', 'LocallyLinearEmbedding', 'KernelPCA') and _is_32bit():
+        # Those transformers yield non-deterministic output when executed on
+        # a 32bit Python. The same transformers are stable on 64bit Python.
+        # FIXME: try to isolate a minimalistic reproduction case only depending
+        # on numpy & scipy and/or maybe generate a test dataset that does not
+        # cause such unstable behaviors.
+        msg = name + ' is non deterministic on 32bit Python'
+        raise SkipTest(msg)
     n_samples, n_features = np.asarray(X).shape
     # catch deprecation warnings
     with warnings.catch_warnings(record=True):


### PR DESCRIPTION
This PR intends to make `preprocessing.LabelEncoder` more friendly for production/pipeline usage by adding a `new_labels` constructor argument.

Instead of always raising ValueError for unseen/new labels in `transform`, LabelEncoder may be initialized with `new_labels` as:
- `"raise"`: current behavior, i.e., raise ValueError; _to remain default behavior_
- `"nan"`: return np.nan for unseen/new labels
- `"update"`: update `classes_` with new IDs `[N, ..., N+m-1]` for `m` new labels and assign
- `"label"`: set newly seen labels to have fixed class `new_label_class=-1`

Tests and documentation updates included.

(edit: adding `"label"` to list for quick summary)
