### PR TITLE
[WIP] Gaussian Process revisited (refactoring of correlation models + some new features/bugfixes)

### DIFF
--- a/examples/gaussian_process/gp_diabetes_dataset.py
+++ b/examples/gaussian_process/gp_diabetes_dataset.py
@@ -40,7 +40,7 @@ gp = GaussianProcess(regr='constant', corr='absolute_exponential',
 gp.fit(X, y)
 
 # Deactivate maximum likelihood estimation for the cross-validation loop
-gp.theta0 = gp.theta  # Given correlation parameter = MLE
+gp.theta0 = gp.theta_  # Given correlation parameter = MLE
 gp.thetaL, gp.thetaU = None, None  # None bounds deactivate MLE
 
 # Perform a cross-validation estimate of the coefficient of determination using

--- a/examples/gaussian_process/plot_gp_learning_curve.py
+++ b/examples/gaussian_process/plot_gp_learning_curve.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+==========================================================
+Gaussian Processes regression: comparing different kernels
+==========================================================
+
+Three variants of the squared exponential covariance function are compared:
+ * Isotropic squared exponential: a global length scale is learn from data.
+ * Automatic relevance determination (ARD): every dimension gets its own
+   characteristic length scale, irrelevant dimensions can be ignored if thetaL
+   is sufficiently small.
+ * Factor analysis distance (FAD): A low-rank approximation of a full
+   covariance matrix for the squared exponential kernel is learned.
+   Correlations between different dimensions can be identified and exploited
+   to some extent.
+
+The target function maps a 4-dimensional vector onto a real value. One of
+the dimensions is ignored (and should thus be pruned away by ARD). The other
+dimensions are correlated, which can be exploited by FAD.
+
+The hyperparameters are optimized within
+.. math::
+   \theta_i \in [1e-4, 1e2]
+
+See Rasmussen and Williams 2006, p107 for details regarding the different
+variants of the squared exponential kernel.
+
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from sklearn.learning_curve import learning_curve
+from sklearn.gaussian_process import GaussianProcess
+
+np.random.seed(1)
+
+
+def f(X):
+    """ Target function for GPR.
+
+    Note that one dimension (X[:, 3]) is irrelevant and should thus be ignored
+    by ARD. Furthermore, the values x in R^3 and
+    x + \alpha (1, 2 , 0) + \beta (1, 0, 2) have the same value for all x and
+    all alpha and beta. This can be exploited by FAD.
+    """
+    return np.tanh(2 * X[:, 0] - X[:, 1] - X[:, 2])
+
+Xtrain = np.random.random((200, 4)) * 2 - 1
+ytrain = f(Xtrain)
+
+plt.figure()
+colors = ['r', 'g', 'b', 'c', 'm']
+labels = {1: "Isotropic", 4: "Automatic Relevance Determination",
+          8: "Factor Analysis"}
+for i, n in enumerate(labels.keys()):
+    train_sizes, train_scores, test_scores = \
+        learning_curve(GaussianProcess(corr='squared_exponential',
+                                       theta0=[1.0] * n, thetaL=[1e-4] * n,
+                                       thetaU=[1e2] * n),
+                       Xtrain, ytrain, scoring="mean_squared_error",
+                       cv=10, n_jobs=4)
+    test_scores = -test_scores  # Scores correspond to negative MSE
+    test_scores_mean = np.mean(test_scores, axis=1)
+    test_scores_min = np.min(test_scores, axis=1)
+    test_scores_max = np.max(test_scores, axis=1)
+
+    plt.plot(train_sizes, test_scores_mean, label=labels[n],
+             color=colors[i])
+    plt.fill_between(train_sizes, test_scores_min, test_scores_max,
+                     alpha=0.2, color=colors[i])
+
+plt.legend(loc="best")
+plt.title("Learning Curve")
+plt.xlabel("Training examples")
+plt.ylabel("Mean Squared Error")
+plt.yscale("symlog", linthreshy=1e-10)
+plt.show()

--- a/examples/gaussian_process/plot_gp_nonstationary.py
+++ b/examples/gaussian_process/plot_gp_nonstationary.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+=========================================================
+Gaussian Processes regression: non-stationary correlation
+=========================================================
+
+A simple one-dimensional regression task which is complicated by a
+discontinuity at x=0. Because of this discontinuity, the global GP
+hyperparameters are chosen such that the correlation drops quickly with
+increasing distance of the datapoints. This is inappropriate for all pairs of
+datapoints which are not separated by the discontinuity.
+
+A non-stationary correlation model, which assigns shorter length-scales to
+regions close to the discontinuity can reduce this issue. In this script,
+a local length-scale model is provided and only a global modifier of the
+length scales is learned. This non-stationary model generalizes more globally
+and obtains a considerably higher posterior probability.
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+import numpy as np
+from scipy.special import gamma, kv
+from sklearn.gaussian_process import GaussianProcess
+from sklearn.gaussian_process.correlation_models \
+    import MACHINE_EPSILON, l1_cross_differences
+from matplotlib import pyplot as pl
+
+np.random.seed(0)
+
+
+def f(x):
+    """The function to predict.
+
+    The function has a discontinuity at x=0.
+    """
+    return np.where(x[:, 0] > 0, np.sin(x[:, 0]), np.cos(-x[:, 0])) - 2
+
+
+#----------------------------------------------------------------------
+# Correlation model
+
+def length_scale(X):
+    """ Predetermined length-scales for the test problem.
+
+    Length-scales are smaller close to the discontinuity at x=0
+    """
+    return 10**np.minimum(0, 5 * X[:, 0] ** 2 - 1.0)
+
+
+class NonStationaryCorrelation(object):
+    """ Non-stationary correlation model with predetermined length-scales."""
+
+    def fit(self, X, nugget=10. * MACHINE_EPSILON):
+        self.X = X
+        self.nugget = nugget
+        self.n_samples = self.X.shape[0]
+
+        # Calculate array with shape (n_eval, n_features) giving the
+        # componentwise distances between locations x and x' at which the
+        # correlation model should be evaluated.
+        self.D, self.ij = l1_cross_differences(self.X)
+
+        # Calculate length scales
+        self.l_train = length_scale(self.X)
+
+    def __call__(self, theta, X=None):
+        # Prepare distances and length scale information for any pair of
+        # datapoints, whose correlation shall be computed
+        if X is not None:
+            # Get pairwise componentwise L1-differences to the input training
+            # set
+            d = X[:, np.newaxis, :] - self.X[np.newaxis, :, :]
+            d = d.reshape((-1, X.shape[1]))
+            # Calculate length scales
+            l_query = length_scale(X)
+            l = np.transpose([np.tile(self.l_train, len(l_query)),
+                              np.repeat(l_query, len(self.l_train))])
+        else:
+            # No external datapoints given; auto-correlation of training set
+            # is used instead
+            d = self.D
+            l = self.l_train[self.ij]
+
+        # Compute general Matern kernel for nu=1.5
+        nu = 1.5
+        if d.ndim > 1 and theta.size == d.ndim:
+            activation = np.sum(theta.reshape(1, d.ndim) * d ** 2, axis=1)
+        else:
+            activation = theta[0] * np.sum(d ** 2, axis=1)
+        tmp = 0.5*(l**2).sum(1)
+        tmp2 = 2*np.sqrt(nu * activation / tmp)
+        r = np.sqrt(l[:, 0]) * np.sqrt(l[:, 1]) / (gamma(nu) * 2**(nu - 1))
+        r /= np.sqrt(tmp)
+        r *= tmp2**nu * kv(nu, tmp2)
+
+        # Convert correlations to 2d matrix
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:  # exploit symmetry of auto-correlation
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
+
+    def log_prior(self, theta):
+        # Just use a flat prior
+        return 0
+
+#----------------------------------------------------------------------
+# Actual test data
+X = np.random.random(50)[:, None] * 4 - 2
+
+# Observations
+y = f(X).ravel()
+
+# Mesh the input space for evaluations of the real function, the prediction and
+# its MSE
+x = np.atleast_2d(np.linspace(-2, 2, 1000)).T
+
+# Instanciate one Gaussian Process model for the stationary Matern kernel and
+# one for the non-stationary one
+gp_stationary = \
+    GaussianProcess(corr='matern_1.5', theta0=1e0, thetaL=1e-2, thetaU=1e+2,
+                    random_start=100)
+gp_non_stationary = \
+    GaussianProcess(corr=NonStationaryCorrelation(),
+                    theta0=1e0, thetaL=1e-2, thetaU=1e+2,
+                    random_start=100)
+
+# Fit to data using Maximum Likelihood Estimation of the parameters
+gp_stationary.fit(X, y)
+gp_non_stationary.fit(X, y)
+print("Theta:\n\tStationary: {:.3f} \t Non-stationary: {:.3f}"
+      .format(gp_stationary.theta_[0], gp_non_stationary.theta_[0]))
+print("Posterior probability (negative, average, log):\n\t"
+      "Stationary: {:.5f} \t Non-stationary: {:.5f}"
+      .format(gp_stationary.posterior_function_value_,
+              gp_non_stationary.posterior_function_value_))
+
+# Plot predictions
+for title, gp in [("stationary", gp_stationary),
+                  ("non-stationary", gp_non_stationary)]:
+    # Make the prediction on the meshed x-axis (ask for MSE as well)
+    y_pred, MSE = gp.predict(x, eval_MSE=True)
+    sigma = np.sqrt(MSE)
+
+    # Plot the function, the prediction and the 95% confidence interval
+    # based on the MSE
+    fig = pl.figure()
+    pl.plot(x, f(x), 'r:',
+            label=u'$f(x) = -2 + sin(x)$ if $x > 0$ else $-2 + cos(-x)$')
+    pl.plot(X, y, 'r.', markersize=10, label=u'Observations')
+    pl.plot(x, y_pred, 'b-', label=u'Prediction')
+    pl.fill(np.concatenate([x, x[::-1]]),
+            np.concatenate([y_pred - 1.9600 * sigma,
+                           (y_pred + 1.9600 * sigma)[::-1]]),
+            alpha=.5, fc='b', ec='None', label='95% confidence interval')
+    if gp == gp_non_stationary:
+        pl.plot(x, length_scale(x), label="Length scales")
+    pl.xlabel('$x$')
+    pl.ylabel('$f(x)$')
+    pl.ylim(-5, 5)
+    pl.legend(loc='upper left')
+    pl.title(title)
+
+pl.show()

--- a/examples/gaussian_process/plot_matern_kernel.py
+++ b/examples/gaussian_process/plot_matern_kernel.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+============================================================================
+Gaussian Processes regression: comparing different variants of Matern kernel
+============================================================================
+
+Gaussian Process regression with four different variants of the Matern kernel
+is compared (for activ=dx.T * M * dx and M being a covariance matrix of size
+n*n encoded in theta):
+ * The Matern kernel for nu=1.5:
+   r(theta, dx) = (1 + np.sqrt(3*activ))*exp(-np.sqrt(3*activ))
+ * The Matern kernel for nu=2.5:
+   r(theta, dx) = (1 + np.sqrt(5*activ) + 5/3*activ)*exp(-np.sqrt(5*activ))
+ * The absolute-exponential kernel which corresponds to a Matern kernel
+   with nu=0.5
+ * The squared-exponential kernel which corresponds to a Matern kernel
+   for the limit of nu becoming infinitely large
+
+The target function is a twice differentiable function which is created by
+fitting a spline to randomly sampled data over the interval [0, 10]. The
+squared-exponential kernel is expected to be too smooth for this function
+while the absolute-exponential kernel is typically too rough.
+
+See Rasmussen and Williams 2006, pp84 for details regarding the different
+variants of the Matern kernel.
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+import numpy as np
+from scipy.interpolate import InterpolatedUnivariateSpline
+from scipy.stats import sem
+from sklearn.gaussian_process.gaussian_process import GaussianProcess
+from sklearn.learning_curve import learning_curve
+import matplotlib.pyplot as plt
+
+np.random.seed(0)
+
+# Generate a twice-differentiable target function by fitting a spline to
+# random data points
+xt = np.linspace(0, 10, 10)
+yt = np.random.random(10)
+f = InterpolatedUnivariateSpline(xt, yt, k=2)
+
+# Train GaussianProcesses with squared-exponential and Matern (nu=2.5)
+# correlation models and plot resulting predictions
+x = np.random.uniform(0, 10, 25)
+y = f(x)
+
+gp_matern = GaussianProcess(corr="matern_2.5", theta0=1e-1, thetaL=1e-2,
+                            thetaU=1e1).fit(x[:, None], y)
+gp_se = GaussianProcess(corr="squared_exponential", theta0=1e-1, thetaL=1e-2,
+                        thetaU=1e1).fit(x[:, None], y)
+gp_ae = GaussianProcess(corr="absolute_exponential", theta0=1e-1, thetaL=1e-2,
+                        thetaU=1e1).fit(x[:, None], y)
+
+xp = np.linspace(0, 10, 100)
+plt.figure(0)
+plt.scatter(x, y, c='k', s=100)
+plt.plot(xp, f(xp), label="True", c='b')
+plt.plot(xp, gp_se.predict(xp[:, None]), label="squared_exponential", c='g')
+plt.plot(xp, gp_matern.predict(xp[:, None]), label="matern_2.5", c='r')
+plt.plot(xp, gp_ae.predict(xp[:, None]), label="absolute_exponential", c='m')
+plt.legend(loc='best')
+
+# Plot learning curve of GaussianProcess for different correlation models
+x = np.random.uniform(0, 10, 100)
+y = f(x)
+plt.figure(1)
+colors = ['g', 'r', 'c', 'm']
+for i, corr in enumerate(["squared_exponential", "matern_1.5", "matern_2.5",
+                          "absolute_exponential"]):
+    train_sizes, train_scores, test_scores = \
+        learning_curve(GaussianProcess(corr=corr, theta0=1e-1, thetaL=1e-3,
+                                       thetaU=1e1),
+                       x[:, None], y, scoring="mean_squared_error", cv=25,
+                       n_jobs=4)
+    test_scores = -test_scores  # Scores correspond to negative MSE
+    plt.errorbar(train_sizes, np.mean(test_scores, axis=1),
+                 sem(test_scores, axis=1), color=colors[i], label=corr)
+plt.xlabel("Training examples")
+plt.ylabel("Mean Squared Error")
+plt.legend(loc='best')
+plt.yscale('log')
+plt.show()

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -15,7 +15,6 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 
 from ..utils import array2d
-from ..metrics.pairwise import manhattan_distances
 from ..externals.six import with_metaclass
 
 MACHINE_EPSILON = np.finfo(np.double).eps
@@ -118,8 +117,10 @@ class StationaryCorrelation(with_metaclass(ABCMeta, object)):
         """
         theta = np.asarray(theta, dtype=np.float)
         if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+            # Get pairwise componentwise L1-differences to the input training
+            # set
+            d = X[:, np.newaxis, :] - self.X[np.newaxis, :, :]
+            d = d.reshape((-1, X.shape[1]))
         else:
             # No external datapoints given; auto-correlation of training set
             # is used instead

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -152,6 +152,27 @@ class StationaryCorrelation(with_metaclass(ABCMeta, object)):
             R[self.ij[:, 1], self.ij[:, 0]] = r
             return R
 
+    def log_prior(self, theta):
+        """ Returns the (log) prior probability of parameters theta.
+
+        The prior is assumed to be uniform over the parameter space.
+        NOTE: The returned quantity is an improper prior as its integral over
+              the parameter space is not equal to 1.
+
+        Parameters
+        ----------
+        theta : array_like, shape=(1,) or (n_features,)
+            An array with shape 1 (isotropic) or n_features (anisotropic)
+            giving the autocorrelation parameter(s).
+
+        Returns
+        -------
+        log_p : float
+            The (log) prior probability of parameters theta. An improper
+            probability.
+        """
+        return 0
+
     @abstractmethod
     def _compute_corr(self, theta, d, n_features):
         """ Correlation for given pairwise, component-wise L1-differences.

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -2,6 +2,8 @@
 
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 #         (mostly translation, see implementation details)
+#         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+#         (converting to a object-oriented, more modular design)
 # Licence: BSD 3 clause
 
 """
@@ -69,30 +71,7 @@ class StationaryCorrelation(object):
 #                raise Exception("Multiple input features cannot have the same"
 #                                " value.")
 
-
-class AbsoluteExponential(StationaryCorrelation):
-
     def __call__(self, theta, X=None):
-        """
-        Absolute exponential autocorrelation model.
-        (Ornstein-Uhlenbeck stochastic process)::
-
-                                                n
-            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i| )
-                                              i = 1
-
-        Parameters
-        ----------
-        theta : array_like
-            An array with shape 1 (isotropic) or n (anisotropic) giving the
-            autocorrelation parameter(s).
-
-        Returns
-        -------
-        r : array_like
-            An array with shape (n_eval, ) containing the values of the
-            autocorrelation model.
-        """
         theta = np.asarray(theta, dtype=np.float)
         if X is not None:
             # Get pairwise componentwise L1-distances to the input training set
@@ -105,12 +84,7 @@ class AbsoluteExponential(StationaryCorrelation):
         else:
             n_features = 1
 
-        if theta.size == 1:
-            r = np.exp(- theta[0] * np.sum(d, axis=1))
-        elif theta.size != n_features:
-            raise ValueError("Length of theta must be 1 or %s" % n_features)
-        else:
-            r = np.exp(- np.sum(theta.reshape(1, n_features) * d, axis=1))
+        r = self._compute_corr(theta, d, n_features)
 
         if X is not None:
             return r.reshape(-1, self.n_samples)
@@ -119,95 +93,113 @@ class AbsoluteExponential(StationaryCorrelation):
             R[self.ij[:, 0], self.ij[:, 1]] = r
             R[self.ij[:, 1], self.ij[:, 0]] = r
             return R
+
+
+class AbsoluteExponential(StationaryCorrelation):
+    """ Absolute exponential autocorrelation model.
+
+    Absolute exponential autocorrelation model (Ornstein-Uhlenbeck stochastic
+    process)::
+
+                                              n
+            theta, d --> r(theta, d) = exp(  sum  - theta_i * d_i )
+                                             i = 1
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
+
+        Parameters
+        ----------
+        theta : array_like, shape=(1,) or (n_features,)
+            An array with shape 1 (isotropic) or n_features (anisotropic)
+            giving the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
+
+        Returns
+        -------
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
+        """
+        if theta.size == 1:
+            return np.exp(- theta[0] * np.sum(d, axis=1))
+        elif theta.size != n_features:
+            raise ValueError("Length of theta must be 1 or %s" % n_features)
+        else:
+            return np.exp(- np.sum(theta.reshape(1, n_features) * d, axis=1))
 
 
 class SquaredExponential(StationaryCorrelation):
+    """ Squared exponential correlation model.
 
