### PR TITLE
[MRG+1] DOC fix formatting of Attributes sections in documentation

### DIFF
--- a/doc/sphinxext/numpy_ext/docscrape_sphinx.py
+++ b/doc/sphinxext/numpy_ext/docscrape_sphinx.py
@@ -188,14 +188,14 @@ class SphinxDocString(NumpyDocString):
         out += self._str_index() + ['']
         out += self._str_summary()
         out += self._str_extended_summary()
-        for param_list in ('Parameters', 'Returns', 'Raises'):
+        for param_list in ('Parameters', 'Returns', 'Raises', 'Attributes'):
             out += self._str_param_list(param_list)
         out += self._str_warnings()
         out += self._str_see_also(func_role)
         out += self._str_section('Notes')
         out += self._str_references()
         out += self._str_examples()
-        for param_list in ('Attributes', 'Methods'):
+        for param_list in ('Methods',):
             out += self._str_member_list(param_list)
         out = self._str_indent(out, indent)
         return '\n'.join(out)

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -220,19 +220,19 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
 
     Attributes
     ----------
-    `cluster_centers_indices_` : array, shape (n_clusters,)
+    cluster_centers_indices_ : array, shape (n_clusters,)
         Indices of cluster centers
 
-    `cluster_centers_` : array, shape (n_clusters, n_features)
+    cluster_centers_ : array, shape (n_clusters, n_features)
         Cluster centers (if affinity != ``precomputed``).
 
-    `labels_` : array, shape (n_samples,)
+    labels_ : array, shape (n_samples,)
         Labels of each point
 
-    `affinity_matrix_` : array, shape (n_samples, n_samples)
+    affinity_matrix_ : array, shape (n_samples, n_samples)
         Stores the affinity matrix used in ``fit``.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations taken to converge.
 
     Notes

--- a/sklearn/cluster/bicluster/spectral.py
+++ b/sklearn/cluster/bicluster/spectral.py
@@ -236,17 +236,17 @@ class SpectralCoclustering(BaseSpectral):
 
     Attributes
     ----------
-    `rows_` : array-like, shape (n_row_clusters, n_rows)
+    rows_ : array-like, shape (n_row_clusters, n_rows)
         Results of the clustering. `rows[i, r]` is True if
         cluster `i` contains row `r`. Available only after calling ``fit``.
 
-    `columns_` : array-like, shape (n_column_clusters, n_columns)
+    columns_ : array-like, shape (n_column_clusters, n_columns)
         Results of the clustering, like `rows`.
 
-    `row_labels_` : array-like, shape (n_rows,)
+    row_labels_ : array-like, shape (n_rows,)
         The bicluster label of each row.
 
-    `column_labels_` : array-like, shape (n_cols,)
+    column_labels_ : array-like, shape (n_cols,)
         The bicluster label of each column.
 
     References
@@ -364,17 +364,17 @@ class SpectralBiclustering(BaseSpectral):
 
     Attributes
     ----------
-    `rows_` : array-like, shape (n_row_clusters, n_rows)
+    rows_ : array-like, shape (n_row_clusters, n_rows)
         Results of the clustering. `rows[i, r]` is True if
         cluster `i` contains row `r`. Available only after calling ``fit``.
 
-    `columns_` : array-like, shape (n_column_clusters, n_columns)
+    columns_ : array-like, shape (n_column_clusters, n_columns)
         Results of the clustering, like `rows`.
 
-    `row_labels_` : array-like, shape (n_rows,)
+    row_labels_ : array-like, shape (n_rows,)
         Row partition labels.
 
-    `column_labels_` : array-like, shape (n_cols,)
+    column_labels_ : array-like, shape (n_cols,)
         Column partition labels.
 
     References

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -201,13 +201,13 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
     Attributes
     ----------
-    `core_sample_indices_` : array, shape = [n_core_samples]
+    core_sample_indices_ : array, shape = [n_core_samples]
         Indices of core samples.
 
-    `components_` : array, shape = [n_core_samples, n_features]
+    components_ : array, shape = [n_core_samples, n_features]
         Copy of each core sample found by training.
 
-    `labels_` : array, shape = [n_samples]
+    labels_ : array, shape = [n_samples]
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -567,16 +567,16 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
 
     Attributes
     ----------
-    `labels_` : array [n_samples]
+    labels_ : array [n_samples]
         cluster labels for each point
 
-    `n_leaves_` : int
+    n_leaves_ : int
         Number of leaves in the hierarchical tree.
 
-    `n_components_` : int
+    n_components_ : int
         The estimated number of connected components in the graph.
 
-    `children_` : array-like, shape = [n_nodes, 2]
+    children_ : array-like, shape = [n_nodes, 2]
         The children of each non-leaf node. Values less than `n_samples`
         refer to leaves of the tree. A greater value `i` indicates a node with
         children `children_[i - n_samples]`.
@@ -727,16 +727,16 @@ class Ward(AgglomerativeClustering):
 
     Attributes
     ----------
-    `labels_` : array [n_features]
+    labels_ : array [n_features]
         cluster labels for each feature
 
-    `n_leaves_` : int
+    n_leaves_ : int
         Number of leaves in the hierarchical tree.
 
-    `n_components_` : int
+    n_components_ : int
         The estimated number of connected components in the graph.
 
-    `children_` : array-like, shape = [n_nodes, 2]
+    children_ : array-like, shape = [n_nodes, 2]
         The children of each non-leaf node. Values less than `n_samples`
         refer to leaves of the tree. A greater value `i` indicates a node with
         children `children_[i - n_samples]`.
@@ -797,18 +797,18 @@ class WardAgglomeration(AgglomerationTransform, Ward):
 
     Attributes
     ----------
-    `children_` : array-like, shape = [n_nodes, 2]
+    children_ : array-like, shape = [n_nodes, 2]
         The children of each non-leaf node. Values less than `n_samples` refer
         to leaves of the tree. A greater value `i` indicates a node with
         children `children_[i - n_samples]`.
 
-    `labels_` : array [n_features]
+    labels_ : array [n_features]
         cluster labels for each feature
 
-    `n_leaves_` : int
+    n_leaves_ : int
         Number of leaves in the hierarchical tree.
 
