### PR TITLE
[MRG+1] Refactor and clean IsotonicRegression

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -290,7 +290,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             sample_weight = weight
 
         # Build y_
-        self._build_y(X, y, sample_weight)
+        order_inv = self._build_y(X, y, sample_weight)
 
         # Handle the left and right bounds on X
         self.X_min_ = np.min(self.X_)
@@ -325,7 +325,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
                              .format(self.out_of_bounds))
 
         if self.out_of_bounds == "clip":
-            T = self.f_(np.clip(T, self.X_min_, self.X_max_))
+            T = np.clip(T, self.X_min_, self.X_max_)
         return self.f_(T)
 
     def fit_transform(self, X, y, sample_weight=None, weight=None):

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -202,6 +202,10 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
     `X_max_` : float
         Maximum value of input array X_ for right bound.
 
+    `f_` : function
+        The stepwise interpolating function that covers the domain
+        X_.
+
     References
     ----------
     Isotonic Median Regression: A Linear Programming Approach
@@ -278,7 +282,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         Notes
         -----
-        X is stored for future use, as `transform` needs x to interpolate
+        X is stored for future use, as `transform` needs X to interpolate
         new input data.
         """
         if weight is not None:
@@ -290,7 +294,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         # Build y_
         order_inv = self._build_y(X, y, sample_weight)
 
-        # Handle the left and right bounds on x
+        # Handle the left and right bounds on X
         self.X_min_ = np.min(self.X_)
         self.X_max_ = np.max(self.X_)
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -218,7 +218,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
     def _check_fit_data(self, x, y, sample_weight=None):
         if len(x.shape) != 1:
-            raise ValueError("x should be a vector")
+            raise ValueError("x should be a 1d array")
 
     def _build_f(self, x, y):
         """Build the f_ interp1d function."""
@@ -314,7 +314,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         """
         T = as_float_array(T)
         if len(T.shape) != 1:
-            raise ValueError("T should be a vector")
+            raise ValueError("T should be a 1d array")
 
         # Handle the out_of_bounds argument by setting bounds_error and T
         if self.out_of_bounds == "clip":

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -290,7 +290,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
             sample_weight = weight
 
         # Build y_
-        order_inv = self._build_y(X, y, sample_weight)
+        self._build_y(X, y, sample_weight)
 
         # Handle the left and right bounds on X
         self.X_min_ = np.min(self.X_)
@@ -325,9 +325,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
                              .format(self.out_of_bounds))
 
         if self.out_of_bounds == "clip":
-            return self.f_(np.clip(T, self.X_min_, self.X_max_))
-        elif self.out_of_bounds in ["raise", "nan"]:
-            return self.f_(T)
+            T = self.f_(np.clip(T, self.X_min_, self.X_max_))
+        return self.f_(T)
 
     def fit_transform(self, X, y, sample_weight=None, weight=None):
         """Fit model and transform y by linear interpolation.

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -218,7 +218,21 @@ def test_isotonic_regression_oob_bad():
     assert_raises(ValueError, ir.fit, x, y)
 
 
-def test_isotonic_weight_deprecation():
+def test_isotonic_regression_oob_bad_after():
+    # Set y and x
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression(increasing='auto', out_of_bounds="raise")
+
+    # Make sure that we throw an error for bad out_of_bounds value in transform
+    ir.fit(x, y)
+    ir.out_of_bounds = "xyz"
+    assert_raises(ValueError, ir.transform, x)
+
+
+def test_isotonic_fit_weight_deprecation():
     # Test deprecation of the weight argument
     y = np.array([3, 7, 5, 9, 8, 7, 10])
     x = np.arange(len(y))
@@ -226,6 +240,17 @@ def test_isotonic_weight_deprecation():
     # Create model and fit
     ir = IsotonicRegression()
     assert_warns(DeprecationWarning, ir.fit, x, y,
+                 weight=[1.0/len(y)] * len(y))
+
+
+def test_isotonic_fit_transform_weight_deprecation():
+    # Test deprecation of the weight argument
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression()
+    assert_warns(DeprecationWarning, ir.fit_transform, x, y,
                  weight=[1.0/len(y)] * len(y))
 
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -212,10 +212,9 @@ def test_isotonic_regression_oob_bad():
 
     # Create model and fit
     ir = IsotonicRegression(increasing='auto', out_of_bounds="xyz")
-    ir.fit(x, y)
 
     # Make sure that we throw an error for bad out_of_bounds value
-    assert_raises(ValueError, ir.predict, [min(x)-10, max(x)+10])
+    assert_raises(ValueError, ir.fit, x, y)
 
 
 if __name__ == "__main__":

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -6,7 +6,8 @@ from sklearn.isotonic import check_increasing, isotonic_regression,\
 from sklearn.utils.testing import assert_raises, assert_array_equal,\
     assert_true, assert_false, assert_equal
 
-from sklearn.utils.testing import assert_warns_message, assert_no_warnings
+from sklearn.utils.testing import assert_warns, assert_warns_message,\
+    assert_no_warnings
 
 
 def test_check_increasing_up():
@@ -215,6 +216,27 @@ def test_isotonic_regression_oob_bad():
 
     # Make sure that we throw an error for bad out_of_bounds value
     assert_raises(ValueError, ir.fit, x, y)
+
+
+def test_isotonic_weight_deprecation():
+    # Test deprecation of the weight argument
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Create model and fit
+    ir = IsotonicRegression()
+    assert_warns(DeprecationWarning, ir.fit, x, y,
+                 weight=[1.0/len(y)] * len(y))
+
+
+def test_isotonic_regression_weight_deprecation():
+    # Test deprecation of the weight argument
+    y = np.array([3, 7, 5, 9, 8, 7, 10])
+    x = np.arange(len(y))
+
+    # Call fit method
+    assert_warns(DeprecationWarning, isotonic_regression, y,
+                 weight=[1.0/len(y)] * len(y))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactor and clean IsotonicRegression:
- Rename `X` to `x` to properly reflect that input is a vector, not matrix
- Refactor the `y=isotonic_regression(...)` logic into `_build_y`
- Refactor the `interp1d` logic into `_build_f`
- Store `f=interp1d(...)` so that it is not re-calculated on each call to `transform`

Sorry about the last one, @agramfort.  Reset and sync'd.
