### PR TITLE
catch_warnings blocks more robust

### DIFF
--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import sparse
 from scipy.cluster import hierarchy
 
-from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_true, clean_warning_registry
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -43,6 +43,7 @@ def test_linkage_misc():
     FeatureAgglomeration().fit(X)
 
     # Deprecation of Ward class
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", DeprecationWarning)
         Ward().fit(X)
@@ -91,6 +92,7 @@ def test_unstructured_linkage_tree():
     for this_X in (X, X[0]):
         # With specified a number of clusters just for the sake of
         # raising a warning and testing the warning code
+        clean_warning_registry()
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter("ignore", DeprecationWarning)
             children, n_nodes, n_leaves, parent = assert_warns(
@@ -100,6 +102,7 @@ def test_unstructured_linkage_tree():
 
     for tree_builder in _TREE_BUILDERS.values():
         for this_X in (X, X[0]):
+            clean_warning_registry()
             with warnings.catch_warnings(record=True) as warning_list:
                 warnings.simplefilter("always", UserWarning)
                 warnings.simplefilter("ignore", DeprecationWarning)
@@ -207,6 +210,7 @@ def test_ward_agglomeration():
     X = rnd.randn(50, 100)
     connectivity = grid_to_graph(*mask.shape)
     assert_warns(DeprecationWarning, WardAgglomeration)
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", DeprecationWarning)
         if hasattr(np, 'VisibleDeprecationWarning'):

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -43,7 +43,10 @@ def test_linkage_misc():
     FeatureAgglomeration().fit(X)
 
     # Deprecation of Ward class
-    warning_list = assert_warns(DeprecationWarning, Ward.fit, X)
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always", DeprecationWarning)
+        Ward().fit(X)
     assert_equal(len(warning_list), 1)
 
     # test hiearchical clustering on a precomputed distances matrix

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import sparse
 from scipy.cluster import hierarchy
 
-from sklearn.utils.testing import assert_true, clean_warning_registry
+from sklearn.utils.testing import assert_true, clean_warning_registry, ignore_warnings
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -43,11 +43,7 @@ def test_linkage_misc():
     FeatureAgglomeration().fit(X)
 
     # Deprecation of Ward class
-    clean_warning_registry()
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always", DeprecationWarning)
-        Ward().fit(X)
-    assert_equal(len(warning_list), 1)
+    assert_warns(DeprecationWarning, Ward).fit(X)
 
     # test hiearchical clustering on a precomputed distances matrix
     dis = cosine_distances(X)
@@ -102,16 +98,10 @@ def test_unstructured_linkage_tree():
 
     for tree_builder in _TREE_BUILDERS.values():
         for this_X in (X, X[0]):
-            clean_warning_registry()
-            with warnings.catch_warnings(record=True) as warning_list:
-                warnings.simplefilter("always", UserWarning)
-                warnings.simplefilter("ignore", DeprecationWarning)
+#            clean_warning_registry()
+            with ignore_warnings():
+                children, n_nodes, n_leaves, parent = assert_warns(UserWarning, tree_builder, this_X.T, n_clusters=10)
 
-                # With specified a number of clusters just for the sake of
-                # raising a warning and testing the warning code
-                children, n_nodes, n_leaves, parent = tree_builder(
-                    this_X.T, n_clusters=10)
-            assert_equal(len(warning_list), 1)
             n_nodes = 2 * X.shape[1] - 1
             assert_equal(len(children) + n_leaves, n_nodes)
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -43,10 +43,7 @@ def test_linkage_misc():
     FeatureAgglomeration().fit(X)
 
     # Deprecation of Ward class
-    clean_warning_registry()
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always", DeprecationWarning)
-        Ward().fit(X)
+    warning_list = assert_warns(DeprecationWarning, Ward.fit, X)
     assert_equal(len(warning_list), 1)
 
     # test hiearchical clustering on a precomputed distances matrix

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -88,9 +88,7 @@ def test_unstructured_linkage_tree():
     for this_X in (X, X[0]):
         # With specified a number of clusters just for the sake of
         # raising a warning and testing the warning code
-        clean_warning_registry()
-        with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with ignore_warnings():
             children, n_nodes, n_leaves, parent = assert_warns(
                 UserWarning, ward_tree, this_X.T, n_clusters=10)
         n_nodes = 2 * X.shape[1] - 1
@@ -98,9 +96,9 @@ def test_unstructured_linkage_tree():
 
     for tree_builder in _TREE_BUILDERS.values():
         for this_X in (X, X[0]):
-#            clean_warning_registry()
             with ignore_warnings():
-                children, n_nodes, n_leaves, parent = assert_warns(UserWarning, tree_builder, this_X.T, n_clusters=10)
+                children, n_nodes, n_leaves, parent = assert_warns(
+                    UserWarning, tree_builder, this_X.T, n_clusters=10)
 
             n_nodes = 2 * X.shape[1] - 1
             assert_equal(len(children) + n_leaves, n_nodes)
@@ -200,15 +198,10 @@ def test_ward_agglomeration():
     X = rnd.randn(50, 100)
     connectivity = grid_to_graph(*mask.shape)
     assert_warns(DeprecationWarning, WardAgglomeration)
-    clean_warning_registry()
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always", DeprecationWarning)
-        if hasattr(np, 'VisibleDeprecationWarning'):
-            # Let's not catch the numpy internal DeprecationWarnings
-            warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+
+    with ignore_warnings():
         ward = WardAgglomeration(n_clusters=5, connectivity=connectivity)
         ward.fit(X)
-        assert_equal(len(warning_list), 1)
     agglo = FeatureAgglomeration(n_clusters=5, connectivity=connectivity)
     agglo.fit(X)
     assert_array_equal(agglo.labels_, ward.labels_)

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -42,7 +42,7 @@ def test_spectral_clustering():
                                            affinity='precomputed',
                                            eigen_solver=eigen_solver,
                                            assign_labels=assign_labels
-                ).fit(mat)
+                                           ).fit(mat)
                 labels = model.labels_
                 if labels[0] == 0:
                     labels = 1 - labels
