### PR TITLE
[WIP] Ridge path

### DIFF
--- a/sklearn/linear_model/__init__.py
+++ b/sklearn/linear_model/__init__.py
@@ -21,7 +21,7 @@ from .coordinate_descent import (Lasso, ElasticNet, LassoCV, ElasticNetCV,
 from .sgd_fast import Hinge, Log, ModifiedHuber, SquaredLoss, Huber
 from .stochastic_gradient import SGDClassifier, SGDRegressor
 from .ridge import (Ridge, RidgeCV, RidgeClassifier, RidgeClassifierCV,
-                    ridge_regression)
+                    ridge_regression, ridge_path)
 from .logistic import (LogisticRegression, LogisticRegressionCV,
                        logistic_regression_path)
 from .omp import (orthogonal_mp, orthogonal_mp_gram, OrthogonalMatchingPursuit,
@@ -76,5 +76,6 @@ __all__ = ['ARDRegression',
            'logistic_regression_path',
            'orthogonal_mp',
            'orthogonal_mp_gram',
+           'ridge_path',
            'ridge_regression',
            'RANSACRegressor']

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1025,7 +1025,7 @@ class _BaseRidgeCV(LinearModel):
             self.coef_ = estimator.coef_
             self.intercept_ = estimator.intercept_
         else:
-            if self.solver == 'eigen':
+            if self.solver in ['eigen', 'svd']:
                 cv = check_cv(self.cv)
                 scorer = check_scoring(self,
                                        scoring=self.scoring,
@@ -1058,7 +1058,7 @@ class _BaseRidgeCV(LinearModel):
                     predictions = ridge_path(
                         X_train, y_train, alphas,
                         (X[test] - X_train_mean) / X_train_std,
-                        solver='eigen') + y_train_mean[np.newaxis]
+                        solver=self.solver) + y_train_mean[np.newaxis]
                     for score, prediction in zip(scores, predictions):
                         score[:] = scorer(
                             identity_estimator, y[test], prediction)
@@ -1075,7 +1075,7 @@ class _BaseRidgeCV(LinearModel):
                     copy=self.copyX, sample_weight=sample_weight)
                 self.coef_ = ridge_path(X, y,
                                         np.atleast_2d(self.best_alphas_),
-                                        solver='eigen')[0].T
+                                        solver=self.solver)[0].T
                 self._set_intercept(X_mean, y_mean, X_std)
             else:
                 # do the old grid search

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1012,12 +1012,14 @@ class _RidgeGCV(LinearModel):
                                score_overrides_loss=True)
         error = scorer is None
 
-        if gcv_mode == 'eigen' and not with_sw:
+        if gcv_mode == 'eigen':
             alphas = np.atleast_2d(self.alphas.T).T
             mode = 'looe' if error else 'loov'
             y_is_raveled = y.ndim == 1
             y = np.atleast_2d(y.T).T
-            out, C = _kernel_ridge_path_eigen(X, y, alphas, mode=mode)
+            out, C = _kernel_ridge_path_eigen(X, y, alphas,
+                                              sample_weight=sample_weight,
+                                              mode=mode)
             if mode == 'looe':
                 out = out ** 2
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -162,6 +162,7 @@ def ridge_path(X_train, Y_train, alphas, X_test=None, solver="eigen"):
     else:
         path = feature_ridge_path_eigen(X_train, Y_train, alphas, X_test)
 
+    return path
 
 
 def _solve_sparse_cg(X, y, alpha, max_iter=None, tol=1e-3):

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -973,7 +973,7 @@ class _RidgeGCV(LinearModel):
 
 class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=np.array([0.1, 1.0, 10.0]),
-                 fit_intercept=True, normalize=False, scoring=None,
+                 fit_intercept=True, normalize=False,
                  scoring=None, cv=None, gcv_mode=None,
                  store_cv_values=False, solver=None, copyX=True):
         self.alphas = alphas
