### PR TITLE
[MRG+1] Use the Gram Variant when precompute is True

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -467,12 +467,16 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                 coef_, l1_reg, l2_reg, X.data, X.indices,
                 X.indptr, y, X_sparse_scaling,
                 max_iter, tol, positive)
-        elif not multi_output:
-            model = cd_fast.enet_coordinate_descent(
-                coef_, l1_reg, l2_reg, X, y, max_iter, tol, positive)
-        else:
+        elif multi_output:
             model = cd_fast.enet_coordinate_descent_multi_task(
                 coef_, l1_reg, l2_reg, X, y, max_iter, tol)
+        elif isinstance(precompute, np.ndarray):
+            model = cd_fast.enet_coordinate_descent_gram(
+                coef_, l1_reg, l2_reg, precompute, Xy, y, max_iter,
+                tol, positive)
+        else:
+            model = cd_fast.enet_coordinate_descent(
+                coef_, l1_reg, l2_reg, X, y, max_iter, tol, positive)
         coef_, dual_gap_, eps_ = model
         coefs[..., i] = coef_
         dual_gaps[i] = dual_gap_

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -474,9 +474,12 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
             model = cd_fast.enet_coordinate_descent_gram(
                 coef_, l1_reg, l2_reg, precompute, Xy, y, max_iter,
                 tol, positive)
-        else:
+        elif precompute is False:
             model = cd_fast.enet_coordinate_descent(
                 coef_, l1_reg, l2_reg, X, y, max_iter, tol, positive)
+        else:
+            raise ValueError("Precompute should be one of True, False, "
+                            "'auto' or array-like")
         coef_, dual_gap_, eps_ = model
         coefs[..., i] = coef_
         dual_gaps[i] = dual_gap_

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -460,6 +460,13 @@ def test_sparse_input_dtype_enet_and_lassocv():
     assert_almost_equal(clf.coef_, clf1.coef_, decimal=6)
 
 
+def test_precompute_invalid_argument():
+    X, y, _, _ = build_dataset()
+    for clf in [ElasticNetCV(precompute="invalid"),
+                LassoCV(precompute="invalid")]:
+        assert_raises(ValueError, clf.fit, X, y)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
The algorithm `cd_fast.enet_coordinate_descent_gram` is unused even when.

a] precompute is True
b] precompute is "auto" and n_samples >> n_features.

This PR fixes this issue.
