### PR TITLE
[MRG+1] Sparse One vs. Rest

### DIFF
--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -33,7 +33,8 @@ by decomposing such problems into binary classification problems.
     several joint classification tasks. This is a generalization
     of the multi-label classification task, where the set of classification
     problem is restricted to binary classification, and of the multi-class
-    classification task. *The output format is a 2d numpy array.*
+    classification task. *The output format is a 2d numpy array or sparse 
+    matrix.*
 
     The set of labels can be different for each output variable.
     For instance a sample could be assigned "pear" for an output variable that

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -86,7 +86,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     """Fit a one-vs-the-rest strategy."""
     _check_estimator(estimator)
 
-    lb = LabelBinarizer(sparse_output=sp.issparse(y))
+    lb = LabelBinarizer(sparse_output=True)
 
     Y = lb.fit_transform(y)
 
@@ -94,7 +94,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
         estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)
                                              (estimator,
                                               X,
-                                              Y.getcol(i).toarray(),
+                                              Y.getcol(i).toarray().ravel(),
                                               classes=["not %s" % i, i])
                                              for i in range(Y.shape[1]))
     else:

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -109,6 +109,9 @@ def predict_ovr(estimators, label_binarizer, X):
     e = estimators[0]
     thresh = 0 if hasattr(e, "decision_function") and is_classifier(e) else .5
 
+    # XXX: this needs to handle multiclass correctly, a copy of 
+    # inverse_transform is needed where only the thresholding behavior is used
+
     Y = sp.coo_matrix(np.array(_predict_binary(e, X) > thresh, dtype=np.int))
 
     for e in estimators[1:]:

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -114,7 +114,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     Y = lb.fit_transform(y)
     Y = Y.tocsc()
     columns = (col.toarray().ravel() for col in Y.T)
-    # In cases where indivdual estimators are very fast to train setting
+    # In cases where individual estimators are very fast to train setting
     # n_jobs > 1 in can results in slower performance due to the overhead
     # of spawning threads.
     estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -112,7 +112,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
 
 
 def _get_col(Y, i):
-    """Y is CSC matrix, i is the column index. Returns the dense column."""
+    """Y is CSC matrix, i is the column. Returns a dense binary column."""
     c = np.zeros(Y.shape[0], dtype=int)
     c[Y.indices[Y.indptr[i]:Y.indptr[i+1]]] = Y.data[Y.indptr[i]:Y.indptr[i+1]]
     return c

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -87,9 +87,7 @@ def _check_estimator(estimator):
 def fit_ovr(estimator, X, y, n_jobs=1):
     """Fit a one-vs-the-rest strategy."""
     _check_estimator(estimator)
-    sparse_putput = (type_of_target(y).startswith("multiclass") and 
-                     len(unique_labels(y)) == 3)
-    lb = LabelBinarizer(sparse_output=sparse_putput)
+    lb = LabelBinarizer(sparse_output=True)
     Y = lb.fit_transform(y)
 
     if sp.issparse(Y):
@@ -103,8 +101,14 @@ def fit_ovr(estimator, X, y, n_jobs=1):
                                           column,
                                           classes=["not %s" % i, i])
                                          for i, column in enumerate(columns))
-
     return estimators, lb
+
+
+def _get_col(Y, i):
+    """Y is CSC matrix, i is the column. Returns a dense binary column."""
+    c = np.zeros(Y.shape[0], dtype=int)
+    c[Y.indices[Y.indptr[i]:Y.indptr[i+1]]] = Y.data[Y.indptr[i]:Y.indptr[i+1]]
+    return c
 
 
 def predict_ovr(estimators, label_binarizer, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -86,15 +86,13 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     """Fit a one-vs-the-rest strategy"""
     _check_estimator(estimator)
 
-    # XXX benchmark one line vs the other
     lb = LabelBinarizer(sparse_output=True)
-    # lb = LabelBinarizer(sparse_output=sp.issparse(y))
 
     Y = lb.fit_transform(y)
 
     if sp.issparse(Y):
         Y = Y.tocsc()
-        columns = [_get_col(Y, i) for i in range(Y.shape[1])]
+        columns = (_get_col(Y, i) for i in range(Y.shape[1]))
     else:
         columns = Y.T
     estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -89,7 +89,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     _check_estimator(estimator)
 
     if (type_of_target(y).startswith("multiclass") and 
-        len(unique_labels(y)) >=3):
+        len(unique_labels(y)) == 3):
         lb = LabelBinarizer(sparse_output=False)
     else:
         lb = LabelBinarizer(sparse_output=True)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -109,7 +109,6 @@ def fit_ovr(estimator, X, y, n_jobs=1):
 
 def predict_ovr(estimators, label_binarizer, X):
     """Make predictions using the one-vs-the-rest strategy."""
-
     e = estimators[0]
     thresh = 0 if hasattr(e, "decision_function") and is_classifier(e) else .5
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -91,14 +91,19 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     Y = lb.fit_transform(y)
 
     if sp.issparse(Y):
-        estimators = Parallel(n_jobs=n_jobs)(
-            delayed(_fit_binary)(estimator, X, Y.getcol(i).toarray(),
-                classes=["not %s" % i, i]) for i in range(Y.shape[1]))
+        estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)
+                                             (estimator,
+                                              X,
+                                              Y.getcol(i).toarray(),
+                                              classes=["not %s" % i, i])
+                                             for i in range(Y.shape[1]))
     else:
