### PR TITLE
Add UNICODE flag to re.compile() in text tokenization

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -204,7 +204,7 @@ class VectorizerMixin(object):
         """Return a function that splits a string into a sequence of tokens"""
         if self.tokenizer is not None:
             return self.tokenizer
-        token_pattern = re.compile(self.token_pattern)
+        token_pattern = re.compile(self.token_pattern, flags=re.UNICODE)
         return lambda doc: token_pattern.findall(doc)
 
     def get_stop_words(self):


### PR DESCRIPTION
So that the `token_pattern` can use `\w`, etc, in unicode mode.
