### PR TITLE
[MRG] big fat warning about multithreaded BLAS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,13 @@ tests you need nose >= 1.1.2.
 This configuration matches the Ubuntu Precise 12.04 LTS release from April
 2012.
 
+scikit-learn also uses CBLAS, the C interface to the Basic Linear Algebra
+Subprograms library. scikit-learn comes with a reference implementation, but
+the system CBLAS will be detected by the build system and used if present.
+CBLAS exists in many implementations; see `Linear algebra libraries
+<http://scikit-learn.org/stable/modules/computational_performance.html#linear-algebra-libraries>`_
+for known issues.
+
 
 Install
 =======

--- a/doc/modules/computational_performance.rst
+++ b/doc/modules/computational_performance.rst
@@ -245,12 +245,11 @@ Basically, you ought to make sure that Numpy is built using an optimized `BLAS
 
 Not all models benefit from optimized BLAS and Lapack implementations. For
 instance models based on (randomized) decision trees typically do not rely on
-BLAS calls in their inner loops. Nor do models implemented in third party C++
-library (like ``LinearSVC``, ``LogisticRegression`` from ``liblinear`` and SVC /
-SVR from ``libsvm``). On the other hand a linear model implemented with a BLAS
-DGEMM call (via ``numpy.dot``) will typically benefit hugely from a tuned BLAS
-implementation and lead to orders of magnitude speedup over a non-optimized
-BLAS.
+BLAS calls in their inner loops, nor do kernel SVMs (``SVC``, ``SVR``,
+``NuSVC``, ``NuSVR``).  On the other hand a linear model implemented with a
+BLAS DGEMM call (via ``numpy.dot``) will typically benefit hugely from a tuned
+BLAS implementation and lead to orders of magnitude speedup over a
+non-optimized BLAS.
 
 You can display the BLAS / LAPACK implementation used by your NumPy / SciPy /
 scikit-learn install with the following commands::
@@ -270,6 +269,24 @@ and in this
 `blog post <http://danielnouri.org/notes/2012/12/19/libblas-and-liblapack-issues-and-speed,-with-scipy-and-ubuntu/>`_
 from Daniel Nouri which has some nice step by step install instructions for
 Debian / Ubuntu.
+
+.. warning::
+
+    Multithreaded BLAS libraries sometimes conflict with Python's
+    ``multiprocessing`` module, which is used by e.g. ``GridSearchCV`` and
+    most other estimators that take an ``n_jobs`` argument (with the exception
+    of ``SGDClassifier``, ``SGDRegressor``, ``Perceptron``,
+    ``PassiveAggressiveClassifier`` and tree-based methods such as random
+    forests). This is true of Apple's Accelerate and OpenBLAS when built with
+    OpenMP support.
+
+    Besides scikit-learn, NumPy and SciPy also use BLAS internally, as
+    explained earlier.
+
+    If you experience hanging subprocesses with ``n_jobs>1`` or ``n_jobs=-1``,
+    make sure you have a single-threaded BLAS library, or set ``n_jobs=1``,
+    or upgrade to Python 3.4 which has a new version of ``multiprocessing``
+    that should be immune to this problem.
 
 Model Compression
 -----------------


### PR DESCRIPTION
#3288 is yet another case where someone sees Python crash, apparently because `multiprocessing` and BLAS (here Apple's Accelerate) don't like each other. I've decided to document the situation better and put a link in the README.

I wasn't aware of a better way to link to the docs from the README, so I just put in the full URL.

Also changed the description of non-BLAS-using parts: `LinearSVC` and `LogisticRegression` actually do use it since bb5f643d0cc9c9e197bed1b082a913f333d419dc (and their `predict` method has used `np.dot` for quite a while).