-        estimators = Parallel(n_jobs=n_jobs)(
-            delayed(_fit_binary)(estimator, X, Y[:, i],
-                classes=["not %s" % i, i]) for i in range(Y.shape[1]))
-
+        estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)
+                                             (estimator,
+                                              X,
+                                              Y[:, i],
+                                              classes=["not %s" % i, i])
+                                             for i in range(Y.shape[1]))
     return estimators, lb
 
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -118,7 +118,8 @@ def fit_ovr(estimator, X, y, n_jobs=1):
                                          (estimator,
                                           X,
                                           column,
-                                          classes=["not %s" % i, i])
+                                          classes=["not %s" % i,
+                                                   lb.classes_[i]])
                                          for i, column in enumerate(columns))
     return estimators, lb
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -87,7 +87,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     _check_estimator(estimator)
 
     # XXX benchmark one line vs the other
-    lb = LabelBinarizer(sparse_output=sp.issparse(y))
+    lb = LabelBinarizer(sparse_output=True)
     # lb = LabelBinarizer(sparse_output=sp.issparse(y))
 
     Y = lb.fit_transform(y)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -86,7 +86,9 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     """Fit a one-vs-the-rest strategy."""
     _check_estimator(estimator)
 
-    lb = LabelBinarizer(sparse_output=True)
+    # XXX benchmark one line vs the other
+    lb = LabelBinarizer(sparse_output=sp.issparse(y))
+    # lb = LabelBinarizer(sparse_output=sp.issparse(y))
 
     Y = lb.fit_transform(y)
 
@@ -120,7 +122,7 @@ def predict_ovr(estimators, label_binarizer, X):
             pred = _predict_binary(e, X)
             np.maximum(maxima, pred, out=maxima)
             argmaxima[maxima == pred] = i
-        return np.array(argmaxima.T, dtype=label_binarizer.classes_.dtype)
+        return label_binarizer.classes_[np.array(argmaxima.T)]
     else:
         indices = array.array('i')
         indptr = array.array('i', [0])

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -90,7 +90,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
 
     if (type_of_target(y).startswith("multiclass") and 
         len(unique_labels(y)) >=3):
-        lb = LabelBinarizer(sparse_output=True)
+        lb = LabelBinarizer(sparse_output=False)
     else:
         lb = LabelBinarizer(sparse_output=True)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -293,8 +293,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         Returns
         -------
-            y : {array-like, sparse matrix}, shape = [n_samples] or
-                [n_samples, n_classes]. Predicted multi-class targets.
+        y : {array-like, sparse matrix}, shape = [n_samples] or
+            [n_samples, n_classes]. Predicted multi-class targets.
         """
         self._check_is_fitted()
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -89,12 +89,8 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     _check_estimator(estimator)
     lb = LabelBinarizer(sparse_output=True)
     Y = lb.fit_transform(y)
-
-    if sp.issparse(Y):
-        Y = Y.tocsc()
-        columns = (Y.getcol(i).toarray().ravel() for i in range(Y.shape[1]))
-    else:
-        columns = Y.T
+    Y = Y.tocsc()
+    columns = (Y.getcol(i).toarray().ravel() for i in range(Y.shape[1]))
     estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)
                                          (estimator,
                                           X,
@@ -102,13 +98,6 @@ def fit_ovr(estimator, X, y, n_jobs=1):
                                           classes=["not %s" % i, i])
                                          for i, column in enumerate(columns))
     return estimators, lb
-
-
-def _get_col(Y, i):
-    """Y is CSC matrix, i is the column. Returns a dense binary column."""
-    c = np.zeros(Y.shape[0], dtype=int)
-    c[Y.indices[Y.indptr[i]:Y.indptr[i+1]]] = Y.data[Y.indptr[i]:Y.indptr[i+1]]
-    return c
 
 
 def predict_ovr(estimators, label_binarizer, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -83,7 +83,7 @@ def _check_estimator(estimator):
 
 
 def fit_ovr(estimator, X, y, n_jobs=1):
-    """Fit a one-vs-the-rest strategy"""
+    """Fit a one-vs-the-rest strategy."""
     _check_estimator(estimator)
 
     lb = LabelBinarizer(sparse_output=True)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -83,7 +83,7 @@ def _check_estimator(estimator):
 
 
 def fit_ovr(estimator, X, y, n_jobs=1):
-    """Fit a one-vs-the-rest strategy."""
+    """Fit a one-vs-the-rest strategy"""
     _check_estimator(estimator)
 
     # XXX benchmark one line vs the other

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -114,15 +114,14 @@ def predict_ovr(estimators, label_binarizer, X):
     thresh = 0 if hasattr(e, "decision_function") and is_classifier(e) else .5
 
     if label_binarizer.y_type_ == "multiclass":
-        Y = np.array([])
-        for x in X:
-            x_scores = np.array([])
-            for e in estimators:
-                x_scores = np.append(x_scores, _predict_binary(e, x))
-            c = label_binarizer.classes_[x_scores.argmax()]
-            Y = np.append(Y, c)
-        return np.array(Y.T, dtype=label_binarizer.classes_.dtype)
-
+        maxima = np.empty(X.shape[0], dtype=float)
+        maxima.fill(-np.inf)
+        argmaxima = np.zeros(X.shape[0], dtype=int)
+        for i, e in enumerate(estimators):
+            pred = _predict_binary(e, X)
+            np.maximum(maxima, pred, out=maxima)
+            argmaxima[maxima == pred] = i
+        return np.array(argmaxima.T, dtype=label_binarizer.classes_.dtype)
     else:
         indices = array.array('i')
         indptr = array.array('i', [0])

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -127,7 +127,7 @@ def predict_ovr(estimators, label_binarizer, X):
             argmaxima[maxima == pred] = i
         return label_binarizer.classes_[np.array(argmaxima.T)]
     else:
-        len_X = X.shape[0] if sp.issparse(X) else len(X)
+        n_samples = X.shape[0] if sp.issparse(X) else len(X)
         indices = array.array('i')
         indptr = array.array('i', [0])
         for e in estimators:
@@ -135,7 +135,7 @@ def predict_ovr(estimators, label_binarizer, X):
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
         indicator = sp.csc_matrix((data, indices, indptr),
-                                  shape=(len_X, len(estimators)))
+                                  shape=(n_samples, len(estimators)))
         return label_binarizer.inverse_transform(indicator)
 
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -115,7 +115,7 @@ def predict_ovr(estimators, label_binarizer, X):
                 x_scores = np.append(x_scores, _predict_binary(e, x))
             c = label_binarizer.classes_[x_scores.argmax()]
             Y = np.append(Y,c)
-        return Y.T
+        return np.array(Y.T, dtype=label_binarizer.classes_.dtype)
 
     else:
         Y = sp.coo_matrix(np.array(_predict_binary(e, X) > thresh,

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -216,9 +216,9 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data.
 
-        y : array-like, shape = [n_samples] or [n_samples, n_classes]
-            Multi-class targets. An indicator matrix turns on multilabel
-            classification.
+        y : {array-like, sparse matrix}, shape = [n_samples] or
+            [n_samples, n_classes] Multi-class targets. An indicator matrix
+            turns on multilabel classification.
 
         Returns
         -------
@@ -268,7 +268,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         Returns
         -------
-        T : array-like, shape = [n_samples, n_classes]
+        T : {array-like, sparse matrix}, shape = [n_samples, n_classes]
             Returns the probability of the sample for each class in the model,
             where classes are ordered as they are in `self.classes_`.
         """
