### PR TITLE
[MRG] Remove deprecated parameters whose removal was scheduled for 0.15

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1076,8 +1076,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
 
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
-                    verbose=0, fit_params=None, score_func=None,
-                    pre_dispatch='2*n_jobs'):
+                    verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Evaluate a score by cross-validation
 
     Parameters
@@ -1140,7 +1139,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         y = np.asarray(y)
 
     cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
-    scorer = check_scoring(estimator, score_func=score_func, scoring=scoring)
+    scorer = check_scoring(estimator, scoring=scoring)
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
@@ -1377,7 +1376,7 @@ def _check_cv(cv, X=None, y=None, classifier=False, warn_mask=False):
     return cv
 
 
-def permutation_test_score(estimator, X, y, score_func=None, cv=None,
+def permutation_test_score(estimator, X, y, cv=None,
                            n_permutations=100, n_jobs=1, labels=None,
                            random_state=0, verbose=0, scoring=None):
     """Evaluate the significance of a cross-validated score with permutations
@@ -1431,8 +1430,8 @@ def permutation_test_score(estimator, X, y, score_func=None, cv=None,
         The scores obtained for each permutations.
 
     pvalue : float
-        The returned value equals p-value if `score_func` returns bigger
-        numbers for better scores (e.g., accuracy_score). If `score_func` is
+        The returned value equals p-value if `scoring` returns bigger
+        numbers for better scores (e.g., accuracy_score). If `scoring` is
         rather a loss function (i.e. when lower is better such as with
         `mean_squared_error`) then this is actually the complement of the
         p-value:  1 - p-value.
@@ -1448,7 +1447,7 @@ def permutation_test_score(estimator, X, y, score_func=None, cv=None,
     """
     X, y = check_arrays(X, y, sparse_format='csr', allow_nans=True)
     cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
-    scorer = check_scoring(estimator, scoring=scoring, score_func=score_func)
+    scorer = check_scoring(estimator, scoring=scoring)
     random_state = check_random_state(random_state)
 
     # We clone the estimator to make sure that all the folds are

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -298,12 +298,11 @@ class RFECV(RFE, MetaEstimatorMixin):
            Mach. Learn., 46(1-3), 389--422, 2002.
     """
     def __init__(self, estimator, step=1, cv=None, scoring=None,
-                 loss_func=None, estimator_params={}, verbose=0):
+                 estimator_params={}, verbose=0):
         self.estimator = estimator
         self.step = step
         self.cv = cv
         self.scoring = scoring
-        self.loss_func = loss_func
         self.estimator_params = estimator_params
         self.verbose = verbose
 
@@ -328,8 +327,7 @@ class RFECV(RFE, MetaEstimatorMixin):
                   verbose=self.verbose - 1)
 
         cv = check_cv(self.cv, X, y, is_classifier(self.estimator))
-        scorer = check_scoring(self.estimator, scoring=self.scoring,
-                               loss_func=self.loss_func)
+        scorer = check_scoring(self.estimator, scoring=self.scoring)
         scores = np.zeros(X.shape[1])
 
         # Cross-validation

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -15,6 +15,7 @@ from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics.scorer import SCORERS
+from sklearn.metrics import make_scorer
 
 
 def test_rfe_set_params():
@@ -88,8 +89,9 @@ def test_rfecv():
     assert_array_equal(X_r_sparse.toarray(), iris.data)
 
     # Test using a customized loss function
+    scoring = make_scorer(zero_one_loss, greater_is_better=False)
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, cv=5,
-                  loss_func=zero_one_loss)
+                  scoring=scoring)
     ignore_warnings(rfecv.fit)(X, y)
     X_r = rfecv.transform(X)
     assert_array_equal(X_r, iris.data)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -277,14 +277,12 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     """Base class for hyper parameter search with cross-validation."""
 
     @abstractmethod
-    def __init__(self, estimator, scoring=None, loss_func=None,
-                 score_func=None, fit_params=None, n_jobs=1, iid=True,
+    def __init__(self, estimator, scoring=None,
+                 fit_params=None, n_jobs=1, iid=True,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs'):
 
         self.scoring = scoring
         self.estimator = estimator
-        self.loss_func = loss_func
-        self.score_func = score_func
         self.n_jobs = n_jobs
         self.fit_params = fit_params if fit_params is not None else {}
         self.iid = iid
@@ -342,9 +340,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
         estimator = self.estimator
         cv = self.cv
-        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring,
-                                     loss_func=self.loss_func,
-                                     score_func=self.score_func)
+        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
 
         n_samples = _num_samples(X)
         X, y = check_arrays(X, y, allow_lists=True, sparse_format='csr',
@@ -510,8 +506,8 @@ class GridSearchCV(BaseSearchCV):
                          degree=..., gamma=..., kernel='rbf', max_iter=-1,
                          probability=False, random_state=None, shrinking=True,
                          tol=..., verbose=False),
-           fit_params={}, iid=..., loss_func=..., n_jobs=1,
-           param_grid=..., pre_dispatch=..., refit=..., score_func=...,
+           fit_params={}, iid=..., n_jobs=1,
+           param_grid=..., pre_dispatch=..., refit=...,
            scoring=..., verbose=...)
 
 
@@ -570,11 +566,11 @@ class GridSearchCV(BaseSearchCV):
 
     """
 
-    def __init__(self, estimator, param_grid, scoring=None, loss_func=None,
-                 score_func=None, fit_params=None, n_jobs=1, iid=True,
+    def __init__(self, estimator, param_grid, scoring=None,
+                 fit_params=None, n_jobs=1, iid=True,
                  refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs'):
         super(GridSearchCV, self).__init__(
-            estimator, scoring, loss_func, score_func, fit_params, n_jobs, iid,
+            estimator, scoring, fit_params, n_jobs, iid,
             refit, cv, verbose, pre_dispatch)
         self.param_grid = param_grid
         _check_param_grid(param_grid)

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -565,7 +565,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         self.normalize = normalize
         self.precompute = precompute
 
-    def fit(self, X, y, Gram=None, Xy=None):
+    def fit(self, X, y):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -575,15 +575,6 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
 
         y : array-like, shape (n_samples,) or (n_samples, n_targets)
             Target values.
-
-        Gram : array-like, shape (n_features, n_features) (optional)
-            Gram matrix of the input data: X.T * X
-            WARNING : will be deprecated in 0.15
-
-        Xy : array-like, shape (n_features,) or (n_features, n_targets)
-            (optional)
-            Input targets multiplied by X: X.T * y
-            WARNING : will be deprecated in 0.15
 
 
         Returns
@@ -598,35 +589,8 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         precompute = self.precompute
 
         copy_Gram = True
-        copy_Xy = True
         copy_X = True
-
-        if Gram is not None:
-            warnings.warn("Gram will be removed in 0.15."
-                          " Use the orthogonal_mp function for"
-                          " low level memory control.",
-                          DeprecationWarning, stacklevel=2)
-
-        if Xy is not None:
-            warnings.warn("Xy will be removed in 0.15."
-                          " Use the orthogonal_mp function for"
-                          " low level memory control.",
-                          DeprecationWarning, stacklevel=2)
-
-        if (Gram is not None or Xy is not None) and (self.fit_intercept
-                                                     or self.normalize):
-            warnings.warn('Mean subtraction (fit_intercept) and normalization '
-                          'cannot be applied on precomputed Gram and Xy '
-                          'matrices. Your precomputed values are ignored and '
-                          'recomputed. To avoid this, do the scaling yourself '
-                          'and call with fit_intercept and normalize set to '
-                          'False.', RuntimeWarning, stacklevel=2)
-            Gram, Xy = None, None
-
-        if Gram is not None:
-            precompute = Gram
-            if Xy is not None and copy_Xy:
-                Xy = Xy.copy()
+        Xy = None
 
         X, y, X_mean, y_mean, X_std, Gram, Xy = \
             _pre_fit(X, y, Xy, precompute, self.normalize, self.fit_intercept,

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -510,23 +510,6 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         very large. Note that if you already have such matrices, you can pass
         them directly to the fit method.
 
-    copy_X : bool, optional
-        Whether the design matrix X must be copied by the algorithm. A false
-        value is only helpful if X is already Fortran-ordered, otherwise a
-        copy is made anyway.
-        WARNING : will be deprecated in 0.15
-
-    copy_Gram : bool, optional
-        Whether the gram matrix must be copied by the algorithm. A false
-        value is only helpful if X is already Fortran-ordered, otherwise a
-        copy is made anyway.
-        WARNING : will be deprecated in 0.15
-
-    copy_Xy : bool, optional
-        Whether the covariance vector Xy must be copied by the algorithm.
-        If False, it may be overwritten.
-        WARNING : will be deprecated in 0.15
-
     Attributes
     ----------
     `coef_` : array, shape (n_features,) or (n_features, n_targets)

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -251,7 +251,7 @@ def _gram_omp(Gram, Xy, n_nonzero_coefs, tol_0=None, tol=None,
 
 
 def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
-                  copy_X=True, return_path=False, precompute_gram=None):
+                  copy_X=True, return_path=False):
     """Orthogonal Matching Pursuit (OMP)
 
     Solves n_targets Orthogonal Matching Pursuit problems.
@@ -321,14 +321,6 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     http://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
     """
-    if precompute_gram is not None:
-        warnings.warn("precompute_gram will be removed in 0.15."
-                      " Use the precompute parameter.",
-                      DeprecationWarning, stacklevel=2)
-        precompute = precompute_gram
-
-    del precompute_gram
-
     X = array2d(X, order='F', copy=copy_X)
     copy_X = False
     y = np.asarray(y)
@@ -567,13 +559,12 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     """
     def __init__(self, copy_X=None, copy_Gram=None, copy_Xy=None,
                  n_nonzero_coefs=None, tol=None, fit_intercept=True,
-                 normalize=True, precompute='auto', precompute_gram=None):
+                 normalize=True, precompute='auto'):
         self.n_nonzero_coefs = n_nonzero_coefs
         self.tol = tol
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.precompute = precompute
-        self.precompute_gram = precompute_gram
         self.copy_Gram = copy_Gram
         self.copy_Xy = copy_Xy
         self.copy_X = copy_X
@@ -608,13 +599,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         y = np.asarray(y)
         n_features = X.shape[1]
 
-        if self.precompute_gram is not None:
-            warnings.warn("precompute_gram will be removed in 0.15."
-                          " Use the precompute parameter.",
-                          DeprecationWarning, stacklevel=2)
-            precompute = self.precompute_gram
-        else:
-            precompute = self.precompute
+        precompute = self.precompute
 
         if self.copy_Gram is not None:
             warnings.warn("copy_Gram will be removed in 0.15."

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -557,17 +557,13 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
     decomposition.sparse_encode
 
     """
-    def __init__(self, copy_X=None, copy_Gram=None, copy_Xy=None,
-                 n_nonzero_coefs=None, tol=None, fit_intercept=True,
+    def __init__(self, n_nonzero_coefs=None, tol=None, fit_intercept=True,
                  normalize=True, precompute='auto'):
         self.n_nonzero_coefs = n_nonzero_coefs
         self.tol = tol
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.precompute = precompute
-        self.copy_Gram = copy_Gram
-        self.copy_Xy = copy_Xy
-        self.copy_X = copy_X
 
     def fit(self, X, y, Gram=None, Xy=None):
         """Fit the model using X, y as training data.
@@ -601,32 +597,9 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
 
         precompute = self.precompute
 
-        if self.copy_Gram is not None:
-            warnings.warn("copy_Gram will be removed in 0.15."
-                          " Use the orthogonal_mp function for"
-                          " low level memory control.",
-                          DeprecationWarning, stacklevel=2)
-            copy_Gram = self.copy_Gram
-        else:
-            copy_Gram = True
-
-        if self.copy_Xy is not None:
-            warnings.warn("copy_Xy will be removed in 0.15."
-                          " Use the orthogonal_mp function for"
-                          " low level memory control.",
-                          DeprecationWarning, stacklevel=2)
-            copy_Xy = self.copy_Xy
-        else:
-            copy_Xy = True
-
-        if self.copy_X is not None:
-            warnings.warn("copy_X will be removed in 0.15."
-                          " Use the orthogonal_mp function for"
-                          " low level memory control.",
-                          DeprecationWarning, stacklevel=2)
-            copy_X = self.copy_X
-        else:
-            copy_X = True
+        copy_Gram = True
+        copy_Xy = True
+        copy_X = True
 
         if Gram is not None:
             warnings.warn("Gram will be removed in 0.15."
@@ -856,7 +829,6 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
         best_n_nonzero_coefs = np.argmin(mse_folds.mean(axis=0)) + 1
         self.n_nonzero_coefs_ = best_n_nonzero_coefs
         omp = OrthogonalMatchingPursuit(n_nonzero_coefs=best_n_nonzero_coefs,
-                                        copy_X=None,
                                         fit_intercept=self.fit_intercept,
                                         normalize=self.normalize)
         omp.fit(X, y)

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1034,7 +1034,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
             scoring=scoring, score_func=score_func, loss_func=loss_func, cv=cv)
         self.class_weight = class_weight
 
-    def fit(self, X, y, sample_weight=None, class_weight=None):
+    def fit(self, X, y, sample_weight=None):
         """Fit the ridge classifier.
 
         Parameters
@@ -1049,24 +1049,11 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         sample_weight : float or numpy array of shape (n_samples,)
             Sample weight.
 
-        class_weight : dict, optional
-            Weights associated with classes in the form
-            ``{class_label : weight}``. If not given, all classes are
-            supposed to have weight one. This is parameter is
-            deprecated.
-
         Returns
         -------
         self : object
             Returns self.
         """
-        if class_weight is None:
-            class_weight = self.class_weight
-        else:
-            warnings.warn("'class_weight' is now an initialization parameter."
-                          " Using it in the 'fit' method is deprecated and "
-                          "will be removed in 0.15.", DeprecationWarning,
-                          stacklevel=2)
         if sample_weight is None:
             sample_weight = 1.
 
@@ -1074,7 +1061,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Y = self._label_binarizer.fit_transform(y)
         if not self._label_binarizer.y_type_.startswith('multilabel'):
             y = column_or_1d(y, warn=True)
-        cw = compute_class_weight(class_weight,
+        cw = compute_class_weight(self.class_weight,
                                   self.classes_, Y)
         # modify the sample weights with the corresponding class weight
         sample_weight *= cw[np.searchsorted(self.classes_, y)]

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -631,15 +631,12 @@ class _RidgeGCV(LinearModel):
 
     def __init__(self, alphas=[0.1, 1.0, 10.0],
                  fit_intercept=True, normalize=False,
-                 scoring=None, score_func=None,
-                 loss_func=None, copy_X=True,
+                 scoring=None, copy_X=True,
                  gcv_mode=None, store_cv_values=False):
         self.alphas = np.asarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring
-        self.score_func = score_func
-        self.loss_func = loss_func
         self.copy_X = copy_X
         self.gcv_mode = gcv_mode
         self.store_cv_values = store_cv_values
@@ -767,8 +764,6 @@ class _RidgeGCV(LinearModel):
         C = []
 
         scorer = check_scoring(self, scoring=self.scoring, allow_none=True,
-                               loss_func=self.loss_func,
-                               score_func=self.score_func,
                                score_overrides_loss=True)
         error = scorer is None
 
@@ -817,14 +812,12 @@ class _RidgeGCV(LinearModel):
 class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=np.array([0.1, 1.0, 10.0]),
                  fit_intercept=True, normalize=False, scoring=None,
-                 score_func=None, loss_func=None, cv=None, gcv_mode=None,
+                 cv=None, gcv_mode=None,
                  store_cv_values=False):
         self.alphas = alphas
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring
-        self.score_func = score_func
-        self.loss_func = loss_func
         self.cv = cv
         self.gcv_mode = gcv_mode
         self.store_cv_values = store_cv_values
@@ -852,8 +845,6 @@ class _BaseRidgeCV(LinearModel):
                                   fit_intercept=self.fit_intercept,
                                   normalize=self.normalize,
                                   scoring=self.scoring,
-                                  score_func=self.score_func,
-                                  loss_func=self.loss_func,
                                   gcv_mode=self.gcv_mode,
                                   store_cv_values=self.store_cv_values)
             estimator.fit(X, y, sample_weight=sample_weight)
@@ -1027,11 +1018,10 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     advantage of the multi-variate response support in Ridge.
     """
     def __init__(self, alphas=np.array([0.1, 1.0, 10.0]), fit_intercept=True,
-                 normalize=False, scoring=None, score_func=None,
-                 loss_func=None, cv=None, class_weight=None):
+                 normalize=False, scoring=None, cv=None, class_weight=None):
         super(RidgeClassifierCV, self).__init__(
             alphas=alphas, fit_intercept=fit_intercept, normalize=normalize,
-            scoring=scoring, score_func=score_func, loss_func=loss_func, cv=cv)
+            scoring=scoring, cv=cv)
         self.class_weight = class_weight
 
     def fit(self, X, y, sample_weight=None):

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -116,32 +116,15 @@ def test_estimator():
 
     omp.set_params(fit_intercept=False, normalize=False)
 
-    assert_warns(DeprecationWarning, omp.fit, X, y[:, 0], Gram=G, Xy=Xy[:, 0])
+    omp.fit(X, y[:, 0])
     assert_equal(omp.coef_.shape, (n_features,))
     assert_equal(omp.intercept_, 0)
     assert_true(np.count_nonzero(omp.coef_) <= n_nonzero_coefs)
 
-    assert_warns(DeprecationWarning, omp.fit, X, y, Gram=G, Xy=Xy)
+    omp.fit(X, y)
     assert_equal(omp.coef_.shape, (n_targets, n_features))
     assert_equal(omp.intercept_, 0)
     assert_true(np.count_nonzero(omp.coef_) <= n_targets * n_nonzero_coefs)
-
-
-def test_scaling_with_gram():
-    omp1 = OrthogonalMatchingPursuit(n_nonzero_coefs=1,
-                                     fit_intercept=False, normalize=False)
-    omp2 = OrthogonalMatchingPursuit(n_nonzero_coefs=1,
-                                     fit_intercept=True, normalize=False)
-    omp3 = OrthogonalMatchingPursuit(n_nonzero_coefs=1,
-                                     fit_intercept=False, normalize=True)
-
-    f, w = assert_warns, DeprecationWarning
-    f(w, omp1.fit, X, y, Gram=G)
-    f(w, omp1.fit, X, y, Gram=G, Xy=Xy)
-    f(w, omp2.fit, X, y, Gram=G)
-    f(w, omp2.fit, X, y, Gram=G, Xy=Xy)
-    f(w, omp3.fit, X, y, Gram=G)
-    f(w, omp3.fit, X, y, Gram=G, Xy=Xy)
 
 
 def test_identical_regressors():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
 from sklearn.metrics.scorer import SCORERS
+from sklearn.metrics import make_scorer
 
 from sklearn.linear_model.base import LinearRegression
 from sklearn.linear_model.ridge import ridge_regression
@@ -322,13 +323,15 @@ def _test_ridge_loo(filter_):
 
     # check that we get same best alpha with custom loss_func
     f = ignore_warnings
-    ridge_gcv2 = RidgeCV(fit_intercept=False, loss_func=mean_squared_error)
+    scoring = make_scorer(mean_squared_error, greater_is_better=False)
+    ridge_gcv2 = RidgeCV(fit_intercept=False, scoring=scoring)
     f(ridge_gcv2.fit)(filter_(X_diabetes), y_diabetes)
     assert_equal(ridge_gcv2.alpha_, alpha_)
 
     # check that we get same best alpha with custom score_func
     func = lambda x, y: -mean_squared_error(x, y)
-    ridge_gcv3 = RidgeCV(fit_intercept=False, score_func=func)
+    scoring = make_scorer(func)
+    ridge_gcv3 = RidgeCV(fit_intercept=False, scoring=scoring)
     f(ridge_gcv3.fit)(filter_(X_diabetes), y_diabetes)
     assert_equal(ridge_gcv3.alpha_, alpha_)
 

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -119,8 +119,7 @@ def _set_diag(laplacian, value):
 
 def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
                        random_state=None, eigen_tol=0.0,
-                       norm_laplacian=True, drop_first=True,
-                       mode=None):
+                       norm_laplacian=True, drop_first=True):
     """Project the sample on the first eigen vectors of the graph Laplacian.
 
     The adjacency matrix is used to compute a normalized graph Laplacian
@@ -189,15 +188,9 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
     try:
         from pyamg import smoothed_aggregation_solver
     except ImportError:
-        if eigen_solver == "amg" or mode == "amg":
+        if eigen_solver == "amg":
             raise ValueError("The eigen_solver was set to 'amg', but pyamg is "
                              "not available.")
-
-    if not mode is None:
-        warnings.warn("'mode' was renamed to eigen_solver "
-                      "and will be removed in 0.15.",
-                      DeprecationWarning)
-        eigen_solver = mode
 
     if eigen_solver is None:
         eigen_solver = 'arpack'

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -176,8 +176,8 @@ def _passthrough_scorer(estimator, *args, **kwargs):
     return estimator.score(*args, **kwargs)
 
 
-def check_scoring(estimator, scoring=None, allow_none=False, loss_func=None,
-                  score_func=None, score_overrides_loss=False):
+def check_scoring(estimator, scoring=None, allow_none=False,
+                  score_overrides_loss=False):
     """Determine scorer from user options.
 
     A TypeError will be thrown if the estimator cannot be scored.