-    def __call__(self, theta, X=None):
-        """
-        Squared exponential correlation model (Radial Basis Function).
-        (Infinitely differentiable stochastic process, very smooth)::
+    Squared exponential correlation model (Radial Basis Function).
+    (Infinitely differentiable stochastic process, very smooth)::
 
-                                                n
-            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * (dx_i)^2 )
-                                              i = 1
+                                              n
+            theta, d --> r(theta, d) = exp(  sum  - theta_i * (d_i)^2 )
+                                            i = 1
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
 
         Parameters
         ----------
-        theta : array_like
-            An array with shape 1 (isotropic) or n (anisotropic) giving the
-            autocorrelation parameter(s).
+        theta : array_like, shape=(1,) or (n_features,)
+            An array with shape 1 (isotropic) or n_features (anisotropic)
+            giving the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
 
         Returns
         -------
-        r : array_like
-            An array with shape (n_eval, ) containing the values of the
-            autocorrelation model.
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
         """
-        theta = np.asarray(theta, dtype=np.float)
-        if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
-        else:
-            d = self.D
-
-        if d.ndim > 1:
-            n_features = d.shape[1]
-        else:
-            n_features = 1
-
         if theta.size == 1:
-            r = np.exp(-theta[0] * np.sum(d ** 2, axis=1))
+            return np.exp(-theta[0] * np.sum(d ** 2, axis=1))
         elif theta.size != n_features:
             raise ValueError("Length of theta must be 1 or %s" % n_features)
         else:
-            r = np.exp(-np.sum(theta.reshape(1, n_features) * d ** 2, axis=1))
-
-        if X is not None:
-            return r.reshape(-1, self.n_samples)
-        else:
-            R = np.eye(self.n_samples) * (1. + self.nugget)
-            R[self.ij[:, 0], self.ij[:, 1]] = r
-            R[self.ij[:, 1], self.ij[:, 0]] = r
-            return R
+            return np.exp(-np.sum(theta.reshape(1, n_features) * d ** 2,
+                          axis=1))
 
 
 class GeneralizedExponential(StationaryCorrelation):
+    """ Generalized exponential correlation model.
 
-    def __call__(self, theta, X=None):
-        """
-        Generalized exponential correlation model.
-        (Useful when one does not know the smoothness of the function to be
-        predicted.)::
+    Generalized exponential correlation model.
+    (Useful when one does not know the smoothness of the function to be
+    predicted.)::
 
-                                                n
-            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i|^p )
-                                              i = 1
+                                          n
+        theta, d --> r(theta, d) = exp(  sum  - theta_i * |d_i|^p )
+                                        i = 1
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
 
         Parameters
         ----------
-        theta : array_like
-            An array with shape 1+1 (isotropic) or n+1 (anisotropic) giving the
-            autocorrelation parameter(s) (theta, p).
+        theta : array_like, shape=(1+1,) or (n_features+1,)
+            An array with shape 1+1 (isotropic) or n_features+1 (anisotropic)
+            giving the autocorrelation parameter(s) (theta, p).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
 
         Returns
         -------
-        r : array_like
-            An array with shape (n_eval, ) with the values of the
-            autocorrelation model.
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
         """
-        theta = np.asarray(theta, dtype=np.float)
-        if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
-        else:
-            d = self.D
-
-        if d.ndim > 1:
-            n_features = d.shape[1]
-        else:
-            n_features = 1
-
         lth = theta.size
         if n_features > 1 and lth == 2:
             theta = np.hstack([np.repeat(theta[0], n_features), theta[1]])
@@ -219,34 +211,32 @@ class GeneralizedExponential(StationaryCorrelation):
 
         td = theta[:, 0:-1].reshape(1, n_features) \
             * np.abs(d) ** theta[:, -1]
-        r = np.exp(- np.sum(td, 1))
-
-        if X is not None:
-            return r.reshape(-1, self.n_samples)
-        else:
-            R = np.eye(self.n_samples) * (1. + self.nugget)
-            R[self.ij[:, 0], self.ij[:, 1]] = r
-            R[self.ij[:, 1], self.ij[:, 0]] = r
-            return R
+        return np.exp(- np.sum(td, 1))
 
 
 class PureNugget(StationaryCorrelation):
+    """ Spatial independence correlation model (pure nugget).
 
-    def __call__(self, theta, X=None):
-        """
-        Spatial independence correlation model (pure nugget).
-        (Useful when one wants to solve an ordinary least squares problem!)::
+    Useful when one wants to solve an ordinary least squares problem!::
 
-                                                 n
-            theta, dx --> r(theta, dx) = 1 if   sum |dx_i| == 0
-                                               i = 1
-                                         0 otherwise
+                                                n
+            theta, d --> r(theta, dx) = 1 if   sum |d_i| == 0
+                                              i = 1
+                                        0 otherwise
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
 
         Parameters
         ----------
         theta : array_like
             None.
 
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
+
 
         Returns
         -------
@@ -254,62 +244,42 @@ class PureNugget(StationaryCorrelation):
             An array with shape (n_eval, ) with the values of the
             autocorrelation model.
         """
-
-        theta = np.asarray(theta, dtype=np.float)
-        if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
-        else:
-            d = self.D
-
         n_eval = d.shape[0]
         r = np.zeros(n_eval)
         r[np.all(d == 0., axis=1)] = 1.
 
-        if X is not None:
-            return r.reshape(-1, self.n_samples)
-        else:
-            R = np.eye(self.n_samples) * (1. + self.nugget)
-            R[self.ij[:, 0], self.ij[:, 1]] = r
-            R[self.ij[:, 1], self.ij[:, 0]] = r
-            return R
+        return r
 
 
 class Cubic(StationaryCorrelation):
+    """ Cubic correlation model.
 
-    def __call__(self, theta, X=None):
-        """
-        Cubic correlation model::
+    Cubic correlation model::
 
-            theta, dx --> r(theta, dx) =
-              n
-            prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
-            j = 1
+        theta, d --> r(theta, d) =
+          n
+        prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
+        j = 1
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
 
         Parameters
         ----------
-        theta : array_like
-            An array with shape 1 (isotropic) or n (anisotropic) giving the
-            autocorrelation parameter(s).
+        theta : array_like, shape=(1,) or (n_features,)
+            An array with shape 1 (isotropic) or n_features (anisotropic)
+            giving the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
 
         Returns
         -------
