### PR TITLE
[MRG+1] Verbose message in RFE to count from 1, not 0

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -346,7 +346,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
                 if self.verbose > 0:
                     print("Finished fold with %d / %d feature ranks, score=%f"
-                          % (k, max(ranking_), score))
+                          % (k+1, max(ranking_), score))
                 scores[k] += score
 
         # Pick the best number of features on average


### PR DESCRIPTION
Verbose message printed while using RFE should count from 1, rather than 0.

```
Finished fold with 0 / 86 feature ranks, score=0.708241
```

Should begin:

```
Finished fold with 1 / 86 feature ranks, score=0.708241
```

At the end of the fold, the current and total feature ranks will be equal instead of differing by 1.
