### PR TITLE
[MRG] skip joblib multiprocessing tests on travis

### DIFF
--- a/continuous_integration/exclude_joblib_mp.txt
+++ b/continuous_integration/exclude_joblib_mp.txt
@@ -1,0 +1,2 @@
+sklearn.externals.joblib.test.test_parallel
+sklearn.externals.joblib.test.test_pool

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -46,3 +46,4 @@ fi
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi
+pip install nose-exclude

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -17,8 +17,16 @@ python setup.py build_ext --inplace
 export SKLEARN_SKIP_NETWORK_TESTS=1
 
 if [[ "$COVERAGE" == "true" ]]; then
-    make test-coverage
+    CONVERAGE_FLAGS="--with-coverage"
 else
-    make test-code
+    CONVERAGE_FLAGS=""
 fi
+
+# Disable joblib tests that use multiprocessing on travis as they tend to cause
+# random crashes when calling `os.fork()`:
+#   OSError: [Errno 12] Cannot allocate memory
+nosetests -s -v $CONVERAGE_FLAGS --with-noseexclude \
+  --exclude-test-file=continuous_integration/exclude_joblib_mp.txt \
+  sklearn
+
 make test-doc test-sphinxext


### PR DESCRIPTION
The travis environment seems to be quite heavily loaded sometimes to the point that process forks cause random test errors such as the following:

```
======================================================================
ERROR: sklearn.externals.joblib.test.test_parallel.test_simple_parallel(None,)
----------------------------------------------------------------------

Traceback (most recent call last):

File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
  self.test(*self.arg)
File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/test/test_parallel.py", line 84, in check_simple_parallel
  Parallel(n_jobs=n_jobs)(delayed(square)(x) for x in X))
File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/parallel.py", line 604, in __call__
  self._pool = MemmapingPool(n_jobs, **poolargs)
File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/pool.py", line 561, in __init__
  super(MemmapingPool, self).__init__(**poolargs)
File "/home/travis/build/scikit-learn/scikit-learn/sklearn/externals/joblib/pool.py", line 400, in __init__
  super(PicklingPool, self).__init__(**poolargs)
File "/usr/lib/python2.7/multiprocessing/pool.py", line 136, in __init__
  self._repopulate_pool()
File "/usr/lib/python2.7/multiprocessing/pool.py", line 199, in _repopulate_pool
  w.start()
File "/usr/lib/python2.7/multiprocessing/process.py", line 130, in start
  self._popen = Popen(self)
File "/usr/lib/python2.7/multiprocessing/forking.py", line 120, in __init__
  self.pid = os.fork()
OSError: [Errno 12] Cannot allocate memory
```

The following skips the numerous embedded joblib tests that call `os.fork()` when run on travis. Note that upstream joblib tests are also running on travis but as there are fewer pull requests on the joblib github project this is a much less frequent issue there.
