### PR TITLE
[BUG]  _BaseRidgeCV doesn't pass scoring if cv is not None / RidgeClassifierCV shouldn't use continuous setting in inner CV

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -870,7 +870,10 @@ class _BaseRidgeCV(LinearModel):
             #fit_params = {'sample_weight' : sample_weight}
             fit_params = {}
             gs = GridSearchCV(Ridge(fit_intercept=self.fit_intercept),
-                              parameters, fit_params=fit_params, cv=self.cv)
+                              parameters, fit_params=fit_params, cv=self.cv,
+                              scoring=self.scoring,
+                              score_func=self.score_func,
+                              loss_func=self.loss_func)
             gs.fit(X, y)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -28,6 +28,7 @@ from sklearn.linear_model.ridge import _solve_cholesky
 from sklearn.linear_model.ridge import _solve_cholesky_kernel
 
 from sklearn.cross_validation import KFold
+from sklearn.cross_validation import StratifiedKFold
 
 
 diabetes = datasets.load_diabetes()
@@ -742,3 +743,22 @@ def test_raises_value_error_if_solver_not_supported():
         ridge_regression(X, y, alpha=1., solver=wrong_solver)
 
     assert_raise_message(exception, message, func)
+
+
+def test_scoring_cv():
+    """Checks whether the scoring argument is used in the case of
+    cv objects other than LOO"""
+
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 2)
+    y = rng.permutation(len(X)) > .8 * len(X)  # unbalanced classes
+
+    cv = StratifiedKFold(y, n_folds=2)
+
+    rccv_accuracy = RidgeClassifierCV(cv=cv, scoring='accuracy')
+    rccv_accuracy.fit(X, y)
+
+    rccv_f1 = RidgeClassifierCV(cv=cv, scoring='f1')
+    rccv_f1.fit(X, y)
+
+


### PR DESCRIPTION
I could not create a failing test for the failure to pass scoring through to the `GridSearchCV` which is involved, since these objects are not persisted in the `_BaseRidgeCV`.

Passing the the `scoring` to the `GridSearchCV` within `_BaseRidgeCV` creates a new problem, since the internal CV of this object seems to be exclusively working in the continuous setting, thus making e.g. `f1_score` raise an exception due to discrepancy of `y_true` and `y_pred` types.

While there may exist consistency proofs for accuracy score wrt continous Ridge, I am unsure if this is the case for f1_score (?). So the solution would be to have `RidgeClassifierCV` use an inner CV evaluated in a classifier setting, not a regression approximation to this setting. This looks like a slightly bigger change than I thought.

The diff I am pushing shows the situation where `RidgeClassifierCV` breaks due to `scoring='f1'` once it is passed through to the `GridSearchCV` within `_BaseRidgeCV`.

I have some ideas for a general refactoring of this code, but will first collect those in a gist for discussion.