@@ -426,7 +426,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data.
 
-        y : numpy array of shape [n_samples]
+        y : {array-like, sparse matrix}, shape [n_samples]
             Multi-class targets.
 
         Returns
@@ -447,7 +447,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         Returns
         -------
-        y : numpy array of shape [n_samples]
+        y : {array-like, sparse matrix}, shape [n_samples]
             Predicted multi-class targets.
         """
         if not hasattr(self, "estimators_"):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -114,6 +114,9 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     Y = lb.fit_transform(y)
     Y = Y.tocsc()
     columns = (col.toarray().ravel() for col in Y.T)
+    # In cases where indivdual estimators are very fast to train setting
+    # n_jobs > 1 in can results in slower performance due to the overhead
+    # of spawning threads.
     estimators = Parallel(n_jobs=n_jobs)(delayed(_fit_binary)
                                          (estimator,
                                           X,

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -129,6 +129,7 @@ def predict_ovr(estimators, label_binarizer, X):
             argmaxima[maxima == pred] = i
         return label_binarizer.classes_[np.array(argmaxima.T)]
     else:
+        len_X = X.shape[0] if sp.issparse(X) else len(X)
         indices = array.array('i')
         indptr = array.array('i', [0])
         for e in estimators:
@@ -136,7 +137,7 @@ def predict_ovr(estimators, label_binarizer, X):
             indptr.append(len(indices))
         data = np.ones(len(indices), dtype=int)
         indicator = sp.csc_matrix((data, indices, indptr),
-                                  shape=(len(X), len(estimators)))
+                                  shape=(len_X, len(estimators)))
         return label_binarizer.inverse_transform(indicator)
 
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -431,7 +431,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Data.
 
-        y : {array-like, sparse matrix}, shape [n_samples]
+        y : numpy array of shape [n_samples]
             Multi-class targets.
 
         Returns
@@ -452,7 +452,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
         Returns
         -------
-        y : {array-like, sparse matrix}, shape [n_samples]
+        y : numpy array of shape [n_samples]
             Predicted multi-class targets.
         """
         if not hasattr(self, "estimators_"):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -42,6 +42,8 @@ from .base import MetaEstimatorMixin
 from .preprocessing import LabelBinarizer
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
+from .utils.multiclass import type_of_target
+from .utils.multiclass import unique_labels
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
 
@@ -86,7 +88,11 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     """Fit a one-vs-the-rest strategy."""
     _check_estimator(estimator)
 
-    lb = LabelBinarizer(sparse_output=True)
+    if (type_of_target(y).startswith("multiclass") and 
+        len(unique_labels(y)) >=3):
+        lb = LabelBinarizer(sparse_output=True)
+    else:
+        lb = LabelBinarizer(sparse_output=True)
 
     Y = lb.fit_transform(y)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -492,10 +492,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
                           shape=(n_samples, n_classes))
 
     elif y_type == "multilabel-indicator":
-        if sp.issparse(y) and y.format == 'csc':
-            Y = sp.csc_matrix(y)
-        else:
-            Y = sp.csr_matrix(y)
+        Y = sp.csr_matrix(y)
         if pos_label != 1:
             data = np.empty_like(Y.data)
             data.fill(pos_label)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -201,6 +201,13 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     `classes_` : array of shape [n_class]
         Holds the label for each class.
 
