### PR TITLE
[MRG+1]: FIX : allow nd X for cross_val_score (was working in 0.14)

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1079,8 +1079,8 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
     estimator : estimator object implementing 'fit'
         The object to use to fit the data.
 
-    X : array-like of shape at least 2D
-        The data to fit.
+    X : sequence
+        The data to fit. Can be for example a list or an array at least 2d.
 
     y : array-like, optional, default: None
         The target variable to try to predict in the case of

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1129,7 +1129,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         Array of scores of the estimator for each run of the cross validation.
     """
     X, y = check_arrays(X, y, sparse_format='csr', allow_lists=True,
-                        allow_nans=True)
+                        allow_nans=True, allow_nd=True)
     if y is not None:
         y = np.asarray(y)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -214,6 +214,9 @@ def check_arrays(*arrays, **options):
 
     allow_nans : boolean, False by default
         Allows nans in the arrays
+
+    allow_nd : boolean, False by default
+        Allows arrays of more than 2 dimensions.
     """
     sparse_format = options.pop('sparse_format', None)
     if sparse_format not in (None, 'csr', 'csc', 'dense'):
@@ -223,6 +226,7 @@ def check_arrays(*arrays, **options):
     dtype = options.pop('dtype', None)
     allow_lists = options.pop('allow_lists', False)
     allow_nans = options.pop('allow_nans', False)
+    allow_nd = options.pop('allow_nd', False)
 
     if options:
         raise TypeError("Unexpected keyword arguments: %r" % options.keys())
@@ -269,7 +273,7 @@ def check_arrays(*arrays, **options):
                 if not allow_nans:
                     _assert_all_finite(array)
 
-            if array.ndim >= 3:
+            if not allow_nd and array.ndim >= 3:
                 raise ValueError("Found array with dim %d. Expected <= 2" %
                                  array.ndim)
 


### PR DESCRIPTION
cc @ogrisel

would be great to get this in the release

breaks cross val in mne-python
