### PR TITLE
[MRG] Get rid of "DeprecationWarning: using a non-integer number instead of an integer" when running the tests

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -472,7 +472,7 @@ class PatchExtractor(BaseEstimator):
         X = np.reshape(X, (n_images, i_h, i_w, -1))
         n_channels = X.shape[-1]
         if self.patch_size is None:
-            patch_size = i_h / 10, i_w / 10
+            patch_size = i_h // 10, i_w // 10
         else:
             patch_size = self.patch_size
 

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -281,7 +281,7 @@ def extract_patches(arr, patch_shape=8, extraction_step=1):
     slices = [slice(None, None, st) for st in extraction_step]
     indexing_strides = arr[slices].strides
 
-    patch_indices_shape = ((np.array(arr.shape) - np.array(patch_shape)) /
+    patch_indices_shape = ((np.array(arr.shape) - np.array(patch_shape)) //
                            np.array(extraction_step)) + 1
 
     shape = tuple(list(patch_indices_shape) + list(patch_shape))

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -100,9 +100,9 @@ def test_ridge_singular():
     # test on a singular matrix
     rng = np.random.RandomState(0)
     n_samples, n_features = 6, 6
-    y = rng.randn(n_samples / 2)
+    y = rng.randn(n_samples // 2)
     y = np.concatenate((y, y))
-    X = rng.randn(n_samples / 2, n_features)
+    X = rng.randn(n_samples // 2, n_features)
     X = np.concatenate((X, X), axis=0)
 
     ridge = Ridge(alpha=0)

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -153,8 +153,8 @@ def _test_sparse_enet_not_as_toy_dataset(alpha, fit_intercept, positive):
     X, y = make_sparse_data(n_samples, n_features, n_informative,
                             positive=positive)
 
-    X_train, X_test = X[n_samples / 2:], X[:n_samples / 2]
-    y_train, y_test = y[n_samples / 2:], y[:n_samples / 2]
+    X_train, X_test = X[n_samples // 2:], X[:n_samples // 2]
+    y_train, y_test = y[n_samples // 2:], y[:n_samples // 2]
 
     s_clf = ElasticNet(alpha=alpha, l1_ratio=0.8, fit_intercept=fit_intercept,
                        max_iter=max_iter, tol=1e-7, positive=positive,
@@ -197,8 +197,8 @@ def test_sparse_lasso_not_as_toy_dataset():
     n_informative = 10
     X, y = make_sparse_data(n_samples=n_samples, n_informative=n_informative)
 
-    X_train, X_test = X[n_samples / 2:], X[:n_samples / 2]
-    y_train, y_test = y[n_samples / 2:], y[:n_samples / 2]
+    X_train, X_test = X[n_samples // 2:], X[:n_samples // 2]
+    y_train, y_test = y[n_samples // 2:], y[:n_samples // 2]
 
     s_clf = Lasso(alpha=0.1, fit_intercept=False, max_iter=max_iter, tol=1e-7)
     s_clf.fit(X_train, y_train)

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -304,7 +304,7 @@ def locally_linear_embedding(
             M.flat[::M.shape[0] + 1] += 1  # W = W - I = W - I
 
     elif method == 'hessian':
-        dp = n_components * (n_components + 1) / 2
+        dp = n_components * (n_components + 1) // 2
 
         if n_neighbors <= n_components + dp:
             raise ValueError("for method='hessian', n_neighbors must be "

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -177,8 +177,8 @@ def test_contingency_matrix():
 
 
 def test_exactly_zero_info_score():
-    """Check numerical stabability when information is exactly zero"""
-    for i in np.logspace(1, 4, 4):
+    """Check numerical stability when information is exactly zero"""
+    for i in np.logspace(1, 4, 4).astype(np.int):
         labels_a, labels_b = np.ones(i, dtype=np.int),\
             np.arange(i, dtype=np.int)
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -519,7 +519,7 @@ def cartesian(arrays, out=None):
     if out is None:
         out = np.empty([n, len(arrays)], dtype=dtype)
 
-    m = n / arrays[0].size
+    m = n // arrays[0].size
     out[:, 0] = np.repeat(arrays[0], m)
     if arrays[1:]:
         cartesian(arrays[1:], out=out[0:m, 1:])

--- a/sklearn/utils/tests/test_shortest_path.py
+++ b/sklearn/utils/tests/test_shortest_path.py
@@ -37,7 +37,7 @@ def generate_graph(N=20):
     dist_matrix += dist_matrix.T
 
     #make graph sparse
-    i = (rng.randint(N, size=N * N / 2), rng.randint(N, size=N * N / 2))
+    i = (rng.randint(N, size=N * N // 2), rng.randint(N, size=N * N // 2))
     dist_matrix[i] = 0
 
     #set diagonal to zero


### PR DESCRIPTION
This addresses #3398. As far as I could see I removed all of them except a couple in hmm.py which I thought wasn't worth touching since it is going away.
