### PR TITLE
[MRG+1] Sparse multilabel target support in metrics

### DIFF
--- a/benchmarks/bench_multilabel_metrics.py
+++ b/benchmarks/bench_multilabel_metrics.py
@@ -12,11 +12,13 @@ import argparse
 import sys
 
 import matplotlib.pyplot as plt
+import scipy.sparse as sp
 import numpy as np
 
 from sklearn.datasets import make_multilabel_classification
 from sklearn.metrics import (f1_score, accuracy_score, hamming_loss,
                              jaccard_similarity_score)
+from sklearn.utils.testing import ignore_warnings
 
 
 METRICS = {
@@ -30,9 +32,12 @@ METRICS = {
 FORMATS = {
     'sequences': lambda y: [list(np.flatnonzero(s)) for s in y],
     'dense': lambda y: y,
+    'csr': lambda y: sp.csr_matrix(y),
+    'csc': lambda y: sp.csc_matrix(y),
 }
 
 
+@ignore_warnings
 def benchmark(metrics=tuple(v for k, v in sorted(METRICS.items())),
               formats=tuple(v for k, v in sorted(FORMATS.items())),
               samples=1000, classes=4, density=.2,
@@ -109,7 +114,7 @@ def _tabulate(results, metrics, formats):
 
 
 def _plot(results, metrics, formats, title, x_ticks, x_label,
-          format_markers=('x', '|', 'o'),
+          format_markers=('x', '|', 'o', '+'),
           metric_colors=('c', 'm', 'y', 'k', 'g', 'r', 'b')):
     """
     Plot the results by metric, format and some other variable given by

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -261,7 +261,7 @@ where :math:`1(x)` is the `indicator function
 
 In the multilabel case with binary label indicators: ::
 
-  >>> accuracy_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
+  >>> accuracy_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
   0.5
 
 .. topic:: Example:
@@ -374,7 +374,7 @@ where :math:`1(x)` is the `indicator function
 
 In the multilabel case with binary label indicators: ::
 
-  >>> hamming_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.zeros((2, 2)))
+  >>> hamming_loss(np.array([[0, 1], [1, 1]]), np.zeros((2, 2)))
   0.75
 
 .. note::
@@ -426,7 +426,7 @@ score is equal to the classification accuracy.
 
 In the multilabel case with binary label indicators: ::
 
-  >>> jaccard_similarity_score(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
+  >>> jaccard_similarity_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
   0.75
 
 .. _precision_recall_f_measure_metrics:
@@ -889,7 +889,7 @@ where :math:`1(x)` is the `indicator function
 
 In the multilabel case with binary label indicators: ::
 
-  >>> zero_one_loss(np.array([[0.0, 1.0], [1.0, 1.0]]), np.ones((2, 2)))
+  >>> zero_one_loss(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
   0.5
 
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -116,10 +116,10 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -262,10 +262,10 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True,
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -420,10 +420,10 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
     normalize : bool, optional (default=True)
@@ -494,10 +494,10 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -577,10 +577,10 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     beta: float
@@ -736,10 +736,10 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     beta : float, 1.0 by default
@@ -969,10 +969,10 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -1051,10 +1051,10 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     labels : array
@@ -1126,10 +1126,10 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) target values.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
     labels : array, shape = [n_labels]
@@ -1220,10 +1220,10 @@ def hamming_loss(y_true, y_pred, classes=None):
 
     Parameters
     ----------
-    y_true : array-like or label indicator matrix
+    y_true : 1d array-like, or label indicator array / sparse matrix
         Ground truth (correct) labels.
 
-    y_pred : array-like or label indicator matrix
+    y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
     classes : array, shape = [n_labels], optional

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -24,21 +24,24 @@ import warnings
 import numpy as np
 
 from scipy.sparse import coo_matrix
+from scipy.sparse import csr_matrix
 from scipy.spatial.distance import hamming as sp_hamming
 
-from ..externals.six.moves import zip
-from ..preprocessing import label_binarize
 from ..preprocessing import LabelBinarizer
 from ..preprocessing import LabelEncoder
-from ..utils import check_array, check_consistent_length
+from ..utils import check_array
+from ..utils import check_consistent_length
+from ..preprocessing import MultiLabelBinarizer
 from ..utils import column_or_1d
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target
+from ..utils.validation import _num_samples
+from ..utils.sparsefuncs import count_nonzero
 
 from .base import UndefinedMetricWarning
 
 
-def _check_clf_targets(y_true, y_pred):
+def _check_targets(y_true, y_pred):
     """Check that y_true and y_pred belong to the same classification task
 
     This converts multiclass or binary types to a common shape, and raises a
@@ -46,11 +49,12 @@ def _check_clf_targets(y_true, y_pred):
     multilabel formats, for the presence of continuous-valued or multioutput
     targets, or for targets of different lengths.
 
-    Column vectors are squeezed to 1d.
+    Column vectors are squeezed to 1d, while multilabel formats are returned
+    as CSR sparse label indicators.
 
     Parameters
     ----------
-    y_true : array-like,
+    y_true : array-like
 
     y_pred : array-like
 
@@ -88,6 +92,17 @@ def _check_clf_targets(y_true, y_pred):
     if y_type in ["binary", "multiclass"]:
         y_true = column_or_1d(y_true)
         y_pred = column_or_1d(y_pred)
+
+    if y_type.startswith('multilabel'):
+        if y_type == 'multilabel-sequences':
+            labels = unique_labels(y_true, y_pred)
+            binarizer = MultiLabelBinarizer(classes=labels, sparse_output=True)
+            y_true = binarizer.fit_transform(y_true)
+            y_pred = binarizer.fit_transform(y_pred)
+
+        y_true = csr_matrix(y_true)
+        y_pred = csr_matrix(y_pred)
+        y_type = 'multilabel-indicator'
 
     return y_type, y_true, y_pred
 
@@ -150,12 +165,10 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     """
 
     # Compute accuracy for each possible representation
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
-    if y_type == 'multilabel-indicator':
-        score = (y_pred != y_true).sum(axis=1) == 0
-    elif y_type == 'multilabel-sequences':
-        score = np.array([len(set(true) ^ set(pred)) == 0
-                          for pred, true in zip(y_pred, y_true)])
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+    if y_type.startswith('multilabel'):
+        differing_labels = count_nonzero(y_true - y_pred, axis=1)
+        score = differing_labels == 0
     else:
         score = y_true == y_pred
 
@@ -211,7 +224,7 @@ def confusion_matrix(y_true, y_pred, labels=None):
            [1, 0, 2]])
 
     """
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     if y_type not in ("binary", "multiclass"):
         raise ValueError("%s is not supported" % y_type)
 
@@ -308,39 +321,18 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True,
     """
 
     # Compute accuracy for each possible representation
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
-    if y_type == 'multilabel-indicator':
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+    if y_type.startswith('multilabel'):
         with np.errstate(divide='ignore', invalid='ignore'):
-            # oddly, we may get an "invalid" rather than a "divide"
-            # error here
-            y_pred_pos_label = y_pred == 1
-            y_true_pos_label = y_true == 1
-            pred_inter_true = np.sum(np.logical_and(y_pred_pos_label,
-                                                    y_true_pos_label),
-                                     axis=1)
-            pred_union_true = np.sum(np.logical_or(y_pred_pos_label,
-                                                   y_true_pos_label),
-                                     axis=1)
-            score = pred_inter_true / pred_union_true
+            # oddly, we may get an "invalid" rather than a "divide" error here
+            pred_or_true = count_nonzero(y_true + y_pred, axis=1)
+            pred_and_true = count_nonzero(y_true.multiply(y_pred), axis=1)
+            score = pred_and_true / pred_or_true
 
             # If there is no label, it results in a Nan instead, we set
             # the jaccard to 1: lim_{x->0} x/x = 1
             # Note with py2.6 and np 1.3: we can't check safely for nan.
-            score[pred_union_true == 0.0] = 1.0
-
-    elif y_type == 'multilabel-sequences':
-        score = np.empty(len(y_true), dtype=np.float)
-        for i, (true, pred) in enumerate(zip(y_pred, y_true)):
-            true_set = set(true)
-            pred_set = set(pred)
-            size_true_union_pred = len(true_set | pred_set)
-            # If there is no label, it results in a Nan instead, we set
-            # the jaccard to 1: lim_{x->0} x/x = 1
-            if size_true_union_pred == 0:
-                score[i] = 1.
-            else:
-                score[i] = (len(true_set & pred_set) /
-                            size_true_union_pred)
+            score[pred_or_true == 0.0] = 1.0
     else:
         score = y_true == y_pred
 
@@ -401,7 +393,7 @@ def matthews_corrcoef(y_true, y_pred):
     -0.33...
 
     """
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
     if y_type != "binary":
         raise ValueError("%s is not supported" % y_type)
@@ -482,7 +474,7 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
         if sample_weight is not None:
             n_samples = np.sum(sample_weight)
         else:
-            n_samples = len(y_true)
+            n_samples = _num_samples(y_true)
         return n_samples - score
 
 
@@ -839,7 +831,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     if beta <= 0:
         raise ValueError("beta should be >0 in the F-beta score")
 
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
     label_order = labels  # save this for later
     if labels is None:
@@ -850,28 +842,16 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     ### Calculate tp_sum, pred_sum, true_sum ###
 
     if y_type.startswith('multilabel'):
-        if y_type == 'multilabel-sequences':
-            y_true = label_binarize(y_true, labels, multilabel=True)
-            y_pred = label_binarize(y_pred, labels, multilabel=True)
-        else:
-            # set negative labels to zero
-            y_true = y_true == 1
-            y_pred = y_pred == 1
-
-        if sample_weight is None:
-            sum_weight = 1
-            dtype = int
-        else:
-            sum_weight = np.expand_dims(sample_weight, 1)
-            dtype = float
-
         sum_axis = 1 if average == 'samples' else 0
-        tp_sum = np.multiply(np.logical_and(y_true, y_pred),
-                             sum_weight).sum(axis=sum_axis, dtype=dtype)
-        pred_sum = np.sum(np.multiply(y_pred, sum_weight),
-                          axis=sum_axis, dtype=dtype)
-        true_sum = np.sum(np.multiply(y_true, sum_weight),
-                          axis=sum_axis, dtype=dtype)
+
+        # calculate weighted counts
+        true_and_pred = y_true.multiply(y_pred)
+        tp_sum = count_nonzero(true_and_pred, axis=sum_axis,
+                               sample_weight=sample_weight)
+        pred_sum = count_nonzero(y_pred, axis=sum_axis,
+                                 sample_weight=sample_weight)
+        true_sum = count_nonzero(y_true, axis=sum_axis,
+                                 sample_weight=sample_weight)
 
     elif average == 'samples':
         raise ValueError("Sample-based precision, recall, fscore is "
@@ -1296,20 +1276,16 @@ def hamming_loss(y_true, y_pred, classes=None):
     >>> hamming_loss(np.array([[0, 1], [1, 1]]), np.zeros((2, 2)))
     0.75
     """
-    y_type, y_true, y_pred = _check_clf_targets(y_true, y_pred)
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
     if classes is None:
         classes = unique_labels(y_true, y_pred)
     else:
         classes = np.asarray(classes)
 
-    if y_type == 'multilabel-indicator':
-        return np.mean(y_true != y_pred)
-    elif y_type == 'multilabel-sequences':
-        loss = np.array([len(set(pred).symmetric_difference(true))
-                         for pred, true in zip(y_pred, y_true)])
-
-        return np.mean(loss) / np.size(classes)
+    if y_type.startswith('multilabel'):
+        n_differences = count_nonzero(y_true - y_pred)
+        return (n_differences / (y_true.shape[0] * len(classes)))
 
     elif y_type in ["binary", "multiclass"]:
         return sp_hamming(y_true, y_pred)

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -33,4 +33,3 @@ from .regression import r2_score
 
 # Deprecated in 0.16
 from .ranking import auc_score
-

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -42,7 +42,7 @@ from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 
 
-from sklearn.metrics.classification import _check_clf_targets
+from sklearn.metrics.classification import _check_targets
 from sklearn.metrics.base import UndefinedMetricWarning
 
 
@@ -956,8 +956,8 @@ def test_fscore_warnings():
 
 
 @ignore_warnings  # sequence of sequences is deprecated
-def test__check_clf_targets():
-    """Check that _check_clf_targets correctly merges target types, squeezes
+def test__check_targets():
+    """Check that _check_targets correctly merges target types, squeezes
     output and fails if input lengths differ."""
     IND = 'multilabel-indicator'
     SEQ = 'multilabel-sequences'
@@ -985,7 +985,7 @@ def test__check_clf_targets():
     # (types will be tried in either order)
     EXPECTED = {
         (IND, IND): IND,
-        (SEQ, SEQ): SEQ,
+        (SEQ, SEQ): IND,
         (MC, MC): MC,
         (BIN, BIN): BIN,
 
@@ -1023,27 +1023,30 @@ def test__check_clf_targets():
         except KeyError:
             expected = EXPECTED[type2, type1]
         if expected is None:
-            assert_raises(ValueError, _check_clf_targets, y1, y2)
+            assert_raises(ValueError, _check_targets, y1, y2)
 
             if type1 != type2:
                 assert_raise_message(
                     ValueError,
                     "Can't handle mix of {0} and {1}".format(type1, type2),
-                    _check_clf_targets, y1, y2)
+                    _check_targets, y1, y2)
 
             else:
                 if type1 not in (BIN, MC, SEQ, IND):
                     assert_raise_message(ValueError,
                                          "{0} is not supported".format(type1),
-                                         _check_clf_targets, y1, y2)
+                                         _check_targets, y1, y2)
 
         else:
-            merged_type, y1out, y2out = _check_clf_targets(y1, y2)
+            merged_type, y1out, y2out = _check_targets(y1, y2)
             assert_equal(merged_type, expected)
-            if not merged_type.startswith('multilabel'):
+            if merged_type.startswith('multilabel'):
+                assert_equal(y1out.format, 'csr')
+                assert_equal(y2out.format, 'csr')
+            else:
                 assert_array_equal(y1out, np.squeeze(y1))
                 assert_array_equal(y2out, np.squeeze(y2))
-            assert_raises(ValueError, _check_clf_targets, y1[:-1], y2)
+            assert_raises(ValueError, _check_targets, y1[:-1], y2)
 
 
 def test_hinge_loss_binary():

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -262,7 +262,7 @@ def min_max_axis(X, axis):
 
     Parameters
     ----------
-    X: CSR or CSC sparse matrix, shape (n_samples, n_features)
+    X : CSR or CSC sparse matrix, shape (n_samples, n_features)
         Input data.
 
     Returns
@@ -278,3 +278,51 @@ def min_max_axis(X, axis):
         return sparse_min_max(X, axis=axis)
     else:
         _raise_typeerror(X)
+
+
+def count_nonzero(X, axis=None, sample_weight=None):
+    """A variant of X.getnnz() with extension to weighting on axis 0
+
+    Useful in efficiently calculating multilabel metrics.
+
+    Parameters
+    ----------
+    X : CSR sparse matrix, shape = (n_samples, n_labels)
+        Input data.
+
+    axis : None, 0 or 1
+        The axis on which the data is aggregated.
+
+    sample_weight : array, shape = (n_samples,), optional
+        Weight for each row of X.
+    """
+    if axis == -1:
+        axis = 1
+    elif axis == -2:
+        axis = 0
+    elif X.format != 'csr':
+        raise TypeError('Expected CSR sparse format, got {0}'.format(X.format))
+
+    # We rely here on the fact that np.diff(Y.indptr) for a CSR
+    # will return the number of nonzero entries in each row.
+    # A bincount over Y.indices will return the number of nonzeros
+    # in each column. See ``csr_matrix.getnnz`` in scipy >= 0.14.
+    if axis is None:
+        if sample_weight is None:
+            return X.nnz
+        else:
+            return np.dot(np.diff(X.indptr), sample_weight)
+    elif axis == 1:
+        out = np.diff(X.indptr)
+        if sample_weight is None:
+            return out
+        return out * sample_weight
+    elif axis == 0:
+        if sample_weight is None:
+            return np.bincount(X.indices, minlength=X.shape[1])
+        else:
+            weights = np.repeat(sample_weight, np.diff(X.indptr))
+            return np.bincount(X.indices, minlength=X.shape[1],
+                               weights=weights)
+    else:
+        raise ValueError('Unsupported axis: {0}'.format(axis))


### PR DESCRIPTION
This introduces a series of helper classes that abstract away aggregation over multilabel structures. This enables efficient calculation in sparse and dense binary indicator matrices, while maintaining support for the deprecated sequences format.
