### PR TITLE
Use float as percentage in min_samples_split and min_samples_leaf of DecisionTree

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -163,20 +163,20 @@ in bias::
     >>> X, y = make_blobs(n_samples=10000, n_features=10, centers=100,
     ...     random_state=0)
 
-    >>> clf = DecisionTreeClassifier(max_depth=None, min_samples_split=1,
+    >>> clf = DecisionTreeClassifier(max_depth=None, min_samples_split=2,
     ...     random_state=0)
     >>> scores = cross_val_score(clf, X, y)
     >>> scores.mean()                             # doctest: +ELLIPSIS
     0.97...
 
     >>> clf = RandomForestClassifier(n_estimators=10, max_depth=None,
-    ...     min_samples_split=1, random_state=0)
+    ...     min_samples_split=2, random_state=0)
     >>> scores = cross_val_score(clf, X, y)
     >>> scores.mean()                             # doctest: +ELLIPSIS
     0.999...
 
     >>> clf = ExtraTreesClassifier(n_estimators=10, max_depth=None,
-    ...     min_samples_split=1, random_state=0)
+    ...     min_samples_split=2, random_state=0)
     >>> scores = cross_val_score(clf, X, y)
     >>> scores.mean() > 0.999
     True

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -315,8 +315,7 @@ Tips on practical use
     samples at a leaf node.  A very small number will usually mean the tree
     will overfit, whereas a large number will prevent the tree from learning
     the data. Try ``min_samples_leaf=5`` as an initial value. If the sample size
-    varies greatly, a float number can be used as percentage in these two
-    parameters in case the sample size varies greatly.
+    varies greatly, a float number can be used as percentage in these two parameters.
     The main difference between the two is that ``min_samples_leaf`` guarantees
     a minimum number of samples in a leaf, while ``min_samples_split`` can
     create arbitrary small leaves, though ``min_samples_split`` is more common

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -314,7 +314,9 @@ Tips on practical use
   * Use ``min_samples_split`` or ``min_samples_leaf`` to control the number of
     samples at a leaf node.  A very small number will usually mean the tree
     will overfit, whereas a large number will prevent the tree from learning
-    the data.  Try ``min_samples_leaf=5`` as an initial value.
+    the data. Try ``min_samples_leaf=5`` as an initial value. If the sample size
+    varies greatly, a float number can be used as percentage in these two
+    parameters in case the sample size varies greatly.
     The main difference between the two is that ``min_samples_leaf`` guarantees
     a minimum number of samples in a leaf, while ``min_samples_split`` can
     create arbitrary small leaves, though ``min_samples_split`` is more common

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -694,18 +694,22 @@ class RandomForestClassifier(ForestClassifier):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
         Note: this parameter is tree-specific.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -860,18 +864,22 @@ class RandomForestRegressor(ForestRegressor):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
         Note: this parameter is tree-specific.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1016,18 +1024,22 @@ class ExtraTreesClassifier(ForestClassifier):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
         Note: this parameter is tree-specific.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1185,18 +1197,22 @@ class ExtraTreesRegressor(ForestRegressor):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
         Note: this parameter is tree-specific.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1324,18 +1340,22 @@ class RandomTreesEmbedding(BaseForest):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
         Note: this parameter is tree-specific.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -692,14 +692,20 @@ class RandomForestClassifier(ForestClassifier):
         Ignored if ``max_samples_leaf`` is not None.
         Note: this parameter is tree-specific.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
         Note: this parameter is tree-specific.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples in newly created leaves.  A split is
-        discarded if after the split, one of the leaves would contain less then
-        ``min_samples_leaf`` samples.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -852,14 +858,20 @@ class RandomForestRegressor(ForestRegressor):
         Ignored if ``max_samples_leaf`` is not None.
         Note: this parameter is tree-specific.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
         Note: this parameter is tree-specific.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples in newly created leaves.  A split is
-        discarded if after the split, one of the leaves would contain less then
-        ``min_samples_leaf`` samples.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1002,14 +1014,20 @@ class ExtraTreesClassifier(ForestClassifier):
         Ignored if ``max_samples_leaf`` is not None.
         Note: this parameter is tree-specific.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
         Note: this parameter is tree-specific.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples in newly created leaves.  A split is
-        discarded if after the split, one of the leaves would contain less then
-        ``min_samples_leaf`` samples.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1165,14 +1183,20 @@ class ExtraTreesRegressor(ForestRegressor):
         Ignored if ``max_samples_leaf`` is not None.
         Note: this parameter is tree-specific.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
         Note: this parameter is tree-specific.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples in newly created leaves.  A split is