@@ -202,32 +202,12 @@ def check_scoring(estimator, scoring=None, allow_none=False, loss_func=None,
         A scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
     """
-    has_scoring = not (scoring is None and loss_func is None and
-                       score_func is None)
+    has_scoring = scoring is not None
     if not hasattr(estimator, 'fit'):
         raise TypeError("estimator should a be an estimator implementing "
                         "'fit' method, %r was passed" % estimator)
     elif hasattr(estimator, 'predict') and has_scoring:
-        scorer = None
-        if loss_func is not None or score_func is not None:
-            if loss_func is not None:
-                warn("Passing a loss function is "
-                     "deprecated and will be removed in 0.15. "
-                     "Either use strings or score objects. "
-                     "The relevant new parameter is called ''scoring''. ",
-                     category=DeprecationWarning, stacklevel=2)
-                scorer = make_scorer(loss_func, greater_is_better=False)
-            if score_func is not None:
-                warn("Passing function as ``score_func`` is "
-                     "deprecated and will be removed in 0.15. "
-                     "Either use strings or score objects. "
-                     "The relevant new parameter is called ''scoring''.",
-                     category=DeprecationWarning, stacklevel=2)
-                if loss_func is None or score_overrides_loss:
-                    scorer = make_scorer(score_func)
-        else:
-            scorer = get_scorer(scoring)
-        return scorer
+        return get_scorer(scoring)
     elif hasattr(estimator, 'score'):
         return _passthrough_scorer
     elif not has_scoring:

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -24,7 +24,6 @@ from sklearn.datasets import make_regression
 from sklearn.datasets import load_digits
 from sklearn.datasets import load_iris
 from sklearn.metrics import accuracy_score
-from sklearn.metrics import f1_score
 from sklearn.metrics import explained_variance_score
 from sklearn.metrics import fbeta_score
 from sklearn.metrics import make_scorer
@@ -564,7 +563,8 @@ def test_cross_val_score_score_func():
         return 1.0
 
     with warnings.catch_warnings(record=True):
-        score = cval.cross_val_score(clf, X, y, score_func=score_func)
+        scoring = make_scorer(score_func)
+        score = cval.cross_val_score(clf, X, y, scoring=scoring)
     assert_array_equal(score, [1.0, 1.0, 1.0])
     assert len(_score_func_args) == 3
 
@@ -626,11 +626,6 @@ def test_cross_val_score_with_score_func_classification():
     f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
                                      scoring="f1", cv=5)
     assert_array_almost_equal(f1_scores, [0.97, 1., 0.97, 0.97, 1.], 2)
-    # also test deprecated old way
-    with warnings.catch_warnings(record=True):
-        f1_scores = cval.cross_val_score(clf, iris.data, iris.target,
-                                         score_func=f1_score, cv=5)
-    assert_array_almost_equal(f1_scores, [0.97, 1., 0.97, 0.97, 1.], 2)
 
 
 def test_cross_val_score_with_score_func_regression():
@@ -654,9 +649,8 @@ def test_cross_val_score_with_score_func_regression():
     assert_array_almost_equal(mse_scores, expected_mse, 2)
 
     # Explained variance
-    with warnings.catch_warnings(record=True):
-        ev_scores = cval.cross_val_score(reg, X, y, cv=5,
-                                         score_func=explained_variance_score)
+    scoring = make_scorer(explained_variance_score)
+    ev_scores = cval.cross_val_score(reg, X, y, cv=5, scoring=scoring)
     assert_array_almost_equal(ev_scores, [0.94, 0.97, 0.97, 0.99, 0.92], 2)
 
 
@@ -709,7 +703,7 @@ def test_permutation_score():
     # test with deprecated interface
     with warnings.catch_warnings(record=True):
         score, scores, pvalue = cval.permutation_test_score(
-            svm, X, y, score_func=accuracy_score, cv=cv)
+            svm, X, y, scoring=make_scorer(accuracy_score), cv=cv)
     assert_less(score, 0.5)
     assert_greater(pvalue, 0.2)
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -354,43 +354,6 @@ def test_grid_search_sparse_scoring():
     assert_array_equal(y_pred, y_pred3)
 
 
-def test_deprecated_score_func():
-    # test that old deprecated way of passing a score / loss function is still
-    # supported
-    X, y = make_classification(n_samples=200, n_features=100, random_state=0)
-    clf = LinearSVC(random_state=0)
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, scoring="f1")
-    cv.fit(X[:180], y[:180])
-    y_pred = cv.predict(X[180:])
-    C = cv.best_estimator_.C
-
-    clf = LinearSVC(random_state=0)
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, score_func=f1_score)
-    with warnings.catch_warnings(record=True):
-        # catch deprecation warning
-        cv.fit(X[:180], y[:180])
-    y_pred_func = cv.predict(X[180:])
-    C_func = cv.best_estimator_.C
-
-    assert_array_equal(y_pred, y_pred_func)
-    assert_equal(C, C_func)
-
-    # test loss where greater is worse
-    def f1_loss(y_true_, y_pred_):
-        return -f1_score(y_true_, y_pred_)
-
-    clf = LinearSVC(random_state=0)
-    cv = GridSearchCV(clf, {'C': [0.1, 1.0]}, loss_func=f1_loss)
-    with warnings.catch_warnings(record=True):
-        # catch deprecation warning
-        cv.fit(X[:180], y[:180])
-    y_pred_loss = cv.predict(X[180:])
-    C_loss = cv.best_estimator_.C
-
-    assert_array_equal(y_pred, y_pred_loss)
-    assert_equal(C, C_loss)
-
-
 def test_grid_search_precomputed_kernel():
     """Test that grid search works when the input features are given in the
     form of a precomputed kernel matrix """


### PR DESCRIPTION
Some deprecated parameters were scheduled for removal for 0.15 but managed to escape it. 

The one with most impact was score_func and loss_func from sklearn.metrics.scorer.check_scoring, which was still used in quite a few different places, e.g. cross_validation.py, grid_search.py, a few different tests, ...