-        r : array_like
-            An array with shape (n_eval, ) with the values of the
-            autocorrelation model.
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
         """
-        theta = np.asarray(theta, dtype=np.float)
-        if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
-        else:
-            d = self.D
-
-        if d.ndim > 1:
-            n_features = self.D.shape[1]
-        else:
-            n_features = 1
-
         lth = theta.size
         if lth == 1:
             td = np.abs(d) * theta
@@ -320,52 +290,38 @@ class Cubic(StationaryCorrelation):
 
         td[td > 1.] = 1.
         ss = 1. - td ** 2. * (3. - 2. * td)
-        r = np.prod(ss, 1)
-
-        if X is not None:
-            return r.reshape(-1, self.n_samples)
-        else:
-            R = np.eye(self.n_samples) * (1. + self.nugget)
-            R[self.ij[:, 0], self.ij[:, 1]] = r
-            R[self.ij[:, 1], self.ij[:, 0]] = r
-            return R
+        return np.prod(ss, 1)
 
 
 class Linear(StationaryCorrelation):
+    """ Linear correlation model.
 
-    def __call__(self, theta, X=None):
-        """
-        Linear correlation model::
+    Linear correlation model::
 
-            theta, dx --> r(theta, dx) =
-                  n
-                prod max(0, 1 - theta_j*d_ij) ,  i = 1,...,m
-                j = 1
+        theta, d --> r(theta, d) =
+              n
+            prod max(0, 1 - theta_j*d_ij) ,  i = 1,...,m
+            j = 1
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
 
         Parameters
         ----------
-        theta : array_like
-            An array with shape 1 (isotropic) or n (anisotropic) giving the
-            autocorrelation parameter(s).
+        theta : array_like, shape=(1,) or (n_features,)
+            An array with shape 1 (isotropic) or n_features (anisotropic)
+            giving the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
 
         Returns
         -------
-        r : array_like
-            An array with shape (n_eval, ) with the values of the
-            autocorrelation model.
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
         """
-        theta = np.asarray(theta, dtype=np.float)
-        if X is not None:
-            # Get pairwise componentwise L1-distances to the input training set
-            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
-        else:
-            d = self.D
-
-        if d.ndim > 1:
-            n_features = d.shape[1]
-        else:
-            n_features = 1
-
         lth = theta.size
         if lth == 1:
             td = np.abs(d) * theta
@@ -376,12 +332,4 @@ class Linear(StationaryCorrelation):
 
         td[td > 1.] = 1.
         ss = 1. - td
-        r = np.prod(ss, 1)
-
-        if X is not None:
-            return r.reshape(-1, self.n_samples)
-        else:
-            R = np.eye(self.n_samples) * (1. + self.nugget)
-            R[self.ij[:, 0], self.ij[:, 1]] = r
-            R[self.ij[:, 1], self.ij[:, 0]] = r
-            return R
+        return np.prod(ss, 1)

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -8,277 +8,380 @@
 The built-in correlation models submodule for the gaussian_process module.
 """
 
-
 import numpy as np
 
+from ..utils import array2d
+from ..metrics.pairwise import manhattan_distances
 
-def absolute_exponential(theta, d):
+
+def l1_cross_distances(X):
     """
-    Absolute exponential autocorrelation model.
-    (Ornstein-Uhlenbeck stochastic process)::
-
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i| )
-                                          i = 1
+    Computes the nonzero componentwise L1 cross-distances between the vectors
+    in X.
 
     Parameters
     ----------
-    theta : array_like
-        An array with shape 1 (isotropic) or n (anisotropic) giving the
-        autocorrelation parameter(s).
 
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
+    X: array_like
+        An array with shape (n_samples, n_features)
 
     Returns
     -------
-    r : array_like
-        An array with shape (n_eval, ) containing the values of the
-        autocorrelation model.
+
+    D: array with shape (n_samples * (n_samples - 1) / 2, n_features)
+        The array of componentwise L1 cross-distances.
+
+    ij: arrays with shape (n_samples * (n_samples - 1) / 2, 2)
+        The indices i and j of the vectors in X associated to the cross-
+        distances in D: D[k] = np.abs(X[ij[k, 0]] - Y[ij[k, 1]]).
     """
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.abs(np.asarray(d, dtype=np.float))
+    X = array2d(X)
+    n_samples, n_features = X.shape
+    n_nonzero_cross_dist = n_samples * (n_samples - 1) // 2
+    ij = np.zeros((n_nonzero_cross_dist, 2), dtype=np.int)
+    D = np.zeros((n_nonzero_cross_dist, n_features))
+    ll_1 = 0
+    for k in range(n_samples - 1):
+        ll_0 = ll_1
+        ll_1 = ll_0 + n_samples - k - 1
+        ij[ll_0:ll_1, 0] = k
+        ij[ll_0:ll_1, 1] = np.arange(k + 1, n_samples)
+        D[ll_0:ll_1] = np.abs(X[k] - X[(k + 1):n_samples])
 
-    if d.ndim > 1:
-        n_features = d.shape[1]
-    else:
-        n_features = 1
-
-    if theta.size == 1:
-        return np.exp(- theta[0] * np.sum(d, axis=1))
-    elif theta.size != n_features:
-        raise ValueError("Length of theta must be 1 or %s" % n_features)
-    else:
-        return np.exp(- np.sum(theta.reshape(1, n_features) * d, axis=1))
-
-
-def squared_exponential(theta, d):
-    """
-    Squared exponential correlation model (Radial Basis Function).
-    (Infinitely differentiable stochastic process, very smooth)::
-
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * (dx_i)^2 )
-                                          i = 1
-
-    Parameters
-    ----------
-    theta : array_like
-        An array with shape 1 (isotropic) or n (anisotropic) giving the
-        autocorrelation parameter(s).
-
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
-
-    Returns
-    -------
-    r : array_like
-        An array with shape (n_eval, ) containing the values of the
-        autocorrelation model.
-    """
-
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
-
-    if d.ndim > 1:
-        n_features = d.shape[1]
-    else:
-        n_features = 1
-
-    if theta.size == 1:
-        return np.exp(-theta[0] * np.sum(d ** 2, axis=1))
-    elif theta.size != n_features:
-        raise ValueError("Length of theta must be 1 or %s" % n_features)
-    else:
-        return np.exp(-np.sum(theta.reshape(1, n_features) * d ** 2, axis=1))
+    return D, ij
 
 
-def generalized_exponential(theta, d):
-    """
-    Generalized exponential correlation model.
-    (Useful when one does not know the smoothness of the function to be
-    predicted.)::
+class StationaryCorrelation(object):
 
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i|^p )
-                                          i = 1
+    def __init__(self, X, nugget, storage_mode='full'):  # TODO: Storage mode
+        self.X = X
+        self.nugget = nugget
+        self.n_samples = X.shape[0]
 
-    Parameters
-    ----------
-    theta : array_like
-        An array with shape 1+1 (isotropic) or n+1 (anisotropic) giving the
-        autocorrelation parameter(s) (theta, p).
-
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
-
-    Returns
-    -------
-    r : array_like
-        An array with shape (n_eval, ) with the values of the autocorrelation
-        model.
-    """
-
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
-
-    if d.ndim > 1:
-        n_features = d.shape[1]
-    else:
-        n_features = 1
-
-    lth = theta.size
-    if n_features > 1 and lth == 2:
-        theta = np.hstack([np.repeat(theta[0], n_features), theta[1]])
-    elif lth != n_features + 1:
-        raise Exception("Length of theta must be 2 or %s" % (n_features + 1))
-    else:
-        theta = theta.reshape(1, lth)
-
-    td = theta[:, 0:-1].reshape(1, n_features) * np.abs(d) ** theta[:, -1]
-    r = np.exp(- np.sum(td, 1))
-
-    return r
+        # Calculate array with shape (n_eval, n_features) giving the
+        # componentwise distances between locations x and x' at which the
+        # correlation model should be evaluated.
+        self.D, self.ij = l1_cross_distances(self.X)
+        self.D = np.abs(np.asarray(self.D, dtype=np.float))
+        # TODO:
+#           if (np.min(np.sum(self.D, axis=1)) == 0.
+#                    and self.corr != correlation.pure_nugget):
+#                raise Exception("Multiple input features cannot have the same"
+#                                " value.")
 
 
-def pure_nugget(theta, d):
-    """
-    Spatial independence correlation model (pure nugget).
-    (Useful when one wants to solve an ordinary least squares problem!)::
+class AbsoluteExponential(StationaryCorrelation):
 
