### PR TITLE
[MRG-0] Make LabelEncoder more friendly to new labels

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -398,7 +398,7 @@ follows::
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder(new_labels='raise')
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
     array([0, 0, 1, 2])
@@ -429,11 +429,11 @@ below).
     >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder(new_labels=-1)
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -418,6 +418,20 @@ hashable and comparable) to numerical labels::
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']
 
+By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
+labels are passed in ``transform`` that were not seen in ``fit``.  This
+behavior can be handled with the ``new_labels`` parameter, which supports
+``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
+handling new labels.  For example, the ``"label"`` strategy will assign
+the unseen values a label of ``-1``.
+
+    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
+    LabelEncoder(new_label_class=-1, new_labels='label')
+    >>> list(le.classes_)
+    ['amsterdam', 'paris', 'tokyo']
+    >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
+    array([ 2,  2,  1, -1])
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -398,8 +398,8 @@ follows::
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder(new_labels='raise')
-    >>> le.classes_
-    array([1, 2, 6])
+    >>> list(le.get_classes())
+    [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
     array([0, 0, 1, 2])
     >>> le.inverse_transform([0, 0, 1, 2])
@@ -429,11 +429,11 @@ below).
     >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder(new_labels=-1)
-    >>> le.get_classes()
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
-    >>> le.get_classes()
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -421,17 +421,20 @@ hashable and comparable) to numerical labels::
 By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
 labels are passed in ``transform`` that were not seen in ``fit``.  This
 behavior can be handled with the ``new_labels`` parameter, which supports
-``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
-handling new labels.  For example, the ``"label"`` strategy will assign
-the unseen values a label of ``-1``.
+``"raise"``, ``"update"``, and integer strategies for
+handling new labels.  For example, the integer strategy will assign
+the unseen values an arbitrary, user-specified integer label (e.g., ``-1``
+below).
 
-    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='label')
-    >>> list(le.classes_)
+    LabelEncoder(new_labels=-1)
+    >>> le.get_classes()
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
+    >>> le.get_classes()
+    ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values
 ============================

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -260,7 +260,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self._check_fitted()
 
         y = np.asarray(y)
-        return self.classes_[y]
+        return self.get_classes()[y]
 
 
 class LabelBinarizer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -68,12 +68,14 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If an integer value is passed, then re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
           taken if a non-negative value is passed to not accidentally
-          intersect.
+          intersect.  Additionally, ``inverse_transform`` will fail for a
+          value that does not intersect with the ``fit``-time label set.
 
     Attributes
     ----------
     `classes_` : array of shape (n_class,)
-        Holds the label for each class.
+        Holds the label for each class that were seen at fit.  See
+        ``get_classes()`` to retrieve all observed labels.
 
     `new_label_mapping_` : dictionary
         Stores the mapping for classes not seen during original ``fit``.
@@ -130,6 +132,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         # If we've seen updates, include them in the order they were added.
         if len(self.new_label_mapping_) > 0:
+            # Sort the post-fit time labels to return into the class array.
             sorted_new, _ = zip(*sorted(self.new_label_mapping_.iteritems(),
                                         key=operator.itemgetter(1)))
             return np.append(self.classes_, sorted_new)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -133,7 +133,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # If we've seen updates, include them in the order they were added.
         if len(self.new_label_mapping_) > 0:
             # Sort the post-fit time labels to return into the class array.
-            sorted_new, _ = zip(*sorted(self.new_label_mapping_.iteritems(),
+            sorted_new, _ = zip(*sorted(self.new_label_mapping_.items(),
                                         key=operator.itemgetter(1)))
             return np.append(self.classes_, sorted_new)
         else:

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -228,6 +228,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                                      for value in y[missing_mask]]
                 return out
             elif type(self.new_labels) in [int]:
+                # Update the new label mapping
+                self.new_label_mapping_.update(dict(zip(diff_new,
+                                                        [self.new_labels]
+                                                        * len(diff_new))))
+
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff_fit)
 
@@ -259,8 +264,24 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         self._check_fitted()
 