+    `y_type_` : str,
+        Represents the type of the target data as evaluated by
+        utils.multiclass.type_of_target. Possible type are 'continuous',
+        'continuous-multioutput', 'binary', 'multiclass',
+        'mutliclass-multioutput', 'multilabel-sequences',
+        'multilabel-indicator', and 'unknown'.
+
     `multilabel_` : boolean
         True if the transformer was fitted on a multilabel rather than a
         multiclass set of labels. The multilabel_ attribute is deprecated

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -517,6 +517,8 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
 
         if pos_switch:
             Y[Y == pos_label] = 0
+    else:
+        Y.data = astype(Y.data, int, copy=False)
 
     # preserve label ordering
     if np.any(classes != sorted_class):
@@ -524,7 +526,10 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
         Y = Y[:, indices]
 
     if y_type == "binary":
-        Y = Y[:, -1].reshape((-1, 1))
+        if sparse_output:
+            Y = Y.getcol(-1)
+        else:
+            Y = Y[:, -1].reshape((-1, 1))
 
     return Y
 
@@ -600,6 +605,8 @@ def _inverse_binarize_thresholding(y, output_type, classes, threshold):
 
     # Inverse transform data
     if output_type == "binary":
+        if sp.issparse(y):
+            y = y.toarray()
         if y.ndim == 2 and y.shape[1] == 2:
             return classes[y[:, 1]]
         else:

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -492,7 +492,14 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
                           shape=(n_samples, n_classes))
 
     elif y_type == "multilabel-indicator":
-        Y = sp.csr_matrix(y)
+        # XXX simplify this conditional path
+        if sp.issparse(y):
+            if y.format not in ('csr', 'csc'):
+                Y = sp.csr_matrix(y)
+            else:
+                Y = y
+        else:
+            Y = sp.csr_matrix(y)
         if pos_label != 1:
             data = np.empty_like(Y.data)
             data.fill(pos_label)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -492,12 +492,8 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
                           shape=(n_samples, n_classes))
 
     elif y_type == "multilabel-indicator":
-        # XXX simplify this conditional path
-        if sp.issparse(y):
-            if y.format not in ('csr', 'csc'):
-                Y = sp.csr_matrix(y)
-            else:
-                Y = y
+        if sp.issparse(y) and y.format == 'csc':
+            Y = sp.csc_matrix(y)
         else:
             Y = sp.csr_matrix(y)
         if pos_label != 1:

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -308,6 +308,10 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self : returns an instance of self.
         """
         self.y_type_ = type_of_target(y)
+        if 'multioutput' in self.y_type_:
+            raise ValueError("Multioutput target data is not supported with "
+                             "label binarization")
+
         self.sparse_input_ = sp.issparse(y)
         self.classes_ = unique_labels(y)
         return self
@@ -469,6 +473,9 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
         pos_label = -neg_label
 
     y_type = type_of_target(y)
+    if 'multioutput' in y_type:
+        raise ValueError("Multioutput target data is not supported with label "
+                         "binarization")
 
     n_samples = y.shape[0] if sp.issparse(y) else len(y)
     n_classes = len(classes)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -194,6 +194,11 @@ def test_label_binarizer_errors():
                   y=np.array([[1, 2, 3], [2, 1, 3]]), output_type="binary",
                   classes=[1, 2, 3], threshold=0)
 
+    # Fail on multioutput data
+    assert_raises(ValueError, LabelBinarizer().fit, np.array([[1, 3], [2, 1]]))
+    assert_raises(ValueError, label_binarize, np.array([[1, 3], [2, 1]]),
+                  [1, 2, 3])
+
 
 def test_label_encoder():
     """Test LabelEncoder's transform and inverse_transform methods"""

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -467,6 +467,15 @@ def test_label_binarize_binary():
 
     yield check_binarized_results, y, classes, pos_label, neg_label, expected
 
+    # Binary case where sparse_output = True will no result in a Value Error
+    y = [0, 1, 0]
+    classes = [0, 1]
+    pos_label = 3
+    neg_label = 0
+    expected = np.array([[3, 0], [0, 3], [3, 0]])[:, 1].reshape((-1, 1))
+
+    yield check_binarized_results, y, classes, pos_label, neg_label, expected
+
 
 def test_label_binarize_multiclass():
     y = [0, 1, 2]

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -467,7 +467,7 @@ def test_label_binarize_binary():
 
     yield check_binarized_results, y, classes, pos_label, neg_label, expected
 
-    # Binary case where sparse_output = True will no result in a Value Error
+    # Binary case where sparse_output = True will not result in a ValueError
     y = [0, 1, 0]
     classes = [0, 1]
     pos_label = 3

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -117,6 +117,34 @@ def test_ovr_always_present():
     assert_array_equal(y_pred[:, -1], np.zeros(X.shape[0]))
 
 
