### PR TITLE
[MRG+1] Skip test for OrthogonalMatchingPursuitCV if running on Travis

### DIFF
--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import check_skip_travis
 
 
 from sklearn.linear_model import (orthogonal_mp, orthogonal_mp_gram,
@@ -188,6 +189,7 @@ def test_omp_path():
 
 
 def test_omp_cv():
+    check_skip_travis()
     y_ = y[:, 0]
     gamma_ = gamma[:, 0]
     ompcv = OrthogonalMatchingPursuitCV(normalize=True, fit_intercept=False,

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -189,6 +189,7 @@ def test_omp_path():
 
 
 def test_omp_cv():
+    # FIXME: This test is unstable on Travis, see issue #3190 for more detail.
     check_skip_travis()
     y_ = y[:, 0]
     gamma_ = gamma[:, 0]

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -602,4 +602,10 @@ def check_skip_network():
         raise SkipTest("Text tutorial requires large dataset download")
 
 
+def check_skip_travis():
+    """Skip test if being run on Travis."""
+    if os.environ.get('TRAVIS') == "true":
+        raise SkipTest("This test needs to be skipped on Travis")
+
 with_network = with_setup(check_skip_network)
+with_travis = with_setup(check_skip_travis)


### PR DESCRIPTION
OrthogonalMatchingPursuitCV has been having heisen-failures on Travis for quite some time. 

See #3190 for more details.

I have been unable to replicate this test on a local box using varying Python, numpy, scipy, and BLAS implementations. I have also been unable to replicate this using a CoreOS VM on Rackspace using Docker (along with the above veriations), and severely limiting memory available to the container. One way to avoid this failure is simply skip this particular test on Travis, using a similar technique as #3333.
