### PR TITLE
[MRG+2] Nonrepeating ROC thresholds

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -189,6 +189,11 @@ Backports
   Used in ``sklearn.cluster.hierarchical``, as well as in tests for
   :mod:`sklearn.feature_extraction`.
 
+- :func:`fixes.isclose`
+  (backported from ``numpy.isclose`` in numpy 1.8.1).
+  In versions before 1.7, this function was not available in
+  numpy. Used in ``sklearn.metrics``.
+
 
 ARPACK
 ------

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -725,8 +725,10 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # y_score typically has many tied values. Here we extract
     # the indices associated with the distinct values. We also
     # concatenate a value for the end of the curve.
-    y_round = np.round(y_score, 6) # a million thresholds should be enough?
-    distinct_value_indices = np.where(np.diff(y_round))[0]
+    # We need to use isclose to avoid spurious repeated thresholds
+    # stemming from floating point roundoff errors.
+    distinct_value_indices = np.where(np.logical_not(np.isclose(
+        np.diff(y_score), 0)))[0]
     threshold_idxs = np.r_[distinct_value_indices, y_true.size - 1]
 
     # accumulate the true positives with decreasing threshold

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -725,7 +725,8 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # y_score typically has many tied values. Here we extract
     # the indices associated with the distinct values. We also
     # concatenate a value for the end of the curve.
-    distinct_value_indices = np.where(np.diff(y_score))[0]
+    y_round = np.round(y_score, 6) # a million thresholds should be enough?
+    distinct_value_indices = np.where(np.diff(y_round))[0]
     threshold_idxs = np.r_[distinct_value_indices, y_true.size - 1]
 
     # accumulate the true positives with decreasing threshold

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -35,6 +35,7 @@ from ..utils import deprecated
 from ..utils import column_or_1d
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target
+from ..utils.fixes import isclose
 
 
 ###############################################################################
@@ -727,7 +728,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # concatenate a value for the end of the curve.
     # We need to use isclose to avoid spurious repeated thresholds
     # stemming from floating point roundoff errors.
