### PR TITLE
[MRG] ENH faster, low-memory PolynomialFeatures

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2,10 +2,12 @@
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
+#          Joel Nothman <joel.nothman@gmail.com>
 # License: BSD 3 clause
 
 from itertools import chain, combinations
 import numbers
+import warnings
 
 import numpy as np
 from scipy import sparse
@@ -432,8 +434,9 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     Attributes
     ----------
 
-    powers_ :
-         powers_[i, j] is the exponent of the jth input in the ith output.
+    sparse_powers_: CSC matrix, shape (n_in_features, n_out_features)
+         sparse_powers_[j, i] is the exponent of the jth input in the
+         ith output.
 
     Notes
     -----
@@ -453,21 +456,34 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     def _power_matrix(n_features, degree, interaction_only, include_bias):
         """Compute the matrix of polynomial powers"""
         comb = (combinations if interaction_only else combinations_w_r)
-        start = int(not include_bias)
-        combn = chain.from_iterable(comb(range(n_features), i)
-                                    for i in range(start, degree + 1))
-        powers = np.vstack(np.bincount(c, minlength=n_features) for c in combn)
-        return powers
+        stack = []
+        if include_bias:
+            stack.append(sparse.csr_matrix((1, n_features)))
+        for i in range(1, degree + 1):
+            combs = sum(comb(range(n_features), i), ())
+            n_combs = len(combs) // i
+            stack.append(sparse.csr_matrix((np.ones(len(combs)), combs,
+                                            np.arange(0, len(combs) + i, i)),
+                                           shape=(n_combs, n_features)))
+        return sparse.vstack(stack)
 
     def fit(self, X, y=None):
         """
         Compute the polynomial feature combinations
         """
         n_samples, n_features = check_array(X).shape
-        self.powers_ = self._power_matrix(n_features, self.degree,
-                                          self.interaction_only,
-                                          self.include_bias)
+        powers = self._power_matrix(n_features, self.degree,
+                                    self.interaction_only,
+                                    self.include_bias)
+        self.sparse_powers_ = powers.T
         return self
+
+    @property
+    def powers_(self):
+        warnings.warn('PolynomialFeatures.powers_ is deprecated and will be '
+                      'removed in version 0.18. sparse_powers_ replaces it, '
+                      'but contains its transpose.', DeprecationWarning)
+        return self.sparse_powers_.A.T
 
     def transform(self, X, y=None):
         """Transform data to polynomial features
@@ -486,10 +502,14 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         X = check_array(X)
         n_samples, n_features = X.shape
 
-        if n_features != self.powers_.shape[1]:
+        if n_features != self.sparse_powers_.shape[0]:
             raise ValueError("X shape does not match training shape")
 
-        return (X[:, None, :] ** self.powers_).prod(-1)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            logX = X.astype(complex)
+            logX = np.log(logX, out=logX)
+        return np.exp(logX * self.sparse_powers_).real
 
 
 def normalize(X, norm='l2', axis=1, copy=True):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -5,7 +5,7 @@
 #          Joel Nothman <joel.nothman@gmail.com>
 # License: BSD 3 clause
 
-from itertools import chain, combinations
+from itertools import combinations
 import numbers
 import warnings
 
@@ -498,6 +498,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         XP : np.ndarray shape [n_samples, NP]
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
+            The output dtype will be of the same kind as the input.
         """
         X = check_array(X)
         n_samples, n_features = X.shape

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -509,7 +509,10 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
             warnings.simplefilter('ignore', RuntimeWarning)
             logX = X.astype(complex)
             logX = np.log(logX, out=logX)
-        return np.exp(logX * self.sparse_powers_).real
+        out = np.exp(logX * self.sparse_powers_).real
+        if X.dtype.kind in 'biu':  # boolean, integer, uint
+            out = np.around(out, out=out).astype(X.dtype)
+        return out
 
 
 def normalize(X, norm='l2', axis=1, copy=True):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -70,6 +70,27 @@ def test_polynomial_features():
     assert_raises(ValueError, interact.transform, X[:, 1:])
 
 
+def test_polynomial_features_dtype():
+    """Check that PolynomialFeatures correctly returns the input dtype
+
+    This also checks for integer rounding where a float intermediary is used.
+    """
+
+    Xs = [np.arange(20, dtype=int),
+          np.arange(20, dtype=np.uint32),
+          np.arange(2, dtype=bool),
+          np.linspace(0, 10, 10)]
+    for X_row in Xs:
+        X = X_row[None, :]
+        # identity transformation
+        out = PolynomialFeatures(degree=1, include_bias=False).fit_transform(X)
+        assert_array_almost_equal(out, X)
+        assert_equal(out.dtype.kind, X.dtype.kind)
+        # in case identity is handled specially:
+        out = PolynomialFeatures(degree=2).fit_transform(X)
+        assert_equal(out.dtype.kind, X.dtype.kind)
+
+
 def test_scaler_1d():
     """Test scaling of dataset along single axis"""
     rng = np.random.RandomState(0)
@@ -719,6 +740,7 @@ def test_one_hot_encoder_sparse():
     # test negative input to transform
     enc.fit([[0], [1]])
     assert_raises(ValueError, enc.transform, [[0], [-1]])
+
 
 def test_one_hot_encoder_dense():
     """check for sparse=False"""


### PR DESCRIPTION
This is an alternative to #3512 for fast and low-memory `PolynomialFeatures`. It makes use of the powers matrix sparsity, and uses logarithmic space so that sparse matrix multiplication can be used. The alternative in #3512 saves time and memory by processing each sample at a time in a Python for loop.

~~I have marked this WIP as:~~
- ~~in some cases (e.g. binary-valued features), a float-typed output, as required for logarithmic calculations, isn't ideal.~~
- ~~the docstring tests are failing for this reason~~
- ~~testing of return values and their dtypes is needed~~
- ~~we might now consider accepting some sparse input, but that may be up for debate.~~ left for another PR (has potential to make messy code)
