### PR TITLE
FIX: My name was linked to the wrong github account

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -2535,7 +2535,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Johannes Schönberger: https://github.com/ahojnnes
 
-.. _Manoj Kumar: https://github.com/Manoj-Kumar-S
+.. _Manoj Kumar: https://manojbits.wordpress.com
 
 .. _Andrew Tulloch: http://tullo.ch
 


### PR DESCRIPTION
My name was linked to my old and wrong github account. This Pull Request fixes this issue.
