### PR TITLE
[MRG] use more interesting range for C in logistic l1 l2 example.

### DIFF
--- a/examples/linear_model/plot_logistic_l1_l2_sparsity.py
+++ b/examples/linear_model/plot_logistic_l1_l2_sparsity.py
@@ -37,7 +37,7 @@ y = (y > 4).astype(np.int)
 
 
 # Set regularization parameter
-for i, C in enumerate(10. ** np.arange(1, 4)):
+for i, C in enumerate((100, 1, 0.01)):
     # turn down tolerance for short training time
     clf_l1_LR = LogisticRegression(C=C, penalty='l1', tol=0.01)
     clf_l2_LR = LogisticRegression(C=C, penalty='l2', tol=0.01)
@@ -53,7 +53,7 @@ for i, C in enumerate(10. ** np.arange(1, 4)):
     sparsity_l1_LR = np.mean(coef_l1_LR == 0) * 100
     sparsity_l2_LR = np.mean(coef_l2_LR == 0) * 100
 
-    print("C=%d" % C)
+    print("C=%.2f" % C)
     print("Sparsity with L1 penalty: %.2f%%" % sparsity_l1_LR)
     print("score with L1 penalty: %.4f" % clf_l1_LR.score(X, y))
     print("Sparsity with L2 penalty: %.2f%%" % sparsity_l2_LR)
@@ -69,7 +69,7 @@ for i, C in enumerate(10. ** np.arange(1, 4)):
                    cmap='binary', vmax=1, vmin=0)
     l2_plot.imshow(np.abs(coef_l2_LR.reshape(8, 8)), interpolation='nearest',
                    cmap='binary', vmax=1, vmin=0)
-    plt.text(-8, 3, "C = %d" % C)
+    plt.text(-8, 3, "C = %.2f" % C)
 
     l1_plot.set_xticks(())
     l1_plot.set_yticks(())


### PR DESCRIPTION
Before this change, output is (http://scikit-learn.org/dev/auto_examples/linear_model/plot_logistic_l1_l2_sparsity.html#example-linear-model-plot-logistic-l1-l2-sparsity-py):
C=10
Sparsity with L1 penalty: 6.25%
score with L1 penalty: 0.9104
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.9093
C=100
Sparsity with L1 penalty: 6.25%
score with L1 penalty: 0.9098
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.9098
C=1000
Sparsity with L1 penalty: 4.69%
score with L1 penalty: 0.9098
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.9098

With this change, output is:
C=100.00
Sparsity with L1 penalty: 6.25%
score with L1 penalty: 0.9110
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.9098
C=1.00
Sparsity with L1 penalty: 9.38%
score with L1 penalty: 0.9104
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.9093
C=0.01
Sparsity with L1 penalty: 85.94%
score with L1 penalty: 0.8625
Sparsity with L2 penalty: 4.69%
score with L2 penalty: 0.8915

And here is the new image:
![l1_l2](https://cloud.githubusercontent.com/assets/1739/3613943/6d27c668-0dbc-11e4-95d1-0c508266e130.png)