-    `n_components_` : int
+    n_components_ : int
         The estimated number of connected components in the graph.
 
     """

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -648,13 +648,13 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     Attributes
     ----------
-    `cluster_centers_` : array, [n_clusters, n_features]
+    cluster_centers_ : array, [n_clusters, n_features]
         Coordinates of cluster centers
 
-    `labels_` :
+    labels_ :
         Labels of each point
 
-    `inertia_` : float
+    inertia_ : float
         Sum of distances of samples to their closest cluster center.
 
     Notes
@@ -1109,13 +1109,13 @@ class MiniBatchKMeans(KMeans):
     Attributes
     ----------
 
-    `cluster_centers_` : array, [n_clusters, n_features]
+    cluster_centers_ : array, [n_clusters, n_features]
         Coordinates of cluster centers
 
-    `labels_` :
+    labels_ :
         Labels of each point (if compute_labels is set to True).
 
-    `inertia_` : float
+    inertia_ : float
         The value of the inertia criterion associated with the chosen
         partition (if compute_labels is set to True). The inertia is
         defined as the sum of square distances of samples to their nearest

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -262,10 +262,10 @@ class MeanShift(BaseEstimator, ClusterMixin):
 
     Attributes
     ----------
-    `cluster_centers_` : array, [n_clusters, n_features]
+    cluster_centers_ : array, [n_clusters, n_features]
         Coordinates of cluster centers.
 
-    `labels_` :
+    labels_ :
         Labels of each point.
 
     Notes

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -349,11 +349,11 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
 
     Attributes
     ----------
-    `affinity_matrix_` : array-like, shape (n_samples, n_samples)
+    affinity_matrix_ : array-like, shape (n_samples, n_samples)
         Affinity matrix used for clustering. Available only if after calling
         ``fit``.
 
-    `labels_` :
+    labels_ :
         Labels of each point
 
     Notes

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -97,10 +97,10 @@ class EmpiricalCovariance(BaseEstimator):
 
     Attributes
     ----------
-    `covariance_` : 2D ndarray, shape (n_features, n_features)
+    covariance_ : 2D ndarray, shape (n_features, n_features)
         Estimated covariance matrix
 
-    `precision_` : 2D ndarray, shape (n_features, n_features)
+    precision_ : 2D ndarray, shape (n_features, n_features)
         Estimated pseudo-inverse matrix.
         (stored only if store_precision is True)
 
@@ -136,7 +136,7 @@ class EmpiricalCovariance(BaseEstimator):
 
         Returns
         -------
-        `precision_` : array-like,
+        precision_ : array-like,
             The precision matrix associated to the current covariance object.
 
         """

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -284,13 +284,13 @@ class GraphLasso(EmpiricalCovariance):
 
     Attributes
     ----------
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated covariance matrix
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     See Also
@@ -358,13 +358,13 @@ def graph_lasso_path(X, alphas, cov_init=None, X_test=None, mode='cd',
 
     Returns
     -------
-    `covariances_` : List of 2D ndarray, shape (n_features, n_features)
+    covariances_ : List of 2D ndarray, shape (n_features, n_features)
         The estimated covariance matrices.
 
-    `precisions_` : List of 2D ndarray, shape (n_features, n_features)
+    precisions_ : List of 2D ndarray, shape (n_features, n_features)
         The estimated (sparse) precision matrices.
 
-    `scores_` : List of float
+    scores_ : List of float
         The generalisation error (log-likelihood) on the test data.
         Returned only if test data is passed.
     """
@@ -452,22 +452,22 @@ class GraphLassoCV(GraphLasso):
 
     Attributes
     ----------
-    `covariance_` : numpy.ndarray, shape (n_features, n_features)
+    covariance_ : numpy.ndarray, shape (n_features, n_features)
         Estimated covariance matrix.
 
-    `precision_` : numpy.ndarray, shape (n_features, n_features)
+    precision_ : numpy.ndarray, shape (n_features, n_features)
         Estimated precision matrix (inverse covariance).
 
-    `alpha_`: float
+    alpha_ : float
         Penalization parameter selected.
 
-    `cv_alphas_`: list of float
+    cv_alphas_ : list of float
         All penalization parameters explored.
 
     `grid_scores`: 2D numpy.ndarray (n_alphas, n_folds)
         Log-likelihood score on left-out data across folds.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run for the optimal alpha.
 
     See Also

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -111,17 +111,17 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
       The amount of contamination of the data set, i.e. the proportion of \
       outliers in the data set.
 
-    `location_` : array-like, shape (n_features,)
+    location_ : array-like, shape (n_features,)
         Estimated robust location
 
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated robust covariance matrix
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
         (stored only if store_precision is True)
 
-    `support_` : array-like, shape (n_samples,)
+    support_ : array-like, shape (n_samples,)
         A mask of the observations that have been used to compute the
         robust estimates of location and shape.
 

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -523,32 +523,32 @@ class MinCovDet(EmpiricalCovariance):
 
     Attributes
     ----------
-    `raw_location_` : array-like, shape (n_features,)
+    raw_location_ : array-like, shape (n_features,)
         The raw robust estimated location before correction and re-weighting.
 
-    `raw_covariance_` : array-like, shape (n_features, n_features)
+    raw_covariance_ : array-like, shape (n_features, n_features)
         The raw robust estimated covariance before correction and re-weighting.
 
-    `raw_support_` : array-like, shape (n_samples,)
+    raw_support_ : array-like, shape (n_samples,)
         A mask of the observations that have been used to compute
         the raw robust estimates of location and shape, before correction
         and re-weighting.
 
-    `location_` : array-like, shape (n_features,)
+    location_ : array-like, shape (n_features,)
         Estimated robust location
 
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated robust covariance matrix
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
         (stored only if store_precision is True)
 
-    `support_` : array-like, shape (n_samples,)
+    support_ : array-like, shape (n_samples,)
         A mask of the observations that have been used to compute
         the robust estimates of location and shape.
 
-    `dist_` : array-like, shape (n_samples,)
+    dist_ : array-like, shape (n_samples,)
         Mahalanobis distances of the training set (on which `fit` is called)
         observations.
 

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -75,10 +75,10 @@ class ShrunkCovariance(EmpiricalCovariance):
 
     Attributes
     ----------
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated covariance matrix
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
         (stored only if store_precision is True)
 
@@ -331,14 +331,14 @@ class LedoitWolf(EmpiricalCovariance):
 
     Attributes
     ----------
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated covariance matrix
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
         (stored only if store_precision is True)
 
-    `shrinkage_` : float, 0 <= shrinkage <= 1
+    shrinkage_ : float, 0 <= shrinkage <= 1
         Coefficient in the convex combination used for the computation
         of the shrunk estimate.
 
@@ -491,14 +491,14 @@ class OAS(EmpiricalCovariance):
 
     Attributes
     ----------
-    `covariance_` : array-like, shape (n_features, n_features)
+    covariance_ : array-like, shape (n_features, n_features)
         Estimated covariance matrix.
 
-    `precision_` : array-like, shape (n_features, n_features)
+    precision_ : array-like, shape (n_features, n_features)
         Estimated pseudo inverse matrix.
         (stored only if store_precision is True)
 
-    `shrinkage_` : float, 0 <= shrinkage <= 1
+    shrinkage_ : float, 0 <= shrinkage <= 1
       coefficient in the convex combination used for the computation
       of the shrunk estimate.
 

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -29,31 +29,31 @@ class CCA(_PLS):
 
     Attributes
     ----------
-    `x_weights_` : array, [p, n_components]
+    x_weights_ : array, [p, n_components]
         X block weights vectors.
 
-    `y_weights_` : array, [q, n_components]
+    y_weights_ : array, [q, n_components]
         Y block weights vectors.
 
-    `x_loadings_` : array, [p, n_components]
+    x_loadings_ : array, [p, n_components]
         X block loadings vectors.
 
-    `y_loadings_` : array, [q, n_components]
+    y_loadings_ : array, [q, n_components]
         Y block loadings vectors.
 
-    `x_scores_` : array, [n_samples, n_components]
+    x_scores_ : array, [n_samples, n_components]
         X scores.
 
-    `y_scores_` : array, [n_samples, n_components]
+    y_scores_ : array, [n_samples, n_components]
         Y scores.
 
-    `x_rotations_` : array, [p, n_components]
+    x_rotations_ : array, [p, n_components]
         X block to latents rotations.
 
-    `y_rotations_` : array, [q, n_components]
+    y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
 
-    `n_iter_` : array-like
+    n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
         component.
 

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -154,34 +154,34 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
 
     Attributes
     ----------
-    `x_weights_` : array, [p, n_components]
+    x_weights_ : array, [p, n_components]
         X block weights vectors.
 
-    `y_weights_` : array, [q, n_components]
+    y_weights_ : array, [q, n_components]
         Y block weights vectors.
 
-    `x_loadings_` : array, [p, n_components]
+    x_loadings_ : array, [p, n_components]
         X block loadings vectors.
 
-    `y_loadings_` : array, [q, n_components]
+    y_loadings_ : array, [q, n_components]
         Y block loadings vectors.
 
-    `x_scores_` : array, [n_samples, n_components]
+    x_scores_ : array, [n_samples, n_components]
         X scores.
 
-    `y_scores_` : array, [n_samples, n_components]
+    y_scores_ : array, [n_samples, n_components]
         Y scores.
 
-    `x_rotations_` : array, [p, n_components]
+    x_rotations_ : array, [p, n_components]
         X block to latents rotations.
 
-    `y_rotations_` : array, [q, n_components]
+    y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
 
     coefs: array, [p, q]
         The coefficients of the linear model: Y = X coefs + Err
 
-    `n_iter_` : array-like
+    n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
         component. Not useful if the algorithm given is "svd".
 
@@ -475,34 +475,34 @@ class PLSRegression(_PLS):
 
     Attributes
     ----------
-    `x_weights_` : array, [p, n_components]
+    x_weights_ : array, [p, n_components]
         X block weights vectors.
 
-    `y_weights_` : array, [q, n_components]
+    y_weights_ : array, [q, n_components]
         Y block weights vectors.
 
-    `x_loadings_` : array, [p, n_components]
+    x_loadings_ : array, [p, n_components]
         X block loadings vectors.
 
-    `y_loadings_` : array, [q, n_components]
+    y_loadings_ : array, [q, n_components]
         Y block loadings vectors.
 
-    `x_scores_` : array, [n_samples, n_components]
+    x_scores_ : array, [n_samples, n_components]
         X scores.
 
-    `y_scores_` : array, [n_samples, n_components]
+    y_scores_ : array, [n_samples, n_components]
         Y scores.
 
-    `x_rotations_` : array, [p, n_components]
+    x_rotations_ : array, [p, n_components]
         X block to latents rotations.
 
-    `y_rotations_` : array, [q, n_components]
+    y_rotations_ : array, [q, n_components]
         Y block to latents rotations.
 
     coefs: array, [p, q]
         The coefficients of the linear model: Y = X coefs + Err
 
-    `n_iter_` : array-like
+    n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
         component.
 
@@ -599,31 +599,31 @@ class PLSCanonical(_PLS):
 
     Attributes
     ----------
-    `x_weights_` : array, shape = [p, n_components]
+    x_weights_ : array, shape = [p, n_components]
         X block weights vectors.
 
-    `y_weights_` : array, shape = [q, n_components]
+    y_weights_ : array, shape = [q, n_components]
         Y block weights vectors.
 
-    `x_loadings_` : array, shape = [p, n_components]
+    x_loadings_ : array, shape = [p, n_components]
         X block loadings vectors.
 
-    `y_loadings_` : array, shape = [q, n_components]
+    y_loadings_ : array, shape = [q, n_components]
         Y block loadings vectors.
 
-    `x_scores_` : array, shape = [n_samples, n_components]
+    x_scores_ : array, shape = [n_samples, n_components]
         X scores.
 
-    `y_scores_` : array, shape = [n_samples, n_components]
+    y_scores_ : array, shape = [n_samples, n_components]
         Y scores.
 
-    `x_rotations_` : array, shape = [p, n_components]
+    x_rotations_ : array, shape = [p, n_components]
         X block to latents rotations.
 
-    `y_rotations_` : array, shape = [q, n_components]
+    y_rotations_ : array, shape = [q, n_components]
         Y block to latents rotations.
 
-    `n_iter_` : array-like
+    n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
         component. Not useful if the algorithm provided is "svd".
 
@@ -711,16 +711,16 @@ class PLSSVD(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `x_weights_` : array, [p, n_components]
+    x_weights_ : array, [p, n_components]
         X block weights vectors.
 
-    `y_weights_` : array, [q, n_components]
+    y_weights_ : array, [q, n_components]
         Y block weights vectors.
 
-    `x_scores_` : array, [n_samples, n_components]
+    x_scores_ : array, [n_samples, n_components]
         X scores.
 
-    `y_scores_` : array, [n_samples, n_components]
+    y_scores_ : array, [n_samples, n_components]
         Y scores.
 
     See also

--- a/sklearn/datasets/mlcomp.py
+++ b/sklearn/datasets/mlcomp.py
@@ -28,7 +28,7 @@ def load_mlcomp(name_or_id, set_="raw", mlcomp_root=None, **kwargs):
     name_or_id : the integer id or the string name metadata of the MLComp
                  dataset to load
 
-    `set_` : select the portion to load: 'train', 'test' or 'raw'
+    set_ : select the portion to load: 'train', 'test' or 'raw'
 
     mlcomp_root : the filesystem path to the root folder where MLComp datasets
                   are stored, if mlcomp_root is None, the MLCOMP_DATASETS_HOME

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -822,7 +822,7 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         The unchanged dictionary atoms
 
     See also
@@ -933,13 +933,13 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         dictionary atoms extracted from the data
 
-    `error_` : array
+    error_ : array
         vector of errors at each iteration
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     Notes
@@ -1092,10 +1092,10 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         components extracted from the data
 
-    `inner_stats_` : tuple of (A, B) ndarrays
+    inner_stats_ : tuple of (A, B) ndarrays
         Internal sufficient statistics that are kept by the algorithm.
         Keeping them is useful in online settings, to avoid loosing the
         history of the evolution, but they shouldn't have any use for the
@@ -1103,7 +1103,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         A (n_components, n_components) is the dictionary covariance matrix.
         B (n_features, n_components) is the data approximation matrix
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     Notes

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -94,16 +94,16 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Components with maximum variance.
 
-    `loglike_` : list, [n_iterations]
+    loglike_ : list, [n_iterations]
         The log likelihood at each iteration.
 
-    `noise_variance_` : array, shape=(n_features,)
+    noise_variance_ : array, shape=(n_features,)
         The estimated noise variance for each feature.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     References

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -411,13 +411,13 @@ class FastICA(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : 2D array, shape (n_components, n_features)
+    components_ : 2D array, shape (n_components, n_features)
         The unmixing matrix.
 
-    `mixing_` : array, shape (n_features, n_components)
+    mixing_ : array, shape (n_features, n_components)
         The mixing matrix.
 
-    `n_iter_`: int
+    n_iter_ : int
         If the algorithm is "deflation", n_iter is the
         maximum number of iterations run across all components. Else
         they are just the number of iterations taken to converge.

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -74,13 +74,16 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     Attributes
     ----------
 
-    `lambdas_`, `alphas_`:
-        Eigenvalues and eigenvectors of the centered kernel matrix
+    lambdas_ :
+        Eigenvalues of the centered kernel matrix
 
-    `dual_coef_`:
+    alphas_ :
+        Eigenvectors of the centered kernel matrix
+
+    dual_coef_ :
         Inverse transform matrix
 
-    `X_transformed_fit_`:
+    X_transformed_fit_ :
         Projection of the fitted data on the kernel principal components
 
     References

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -306,15 +306,15 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Non-negative components of the data.
 
-    `reconstruction_err_` : number
+    reconstruction_err_ : number
         Frobenius norm of the matrix difference between
         the training data and the reconstructed data from
         the fit produced by the model. ``|| X - WH ||_2``
 
-    ``n_iter_`` : int
+    n_iter_ : int
         Number of iterations run.
 
     Examples

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -138,23 +138,23 @@ class PCA(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Components with maximum variance.
 
-    `explained_variance_ratio_` : array, [n_components]
+    explained_variance_ratio_ : array, [n_components]
         Percentage of variance explained by each of the selected components. \
         k is not set then all components are stored and the sum of explained \
         variances is equal to 1.0
 
-    `mean_` : array, [n_features]
+    mean_ : array, [n_features]
         Per-feature empirical mean, estimated from the training set.
 
-    `n_components_` : int
+    n_components_ : int
         The estimated number of components. Relevant when n_components is set
         to 'mle' or a number between 0 and 1 to select using explained
         variance.
 
-    `noise_variance_` : float
+    noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model
         from Tipping and Bishop 1999. See "Pattern Recognition and
         Machine Learning" by C. Bishop, 12.2.1 p. 574 or
@@ -495,15 +495,15 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Components with maximum variance.
 
-    `explained_variance_ratio_` : array, [n_components]
+    explained_variance_ratio_ : array, [n_components]
         Percentage of variance explained by each of the selected components. \
         k is not set then all components are stored and the sum of explained \
         variances is equal to 1.0
 
-    `mean_` : array, [n_features]
+    mean_ : array, [n_features]
         Per-feature empirical mean, estimated from the training set.
 
     Examples

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -60,13 +60,13 @@ class SparsePCA(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Sparse components extracted from the data.
 
-    `error_` : array
+    error_ : array
         Vector of errors at each iteration.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     See also
@@ -212,13 +212,13 @@ class MiniBatchSparsePCA(SparsePCA):
 
     Attributes
     ----------
-    `components_` : array, [n_components, n_features]
+    components_ : array, [n_components, n_features]
         Sparse components extracted from the data.
 
-    `error_` : array
+    error_ : array
         Vector of errors at each iteration.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     See also

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -64,12 +64,12 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, shape (n_components, n_features)
+    components_ : array, shape (n_components, n_features)
 
-    `explained_variance_ratio_` : array, [n_components]
+    explained_variance_ratio_ : array, [n_components]
         Percentage of variance explained by each of the selected components.
 
-    `explained_variance_` : array, [n_components]
+    explained_variance_ : array, [n_components]
         The variance of the training samples transformed by a projection to
         each component.
 

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -43,19 +43,19 @@ class DummyClassifier(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    `classes_` : array or list of array of shape = [n_classes]
+    classes_ : array or list of array of shape = [n_classes]
         Class labels for each output.
 
-    `n_classes_` : array or list of array of shape = [n_classes]
+    n_classes_ : array or list of array of shape = [n_classes]
         Number of label for each output.
 
-    `class_prior_` : array or list of array of shape = [n_classes]
+    class_prior_ : array or list of array of shape = [n_classes]
         Probability of each class for each output.
 
-    `n_outputs_` : int,
+    n_outputs_ : int,
         Number of outputs.
 
-    `outputs_2d_` : bool,
+    outputs_2d_ : bool,
         True if the output at fit is 2d, else false.
 
     """
@@ -306,14 +306,14 @@ class DummyRegressor(BaseEstimator, RegressorMixin):
 
     Attributes
     ----------
-    `constant_` : float or array of shape [n_outputs]
+    constant_ : float or array of shape [n_outputs]
         Mean or median of the training targets or constant value given the by
         the user.
 
-    `n_outputs_` : int,
+    n_outputs_ : int,
         Number of outputs.
 
-    `outputs_2d_` : bool,
+    outputs_2d_ : bool,
         True if the output at fit is 2d, else false.
     """
 

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -378,29 +378,29 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
 
     Attributes
     ----------
-    `base_estimator_`: list of estimators
+    base_estimator_ : list of estimators
         The base estimator from which the ensemble is grown.
 
-    `estimators_`: list of estimators
+    estimators_ : list of estimators
         The collection of fitted base estimators.
 
-    `estimators_samples_`: list of arrays
+    estimators_samples_ : list of arrays
         The subset of drawn samples (i.e., the in-bag samples) for each base
         estimator.
 
-    `estimators_features_`: list of arrays
+    estimators_features_ : list of arrays
         The subset of drawn features for each base estimator.
 
-    `classes_`: array of shape = [n_classes]
+    classes_ : array of shape = [n_classes]
         The classes labels.
 
-    `n_classes_`: int or list
+    n_classes_ : int or list
         The number of classes.
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_decision_function_` : array of shape = [n_samples, n_classes]
+    oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
@@ -732,20 +732,20 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
 
     Attributes
     ----------
-    `estimators_`: list of estimators
+    estimators_ : list of estimators
         The collection of fitted sub-estimators.
 
-    `estimators_samples_`: list of arrays
+    estimators_samples_ : list of arrays
         The subset of drawn samples (i.e., the in-bag samples) for each base
         estimator.
 
-    `estimators_features_`: list of arrays
+    estimators_features_ : list of arrays
         The subset of drawn features for each base estimator.
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_decision_function_` : array of shape = [n_samples, n_classes]
+    oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -33,10 +33,10 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
 
     Attributes
     ----------
-    `base_estimator_`: list of estimators
+    base_estimator_ : list of estimators
         The base estimator from which the ensemble is grown.
 
-    `estimators_`: list of estimators
+    estimators_ : list of estimators
         The collection of fitted base estimators.
     """
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -741,24 +741,24 @@ class RandomForestClassifier(ForestClassifier):
 
     Attributes
     ----------
-    `estimators_`: list of DecisionTreeClassifier
+    estimators_ : list of DecisionTreeClassifier
         The collection of fitted sub-estimators.
 
-    `classes_`: array of shape = [n_classes] or a list of such arrays
+    classes_ : array of shape = [n_classes] or a list of such arrays
         The classes labels (single output problem), or a list of arrays of
         class labels (multi-output problem).
 
-    `n_classes_`: int or list
+    n_classes_ : int or list
         The number of classes (single output problem), or a list containing the
         number of classes for each output (multi-output problem).
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_decision_function_` : array of shape = [n_samples, n_classes]
+    oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
@@ -903,16 +903,16 @@ class RandomForestRegressor(ForestRegressor):
 
     Attributes
     ----------
-    `estimators_`: list of DecisionTreeRegressor
+    estimators_ : list of DecisionTreeRegressor
         The collection of fitted sub-estimators.
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_prediction_` : array of shape = [n_samples]
+    oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
 
     References
@@ -1055,24 +1055,24 @@ class ExtraTreesClassifier(ForestClassifier):
 
     Attributes
     ----------
-    `estimators_`: list of DecisionTreeClassifier
+    estimators_ : list of DecisionTreeClassifier
         The collection of fitted sub-estimators.
 
-    `classes_`: array of shape = [n_classes] or a list of such arrays
+    classes_ : array of shape = [n_classes] or a list of such arrays
         The classes labels (single output problem), or a list of arrays of
         class labels (multi-output problem).
 
-    `n_classes_`: int or list
+    n_classes_ : int or list
         The number of classes (single output problem), or a list containing the
         number of classes for each output (multi-output problem).
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_decision_function_` : array of shape = [n_samples, n_classes]
+    oob_decision_function_ : array of shape = [n_samples, n_classes]
         Decision function computed with out-of-bag estimate on the training
         set. If n_estimators is small it might be possible that a data point
         was never left out during the bootstrap. In this case,
@@ -1221,16 +1221,16 @@ class ExtraTreesRegressor(ForestRegressor):
 
     Attributes
     ----------
-    `estimators_`: list of DecisionTreeRegressor
+    estimators_ : list of DecisionTreeRegressor
         The collection of fitted sub-estimators.
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_score_` : float
+    oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
 
-    `oob_prediction_` : array of shape = [n_samples]
+    oob_prediction_ : array of shape = [n_samples]
         Prediction computed with out-of-bag estimate on the training set.
 
     References
@@ -1352,7 +1352,7 @@ class RandomTreesEmbedding(BaseForest):
 
     Attributes
     ----------
-    `estimators_`: list of DecisionTreeClassifier
+    estimators_ : list of DecisionTreeClassifier
         The collection of fitted sub-estimators.
 
     References

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1050,34 +1050,34 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     Attributes
     ----------
-    `feature_importances_` : array, shape = [n_features]
+    feature_importances_ : array, shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_improvement_` : array, shape = [n_estimators]
+    oob_improvement_ : array, shape = [n_estimators]
         The improvement in loss (= deviance) on the out-of-bag samples
         relative to the previous iteration.
         ``oob_improvement_[0]`` is the improvement in
         loss of the first stage over the ``init`` estimator.
 
-    `oob_score_` : array, shape = [n_estimators]
+    oob_score_ : array, shape = [n_estimators]
         Score of the training dataset obtained using an out-of-bag estimate.
         The i-th score ``oob_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the out-of-bag sample.
         Deprecated: use `oob_improvement_` instead.
 
-    `train_score_` : array, shape = [n_estimators]
+    train_score_ : array, shape = [n_estimators]
         The i-th score ``train_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the in-bag sample.
         If ``subsample == 1`` this is the deviance on the training data.
 
-    `loss_` : LossFunction
+    loss_ : LossFunction
         The concrete ``LossFunction`` object.
 
     `init` : BaseEstimator
         The estimator that provides the initial predictions.
         Set via the ``init`` argument or ``loss.init_estimator``.
 
-    `estimators_`: list of DecisionTreeRegressor
+    estimators_ : list of DecisionTreeRegressor
         The collection of fitted sub-estimators.
 
     See also
@@ -1322,34 +1322,34 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     Attributes
     ----------
-    `feature_importances_` : array, shape = [n_features]
+    feature_importances_ : array, shape = [n_features]
         The feature importances (the higher, the more important the feature).
 
-    `oob_improvement_` : array, shape = [n_estimators]
+    oob_improvement_ : array, shape = [n_estimators]
         The improvement in loss (= deviance) on the out-of-bag samples
         relative to the previous iteration.
         ``oob_improvement_[0]`` is the improvement in
         loss of the first stage over the ``init`` estimator.
 
-    `oob_score_` : array, shape = [n_estimators]
+    oob_score_ : array, shape = [n_estimators]
         Score of the training dataset obtained using an out-of-bag estimate.
         The i-th score ``oob_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the out-of-bag sample.
         Deprecated: use `oob_improvement_` instead.
 
-    `train_score_` : array, shape = [n_estimators]
+    train_score_ : array, shape = [n_estimators]
         The i-th score ``train_score_[i]`` is the deviance (= loss) of the
         model at iteration ``i`` on the in-bag sample.
         If ``subsample == 1`` this is the deviance on the training data.
 
-    `loss_` : LossFunction
+    loss_ : LossFunction
         The concrete ``LossFunction`` object.
 
     `init` : BaseEstimator
         The estimator that provides the initial predictions.
         Set via the ``init`` argument or ``loss.init_estimator``.
 
-    `estimators_`: list of DecisionTreeRegressor
+    estimators_ : list of DecisionTreeRegressor
         The collection of fitted sub-estimators.
 
     See also

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -312,23 +312,23 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
     Attributes
     ----------
-    `estimators_` : list of classifiers
+    estimators_ : list of classifiers
         The collection of fitted sub-estimators.
 
-    `classes_` : array of shape = [n_classes]
+    classes_ : array of shape = [n_classes]
         The classes labels.
 
-    `n_classes_` : int
+    n_classes_ : int
         The number of classes.
 
-    `estimator_weights_` : array of floats
+    estimator_weights_ : array of floats
         Weights for each estimator in the boosted ensemble.
 
-    `estimator_errors_` : array of floats
+    estimator_errors_ : array of floats
         Classification error for each estimator in the boosted
         ensemble.
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances if supported by the ``base_estimator``.
 
     See also
@@ -854,16 +854,16 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
 
     Attributes
     ----------
-    `estimators_` : list of classifiers
+    estimators_ : list of classifiers
         The collection of fitted sub-estimators.
 
-    `estimator_weights_` : array of floats
+    estimator_weights_ : array of floats
         Weights for each estimator in the boosted ensemble.
 
-    `estimator_errors_` : array of floats
+    estimator_errors_ : array of floats
         Regression error for each estimator in the boosted ensemble.
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances if supported by the ``base_estimator``.
 
     See also

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -52,10 +52,10 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `vocabulary_` : dict
+    vocabulary_ : dict
         A dictionary mapping feature names to feature indices.
 
-    `feature_names_` : list
+    feature_names_ : list
         A list of length n_features containing the feature names (e.g., "f=ham"
         and "f=spam").
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -573,10 +573,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     Attributes
     ----------
-    `vocabulary_` : dict
+    vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    `stop_words_` : set
+    stop_words_ : set
         Terms that were ignored because
         they occurred in either too many
         (`max_df`) or in too few (`min_df`) documents.
@@ -1128,7 +1128,7 @@ class TfidfVectorizer(CountVectorizer):
 
     Attributes
     ----------
-    ``idf_`` : array, shape = [n_features], or None
+    idf_ : array, shape = [n_features], or None
         The learned idf vector (global term weights)
         when ``use_idf`` is set to True, None otherwise.
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -58,18 +58,18 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
     Attributes
     ----------
-    `n_features_` : int
+    n_features_ : int
         The number of selected features.
 
-    `support_` : array of shape [n_features]
+    support_ : array of shape [n_features]
         The mask of selected features.
 
-    `ranking_` : array of shape [n_features]
+    ranking_ : array of shape [n_features]
         The feature ranking, such that `ranking_[i]` corresponds to the \
         ranking position of the i-th feature. Selected (i.e., estimated \
         best) features are assigned rank 1.
 
-    `estimator_` : object
+    estimator_ : object
         The external estimator fit on the reduced dataset.
 
     Examples
@@ -252,24 +252,24 @@ class RFECV(RFE, MetaEstimatorMixin):
 
     Attributes
     ----------
-    `n_features_` : int
+    n_features_ : int
         The number of selected features with cross-validation.
-    `support_` : array of shape [n_features]
+    support_ : array of shape [n_features]
         The mask of selected features.
 
-    `ranking_` : array of shape [n_features]
+    ranking_ : array of shape [n_features]
         The feature ranking, such that `ranking_[i]`
         corresponds to the ranking
         position of the i-th feature.
         Selected (i.e., estimated best)
         features are assigned rank 1.
 
-    `grid_scores_` : array of shape [n_subsets_of_features]
+    grid_scores_ : array of shape [n_subsets_of_features]
         The cross-validation scores such that
         `grid_scores_[i]` corresponds to
         the CV score of the i-th subset of features.
 
-    `estimator_` : object
+    estimator_ : object
         The external estimator fit on the reduced dataset.
 
     Examples

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -323,10 +323,10 @@ class SelectPercentile(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
 
     Notes
@@ -379,10 +379,10 @@ class SelectKBest(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
 
     Notes
@@ -434,10 +434,10 @@ class SelectFpr(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
     """
 
@@ -467,10 +467,10 @@ class SelectFdr(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
     """
 
@@ -499,10 +499,10 @@ class SelectFwe(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
     """
 
@@ -537,10 +537,10 @@ class GenericUnivariateSelect(_BaseFilter):
 
     Attributes
     ----------
-    `scores_` : array-like, shape=(n_features,)
+    scores_ : array-like, shape=(n_features,)
         Scores of features.
 
-    `pvalues_` : array-like, shape=(n_features,)
+    pvalues_ : array-like, shape=(n_features,)
         p-values of feature scores.
     """
 

--- a/sklearn/feature_selection/variance_threshold.py
+++ b/sklearn/feature_selection/variance_threshold.py
@@ -23,7 +23,7 @@ class VarianceThreshold(BaseEstimator, SelectorMixin):
 
     Attributes
     ----------
-    `variances_` : array, shape (n_features,)
+    variances_ : array, shape (n_features,)
         Variances of individual features.
 
     Examples

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -165,11 +165,11 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
     Attributes
     ----------
-    `theta_`: array
+    theta_ : array
         Specified theta OR the best set of autocorrelation parameters (the \
         sought maximizer of the reduced likelihood function).
 
-    `reduced_likelihood_function_value_`: array
+    reduced_likelihood_function_value_ : array
         The optimal reduced likelihood function value.
 
     Examples

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -511,7 +511,7 @@ class GridSearchCV(BaseSearchCV):
 
     Attributes
     ----------
-    `grid_scores_` : list of named tuples
+    grid_scores_ : list of named tuples
         Contains scores for all parameter combinations in param_grid.
         Each entry corresponds to one parameter setting.
         Each named tuple has the attributes:
@@ -521,18 +521,18 @@ class GridSearchCV(BaseSearchCV):
               cross-validation folds
             * ``cv_validation_scores``, the list of scores for each fold
 
-    `best_estimator_` : estimator
+    best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data.
 
-    `best_score_` : float
+    best_score_ : float
         Score of best_estimator on the left out data.
 
-    `best_params_` : dict
+    best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
 
-    `scorer_` : function
+    scorer_ : function
         Scorer function used on the held out data to choose the best
         parameters for the model.
 
@@ -667,7 +667,7 @@ class RandomizedSearchCV(BaseSearchCV):
 
     Attributes
     ----------
-    `grid_scores_` : list of named tuples
+    grid_scores_ : list of named tuples
         Contains scores for all parameter combinations in param_grid.
         Each entry corresponds to one parameter setting.
         Each named tuple has the attributes:
@@ -677,15 +677,15 @@ class RandomizedSearchCV(BaseSearchCV):
               cross-validation folds
             * ``cv_validation_scores``, the list of scores for each fold
 
-    `best_estimator_` : estimator
+    best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data.
 
-    `best_score_` : float
+    best_score_ : float
         Score of best_estimator on the left out data.
 
-    `best_params_` : dict
+    best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
 
     Notes

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -104,7 +104,7 @@ def isotonic_regression(y, sample_weight=None, y_min=None, y_max=None,
 
     Returns
     -------
-    `y_` : list of floating-point values
+    y_ : list of floating-point values
         Isotonic fit of y.
 
     References
@@ -184,19 +184,19 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
     Attributes
     ----------
-    `X_` : ndarray (n_samples, )
+    X_ : ndarray (n_samples, )
         A copy of the input X.
 
-    `y_` : ndarray (n_samples, )
+    y_ : ndarray (n_samples, )
         Isotonic fit of y.
 
-    `X_min_` : float
+    X_min_ : float
         Minimum value of input array `X_` for left bound.
 
-    `X_max_` : float
+    X_max_ : float
         Maximum value of input array `X_` for right bound.
 
-    `f_` : function
+    f_ : function
         The stepwise interpolating function that covers the domain
         X_.
 
@@ -302,7 +302,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         Returns
         -------
-        `T_` : array, shape=(n_samples,)
+        T_ : array, shape=(n_samples,)
             The transformed data
         """
         T = as_float_array(T)
@@ -336,7 +336,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         Returns
         -------
-        `y_` : array, shape=(n_samples,)
+        y_ : array, shape=(n_samples,)
             The transformed data.
 
         Notes
@@ -367,7 +367,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         Returns
         -------
-        `T_` : array, shape=(n_samples,)
+        T_ : array, shape=(n_samples,)
             Transformed data.
         """
         return self.transform(T)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -378,13 +378,13 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `components_` : array, shape (n_components, n_features)
+    components_ : array, shape (n_components, n_features)
         Subset of training points used to construct the feature map.
 
-    `component_indices_` : array, shape (n_components)
+    component_indices_ : array, shape (n_components)
         Indices of ``components_`` in the training set.
 
-    `normalization_` : array, shape (n_components, n_components)
+    normalization_ : array, shape (n_components, n_components)
         Normalization matrix needed for embedding.
         Square root of the kernel matrix on ``components_``.
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -42,26 +42,26 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     Attributes
     ----------
-    `coef_` : array-like, shape = [rank, n_classes - 1]
+    coef_ : array-like, shape = [rank, n_classes - 1]
         Coefficients of the features in the linear decision
         function. rank is min(rank_features, n_classes) where
         rank_features is the dimensionality of the spaces spanned
         by the features (i.e. n_features excluding redundant features).
 
-    `covariance_` : array-like, shape = [n_features, n_features]
+    covariance_ : array-like, shape = [n_features, n_features]
         Covariance matrix (shared by all classes).
 
-    `means_` : array-like, shape = [n_classes, n_features]
+    means_ : array-like, shape = [n_classes, n_features]
         Class means.
 
-    `priors_` : array-like, shape = [n_classes]
+    priors_ : array-like, shape = [n_classes]
         Class priors (sum to 1).
 
-    `scalings_` : array-like, shape = [rank, n_classes - 1]
+    scalings_ : array-like, shape = [rank, n_classes - 1]
         Scaling of the features in the space spanned by the class
         centroids.
 
-    `xbar_` : float, shape = [n_features]
+    xbar_ : float, shape = [n_features]
         Overall mean.
 
     Examples

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -309,13 +309,13 @@ class LinearRegression(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape (n_features, ) or (n_targets, n_features)
+    coef_ : array, shape (n_features, ) or (n_targets, n_features)
         Estimated coefficients for the linear regression problem.
         If multiple targets are passed during the fit (y 2D), this
         is a 2D array of shape (n_targets, n_features), while if only
         one target is passed, this is a 1D array of length n_features.
 
-    `intercept_` : array
+    intercept_ : array
         Independent term in the linear model.
 
     Notes

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -73,16 +73,16 @@ class BayesianRidge(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = (n_features)
+    coef_ : array, shape = (n_features)
         Coefficients of the regression model (mean of distribution)
 
-    `alpha_` : float
+    alpha_ : float
        estimated precision of the noise.
 
-    `lambda_` : array, shape = (n_features)
+    lambda_ : array, shape = (n_features)
        estimated precisions of the weights.
 
-    `scores_` : float
+    scores_ : float
         if computed, value of the objective function (to be maximized)
 
     Examples
@@ -274,19 +274,19 @@ class ARDRegression(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = (n_features)
+    coef_ : array, shape = (n_features)
         Coefficients of the regression model (mean of distribution)
 
-    `alpha_` : float
+    alpha_ : float
        estimated precision of the noise.
 
-    `lambda_` : array, shape = (n_features)
+    lambda_ : array, shape = (n_features)
        estimated precisions of the weights.
 
-    `sigma_` : array, shape = (n_features, n_features)
+    sigma_ : array, shape = (n_features, n_features)
         estimated variance-covariance matrix of the weights
 
-    `scores_` : float
+    scores_ : float
         if computed, value of the objective function (to be maximized)
 
     Examples

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -618,17 +618,17 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    ``coef_`` : array, shape = (n_features,) | (n_targets, n_features)
+    coef_ : array, shape = (n_features,) | (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    ``sparse_coef_`` : scipy.sparse matrix, shape = (n_features, 1) | \
+    sparse_coef_ : scipy.sparse matrix, shape = (n_features, 1) | \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    ``intercept_`` : float | array, shape = (n_targets,)
+    intercept_ : float | array, shape = (n_targets,)
         independent term in decision function.
 
-    ``n_iter_`` : array-like, shape (n_targets,)
+    n_iter_ : array-like, shape (n_targets,)
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -822,17 +822,17 @@ class Lasso(ElasticNet):
 
     Attributes
     ----------
-    ``coef_`` : array, shape = (n_features,) | (n_targets, n_features)
+    coef_ : array, shape = (n_features,) | (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    ``sparse_coef_`` : scipy.sparse matrix, shape = (n_features, 1) | \
+    sparse_coef_ : scipy.sparse matrix, shape = (n_features, 1) | \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    ``intercept_`` : float | array, shape = (n_targets,)
+    intercept_ : float | array, shape = (n_targets,)
         independent term in decision function.
 
-    ``n_iter_`` : int | array-like, shape (n_targets,)
+    n_iter_ : int | array-like, shape (n_targets,)
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -1227,26 +1227,26 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
     Attributes
     ----------
-    ``alpha_`` : float
+    alpha_ : float
         The amount of penalization chosen by cross validation
 
-    ``coef_`` : array, shape = (n_features,) | (n_targets, n_features)
+    coef_ : array, shape = (n_features,) | (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    ``intercept_`` : float | array, shape = (n_targets,)
+    intercept_ : float | array, shape = (n_targets,)
         independent term in decision function.
 
-    ``mse_path_`` : array, shape = (n_alphas, n_folds)
+    mse_path_ : array, shape = (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    ``alphas_`` : numpy array, shape = (n_alphas,)
+    alphas_ : numpy array, shape = (n_alphas,)
         The grid of alphas used for fitting
 
-    ``dual_gap_`` : ndarray, shape ()
+    dual_gap_ : ndarray, shape ()
         The dual gap at the end of the optimization for the optimal alpha
         (``alpha_``).
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
@@ -1342,27 +1342,27 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
     Attributes
     ----------
-    ``alpha_`` : float
+    alpha_ : float
         The amount of penalization chosen by cross validation
 
-    ``l1_ratio_`` : float
+    l1_ratio_ : float
         The compromise between l1 and l2 penalization chosen by
         cross validation
 
-    ``coef_`` : array, shape = (n_features,) | (n_targets, n_features)
+    coef_ : array, shape = (n_features,) | (n_targets, n_features)
         Parameter vector (w in the cost function formula),
 
-    ``intercept_`` : float | array, shape = (n_targets, n_features)
+    intercept_ : float | array, shape = (n_targets, n_features)
         Independent term in the decision function.
 
-    ``mse_path_`` : array, shape = (n_l1_ratio, n_alpha, n_folds)
+    mse_path_ : array, shape = (n_l1_ratio, n_alpha, n_folds)
         Mean square error for the test set on each fold, varying l1_ratio and
         alpha.
 
-    ``alphas_`` : numpy array, shape = (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : numpy array, shape = (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio.
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
@@ -1474,14 +1474,14 @@ class MultiTaskElasticNet(Lasso):
 
     Attributes
     ----------
-    ``intercept_`` : array, shape = (n_tasks,)
+    intercept_ : array, shape = (n_tasks,)
         Independent term in decision function.
 
-    ``coef_`` : array, shape = (n_tasks, n_features)
+    coef_ : array, shape = (n_tasks, n_features)
         Parameter vector (W in the cost function formula). If a 1D y is \
         passed in at fit (non multi-task usage), ``coef_`` is then a 1D array
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -1633,13 +1633,13 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     Attributes
     ----------
-    ``coef_`` : array, shape = (n_tasks, n_features)
+    coef_ : array, shape = (n_tasks, n_features)
         parameter vector (W in the cost function formula)
 
-    ``intercept_`` : array, shape = (n_tasks,)
+    intercept_ : array, shape = (n_tasks,)
         independent term in decision function.
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -1750,26 +1750,26 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
 
     Attributes
     ----------
-    ``intercept_`` : array, shape (n_tasks,)
+    intercept_ : array, shape (n_tasks,)
         Independent term in decision function.
 
-    ``coef_`` : array, shape (n_tasks, n_features)
+    coef_ : array, shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
 
-    ``alpha_`` : float
+    alpha_ : float
         The amount of penalization chosen by cross validation
 
-    ``mse_path_`` : array, shape (n_alphas, n_folds) or
+    mse_path_ : array, shape (n_alphas, n_folds) or
                     (n_l1_ratio, n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    ``alphas_`` : numpy array, shape (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : numpy array, shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio
 
-    ``l1_ratio_`` : float
+    l1_ratio_ : float
         best l1_ratio obtained by cross-validation.
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
@@ -1884,22 +1884,22 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
 
     Attributes
     ----------
-    ``intercept_`` : array, shape (n_tasks,)
+    intercept_ : array, shape (n_tasks,)
         Independent term in decision function.
 
-    ``coef_`` : array, shape (n_tasks, n_features)
+    coef_ : array, shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
 
-    ``alpha_`` : float
+    alpha_ : float
         The amount of penalization chosen by cross validation
 
-    ``mse_path_`` : array, shape (n_alphas, n_folds)
+    mse_path_ : array, shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    ``alphas_`` : numpy array, shape (n_alphas,)
+    alphas_ : numpy array, shape (n_alphas,)
         The grid of alphas used for fitting.
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -494,26 +494,26 @@ class Lars(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    ``alphas_`` : array, shape (n_alphas + 1,) | list of n_targets such arrays
+    alphas_ : array, shape (n_alphas + 1,) | list of n_targets such arrays
         Maximum of covariances (in absolute value) at each iteration. \
         ``n_alphas`` is either ``n_nonzero_coefs`` or ``n_features``, \
         whichever is smaller.
 
-    ``active_`` : list, length = n_alphas | list of n_targets such lists
+    active_ : list, length = n_alphas | list of n_targets such lists
         Indices of active variables at the end of the path.
 
-    ``coef_path_`` : array, shape (n_features, n_alphas + 1) \
+    coef_path_ : array, shape (n_features, n_alphas + 1) \
         | list of n_targets such arrays
         The varying values of the coefficients along the path. It is not
         present if the ``fit_path`` parameter is ``False``.
 
-    ``coef_`` : array, shape (n_features,) or (n_targets, n_features)
+    coef_ : array, shape (n_features,) or (n_targets, n_features)
         Parameter vector (w in the formulation formula).
 
-    ``intercept_`` : float | array, shape (n_targets,)
+    intercept_ : float | array, shape (n_targets,)
         Independent term in decision function.
 
-    ``n_iter_`` : array-like or int
+    n_iter_ : array-like or int
         The number of iterations taken by lars_path to find the
         grid of alphas for each target.
 
@@ -708,27 +708,27 @@ class LassoLars(Lars):
 
     Attributes
     ----------
-    ``alphas_`` : array, shape (n_alphas + 1,) | list of n_targets such arrays
+    alphas_ : array, shape (n_alphas + 1,) | list of n_targets such arrays
         Maximum of covariances (in absolute value) at each iteration. \
         ``n_alphas`` is either ``max_iter``, ``n_features``, or the number of \
         nodes in the path with correlation greater than ``alpha``, whichever \
         is smaller.
 
-    ``active_`` : list, length = n_alphas | list of n_targets such lists
+    active_ : list, length = n_alphas | list of n_targets such lists
         Indices of active variables at the end of the path.
 
-    ``coef_path_`` : array, shape (n_features, n_alphas + 1) or list
+    coef_path_ : array, shape (n_features, n_alphas + 1) or list
         If a list is passed it's expected to be one of n_targets such arrays.
         The varying values of the coefficients along the path. It is not
         present if the ``fit_path`` parameter is ``False``.
 
-    ``coef_`` : array, shape (n_features,) or (n_targets, n_features)
+    coef_ : array, shape (n_features,) or (n_targets, n_features)
         Parameter vector (w in the formulation formula).
 
-    ``intercept_`` : float | array, shape (n_targets,)
+    intercept_ : float | array, shape (n_targets,)
         Independent term in decision function.
 
-    ``n_iter_`` : array-like or int.
+    n_iter_ : array-like or int.
         The number of iterations taken by lars_path to find the
         grid of alphas for each target.
 
@@ -910,29 +910,29 @@ class LarsCV(Lars):
 
     Attributes
     ----------
-    ``coef_`` : array, shape (n_features,)
+    coef_ : array, shape (n_features,)
         parameter vector (w in the formulation formula)
 
-    ``intercept_`` : float
+    intercept_ : float
         independent term in decision function
 
-    ``coef_path_`` : array, shape (n_features, n_alphas)
+    coef_path_ : array, shape (n_features, n_alphas)
         the varying values of the coefficients along the path
 
-    ``alpha_`` : float
+    alpha_ : float
         the estimated regularization parameter alpha
 
-    ``alphas_`` : array, shape (n_alphas,)
+    alphas_ : array, shape (n_alphas,)
         the different values of alpha along the path
 
-    ``cv_alphas_`` : array, shape (n_cv_alphas,)
+    cv_alphas_ : array, shape (n_cv_alphas,)
         all the values of alpha along the path for the different folds
 
-    ``cv_mse_path_`` : array, shape (n_folds, n_cv_alphas)
+    cv_mse_path_ : array, shape (n_folds, n_cv_alphas)
         the mean square error on left-out for each fold along the path
         (alpha values given by ``cv_alphas``)
 
-    ``n_iter_`` : array-like or int
+    n_iter_ : array-like or int
         the number of iterations run by Lars with the optimal alpha.
 
     See also
@@ -1085,29 +1085,29 @@ class LassoLarsCV(LarsCV):
 
     Attributes
     ----------
-    ``coef_`` : array, shape (n_features,)
+    coef_ : array, shape (n_features,)
         parameter vector (w in the formulation formula)
 
-    ``intercept_`` : float
+    intercept_ : float
         independent term in decision function.
 
-    ``coef_path_`` : array, shape (n_features, n_alphas)
+    coef_path_ : array, shape (n_features, n_alphas)
         the varying values of the coefficients along the path
 
-    ``alpha_`` : float
+    alpha_ : float
         the estimated regularization parameter alpha
 
-    ``alphas_`` : array, shape (n_alphas,)
+    alphas_ : array, shape (n_alphas,)
         the different values of alpha along the path
 
-    ``cv_alphas_`` : array, shape (n_cv_alphas,)
+    cv_alphas_ : array, shape (n_cv_alphas,)
         all the values of alpha along the path for the different folds
 
-    ``cv_mse_path_`` : array, shape (n_folds, n_cv_alphas)
+    cv_mse_path_ : array, shape (n_folds, n_cv_alphas)
         the mean square error on left-out for each fold along the path
         (alpha values given by ``cv_alphas``)
 
-    ``n_iter_`` : array-like or int
+    n_iter_ : array-like or int
         the number of iterations run by Lars with the optimal alpha.
 
     Notes
@@ -1181,16 +1181,16 @@ class LassoLarsIC(LassoLars):
 
     Attributes
     ----------
-    ``coef_`` : array, shape (n_features,)
+    coef_ : array, shape (n_features,)
         parameter vector (w in the formulation formula)
 
-    ``intercept_`` : float
+    intercept_ : float
         independent term in decision function.
 
-    ``alpha_`` : float
+    alpha_ : float
         the alpha parameter chosen by the information criterion
 
-    ``n_iter_`` : int
+    n_iter_ : int
         number of iterations run by lars_path to find the grid of
         alphas.
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -632,10 +632,10 @@ class LogisticRegression(BaseLibLinear, LinearClassifierMixin,
 
     Attributes
     ----------
-    `coef_` : array, shape (n_classes, n_features)
+    coef_ : array, shape (n_classes, n_features)
         Coefficient of the features in the decision function.
 
-    `intercept_` : array, shape (n_classes,)
+    intercept_ : array, shape (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.
         If `fit_intercept` is set to False, the intercept is set to zero.
 
@@ -813,7 +813,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
     Attributes
     ----------
-    `coef_` : array, shape (1, n_features) or (n_classes, n_features)
+    coef_ : array, shape (1, n_features) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem
@@ -821,16 +821,16 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         `coef_` is readonly property derived from `raw_coef_` that
         follows the internal memory layout of liblinear.
 
-    `intercept_` : array, shape (1,) or (n_classes,)
+    intercept_ : array, shape (1,) or (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True
         and is of shape(1,) when the problem is binary.
 
-    `Cs_` : array
+    Cs_ : array
         Array of C i.e. inverse of regularization parameter values used
         for cross-validation.
 
-    `coefs_paths_` : array, shape (n_folds, len(Cs_), n_features) or
+    coefs_paths_ : array, shape (n_folds, len(Cs_), n_features) or
                      (n_folds, len(Cs_), n_features + 1)
         dict with classes as the keys, and the path of coefficients obtained
         during cross-validating across each fold and then across each Cs
@@ -839,13 +839,13 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         (n_folds, len(Cs_), n_features + 1) depending on whether the
         intercept is fit or not.
 
-    `scores_` : dict
+    scores_ : dict
         dict with classes as the keys, and the values as the
         grid of scores obtained during cross-validating each fold, after doing
         an OvA for the corresponding class.
         Each dict value has shape (n_folds, len(Cs))
 
-    `C_` : array, shape (n_classes,) or (n_classes - 1,)
+    C_ : array, shape (n_classes,) or (n_classes - 1,)
         Array of C that maps to the best scores across every class. If refit is
         set to False, then for each class, the best C is the average of the
         C's that correspond to the best scores for each fold.

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -553,13 +553,13 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape (n_features,) or (n_features, n_targets)
+    coef_ : array, shape (n_features,) or (n_features, n_targets)
         parameter vector (w in the formula)
 
-    `intercept_` : float or array, shape (n_targets,)
+    intercept_ : float or array, shape (n_targets,)
         independent term in decision function.
 
-    `n_iter_` : int or array-like
+    n_iter_ : int or array-like
         Number of active features across every target.
 
     Notes
@@ -752,17 +752,17 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
 
     Attributes
     ----------
-    `intercept_` : float or array, shape (n_targets,)
+    intercept_ : float or array, shape (n_targets,)
         Independent term in decision function.
 
-    `coef_` : array, shape (n_features,) or (n_features, n_targets)
+    coef_ : array, shape (n_features,) or (n_features, n_targets)
         Parameter vector (w in the problem formulation).
 
-    `n_nonzero_coefs_` : int
+    n_nonzero_coefs_ : int
         Estimated number of non-zero coefficients giving the best mean squared
         error over the cross-validation folds.
 
-    `n_iter_` : int or array-like
+    n_iter_ : int or array-like
         Number of active features across every target for the model refit with
         the best hyperparameters got by cross-validating across all folds.
 

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -50,11 +50,11 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    `coef_` : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
     n_features]
         Weights assigned to the features.
 
-    `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
     See also
@@ -190,11 +190,11 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    `coef_` : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
     n_features]
         Weights assigned to the features.
 
