### PR TITLE
[MRG+1] PLSRegression again supports 1d target

### DIFF
--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -235,16 +235,14 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         # copy since this will contains the residuals (deflated) matrices
         check_consistent_length(X, Y)
         X = check_array(X, dtype=np.float, copy=self.copy)
-        Y = check_array(Y, dtype=np.float, copy=self.copy)
+        Y = check_array(Y, dtype=np.float, copy=self.copy, ensure_2d=False)
+        if Y.ndim == 1:
+            Y = Y[:, None]
 
         n = X.shape[0]
         p = X.shape[1]
         q = Y.shape[1]
 
-        if n != Y.shape[0]:
-            raise ValueError(
-                'Incompatible shapes: X has %s samples, while Y '
-                'has %s' % (X.shape[0], Y.shape[0]))
         if self.n_components < 1 or self.n_components > p:
             raise ValueError('invalid number of components')
         if self.algorithm not in ("svd", "nipals"):
@@ -452,7 +450,7 @@ class PLSRegression(_PLS):
         Training vectors, where n_samples in the number of samples and
         p is the number of predictors.
 
-    Y : array-like of response, shape = [n_samples, q]
+    Y : array-like of response, shape = [n_samples, q] or [n_samples]
         Training vectors, where n_samples in the number of samples and
         q is the number of response variables.
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -235,6 +235,19 @@ def test_PLSSVD():
         assert_equal(n_components, pls.y_scores_.shape[1])
 
 
+def test_univariate_pls_regression():
+    """Ensure 1d Y is correctly interpreted"""
+    d = load_linnerud()
+    X = d.data
+    Y = d.target
+
+    clf = pls_.PLSRegression()
+    # Compare 1d to column vector
+    model1 = clf.fit(X, Y[:, 0]).coefs
+    model2 = clf.fit(X, Y[:, :1]).coefs
+    assert_array_almost_equal(model1, model2)
+
+
 def test_scale():
     d = load_linnerud()
     X = d.data


### PR DESCRIPTION
`plot_compare_cross_decomposition.py` was broken by the change in validation helper functions: `_PLS` calls `Y = check_array(Y)` which returns `Y[None, :]` if Y is 1d. It should be `Y[:, None]`.

Note that the 1d input, while used in an example, was not covered by the docstring (nor tested, obviously). I would like to confirm that this is correct behaviour.

Partial fix for #3872
