### PR TITLE
Remove duplicate GaussianNB.fit() code

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -270,7 +270,7 @@ class GaussianNB(BaseNB):
             Must be provided at the first call to partial_fit, can be omitted
             in subsequent calls.
 
-        _refit: boolean
+        _refit: bool
             If true, act as though this were the first time we called
             _partial_fit (ie, throw away any past fitting and start over).
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -310,8 +310,8 @@ def type_of_target(y):
 def _check_partial_fit_first_call(clf, classes=None):
     """Private helper function for factorizing common classes param logic
 
-    Estimator that implement the ``partial_fit`` API need to be provided with
-    the list of possible classes at the first call to partial fit.and
+    Estimators that implement the ``partial_fit`` API need to be provided with
+    the list of possible classes at the first call to partial_fit.
 
     Subsequent calls to partial_fit should check that ``classes`` is still
     consistent with a previous value of ``clf.classes_`` when provided.


### PR DESCRIPTION
Follow-on to #3324. 

`GaussianNB.fit` is substantially duplicated by `partial_fit`, and the latter is more flexible, so just have the former call the latter. There should be no significant degradation in performance or numerical stability, since the mean/variance update will just call `numpy.mean` and `numpy.var` when `n_past == 0` rather than trying anything fancy.