-        discarded if after the split, one of the leaves would contain less then
-        ``min_samples_leaf`` samples.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1298,14 +1322,20 @@ class RandomTreesEmbedding(BaseForest):
         min_samples_split samples.
         Ignored if ``max_samples_leaf`` is not None.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
         Note: this parameter is tree-specific.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples in newly created leaves.  A split is
-        discarded if after the split, one of the leaves would contain less then
-        ``min_samples_leaf`` samples.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
         Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -994,17 +994,19 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
 
 
     min_weight_fraction_leaf : float, optional (default=0.)
@@ -1020,14 +1022,15 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
-          - If int, then consider `max_features` features at each split.
-          - If float, then `max_features` is a percentage and
-            `int(max_features * n_features)` features are considered at each
-            split.
-          - If "auto", then `max_features=sqrt(n_features)`.
-          - If "sqrt", then `max_features=sqrt(n_features)`.
-          - If "log2", then `max_features=log2(n_features)`.
-          - If None, then `max_features=n_features`.
+
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a percentage and
+          `int(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=sqrt(n_features)`.
+        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
 
         Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.
@@ -1271,17 +1274,19 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
@@ -1296,14 +1301,15 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
-          - If int, then consider `max_features` features at each split.
-          - If float, then `max_features` is a percentage and
-            `int(max_features * n_features)` features are considered at each
-            split.
-          - If "auto", then `max_features=n_features`.
-          - If "sqrt", then `max_features=sqrt(n_features)`.
-          - If "log2", then `max_features=log2(n_features)`.
-          - If None, then `max_features=n_features`.
+
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a percentage and
+          `int(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=n_features`.
+        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
 
         Choosing `max_features < n_features` leads to a reduction of variance
         and an increase in bias.

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -992,11 +992,20 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         of the input variables.
         Ignored if ``max_samples_leaf`` is not None.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples required to be at a leaf node.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
+
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
@@ -1260,11 +1269,19 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         for best performance; the best value depends on the interaction
         of the input variables.
 
-    min_samples_split : integer, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
 
-    min_samples_leaf : integer, optional (default=1)
-        The minimum number of samples required to be at a leaf node.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -561,7 +561,7 @@ def check_min_samples_split(name, X, y):
     assert_raises(ValueError,
                   ForestEstimator(min_samples_split=0).fit, X, y)
     assert_raises(ValueError,
-                  ForestEstimator(min_samples_split=1.0).fit, X, y)
+                  ForestEstimator(min_samples_split=1.1).fit, X, y)
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes
@@ -602,7 +602,7 @@ def check_min_samples_leaf(name, X, y):
     assert_raises(ValueError,
                   ForestEstimator(min_samples_leaf=0).fit, X, y)
     assert_raises(ValueError,
-                  ForestEstimator(min_samples_leaf=0.6).fit, X, y)
+                  ForestEstimator(min_samples_leaf=1.0).fit, X, y)
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -56,6 +56,10 @@ perm = rng.permutation(boston.target.size)
 boston.data = boston.data[perm]
 boston.target = boston.target[perm]
 
