### PR TITLE
bug fix for t-SNE (issue #3526)

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -431,8 +431,12 @@ class TSNE(BaseEstimator):
             distances = X
         else:
             if self.verbose:
-                print("[t-SNE] Computing pairwise distances...")
-            distances = pairwise_distances(X, metric=self.metric)
+                print("[t-SNE] Computing pairwise distances...")\
+            
+            if self.metric == "euclidean":
+                distances = pairwise_distances(X, metric=self.metric, squared=True)
+            else:
+                distances = pairwise_distances(X, metric=self.metric)
 
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # alpha = n_components - 1 comes from "Learning a Parametric Embedding

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -432,7 +432,7 @@ class TSNE(BaseEstimator):
         else:
             if self.verbose:
                 print("[t-SNE] Computing pairwise distances...")
-            distances = pairwise_distances(X, metric=self.metric, squared=True)
+            distances = pairwise_distances(X, metric=self.metric)
 
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # alpha = n_components - 1 comes from "Learning a Parametric Embedding


### PR DESCRIPTION
Some of the pairwise distances do not support the additional `squared` parameter. I suggest using `sqeuclidian` and such whenever this is required.
