### PR TITLE
MAINT remove residual sparsefuncs*.so when compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clean: clean-ctags
 
 in: inplace # just a shortcut
 inplace:
+	rm -f sklearn/utils.sparsefuncs*.so  # to avoid errors in 0.15 upgrade
 	$(PYTHON) setup.py build_ext -i
 
 test-code: in


### PR DESCRIPTION
The sparsefuncs -> sparsefuncs_fast rename in bbb8f1d has caused a lot of errors being reported (`ImportError: cannot import name 'inplace_column_scale'` or similar) due to dirty working copies. This attempts to avoid that by removing the old file explicitly. Ideally this deletion would only remain in the codebase for a short while, while <=0.14 users pull in the file rename.

The current solution may be too simple:
- many users may be using `python setup.py build --inplace` directly
- I do not think the current solution suffices in Windows
