### PR TITLE
[MRG+1] Multi-output scoring, or 2493 cont'd for real

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -963,7 +963,25 @@ Regression metrics
 The :mod:`sklearn.metrics` implements several losses, scores and utility
 functions to measure regression performance. Some of those have been enhanced
 to handle the multioutput case: :func:`mean_absolute_error`,
-:func:`mean_absolute_error` and :func:`r2_score`.
+:func:`mean_absolute_error`, :func:`explained_variance_score` and 
+:func:`r2_score`.
+
+
+These functions have an ``output_weights`` keyword argument which specifies
+the way the scores for each individual target should be averaged. The default
+is ``'uniform'``, which entails a uniformly weighted mean over outputs. If
+an ``ndarray`` of shape ``(n_outputs,)`` is passed, then its entries are
+interpreted as weights and an according weighted average is returned. If
+``output_weights=None`` is specified, then all unaltered individual scores
+will be returned in an array of shape ``(n_outputs,)``.
+
+
+The :func:`r2_score` and :func:`explained_variance_score` additionally
+accept ``output_weights='variance'``, which will lead to a weighting of 
+each individual score by the variance of the corresponding target variable.
+This setting quantifies the globally captured unscaled variance. If the 
+target variables are of different scale, then this score puts more
+importance on well explaining the higher variance variables.
 
 
 Explained variance score
@@ -982,6 +1000,7 @@ variance is  estimated  as follow:
 
 The best possible score is 1.0, lower values are worse.
 
+
 Here a small example of usage of the :func:`explained_variance_score`
 function::
 
@@ -990,6 +1009,14 @@ function::
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
     0.957...
+    >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+    >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
+    >>> explained_variance_score(y_true, y_pred, output_weights=None)
+    ... # doctest: +ELLIPSIS
+    array([ 0.967...,  1.        ])
+    >>> explained_variance_score(y_true, y_pred, output_weights=[0.3, 0.7])
+    ... # doctest: +ELLIPSIS
+    0.990...
 
 Mean absolute error
 -------------------
@@ -1007,6 +1034,7 @@ and :math:`y_i` is the corresponding true value, then the mean absolute error
 
   \text{MAE}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1} \left| y_i - \hat{y}_i \right|.
 
+
 Here a small example of usage of the :func:`mean_absolute_error` function::
 
   >>> from sklearn.metrics import mean_absolute_error
@@ -1018,7 +1046,11 @@ Here a small example of usage of the :func:`mean_absolute_error` function::
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> mean_absolute_error(y_true, y_pred)
   0.75
-
+  >>> mean_absolute_error(y_true, y_pred, output_weights=None)
+  array([ 0.5,  1. ])
+  >>> mean_absolute_error(y_true, y_pred, output_weights=[0.3, 0.7])
+  ... # doctest: +ELLIPSIS
+  0.849...
 
 
 Mean squared error
@@ -1074,6 +1106,7 @@ over :math:`n_{\text{samples}}` is defined as
 
 where :math:`\bar{y} =  \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}} - 1} y_i`.
 
+
 Here a small example of usage of the :func:`r2_score` function::
 
   >>> from sklearn.metrics import r2_score
@@ -1083,8 +1116,18 @@ Here a small example of usage of the :func:`r2_score` function::
   0.948...
   >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
-  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> r2_score(y_true, y_pred, output_weights='variance')  # doctest: +ELLIPSIS
   0.938...
+  >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+  >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
+  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  0.936...
+  >>> r2_score(y_true, y_pred, output_weights=None)
+  ... # doctest: +ELLIPSIS
+  array([ 0.965...,  0.908...])
+  >>> r2_score(y_true, y_pred, output_weights=[0.3, 0.7])
+  ... # doctest: +ELLIPSIS
+  0.925...
 
 
 .. topic:: Example:

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -277,6 +277,7 @@ MULTILABELS_METRICS = [
 # Regression metrics with "multioutput-continuous" format support
 MULTIOUTPUT_METRICS = [
     "mean_absolute_error", "mean_squared_error", "r2_score",
+    "explained_variance_score"
 ]
 
 # Symmetric with respect to their input arguments y_true and y_pred

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.metrics import explained_variance_score
 from sklearn.metrics import mean_absolute_error
@@ -38,8 +39,11 @@ def test_multioutput_regression():
     error = mean_absolute_error(y_true, y_pred)
     assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
 
-    error = r2_score(y_true, y_pred)
-    assert_almost_equal(error, 1 - 5. / 2)
+    error = r2_score(y_true, y_pred, output_weights='variance')
+    assert_almost_equal(error, 1. - 5. / 2)
+    error = r2_score(y_true, y_pred, output_weights='uniform')
+    assert_almost_equal(error, -.875)
+
 
 
 def test_regression_metrics_at_limits():
@@ -63,7 +67,8 @@ def test__check_reg_targets():
                                                             repeat=2):
 
         if type1 == type2 and n_out1 == n_out2:
-            y_type, y_check1, y_check2 = _check_reg_targets(y1, y2)
+            y_type, y_check1, y_check2, output_weights = _check_reg_targets(
+                y1, y2, None)
             assert_equal(type1, y_type)
             if type1 == 'continuous':
                 assert_array_equal(y_check1, np.reshape(y1, (-1, 1)))
@@ -72,4 +77,68 @@ def test__check_reg_targets():
                 assert_array_equal(y_check1, y1)
                 assert_array_equal(y_check2, y2)
         else:
-            assert_raises(ValueError, _check_reg_targets, y1, y2)
+            assert_raises(ValueError, _check_reg_targets, y1, y2, None)
+
+
+def test_regression_multioutput_array():
+    y_true = [[1, 2], [2.5, -1], [4.5, 3], [5, 7]]
+    y_pred = [[1, 1], [2, -1], [5, 4], [5, 6.5]]
+
+    mse = mean_squared_error(y_true, y_pred, output_weights=None)
+    mae = mean_absolute_error(y_true, y_pred, output_weights=None)
+    r =  r2_score(y_true, y_pred, output_weights=None)
+    evs =  explained_variance_score(y_true, y_pred, output_weights=None)
+
+    assert_array_equal(mse, np.array([0.125, 0.5625]))
+    assert_array_equal(mae, np.array([0.25, 0.625]))
+    assert_array_almost_equal(r, np.array([0.95, 0.93]), decimal=2)
+    assert_array_almost_equal(evs, np.array([0.95, 0.93]), decimal=2)
+
+    # mean_absolute_error and mean_squared_error are equal because
+    # it is a binary problem.
+    y_true = [[0, 0]]*4
+    y_pred = [[1, 1]]*4
+    mse = mean_squared_error(y_true, y_pred, output_weights=None)
+    mae = mean_absolute_error(y_true, y_pred, output_weights=None)
+    r =  r2_score(y_true, y_pred, output_weights=None)
+    assert_array_equal(mse, np.array([1., 1.]))
+    assert_array_equal(mae, np.array([1., 1.]))
+    assert_array_almost_equal(r, np.array([0., 0.]))
+
+    r = r2_score([[0, -1], [0, 1]], [[2, 2], [1, 1]], output_weights=None)
+    assert_array_equal(r, np.array([0, -3.5]))
+    assert_equal(np.mean(r), r2_score([[0, -1], [0, 1]], [[2, 2], [1, 1]]))
+    evs = explained_variance_score([[0, -1], [0, 1]], [[2, 2], [1, 1]],
+        output_weights=None)
+    assert_array_equal(evs, np.array([0, -1.25]))
+
+    # Checking for the condition in which both numerator and denominator is
+    # zero.
+    y_true = [[1, 3], [-1, 2]]
+    y_pred = [[1, 4], [-1, 1]]
+    r =  r2_score(y_true, y_pred, output_weights=None)
+    assert_array_equal(r, np.array([1., -3.]))
+    assert_equal(np.mean(r), r2_score(y_true, y_pred))
+    evs =  explained_variance_score(y_true, y_pred, output_weights=None)
+    assert_array_equal(evs, np.array([1., -3.]))
+    assert_equal(np.mean(evs), explained_variance_score(y_true, y_pred))
+
+
+def test_regression_custom_weights():
+    y_true = [[1, 2], [2.5, -1], [4.5, 3], [5, 7]]
+    y_pred = [[1, 1], [2, -1], [5, 4], [5, 6.5]]
+
+    msew = mean_squared_error(y_true, y_pred, output_weights=[0.4, 0.6],
+                              sample_weight=None)
+    maew = mean_absolute_error(y_true, y_pred, output_weights=[0.4, 0.6],
+                               sample_weight=None)
+    rw =  r2_score(y_true, y_pred, output_weights=[0.4, 0.6],
+                   sample_weight=None)
+    evsw =  explained_variance_score(y_true, y_pred,
+                                     output_weights=[0.4, 0.6],
+                                     sample_weight=None)
+
+    assert_almost_equal(msew, 0.39, decimal=2)
+    assert_almost_equal(maew, 0.475, decimal=3)
+    assert_almost_equal(rw, 0.94, decimal=2)
+    assert_almost_equal(evsw, 0.94, decimal=2)


### PR DESCRIPTION
This time taking into account the refactoring of metrics.py into several files.

This replaces https://github.com/scikit-learn/scikit-learn/pull/3456, which I closed.
