### PR TITLE
DOC: write cost function of logistic regression

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -344,7 +344,7 @@ The objective function to minimize is:
 
 where;
 
-.. math:: ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
+.. math:: ||W||_{2 1} = \sum_i \sqrt{\sum_j w_{ij}^2}
 
 
 The implementation in the class :class:`MultiTaskLasso` uses coordinate descent as

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -645,15 +645,21 @@ Logistic regression
 ===================
 
 Logistic regression, despite its name, is a linear model for classification
-rather than regression.
-As such, it minimizes a "hit or miss" cost function
-rather than the sum of square residuals (as in ordinary regression).
-Logistic regression is also known in the literature as
+rather than regression. Logistic regression is also known in the literature as
 logit regression, maximum-entropy classification (MaxEnt)
 or the log-linear classifier.
 
 The :class:`LogisticRegression` class can be used to do L1 or L2 penalized
-logistic regression. L1 penalization yields sparse predicting weights.
+logistic regression. Binary class L2 penalized logistic regression can be 
+formulated as the solution to the optimization problem
+
+.. math:: \underset{w}{min\,} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i X_i w) + 1) 
+
+Similarly, L1 regularized logistic regression solves the following optimization problem
+
+.. math:: \underset{w}{min\,} \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i X_i w) + 1) 
+
+L1 penalization yields sparse predicting weights.
 For L1 penalization :func:`sklearn.svm.l1_min_c` allows to calculate
 the lower bound for C in order to get a non "null" (all feature weights to
 zero) model.


### PR DESCRIPTION
Improve documentation of logistic regression by displaying the exact 
form of the cost function (as is done for other models).

I feel it important to state clearly what is the cost function of the
model because:

```
* Some might want to compare their implementation against this one,
in which case it is important to know exactly what is the form of the
cost function.

* Furthermore since the models are quite inconsistent in terms of
notation for the regularization parameter: some models in this
module penalize by 1/C, others by alpha and others by alpha/2.
```
