### PR TITLE
FIX: Remove raw_coef_ attribute that eats up memory

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -69,9 +69,6 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
     `coef_` : array, shape = [n_classes, n_features]
         Coefficient of the features in the decision function.
 
-        `coef_` is readonly property derived from `raw_coef_` that \
-        follows the internal memory layout of liblinear.
-
     `intercept_` : array, shape = [n_classes]
         Intercept (a.k.a. bias) added to the decision function.
         If `fit_intercept` is set to False, the intercept is set to zero.

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -694,23 +694,22 @@ class BaseLibLinear(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         # LibLinear wants targets as doubles, even for classification
         y_ind = np.asarray(y_ind, dtype=np.float64).ravel()
-        self.raw_coef_ = liblinear.train_wrap(X, y_ind,
-                                              sp.isspmatrix(X),
-                                              self._get_solver_type(),
-                                              self.tol, self._get_bias(),
-                                              self.C,
-                                              self.class_weight_,
-                                              rnd.randint(np.iinfo('i').max))
+        raw_coef_ = liblinear.train_wrap(X, y_ind,
+                                         sp.isspmatrix(X),
+                                         self._get_solver_type(),
+                                         self.tol, self._get_bias(),
+                                         self.C, self.class_weight_,
+                                         rnd.randint(np.iinfo('i').max))
         # Regarding rnd.randint(..) in the above signature:
         # seed for srand in range [0..INT_MAX); due to limitations in Numpy
         # on 32-bit platforms, we can't get to the UINT_MAX limit that
         # srand supports
 
         if self.fit_intercept:
-            self.coef_ = self.raw_coef_[:, :-1]
-            self.intercept_ = self.intercept_scaling * self.raw_coef_[:, -1]
+            self.coef_ = raw_coef_[:, :-1]
+            self.intercept_ = self.intercept_scaling * raw_coef_[:, -1]
         else:
-            self.coef_ = self.raw_coef_
+            self.coef_ = raw_coef_
             self.intercept_ = 0.
 
         if self.multi_class == "crammer_singer" and len(self.classes_) == 2:

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -156,14 +156,16 @@ def test_linearsvc():
 
     assert_true(sp_clf.fit_intercept)
 
-    assert_array_almost_equal(clf.raw_coef_, sp_clf.raw_coef_, decimal=4)
+    assert_array_almost_equal(clf.coef_, sp_clf.coef_, decimal=4)
+    assert_array_almost_equal(clf.intercept_, sp_clf.intercept_, decimal=4)
 
     assert_array_almost_equal(clf.predict(X), sp_clf.predict(X_sp))
 
     clf.fit(X2, Y2)
     sp_clf.fit(X2_sp, Y2)
 
-    assert_array_almost_equal(clf.raw_coef_, sp_clf.raw_coef_, decimal=4)
+    assert_array_almost_equal(clf.coef_, sp_clf.coef_, decimal=4)
+    assert_array_almost_equal(clf.intercept_, sp_clf.intercept_, decimal=4)
 
 
 def test_linearsvc_iris():
@@ -174,7 +176,8 @@ def test_linearsvc_iris():
 
     assert_equal(clf.fit_intercept, sp_clf.fit_intercept)
 
-    assert_array_almost_equal(clf.raw_coef_, sp_clf.raw_coef_, decimal=1)
+    assert_array_almost_equal(clf.coef_, sp_clf.coef_, decimal=1)
+    assert_array_almost_equal(clf.intercept_, sp_clf.intercept_, decimal=1)
     assert_array_almost_equal(
         clf.predict(iris.data.toarray()), sp_clf.predict(iris.data))
 


### PR DESCRIPTION
I reproduce the same behaviour, It is even more visible in larger datasets like 20_newsgroup.

With raw_coef : 40 MB
Without: 20 MB

Fixes https://github.com/scikit-learn/scikit-learn/issues/3413
