### PR TITLE
[MRG] FIX: Raise error when n_estimators = 0 in ensemble models.

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -53,7 +53,12 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
         self.estimators_ = []
 
     def _validate_estimator(self, default=None):
-        """Check the estimator and set the `base_estimator_` attribute."""
+        """Check the estimator and the n_estimator attribute, set the
+        `base_estimator_` attribute."""
+        if self.n_estimators <= 0:
+            raise ValueError("n_estimators must be greater than zero, "
+                             "got {0}.".format(self.n_estimators))
+
         if self.base_estimator is not None:
             self.base_estimator_ = self.base_estimator
         else:

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -8,6 +8,7 @@ Testing for the base module (sklearn.ensemble.base).
 from numpy.testing import assert_equal
 from nose.tools import assert_true
 
+from sklearn.utils.testing import assert_raise_message
 from sklearn.datasets import load_iris
 from sklearn.ensemble import BaggingClassifier
 from sklearn.linear_model import Perceptron
@@ -30,3 +31,13 @@ def test_base():
     assert_equal(3, len(ensemble.estimators_))
 
     assert_true(isinstance(ensemble[0], Perceptron))
+
+
+def test_base_zero_n_estimators():
+    """Check that instantiating a BaseEnsemble with n_estimators<=0 raises
+    a ValueError."""
+    ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators=0)
+    iris = load_iris()
+    assert_raise_message(ValueError,
+                         "n_estimators must be greater than zero, got 0.",
+                         ensemble.fit, iris.data, iris.target)


### PR DESCRIPTION
It is possible to do:
`clf = ensemble.RandomForestClassifier(n_estimators=0)`
then 
`clf.fit(X, y)` raises a division by zero error.

0.14.1 raised a ValueError, behavior changed with PR: 
ENH bagging meta-estimator.
74d395215bbd2009dc922967b41c43f5469942ce

This PR just resets the 0.14.1 behavior.