+        if type(self.new_labels) in [int]:
+            warnings.warn('When ``new_labels`` uses an integer '
+                          're-labeling strategy, the ``inverse_transform`` '
+                          'is not necessarily one-to-one mapping; any '
+                          'labels not present during initial ``fit`` will '
+                          'not be mapped.',
+                          UserWarning)
+
         y = np.asarray(y)
-        return self.get_classes()[y]
+        try:
+            return self.get_classes()[y]
+        except IndexError:
+            # Raise exception
+            num_classes = len(self.get_classes())
+            raise ValueError("Classes were passed to ``inverse_transform`` "
+                             "with integer new_labels strategy ``fit``-time: "
+                             "{0}"
+                             .format(np.setdiff1d(y, range(num_classes))))
 
 
 class LabelBinarizer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -4,13 +4,13 @@
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Hamzeh Alsalhi <ha258@cornell.edu>
+#          Michael Bommarito <michael@bommaritollc.com>
 # License: BSD 3 clause
 
 from collections import defaultdict
 import itertools
 import array
 import warnings
-import operator
 
 import operator
 import numpy as np
@@ -65,7 +65,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"raise"``, then raise ValueError.
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If an integer value is passed, then use re-label with this value.
+        - If an integer value is passed, then re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
           taken if a non-negative value is passed to not accidentally
           intersect.
@@ -85,8 +85,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
-    >>> le.classes_
+    LabelEncoder(new_labels='raise')
+    >>> le.get_classes()
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
     array([0, 0, 1, 2]...)
@@ -98,8 +98,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
-    >>> list(le.classes_)
+    LabelEncoder(new_labels='raise')
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
     array([2, 2, 1]...)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -215,10 +215,9 @@ def test_label_encoder_get_classes():
     le = LabelEncoder(new_labels="update")
     le.fit([1, 1, 4, 5, -1, 0])
     assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
-    assert_array_equal(le.classes_, le.get_classes())
+    assert_array_equal(le.classes_, le.classes_)
     le.transform([10])
-    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
-    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5, 10])
 
 
 def test_label_encoder_new_label_update():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -235,6 +235,8 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
     assert_array_equal(le.transform(["_", "z", "a"]),
                        [3, 4, 0])
+    assert_array_equal(le.inverse_transform([3, 4, 0]),
+                       ["_", "z", "a"])
 
 
 def test_label_encoder_new_label_replace():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -250,6 +250,7 @@ def test_label_encoder_new_label_replace():
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "d"]),
                        [1, 2, -99])
+    assert_warns(UserWarning, le.inverse_transform, [2, 1, 0])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,6 +210,52 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_get_classes():
+    """Test LabelEncoder's get_classes method."""
+    le = LabelEncoder(new_labels="update")
+    le.fit([1, 1, 4, 5, -1, 0])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.classes_, le.get_classes())
+    le.transform([10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+
+
+def test_label_encoder_new_label_update():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="update")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "_"]),
+                       [1, 2, 3])
+    assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
+    assert_array_equal(le.transform(["_", "z", "a"]),
+                       [3, 4, 0])
+
+
+def test_label_encoder_new_label_replace():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels=-99)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, -99])
+
+
+def test_label_encoder_new_label_arg():
+    """Test LabelEncoder's  new_labels argument handling"""
+    le = LabelEncoder(new_labels="xyz")
+    assert_raises(ValueError, le.fit, ["a", "b", "b", "c"])
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()


### PR DESCRIPTION
This is a final, cleanly rebased version of PR 3243 (https://github.com/scikit-learn/scikit-learn/pull/3243) incorporating discussions.
## Summary:

This PR intends to make `preprocessing.LabelEncoder` more friendly for production/pipeline usage by adding a `new_labels` constructor argument.

Instead of always raising `ValueError` for unseen/new labels in transform, `LabelEncoder` may be initialized with new_labels as:
- `"raise"`: current behavior, i.e., raise `ValueError`; to remain default behavior
- `"update"`: update classes with new IDs `[N, ..., N+m-1]` for m new labels and assign
- an integer value: set newly seen labels to have fixed value corresponding to this integer value

**N.B.**: `.classes_` is not a property to support the `new_labels="update"` behavior.

Tests and documentation updates included.
