### PR TITLE
Truncating in MinMaxScaler

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -169,6 +169,12 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         Set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array).
 
+    truncate : boolean, optional, default is False
+        If True, :meth:`transform` will truncate any inputs that lie outside
+        the min/max of the values passed to :meth:`fit` to lie on the ends
+        of feature_range. Normally, the transform of these points will be
+        outside feature_range.
+
     Attributes
     ----------
     min_ : ndarray, shape (n_features,)
@@ -178,9 +184,10 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         Per feature relative scaling of the data.
     """
 
-    def __init__(self, feature_range=(0, 1), copy=True):
+    def __init__(self, feature_range=(0, 1), copy=True, truncate=False):
         self.feature_range = feature_range
         self.copy = copy
+        self.truncate = truncate
 
     def fit(self, X, y=None):
         """Compute the minimum and maximum to be used for later scaling.
@@ -221,10 +228,16 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X = check_array(X, copy=self.copy, ensure_2d=False)
         X *= self.scale_
         X += self.min_
+        if self.truncate:
+            np.maximum(self.feature_range[0], X, out=X)
+            np.minimum(self.feature_range[1], X, out=X)
         return X
 
     def inverse_transform(self, X):
         """Undo the scaling of X according to feature_range.
+
+        Note that if truncate is true, any truncated points will not
+        be restored exactly.
 
         Parameters
         ----------

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -15,6 +15,7 @@ import warnings
 import sys
 import re
 import platform
+import operator
 
 import scipy as sp
 import scipy.io
@@ -45,6 +46,7 @@ from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_less
+from numpy.testing.utils import assert_array_compare
 import numpy as np
 
 from sklearn.base import (ClassifierMixin, RegressorMixin, TransformerMixin,
@@ -53,7 +55,9 @@ from sklearn.base import (ClassifierMixin, RegressorMixin, TransformerMixin,
 __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
            "assert_raises_regexp", "raises", "with_setup", "assert_true",
            "assert_false", "assert_almost_equal", "assert_array_equal",
-           "assert_array_almost_equal", "assert_array_less",
+           "assert_array_almost_equal",
+           "assert_array_less", "assert_array_less_equal",
+           "assert_array_greater", "assert_array_greater_equal",
            "assert_less", "assert_less_equal",
            "assert_greater", "assert_greater_equal"]
 
@@ -118,6 +122,23 @@ def assert_greater_equal(a, b, msg=None):
     if msg is not None:
         message += ": " + msg
     assert a >= b, message
+
+
+# like numpy.testing.assert_array_less, since numpy doesn't have those
+def assert_array_greater(x, y, err_msg='', verbose=True):
+    assert_array_compare(operator.__gt__, x, y, err_msg=err_msg,
+                         verbose=verbose,
+                         header='Arrays are not greater-ordered')
+
+def assert_array_greater_equal(x, y, err_msg='', verbose=True):
+    assert_array_compare(operator.__ge__, x, y, err_msg=err_msg,
+                         verbose=verbose,
+                         header='Arrays are not greater-or-equal-ordered')
+
+def assert_array_less_equal(x, y, err_msg='', verbose=True):
+    assert_array_compare(operator.__le__, x, y, err_msg=err_msg,
+                         verbose=verbose,
+                         header='Arrays are not less-or-equal-ordered')
 
 
 # To remove when we support numpy 1.7


### PR DESCRIPTION
The output of MinMaxScaler doesn't always lie within the passed feature range, if data that you transform() has values outside the range of the values that you fit() on. If you're using it just to make the scale of the data nicer, this probably doesn't matter, but if your algorithm actually relies on the data lying in a certain range ([example](https://github.com/dougalsutherland/skl-groups/blob/2c7874e824b6f4c78d15c5e1c3f963b444a98b6e/skl_groups/summaries/l2_density.py)) this is no good.

So, this PR adds optional support for truncation, so that values that would be transformed outside of feature_range are clipped to the ends of it. It also adds a fit_feature_range to make truncation less likely (e.g. if you need your data to lie in [0, 1], you can make your training data like in [.1, .9] and then test values have more of a range to avoid clipping).

Incidentally, I also add assert_array_{less_equal,greater,greater_equal} because my tests wanted them and it's silly that numpy only provides assert_array_less.