@@ -1023,8 +1023,6 @@ class _BaseRidgeCV(LinearModel):
                 scorer = check_scoring(self,
                                        scoring=self.scoring,
                                        allow_none=True,
-                                       loss_func=self.loss_func,
-                                       score_func=self.score_func,
                                        score_overrides_loss=True)
 
                 alphas = np.atleast_2d(np.array(self.alphas).T).T

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -980,11 +980,7 @@ class _RidgeGCV(LinearModel):
             else:
                 gcv_mode = 'svd'
 
-        if gcv_mode == 'eigen':
-            pass
-        elif gcv_mode == 'svd':
-            pass
-        else:
+        if gcv_mode not in ['eigen', 'svd']:
             raise ValueError('bad gcv_mode "%s"' % gcv_mode)
 
         n_y = 1 if len(y.shape) == 1 else y.shape[1]

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -979,11 +979,6 @@ class _RidgeGCV(LinearModel):
                 gcv_mode = 'eigen'
             else:
                 gcv_mode = 'svd'
-        elif gcv_mode == "svd" and with_sw:
-            # FIXME non-uniform sample weights not yet supported
-            warnings.warn("non-uniform sample weights unsupported for svd, "
-                          "forcing usage of eigen")
-            gcv_mode = 'eigen'
 
         if gcv_mode == 'eigen':
             pass

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -119,6 +119,13 @@ def ridge_path(X_train, Y_train, alphas, X_test=None, solver="eigen"):
     solver : str, {'eigen'}, (default 'eigen')
         The solver to use for ridge_path.
 
+    Returns
+    -------
+    coef or predictions : ndarray
+        shape = (n_penalties, n_features, n_targets) (coef) or
+                (n_penalties, n_samples, n_targets) (predictions)
+        If X_test is provided, predictions are returned, otherwise coef.
+
     Notes
     -----
     This solver does not fit the intercept.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -104,20 +104,16 @@ def ridge_path(X_train, Y_train, alphas, X_test=None, solver="eigen"):
     Parameters
     ----------
 
-    X_train : ndarray
-        shape = (n_samples, n_features)
+    X_train : ndarray, shape = (n_samples, n_features)
         Training data
 
-    Y_train : ndarray
-        shape = (n_samples, n_targets) or (n_samples,)
+    Y_train : ndarray, shape = (n_samples, n_targets) or (n_samples,)
         Training targets
 
-    alphas : ndarray
-        shape=(n_penalties, n_targets) or (n_penalties, 1)
+    alphas : ndarray, shape=(n_penalties, n_targets) or (n_penalties, 1)
         Penalties on regularization path. Can be global or per target
 
-    X_test : ndarray, optional
-        shape=(n_test_samples, n_features)
+    X_test : ndarray, shape=(n_test_samples, n_features), optional
         Test set. If specified, ridge_path returns predictions on X_test,
         otherwise it returns coefficients. Recommended if only predictions
         are of interest, especially in the n_samples << n_features case,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -340,17 +340,6 @@ def _solve_cholesky_kernel(K, y, alpha, sample_weight=None):
         return dual_coefs.T
 
 
