### PR TITLE
[MRG+1] exception in bootstrap must be evoked when n_train + n_test > n (resolves issue #3290)

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -161,7 +161,6 @@ Classes
    :toctree: generated/
    :template: class.rst
 
-   cross_validation.Bootstrap
    cross_validation.KFold
    cross_validation.LeaveOneLabelOut
    cross_validation.LeaveOneOut

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -382,48 +382,32 @@ See also
 stratified splits, *i.e* which creates splits by preserving the same
 percentage for each target class as in the complete set.
 
-.. _Bootstrap:
-
-Bootstrapping cross-validation
-------------------------------
-
-:class:`Bootstrap`
-
-Bootstrapping_ is a general statistics technique that iterates the
-computation of an estimator on a resampled dataset.
-
-The :class:`Bootstrap` iterator will generate a user defined number
-of independent train / test dataset splits. Samples are then drawn
-(with replacement) on each side of the split. It furthermore possible
-to control the size of the train and test subset to make their union
-smaller than the total dataset if it is very large.
-
-.. note::
-
-  Contrary to other cross-validation strategies, bootstrapping
-  will allow some samples to occur several times in each splits.
-
-.. _Bootstrapping: http://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29
-
-  >>> bs = cross_validation.Bootstrap(9, n_iter=3, random_state=0)
-  >>> for train_index, test_index in bs:
-  ...     print("%s %s" % (train_index, test_index))
-  ...
-  [1 8 7 7 8] [0 3 0 5]
-  [5 4 2 4 2] [6 7 1 0]
-  [4 7 0 1 1] [5 3 6 5]
-
 A note on shuffling
 ===================
 
-If the data ordering is not arbitrary (e.g. samples with the same label are contiguous), shuffling it first may be essential to getting a meaningful cross-validation result. However, the opposite may be true if the samples are not independent and identically distributed. For example if samples correspond to news articles, and are ordered by their time of publication, then shuffling the data will likely lead to a model that is overfit and an inflated validation score: it will be tested on samples that are artificially similar (close in time) to training samples.
+If the data ordering is not arbitrary (e.g. samples with the same label are
+contiguous), shuffling it first may be essential to get a meaningful cross-
+validation result. However, the opposite may be true if the samples are not
+independently and identically distributed. For example, if samples correspond
+to news articles, and are ordered by their time of publication, then shuffling
+the data will likely lead to a model that is overfit and an inflated validation
+score: it will be tested on samples that are artificially similar (close in
+time) to training samples.
 
-Some cross validation iterators, such as :class:`KFold`, have an inbuilt option to shuffle the data indices before splitting them. Note that:
+Some cross validation iterators, such as :class:`KFold`, have an inbuilt option
+to shuffle the data indices before splitting them. Note that:
 
 * This consumes less memory than shuffling the data directly.
-* By default no shuffling occurs, including for the (stratified) K fold cross-validation performed by specifying ``cv=some_integer`` to :func:`cross_val_score`, grid search, etc. Keep in mind that :func:`train_test_split` still returns a random split.
-* The ``random_state`` parameter defaults to ``None``, meaning that the shuffling will be different every time ``KFold(..., shuffle=True)`` is iterated. However, ``GridSearchCV`` will use the same shuffling for each set of parameters validated by a single call to its ``fit`` method.
-* To ensure results are repeatable (*on the same platform*), use a fixed value for ``random_state``.
+* By default no shuffling occurs, including for the (stratified) K fold cross-
+  validation performed by specifying ``cv=some_integer`` to
+  :func:`cross_val_score`, grid search, etc. Keep in mind that
+  :func:`train_test_split` still returns a random split.
+* The ``random_state`` parameter defaults to ``None``, meaning that the
+  shuffling will be different every time ``KFold(..., shuffle=True)`` is
+  iterated. However, ``GridSearchCV`` will use the same shuffling for each set
+  of parameters validated by a single call to its ``fit`` method.
+* To ensure results are repeatable (*on the same platform*), use a fixed value
+  for ``random_state``.
 
 Cross validation and model selection
 ====================================

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -240,6 +240,10 @@ API changes summary
    - :class:`cluster.WardClustering` is deprecated. Use
    - :class:`cluster.AgglomerativeClustering` instead.
 
+   - :class:`cross_validation.Bootstrap` is deprecated.
+     :class:`cross_validation.KFold` or
+     :class:`cross_validation.ShuffleSplit` are recommended instead.
+
    - Direct support for the sequence of sequences (or list of lists) multilabel
      format is deprecated. To convert to and from the supported binary
      indicator matrix format, use
@@ -305,6 +309,9 @@ API changes summary
    - Fix :func:`utils.compute_class_weight` when class_weight is "auto".
      Previously it was broken for input of non-int dtype and the weighted
      array that was returned was wrong. By `Manoj Kumar`_.
+
+   - Fix :class:`cross_validation.Bootstrap` to return ``ValueError``
+     when `n_train` + `n_test` > `n`. By `Ronald Phlypo`_.
 
 .. _changes_0_14:
 
@@ -2548,3 +2555,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Jeffrey Blackburne: https://github.com/jblackburne
 
 .. _Hamzeh Alsalhi: https://github.com/hamsal
+
+.. _Ronald Phlypo: https://github.com/rphlypo

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -676,6 +676,11 @@ class Bootstrap(object):
 
     def __init__(self, n, n_iter=3, train_size=.5, test_size=None,
                  random_state=None, n_bootstraps=None):
+        # See, e.g., http://youtu.be/BzHz0J9a6k0?t=9m38s for a motivation
+        # behind this deprecation
+        warnings.warn("Bootstrap will no longer be supported as a " +
+                      "cross-validation method as of version 0.15 and " +
+                      "will be removed in 0.17", DeprecationWarning)
         self.n = n
         if n_bootstraps is not None:  # pragma: no cover
             warnings.warn("n_bootstraps was renamed to n_iter and will "
@@ -702,9 +707,10 @@ class Bootstrap(object):
             self.test_size = self.n - self.train_size
         else:
             raise ValueError("Invalid value for test_size: %r" % test_size)
-        if self.test_size > n:
-            raise ValueError("test_size=%d should not be larger than n=%d" %
-                             (self.test_size, n))
+        if self.test_size > n - self.train_size:
+            raise ValueError("test_size + train_size=%d, should not be " +
+                             "larger than n=%d" %
+                             (self.test_size + self.train_size, n))
 
         self.random_state = random_state
 
@@ -1191,8 +1197,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose, parameters,
     Returns
     -------
     train_score : float, optional
-        Score on training set, returned only if `return_train_score` is `True`. 
-        
+        Score on training set, returned only if `return_train_score` is `True`.
+
     test_score : float
         Score on test set.
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -757,7 +757,8 @@ def test_cross_val_generator_with_indices():
                         labels, indices=True)
     lopo = assert_warns(DeprecationWarning, cval.LeavePLabelOut,
                         labels, 2, indices=True)
-    b = cval.Bootstrap(2)  # only in index mode
+    # Bootstrap as a cross-validation is deprecated
+    b = assert_warns(DeprecationWarning, cval.Bootstrap, 2)
     ss = assert_warns(DeprecationWarning, cval.ShuffleSplit,
                       2, indices=True)
     for cv in [loo, lpo, kf, skf, lolo, lopo, b, ss]:
@@ -768,6 +769,7 @@ def test_cross_val_generator_with_indices():
             y_train, y_test = y[train], y[test]
 
 
+@ignore_warnings
 def test_cross_val_generator_with_default_indices():
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
     y = np.array([1, 1, 2, 2])
@@ -816,14 +818,16 @@ def test_cross_val_generator_mask_indices_same():
             assert_array_equal(np.where(train_mask)[0], train_ind)
             assert_array_equal(np.where(test_mask)[0], test_ind)
 
-
+@ignore_warnings
 def test_bootstrap_errors():
     assert_raises(ValueError, cval.Bootstrap, 10, train_size=100)
     assert_raises(ValueError, cval.Bootstrap, 10, test_size=100)
     assert_raises(ValueError, cval.Bootstrap, 10, train_size=1.1)
     assert_raises(ValueError, cval.Bootstrap, 10, test_size=1.1)
+    assert_raises(ValueError, cval.Bootstrap, 10, train_size=0.6,
+                  test_size=0.5)
 
-
+@ignore_warnings
 def test_bootstrap_test_sizes():
     assert_equal(cval.Bootstrap(10, test_size=0.2).test_size, 2)
     assert_equal(cval.Bootstrap(10, test_size=2).test_size, 2)


### PR DESCRIPTION
Since `self.test_size` + `self.train_size` may not exceed n, the test `self.test_size > n` is insufficient for throwing a `ValueError` exception.