-    `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
     See also

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -60,11 +60,11 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
     n_features]
         Weights assigned to the features.
 
-    `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
     Notes

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -267,10 +267,10 @@ class RandomizedLasso(BaseRandomizedLinearModel):
 
     Attributes
     ----------
-    `scores_` : array, shape = [n_features]
+    scores_ : array, shape = [n_features]
         Feature scores between 0 and 1.
 
-    `all_scores_` : array, shape = [n_features, n_reg_parameter]
+    all_scores_ : array, shape = [n_features, n_reg_parameter]
         Feature scores between 0 and 1 for all values of the regularization \
         parameter. The reference article suggests ``scores_`` is the max of \
         ``all_scores_``.
@@ -435,10 +435,10 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
 
     Attributes
     ----------
-    `scores_` : array, shape = [n_features]
+    scores_ : array, shape = [n_features]
         Feature scores between 0 and 1.
 
-    `all_scores_` : array, shape = [n_features, n_reg_parameter]
+    all_scores_ : array, shape = [n_features, n_reg_parameter]
         Feature scores between 0 and 1 for all values of the regularization \
         parameter. The reference article suggests ``scores_`` is the max \
         of ``all_scores_``.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -438,7 +438,7 @@ class Ridge(_BaseRidge, RegressorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = [n_features] or [n_targets, n_features]
+    coef_ : array, shape = [n_features] or [n_targets, n_features]
         Weight vector(s).
 
     See also
@@ -531,7 +531,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     Attributes
     ----------
-    `coef_` : array, shape = [n_features] or [n_classes, n_features]
+    coef_ : array, shape = [n_features] or [n_classes, n_features]
         Weight vector(s).
 
     See also
@@ -923,20 +923,20 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
     Attributes
     ----------
-    `cv_values_` : array, shape = [n_samples, n_alphas] or \
+    cv_values_ : array, shape = [n_samples, n_alphas] or \
         shape = [n_samples, n_targets, n_alphas], optional
         Cross-validation values for each alpha (if `store_cv_values=True` and \
         `cv=None`). After `fit()` has been called, this attribute will \
         contain the mean squared errors (by default) or the values of the \
         `{loss,score}_func` function (if provided in the constructor).
 
-    `coef_` : array, shape = [n_features] or [n_targets, n_features]
+    coef_ : array, shape = [n_features] or [n_targets, n_features]
         Weight vector(s).
 
-    `alpha_` : float
+    alpha_ : float
         Estimated regularization parameter.
 
-    `intercept_` : float | array, shape = (n_targets,)
+    intercept_ : float | array, shape = (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
@@ -989,17 +989,17 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    `cv_values_` : array, shape = [n_samples, n_alphas] or \
+    cv_values_ : array, shape = [n_samples, n_alphas] or \
     shape = [n_samples, n_responses, n_alphas], optional
         Cross-validation values for each alpha (if `store_cv_values=True` and
     `cv=None`). After `fit()` has been called, this attribute will contain \
     the mean squared errors (by default) or the values of the \
     `{loss,score}_func` function (if provided in the constructor).
 
-    `coef_` : array, shape = [n_features] or [n_targets, n_features]
+    coef_ : array, shape = [n_features] or [n_targets, n_features]
         Weight vector(s).
 
-    `alpha_` : float
+    alpha_ : float
         Estimated regularization parameter
 
     See also

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -593,11 +593,11 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
     n_features]
         Weights assigned to the features.
 
-    `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
     Examples
@@ -1027,10 +1027,10 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
 
     Attributes
     ----------
-    `coef_` : array, shape = [n_features]
+    coef_ : array, shape = [n_features]
         Weights asigned to the features.
 
-    `intercept_` : array, shape = [1]
+    intercept_ : array, shape = [1]
         The intercept term.
 
     Examples

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -53,20 +53,20 @@ class Isomap(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `embedding_` : array-like, shape (n_samples, n_components)
+    embedding_ : array-like, shape (n_samples, n_components)
         Stores the embedding vectors.
 
-    `kernel_pca_` : object
+    kernel_pca_ : object
         `KernelPCA` object used to implement the embedding.
 
-    `training_data_` : array-like, shape (n_samples, n_features)
+    training_data_ : array-like, shape (n_samples, n_features)
         Stores the training data.
 
-    `nbrs_` : sklearn.neighbors.NearestNeighbors instance
+    nbrs_ : sklearn.neighbors.NearestNeighbors instance
         Stores nearest neighbors instance, including BallTree or KDtree
         if applicable.
 
-    `dist_matrix_` : array-like, shape (n_samples, n_samples)
+    dist_matrix_ : array-like, shape (n_samples, n_samples)
         Stores the geodesic distance matrix of training data.
 
     References

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -562,13 +562,13 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `embedding_vectors_` : array-like, shape [n_components, n_samples]
+    embedding_vectors_ : array-like, shape [n_components, n_samples]
         Stores the embedding vectors
 
-    `reconstruction_error_` : float
+    reconstruction_error_ : float
         Reconstruction error associated with `embedding_vectors_`
 
-    `nbrs_` : NearestNeighbors object
+    nbrs_ : NearestNeighbors object
         Stores nearest neighbors instance, including BallTree or KDtree
         if applicable.
 

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -323,10 +323,10 @@ class MDS(BaseEstimator):
 
     Attributes
     ----------
-    ``embedding_`` : array-like, shape [n_components, n_samples]
+    embedding_ : array-like, shape [n_components, n_samples]
         Stores the position of the dataset in the embedding space
 
-    ``stress_`` : float
+    stress_ : float
         The final value of the stress (sum of squared distance of the
         disparities and the distances for all constrained points)
 

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -343,10 +343,10 @@ class SpectralEmbedding(BaseEstimator):
     Attributes
     ----------
 
-    `embedding_` : array, shape = (n_samples, n_components)
+    embedding_ : array, shape = (n_samples, n_components)
         Spectral embedding of the training matrix.
 
-    `affinity_matrix_` : array, shape = (n_samples, n_samples)
+    affinity_matrix_ : array, shape = (n_samples, n_samples)
         Affinity_matrix constructed from samples or precomputed.
 
     References

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -359,10 +359,10 @@ class TSNE(BaseEstimator):
 
     Attributes
     ----------
-    `embedding_` : array-like, shape (n_samples, n_components)
+    embedding_ : array-like, shape (n_samples, n_components)
         Stores the embedding vectors.
 
-    `training_data_` : array-like, shape (n_samples, n_features)
+    training_data_ : array-like, shape (n_samples, n_features)
         Stores the training data.
 
     Examples

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -164,13 +164,13 @@ class DPGMM(GMM):
     n_components : int
         Number of mixture components.
 
-    `weights_` : array, shape (`n_components`,)
+    weights_ : array, shape (`n_components`,)
         Mixing weights for each mixture component.
 
-    `means_` : array, shape (`n_components`, `n_features`)
+    means_ : array, shape (`n_components`, `n_features`)
         Mean parameters for each mixture component.
 
-    `precs_` : array
+    precs_ : array
         Precision (inverse covariance) parameters for each mixture
         component.  The shape depends on `covariance_type`::
 
@@ -179,7 +179,7 @@ class DPGMM(GMM):
             (`n_components`, `n_features`)                if 'diag',
             (`n_components`, `n_features`, `n_features`)  if 'full'
 
-    `converged_` : bool
+    converged_ : bool
         True when convergence was reached in fit(), False otherwise.
 
     See Also
@@ -619,13 +619,13 @@ class VBGMM(DPGMM):
     n_components : int (read-only)
         Number of mixture components.
 
-    `weights_` : array, shape (`n_components`,)
+    weights_ : array, shape (`n_components`,)
         Mixing weights for each mixture component.
 
-    `means_` : array, shape (`n_components`, `n_features`)
+    means_ : array, shape (`n_components`, `n_features`)
         Mean parameters for each mixture component.
 
-    `precs_` : array
+    precs_ : array
         Precision (inverse covariance) parameters for each mixture
         component.  The shape depends on `covariance_type`::
 
@@ -634,7 +634,7 @@ class VBGMM(DPGMM):
             (`n_components`, `n_features`)                if 'diag',
             (`n_components`, `n_features`, `n_features`)  if 'full'
 
-    `converged_` : bool
+    converged_ : bool
         True when convergence was reached in fit(), False
         otherwise.
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -155,13 +155,13 @@ class GMM(BaseEstimator):
 
     Attributes
     ----------
-    `weights_` : array, shape (`n_components`,)
+    weights_ : array, shape (`n_components`,)
         This attribute stores the mixing weights for each mixture component.
 
-    `means_` : array, shape (`n_components`, `n_features`)
+    means_ : array, shape (`n_components`, `n_features`)
         Mean parameters for each mixture component.
 
-    `covars_` : array
+    covars_ : array
         Covariance parameters for each mixture component.  The shape
         depends on `covariance_type`::
 
@@ -170,7 +170,7 @@ class GMM(BaseEstimator):
             (n_components, n_features)             if 'diag',
             (n_components, n_features, n_features) if 'full'
 
-    `converged_` : bool
+    converged_ : bool
         True when convergence was reached in fit(), False otherwise.
 
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -223,15 +223,15 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     Attributes
     ----------
-    `estimators_` : list of `n_classes` estimators
+    estimators_ : list of `n_classes` estimators
         Estimators used for predictions.
 
-    `classes_` : array, shape = [`n_classes`]
+    classes_ : array, shape = [`n_classes`]
         Class labels.
-    `label_binarizer_` : LabelBinarizer object
+    label_binarizer_ : LabelBinarizer object
         Object used to transform multiclass labels to binary labels and
         vice-versa.
-    `multilabel_` : boolean
+    multilabel_ : boolean
         Whether a OneVsRestClassifier is a multilabel classifier.
     """
 
@@ -460,10 +460,10 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     Attributes
     ----------
-    `estimators_` : list of `n_classes * (n_classes - 1) / 2` estimators
+    estimators_ : list of `n_classes * (n_classes - 1) / 2` estimators
         Estimators used for predictions.
 
-    `classes_` : numpy array of shape [n_classes]
+    classes_ : numpy array of shape [n_classes]
         Array containing labels.
     """
 
@@ -566,7 +566,7 @@ def fit_ecoc(estimator, X, y, code_size=1.5, random_state=None, n_jobs=1):
     classes : numpy array of shape [n_classes]
         Array containing labels.
 
-    `code_book_`: numpy array of shape [n_classes, code_size]
+    code_book_ : numpy array of shape [n_classes, code_size]
         Binary array containing the code of each class.
     """
     ecoc =  OutputCodeClassifier(estimator, random_state=random_state,
@@ -622,13 +622,13 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
 
     Attributes
     ----------
-    `estimators_` : list of `int(n_classes * code_size)` estimators
+    estimators_ : list of `int(n_classes * code_size)` estimators
         Estimators used for predictions.
 
-    `classes_` : numpy array of shape [n_classes]
+    classes_ : numpy array of shape [n_classes]
         Array containing labels.
 
-    `code_book_` : numpy array of shape [n_classes, code_size]
+    code_book_ : numpy array of shape [n_classes, code_size]
         Binary array containing the code of each class.
 
     References

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -112,16 +112,16 @@ class GaussianNB(BaseNB):
 
     Attributes
     ----------
-    `class_prior_` : array, shape (n_classes,)
+    class_prior_ : array, shape (n_classes,)
         probability of each class.
 
-    `class_count_` : array, shape (n_classes,)
+    class_count_ : array, shape (n_classes,)
         number of training samples observed in each class.
 
-    `theta_` : array, shape (n_classes, n_features)
+    theta_ : array, shape (n_classes, n_features)
         mean of each feature per class
 
-    `sigma_` : array, shape (n_classes, n_features)
+    sigma_ : array, shape (n_classes, n_features)
         variance of each feature per class
 
     Examples
@@ -517,26 +517,26 @@ class MultinomialNB(BaseDiscreteNB):
 
     Attributes
     ----------
-    `class_log_prior_` : array, shape (n_classes, )
+    class_log_prior_ : array, shape (n_classes, )
         Smoothed empirical log probability for each class.
 
-    `intercept_` : property
+    intercept_ : property
         Mirrors ``class_log_prior_`` for interpreting MultinomialNB
         as a linear model.
 
-    `feature_log_prob_`: array, shape (n_classes, n_features)
+    feature_log_prob_ : array, shape (n_classes, n_features)
         Empirical log probability of features
         given a class, ``P(x_i|y)``.
 
-    `coef_` : property
+    coef_ : property
         Mirrors ``feature_log_prob_`` for interpreting MultinomialNB
         as a linear model.
 
-    `class_count_` : array, shape (n_classes,)
+    class_count_ : array, shape (n_classes,)
         Number of samples encountered for each class during fitting. This
         value is weighted by the sample weight when provided.
 
-    `feature_count_` : array, shape (n_classes, n_features)
+    feature_count_ : array, shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
         during fitting. This value is weighted by the sample weight when
         provided.
@@ -621,17 +621,17 @@ class BernoulliNB(BaseDiscreteNB):
 
     Attributes
     ----------
-    `class_log_prior_` : array, shape = [n_classes]
+    class_log_prior_ : array, shape = [n_classes]
         Log probability of each class (smoothed).
 
-    `feature_log_prob_` : array, shape = [n_classes, n_features]
+    feature_log_prob_ : array, shape = [n_classes, n_features]
         Empirical log probability of features given a class, P(x_i|y).
 
-    `class_count_` : array, shape = [n_classes]
+    class_count_ : array, shape = [n_classes]
         Number of samples encountered for each class during fitting. This
         value is weighted by the sample weight when provided.
 
-    `feature_count_` : array, shape = [n_classes, n_features]
+    feature_count_ : array, shape = [n_classes, n_features]
         Number of samples encountered for each (class, feature)
         during fitting. This value is weighted by the sample weight when
         provided.

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -35,7 +35,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    `centroids_` : array-like, shape = [n_classes, n_features]
+    centroids_ : array-like, shape = [n_classes, n_features]
         Centroid of each class
 
     Examples

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -62,13 +62,13 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `intercept_hidden_` : array-like, shape (n_components,)
+    intercept_hidden_ : array-like, shape (n_components,)
         Biases of the hidden units.
 
-    `intercept_visible_` : array-like, shape (n_features,)
+    intercept_visible_ : array-like, shape (n_features,)
         Biases of the visible units.
 
-    `components_` : array-like, shape (n_components, n_features)
+    components_ : array-like, shape (n_components, n_features)
         Weight matrix, where n_features in the number of
         visible units and n_components is the number of hidden units.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -171,10 +171,10 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `min_` : ndarray, shape (n_features,)
+    min_ : ndarray, shape (n_features,)
         Per feature adjustment for minimum.
 
-    `scale_` : ndarray, shape (n_features,)
+    scale_ : ndarray, shape (n_features,)
         Per feature relative scaling of the data.
     """
 
@@ -279,10 +279,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `mean_` : array of floats with shape [n_features]
+    mean_ : array of floats with shape [n_features]
         The mean value for each feature in the training set.
 
-    `std_` : array of floats with shape [n_features]
+    std_ : array of floats with shape [n_features]
         The standard deviation for each feature in the training set.
 
     See also
@@ -432,7 +432,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     Attributes
     ----------
 
-    `powers_`:
+    powers_ :
          powers_[i, j] is the exponent of the jth input in the ith output.
 
     Notes
@@ -928,17 +928,17 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `active_features_` : array
+    active_features_ : array
         Indices for active features, meaning values that actually occur
         in the training set. Only available when n_values is ``'auto'``.
 
-    `feature_indices_` : array of shape (n_features,)
+    feature_indices_ : array of shape (n_features,)
         Indices to feature ranges.
         Feature ``i`` in the original data is mapped to features
         from ``feature_indices_[i]`` to ``feature_indices_[i+1]``
         (and then potentially masked by `active_features_` afterwards)
 
-    `n_values_` : array of shape (n_features,)
+    n_values_ : array of shape (n_features,)
         Maximum number of values per feature.
 
     Examples

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -128,7 +128,7 @@ class Imputer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `statistics_` : array of shape (n_features,)
+    statistics_ : array of shape (n_features,)
         The imputation fill value for each feature if axis == 0.
 
     Notes

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -55,7 +55,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `classes_` : array of shape (n_class,)
+    classes_ : array of shape (n_class,)
         Holds the label for each class.
 
     Examples
@@ -198,26 +198,26 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `classes_` : array of shape [n_class]
+    classes_ : array of shape [n_class]
         Holds the label for each class.
 
-    `y_type_` : str,
+    y_type_ : str,
         Represents the type of the target data as evaluated by
         utils.multiclass.type_of_target. Possible type are 'continuous',
         'continuous-multioutput', 'binary', 'multiclass',
         'mutliclass-multioutput', 'multilabel-sequences',
         'multilabel-indicator', and 'unknown'.
 
-    `multilabel_` : boolean
+    multilabel_ : boolean
         True if the transformer was fitted on a multilabel rather than a
         multiclass set of labels. The multilabel_ attribute is deprecated
         and will be removed in 0.18
 
-    `sparse_input_` : boolean,
+    sparse_input_ : boolean,
         True if the input data to transform is given as a sparse matrix, False
         otherwise.
 
-    `indicator_matrix_` : str
+    indicator_matrix_ : str
         'sparse' when the input data to tansform is a multilable-indicator and
         is sparse, None otherwise. The indicator_matrix_ attribute is
         deprecated as of version 0.16 and will be removed in 0.18
@@ -659,7 +659,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `classes_` : array of labels
+    classes_ : array of labels
         A copy of the `classes` parameter where provided,
         or otherwise, the sorted set of classes found when fitting.
 

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -38,20 +38,20 @@ class QDA(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
-    `covariances_` : list of array-like, shape = [n_features, n_features]
+    covariances_ : list of array-like, shape = [n_features, n_features]
         Covariance matrices of each class.
 
-    `means_` : array-like, shape = [n_classes, n_features]
+    means_ : array-like, shape = [n_classes, n_features]
         Class means.
 
-    `priors_` : array-like, shape = [n_classes]
+    priors_ : array-like, shape = [n_classes]
         Class priors (sum to 1).
 
-    `rotations_` : list of arrays
+    rotations_ : list of arrays
         For each class an array of shape [n_samples, n_samples], the
         rotation of the Gaussian distribution, i.e. its principal axis.
 
-    `scalings_` : array-like, shape = [n_classes, n_features]
+    scalings_ : array-like, shape = [n_classes, n_features]
         Contains the scaling of the Gaussian
         distributions along the principal axes for each
         class, i.e. the variance in the rotated coordinate system.

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -446,10 +446,10 @@ class GaussianRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    ``n_component_`` : int
+    n_component_ : int
         Concrete number of components computed when n_components="auto".
 
-    ``components_`` : numpy array of shape [n_components, n_features]
+    components_ : numpy array of shape [n_components, n_features]
         Random matrix used for the projection.
 
     See Also
@@ -550,13 +550,13 @@ class SparseRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    ``n_component_`` : int
+    n_component_ : int
         Concrete number of components computed when n_components="auto".
 
-    ``components_`` : CSR matrix with shape [n_components, n_features]
+    components_ : CSR matrix with shape [n_components, n_features]
         Random matrix used for the projection.
 
-    ``density_`` : float in range 0.0 - 1.0
+    density_ : float in range 0.0 - 1.0
         Concrete density computed from when density = "auto".
 
     See Also

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -282,19 +282,19 @@ class LabelPropagation(BaseLabelPropagation):
 
     Attributes
     ----------
-    `X_` : array, shape = [n_samples, n_features]
+    X_ : array, shape = [n_samples, n_features]
         Input array.
 
-    `classes_` : array, shape = [n_classes]
+    classes_ : array, shape = [n_classes]
         The distinct labels used in classifying instances.
 
-    `label_distributions_` : array, shape = [n_samples, n_classes]
+    label_distributions_ : array, shape = [n_samples, n_classes]
         Categorical distribution for each item.
 
-    `transduction_` : array, shape = [n_samples]
+    transduction_ : array, shape = [n_samples]
         Label assigned to each item via the transduction.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     Examples
@@ -364,19 +364,19 @@ class LabelSpreading(BaseLabelPropagation):
 
     Attributes
     ----------
-    `X_` : array, shape = [n_samples, n_features]
+    X_ : array, shape = [n_samples, n_features]
         Input array.
 
-    `classes_` : array, shape = [n_classes]
+    classes_ : array, shape = [n_classes]
         The distinct labels used in classifying instances.
 
-    `label_distributions_` : array, shape = [n_samples, n_classes]
+    label_distributions_ : array, shape = [n_samples, n_classes]
         Categorical distribution for each item.
 
-    `transduction_` : array, shape = [n_samples]
+    transduction_ : array, shape = [n_samples]
         Label assigned to each item via the transduction.
 
-    `n_iter_` : int
+    n_iter_ : int
         Number of iterations run.
 
     Examples

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -83,7 +83,7 @@ class LinearSVC(BaseLibLinear, LinearClassifierMixin, _LearntSelectorMixin,
 
     Attributes
     ----------
-    `coef_` : array, shape = [n_features] if n_classes == 2 \
+    coef_ : array, shape = [n_features] if n_classes == 2 \
             else [n_classes, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
@@ -91,7 +91,7 @@ class LinearSVC(BaseLibLinear, LinearClassifierMixin, _LearntSelectorMixin,
         `coef_` is readonly property derived from `raw_coef_` that \
         follows the internal memory layout of liblinear.
 
-    `intercept_` : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
 
     Notes
@@ -216,30 +216,30 @@ class SVC(BaseSVC):
 
     Attributes
     ----------
-    `support_` : array-like, shape = [n_SV]
+    support_ : array-like, shape = [n_SV]
         Index of support vectors.
 
-    `support_vectors_` : array-like, shape = [n_SV, n_features]
+    support_vectors_ : array-like, shape = [n_SV, n_features]
         Support vectors.
 
-    `n_support_` : array-like, dtype=int32, shape = [n_class]
+    n_support_ : array-like, dtype=int32, shape = [n_class]
         number of support vector for each class.
 
-    `dual_coef_` : array, shape = [n_class-1, n_SV]
+    dual_coef_ : array, shape = [n_class-1, n_SV]
         Coefficients of the support vector in the decision function. \
         For multiclass, coefficient for all 1-vs-1 classifiers. \
         The layout of the coefficients in the multiclass case is somewhat \
         non-trivial. See the section about multi-class classification in the \
         SVM section of the User Guide for details.
 
-    `coef_` : array, shape = [n_class-1, n_features]
+    coef_ : array, shape = [n_class-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    `intercept_` : array, shape = [n_class * (n_class-1) / 2]
+    intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
     Examples
@@ -340,30 +340,30 @@ class NuSVC(BaseSVC):
 
     Attributes
     ----------
-    `support_` : array-like, shape = [n_SV]
+    support_ : array-like, shape = [n_SV]
         Index of support vectors.
 
-    `support_vectors_` : array-like, shape = [n_SV, n_features]
+    support_vectors_ : array-like, shape = [n_SV, n_features]
         Support vectors.
 
-    `n_support_` : array-like, dtype=int32, shape = [n_class]
+    n_support_ : array-like, dtype=int32, shape = [n_class]
         number of support vector for each class.
 
-    `dual_coef_` : array, shape = [n_class-1, n_SV]
+    dual_coef_ : array, shape = [n_class-1, n_SV]
         Coefficients of the support vector in the decision function. \
         For multiclass, coefficient for all 1-vs-1 classifiers. \
         The layout of the coefficients in the multiclass case is somewhat \
         non-trivial. See the section about multi-class classification in \
         the SVM section of the User Guide for details.
 
-    `coef_` : array, shape = [n_class-1, n_features]
+    coef_ : array, shape = [n_class-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    `intercept_` : array, shape = [n_class * (n_class-1) / 2]
+    intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
     Examples
@@ -464,23 +464,23 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     Attributes
     ----------
-    `support_` : array-like, shape = [n_SV]
+    support_ : array-like, shape = [n_SV]
         Index of support vectors.
 
-    `support_vectors_` : array-like, shape = [nSV, n_features]
+    support_vectors_ : array-like, shape = [nSV, n_features]
         Support vectors.
 
-    `dual_coef_` : array, shape = [n_classes-1, n_SV]
+    dual_coef_ : array, shape = [n_classes-1, n_SV]
         Coefficients of the support vector in the decision function.
 
-    `coef_` : array, shape = [n_classes-1, n_features]
+    coef_ : array, shape = [n_classes-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    `intercept_` : array, shape = [n_class * (n_class-1) / 2]
+    intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
     Examples
@@ -580,23 +580,23 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     Attributes
     ----------
-    `support_` : array-like, shape = [n_SV]
+    support_ : array-like, shape = [n_SV]
         Index of support vectors.
 
-    `support_vectors_` : array-like, shape = [nSV, n_features]
+    support_vectors_ : array-like, shape = [nSV, n_features]
         Support vectors.
 
-    `dual_coef_` : array, shape = [n_classes-1, n_SV]
+    dual_coef_ : array, shape = [n_classes-1, n_SV]
         Coefficients of the support vector in the decision function.
 
-    `coef_` : array, shape = [n_classes-1, n_features]
+    coef_ : array, shape = [n_classes-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    `intercept_` : array, shape = [n_class * (n_class-1) / 2]
+    intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
 
     Examples
@@ -690,23 +690,23 @@ class OneClassSVM(BaseLibSVM):
 
     Attributes
     ----------
-    `support_` : array-like, shape = [n_SV]
+    support_ : array-like, shape = [n_SV]
         Index of support vectors.
 
-    `support_vectors_` : array-like, shape = [nSV, n_features]
+    support_vectors_ : array-like, shape = [nSV, n_features]
         Support vectors.
 
-    `dual_coef_` : array, shape = [n_classes-1, n_SV]
+    dual_coef_ : array, shape = [n_classes-1, n_SV]
         Coefficient of the support vector in the decision function.
 
-    `coef_` : array, shape = [n_classes-1, n_features]
+    coef_ : array, shape = [n_classes-1, n_features]
         Weights asigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`
 
-    `intercept_` : array, shape = [n_classes-1]
+    intercept_ : array, shape = [n_classes-1]
         Constants in decision function.
 
     """

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -414,22 +414,22 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     Attributes
     ----------
-    `tree_` : Tree object
+    tree_ : Tree object
         The underlying Tree object.
 
-    `max_features_` : int,
+    max_features_ : int,
         The infered value of max_features.
 
-    `classes_` : array of shape = [n_classes] or a list of such arrays
+    classes_ : array of shape = [n_classes] or a list of such arrays
         The classes labels (single output problem),
         or a list of arrays of class labels (multi-output problem).
 
-    `n_classes_` : int or list
+    n_classes_ : int or list
         The number of classes (for single output problems),
         or a list containing the number of classes for each
         output (for multi-output problems).
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances. The higher, the more important the
         feature. The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
@@ -624,13 +624,13 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     Attributes
     ----------
-    `tree_` : Tree object
+    tree_ : Tree object
         The underlying Tree object.
 
-    `max_features_` : int,
+    max_features_ : int,
         The infered value of max_features.
 
-    `feature_importances_` : array of shape = [n_features]
+    feature_importances_ : array of shape = [n_features]
         The feature importances.
         The higher, the more important the feature.
         The importance of a feature is computed as the


### PR DESCRIPTION
The Attributes sections of class documentation are currently formatted poorly and [appear after](http://scikit-learn.org/dev/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html) See Also, References, etc.

This PR uses the same formatting code for Attributes as for Parameters, and places them together, as they are conventionally in docstrings. The inconsistent convention to surround attribute names with backticks was [critiqued](http://sourceforge.net/p/scikit-learn/mailman/message/30617924/) by @vene in March 2013; this PR gets rid of that inconsistency. It also fixes up a few misformatted Attribute descriptions (missing space before `:`) and Returns descriptions (surrounded by backticks).
