### PR TITLE
Kullback-Leibler divergence as a parameter of TSNE

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -365,7 +365,7 @@ class TSNE(BaseEstimator):
     `training_data_` : array-like, shape (n_samples, n_features)
         Stores the training data.
 
-    `error` : float
+    `error_` : float
         Stores the error (Kullback-Leibler divergence) after embedding.
 
     Examples
@@ -405,7 +405,6 @@ class TSNE(BaseEstimator):
         self.init = init
         self.verbose = verbose
         self.random_state = random_state
-        self.error = 0
 
     def _fit(self, X):
         """Fit the model using X as training data.
@@ -503,7 +502,7 @@ class TSNE(BaseEstimator):
             print("[t-SNE] Error after %d iterations: %f" % (it + 1, error))
 
         X_embedded = params.reshape(n_samples, self.n_components)
-        self.error = error
+        self.error_ = error
 
         return X_embedded
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -365,6 +365,9 @@ class TSNE(BaseEstimator):
     `training_data_` : array-like, shape (n_samples, n_features)
         Stores the training data.
 
+    `error` : float
+        Stores the error (Kullback-Leibler divergence) after embedding.
+
     Examples
     --------
 
@@ -402,6 +405,7 @@ class TSNE(BaseEstimator):
         self.init = init
         self.verbose = verbose
         self.random_state = random_state
+        self.error = 0
 
     def _fit(self, X):
         """Fit the model using X as training data.
@@ -499,6 +503,7 @@ class TSNE(BaseEstimator):
             print("[t-SNE] Error after %d iterations: %f" % (it + 1, error))
 
         X_embedded = params.reshape(n_samples, self.n_components)
+        self.error = error
 
         return X_embedded
 


### PR DESCRIPTION
As in [1], I think it may be useful for the user to have access to the variable 'error' (Kullback-Leibler divergence, AFAIC). In fact one can choose between many t-SNE embedding on the same dataset by looking at the error [2].

[1] http://datascience.stackexchange.com/questions/762/t-sne-python-implementation-kullback-leibler-divergence/
[2] http://homepage.tudelft.nl/19j49/t-SNE.html
