### PR TITLE
Patch for errors introduced in the sparse label binarizer

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -530,7 +530,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
 def _inverse_binarize_multiclass(y, classes):
     """Inverse label binarization transformation for multiclass.
 
-    Multiclass uses the maximal score instead of a threshold
+    Multiclass uses the maximal score instead of a threshold.
     """
     classes = np.asarray(classes)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -19,6 +19,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils.fixes import np_version
 from ..utils.fixes import sparse_min_max
 from ..utils import deprecated, column_or_1d
+from ..utils import astype
 
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -508,8 +508,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
         return Y
 
     if not sparse_output:
-        Y = Y.toarray()
-        Y = Y.astype(int, copy=False)
+        Y = Y.toarray().astype(int, copy=False)
 
         if neg_label != 0:
             Y[Y == 0] = neg_label

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -509,6 +509,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
 
     if not sparse_output:
         Y = Y.toarray()
+        Y = Y.astype(int, copy=False)
 
         if neg_label != 0:
             Y[Y == 0] = neg_label

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -18,8 +18,8 @@ from ..base import BaseEstimator, TransformerMixin
 
 from ..utils.fixes import np_version
 from ..utils.fixes import sparse_min_max
+from ..utils.fixes import astype
 from ..utils import deprecated, column_or_1d
-from ..utils import astype
 
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -16,8 +16,10 @@ import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
 
+
 from ..utils.fixes import np_version
 from ..utils.fixes import sparse_min_max
+from ..utils.fixes import astype
 from ..utils import deprecated, column_or_1d
 
 from ..utils.multiclass import unique_labels
@@ -508,7 +510,8 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
         return Y
 
     if not sparse_output:
-        Y = Y.toarray().astype(int, copy=False)
+        Y = Y.toarray()
+        Y = astype(Y, int, copy=False)
 
         if neg_label != 0:
             Y[Y == 0] = neg_label
@@ -524,6 +527,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
     if y_type == "binary":
         Y = Y[:, -1].reshape((-1, 1))
 
+    print Y
     return Y
 
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -16,10 +16,8 @@ import scipy.sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin
 
-
 from ..utils.fixes import np_version
 from ..utils.fixes import sparse_min_max
-from ..utils.fixes import astype
 from ..utils import deprecated, column_or_1d
 
 from ..utils.multiclass import unique_labels
@@ -527,7 +525,6 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
     if y_type == "binary":
         Y = Y[:, -1].reshape((-1, 1))
 
-    print Y
     return Y
 
 


### PR DESCRIPTION
The error:

```
======================================================================
ERROR: Test that ovr works with classes that are always present or absent
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/anaconda/envs/testenv/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/tests/test_multiclass.py", line 73, in test_ovr_always_present
    assert_warns(UserWarning, ovr.fit, X, y)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/utils/testing.py", line 135, in assert_warns
    result = func(*args, **kw)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/multiclass.py", line 202, in fit
    n_jobs=self.n_jobs)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/multiclass.py", line 92, in fit_ovr
    for i in range(Y.shape[1]))
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/parallel.py", line 644, in __call__
    self.dispatch(function, args, kwargs)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/parallel.py", line 391, in dispatch
    job = ImmediateApply(func, args, kwargs)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/parallel.py", line 129, in __init__
    self.results = func(*args, **kwargs)
  File "/home/travis/build/scikit-learn/scikit-learn/sklearn/multiclass.py", line 57, in _fit_binary
    str(classes[c]))
TypeError: list indices must be integers, not numpy.float64
----------------------------------------------------------------------
```