-def _solve_svd(X, y, alpha):
-    U, s, Vt = linalg.svd(X, full_matrices=False)
-    idx = s > 1e-15  # same default value as scipy.linalg.pinv
-    s_nnz = s[idx][:, np.newaxis]
-    UTy = np.dot(U.T, y)
-    d = np.zeros((s.size, alpha.size))
-    d[idx] = s_nnz / (s_nnz ** 2 + alpha)
-    d_UT_y = d * UTy
-    return np.dot(Vt.T, d_UT_y).T
-
-
 def _deprecate_dense_cholesky(solver):
     if solver == 'dense_cholesky':
         warnings.warn(DeprecationWarning("The name 'dense_cholesky' is "

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -362,7 +362,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         Individual weights for each sample. If sample_weight is set, then
         the solver will automatically be set to 'cholesky'
 
-    solver : {'auto', 'svd', 'cholesky', 'lsqr', 'sparse_cg'}
+    solver : {'auto', 'svd', 'cholesky', 'lsqr', 'sparse_cg', 'eigen'}
         Solver to use in the computational routines:
 
         - 'auto' chooses the solver automatically based on the type of data.
@@ -383,6 +383,9 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fatest but may not be available
           in old scipy versions. It also uses an iterative procedure.
+
+        - 'eigen' uses an eigenvalue decomposition of X.T.dot(X) or 
+          X.dot(X.T) to compute the Ridge coefficients
 
         All three solvers support both dense and sparse data.
 
@@ -582,6 +585,9 @@ class Ridge(_BaseRidge, RegressorMixin):
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fatest but may not be available
           in old scipy versions. It also uses an iterative procedure.
+
+        - 'eigen' uses an eigenvalue decomposition of X.T.dot(X) or 
+          X.dot(X.T) to compute the Ridge coefficients
 
         All three solvers support both dense and sparse data.
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -509,7 +509,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                 solver = 'svd'
 
     if solver == 'svd':
-        coef = _solve_svd(X, y, alpha)
+        coef = ridge_path(X, y, np.atleast_2d(alpha), solver='svd')[0].T
 
     if solver == 'eigen':
         coef = ridge_path(X, y, np.atleast_2d(alpha), solver='eigen')[0].T

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -93,14 +93,13 @@ def _precomp_kernel_ridge_path_eigen(gramX_train, Y_train, alphas,
                          "or change mode.")
 
     if sample_weight is not None:
-        sqrt_sw = np.sqrt(sample_weight.ravel())
+        sw = sample_weight.reshape(-1, 1)
         if copy:
-            gramX_train = (gramX_train * sqrt_sw[:, np.newaxis]) * sqrt_sw
-            Y_train = sqrt_sw[:, np.newaxis] * Y_train
+            gramX_train = sw * gramX_train
+            Y_train = sw * Y_train
         else:
-            gramX_train *= sqrt_sw[:, np.newaxis]
-            gramX_train *= sqrt_sw
-            Y_train *= sqrt_sw[:, np.newaxis]
+            gramX_train *= sw
+            Y_train *= sw
 
     eig_val_train, eig_vect_train = linalg.eigh(gramX_train)
     VTY = eig_vect_train.T.dot(Y_train)
@@ -114,8 +113,6 @@ def _precomp_kernel_ridge_path_eigen(gramX_train, Y_train, alphas,
 
     if gramX_test is None:
         dual_coef = eig_vect_train.dot(v_alpha_VTY).transpose(1, 0, 2)
-        if sample_weight is not None:
-            dual_coef *= sqrt_sw[:, np.newaxis]
         if mode == 'normal':
             output = dual_coef
         elif mode in ['looe', 'loov']:
@@ -129,11 +126,7 @@ def _precomp_kernel_ridge_path_eigen(gramX_train, Y_train, alphas,
         else:
             raise ValueError("mode not understood")
     else:
-        if sample_weight is not None:
-            predict_mat = gramX_test.dot(
-                sqrt_sw[:, np.newaxis] * eig_vect_train)
-        else:
-            predict_mat = gramX_test.dot(eig_vect_train)
+        predict_mat = gramX_test.dot(eig_vect_train)
         predictions = predict_mat.dot(v_alpha_VTY).transpose(1, 0, 2)
         output = predictions
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -288,10 +288,17 @@ def _test_ridge_loo(filter_):
     ridge_gcv = _RidgeGCV(fit_intercept=False)
     ridge = Ridge(alpha=1.0, fit_intercept=False)
 
-    # generalized cross-validation (efficient leave-one-out)
-    decomp = ridge_gcv._pre_compute(X_diabetes, y_diabetes)
-    errors, c = ridge_gcv._errors(1.0, y_diabetes, *decomp)
-    values, c = ridge_gcv._values(1.0, y_diabetes, *decomp)
+    alphas = np.array([1.])
+    errors, _ = _kernel_ridge_path_eigen(X_diabetes,
+                                         y_diabetes[:, np.newaxis],
+                                         alphas,
+                                         mode='looe')
+    errors = errors.ravel() ** 2
+    values, _ = _kernel_ridge_path_eigen(X_diabetes,
+                                         y_diabetes[:, np.newaxis],
+                                         alphas,
+                                         mode='loov')
+    values = values.ravel()
 
     # brute-force leave-one-out: remove one example at a time
     errors2 = []

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -884,3 +884,20 @@ def test__ridge_gcv_path_svd_against_eigen():
 
     assert_array_almost_equal(eigen_solved, svd_solved)
 
+
+def test__ridge_gcv_path_svd_with_sample_weights_against_eigen():
+    n_samples, n_features, n_targets = 20, 5, 7
+    X, Y, W, _, _ = make_noisy_forward_data(n_samples, n_features, n_targets)
+    alphas = np.logspace(-3, 3, 9)[:, np.newaxis] * \
+        np.arange(1, n_targets + 1)
+
+    rng = np.random.RandomState(42)
+    sample_weights = rng.randn(n_samples) ** 2
+
+    looe_eigen = _kernel_ridge_path_eigen(
+        X, Y, alphas, sample_weight=sample_weights, mode='looe')[0]
+    looe_svd = _ridge_gcv_path_svd(X, Y, alphas,
+                                   sample_weight=sample_weights,
+                                   mode='looe')
+
+    assert_array_almost_equal(looe_eigen, looe_svd)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -674,3 +674,26 @@ def test_raises_value_error_if_solver_not_supported():
         ridge_regression(X, y, alpha=1., solver=wrong_solver)
 
     assert_raise_message(exception, message, func)
+
+
+def test_ridge_cv_eigen_solver():
+
+    alphas = np.logspace(-3, 3, 10)
+    cv = KFold(len(y_diabetes), 2)
+    ridge_cv = RidgeCV(alphas=alphas, solver=None, cv=cv,
+                       fit_intercept=False)
+    ridge_cv_eigen = RidgeCV(alphas=alphas, solver='eigen', cv=cv,
+                             fit_intercept=False)
+
+    ridge_cv.fit(X_diabetes, y_diabetes)
+    ridge_cv_eigen.fit(X_diabetes, y_diabetes[:, np.newaxis])
+
+    assert_array_almost_equal(ridge_cv.coef_, ridge_cv_eigen.coef_[0])
+
+    ridge_cv.fit_intercept = True
+    ridge_cv_eigen.fit_intercept = True
+
+    ridge_cv.fit(X_diabetes, y_diabetes)
+    ridge_cv_eigen.fit(X_diabetes, y_diabetes[:, np.newaxis])
+
+    assert_array_almost_equal(ridge_cv.coef_, ridge_cv_eigen.coef_[0])

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -762,7 +762,7 @@ def test__precomp_kernel_ridge_path_eigen_loov():
     cv = LeaveOneOut(n_samples)
 
     loov = _precomp_kernel_ridge_path_eigen(gramX, Y, alphas[:, np.newaxis],
-                                            mode='loov')
+                                            mode='loov')[0]
 
     loov_normal = [
         _precomp_kernel_ridge_path_eigen(
@@ -773,3 +773,16 @@ def test__precomp_kernel_ridge_path_eigen_loov():
 
     assert_array_almost_equal(
         loov, np.array(loov_normal).squeeze().transpose(1, 0, 2))
+
+
+def test_ridge_svd_tall():
+    """Make sure the SVD approach also works for tall matrices"""
+
+    n_samples, n_features, n_targets = 20, 5, 2
+    X, Y, W, _, _ = make_noisy_forward_data(
+        n_samples, n_features, n_targets)
+
+    coef_svd = Ridge(alpha=1, solver='svd').fit(X, Y).coef_
+    coef_cholesky = Ridge(alpha=1, solver='cholesky').fit(X, Y).coef_
+
+    assert_array_almost_equal(coef_svd, coef_cholesky)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -678,27 +678,28 @@ def test_raises_value_error_if_solver_not_supported():
     assert_raise_message(exception, message, func)
 
 
-def test_ridge_cv_eigen_solver():
+def test_ridge_cv_path_solvers():
 
     alphas = np.logspace(-3, 3, 10)
     cv = KFold(len(y_diabetes), 2)
-    ridge_cv = RidgeCV(alphas=alphas, solver=None, cv=cv,
+
+    for solver in ['eigen', 'svd']:
+        ridge_cv = RidgeCV(alphas=alphas, solver=None, cv=cv,
                        fit_intercept=False)
-    ridge_cv_eigen = RidgeCV(alphas=alphas, solver='eigen', cv=cv,
-                             fit_intercept=False)
+        ridge_cv_path = RidgeCV(alphas=alphas, solver=solver, cv=cv,
+                                fit_intercept=False)
 
-    ridge_cv.fit(X_diabetes, y_diabetes)
-    ridge_cv_eigen.fit(X_diabetes, y_diabetes[:, np.newaxis])
+        ridge_cv.fit(X_diabetes, y_diabetes)
+        ridge_cv_path.fit(X_diabetes, y_diabetes[:, np.newaxis])
+        assert_array_almost_equal(ridge_cv.coef_, ridge_cv_path.coef_[0])
 
-    assert_array_almost_equal(ridge_cv.coef_, ridge_cv_eigen.coef_[0])
+        ridge_cv.fit_intercept = True
+        ridge_cv_path.fit_intercept = True
 
-    ridge_cv.fit_intercept = True
-    ridge_cv_eigen.fit_intercept = True
+        ridge_cv.fit(X_diabetes, y_diabetes)
+        ridge_cv_path.fit(X_diabetes, y_diabetes[:, np.newaxis])
 
-    ridge_cv.fit(X_diabetes, y_diabetes)
-    ridge_cv_eigen.fit(X_diabetes, y_diabetes[:, np.newaxis])
-
-    assert_array_almost_equal(ridge_cv.coef_, ridge_cv_eigen.coef_[0])
+        assert_array_almost_equal(ridge_cv.coef_, ridge_cv_path.coef_[0])
 
 
 def make_noisy_forward_data(

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -846,7 +846,7 @@ def test_kernel_ridge_path_with_sample_weights():
         np.arange(1, n_targets + 1)
 
     rng = np.random.RandomState(42)
-    sample_weights = np.ones(n_samples)  # rng.randn(n_samples) ** 2
+    sample_weights = rng.randn(n_samples) ** 2
 
     cv = LeaveOneOut(n_samples)
     cv_predictions = np.array([[

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -31,6 +31,7 @@ from sklearn.linear_model.ridge import _solve_cholesky_kernel
 from sklearn.linear_model.ridge import ridge_path
 from sklearn.linear_model.ridge import _precomp_kernel_ridge_path_eigen
 from sklearn.linear_model.ridge import _kernel_ridge_path_eigen
+from sklearn.linear_model.ridge import _ridge_gcv_path_svd
 
 from sklearn.cross_validation import KFold
 from sklearn.cross_validation import LeaveOneOut
@@ -869,3 +870,17 @@ def test_kernel_ridge_path_with_sample_weights():
         X, Y, alphas, sample_weight=sample_weights, mode='looe')[0]
 
     assert_array_almost_equal(cv_errors, ridge_path_gcv_errors)
+
+
+def test__ridge_gcv_path_svd_against_eigen():
+    n_samples, n_features, n_targets = 20, 5, 7
+    X, Y, W, _, _ = make_noisy_forward_data(n_samples, n_features, n_targets)
+    alphas = np.logspace(-3, 3, 9)[:, np.newaxis] * \
+        np.arange(1, n_targets + 1)
+
+    eigen_solved, c = _kernel_ridge_path_eigen(X, Y, alphas, mode='looe')
+    svd_solved = _ridge_gcv_path_svd(X, Y, alphas, mode='looe')
+
+
+    assert_array_almost_equal(eigen_solved, svd_solved)
+

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -879,7 +879,7 @@ def test__ridge_gcv_path_svd_against_eigen():
         np.arange(1, n_targets + 1)
 
     eigen_solved, c = _kernel_ridge_path_eigen(X, Y, alphas, mode='looe')
-    svd_solved = _ridge_gcv_path_svd(X, Y, alphas, mode='looe')
+    svd_solved, c2 = _ridge_gcv_path_svd(X, Y, alphas, mode='looe')
 
 
     assert_array_almost_equal(eigen_solved, svd_solved)
@@ -898,6 +898,6 @@ def test__ridge_gcv_path_svd_with_sample_weights_against_eigen():
         X, Y, alphas, sample_weight=sample_weights, mode='looe')[0]
     looe_svd = _ridge_gcv_path_svd(X, Y, alphas,
                                    sample_weight=sample_weights,
-                                   mode='looe')
+                                   mode='looe')[0]
 
     assert_array_almost_equal(looe_eigen, looe_svd)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -786,3 +786,24 @@ def test_ridge_svd_tall():
     coef_cholesky = Ridge(alpha=1, solver='cholesky').fit(X, Y).coef_
 
     assert_array_almost_equal(coef_svd, coef_cholesky)
+
+
+def test_ridge_gcv_looe_on_dense_data():
+
+    n_samples, n_features, n_targets = 50, 10, 2
+    X, Y, W, _, _ = make_noisy_forward_data(n_samples, n_features, n_targets)
+
+    alphas = np.logspace(-3, 3, 9)
+
+    sample_weights = np.ones(len(X))
+
+    # adding sample weights will go to the old branch, without it will go
+    # to the new branch
+
+    old_coef = _RidgeGCV(alphas=alphas, gcv_mode="eigen").fit(
+        X, Y, sample_weight=sample_weights).coef_
+
+    new_coef = _RidgeGCV(alphas=alphas, gcv_mode="eigen").fit(X, Y).coef_
+
+    assert_array_almost_equal(old_coef, new_coef)
+

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -320,9 +320,16 @@ def _test_ridge_loo(filter_):
 
     # generalized cross-validation (efficient leave-one-out,
     # SVD variation)
-    decomp = ridge_gcv._pre_compute_svd(X_diabetes, y_diabetes)
-    errors3, c = ridge_gcv._errors_svd(ridge.alpha, y_diabetes, *decomp)
-    values3, c = ridge_gcv._values_svd(ridge.alpha, y_diabetes, *decomp)
+    errors3_, c = _ridge_gcv_path_svd(X_diabetes,
+                                      np.atleast_2d(y_diabetes.T).T,
+                                      np.atleast_2d(ridge.alpha),
+                                      mode='looe')
+    errors3 = (errors3_ ** 2).ravel()
+    values3, c = _ridge_gcv_path_svd(X_diabetes,
+                                      np.atleast_2d(y_diabetes.T).T,
+                                      np.atleast_2d(ridge.alpha),
+                                      mode='loov')
+    values3 = values3.ravel()
 
     # check that efficient and SVD efficient LOO give same results
     assert_almost_equal(errors, errors3)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -724,6 +724,7 @@ def make_noisy_forward_data(
     n_features=200,
     n_targets=10,
     train_frac=.8,
+    noise_levels=None,
     random_state=42):
     """Creates a simple, dense, noisy forward linear model with multiple
     output."""
@@ -734,7 +735,9 @@ def make_noisy_forward_data(
     X = rng.randn(n_samples, n_features)
     W = rng.randn(n_features, n_targets)
     Y_clean = X.dot(W)
-    noise_levels = rng.randn(n_targets) ** 2
+    if noise_levels is None:
+        noise_levels = rng.randn(n_targets) ** 2
+    noise_levels = np.atleast_1d(noise_levels) * np.ones(n_targets)
     noise = rng.randn(*Y_clean.shape) * noise_levels * Y_clean.std(0)
     Y = Y_clean + noise
     return X, Y, W, train, test
@@ -908,3 +911,36 @@ def test__ridge_gcv_path_svd_with_sample_weights_against_eigen():
                                    mode='looe')[0]
 
     assert_array_almost_equal(looe_eigen, looe_svd)
+
+
+def test_best_alpha_scales_with_target():
+    """Best penalty must be selected per target and yield corresponding
+    coefficients"""
+
+    n_samples, n_features, n_targets = 20, 10, 10
+    noise_levels = np.arange(10) / 5.
+    X, Y, W, _, _ = make_noisy_forward_data(
+        n_samples, n_features, n_targets, noise_levels=noise_levels)
+
+    alphas = np.logspace(-3, 3, 35)
+
+    cv_mses = []
+    coefs = []
+    best_alphas = []
+    for y in Y.T:
+        ridge_gcv = _RidgeGCV(alphas=alphas, store_cv_values=True,
+                          fit_intercept=False)
+
+        ridge_gcv.fit(X, y)
+        cv_mses.append(ridge_gcv.cv_values_.mean(0))
+        coefs.append(ridge_gcv.coef_)
+        best_alphas.append(ridge_gcv.alpha_)
+
+    ridge_gcv.fit(X, Y)
+    assert_array_almost_equal(
+        np.array(cv_mses), ridge_gcv.cv_values_.mean(0))
+    assert_array_almost_equal(np.array(coefs),
+                              ridge_gcv.coef_)
+
+
+

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -57,7 +57,7 @@ def test_ridge():
     rng = np.random.RandomState(0)
     alpha = 1.0
 
-    for solver in ("svd", "sparse_cg", "cholesky", "lsqr"):
+    for solver in ("svd", "sparse_cg", "cholesky", "lsqr", "eigen"):
         # With more samples than features
         n_samples, n_features = 6, 5
         y = rng.randn(n_samples)
@@ -266,7 +266,7 @@ def test_ridge_individual_penalties():
 
     coefs_indiv_pen = [
         Ridge(alpha=penalties, solver=solver, tol=1e-6).fit(X, y).coef_
-        for solver in ['svd', 'sparse_cg', 'lsqr', 'cholesky']]
+        for solver in ['svd', 'sparse_cg', 'lsqr', 'cholesky', 'eigen']]
     for coef_indiv_pen in coefs_indiv_pen:
         assert_array_almost_equal(coef_cholesky, coef_indiv_pen)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -858,8 +858,7 @@ def test_kernel_ridge_path_with_sample_weights():
     cv_errors = Y[np.newaxis] - cv_predictions.reshape(
         len(alphas), n_samples, n_targets)
 
-
-    ridge_path_gcv_errors = _kernel_ridge_path_eigen(X, Y, alphas,
-                                                     mode='looe')[0]
+    ridge_path_gcv_errors = _kernel_ridge_path_eigen(
+        X, Y, alphas, sample_weight=sample_weights, mode='looe')[0]
 
     assert_array_almost_equal(cv_errors, ridge_path_gcv_errors)


### PR DESCRIPTION
Adressing https://github.com/scikit-learn/scikit-learn/issues/3373

A first implementation of a ridge path using `'eigen'` solver. This solver is now available in `ridge_regression`, which calls upon a reduced functionality of `ridge_path`.

Next steps:
- The same path approach can be straightforwardly used with SVD as well: Write svd path and replace in ridge_regression
- Attack `RidgeCV`: Replace the `GridSearchCV` by `ridge_path` if `eigen` or `svd` are selected.
- Incorporate `ridge_path_looe` from the gist https://gist.github.com/eickenberg/e9eb106f12e40d017fd0
- Adjust `RidgeCV` to use the looe functionalities
