### PR TITLE
[MRG+1] MAINT: Remove BaseLibLinear for LogisticRegression

### DIFF
--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -372,7 +372,7 @@ function or **logistic** function:
     LogisticRegression(C=100000.0, class_weight=None, dual=False,
               fit_intercept=True, intercept_scaling=1, max_iter=100,
               multi_class='ovr', penalty='l2', random_state=None,
-              solver='liblinear', tol=0.0001, verbose=False)
+              solver='liblinear', tol=0.0001, verbose=0)
 
 This is known as :class:`LogisticRegression`.
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -372,7 +372,7 @@ function or **logistic** function:
     LogisticRegression(C=100000.0, class_weight=None, dual=False,
               fit_intercept=True, intercept_scaling=1, max_iter=100,
               multi_class='ovr', penalty='l2', random_state=None,
-              solver='liblinear', tol=0.0001)
+              solver='liblinear', tol=0.0001, verbose=False)
 
 This is known as :class:`LogisticRegression`.
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -485,7 +485,7 @@ def test_logistic_regression_convergence_warnings():
     """Test that warnings are raised if model does not converge"""
 
     X, y = make_classification(n_samples=20, n_features=20)
-    clf_lib = LogisticRegression(solver='liblinear', max_iter=2)
+    clf_lib = LogisticRegression(solver='liblinear', max_iter=2, verbose=1)
     assert_warns(ConvergenceWarning, clf_lib.fit, X, y)
     assert_equal(clf_lib.n_iter_, 2)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -715,8 +715,9 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     y_ind = enc.fit_transform(y)
     classes_ = enc.classes_
     if len(classes_) < 2:
-        raise ValueError("The number of classes has to be greater than"
-                         " one.")
+        raise ValueError("This solver needs samples of at least 2 classes"
+                         " in the data, but the data contains only one"
+                         " class: %r" % classes_[0])
 
     class_weight_ = compute_class_weight(class_weight, classes_, y)
     liblinear.set_verbosity_wrap(verbose)
@@ -744,7 +745,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     # on 32-bit platforms, we can't get to the UINT_MAX limit that
     # srand supports
     n_iter_ = max(n_iter_)
-    if n_iter_ >= max_iter:
+    if n_iter_ >= max_iter and verbose > 0:
         warnings.warn("Liblinear failed to converge, increase "
                       "the number of iterations.", ConvergenceWarning)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -583,7 +583,7 @@ class BaseSVC(BaseLibSVM, ClassifierMixin):
             self.probability, self.n_support_,
             self.probA_, self.probB_)
 
-def _get_solver_type(multi_class, penalty, loss, dual):
+def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
     """Find the liblinear magic number for the solver.
 
     This number depends on the values of the following attributes:
@@ -674,8 +674,8 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     dual : bool
         Dual or primal formulation,
 
-    verbose : bool | int
-        Amonut of verbosity.
+    verbose : int
+        Set verbose to any positive number for verbosity.
 
     max_iter : int
         Number of iterations.
@@ -728,9 +728,13 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     if fit_intercept:
         bias = intercept_scaling
 
+    libsvm.set_verbosity_wrap(verbose)
+    libsvm_sparse.set_verbosity_wrap(verbose)
+    liblinear.set_verbosity_wrap(verbose)
+
     # LibLinear wants targets as doubles, even for classification
     y_ind = np.asarray(y_ind, dtype=np.float64).ravel()
-    solver_type = _get_solver_type(multi_class, penalty, loss, dual)
+    solver_type = _get_liblinear_solver_type(multi_class, penalty, loss, dual)
     raw_coef_, n_iter_  = liblinear.train_wrap(
         X, y_ind, sp.isspmatrix(X), solver_type, tol, bias, C,
         class_weight_, max_iter, rnd.randint(np.iinfo('i').max)
@@ -752,7 +756,3 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         intercept_ = 0.
 
     return coef_, intercept_, n_iter_
-
-libsvm.set_verbosity_wrap(0)
-libsvm_sparse.set_verbosity_wrap(0)
-liblinear.set_verbosity_wrap(0)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -173,8 +173,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
             raise ValueError("Penalty term must be positive; got (C=%r)"
                              % self.C)
 
-        X = check_array(X, accept_sparse='csr', dtype=np.float64, order="C")
-        X, y = check_X_y(X, y, accept_sparse='csr')
+        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
         self.classes_ = np.unique(y)
         self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
             X, y, self.C, self.fit_intercept, self.intercept_scaling,

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1,11 +1,14 @@
-from .base import BaseLibLinear, BaseSVC, BaseLibSVM
-from ..base import RegressorMixin
+import numpy as np
+
+from .base import _fit_liblinear, BaseSVC, BaseLibSVM
+from ..base import BaseEstimator, RegressorMixin
 from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin
 from ..feature_selection.from_model import _LearntSelectorMixin
+from ..utils import check_array, check_X_y
 
 
-class LinearSVC(BaseLibLinear, LinearClassifierMixin, _LearntSelectorMixin,
-                SparseCoefMixin):
+class LinearSVC(BaseEstimator, LinearClassifierMixin,
+                _LearntSelectorMixin, SparseCoefMixin):
     """Linear Support Vector Classification.
 
     Similar to SVC with parameter kernel='linear', but implemented in terms of
