### PR TITLE
[MRG] Eliminate dense cholesky warning during tests

### DIFF
--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -147,7 +147,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         """
         ridge_alpha = self.ridge_alpha if ridge_alpha is None else ridge_alpha
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,
-                             solver='dense_cholesky')
+                             solver='cholesky')
         s = np.sqrt((U ** 2).sum(axis=0))
         s[s == 0] = 1
         U /= s


### PR DESCRIPTION
Sparse PCA was still using the 'dense_cholesky' name for the internal ridge solver. Switching this to 'cholesky' eliminates a DeprecationWarning during tests, and should have the exact same functionality.
