### PR TITLE
[MRG+1] update sklearn.svm.bounds to use recent helpers

### DIFF
--- a/sklearn/svm/bounds.py
+++ b/sklearn/svm/bounds.py
@@ -63,7 +63,8 @@ def l1_min_c(X, y, loss='l2', fit_intercept=True, intercept_scaling=1.0):
         den = max(den, abs(np.dot(Y, bias)).max())
 
     if den == 0.0:
-        raise ValueError('Ill-posed l1_min_c calculation')
+        raise ValueError('Ill-posed l1_min_c calculation: l1 will always '
+                         'select zero coefficients for this data')
     if loss == 'l2':
         return 0.5 / den
     else:  # loss == 'log':

--- a/sklearn/svm/bounds.py
+++ b/sklearn/svm/bounds.py
@@ -1,5 +1,12 @@
-import operator
+"""Determination of parameter bounds"""
+# Author: Paolo Losi
+# License: BSD 3 clause
+
 import numpy as np
+
+from ..preprocessing import LabelBinarizer
+from ..utils.validation import check_consistent_length, check_array
+from ..utils.extmath import safe_sparse_dot
 
 
 def l1_min_c(X, y, loss='l2', fit_intercept=True, intercept_scaling=1.0):
@@ -41,41 +48,19 @@ def l1_min_c(X, y, loss='l2', fit_intercept=True, intercept_scaling=1.0):
     l1_min_c: float
         minimum value for C
     """
-    import scipy.sparse as sp
 
     if loss not in ('l2', 'log'):
         raise ValueError('loss type not in ("l2", "log")')
 
-    y = np.asarray(y)
+    X = check_array(X, accept_sparse='csc')
+    check_consistent_length(X, y)
 
-    if sp.issparse(X):
-        X = sp.csc_matrix(X)
-        hstack = sp.hstack
-        dot = operator.mul
-    else:
-        X = np.asarray(X)
-        hstack = np.hstack
-        dot = np.dot
-
+    Y = LabelBinarizer(neg_label=-1).fit_transform(y).T
+    # maximum absolute value over classes and features
+    den = np.max(np.abs(safe_sparse_dot(Y, X)))
     if fit_intercept:
         bias = intercept_scaling * np.ones((np.size(y), 1))
-        X = hstack((X, bias))
-
-    classes = np.unique(y)
-    n_classes = np.size(classes)
-    if n_classes <= 2:
-        c = classes[0]
-        y = y.reshape((1, -1))
-        _y = np.empty(y.shape)
-        _y[y == c] = 1
-        _y[y != c] = -1
-    else:
-        _y = np.empty((n_classes, np.size(y)))
-        for i, c in enumerate(classes):
-            _y[i, y == c] = 1
-            _y[i, y != c] = -1
-
-    den = np.max(np.abs(dot(_y, X)))
+        den = max(den, abs(np.dot(Y, bias)).max())
 
     if den == 0.0:
         raise ValueError('Ill-posed l1_min_c calculation')


### PR DESCRIPTION
Here was some code with stale conventions. If it is useful code, perhaps it should be available in `linear_model` (and for alpha), not just in `svm`.
