### PR TITLE
[MRG] whats_new.rst: missing backported fixes for 0.15.1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,13 +66,11 @@ API changes summary
       :func:`multiclass.fit_ecoc` and :func:`multiclass.predict_ecoc`
       are deprecated. Use the underlying estimators instead.
 
+
 .. _changes_0_15_1:
 
 0.15.1
 ======
-
-.. _changes_0_15:
-
 
 Bug fixes
 ---------
@@ -86,6 +84,25 @@ Bug fixes
      the default behavior of 0.14.1 for backward compatibility. By
      `Hamzeh Alsalhi`_.
 
+   - Fixed :class:`cluster.KMeans` stopping criterion that prevented early
+     convergence detection. By Edward Raff and `Gael Varoquaux`_.
+
+   - Fixed the behavior of :class:`multiclass.OneVsOneClassifier`.
+     in case of ties at the per-class vote level by computing the correct
+     per-class sum of prediction scores. By `Andreas Müller`_.
+
+   - Made :func:`cross_valiation.cross_val_score` and
+     :class:`grid_search.GridSearchCV` accept Python lists as input data.
+     This is especially useful for cross-validation and model selection of
+     text processing pipelines. By `Andreas Müller`_.
+
+   - Fixed data input checks of most estimators to accept input data that
+     implements the NumPy ``__array__`` protocol such as ``pandas.Series``
+     and ``pandas.DataFrame`` in recent versions of pandas. By
+     `Gael Varoquaux`_.
+
+
+.. _changes_0_15:
 
 0.15
 ====


### PR DESCRIPTION
Please @amueller and @GaelVaroquaux have a look at the summary of the fixes that were backported in the 0.15.X since the 0.15.0 release.

Once merged to master I will backport this doc change to the 0.15.X branch.
