### PR TITLE
Bugfixes in gaussian_process subpackage (continued)

### DIFF
--- a/examples/gaussian_process/gp_diabetes_dataset.py
+++ b/examples/gaussian_process/gp_diabetes_dataset.py
@@ -40,7 +40,7 @@ gp = GaussianProcess(regr='constant', corr='absolute_exponential',
 gp.fit(X, y)
 
 # Deactivate maximum likelihood estimation for the cross-validation loop
-gp.theta0 = gp.theta  # Given correlation parameter = MLE
+gp.theta0 = gp.theta_  # Given correlation parameter = MLE
 gp.thetaL, gp.thetaU = None, None  # None bounds deactivate MLE
 
 # Perform a cross-validation estimate of the coefficient of determination using

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -736,9 +736,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     raise ve
 
                 optimal_theta = 10. ** log10_optimal_theta
-                optimal_minus_rlf_value, optimal_par = \
+                optimal_rlf_value, optimal_par = \
                     self.reduced_likelihood_function(theta=optimal_theta)
-                optimal_rlf_value = - optimal_minus_rlf_value
 
                 # Compare the new optimizer to the best previous one
                 if k > 0:

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -7,7 +7,7 @@
 from __future__ import print_function
 
 import numpy as np
-from scipy import linalg, optimize, rand
+from scipy import linalg, optimize
 
 from ..base import BaseEstimator, RegressorMixin
 from ..metrics.pairwise import manhattan_distances
@@ -721,8 +721,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                     # Generate a random starting point log10-uniformly
                     # distributed between bounds
                     log10theta0 = np.log10(self.thetaL) \
-                        + rand(self.theta0.size).reshape(self.theta0.shape) \
-                        * np.log10(self.thetaU / self.thetaL)
+                        + self.random_state.rand(self.theta0.size).reshape(
+                            self.theta0.shape) * np.log10(self.thetaU
+                                                          / self.thetaL)
                     theta0 = 10. ** log10theta0
 
                 # Run Cobyla

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -135,3 +135,26 @@ def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
     y_pred = gp.predict(X)
     assert_true(np.allclose(y_pred, y))
+
+def test_random_starts():
+    """
+    Test that an increasing number of random-starts of GP fitting only
+    increases the reduced likelihood function of the optimal theta.
+    """
+    n_input_dims = 3
+    n_samples = 100
+    np.random.seed(0)
+    X = np.random.random(n_input_dims*n_samples).reshape(n_samples,
+                                                         n_input_dims) * 2 - 1
+    y = np.sin(X).sum(axis=1) + np.sin(3*X).sum(axis=1)
+    best_likelihood = -np.inf
+    for random_start in range(1, 10):
+        gp = GaussianProcess(regr="constant", corr="squared_exponential",
+                             theta0=[1e-0]*n_input_dims,
+                             thetaL=[1e-4]*n_input_dims,
+                             thetaU=[1e+1]*n_input_dims,
+                             random_start=random_start, random_state=0,
+                             verbose=False).fit(X, y)
+        rlf = gp.reduced_likelihood_function()[0]
+        assert_true(rlf >= best_likelihood)
+        best_likelihood = rlf


### PR DESCRIPTION
This is a continuation of the inactive PR #2632, which fixed two issues in the gaussian_process package:
- Optimum theta over multiple random-starts was not determined correctly
- gp_diabetes_dataset.py crashed because it tried to access gp.theta rather than gp.theta_

Credit for these fixes goes to  @dubourg. The fixes have already been reviewed by @agramfort, @jaquesgrobler, and @GaelVaroquaux. The only thing missing was a regression test, which I add in this PR (sorry for a new PR, but the old one is apparently inactive and I can not work on it). Furthermore, I removed a call to scipy.rand in GaussianProcess which resulted in inconsistent results for the same random_state.

I hope that this is sufficient for getting this PR merged soon.