-                                             n
-        theta, dx --> r(theta, dx) = 1 if   sum |dx_i| == 0
-                                           i = 1
-                                     0 otherwise
+    def __call__(self, theta, X=None):
+        """
+        Absolute exponential autocorrelation model.
+        (Ornstein-Uhlenbeck stochastic process)::
 
-    Parameters
-    ----------
-    theta : array_like
-        None.
+                                                n
+            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i| )
+                                              i = 1
 
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
+        Parameters
+        ----------
+        theta : array_like
+            An array with shape 1 (isotropic) or n (anisotropic) giving the
+            autocorrelation parameter(s).
 
-    Returns
-    -------
-    r : array_like
-        An array with shape (n_eval, ) with the values of the autocorrelation
-        model.
-    """
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) containing the values of the
+            autocorrelation model.
+        """
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
 
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
+        if d.ndim > 1:
+            n_features = d.shape[1]
+        else:
+            n_features = 1
 
-    n_eval = d.shape[0]
-    r = np.zeros(n_eval)
-    r[np.all(d == 0., axis=1)] = 1.
+        if theta.size == 1:
+            r = np.exp(- theta[0] * np.sum(d, axis=1))
+        elif theta.size != n_features:
+            raise ValueError("Length of theta must be 1 or %s" % n_features)
+        else:
+            r = np.exp(- np.sum(theta.reshape(1, n_features) * d, axis=1))
 
-    return r
-
-
-def cubic(theta, d):
-    """
-    Cubic correlation model::
-
-        theta, dx --> r(theta, dx) =
-          n
-        prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
-        j = 1
-
-    Parameters
-    ----------
-    theta : array_like
-        An array with shape 1 (isotropic) or n (anisotropic) giving the
-        autocorrelation parameter(s).
-
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
-
-    Returns
-    -------
-    r : array_like
-        An array with shape (n_eval, ) with the values of the autocorrelation
-        model.
-    """
-
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
-
-    if d.ndim > 1:
-        n_features = d.shape[1]
-    else:
-        n_features = 1
-
-    lth = theta.size
-    if lth == 1:
-        td = np.abs(d) * theta
-    elif lth != n_features:
-        raise Exception("Length of theta must be 1 or " + str(n_features))
-    else:
-        td = np.abs(d) * theta.reshape(1, n_features)
-
-    td[td > 1.] = 1.
-    ss = 1. - td ** 2. * (3. - 2. * td)
-    r = np.prod(ss, 1)
-
-    return r
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
 
 
-def linear(theta, d):
-    """
-    Linear correlation model::
+class SquaredExponential(StationaryCorrelation):
 
-        theta, dx --> r(theta, dx) =
+    def __call__(self, theta, X=None):
+        """
+        Squared exponential correlation model (Radial Basis Function).
+        (Infinitely differentiable stochastic process, very smooth)::
+
+                                                n
+            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * (dx_i)^2 )
+                                              i = 1
+
+        Parameters
+        ----------
+        theta : array_like
+            An array with shape 1 (isotropic) or n (anisotropic) giving the
+            autocorrelation parameter(s).
+
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) containing the values of the
+            autocorrelation model.
+        """
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
+
+        if d.ndim > 1:
+            n_features = d.shape[1]
+        else:
+            n_features = 1
+
+        if theta.size == 1:
+            r = np.exp(-theta[0] * np.sum(d ** 2, axis=1))
+        elif theta.size != n_features:
+            raise ValueError("Length of theta must be 1 or %s" % n_features)
+        else:
+            r = np.exp(-np.sum(theta.reshape(1, n_features) * d ** 2, axis=1))
+
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
+
+
+class GeneralizedExponential(StationaryCorrelation):
+
+    def __call__(self, theta, X=None):
+        """
+        Generalized exponential correlation model.
+        (Useful when one does not know the smoothness of the function to be
+        predicted.)::
+
+                                                n
+            theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i|^p )
+                                              i = 1
+
+        Parameters
+        ----------
+        theta : array_like
+            An array with shape 1+1 (isotropic) or n+1 (anisotropic) giving the
+            autocorrelation parameter(s) (theta, p).
+
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) with the values of the
+            autocorrelation model.
+        """
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
+
+        if d.ndim > 1:
+            n_features = d.shape[1]
+        else:
+            n_features = 1
+
+        lth = theta.size
+        if n_features > 1 and lth == 2:
+            theta = np.hstack([np.repeat(theta[0], n_features), theta[1]])
+        elif lth != n_features + 1:
+            raise Exception("Length of theta must be 2 or %s"
+                            % (n_features + 1))
+        else:
+            theta = theta.reshape(1, lth)
+
+        td = theta[:, 0:-1].reshape(1, n_features) \
+            * np.abs(d) ** theta[:, -1]
+        r = np.exp(- np.sum(td, 1))
+
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
+
+
+class PureNugget(StationaryCorrelation):
+
+    def __call__(self, theta, X=None):
+        """
+        Spatial independence correlation model (pure nugget).
+        (Useful when one wants to solve an ordinary least squares problem!)::
+
+                                                 n
+            theta, dx --> r(theta, dx) = 1 if   sum |dx_i| == 0
+                                               i = 1
+                                         0 otherwise
+
+        Parameters
+        ----------
+        theta : array_like
+            None.
+
+
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) with the values of the
+            autocorrelation model.
+        """
+
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
+
+        n_eval = d.shape[0]
+        r = np.zeros(n_eval)
+        r[np.all(d == 0., axis=1)] = 1.
+
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
+
+
+class Cubic(StationaryCorrelation):
+
+    def __call__(self, theta, X=None):
+        """
+        Cubic correlation model::
+
+            theta, dx --> r(theta, dx) =
               n
-            prod max(0, 1 - theta_j*d_ij) ,  i = 1,...,m
+            prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
             j = 1
 
-    Parameters
-    ----------
-    theta : array_like
-        An array with shape 1 (isotropic) or n (anisotropic) giving the
-        autocorrelation parameter(s).
+        Parameters
+        ----------
+        theta : array_like
+            An array with shape 1 (isotropic) or n (anisotropic) giving the
+            autocorrelation parameter(s).
 
-    dx : array_like
-        An array with shape (n_eval, n_features) giving the componentwise
-        distances between locations x and x' at which the correlation model
-        should be evaluated.
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) with the values of the
+            autocorrelation model.
+        """
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
 
-    Returns
-    -------
-    r : array_like
-        An array with shape (n_eval, ) with the values of the autocorrelation
-        model.
-    """
+        if d.ndim > 1:
+            n_features = self.D.shape[1]
+        else:
+            n_features = 1
 
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
+        lth = theta.size
+        if lth == 1:
+            td = np.abs(d) * theta
+        elif lth != n_features:
+            raise Exception("Length of theta must be 1 or " + str(n_features))
+        else:
+            td = np.abs(d) * theta.reshape(1, n_features)
 
-    if d.ndim > 1:
-        n_features = d.shape[1]
-    else:
-        n_features = 1
+        td[td > 1.] = 1.
+        ss = 1. - td ** 2. * (3. - 2. * td)
+        r = np.prod(ss, 1)
 
-    lth = theta.size
-    if lth == 1:
-        td = np.abs(d) * theta
-    elif lth != n_features:
-        raise Exception("Length of theta must be 1 or %s" % n_features)
-    else:
-        td = np.abs(d) * theta.reshape(1, n_features)
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R
 
-    td[td > 1.] = 1.
-    ss = 1. - td
-    r = np.prod(ss, 1)
 
-    return r
+class Linear(StationaryCorrelation):
+
+    def __call__(self, theta, X=None):
+        """
+        Linear correlation model::
+
+            theta, dx --> r(theta, dx) =
+                  n
+                prod max(0, 1 - theta_j*d_ij) ,  i = 1,...,m
+                j = 1
+
+        Parameters
+        ----------
+        theta : array_like
+            An array with shape 1 (isotropic) or n (anisotropic) giving the
+            autocorrelation parameter(s).
+
+        Returns
+        -------
+        r : array_like
+            An array with shape (n_eval, ) with the values of the
+            autocorrelation model.
+        """
+        theta = np.asarray(theta, dtype=np.float)
+        if X is not None:
+            # Get pairwise componentwise L1-distances to the input training set
+            d = manhattan_distances(X, Y=self.X, sum_over_features=False)
+        else:
+            d = self.D
+
+        if d.ndim > 1:
+            n_features = d.shape[1]
+        else:
+            n_features = 1
+
+        lth = theta.size
+        if lth == 1:
+            td = np.abs(d) * theta
+        elif lth != n_features:
+            raise Exception("Length of theta must be 1 or %s" % n_features)
+        else:
+            td = np.abs(d) * theta.reshape(1, n_features)
+
+        td[td > 1.] = 1.
+        ss = 1. - td
+        r = np.prod(ss, 1)
+
+        if X is not None:
+            return r.reshape(-1, self.n_samples)
+        else:
+            R = np.eye(self.n_samples) * (1. + self.nugget)
+            R[self.ij[:, 0], self.ij[:, 1]] = r
+            R[self.ij[:, 1], self.ij[:, 0]] = r
+            return R

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -89,7 +89,6 @@ class StationaryCorrelation(with_metaclass(ABCMeta, object)):
         # componentwise distances between locations x and x' at which the
         # correlation model should be evaluated.
         self.D, self.ij = l1_cross_distances(self.X)
-        self.D = np.abs(np.asarray(self.D, dtype=np.float))
         if (np.min(np.sum(self.D, axis=1)) == 0.
            and not isinstance(self.corr, PureNugget)):
             raise Exception("Multiple input features cannot have the same"
@@ -197,6 +196,8 @@ class AbsoluteExponential(StationaryCorrelation):
         r : array_like, shape=(n_eval, )
             An array containing the values of the autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
+        d = np.abs(d)
         if theta.size == 1:
             return np.exp(- theta[0] * np.sum(d, axis=1))
         elif theta.size != n_features:
@@ -234,6 +235,7 @@ class SquaredExponential(StationaryCorrelation):
         r : array_like, shape=(n_eval, )
             An array containing the values of the autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
         if theta.size == 1:
             return np.exp(-theta[0] * np.sum(d ** 2, axis=1))
         elif theta.size != n_features:
@@ -273,6 +275,7 @@ class GeneralizedExponential(StationaryCorrelation):
         r : array_like, shape=(n_eval, )
             An array containing the values of the autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
         lth = theta.size
         if n_features > 1 and lth == 2:
             theta = np.hstack([np.repeat(theta[0], n_features), theta[1]])
@@ -317,6 +320,7 @@ class PureNugget(StationaryCorrelation):
             An array with shape (n_eval, ) with the values of the
             autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
         n_eval = d.shape[0]
         r = np.zeros(n_eval)
         r[np.all(d == 0., axis=1)] = 1.
@@ -353,6 +357,7 @@ class Cubic(StationaryCorrelation):
         r : array_like, shape=(n_eval, )
             An array containing the values of the autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
         lth = theta.size
         if lth == 1:
             td = np.abs(d) * theta
@@ -395,6 +400,7 @@ class Linear(StationaryCorrelation):
         r : array_like, shape=(n_eval, )
             An array containing the values of the autocorrelation model.
         """
