### PR TITLE
[MRG] FIX only use testing.ignore_warnings in tests

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -11,11 +11,10 @@ at which the fixe is no longer needed.
 # License: BSD 3 clause
 
 import inspect
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
-
-from .testing import ignore_warnings
 
 np_version = []
 for x in np.__version__.split('.'):
@@ -103,9 +102,10 @@ else:
 
 
 try:
-    with ignore_warnings():
+    with warnings.catch_warnings(record=True):
         # Don't raise the numpy deprecation warnings that appear in
-        # 1.9
+        # 1.9, but avoid Python bug due to simplefilter('ignore')
+        warnings.simplefilter('always')
         sp.csr_matrix([1.0, 2.0, 3.0]).max(axis=0)
 except (TypeError, AttributeError):
     # in scipy < 14.0, sparse matrix min/max doesn't accept an `axis` argument


### PR DESCRIPTION
Fix for #3530. I think it's a good idea to avoid `sklearn.utils.testing` except in testing code. In this case, its `ignore_warnings` did things to the global Python state, which is fine in testing but uncool in production.