@@ -136,7 +136,7 @@ def test_affinities():
     # on OSX and Linux
     X, y = make_blobs(n_samples=20, random_state=0,
                       centers=[[1, 1], [-1, -1]], cluster_std=0.01
-    )
+                      )
     # nearest neighbors affinity
     clean_warning_registry()
     with warnings.catch_warnings(record=True) as warning_list:

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_equal, clean_warning_registry
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
@@ -42,7 +42,7 @@ def test_spectral_clustering():
                                            affinity='precomputed',
                                            eigen_solver=eigen_solver,
                                            assign_labels=assign_labels
-                                           ).fit(mat)
+                ).fit(mat)
                 labels = model.labels_
                 if labels[0] == 0:
                     labels = 1 - labels
@@ -69,6 +69,7 @@ def test_spectral_amg_mode():
     S = sparse.coo_matrix(S)
     try:
         from pyamg import smoothed_aggregation_solver
+
         amg_loaded = True
     except ImportError:
         amg_loaded = False
@@ -135,8 +136,9 @@ def test_affinities():
     # on OSX and Linux
     X, y = make_blobs(n_samples=20, random_state=0,
                       centers=[[1, 1], [-1, -1]], cluster_std=0.01
-                      )
+    )
     # nearest neighbors affinity
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", UserWarning)
         sp = SpectralClustering(n_clusters=2, affinity='nearest_neighbors',
@@ -169,7 +171,7 @@ def test_affinities():
 
     def histogram(x, y, **kwargs):
         """Histogram kernel implemented as a callable."""
-        assert_equal(kwargs, {})    # no kernel_params that we didn't ask for
+        assert_equal(kwargs, {})  # no kernel_params that we didn't ask for
         return np.minimum(x, y).sum()
 
     sp = SpectralClustering(n_clusters=2, affinity=histogram, random_state=0)
@@ -191,8 +193,8 @@ def test_discretize(seed=8):
             y_true = np.array(y_true, np.float)
             # noise class assignment matrix
             y_indicator = sparse.coo_matrix((np.ones(n_samples),
-                                            (np.arange(n_samples),
-                                             y_true)),
+                                             (np.arange(n_samples),
+                                              y_true)),
                                             shape=(n_samples,
                                                    n_class + 1))
             y_true_noisy = (y_indicator.toarray()

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -12,7 +12,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble.gradient_boosting import ZeroEstimator
 from sklearn.metrics import mean_squared_error
 from sklearn.utils import check_random_state, tosequence
-from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_almost_equal, clean_warning_registry
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
@@ -629,6 +629,7 @@ def test_more_verbose_output():
 def test_warn_deviance():
     """Test if mdeviance and bdeviance give deprecated warning. """
     for loss in ('bdeviance', 'mdeviance'):
+        clean_warning_registry()
         with warnings.catch_warnings(record=True) as w:
             # This will raise a DataConversionWarning that we want to
             # "always" raise, elsewhere the warnings gets ignored in the

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -31,7 +31,7 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_raises
 from sklearn.utils.testing import (assert_in, assert_less, assert_greater,
-                                   assert_warns_message, assert_raise_message)
+                                   assert_warns_message, assert_raise_message, clean_warning_registry)
 
 from collections import defaultdict, Mapping
 from functools import partial
@@ -344,6 +344,7 @@ def test_tfidf_no_smoothing():
          [1, 0, 0]]
     tr = TfidfTransformer(smooth_idf=False, norm='l2')
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as w:
         1. / np.array([0.])
         numpy_provides_div0_warning = len(w) == 1
@@ -595,14 +596,14 @@ def test_vectorizer_max_df():
     vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
     vect.fit(test_data)
     assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_equal(len(vect.vocabulary_.keys()), 4)  # {bcdt} remain
     assert_true('a' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 2)
 
     vect.max_df = 1
     vect.fit(test_data)
     assert_true('a' not in vect.vocabulary_.keys())  # {ae} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 4)    # {bcdt} remain
+    assert_equal(len(vect.vocabulary_.keys()), 4)  # {bcdt} remain
     assert_true('a' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 2)
 
