### PR TITLE
DOC: fix 2 covariance examples rst math markup.

### DIFF
--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -1,4 +1,4 @@
-"""
+r"""
 ================================================================
 Robust covariance estimation and Mahalanobis distances relevance
 ================================================================
@@ -25,8 +25,9 @@ organisation of the observations.
 The Minimum Covariance Determinant estimator is a robust,
 high-breakdown point (i.e. it can be used to estimate the covariance
 matrix of highly contaminated datasets, up to
-:math:`\frac{n_samples-n_features-1}{2}` outliers) estimator of
-covariance. The idea is to find :math:`\frac{n_samples+n_features+1}{2}`
+:math:`\frac{n_\text{samples}-n_\text{features}-1}{2}` outliers) 
+estimator of covariance. The idea is to find 
+:math:`\frac{n_\text{samples}+n_\text{features}+1}{2}`
 observations whose empirical covariance has the smallest determinant,
 yielding a "pure" subset of observations from which to compute
 standards estimates of location and covariance.

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -1,4 +1,4 @@
-"""
+r"""
 =======================================
 Robust vs Empirical covariance estimate
 =======================================
@@ -12,8 +12,10 @@ Minimum Covariance Determinant Estimator
 ----------------------------------------
 The Minimum Covariance Determinant estimator is a robust, high-breakdown point
 (i.e. it can be used to estimate the covariance matrix of highly contaminated
-datasets, up to :math:`\\frac{n_samples - n_features-1}{2}` outliers) estimator of
-covariance. The idea is to find :math:`\\frac{n_samples+n_features+1}{2}`
+datasets, up to 
+:math:`\frac{n_\text{samples} - n_\text{features}-1}{2}` outliers) estimator of
+covariance. The idea is to find 
+:math:`\frac{n_\text{samples} + n_\text{features}+1}{2}`
 observations whose empirical covariance has the smallest determinant, yielding
 a "pure" subset of observations from which to compute standards estimates of
 location and covariance. After a correction step aiming at compensating the
@@ -31,7 +33,8 @@ distributed data sets:
 
 - The mean and the empirical covariance of the full dataset, which break
   down as soon as there are outliers in the data set
-- The robust MCD, that has a low error provided n_samples > 5 * n_features
+- The robust MCD, that has a low error provided 
+  :math:`n_\text{samples} > 5n_\text{features}`
 - The mean and the empirical covariance of the observations that are known
   to be good ones. This can be considered as a "perfect" MCD estimation,
   so one can trust our implementation by comparing to this case.


### PR DESCRIPTION
Some formulas in plot_mahalanobis_distances and
plot_robust_vs_empirical_covariance were not correctly
rendered by sphinx as some characters were not properly
escaped. This is fixed by setting the docstrings as
raw string using r""".

There was also missing braces for the number of features
and samples subscript.