+def test_ovr_multiclass():
+    # Toy dataset where features correspond directly to labels.
+    X = np.array([[0, 0, 5], [0, 5, 0], [3, 0, 0], [0, 0, 6], [6, 0, 0]])
+    y = ["eggs", "spam", "ham", "eggs", "ham"]
+    # y = [[1, 2], [1], [0, 1, 2], [0, 2], [0]]
+    Y = np.array([[0, 0, 1],
+                  [0, 1, 0],
+                  [1, 0, 0],
+                  [0, 0, 1],
+                  [1, 0, 0]])
+
+    classes = set("ham eggs spam".split())
+
+    for base_clf in (MultinomialNB(), LinearSVC(random_state=0),
+                     LinearRegression(), Ridge(),
+                     ElasticNet(), Lasso(alpha=0.5)):
+
+        clf = OneVsRestClassifier(base_clf).fit(X, y)
+        assert_equal(set(clf.classes_), classes)
+        y_pred = clf.predict(np.array([[0, 0, 4]]))[0]
+        assert_equal(set(y_pred), set("eggs"))
+
+        # test input as label indicator matrix
+        clf = OneVsRestClassifier(base_clf).fit(X, Y)
+        y_pred = clf.predict([[0, 0, 4]])[0]
+        assert_array_equal(y_pred, [0, 0, 1])
+
+
 def test_ovr_multilabel():
     # Toy dataset where features correspond directly to labels.
     X = np.array([[0, 4, 5], [0, 5, 0], [3, 3, 3], [4, 0, 6], [6, 0, 0]])

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -86,6 +86,19 @@ def test_ovr_fit_predict_sparse():
         assert_true(sp.issparse(Y_pred_sprs))
         assert_array_equal(Y_pred_sprs.toarray(), Y_pred)
 