+        d = np.asarray(d, dtype=np.float)
         lth = theta.size
         if lth == 1:
             td = np.abs(d) * theta

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -63,23 +63,28 @@ class StationaryCorrelation(with_metaclass(ABCMeta, object)):
     Stationary correlation models dependent only on the relative distance
     and not on the absolute positions of the respective datapoints. We can thus
     work internally solely on these distances.
-
-    Parameters
-    ----------
-    X : array_like, shape=(n_samples, n_features)
-        An array of training datapoints at which observations were made, i.e.,
-        where the outputs y are known
-    nugget : double or ndarray, optional
-        The Gaussian Process nugget parameter
-        The nugget is added to the diagonal of the assumed training covariance;
-        in this way it acts as a Tikhonov regularization in the problem.  In
-        the special case of the squared exponential correlation function, the
-        nugget mathematically represents the variance of the input values.
-        Default assumes a nugget close to machine precision for the sake of
-        robustness (nugget = 10. * MACHINE_EPSILON).
-
     """
-    def __init__(self, X, nugget=10. * MACHINE_EPSILON):
+    def __init__(self):
+        pass
+
+    def fit(self, X, nugget=10. * MACHINE_EPSILON):
+        """ Fits the correlation model for training data X
+
+        Parameters
+        ----------
+        X : array_like, shape=(n_samples, n_features)
+            An array of training datapoints at which observations were made,
+            i.e., where the outputs y are known
+        nugget : double or ndarray, optional
+            The Gaussian Process nugget parameter
+            The nugget is added to the diagonal of the assumed training
+            covariance; in this way it acts as a Tikhonov regularization in
+            the problem.  In the special case of the squared exponential
+            correlation function, the nugget mathematically represents the
+            variance of the input values. Default assumes a nugget close to
+            machine precision for the sake of robustness
+            (nugget = 10. * MACHINE_EPSILON).
+        """
         self.X = X
         self.nugget = nugget
         self.n_samples = X.shape[0]

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -291,6 +291,82 @@ class SquaredExponential(StationaryCorrelation):
                              % n_features)
 
 
+class Matern_1_5(SquaredExponential):
+    """ Matern correlation model for nu=1.5.
+
+    Sample paths are once differentiable. Given by::
+
+        r(theta, dx) = (1 + np.sqrt(3*activ))*exp(-np.sqrt(3*activ))
+    where activ=dx.T * M * dx and M is a covariance matrix of size n*n.
+
+    See Rasmussen and Williams 2006, pp84 for details regarding the different
+    variants of the Matern kernel.
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
+
+        Parameters
+        ----------
+        theta : array_like, shape=(1,) [isotropic]
+                                  (n_features,) [anisotropic] or
+                                  (k*n_features,) [factor analysis distance]
+            An array encoding the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
+
+        Returns
+        -------
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
+        """
+        d = np.asarray(d, dtype=np.float)
+        activ = self._quadratic_activation(theta, d, n_features)
+        tmp = np.sqrt(3 * activ)  # temporary variable for preventing
+                                  # recomputation
+        return (1 + tmp) * np.exp(-tmp)
+
+
+class Matern_2_5(SquaredExponential):
+    """ Matern correlation model for nu=2.5.
+
+    Sample paths are twice differentiable. Given by::
+
+       r(theta, dx) = (1 + np.sqrt(5*activ) + 5/3*activ)*exp(-np.sqrt(5*activ))
+    where activ=dx.T * M * dx and M is a covariance matrix of size n*n.
+
+    See Rasmussen and Williams 2006, pp84 for details regarding the different
+    variants of the Matern kernel.
+    """
+
+    def _compute_corr(self, theta, d, n_features):
+        """ Correlation for given pairwise, component-wise L1-differences.
+
+        Parameters
+        ----------
+        theta : array_like, shape=(1,) [isotropic]
+                                  (n_features,) [anisotropic] or
+                                  (k*n_features,) [factor analysis distance]
+            An array encoding the autocorrelation parameter(s).
+
+        d : array_like, shape=(n_eval, n_features)
+            An array with the pairwise, component-wise L1-differences of x
+            and x' at which the correlation model should be evaluated.
+
+        Returns
+        -------
+        r : array_like, shape=(n_eval, )
+            An array containing the values of the autocorrelation model.
+        """
+        d = np.asarray(d, dtype=np.float)
+        activ = self._quadratic_activation(theta, d, n_features)
+        tmp = np.sqrt(5 * activ)  # temporary variable for preventing
+                                  # recomputation
+        return (1 + tmp + 5.0 / 3.0 * activ) * np.exp(-tmp)
+
+
 class GeneralizedExponential(StationaryCorrelation):
     """ Generalized exponential correlation model.
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -263,8 +263,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             y_mean = np.zeros(1)
             y_std = np.ones(1)
 
-        # Instantiate correlation model
-        self.corr_ = self.corr(X, self.nugget)
+        # Fit correlation model
+        self.corr.fit(X, self.nugget)
 
         # Regression matrix and parameters
         F = self.regr(X)
@@ -400,7 +400,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             # Get regression function and correlation
             f = self.regr(X)
-            r = self.corr_(self.theta_, X)
+            r = self.corr(self.theta_, X)
 
             # Scaled predictor
             y_ = np.dot(f, self.beta) + np.dot(r, self.gamma)
@@ -544,7 +544,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             F = self.regr(self.X)
 
         # Determine (auto-)correlation of training data
-        R = self.corr_(theta)
+        R = self.corr(theta)
 
         # Cholesky decomposition of R
         try:
@@ -674,7 +674,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                         log10_optimal_theta = \
                             optimize.fmin_cobyla(
                                 minus_reduced_likelihood_function,
-                                np.log10(theta0), constraints,
+                                x0=np.log10(theta0), cons=constraints,
                                 iprint=0)
                     else:
                         log10_optimal_theta = \
@@ -713,7 +713,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             # Backup of the given atrributes
             theta0, thetaL, thetaU = self.theta0, self.thetaL, self.thetaU
-            corr = self.corr_
+            corr = self.corr
             verbose = self.verbose
 
             # This will iterate over fmin_cobyla optimizer
