### PR TITLE
FIX When passing a multilabel-indicator to type_of_target(y) that isn't ...

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -285,14 +285,16 @@ def type_of_target(y):
 
     if is_sequence_of_sequences(y):
         return 'multilabel-sequences'
-    elif is_label_indicator_matrix(y):
-        return 'multilabel-indicator'
 
     try:
         y = np.asarray(y)
     except ValueError:
         # known to fail in numpy 1.3 for array of arrays
         return 'unknown'
+
+    if is_label_indicator_matrix(y):
+        return 'multilabel-indicator'
+
     if y.ndim > 2 or (y.dtype == object and len(y) and
                       not isinstance(y.flat[0], string_types)):
         return 'unknown'


### PR DESCRIPTION
...a numpy array, it doesn't type it as a multilabel-indicator.
