### PR TITLE
[MRG+2] MAINT skip tests that require large data download under travis

### DIFF
--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -11,6 +11,11 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python setup.py build_ext --inplace
 
+# Skip tests that require large downloads over the network to save bandwith
+# usage as travis workers are stateless and therefore traditional local
+# disk caching does not work.
+export SKLEARN_SKIP_NETWORK_TESTS=1
+
 if [[ "$COVERAGE" == "true" ]]; then
     make test-coverage
 else

--- a/doc/tutorial/text_analytics/working_with_text_data_fixture.py
+++ b/doc/tutorial/text_analytics/working_with_text_data_fixture.py
@@ -1,3 +1,13 @@
+"""Fixture module to skip the datasets loading when offline
+
+The 20 newsgroups data is rather large and some CI workers such as travis are
+stateless hence will not cache the dataset as regular sklearn users would do.
+
+The following will skip the execution of the working_with_text_data.rst doctests
+is the proper environment variable is configured (see the source code of
+check_skip_network for more details).
+
+"""
 from sklearn.utils.testing import check_skip_network
 
 

--- a/doc/tutorial/text_analytics/working_with_text_data_fixture.py
+++ b/doc/tutorial/text_analytics/working_with_text_data_fixture.py
@@ -1,0 +1,5 @@
+from sklearn.utils.testing import check_skip_network
+
+
+def setup_module():
+    check_skip_network()

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -8,6 +8,7 @@
 #          Arnaud Joly
 #          Denis Engemann
 # License: BSD 3 clause
+import os
 import inspect
 import pkgutil
 import warnings
@@ -578,3 +579,11 @@ def clean_warning_registry():
     for mod in sys.modules.copy().values():
         if hasattr(mod, reg):
             getattr(mod, reg).clear()
+
+
+def check_skip_network():
+    if int(os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', 0)):
+        raise SkipTest("Text tutorial requires large dataset download")
+
+
+with_network = with_setup(check_skip_network)


### PR DESCRIPTION
The text tutorial requires the 20 newsgroups data that gets downloaded over and over by stateless travis workers wasting a significant amount of bandwidth.

Furthermore this should reduce memory pressure that caused some heisen failures when calling `os.fork()` on a large Python process on loaded travis workers.
