### PR TITLE
Added Example for Plotting Hierarchical Clustering Dendrogram

### DIFF
--- a/examples/cluster/plot_hierarchical_clustering_dendrogram.py
+++ b/examples/cluster/plot_hierarchical_clustering_dendrogram.py
@@ -1,0 +1,45 @@
+# Authors: Mathew Kallada
+# License: BSD 3 clause
+"""
+=========================================
+Plot Hierarachical Clustering Dendrogram 
+=========================================
+
+This example plots the corresponding dendrogram of a hierarchical clustering
+using AgglomerativeClustering and the dendrogram method available in scipy.
+"""
+
+import numpy as np
+
+from matplotlib import pyplot as plt
+from scipy.cluster.hierarchy import dendrogram
+from sklearn.datasets import load_iris
+from sklearn.cluster import AgglomerativeClustering
+
+def plot_dendrogram(model, **kwargs):
+
+    # Children of hierarchical clustering
+    children = model.children_
+
+    # Distances between each pair of children
+    # Since we don't have this information, we can use a uniform one for plotting
+    distance = np.arange(children.shape[0])
+
+    # The number of observations contained in each cluster level
+    no_of_observations = np.arange(2, children.shape[0]+2)
+
+    # Create linkage matrix and then plot the dendrogram
+    linkage_matrix = np.column_stack([children, distance, no_of_observations]).astype(float)
+
+    # Plot the corresponding dendrogram
+    dendrogram(linkage_matrix, **kwargs)
+
+
+iris = load_iris()
+x = iris.data[:20]
+model = AgglomerativeClustering(n_clusters=3)
+
+model = model.fit(x)
+plt.title('Hierarchical Clustering Dendrogram')
+plot_dendrogram(model, labels=model.labels_)
+plt.show()


### PR DESCRIPTION
Visualizing the hierarchy of the resulting hierarchical clustering can be useful.

This pull request adds an example for plotting the dendrogram for `AgglometraiveClustering`. This function makes good use of scipy's [dendrogram function](http://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.dendrogram.html).

The corresponding output for this example is shown below:
<img src="http://oi59.tinypic.com/vie8es.jpg" width="400px" height="400px" />

Please let me know if you find this useful, or if I should change anything!

Thanks!,
Mat