-    distinct_value_indices = np.where(np.logical_not(np.isclose(
+    distinct_value_indices = np.where(np.logical_not(isclose(
         np.diff(y_score), 0)))[0]
     threshold_idxs = np.r_[distinct_value_indices, y_true.size - 1]
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -468,8 +468,9 @@ def test_roc_returns_consistency():
 
 
 def test_roc_nonrepeating_thresholds():
-    """Test to ensure that we don't return spurious repeating thresholds
-    due to machine precision issues
+    """Test to ensure that we don't return spurious repeating thresholds.
+
+    Duplicated thresholds can arise due to machine precision issues.
     """
     dataset = datasets.load_digits()
     X = dataset['data']
@@ -481,7 +482,8 @@ def test_roc_nonrepeating_thresholds():
 
     # How well can the classifier predict whether a digit is less than 5?
     # This task contributes floating point roundoff errors to the probabilities
-    probas_pred = clf.fit(X[::2], y[::2]).predict_proba(X[1::2])
+    train, test = slice(None, None, 2), slice(1, None, 2)
+    probas_pred = clf.fit(X[train], y[train]).predict_proba(X[test])
     probas_pred = probas_pred[:, :5].sum(axis=1)
     y_true = [yy < 5 for yy in y[1::2]]
 

--- a/sklearn/metrics/tests/test_metrics.py
+++ b/sklearn/metrics/tests/test_metrics.py
@@ -484,11 +484,11 @@ def test_roc_nonrepeating_thresholds():
     # This task contributes floating point roundoff errors to the probabilities
     train, test = slice(None, None, 2), slice(1, None, 2)
     probas_pred = clf.fit(X[train], y[train]).predict_proba(X[test])
-    probas_pred = probas_pred[:, :5].sum(axis=1)
-    y_true = [yy < 5 for yy in y[1::2]]
+    y_score = probas_pred[:, :5].sum(axis=1)  # roundoff errors begin here
+    y_true = [yy < 5 for yy in y[test]]
 
     # Check for repeating values in the thresholds
-    fpr, tpr, thresholds = roc_curve(y_true, probas_pred)
+    fpr, tpr, thresholds = roc_curve(y_true, y_score)
     assert_equal(thresholds.size, np.unique(np.round(thresholds, 2)).size)
 
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -196,3 +196,46 @@ except ImportError:
                 return
             indices[i:] = [indices[i] + 1] * (r - i)
             yield tuple(pool[i] for i in indices)
+
+
+try:
+    from numpy import isclose
+except ImportError:
+    def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
+        """
+        Returns a boolean array where two arrays are element-wise equal within a
+        tolerance.
+
+        This function was added to numpy v1.7.0, and the version you are running
+        has been backported from numpy v1.8.1. See its documentation for more
+        details.
+        """
+        def within_tol(x, y, atol, rtol):
+            with np.errstate(invalid='ignore'):
+                result = np.less_equal(abs(x-y), atol + rtol * abs(y))
+            if np.isscalar(a) and np.isscalar(b):
+                result = bool(result)
+            return result
+
+        x = np.array(a, copy=False, subok=True, ndmin=1)
+        y = np.array(b, copy=False, subok=True, ndmin=1)
+        xfin = np.isfinite(x)
+        yfin = np.isfinite(y)
+        if all(xfin) and all(yfin):
+            return within_tol(x, y, atol, rtol)
+        else:
+            finite = xfin & yfin
+            cond = np.zeros_like(finite, subok=True)
+            # Because we're using boolean indexing, x & y must be the same shape.
+            # Ideally, we'd just do x, y = broadcast_arrays(x, y). It's in
+            # lib.stride_tricks, though, so we can't import it here.
+            x = x * np.ones_like(cond)
+            y = y * np.ones_like(cond)
+            # Avoid subtraction with infinite/nan values...
+            cond[finite] = within_tol(x[finite], y[finite], atol, rtol)
+            # Check for equality of infinite values...
+            cond[~finite] = (x[~finite] == y[~finite])
+            if equal_nan:
+                # Make NaN == NaN
+                cond[np.isnan(x) & np.isnan(y)] = True
+            return cond

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -203,12 +203,12 @@ try:
 except ImportError:
     def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         """
-        Returns a boolean array where two arrays are element-wise equal within a
-        tolerance.
+        Returns a boolean array where two arrays are element-wise equal within
+        a tolerance.
 
-        This function was added to numpy v1.7.0, and the version you are running
-        has been backported from numpy v1.8.1. See its documentation for more
-        details.
+        This function was added to numpy v1.7.0, and the version you are
+        running has been backported from numpy v1.8.1. See its documentation
+        for more details.
         """
         def within_tol(x, y, atol, rtol):
             with np.errstate(invalid='ignore'):
@@ -226,7 +226,7 @@ except ImportError:
         else:
             finite = xfin & yfin
             cond = np.zeros_like(finite, subok=True)
-            # Because we're using boolean indexing, x & y must be the same shape.
+            # Since we're using boolean indexing, x & y must be the same shape.
             # Ideally, we'd just do x, y = broadcast_arrays(x, y). It's in
             # lib.stride_tricks, though, so we can't import it here.
             x = x * np.ones_like(cond)


### PR DESCRIPTION
Added a unit test to ensure that there are no spurious repeating values in the thresholds returned by roc_curve because of machine precision, and a quick stab at a fix.

Without the fix, the thresholds array produced in the unit test starts with the values [1, 0.99, 0.98, 0.98, ...]. There should be only one 0.98. The undesirable behavior stems from machine epsilon differences between predicted probabilities that are mathematically equivalent.

I am not sure that my suggested fix is the best approach, so I welcome comments.