+# also make a hastie_10_2 dataset
+hastie_X, hastie_y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+hastie_X = hastie_X.astype(np.float32)
+
 FOREST_CLASSIFIERS = {
     "ExtraTreesClassifier": ExtraTreesClassifier,
     "RandomForestClassifier": RandomForestClassifier,
@@ -543,9 +547,8 @@ def check_max_leaf_nodes_max_depth(name, X, y):
 
 
 def test_max_leaf_nodes_max_depth():
-    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
     for name in FOREST_ESTIMATORS:
-        yield check_max_leaf_nodes_max_depth, name, X, y
+        yield check_max_leaf_nodes_max_depth, name, hastie_X, hastie_y
 
 
 def check_min_samples_split(name, X, y):
@@ -573,7 +576,7 @@ def check_min_samples_split(name, X, y):
         assert_greater(np.min(node_samples), 9,
                        "Failed with {0}".format(name))
 
-        est = ForestEstimator(min_samples_split=0.1,
+        est = ForestEstimator(min_samples_split=0.5,
                               max_leaf_nodes=max_leaf_nodes,
                               random_state=0)
         est.fit(X, y)
@@ -585,10 +588,8 @@ def check_min_samples_split(name, X, y):
 
 
 def test_min_samples_split():
-    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
-    X = X.astype(np.float32)
     for name in FOREST_ESTIMATORS:
-        yield check_min_samples_split, name, X, y
+        yield check_min_samples_split, name, hastie_X, hastie_y
 
 
 def check_min_samples_leaf(name, X, y):
@@ -618,7 +619,7 @@ def check_min_samples_leaf(name, X, y):
                        "Failed with {0}".format(name))
 
     for max_leaf_nodes in (None, 1000):
-        est = ForestEstimator(min_samples_leaf=0.05,
+        est = ForestEstimator(min_samples_leaf=0.25,
                               max_leaf_nodes=max_leaf_nodes,
                               random_state=0)
         est.fit(X, y)
@@ -631,10 +632,8 @@ def check_min_samples_leaf(name, X, y):
 
 
 def test_min_samples_leaf():
-    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
-    X = X.astype(np.float32)
     for name in FOREST_ESTIMATORS:
-        yield check_min_samples_leaf, name, X, y
+        yield check_min_samples_leaf, name, hastie_X, hastie_y
 
 
 def check_min_weight_fraction_leaf(name, X, y):
@@ -669,10 +668,8 @@ def check_min_weight_fraction_leaf(name, X, y):
 
 
 def test_min_weight_fraction_leaf():
-    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
-    X = X.astype(np.float32)
     for name in FOREST_ESTIMATORS:
-        yield check_min_weight_fraction_leaf, name, X, y
+        yield check_min_weight_fraction_leaf, name, hastie_X, hastie_y
 
 
 def check_memory_layout(name, dtype):
@@ -737,7 +734,7 @@ def test_1d_input():
 def check_warm_start(name, random_state=42):
     """Test if fitting incrementally with warm start gives a forest of the
     right size and the same results as a normal fit."""
-    X, y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+    X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
     clf_ws = None
     for n_estimators in [5, 10]:
@@ -769,7 +766,7 @@ def test_warm_start():
 def check_warm_start_clear(name):
     """Test if fit clears state and grows a new forest when warm_start==False.
     """
-    X, y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+    X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
     clf = ForestEstimator(n_estimators=5, max_depth=1, warm_start=False,
                           random_state=1)
@@ -791,7 +788,7 @@ def test_warm_start_clear():
 
 def check_warm_start_smaller_n_estimators(name):
     """Test if warm start second fit with smaller n_estimators raises error."""
-    X, y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+    X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
     clf = ForestEstimator(n_estimators=5, max_depth=1, warm_start=True)
     clf.fit(X, y)
@@ -807,7 +804,7 @@ def test_warm_start_smaller_n_estimators():
 def check_warm_start_equal_n_estimators(name):
     """Test if warm start with equal n_estimators does nothing and returns the
     same forest and raises a warning."""
-    X, y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+    X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
     clf = ForestEstimator(n_estimators=5, max_depth=3, warm_start=True,
                           random_state=1)
@@ -832,7 +829,7 @@ def test_warm_start_equal_n_estimators():
 
 def check_warm_start_oob(name):
     """Test that the warm start computes oob score when asked."""
-    X, y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+    X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
     # Use 15 estimators to avoid 'some inputs do not have OOB scores' warning.
     clf = ForestEstimator(n_estimators=15, max_depth=3, warm_start=False,

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -565,7 +565,6 @@ def check_min_samples_split(name, X, y):
         assert_greater(np.min(node_samples), 9,
                        "Failed with {0}".format(name))
 
-    for max_leaf_nodes in (None, 1000):
         est = ForestEstimator(min_samples_split=0.1,
                               max_leaf_nodes=max_leaf_nodes,
                               random_state=0)
@@ -575,6 +574,13 @@ def check_min_samples_split(name, X, y):
 
         assert_greater(np.min(node_samples), 9,
                        "Failed with {0}".format(name))
+
+
+def test_min_samples_split():
+    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
+    X = X.astype(np.float32)
+    for name in FOREST_ESTIMATORS:
+        yield check_min_samples_split, name, X, y
 
 
 def check_min_samples_leaf(name, X, y):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -552,6 +552,14 @@ def check_min_samples_split(name, X, y):
     """Test min_samples_split parameter"""
     ForestEstimator = FOREST_ESTIMATORS[name]
 
+    # test boundary value
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=-1).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=0).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=1.0).fit, X, y)
+
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes
     for max_leaf_nodes in (None, 1000):
@@ -586,6 +594,14 @@ def test_min_samples_split():
 def check_min_samples_leaf(name, X, y):
     """Test if leaves contain more than leaf_count training examples"""
     ForestEstimator = FOREST_ESTIMATORS[name]
+
+    # test boundary value
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_leaf=-1).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_leaf=0).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_leaf=0.6).fit, X, y)
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -81,15 +81,11 @@ def test_parameter_checks():
                   GradientBoostingClassifier(min_samples_split=0.0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_split=-1.0).fit, X, y)
