### PR TITLE
[MRG+1] Add partial_fit to GaussianNB

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -273,7 +273,7 @@ class GaussianNB(BaseNB):
             self.sigma_[:, :] -= epsilon
 
 
-        class2idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+        class2idx = dict((cls, idx) for idx, cls in enumerate(self.classes_))
         for y_i in np.unique(y):
             i = class2idx[y_i]
             X_i = X[y == y_i, :]

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -106,10 +106,10 @@ class GaussianNB(BaseNB):
 
     Attributes
     ----------
-    `class_prior_` : array, shape (n_classes)
+    `class_prior_` : array, shape (n_classes,)
         probability of each class.
 
-    `class_count_` : array, shape (n_classes)
+    `class_count_` : array, shape (n_classes,)
         number of training samples observed in each class.
 
     `theta_` : array, shape (n_classes, n_features)
@@ -141,11 +141,11 @@ class GaussianNB(BaseNB):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X : array-like, shape = (n_samples, n_features)
             Training vectors, where n_samples is the number of samples
             and n_features is the number of features.
 
-        y : array-like, shape = [n_samples]
+        y : array-like, shape = (n_samples,)
             Target values.
 
         Returns
@@ -193,21 +193,21 @@ class GaussianNB(BaseNB):
 
         Parameters
         ----------
-        n_past : scalar
+        n_past : int
             Number of samples represented in old mean and variance.
 
-        mu: array-like, shape (number of Gaussians)
+        mu: array-like, shape (number of Gaussians,)
             Means for Gaussians in original set.
 
-        var: array-like, shape (number of Gaussians)
+        var: array-like, shape (number of Gaussians,)
             Variances for Gaussians in original set.
 
         Returns
         -------
-        mu_new: array-like, shape (number of Gaussians)
+        mu_new: array-like, shape (number of Gaussians,)
             Updated mean for each Gaussian over the combined set.
 
-        var_new: array-like, shape (number of Gaussians)
+        var_new: array-like, shape (number of Gaussians,)
             Updated variance for each Gaussian over the combined set.
         """
         if n_past == 0:
@@ -249,10 +249,10 @@ class GaussianNB(BaseNB):
             Training vectors, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like, shape (n_samples)
+        y : array-like, shape (n_samples,)
             Target values.
 
-        classes : array-like, shape = (n_classes)
+        classes : array-like, shape (n_classes,)
             List of all the classes that can possibly appear in the y vector.
 
             Must be provided at the first call to partial_fit, can be omitted
@@ -295,7 +295,7 @@ class GaussianNB(BaseNB):
             self.class_count_[i] += N_i
 
         self.sigma_[:, :] += epsilon
-        self.class_prior_ = self.class_count_ / np.sum(self.class_count_)
+        self.class_prior_[:] = self.class_count_ / np.sum(self.class_count_)
         return self
 
     def _joint_log_likelihood(self, X):

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -104,6 +104,12 @@ class GaussianNB(BaseNB):
     """
     Gaussian Naive Bayes (GaussianNB)
 
+    Can perform online updates to model parameters via `partial_fit` method.
+    For details on algorithm used to update feature means and variance online,
+    see Stanford CS tech report STAN-CS-79-773 by Chan, Golub, and LeVeque:
+
+        http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf
+
     Attributes
     ----------
     `class_prior_` : array, shape (n_classes,)
@@ -141,11 +147,11 @@ class GaussianNB(BaseNB):
 
         Parameters
         ----------
-        X : array-like, shape = (n_samples, n_features)
+        X : array-like, shape (n_samples, n_features)
             Training vectors, where n_samples is the number of samples
             and n_features is the number of features.
 
-        y : array-like, shape = (n_samples,)
+        y : array-like, shape (n_samples,)
             Target values.
 
         Returns
@@ -222,7 +228,8 @@ class GaussianNB(BaseNB):
         n_total = float(n_past + n_new)
 
         total_ssd = (old_ssd + new_ssd +
-                     n_past * (n_new * mu - new_sum) ** 2 / (n_new * n_total))
+                     (n_past / float(n_new * n_total)) *
+                     (n_new * mu - new_sum) ** 2)
 
         total_sum = new_sum + (mu * n_past)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -136,6 +136,20 @@ def test_discretenb_partial_fit():
         yield check_partial_fit, cls
 
 
+def test_gnb_partial_fit():
+    clf = GaussianNB().fit(X, y)
+    clf_pf = GaussianNB().partial_fit(X, y, np.unique(y))
+    assert_array_almost_equal(clf.theta_, clf_pf.theta_)
+    assert_array_almost_equal(clf.sigma_, clf_pf.sigma_)
+    assert_array_almost_equal(clf.class_prior_, clf_pf.class_prior_)
+
+    clf_pf2 = GaussianNB().partial_fit(X[0::2, :], y[0::2], np.unique(y))
+    clf_pf2.partial_fit(X[1::2], y[1::2])
+    assert_array_almost_equal(clf.theta_, clf_pf2.theta_)
+    assert_array_almost_equal(clf.sigma_, clf_pf2.sigma_)
+    assert_array_almost_equal(clf.class_prior_, clf_pf2.class_prior_)
+
+
 def test_discretenb_pickle():
     """Test picklability of discrete naive Bayes classifiers"""
 


### PR DESCRIPTION
Uses a [method due to Chan, Golub, and LeVeque](http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf) to perform online update of the model parameters in `GaussianNB`. Does not implement sample weighting.

Added tests to `test_naive_bayes` to ensure that `partial_fit` called on the entire toy set produces the same result as `fit`, and that it produces the same result even if the toy set is fitted in two parts.

TODO: `fit` could be a thin wrapper around `partial_fit` rather than duplicating code.
