### PR TITLE
[WIP] Skip common regressor test for OrthogonalMatchingPursuitCV on Travis

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -31,6 +31,7 @@ from sklearn.utils.testing import meta_estimators
 from sklearn.utils.testing import set_random_state
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import SkipTest
+from sklearn.utils.testing import check_skip_travis
 
 import sklearn
 from sklearn.base import (clone, ClassifierMixin, RegressorMixin,
@@ -794,6 +795,9 @@ def test_regressors_int():
     for name, Regressor in regressors:
         if name in dont_test or name in ('CCA'):
             continue
+        elif name in ('OrthogonalMatchingPursuitCV'):
+            # FIXME: This test is unstable on Travis, see issue #3190.
+            check_skip_travis()
         yield (check_regressors_int, name, Regressor, X,
                multioutput_estimator_convert_y_2d(name, y))
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -840,6 +840,9 @@ def test_regressors_train():
 
 
 def check_regressors_train(name, Regressor, X, y):
+    if name == 'OrthogonalMatchingPursuitCV':
+        # FIXME: This test is unstable on Travis, see issue #3190.
+        check_skip_travis()
     rnd = np.random.RandomState(0)
     # catch deprecation warnings
     with warnings.catch_warnings(record=True):
@@ -883,6 +886,9 @@ def test_regressor_pickle():
 
 
 def check_regressors_pickle(name, Regressor, X, y):
+    if name == 'OrthogonalMatchingPursuitCV':
+        # FIXME: This test is unstable on Travis, see issue #3190.
+        check_skip_travis()
     rnd = np.random.RandomState(0)
     # catch deprecation warnings
     with warnings.catch_warnings(record=True):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -793,16 +793,16 @@ def test_regressors_int():
     rnd = np.random.RandomState(0)
     y = rnd.randint(3, size=X.shape[0])
     for name, Regressor in regressors:
-        if name in dont_test or name in ('CCA'):
+        if name in dont_test or name == 'CCA':
             continue
-        elif name in ('OrthogonalMatchingPursuitCV'):
-            # FIXME: This test is unstable on Travis, see issue #3190.
-            check_skip_travis()
         yield (check_regressors_int, name, Regressor, X,
                multioutput_estimator_convert_y_2d(name, y))
 
 
 def check_regressors_int(name, Regressor, X, y):
+    if name == 'OrthogonalMatchingPursuitCV':
+        # FIXME: This test is unstable on Travis, see issue #3190.
+        check_skip_travis()
     rnd = np.random.RandomState(0)
     # catch deprecation warnings
     with warnings.catch_warnings(record=True):


### PR DESCRIPTION
omp_cv and related tests have issues on Travis. Should be fixed long term but for now this will skip the test_regressors_int when running common tests on Travis.
