### PR TITLE
[bug]Fixed bugs when rendering dot file into graphics which is introduced by tree.export_graphviz

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -65,7 +65,7 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
         value = tree.value[node_id]
         if tree.n_outputs == 1:
             value = value[0, :]
-        value = value.astype(int)
+        value = value.astype(float)
 
         if tree.children_left[node_id] == _tree.TREE_LEAF:
             return "%s = %.4f\\nsamples = %s\\nvalue = %s" \

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -65,6 +65,7 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
         value = tree.value[node_id]
         if tree.n_outputs == 1:
             value = value[0, :]
+        value = value.astype(int)
 
         if tree.children_left[node_id] == _tree.TREE_LEAF:
             return "%s = %.4f\\nsamples = %s\\nvalue = %s" \


### PR DESCRIPTION
When exporting a tree into a dot file using `tree.export_graphviz`,  the dot file is usually like this 

```
    digraph Tree {
        0 [label="A <= 1.5000\nerror = 0.451898202175\nsamples = 19396\nvalue = [  6690.  12706.]", shape="box"] ;
        1 [label="B <= 1.5000\nerror = 0.484204229212\nsamples = 6690\nvalue = [ 2667.  4023.]", shape="box"] ;
        0 -> 1 ;
        2 [label="C <= 1.5000\nerror = 0.429043311043\nsamples = 12706\nvalue = [ 4023.  8683.]", shape="box"] ;
        0 -> 2 ;
    }
```

However when sample number is large, `tree.export_graphviz` will create a dot file like this

```
    digraph Tree {
        0 [label="A <= 1.5000\nerror = 0.451898202175\nsamples = 2.48325 e6\nvalue = [  2.470544 e6   1.2706 e4 ]",
        1 [label="B <= 1.5000\nerror = 0.484204229212\nsamples = 2.470544 e6\nvalue = [ 2.667e3  2.467877e6]", shape="box"] ;
        0 -> 1 ;
        2 [label="C <= 1.5000\nerror = 0.429043311043\nsamples = 1.2706 e4\nvalue = [ 4.023 e3  8.683  e3]", shape="box"] ;
        0 -> 2 ;
    }
```

The scientific notation(like `value = [  2.470544 e6   1.2706 e4 ]`)  will broke the dot file rendering process like follows[1][2]:

```
    dot -Tpdf file.dot -o file.pdf
```

The patch will transform the scientific notation(like `value = [  2.470544e6   1.2706e4 ]`) into normal one(like  `value = [  2470544.   12706.]`).

[1] http://scikit-learn.org/stable/modules/tree.html#classification
[2] http://scikit-learn.org/stable/modules/generated/sklearn.tree.export_graphviz.html#sklearn.tree.export_graphviz