@@ -746,13 +746,13 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                                            optimal_theta[(i + 1)::]]
                                           ), X)
 
-                self.corr_ = corr_cut
+                self.corr = corr_cut
                 optimal_theta[i], optimal_rlf_value, optimal_par = \
                     self._arg_max_reduced_likelihood_function()
 
             # Restore the given atrributes
             self.theta0, self.thetaL, self.thetaU = theta0, thetaL, thetaU
-            self.corr_ = corr
+            self.corr = corr
             self.optimizer = 'Welch'
             self.verbose = verbose
 
@@ -785,7 +785,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         # Check correlation model
         if not callable(self.corr):
             if self.corr in self._correlation_types:
-                self.corr = self._correlation_types[self.corr]
+                self.corr = self._correlation_types[self.corr]()
             else:
                 raise ValueError("corr should be one of %s or callable, "
                                  "%s was given."

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -257,7 +257,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             y_std = np.ones(1)
 
         # Instantiate correlation model
-        self.corr = self.corr(X, self.nugget, self.storage_mode)
+        self.corr = self.corr(X, self.nugget)
 
         # Regression matrix and parameters
         F = self.regr(X)

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -176,6 +176,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
     _correlation_types = {
         'absolute_exponential': correlation.AbsoluteExponential,
         'squared_exponential': correlation.SquaredExponential,
+        'matern_1.5': correlation.Matern_1_5,
+        'matern_2.5': correlation.Matern_2_5,
         'generalized_exponential': correlation.GeneralizedExponential,
         'cubic': correlation.Cubic,
         'linear': correlation.Linear}
@@ -682,7 +684,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                                            np.log10(self.thetaU))
                 except ValueError:
                     print("Optimization failed. Try increasing the ``nugget``")
-                    raise ve
+                    raise
 
                 optimal_theta = 10. ** log10_optimal_theta
                 optimal_rlf_value, optimal_par = \

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -31,7 +31,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             'constant', 'linear', 'quadratic'
 
-    corr : string or callable, optional
+    corr : string or instance of StationaryCorrelation, optional
         A stationary autocorrelation function returning the autocorrelation
         between two points x and x'.
         Default assumes a squared-exponential autocorrelation model.

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -708,9 +708,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             # Initialize under isotropy assumption
             if verbose:
                 print("Initialize under isotropy assumption...")
-            self.theta0 = array2d(self.theta0.min())
-            self.thetaL = array2d(self.thetaL.min())
-            self.thetaU = array2d(self.thetaU.max())
+            self.theta0 = np.atleast_1d(self.theta0.min())
+            self.thetaL = np.atleast_1d(self.thetaL.min())
+            self.thetaU = np.atleast_1d(self.thetaU.max())
             theta_iso, optimal_rlf_value_iso, par_iso = \
                 self._arg_max_reduced_likelihood_function()
             optimal_theta = theta_iso + np.zeros(theta0.shape)
@@ -721,18 +721,18 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             for i in self.random_state.permutation(theta0.size):
                 if verbose:
                     print("Proceeding along dimension %d..." % (i + 1))
-                self.theta0 = array2d(theta_iso)
-                self.thetaL = array2d(thetaL[0, i])
-                self.thetaU = array2d(thetaU[0, i])
+                self.theta0 = np.atleast_1d(theta_iso)
+                self.thetaL = np.atleast_1d(thetaL[i])
+                self.thetaU = np.atleast_1d(thetaU[i])
 
                 def corr_cut(t, X=None):
-                    return corr(array2d(np.hstack([optimal_theta[0][0:i],
-                                                   t[0],
-                                                   optimal_theta[0][(i + 1)::]]
-                                                  )), X)
+                    return corr(np.hstack([optimal_theta[0:i],
+                                           t[0],
+                                           optimal_theta[(i + 1)::]]
+                                          ), X)
 
                 self.corr_ = corr_cut
-                optimal_theta[0, i], optimal_rlf_value, optimal_par = \
+                optimal_theta[i], optimal_rlf_value, optimal_par = \
                     self._arg_max_reduced_likelihood_function()
 
             # Restore the given atrributes

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -305,6 +305,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             self.theta_ = self.theta0
             self.reduced_likelihood_function_value_, par = \
                 self.reduced_likelihood_function()
+            self.reduced_likelihood_function_value_ *= -1
             if np.isinf(self.reduced_likelihood_function_value_):
                 raise Exception("Bad point. Try increasing theta0.")
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -147,7 +147,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
     Notes
     -----
-    The presentation implementation is based on a translation of the DACE
+    The present implementation is based on a translation of the DACE
     Matlab toolbox, see reference [NLNS2002]_.
 
     References
@@ -527,7 +527,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             theta = self.theta_
 
         # Initialize output
-        reduced_likelihood_function_value = - np.inf
+        reduced_likelihood_function_value = -np.inf
         par = {}
 
         # Retrieve data
@@ -645,9 +645,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             constraints = []
             for i in range(self.theta0.size):
                 constraints.append(lambda log10t, i=i:
-                                   log10t[i] - np.log10(self.thetaL[0, i]))
+                                   log10t[i] - np.log10(self.thetaL[i]))
                 constraints.append(lambda log10t, i=i:
-                                   np.log10(self.thetaU[0, i]) - log10t[i])
+                                   np.log10(self.thetaU[i]) - log10t[i])
 
             for k in range(self.random_start):
 
@@ -784,12 +784,12 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                              "'light', %s was given." % self.storage_mode)
 
         # Check correlation parameters
-        self.theta0 = array2d(self.theta0)
+        self.theta0 = np.atleast_1d(self.theta0)
         lth = self.theta0.size
 
         if self.thetaL is not None and self.thetaU is not None:
-            self.thetaL = array2d(self.thetaL)
-            self.thetaU = array2d(self.thetaU)
+            self.thetaL = np.atleast_1d(self.thetaL)
+            self.thetaU = np.atleast_1d(self.thetaU)
             if self.thetaL.size != lth or self.thetaU.size != lth:
                 raise ValueError("theta0, thetaL and thetaU must have the "
                                  "same length.")

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -64,22 +64,22 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         An array with shape (n_features, ) or (1, ).
         The parameters in the autocorrelation model.
         If thetaL and thetaU are also specified, theta0 is considered as
-        the starting point for the maximum likelihood estimation of the
+        the starting point for the maximum a posterior estimation of the
         best set of parameters.
         Default assumes isotropic autocorrelation model with theta0 = 1e-1.
 
     thetaL : double array_like, optional
         An array with shape matching theta0's.
         Lower bound on the autocorrelation parameters for maximum
-        likelihood estimation.
-        Default is None, so that it skips maximum likelihood estimation and
+        a posterior estimation.
+        Default is None, so that it skips maximum a posterior estimation and
         it uses theta0.
 
     thetaU : double array_like, optional
         An array with shape matching theta0's.
         Upper bound on the autocorrelation parameters for maximum
-        likelihood estimation.
-        Default is None, so that it skips maximum likelihood estimation and
+        a posterior estimation.
+        Default is None, so that it skips maximum a posterior estimation and
         it uses theta0.
 
     normalize : boolean, optional
@@ -87,7 +87,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         means and standard deviations estimated from the n_samples
         observations provided.
         Default is normalize = True so that data is normalized to ease
-        maximum likelihood estimation.
+        maximum a posterior estimation.
 
     nugget : double or ndarray, optional
         Introduce a nugget effect to allow smooth predictions from noisy
@@ -134,7 +134,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
     ----------
     `theta_`: array
         Specified theta OR the best set of autocorrelation parameters (the \
-        sought maximizer of the reduced likelihood function).
+        sought maximizer of the posterior function).
 
     `reduced_likelihood_function_value_`: array (DEPRECATED)
         The optimal reduced likelihood function value.  Will be removed in the
@@ -300,9 +300,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
         # Determine Gaussian Process model parameters
         if self.thetaL is not None and self.thetaU is not None:
-            # Maximum Likelihood Estimation of the parameters
+            # Maximum a Posterior estimation of the parameters
             if self.verbose:
