### PR TITLE
[FIX] orthogonal LDA transform (conform with R)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,9 @@ Bug fixes
     - Various fixes to the Gaussian processes subpackage by Vincent Dubourg
       and Jan Hendrik Metzen.
 
+    - The ``transform`` of :class:`lda.LDA` now projects the input on the most
+      discriminant directions. By Martin Billinger.
+
 
 API changes summary
 -------------------

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -225,9 +225,10 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         """
         X = check_array(X)
         # center and scale data
-        X = np.dot(X - self.xbar_, self.scalings_)
-        n_comp = X.shape[1] if self.n_components is None else self.n_components
-        return X[:, :n_comp]
+        X_new = np.dot(X - self.xbar_, self.scalings_)
+        n_components = X.shape[1] if self.n_components is None \
+            else self.n_components
+        return X_new[:, :n_components]
 
     def predict(self, X):
         """

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -227,7 +227,7 @@ class LDA(BaseEstimator, ClassifierMixin, TransformerMixin):
         # center and scale data
         X = np.dot(X - self.xbar_, self.scalings_)
         n_comp = X.shape[1] if self.n_components is None else self.n_components
-        return np.dot(X, self.coef_[:n_comp].T)
+        return X[:, :n_comp]
 
     def predict(self, X):
         """

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -57,21 +57,33 @@ def test_lda_orthogonality():
     # arrange four classes with their means in a kite-shaped pattern
     # the longer distance should be transformed to the first component, and
     # the shorter distance to the second component.
-    means = [[0, 0, -1], [0, 2, 0], [0, -2, 0], [0, 0, 5]]
-    X, y = make_blobs(n_samples=10000, n_features=3, cluster_std=1,
-                      centers=means, random_state=123)
+    means = np.array([[0, 0, -1], [0, 2, 0], [0, -2, 0], [0, 0, 5]])
+
+    # Here, we construct perfectly symmetric distributions, so the LDA can
+    # estimate precise means.
+    X, y = [], []
+    for i in range(len(means)):
+        y.extend([i]*6)
+        X.append(means[i] + [0.1, 0, 0])
+        X.append(means[i] + [-0.1, 0, 0])
+        X.append(means[i] + [0, 0.1, 0])
+        X.append(means[i] + [0, -0.1, 0])
+        X.append(means[i] + [0, 0, 0.1])
+        X.append(means[i] + [0, 0, -0.1])
+
+    # Fit LDA and transform the means
     clf = lda.LDA().fit(X, y)
     means_transformed = clf.transform(means)
 
-    # the means of classes 0 and 3 should lie on the first component
     d1 = means_transformed[3] - means_transformed[0]
-    d1 /= np.sqrt(np.sum(d1**2))
-
-    # the means of classes 1 and 2 should lie on the second component
     d2 = means_transformed[2] - means_transformed[1]
+    d1 /= np.sqrt(np.sum(d1**2))
     d2 /= np.sqrt(np.sum(d2**2))
 
-    # the axes are not very precise. The second less so than the first.
-    # Increase number of samples to get more accurate results.
-    assert_almost_equal(np.dot(d1, [1, 0, 0]), 1.0, decimal=3)
-    assert_almost_equal(np.dot(d2, [0, 1, 0]), 1.0, decimal=2)
+    # the means of classes 0 and 3 should lie on the first component
+    assert_almost_equal(np.abs(np.dot(d1[:2], [1, 0])), 1.0)
+
+    # the means of classes 1 and 2 should lie on the second component
+    assert_almost_equal(np.abs(np.dot(d2[:2], [0, 1])), 1.0)
+
+test_lda_orthogonality()

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -75,6 +75,9 @@ def test_lda_orthogonality():
     d1 /= np.sqrt(np.sum(d1**2))
     d2 /= np.sqrt(np.sum(d2**2))
 
+    # the transformed within-class covariance should be the identity matrix
+    assert_almost_equal(np.cov(clf.transform(scatter).T), np.eye(2))
+
     # the means of classes 0 and 3 should lie on the first component
     assert_almost_equal(np.abs(np.dot(d1[:2], [1, 0])), 1.0)
 

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -58,17 +58,13 @@ def test_lda_orthogonality():
     # the shorter distance to the second component.
     means = np.array([[0, 0, -1], [0, 2, 0], [0, -2, 0], [0, 0, 5]])
 
-    # Here, we construct perfectly symmetric distributions, so the LDA can
-    # estimate precise means.
-    X, y = [], []
-    for i in range(len(means)):
-        y.extend([i]*6)
-        X.append(means[i] + [0.1, 0, 0])
-        X.append(means[i] + [-0.1, 0, 0])
-        X.append(means[i] + [0, 0.1, 0])
-        X.append(means[i] + [0, -0.1, 0])
-        X.append(means[i] + [0, 0, 0.1])
-        X.append(means[i] + [0, 0, -0.1])
+    # We construct perfectly symmetric distributions, so the LDA can estimate
+    # precise means.
+    scatter = np.array([[0.1, 0, 0], [-0.1, 0, 0], [0, 0.1, 0], [0, -0.1, 0],
+                        [0, 0, 0.1], [0, 0, -0.1]])
+
+    X = (means[:, np.newaxis, :] + scatter[np.newaxis, :, :]).reshape((-1, 3))
+    y = np.repeat(np.arange(means.shape[0]), scatter.shape[0])
 
     # Fit LDA and transform the means
     clf = lda.LDA().fit(X, y)
@@ -84,5 +80,3 @@ def test_lda_orthogonality():
 
     # the means of classes 1 and 2 should lie on the second component
     assert_almost_equal(np.abs(np.dot(d2[:2], [0, 1])), 1.0)
-
-test_lda_orthogonality()

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -5,7 +5,6 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
-from sklearn.datasets import make_blobs
 
 from sklearn import lda
 


### PR DESCRIPTION
Removed an unnecessary dot product from the `LDA.transform()`. Now it gives the same results as R on the setosa data set. See discussion in #3500 for details.

Regression test included.
