### PR TITLE
Fix labels of inliers vs outliers

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -31,7 +31,7 @@ new observations can then be sorted as inliers or outliers with a
 
     estimator.predict(X_test)
 
-Inliers are labeled 0, while outliers are labeled 1.
+Inliers are labeled 1, while outliers are labeled -1.
 
 Novelty Detection
 =================


### PR DESCRIPTION
At least based on what svm.OneClassSVM does in the example linked from this document, the description was wrong; labels actually assigned are 1/-1 for good/bad respectively, not 0/1.
