### PR TITLE
Fix MinMaxScaler for 1D inputs.

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -204,7 +204,10 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         data_min = np.min(X, axis=0)
         data_range = np.max(X, axis=0) - data_min
         # Do not scale constant features
-        data_range[data_range == 0.0] = 1.0
+        if isinstance(data_range, np.ndarray):
+            data_range[data_range == 0.0] = 1.0
+        elif data_range == 0.:
+            data_range = 1.
         self.scale_ = (feature_range[1] - feature_range[0]) / data_range
         self.min_ = feature_range[0] - data_min * self.scale_
         self.data_range = data_range

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -209,6 +209,29 @@ def test_min_max_scaler_zero_variance_features():
     assert_array_almost_equal(X_trans, X_expected_1_2)
 
 
+def test_min_max_scaler_1d():
+    """Test scaling of dataset along single axis"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(5)
+    X_orig_copy = X.copy()
+
+    scaler = MinMaxScaler()
+    X_scaled = scaler.fit(X).transform(X)
+    assert_array_almost_equal(X_scaled.min(axis=0), 0.0)
+    assert_array_almost_equal(X_scaled.max(axis=0), 1.0)
+
+    # check inverse transform
+    X_scaled_back = scaler.inverse_transform(X_scaled)
+    assert_array_almost_equal(X_scaled_back, X_orig_copy)
+
+    # Test with 1D list
+    X = [0., 1., 2, 0.4, 1.]
+    scaler = MinMaxScaler()
+    X_scaled = scaler.fit(X).transform(X)
+    assert_array_almost_equal(X_scaled.min(axis=0), 0.0)
+    assert_array_almost_equal(X_scaled.max(axis=0), 1.0)
+
+
 def test_scaler_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -7,6 +7,8 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_greater_equal
+from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
@@ -230,6 +232,13 @@ def test_min_max_scaler_1d():
     X_scaled = scaler.fit(X).transform(X)
     assert_array_almost_equal(X_scaled.min(axis=0), 0.0)
     assert_array_almost_equal(X_scaled.max(axis=0), 1.0)
+
+    # Constant feature.
+    X = np.zeros(5)
+    scaler = MinMaxScaler()
+    X_scaled = scaler.fit(X).transform(X)
+    assert_greater_equal(X_scaled.min(), 0.)
+    assert_less_equal(X_scaled.max(), 1.)
 
 
 def test_scaler_without_centering():


### PR DESCRIPTION
Now MinMaxScaler chokes on 1D input arrays (only one feature).

This patches it the same way as already done for the StandardScaler.
