### PR TITLE
[MRG] FIX: some python3 errors while building the doc

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -19,6 +19,7 @@ import sys
 import gzip
 import posixpath
 import subprocess
+import io
 
 
 # Try Python 2 first, otherwise load from Python 3
@@ -425,7 +426,7 @@ carousel_thumbs = {'plot_classifier_comparison_001.png': (1, 600),
 def extract_docstring(filename, ignore_heading=False):
     """ Extract a module-level docstring, if any
     """
-    lines = open(filename).readlines()
+    lines = io.open(filename, encoding='utf-8').readlines()
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
@@ -630,7 +631,7 @@ Examples
 def extract_line_count(filename, target_dir):
     # Extract the line count of a file
     example_file = os.path.join(target_dir, filename)
-    lines = open(example_file).readlines()
+    lines = io.open(example_file, encoding='utf-8').readlines()
     start_row = 0
     if lines and lines[0].startswith('#!'):
         lines.pop(0)
@@ -1039,7 +1040,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
     f.flush()
 
     # save variables so we can later add links to the documentation
-    example_code_obj = identify_names(open(example_file).read())
+    example_code_obj = identify_names(io.open(example_file, encoding='utf-8').read())
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle'
         with open(codeobj_fname, 'wb') as fid:


### PR DESCRIPTION
Some fixes I had to make to compile sklearn with latests sphinx and python 3 (it still does not fully compile but I think this is a step forward).

Those are encoding errors that are fixed for both python 2, 3 by using io.open instead of open.