-    assert_raises(ValueError,
-                  GradientBoostingClassifier(min_samples_split=1.5).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=-1.).fit, X, y)
-    assert_raises(ValueError,
-                  GradientBoostingClassifier(min_samples_leaf=1.5).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_weight_fraction_leaf=-1.).fit,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -81,11 +81,15 @@ def test_parameter_checks():
                   GradientBoostingClassifier(min_samples_split=0.0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_split=-1.0).fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingClassifier(min_samples_split=1.0).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=0).fit, X, y)
     assert_raises(ValueError,
-                  GradientBoostingClassifier(min_samples_leaf=-1.).fit, X, y)
+                  GradientBoostingClassifier(min_samples_leaf=-1.0).fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingClassifier(min_samples_leaf=0.6).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_weight_fraction_leaf=-1.).fit,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -81,11 +81,15 @@ def test_parameter_checks():
                   GradientBoostingClassifier(min_samples_split=0.0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_split=-1.0).fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingClassifier(min_samples_split=1.5).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=-1.).fit, X, y)
+    assert_raises(ValueError,
+                  GradientBoostingClassifier(min_samples_leaf=1.5).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_weight_fraction_leaf=-1.).fit,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -82,14 +82,14 @@ def test_parameter_checks():
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_split=-1.0).fit, X, y)
     assert_raises(ValueError,
-                  GradientBoostingClassifier(min_samples_split=1.0).fit, X, y)
+                  GradientBoostingClassifier(min_samples_split=1.1).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=0).fit, X, y)
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_samples_leaf=-1.0).fit, X, y)
     assert_raises(ValueError,
-                  GradientBoostingClassifier(min_samples_leaf=0.6).fit, X, y)
+                  GradientBoostingClassifier(min_samples_leaf=1.0).fit, X, y)
 
     assert_raises(ValueError,
                   GradientBoostingClassifier(min_weight_fraction_leaf=-1.).fit,
@@ -145,7 +145,7 @@ def test_classification_synthetic():
     X_train, X_test = X[:2000], X[2000:]
     y_train, y_test = y[:2000], y[2000:]
 
-    gbrt = GradientBoostingClassifier(n_estimators=100, min_samples_split=1,
+    gbrt = GradientBoostingClassifier(n_estimators=100, min_samples_split=2,
                                       max_depth=1,
                                       learning_rate=1.0, random_state=0)
     gbrt.fit(X_train, y_train)
@@ -153,7 +153,7 @@ def test_classification_synthetic():
     assert error_rate < 0.085, \
         "GB failed with error %.4f" % error_rate
 
-    gbrt = GradientBoostingClassifier(n_estimators=200, min_samples_split=1,
+    gbrt = GradientBoostingClassifier(n_estimators=200, min_samples_split=2,
                                       max_depth=1,
                                       learning_rate=1.0, subsample=0.5,
                                       random_state=0)
@@ -170,7 +170,7 @@ def test_boston():
         for subsample in (1.0, 0.5):
             clf = GradientBoostingRegressor(n_estimators=100, loss=loss,
                                             max_depth=4, subsample=subsample,
-                                            min_samples_split=1,
+                                            min_samples_split=2,
                                             random_state=1)
 
             assert_raises(ValueError, clf.predict, boston.data)
@@ -197,7 +197,7 @@ def test_regression_synthetic():
     `Bagging Predictors?. Machine Learning 24(2): 123-140 (1996). """
     random_state = check_random_state(1)
     regression_params = {'n_estimators': 100, 'max_depth': 4,
-                         'min_samples_split': 1, 'learning_rate': 0.1,
+                         'min_samples_split': 2, 'learning_rate': 0.1,
                          'loss': 'ls'}
 
     # Friedman1
@@ -234,7 +234,7 @@ def test_feature_importances():
     y = np.array(boston.target, dtype=np.float32)
 
     clf = GradientBoostingRegressor(n_estimators=100, max_depth=5,
-                                    min_samples_split=1, random_state=1)
+                                    min_samples_split=2, random_state=1)
     clf.fit(X, y)
     #feature_importances = clf.feature_importances_
     assert_true(hasattr(clf, 'feature_importances_'))

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -19,7 +19,7 @@ true_result = [-1, 1, 1]
 def test_graphviz_toy():
     """Check correctness of export_graphviz"""
     clf = DecisionTreeClassifier(max_depth=3,
-                                 min_samples_split=1,
+                                 min_samples_split=2,
                                  criterion="gini",
                                  random_state=2)
     clf.fit(X, y)
@@ -76,7 +76,7 @@ def test_graphviz_toy():
 
 def test_graphviz_errors():
     """Check for errors of export_graphviz"""
-    clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
+    clf = DecisionTreeClassifier(max_depth=3, min_samples_split=2)
     clf.fit(X, y)
 
     out = StringIO()

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -453,29 +453,30 @@ def test_min_samples_split():
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes
-    for max_leaf_nodes in (None, 1000):
-        for name, TreeEstimator in ALL_TREES.items():
-            est = TreeEstimator(min_samples_split=10,
-                                max_leaf_nodes=max_leaf_nodes,
-                                random_state=0)
-            est.fit(X, y)
-            # count samples on nodes, -1 means it is a leaf
-            node_samples = est.tree_.n_node_samples[est.tree_.children_left != -1]
+    for max_leaf_nodes, name in product((None, 1000), ALL_TREES.keys()):
+        TreeEstimator = ALL_TREES[name]
 
-            assert_greater(np.min(node_samples), 9,
-                           "Failed with {0}".format(name))
+        # test for integer parameter
+        est = TreeEstimator(min_samples_split=10,
+                            max_leaf_nodes=max_leaf_nodes,
+                            random_state=0)
+        est.fit(X, y)
+        # count samples on nodes, -1 means it is a leaf
+        node_samples = est.tree_.n_node_samples[est.tree_.children_left != -1]
 
-    for max_leaf_nodes in (None, 1000):
-        for name, TreeEstimator in ALL_TREES.items():
-            est = TreeEstimator(min_samples_split=0.2,
-                                max_leaf_nodes=max_leaf_nodes,
-                                random_state=0)
-            est.fit(X, y)
-            # count samples on nodes, -1 means it is a leaf
-            node_samples = est.tree_.n_node_samples[est.tree_.children_left != -1]
+        assert_greater(np.min(node_samples), 9,
+                       "Failed with {0}".format(name))
 
-            assert_greater(np.min(node_samples), 9,
-                           "Failed with {0}".format(name))
+        # test for float parameter
+        est = TreeEstimator(min_samples_split=0.2,
+                            max_leaf_nodes=max_leaf_nodes,
+                            random_state=0)
+        est.fit(X, y)
+        # count samples on nodes, -1 means it is a leaf
+        node_samples = est.tree_.n_node_samples[est.tree_.children_left != -1]
+
+        assert_greater(np.min(node_samples), 9,
+                       "Failed with {0}".format(name))
 
 
 
@@ -486,31 +487,32 @@ def test_min_samples_leaf():
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes
-    for max_leaf_nodes in (None, 1000):
-        for name, TreeEstimator in ALL_TREES.items():
-            est = TreeEstimator(min_samples_leaf=5,
-                                max_leaf_nodes=max_leaf_nodes,
-                                random_state=0)
-            est.fit(X, y)
-            out = est.tree_.apply(X)
-            node_counts = np.bincount(out)
-            # drop inner nodes
-            leaf_count = node_counts[node_counts != 0]
-            assert_greater(np.min(leaf_count), 4,
-                           "Failed with {0}".format(name))
+    for max_leaf_nodes, name in product((None, 1000), ALL_TREES.keys()):
+        TreeEstimator = ALL_TREES[name]
 
-    for max_leaf_nodes in (None, 1000):
-        for name, TreeEstimator in ALL_TREES.items():
-            est = TreeEstimator(min_samples_leaf=0.1,
-                                max_leaf_nodes=max_leaf_nodes,
-                                random_state=0)
-            est.fit(X, y)
-            out = est.tree_.apply(X)
-            node_counts = np.bincount(out)
-            # drop inner nodes
-            leaf_count = node_counts[node_counts != 0]
-            assert_greater(np.min(leaf_count), 4,
-                           "Failed with {0}".format(name))
+        # test integer parameter
+        est = TreeEstimator(min_samples_leaf=5,
+                            max_leaf_nodes=max_leaf_nodes,
+                            random_state=0)
+        est.fit(X, y)
+        out = est.tree_.apply(X)
+        node_counts = np.bincount(out)
+        # drop inner nodes
+        leaf_count = node_counts[node_counts != 0]
+        assert_greater(np.min(leaf_count), 4,
+                       "Failed with {0}".format(name))
+
+        # test float parameter
+        est = TreeEstimator(min_samples_leaf=0.1,
+                            max_leaf_nodes=max_leaf_nodes,
+                            random_state=0)
+        est.fit(X, y)
+        out = est.tree_.apply(X)
+        node_counts = np.bincount(out)
+        # drop inner nodes
+        leaf_count = node_counts[node_counts != 0]
+        assert_greater(np.min(leaf_count), 4,
+                       "Failed with {0}".format(name))
 
 
 def test_min_weight_fraction_leaf():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -463,6 +463,20 @@ def test_min_samples_leaf():
             assert_greater(np.min(leaf_count), 4,
                            "Failed with {0}".format(name))
 
+    for max_leaf_nodes in (None, 1000):
+        for name, TreeEstimator in ALL_TREES.items():
+            est = TreeEstimator(min_samples_leaf=0.1,
+                                min_samples_split=0.01,
+                                max_leaf_nodes=max_leaf_nodes,
+                                random_state=0)
+            est.fit(X, y)
+            out = est.tree_.apply(X)
+            node_counts = np.bincount(out)
+            # drop inner nodes
+            leaf_count = node_counts[node_counts != 0]
+            assert_greater(np.min(leaf_count), 4,
+                           "Failed with {0}".format(name))
+
 
 def test_min_weight_fraction_leaf():
     """Test if leaves contain at least min_weight_fraction_leaf of the

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -401,7 +401,6 @@ def test_error():
         # Invalid values for parameters
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=0.0).fit, X, y)
-        assert_raises(ValueError, TreeEstimator(min_samples_leaf=1.5).fit, X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_weight_fraction_leaf=-1).fit,
                       X, y)
@@ -411,8 +410,6 @@ def test_error():
         assert_raises(ValueError, TreeEstimator(min_samples_split=-1).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_split=0.0).fit,
-                      X, y)
-        assert_raises(ValueError, TreeEstimator(min_samples_split=-1.5).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(max_depth=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(max_features=42).fit, X, y)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -803,9 +803,9 @@ def test_arrays_persist():
     """
     for attr in ['n_classes', 'value', 'children_left', 'children_right',
                  'threshold', 'impurity', 'feature', 'n_node_samples']:
-        value = getattr(DecisionTreeClassifier().fit([[0]], [0]).tree_, attr)
+        value = getattr(DecisionTreeClassifier().fit([[0], [1]], [0, 1]).tree_, attr)
         # if pointing to freed memory, contents may be arbitrary
-        assert_true(-2 <= value.flat[0] < 2,
+        assert_true(-3 <= value.flat[0] < 3,
                     'Array points to arbitrary memory')
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -401,6 +401,7 @@ def test_error():
         # Invalid values for parameters
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=0.0).fit, X, y)
+        assert_raises(ValueError, TreeEstimator(min_samples_leaf=1.0).fit, X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_weight_fraction_leaf=-1).fit,
                       X, y)
@@ -410,6 +411,8 @@ def test_error():
         assert_raises(ValueError, TreeEstimator(min_samples_split=-1).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_split=0.0).fit,
+                      X, y)
+        assert_raises(ValueError, TreeEstimator(min_samples_split=1.1).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(max_depth=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(max_features=42).fit, X, y)

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -232,8 +232,17 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         else:
             min_weight_leaf = 0.
 
+        if isinstance(self.min_samples_leaf, float):
+            min_samples_leaf = int(np.ceil(self.min_samples_leaf * n_samples))
+        else:
+            min_samples_leaf = self.min_samples_leaf
+
         # Set min_samples_split sensibly
-        min_samples_split = max(self.min_samples_split,
+        if isinstance(self.min_samples_split, float):
+            min_samples_split = int(np.ceil(self.min_samples_split * n_samples))
+        else:
+            min_samples_split = self.min_samples_split
+        min_samples_split = max(min_samples_split,
                                 2 * self.min_samples_leaf)
 
         # Build tree
@@ -249,7 +258,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         if not isinstance(self.splitter, Splitter):
             splitter = SPLITTERS[self.splitter](criterion,
                                                 self.max_features_,
-                                                self.min_samples_leaf,
+                                                min_samples_leaf,
                                                 min_weight_leaf,
                                                 random_state)
 
@@ -258,12 +267,12 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise
         if max_leaf_nodes < 0:
             builder = DepthFirstTreeBuilder(splitter, min_samples_split,
-                                            self.min_samples_leaf,
+                                            min_samples_leaf,
                                             min_weight_leaf,
                                             max_depth)
         else:
             builder = BestFirstTreeBuilder(splitter, min_samples_split,
-                                           self.min_samples_leaf,
+                                           min_samples_leaf,
                                            min_weight_leaf,
                                            max_depth,
                                            max_leaf_nodes)
@@ -390,11 +399,19 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         min_samples_split samples.
         Ignored if ``max_samples_leaf`` is not None.
 
-    min_samples_split : int, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
 
-    min_samples_leaf : int, optional (default=1)
-        The minimum number of samples required to be at a leaf node.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
@@ -600,11 +617,19 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         min_samples_split samples.
         Ignored if ``max_samples_leaf`` is not None.
 
-    min_samples_split : int, optional (default=2)
-        The minimum number of samples required to split an internal node.
+    min_samples_split : int, float, optional (default=2)
+        The minimum number of samples required to split an internal node:
+          - If int, then consider `min_samples_split` as the minimum number.
+          - If float, then `min_samples_split` is a percentage and
+            `int(min_samples_split * n_samples)` are the minimum
+            number of samples for each split.
 
-    min_samples_leaf : int, optional (default=1)
-        The minimum number of samples required to be at a leaf node.
+    min_samples_leaf : int, float, optional (default=1)
+        The minimum number of samples required to be at a leaf node:
+          - If int, then consider `min_samples_leaf` as the minimum number.
+          - If float, then `min_samples_leaf` is a percentage and
+            `int(min_samples_leaf * n_samples)` are the minimum
+            number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -210,6 +210,12 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             raise ValueError("min_samples_split must be greater than zero.")
         if self.min_samples_leaf <= 0:
             raise ValueError("min_samples_leaf must be greater than zero.")
+        if isinstance(self.min_samples_leaf, float) \
+                and not 0 < self.min_samples_leaf <= 0.5:
+            raise ValueError("float min_samples_leaf must in (0, 0.5]")
+        if isinstance(self.min_samples_split, float) \
+                and not 0 < self.min_samples_split < 1.0:
+            raise ValueError("float min_samples_split must in (0, 1.0)")
         if not 0 <= self.min_weight_fraction_leaf <= 0.5:
             raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
         if max_depth <= 0:

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -390,14 +390,15 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
-          - If int, then consider `max_features` features at each split.
-          - If float, then `max_features` is a percentage and
-            `int(max_features * n_features)` features are considered at each
-            split.
-          - If "auto", then `max_features=sqrt(n_features)`.
-          - If "sqrt", then `max_features=sqrt(n_features)`.
-          - If "log2", then `max_features=log2(n_features)`.
-          - If None, then `max_features=n_features`.
+
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a percentage and
+          `int(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=sqrt(n_features)`.
+        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -411,17 +412,19 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
@@ -608,14 +611,15 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
-          - If int, then consider `max_features` features at each split.
-          - If float, then `max_features` is a percentage and
-            `int(max_features * n_features)` features are considered at each
-            split.
-          - If "auto", then `max_features=n_features`.
-          - If "sqrt", then `max_features=sqrt(n_features)`.
-          - If "log2", then `max_features=log2(n_features)`.
-          - If None, then `max_features=n_features`.
+
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a percentage and
+          `int(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=n_features`.
+        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
 
         Note: the search for a split does not stop until at least one
         valid partition of the node samples is found, even if it requires to
@@ -629,17 +633,19 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
-          - If int, then consider `min_samples_split` as the minimum number.
-          - If float, then `min_samples_split` is a percentage and
-            `int(min_samples_split * n_samples)` are the minimum
-            number of samples for each split.
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a percentage and
+          `int(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
 
     min_samples_leaf : int, float, optional (default=1)
         The minimum number of samples required to be at a leaf node:
-          - If int, then consider `min_samples_leaf` as the minimum number.
-          - If float, then `min_samples_leaf` is a percentage and
-            `int(min_samples_leaf * n_samples)` are the minimum
-            number of samples for each node.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a percentage and
+          `int(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -203,6 +203,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         self.max_features_ = max_features
 
+        if n_samples < 2:
+            raise ValueError("number of samples should be greater than one")
         if len(y) != n_samples:
             raise ValueError("Number of labels=%d does not match "
                              "number of samples=%d" % (len(y), n_samples))
@@ -210,12 +212,12 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             raise ValueError("min_samples_split must be greater than zero.")
         if self.min_samples_leaf <= 0:
             raise ValueError("min_samples_leaf must be greater than zero.")
-        if isinstance(self.min_samples_leaf, float) \
-                and not 0 < self.min_samples_leaf <= 0.5:
-            raise ValueError("float min_samples_leaf must in (0, 0.5]")
-        if isinstance(self.min_samples_split, float) \
-                and not 0 < self.min_samples_split < 1.0:
-            raise ValueError("float min_samples_split must in (0, 1.0)")
+        if not 0 < min_samples_leaf <= n_samples:
+            raise ValueError("min_samples_leaf must in (0, n_samples], "
+                             "check both the value and type of input parameter")
+        if not 0 < min_samples_split <= n_samples:
+            raise ValueError("min_samples_split must in (0, n_samples], "
+                             "check both the value and type of input parameter")
         if not 0 <= self.min_weight_fraction_leaf <= 0.5:
             raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
         if max_depth <= 0:

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -165,6 +165,18 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         max_leaf_nodes = (-1 if self.max_leaf_nodes is None
                           else self.max_leaf_nodes)
 
+        min_samples_leaf = (int(np.ceil(self.min_samples_leaf * n_samples))
+                            if isinstance(self.min_samples_leaf, float)
+                            else self.min_samples_leaf)
+
+        # Set min_samples_split sensibly
+        min_samples_split = (int(np.ceil(self.min_samples_split * n_samples))
+                             if isinstance(self.min_samples_split, float)
+                             else self.min_samples_split)
+
+        min_samples_split = max(min_samples_split,
+                                2 * self.min_samples_leaf)
+
         if isinstance(self.max_features, six.string_types):
             if self.max_features == "auto":
                 if is_classification:
@@ -231,23 +243,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                                np.sum(sample_weight))
         else:
             min_weight_leaf = 0.
-
-        if isinstance(self.min_samples_leaf, float):
-            if self.min_samples_leaf > 1:
-                raise ValueError("The float min_samples_leaf must be less than 1.0")
-            min_samples_leaf = int(np.ceil(self.min_samples_leaf * n_samples))
-        else:
-            min_samples_leaf = self.min_samples_leaf
-
-        # Set min_samples_split sensibly
-        if isinstance(self.min_samples_split, float):
-            if self.min_samples_split > 1:
-                raise ValueError("The float min_samples_split must be less than 1.0")
-            min_samples_split = int(np.ceil(self.min_samples_split * n_samples))
-        else:
-            min_samples_split = self.min_samples_split
-        min_samples_split = max(min_samples_split,
-                                2 * self.min_samples_leaf)
 
         # Build tree
         criterion = self.criterion

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -170,12 +170,9 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                             else self.min_samples_leaf)
 
         # Set min_samples_split sensibly
-        min_samples_split = (int(np.ceil(self.min_samples_split * n_samples))
+        min_samples_split = (max(int(np.ceil(self.min_samples_split * n_samples)), 2)
                              if isinstance(self.min_samples_split, float)
                              else self.min_samples_split)
-
-        min_samples_split = max(min_samples_split,
-                                2 * self.min_samples_leaf)
 
         if isinstance(self.max_features, six.string_types):
             if self.max_features == "auto":
@@ -212,11 +209,15 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             raise ValueError("min_samples_split must be greater than zero.")
         if self.min_samples_leaf <= 0:
             raise ValueError("min_samples_leaf must be greater than zero.")
+        if (isinstance(self.min_samples_leaf, float)
+            and self.min_samples_leaf == 1.0):
+            raise ValueError("min_samples_leaf cannot be 1.0 "
+                             "in order to avoid ambiguity")
         if not 0 < min_samples_leaf <= n_samples:
             raise ValueError("min_samples_leaf must in (0, n_samples], "
                              "check both the value and type of input parameter")
-        if not 0 < min_samples_split <= n_samples:
-            raise ValueError("min_samples_split must in (0, n_samples], "
+        if not 1 < min_samples_split <= n_samples:
+            raise ValueError("min_samples_split must in [2, n_samples], "
                              "check both the value and type of input parameter")
         if not 0 <= self.min_weight_fraction_leaf <= 0.5:
             raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
@@ -251,6 +252,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                                np.sum(sample_weight))
         else:
             min_weight_leaf = 0.
+
+        min_samples_split = max(min_samples_split, 2 * self.min_samples_leaf)
 
         # Build tree
         criterion = self.criterion

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -233,12 +233,16 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             min_weight_leaf = 0.
 
         if isinstance(self.min_samples_leaf, float):
+            if self.min_samples_leaf > 1:
+                raise ValueError("The float min_samples_leaf must be less than 1.0")
             min_samples_leaf = int(np.ceil(self.min_samples_leaf * n_samples))
         else:
             min_samples_leaf = self.min_samples_leaf
 
         # Set min_samples_split sensibly
         if isinstance(self.min_samples_split, float):
+            if self.min_samples_split > 1:
+                raise ValueError("The float min_samples_split must be less than 1.0")
             min_samples_split = int(np.ceil(self.min_samples_split * n_samples))
         else:
             min_samples_split = self.min_samples_split


### PR DESCRIPTION
A float number can be used as percentage in these two parameters in case the sample size varies greatly.

I found a new parameter `min_weight_fraction_leaf` is added recently. It works in a similar way. But it is still convenient to use float in `min_samples_split` for those sample without weighting.