+        # Test predict_proba
+        Y_proba = clf_sprs.predict_proba(X_test)
+
+        # predict assigns a label if the probability that the
+        # sample has the label is greater than 0.5.
+        pred = Y_proba > .5
+        assert_array_equal(pred, Y_pred_sprs.toarray())
+
+        # Test decision_function
+        clf_sprs = OneVsRestClassifier(svm.SVC()).fit(X_train, sparse(Y_train))
+        dec_pred = (clf_sprs.decision_function(X_test) > 0).astype(int)
+        assert_array_equal(dec_pred, clf_sprs.predict(X_test).toarray())
+
 
 def test_ovr_always_present():
     """Test that ovr works with classes that are always present or absent

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -101,8 +101,7 @@ def test_ovr_fit_predict_sparse():
 
 
 def test_ovr_always_present():
-    """Test that ovr works with classes that are always present or absent.
-    """
+    """Test that ovr works with classes that are always present or absent."""
     # Note: tests is the case where _ConstantPredictor is utilised
     X = np.ones((10, 2))
     X[:5, :] = 0
@@ -145,7 +144,7 @@ def test_ovr_multiclass():
 
     for base_clf in (MultinomialNB(), LinearSVC(random_state=0),
                      LinearRegression(), Ridge(),
-                     ElasticNet(), Lasso(alpha=0.5)):
+                     ElasticNet()):
 
         clf = OneVsRestClassifier(base_clf).fit(X, y)
         assert_equal(set(clf.classes_), classes)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -57,26 +57,26 @@ def test_ovr_fit_predict():
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
     assert_greater(np.mean(iris.target == pred), 0.65)
 
+
 def test_ovr_fit_predict_sparse():
     for sparse in [sp.csr_matrix, sp.csc_matrix, sp.coo_matrix, sp.dok_matrix,
                    sp.lil_matrix]:
         # A classifier which implements decision_function.
         ovr = OneVsRestClassifier(LinearSVC(random_state=0))
-        pred = ovr.fit(iris.data, 
+        pred = ovr.fit(iris.data,
                        sparse(iris.target)).predict(sparse(iris.data))
         assert_equal(len(ovr.estimators_), n_classes)
         assert_true(sp.issparse(pred))
 
         clf = LinearSVC(random_state=0)
         pred2 = clf.fit(iris.data, iris.target).predict(iris.data)
-        assert_equal(np.mean(iris.target == pred.toarray()), 
+        assert_equal(np.mean(iris.target == pred.toarray()),
                      np.mean(iris.target == pred2))
 
         # A classifier which implements predict_proba.
         ovr = OneVsRestClassifier(MultinomialNB())
         pred = ovr.fit(iris.data, iris.target).predict(iris.data)
         assert_greater(np.mean(iris.target == pred), 0.65)
-
 
 
 def test_ovr_always_present():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -114,8 +114,8 @@ def test_ovr_always_present():
 
     [[int(i >= 5), 2, 3] for i in range(10)]
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ignore_warning_class, sp.SparseEfficiencyWarning,
-                 ovr.fit, X, y)
+    assert_warns(UserWarning, ignore_warning_class(sp.SparseEfficiencyWarning,
+                 ovr.fit), X, y)
     y_pred = ovr.predict(X)
     assert_array_equal(np.array(y_pred), np.array(y))
     y_pred = ovr.decision_function(X)
@@ -127,8 +127,8 @@ def test_ovr_always_present():
     y = np.zeros((10, 2))
     y[5:, 0] = 1  # variable label
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ignore_warning_class, sp.SparseEfficiencyWarning,
-                 ovr.fit, X, y)
+    assert_warns(UserWarning, ignore_warning_class(sp.SparseEfficiencyWarning,
+                 ovr.fit), X, y)
     y_pred = ovr.predict_proba(X)
     assert_array_equal(y_pred[:, -1], np.zeros(X.shape[0]))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -46,16 +46,10 @@ def test_ovr_fit_predict():
     # A classifier which implements decision_function.
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
-    print(iris.target)
-
-    print(pred)
     assert_equal(len(ovr.estimators_), n_classes)
 
     clf = LinearSVC(random_state=0)
     pred2 = clf.fit(iris.data, iris.target).predict(iris.data)
-    print(pred2)
-    print(np.mean(iris.target == pred))
-    print(np.mean(iris.target == pred2))
     assert_equal(np.mean(iris.target == pred), np.mean(iris.target == pred2))
 
     # A classifier which implements predict_proba.
@@ -149,14 +143,6 @@ def test_ovr_multilabel_dataset():
         X_test, Y_test = X[80:], Y[80:]
         clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
         Y_pred = clf.predict(X_test)
-
-        ## XXX
-        print(Y)
-        clf = OneVsRestClassifier(base_clf).fit(X_train, sp.coo_matrix(Y_train))
-        Y_pred = clf.predict(X_test)
-        assert_true(sp.issparse(Y_pred))
-        Y_pred = Y_pred.toarray()
-        ##
 
         assert_true(clf.multilabel_)
         assert_almost_equal(precision_score(Y_test, Y_pred, average="micro"),

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -9,7 +9,6 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import ignore_warning_class
 
 from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
@@ -114,8 +113,7 @@ def test_ovr_always_present():
 
     [[int(i >= 5), 2, 3] for i in range(10)]
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ignore_warning_class(sp.SparseEfficiencyWarning,
-                 ovr.fit), X, y)
+    assert_warns(UserWarning, ovr.fit, X, y)
     y_pred = ovr.predict(X)
     assert_array_equal(np.array(y_pred), np.array(y))
     y_pred = ovr.decision_function(X)
@@ -127,8 +125,7 @@ def test_ovr_always_present():
     y = np.zeros((10, 2))
     y[5:, 0] = 1  # variable label
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ignore_warning_class(sp.SparseEfficiencyWarning,
-                 ovr.fit), X, y)
+    assert_warns(UserWarning, X, y)
     y_pred = ovr.predict_proba(X)
     assert_array_equal(y_pred[:, -1], np.zeros(X.shape[0]))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -69,15 +69,14 @@ def test_ovr_fit_predict_sparse():
                    sp.lil_matrix]:
         base_clf = MultinomialNB(alpha=1)
 
-        make_mlb = datasets.make_multilabel_classification
-        X, Y = make_mlb(n_samples=100,
-                        n_features=20,
-                        n_classes=5,
-                        n_labels=3,
-                        length=50,
-                        allow_unlabeled=True,
-                        return_indicator=True,
-                        random_state=0)
+        X, Y = datasets.make_multilabel_classification(n_samples=100,
+                                                       n_features=20,
+                                                       n_classes=5,
+                                                       n_labels=3,
+                                                       length=50,
+                                                       allow_unlabeled=True,
+                                                       return_indicator=True,
+                                                       random_state=0)
 
         X_train, Y_train = X[:80], Y[:80]
         X_test, Y_test = X[80:], Y[80:]

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+import scipy.sparse as sp
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
@@ -45,10 +46,16 @@ def test_ovr_fit_predict():
     # A classifier which implements decision_function.
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
+    print(iris.target)
+
+    print(pred)
     assert_equal(len(ovr.estimators_), n_classes)
 
     clf = LinearSVC(random_state=0)
     pred2 = clf.fit(iris.data, iris.target).predict(iris.data)
+    print(pred2)
+    print(np.mean(iris.target == pred))
+    print(np.mean(iris.target == pred2))
     assert_equal(np.mean(iris.target == pred), np.mean(iris.target == pred2))
 
     # A classifier which implements predict_proba.
@@ -142,6 +149,15 @@ def test_ovr_multilabel_dataset():
         X_test, Y_test = X[80:], Y[80:]
         clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
         Y_pred = clf.predict(X_test)
+
+        ## XXX
+        print(Y)
+        clf = OneVsRestClassifier(base_clf).fit(X_train, sp.coo_matrix(Y_train))
+        Y_pred = clf.predict(X_test)
+        assert_true(sp.issparse(Y_pred))
+        Y_pred = Y_pred.toarray()
+        ##
+
         assert_true(clf.multilabel_)
         assert_almost_equal(precision_score(Y_test, Y_pred, average="micro"),
                             prec,
@@ -379,3 +395,7 @@ def test_ecoc_gridsearch():
     cv.fit(iris.data, iris.target)
     best_C = cv.best_estimator_.estimators_[0].C
     assert_true(best_C in Cs)
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -57,6 +57,27 @@ def test_ovr_fit_predict():
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
     assert_greater(np.mean(iris.target == pred), 0.65)
 
+def test_ovr_fit_predict_sparse():
+    for sparse in [sp.csr_matrix, sp.csc_matrix, sp.coo_matrix, sp.dok_matrix,
+                   sp.lil_matrix]:
+        # A classifier which implements decision_function.
+        ovr = OneVsRestClassifier(LinearSVC(random_state=0))
+        pred = ovr.fit(iris.data, 
+                       sparse(iris.target)).predict(sparse(iris.data))
+        assert_equal(len(ovr.estimators_), n_classes)
+        assert_true(sp.issparse(pred))
+
+        clf = LinearSVC(random_state=0)
+        pred2 = clf.fit(iris.data, iris.target).predict(iris.data)
+        assert_equal(np.mean(iris.target == pred.toarray()), 
+                     np.mean(iris.target == pred2))
+
+        # A classifier which implements predict_proba.
+        ovr = OneVsRestClassifier(MultinomialNB())
+        pred = ovr.fit(iris.data, iris.target).predict(iris.data)
+        assert_greater(np.mean(iris.target == pred), 0.65)
+
+
 
 def test_ovr_always_present():
     """Test that ovr works with classes that are always present or absent

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -9,6 +9,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import ignore_warning_class
 
 from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
