### PR TITLE
[MRG+0] MAINT Re-order argument to put deprecated one at the end

### DIFF
--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -92,8 +92,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         self.tree_ = None
         self.max_features_ = None
 
-    def fit(self, X, y, sample_mask=None, X_argsorted=None, check_input=True,
-            sample_weight=None):
+    def fit(self, X, y, sample_weight=None, check_input=True, sample_mask=None,
+            X_argsorted=None):
         """Build a decision tree from the training set (X, y).
 
         Parameters


### PR DESCRIPTION
Small pull request to follow the conventions:
- fit(X, y, sample_weight=None, ...),
- put deprecated arguments at the end