@@ -136,12 +139,57 @@ class LinearSVC(BaseLibLinear, LinearClassifierMixin, _LearntSelectorMixin,
     def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
                  multi_class='ovr', fit_intercept=True, intercept_scaling=1,
                  class_weight=None, verbose=0, random_state=None, max_iter=1000):
-        super(LinearSVC, self).__init__(
-            penalty=penalty, loss=loss, dual=dual, tol=tol, C=C,
-            multi_class=multi_class, fit_intercept=fit_intercept,
-            intercept_scaling=intercept_scaling,
-            class_weight=class_weight, verbose=verbose,
-            random_state=random_state, max_iter=max_iter)
+        self.penalty = penalty
+        self.loss = loss
+        self.dual = dual
+        self.tol = tol
+        self.C = C
+        self.multi_class = multi_class
+        self.fit_intercept = fit_intercept
+        self.intercept_scaling = intercept_scaling
+        self.class_weight = class_weight
+        self.verbose = verbose
+        self.random_state = random_state
+        self.max_iter = max_iter
+
+    def fit(self, X, y):
+        """Fit the model according to the given training data.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape = [n_samples, n_features]
+            Training vector, where n_samples in the number of samples and
+            n_features is the number of features.
+
+        y : array-like, shape = [n_samples]
+            Target vector relative to X
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        if self.C < 0:
+            raise ValueError("Penalty term must be positive; got (C=%r)"
+                             % self.C)
+
+        X = check_array(X, accept_sparse='csr', dtype=np.float64, order="C")
+        X, y = check_X_y(X, y, accept_sparse='csr')
+        self.classes_ = np.unique(y)
+        self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
+            X, y, self.C, self.fit_intercept, self.intercept_scaling,
+            self.class_weight, self.penalty, self.dual, self.verbose,
+            self.max_iter, self.tol, self.random_state, self.multi_class,
+            self.loss
+            )
+
+        if self.multi_class == "crammer_singer" and len(self.classes_) == 2:
+            self.coef_ = (self.coef_[1] - self.coef_[0]).reshape(1, -1)
+            if self.fit_intercept:
+                intercept = self.intercept_[1] - self.intercept_[0]
+                self.intercept_ = np.array([intercept])
+
+        return self
 
 
 class SVC(BaseSVC):

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -435,18 +435,16 @@ def test_linearsvc_parameters():
     params = [(dual, loss, penalty) for dual in [True, False]
               for loss in ['l1', 'l2', 'lr'] for penalty in ['l1', 'l2']]
 
+    X, y = make_classification(n_samples=5, n_features=5)
+
     for dual, loss, penalty in params:
-            if loss == 'l1' and penalty == 'l1':
-                assert_raises(ValueError, svm.LinearSVC, penalty=penalty,
-                              loss=loss, dual=dual)
-            elif loss == 'l1' and penalty == 'l2' and not dual:
-                assert_raises(ValueError, svm.LinearSVC, penalty=penalty,
-                              loss=loss, dual=dual)
-            elif penalty == 'l1' and dual:
-                assert_raises(ValueError, svm.LinearSVC, penalty=penalty,
-                              loss=loss, dual=dual)
+            clf = svm.LinearSVC(penalty=penalty, loss=loss, dual=dual)
+            if (loss == 'l1' and penalty == 'l1') or (
+                loss == 'l1' and penalty == 'l2' and not dual) or (
+                penalty == 'l1' and dual):
+                assert_raises(ValueError, clf.fit, X, y)
             else:
-                svm.LinearSVC(penalty=penalty, loss=loss, dual=dual)
+                clf.fit(X, y)
 
 
 def test_linearsvc():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -675,7 +675,7 @@ def test_consistent_proba():
 def test_linear_svc_convergence_warnings():
     """Test that warnings are raised if model does not converge"""
 
-    lsvc = svm.LinearSVC(max_iter=2)
+    lsvc = svm.LinearSVC(max_iter=2, verbose=1)
     assert_warns(ConvergenceWarning, lsvc.fit, X, Y)
     assert_equal(lsvc.n_iter_, 2)
 


### PR DESCRIPTION
BaseLibLinear has very little to do with liblinear in master.

This replaces it with a private `_fit_liblinear` function and simplifies the recursive code paths to an extent.