@@ -113,7 +114,8 @@ def test_ovr_always_present():
 
     [[int(i >= 5), 2, 3] for i in range(10)]
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ovr.fit, X, y)
+    assert_warns(UserWarning, ignore_warning_class, sp.SparseEfficiencyWarning,
+                 ovr.fit, X, y)
     y_pred = ovr.predict(X)
     assert_array_equal(np.array(y_pred), np.array(y))
     y_pred = ovr.decision_function(X)
@@ -125,7 +127,8 @@ def test_ovr_always_present():
     y = np.zeros((10, 2))
     y[5:, 0] = 1  # variable label
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, ovr.fit, X, y)
+    assert_warns(UserWarning, ignore_warning_class, sp.SparseEfficiencyWarning,
+                 ovr.fit, X, y)
     y_pred = ovr.predict_proba(X)
     assert_array_equal(y_pred[:, -1], np.zeros(X.shape[0]))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -174,11 +174,7 @@ def test_ovr_binary():
     # Toy dataset where features correspond directly to labels.
     X = np.array([[0, 0, 5], [0, 5, 0], [3, 0, 0], [0, 0, 6], [6, 0, 0]])
     y = ["eggs", "spam", "spam", "eggs", "spam"]
-    Y = np.array([[0],
-                  [1],
-                  [1],
-                  [0],
-                  [1]])
+    Y = np.array([[0, 1, 1, 0, 1]]).T
 
     classes = set("eggs spam".split())
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -62,27 +62,29 @@ def test_ovr_fit_predict_sparse():
     for sparse in [sp.csr_matrix, sp.csc_matrix, sp.coo_matrix, sp.dok_matrix,
                    sp.lil_matrix]:
         base_clf = MultinomialNB(alpha=1)
-        for au, prec, recall in zip((True, False), (0.65, 0.74), (0.72, 0.84)):
-            make_mlb = datasets.make_multilabel_classification
-            X, Y = make_mlb(n_samples=100,
-                            n_features=20,
-                            n_classes=5,
-                            n_labels=2,
-                            length=50,
-                            allow_unlabeled=au,
-                            return_indicator=True,
-                            random_state=0)
 
-            X_train, Y_train = X[:80], Y[:80]
-            X_test, Y_test = X[80:], Y[80:]
-            clf = OneVsRestClassifier(base_clf).fit(X_train, sparse(Y_train))
-            Y_pred = clf.predict(X_test)
+        make_mlb = datasets.make_multilabel_classification
+        X, Y = make_mlb(n_samples=100,
+                        n_features=20,
+                        n_classes=5,
+                        n_labels=3,
+                        length=50,
+                        allow_unlabeled=True,
+                        return_indicator=True,
+                        random_state=0)
 
-            assert_true(clf.multilabel_)
-            assert_almost_equal(precision_score(Y_test, Y_pred.toarray(),
-                                average="micro"), prec, decimal=2)
-            assert_almost_equal(recall_score(Y_test, Y_pred.toarray(),
-                                average="micro"), recall, decimal=2)
+        X_train, Y_train = X[:80], Y[:80]
+        X_test, Y_test = X[80:], Y[80:]
+
+        clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
+        Y_pred = clf.predict(X_test)
+
+        clf_sprs = OneVsRestClassifier(base_clf).fit(X_train, sparse(Y_train))
+        Y_pred_sprs = clf_sprs.predict(X_test)
+
+        assert_true(clf.multilabel_)
+        assert_true(sp.issparse(Y_pred_sprs))
+        assert_array_equal(Y_pred_sprs.toarray(), Y_pred)
 
 
 def test_ovr_always_present():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -101,7 +101,7 @@ def test_ovr_fit_predict_sparse():
 
 
 def test_ovr_always_present():