-                print("Performing Maximum Likelihood Estimation of the "
+                print("Performing Maximum a Posterior estimation of the "
                       "autocorrelation parameters...")
             self.theta_, self.posterior_function_value_, par = \
                 self._arg_max_posterior()

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -305,7 +305,6 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             self.theta_ = self.theta0
             self.reduced_likelihood_function_value_, par = \
                 self.reduced_likelihood_function()
-            self.reduced_likelihood_function_value_ *= -1
             if np.isinf(self.reduced_likelihood_function_value_):
                 raise Exception("Bad point. Try increasing theta0.")
 
@@ -673,9 +672,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     raise ve
 
                 optimal_theta = 10. ** log10_optimal_theta
-                optimal_minus_rlf_value, optimal_par = \
+                optimal_rlf_value, optimal_par = \
                     self.reduced_likelihood_function(theta=optimal_theta)
-                optimal_rlf_value = - optimal_minus_rlf_value
 
                 # Compare the new optimizer to the best previous one
                 if k > 0:

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -257,7 +257,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             y_std = np.ones(1)
 
         # Instantiate correlation model
-        self.corr = self.corr(X, self.nugget)
+        self.corr_ = self.corr(X, self.nugget)
 
         # Regression matrix and parameters
         F = self.regr(X)
@@ -393,7 +393,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             # Get regression function and correlation
             f = self.regr(X)
-            r = self.corr(self.theta_, X)
+            r = self.corr_(self.theta_, X)
 
             # Scaled predictor
             y_ = np.dot(f, self.beta) + np.dot(r, self.gamma)
@@ -537,7 +537,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             F = self.regr(self.X)
 
         # Determine (auto-)correlation of training data
-        R = self.corr(theta)
+        R = self.corr_(theta)
 
         # Cholesky decomposition of R
         try:
@@ -699,7 +699,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
             # Backup of the given atrributes
             theta0, thetaL, thetaU = self.theta0, self.thetaL, self.thetaU
-            corr = self.corr
+            corr = self.corr_
             verbose = self.verbose
 
             # This will iterate over fmin_cobyla optimizer
@@ -726,19 +726,19 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                 self.thetaL = array2d(thetaL[0, i])
                 self.thetaU = array2d(thetaU[0, i])
 
-                def corr_cut(t, d):
+                def corr_cut(t, X=None):
                     return corr(array2d(np.hstack([optimal_theta[0][0:i],
                                                    t[0],
                                                    optimal_theta[0][(i + 1)::]]
-                                                  )), d)
+                                                  )), X)
 
-                self.corr = corr_cut
+                self.corr_ = corr_cut
                 optimal_theta[0, i], optimal_rlf_value, optimal_par = \
                     self._arg_max_reduced_likelihood_function()
 
             # Restore the given atrributes
             self.theta0, self.thetaL, self.thetaU = theta0, thetaL, thetaU
-            self.corr = corr
+            self.corr_ = corr
             self.optimizer = 'Welch'
             self.verbose = verbose
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -111,7 +111,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         It consists in iterating over several one-dimensional optimizations
         instead of running one single multi-dimensional optimization.
         If a callable is passed, it is assumed that this callable handles the
-        optimization iternally. It must accept the an objective function,
+        optimization internally. It must accept an objective function,
         the start position x0 of the optimization, as well as the lower
         and upper boundaries of the search space (xL and xU) as parameters.
         It is expected to return the optimal parameters x_best.
@@ -846,7 +846,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
         # Check optimizer
         if not (self.optimizer in self._optimizer_types
-                or hasattr(self.optimizer, '__call__')) :
+                or hasattr(self.optimizer, '__call__')):
             raise ValueError("optimizer should be one of %s"
                              % self._optimizer_types)
 

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -21,7 +21,7 @@ X2 = np.atleast_2d([2., 4., 5.5, 6.5, 7.5]).T
 y = f(X).ravel()
 
 
-def test_1d(regr=regression.constant, corr=correlation.squared_exponential,
+def test_1d(regr=regression.constant, corr="squared_exponential",
             random_start=10, beta0=None):
     """
     MLE estimation of a one-dimensional Gaussian Process model.
@@ -39,7 +39,7 @@ def test_1d(regr=regression.constant, corr=correlation.squared_exponential,
                 and np.allclose(MSE2, 0., atol=10))
 
 
-def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
+def test_2d(regr=regression.constant, corr="squared_exponential",
             random_start=10, beta0=None):
     """
     MLE estimation of a two-dimensional Gaussian Process model accounting for
@@ -74,7 +74,7 @@ def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
     assert_true(np.all(gp.theta_ <= thetaU)) # Upper bounds of hyperparameters
 
 
-def test_2d_2d(regr=regression.constant, corr=correlation.squared_exponential,
+def test_2d_2d(regr=regression.constant, corr="squared_exponential",
                random_start=10, beta0=None):
     """
     MLE estimation of a two-dimensional Gaussian Process model accounting for

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from sklearn.gaussian_process import GaussianProcess
 from sklearn.gaussian_process import regression_models as regression
-from sklearn.gaussian_process import correlation_models as correlation
 
 
 f = lambda x: x * np.sin(x)
@@ -70,8 +69,8 @@ def test_2d(regr=regression.constant, corr="squared_exponential",
 
     assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.))
 
-    assert_true(np.all(gp.theta_ >= thetaL)) # Lower bounds of hyperparameters
-    assert_true(np.all(gp.theta_ <= thetaU)) # Upper bounds of hyperparameters
+    assert_true(np.all(gp.theta_ >= thetaL))  # Lower bounds of hyperparameters
+    assert_true(np.all(gp.theta_ <= thetaU))  # Upper bounds of hyperparameters
 
 
 def test_2d_2d(regr=regression.constant, corr="squared_exponential",


### PR DESCRIPTION
This PR contains a proposal for a refactoring of the gaussian_process subpackage (mainly the correlation_models module) and some novel features which become possible because of this refactoring. Moreover, some subtle bugs are fixed. In general, I tried to keep the external interface of GaussianProcess fixed and to change only internals.The main purpose of this PR is to begin a discussion on the future of the GP subpackage and revive its further development.

CHANGES:
- Correlation models are now classes instead of functions and inherit from abstract base class StationaryCorrelation. This reduces code-redundancy (DRY) and separates GPs and their correlation models more strictly. Moreover, non-stationary correlation models become possible (see examples/gaussian_process/plot_gp_nonstationary.py) This was not possible formerly since only the differences of the datapoints were passed to the correlation models but not the datapoints themselves.
- The hyperparameters theta are estimated as maximum-a-posterior estimates rather than maximum-likelihood estimates. At the moment, the prior on the hyperparameters theta is uniform such that both result in the same value. However, a non-uniform prior could be used in the future in cases where the risk of overfitting theta to the data is serious (e.g., forcing the factor analysis distance to be close to diagonal etc.)
- Hyperparameters theta are represented as 1D ndarrays instead of 2D 1xn arrays in GaussianProcess. 

NEW FEATURES:
- Matern correlation models for nu=1.5 and nu=2.5 have been added (see https://en.wikipedia.org/wiki/Mat%C3%A9rn_covariance_function). An example script showing the potential benefit of the Matern correlation model compared to squared-exponential and absolute-exponential was added under examples/gaussian_process/plot_matern_kernel.py (see attached image)
- squared_exponential, absolute_exponential and Matern correlation models support factor analysis distance. This can be seen as an extension of learning dimension-specific length scales in which also correlations of feature dimensions can be taken into account. See Rasmussen and Williams 2006, p107 for details. An example script showing the potential benefit of this extension was added under examples/gaussian_process/plot_gp_learning_curve.py (see attached image). 
- GP supports additional optimizers for ML estimation passed as callables. In addition to 'fmin_cobyla' and 'Welch', GaussianProcess allows now to pass other optimizers directly as callables via the parameter optimizer.

BUGFIXES
- Setting optimal_rlf_value correctly in GPs and actually maximizing likelihood over several random starts. The sign of the optimal_rlf_value was set wrongly in _arg_max_reduced_likelihood_function() since it was set to the negative of the return of reduced_likelihood_function(). This error was probably caused by confusing reduced_likelihood_function(theta)  with minus_reduced_likelihood_function(log10t). It resulted, however, in _arg_max_reduced_likelihood_function() returning the worst local maxima instead of the best one when performing several random_starts.
- A typo in gp_diabetes_dataset.py was fixed which caused a crash of the example (gp.theta_ versus gp.theta)

To be discussed:
- The factor analysis distance has hyperparameters that can can take on arbitrary real values (not just positive ones). Since sklearn enforces the hyperparameters theta to be positive, this is internally handled by taking the log of the corresponding components of theta. Are there better ideas?

![plot_gp_learning_curve](https://f.cloud.github.com/assets/1116263/2310367/a7499dde-a2e2-11e3-80f5-6e98a23f0ee8.png)
![plot_matern_kernel](https://f.cloud.github.com/assets/1116263/2310372/adf004fc-a2e2-11e3-8d25-85e69e09fd11.png)