@@ -618,14 +619,14 @@ def test_vectorizer_min_df():
     vect.min_df = 2
     vect.fit(test_data)
     assert_true('c' not in vect.vocabulary_.keys())  # {bcdt} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 2)    # {ae} remain
+    assert_equal(len(vect.vocabulary_.keys()), 2)  # {ae} remain
     assert_true('c' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 4)
 
     vect.min_df = 0.8  # 0.8 * 3 documents -> min_doc_count == 2.4
     vect.fit(test_data)
     assert_true('c' not in vect.vocabulary_.keys())  # {bcdet} ignored
-    assert_equal(len(vect.vocabulary_.keys()), 1)    # {a} remains
+    assert_equal(len(vect.vocabulary_.keys()), 1)  # {a} remains
     assert_true('c' in vect.stop_words_)
     assert_equal(len(vect.stop_words_), 5)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -13,7 +13,7 @@ from sklearn.preprocessing import LabelBinarizer, MultiLabelBinarizer
 from sklearn.utils.fixes import np_version
 from sklearn.utils.validation import check_random_state
 
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises, clean_warning_registry
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -908,7 +908,7 @@ def test_recall_warnings():
                        np.array([[1, 1], [1, 1]]),
                        np.array([[0, 0], [0, 0]]),
                        average='micro')
-
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
         recall_score(np.array([[0, 0], [0, 0]]),
@@ -920,6 +920,7 @@ def test_recall_warnings():
 
 
 def test_precision_warnings():
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
 
@@ -937,6 +938,7 @@ def test_precision_warnings():
 
 
 def test_fscore_warnings():
+    clean_warning_registry()
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter('always')
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -13,7 +13,7 @@ from sklearn.random_projection import sparse_random_matrix
 from sklearn.utils.validation import check_array, check_consistent_length
 from sklearn.utils.validation import check_random_state
 
-from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises, clean_warning_registry
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
@@ -420,6 +420,7 @@ def test_auc_score_non_binary_class():
     assert_raise_message(ValueError, "multiclass format is not supported",
                          roc_auc_score, y_true, y_pred)
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         rng = check_random_state(404)
         y_pred = rng.rand(10)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.linalg as la
 from scipy import sparse
 
-from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_almost_equal, clean_warning_registry
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
@@ -317,22 +317,26 @@ def test_scaler_int():
     X_csc = sparse.csc_matrix(X)
 
     null_transform = StandardScaler(with_mean=False, with_std=False, copy=True)
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         X_null = null_transform.fit_transform(X_csr)
     assert_array_equal(X_null.data, X_csr.data)
     X_orig = null_transform.inverse_transform(X_null)
     assert_array_equal(X_orig.data, X_csr.data)
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler = StandardScaler(with_mean=False).fit(X)
         X_scaled = scaler.transform(X, copy=True)
     assert_false(np.any(np.isnan(X_scaled)))
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler_csr = StandardScaler(with_mean=False).fit(X_csr)
         X_csr_scaled = scaler_csr.transform(X_csr, copy=True)
     assert_false(np.any(np.isnan(X_csr_scaled.data)))
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         scaler_csc = StandardScaler(with_mean=False).fit(X_csc)
         X_csc_scaled = scaler_csr.transform(X_csc, copy=True)
@@ -442,10 +446,12 @@ def test_warning_scaling_integers():
     X = np.array([[1, 2, 0],
                   [0, 0, 0]], dtype=np.uint8)
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         assert_warns(UserWarning, StandardScaler().fit, X)
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         assert_warns(UserWarning, MinMaxScaler().fit, X)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -14,7 +14,7 @@ import pkgutil
 
 from sklearn.externals.six import PY3
 from sklearn.externals.six.moves import zip
-from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import SkipTest
@@ -184,6 +184,7 @@ def test_configure():
         os.chdir(setup_path)
         old_argv = sys.argv
         sys.argv = ['setup.py', 'config']
+        clean_warning_registry()
         with warnings.catch_warnings():
             # The configuration spits out warnings when not finding
             # Blas/Atlas development headers
@@ -201,6 +202,7 @@ def test_class_weight_classifiers():
     # test that class_weight works and that the semantics are consistent
     classifiers = all_estimators(type_filter='classifier')
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         classifiers = [c for c in classifiers
                        if 'class_weight' in c[1]().get_params().keys()]
@@ -228,6 +230,7 @@ def test_class_weight_auto_classifiers():
 
     classifiers = all_estimators(type_filter='classifier')
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         classifiers = [c for c in classifiers
                        if 'class_weight' in c[1]().get_params().keys()]
@@ -256,6 +259,7 @@ def test_class_weight_auto_classifiers():
 def test_class_weight_auto_linear_classifiers():
     classifiers = all_estimators(type_filter='classifier')
 
+    clean_warning_registry()
     with warnings.catch_warnings(record=True):
         linear_classifiers = [
             (name, clazz)


### PR DESCRIPTION
Explicitely calling clean_warning_registry before with block.
Fix for #3494 