-    """Test that ovr works with classes that are always present or absent
+    """Test that ovr works with classes that are always present or absent.
     """
     # Note: tests is the case where _ConstantPredictor is utilised
     X = np.ones((10, 2))

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -125,7 +125,7 @@ def test_ovr_always_present():
     y = np.zeros((10, 2))
     y[5:, 0] = 1  # variable label
     ovr = OneVsRestClassifier(LogisticRegression())
-    assert_warns(UserWarning, X, y)
+    assert_warns(UserWarning, ovr.fit, X, y)
     y_pred = ovr.predict_proba(X)
     assert_array_equal(y_pred[:, -1], np.zeros(X.shape[0]))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -120,7 +120,7 @@ def test_ovr_multilabel():
     X = np.array([[0, 4, 5], [0, 5, 0], [3, 3, 3], [4, 0, 6], [6, 0, 0]])
     y = [["spam", "eggs"], ["spam"], ["ham", "eggs", "spam"],
          ["ham", "eggs"], ["ham"]]
-    #y = [[1, 2], [1], [0, 1, 2], [0, 2], [0]]
+    # y = [[1, 2], [1], [0, 1, 2], [0, 2], [0]]
     Y = np.array([[0, 1, 1],
                   [0, 1, 0],
                   [1, 1, 1],
@@ -408,6 +408,7 @@ def test_ecoc_gridsearch():
     cv.fit(iris.data, iris.target)
     best_C = cv.best_estimator_.estimators_[0].C
     assert_true(best_C in Cs)
+
 
 if __name__ == "__main__":
     import nose

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -14,9 +14,12 @@ from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.multiclass import OutputCodeClassifier
+from sklearn.multiclass import predict_ovr
 
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
+
+from sklearn.preprocessing import LabelBinarizer
 
 from sklearn.svm import LinearSVC
 from sklearn.naive_bayes import MultinomialNB
@@ -40,6 +43,9 @@ n_classes = 3
 def test_ovr_exceptions():
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
     assert_raises(ValueError, ovr.predict, [])
+
+    assert_raises(ValueError, predict_ovr, [LinearSVC(), MultinomialNB()],
+                  LabelBinarizer(), [])
 
 
 def test_ovr_fit_predict():

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -154,13 +154,12 @@ def assert_warns(warning_class, func, *args, **kw):
         if not len(w) > 0:
             raise AssertionError("No warning raised when calling %s"
                                  % func.__name__)
-        found = False
-        for W in w:
-            found = found or W.category is warning_class
+
+        found = any(warning.category is warning_class for warning in w)
 
         if not found:
             raise AssertionError("%s did not give warning: %s( is %s)"
-                                 % (func.__name__, warning_class, w[0]))
+                                 % (func.__name__, warning_class, w))
 
     return result
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -154,10 +154,12 @@ def assert_warns(warning_class, func, *args, **kw):
         if not len(w) > 0:
             raise AssertionError("No warning raised when calling %s"
                                  % func.__name__)
+        found = False
+        for W in w:
+            found = found or W.category is warning_class
 
-        if not w[0].category is warning_class:
-            raise AssertionError("First warning for %s is not a "
-                                 "%s( is %s)"
+        if not found:
+            raise AssertionError("%s did not give warning: %s( is %s)"
                                  % (func.__name__, warning_class, w[0]))
 
     return result
@@ -236,20 +238,6 @@ def assert_no_warnings(func, *args, **kw):
             raise AssertionError("Got warnings when calling %s: %s"
                                  % (func.__name__, w))
     return result
-
-
-def ignore_warning_class(warning_class, fn):
-    """Wraps function fn and ignore any warnings of type warning_class."""
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        # very important to avoid uncontrolled state propagation
-        clean_warning_registry()
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=warning_class)
-            return fn(*args, **kwargs)
-            w[:] = []
-
-    return wrapper
 
 
 def ignore_warnings(obj=None):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -239,7 +239,7 @@ def assert_no_warnings(func, *args, **kw):
 
 
 def ignore_warning_class(warning_class, fn):
-    """Decorator to catch and hide warnings without visual nesting"""
+    """Wraps function fn and ignore any warnings of type warning_class."""
     @wraps(fn)
     def wrapper(*args, **kwargs):
         # very important to avoid uncontrolled state propagation

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -238,6 +238,15 @@ def assert_no_warnings(func, *args, **kw):
     return result
 
 
+def ignore_warning_class(warning_class, func, *args, **kw):
+    """Returns the result of func and ignores warnings of type warning_class"""
+    clean_warning_registry()
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=warning_class)
+        result = func(*args, **kw)
+    return result
+
+
 def ignore_warnings(obj=None):
     """ Context manager and decorator to ignore warnings
 
@@ -579,6 +588,7 @@ def if_not_mac_os(versions=('10.7', '10.8', '10.9'),
     """
     mac_version, _, _ = platform.mac_ver()
     skip = '.'.join(mac_version.split('.')[:2]) in versions
+
     def decorator(func):
         if skip:
             @wraps(func)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -156,11 +156,9 @@ def assert_warns(warning_class, func, *args, **kw):
                                  % func.__name__)
 
         found = any(warning.category is warning_class for warning in w)
-
         if not found:
             raise AssertionError("%s did not give warning: %s( is %s)"
                                  % (func.__name__, warning_class, w))
-
     return result
 
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -238,13 +238,18 @@ def assert_no_warnings(func, *args, **kw):
     return result
 
 
-def ignore_warning_class(warning_class, func, *args, **kw):
-    """Returns the result of func and ignores warnings of type warning_class"""
-    clean_warning_registry()
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=warning_class)
-        result = func(*args, **kw)
-    return result
+def ignore_warning_class(warning_class, fn):
+    """Decorator to catch and hide warnings without visual nesting"""
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        # very important to avoid uncontrolled state propagation
+        clean_warning_registry()
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=warning_class)
+            return fn(*args, **kwargs)
+            w[:] = []
+
+    return wrapper
 
 
 def ignore_warnings(obj=None):


### PR DESCRIPTION
This is a PR for the other parts in PR #2458 concerning sparse output support for the ovr classier. This branch was made off of the sprs-lbl-bin branch from PR #3203 and will be rebased to remove all the sparse label binarizer additions from the diff once the pull request is merged.

Benchmark Experiments using PR #2828 for data generation:
- [x] `fit_ovr`: `sparse_output=True` VS. `sparse_output=sp.issparse(y)`
- [x] `fit_ovr` With input as CSR matrix: Cast to CSC before column extraction VS. Leave as CSR
- [x] Memory profiling for sparse vs. dense target data
- [x] Test the changes to label.py
- [x] Test probability and desicion functions after fitting on sparse target data
- [x] Memory benchmark with `njobs != 1`
