### PR TITLE
[MRG] Label Encoder Unseen Labels

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -398,7 +398,7 @@ follows::
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder(new_labels='raise')
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
     array([0, 0, 1, 2])
@@ -429,11 +429,11 @@ below).
     >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder(new_labels=-1)
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
-    >>> list(le.get_classes())
+    >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_label_class=-1, new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -418,6 +418,20 @@ hashable and comparable) to numerical labels::
     >>> list(le.inverse_transform([2, 2, 1]))
     ['tokyo', 'tokyo', 'paris']
 
+By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
+labels are passed in ``transform`` that were not seen in ``fit``.  This
+behavior can be handled with the ``new_labels`` parameter, which supports
+``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
+handling new labels.  For example, the ``"label"`` strategy will assign
+the unseen values a label of ``-1``.
+
+    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
+    LabelEncoder(new_label_class=-1, new_labels='label')
+    >>> list(le.classes_)
+    ['amsterdam', 'paris', 'tokyo']
+    >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
+    array([ 2,  2,  1, -1])
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -398,8 +398,8 @@ follows::
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
     LabelEncoder(new_labels='raise')
-    >>> le.classes_
-    array([1, 2, 6])
+    >>> list(le.get_classes())
+    [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
     array([0, 0, 1, 2])
     >>> le.inverse_transform([0, 0, 1, 2])
@@ -429,11 +429,11 @@ below).
     >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder(new_labels=-1)
-    >>> le.get_classes()
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
-    >>> le.get_classes()
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels=None)
+    LabelEncoder(classes=None, new_labels=None)
     >>> list(le.classes_)
     [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels=None)
+    LabelEncoder(classes=None, new_labels=None)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -426,7 +426,7 @@ below).
 
     >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels=-1)
+    LabelEncoder(classes=None, new_labels=-1)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
+    LabelEncoder(new_labels='raise')
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
+    LabelEncoder(new_labels='raise')
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -421,17 +421,20 @@ hashable and comparable) to numerical labels::
 By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
 labels are passed in ``transform`` that were not seen in ``fit``.  This
 behavior can be handled with the ``new_labels`` parameter, which supports
-``"raise"``, ``"nan"``, ``"update"``, and ``"label"`` strategies for
-handling new labels.  For example, the ``"label"`` strategy will assign
-the unseen values a label of ``-1``.
+``"raise"``, ``"update"``, and integer strategies for
+handling new labels.  For example, the integer strategy will assign
+the unseen values an arbitrary, user-specified integer label (e.g., ``-1``
+below).
 
-    >>> le = preprocessing.LabelEncoder(new_labels="label")
+    >>> le = preprocessing.LabelEncoder(new_labels=-1)
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='label')
-    >>> list(le.classes_)
+    LabelEncoder(new_labels=-1)
+    >>> le.get_classes()
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
+    >>> le.get_classes()
+    ['amsterdam', 'paris', 'tokyo', 'rome']
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -397,7 +397,7 @@ follows::
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_labels=None)
     >>> list(le.classes_)
     [1, 2, 6]
     >>> le.transform([1, 1, 2, 6])
@@ -410,7 +410,7 @@ hashable and comparable) to numerical labels::
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder(new_labels=None)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"])
@@ -420,9 +420,7 @@ hashable and comparable) to numerical labels::
 
 By default, ``LabelEncoder`` will throw a ``ValueError`` in the event that
 labels are passed in ``transform`` that were not seen in ``fit``.  This
-behavior can be handled with the ``new_labels`` parameter, which supports
-``"raise"``, ``"update"``, and integer strategies for
-handling new labels.  For example, the integer strategy will assign
+behavior can be handled with the ``new_labels`` parameter, which will assign
 the unseen values an arbitrary, user-specified integer label (e.g., ``-1``
 below).
 
@@ -433,8 +431,6 @@ below).
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
-    >>> list(le.classes_)
-    ['amsterdam', 'paris', 'rome', 'tokyo']
 
 Imputation of missing values
 ============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -434,7 +434,7 @@ below).
     >>> le.transform(["tokyo", "tokyo", "paris", "rome"])
     array([ 2,  2,  1, -1])
     >>> list(le.classes_)
-    ['amsterdam', 'paris', 'tokyo', 'rome']
+    ['amsterdam', 'paris', 'rome', 'tokyo']
 
 Imputation of missing values
 ============================

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -260,7 +260,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self._check_fitted()
 
         y = np.asarray(y)
-        return self.classes_[y]
+        return self.get_classes()[y]
 
 
 class LabelBinarizer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -68,12 +68,14 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If an integer value is passed, then re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
           taken if a non-negative value is passed to not accidentally
-          intersect.
+          intersect.  Additionally, ``inverse_transform`` will fail for a
+          value that does not intersect with the ``fit``-time label set.
 
     Attributes
     ----------
     `classes_` : array of shape (n_class,)
-        Holds the label for each class.
+        Holds the label for each class that were seen at fit.  See
+        ``get_classes()`` to retrieve all observed labels.
 
     `new_label_mapping_` : dictionary
         Stores the mapping for classes not seen during original ``fit``.
@@ -130,6 +132,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         # If we've seen updates, include them in the order they were added.
         if len(self.new_label_mapping_) > 0:
+            # Sort the post-fit time labels to return into the class array.
             sorted_new, _ = zip(*sorted(self.new_label_mapping_.iteritems(),
                                         key=operator.itemgetter(1)))
             return np.append(self.classes_, sorted_new)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -57,6 +57,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     Parameters
     ----------
 
+    classes : array-like of shape [n_class], optional (default: None)
+        Holds the label for each class. List of unique sorted labels to encode
+        the target data against. Using this parameter in initilization will
+        allow skipping a call fit before calling transform.
+
+
     new_labels : Int, optional (default: None)
           re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
@@ -76,7 +82,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels=None)
+    LabelEncoder(classes=None, new_labels=None)
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -89,7 +95,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels=None)
+    LabelEncoder(classes=None, new_labels=None)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
@@ -99,12 +105,15 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, new_labels=None):
-        # Check new_labels parameter
+    def __init__(self, classes=None, new_labels=None):
+        if classes is not None:
+            self.classes_ = classes
+
         if new_labels is not None and type(new_labels) is not int:
                 raise ValueError("Value of argument `new_labels`={0} is "
                                  "unknown and not an "
                                  "integer.".format(new_labels))
+
         self.new_labels = new_labels
 
     def _check_fitted(self):
@@ -153,7 +162,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
             Target values.
 
-        classes : array-like, optional (default: None)
+        classes : array-like of shape [n_class], optional (default: None)
             List of unique sorted labels to encode the target data against.
             If None the LabelEncoder must have already been fit and the unique
             labels from the fit will be used.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -133,7 +133,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         # If we've seen updates, include them in the order they were added.
         if len(self.new_label_mapping_) > 0:
             # Sort the post-fit time labels to return into the class array.
-            sorted_new, _ = zip(*sorted(self.new_label_mapping_.iteritems(),
+            sorted_new, _ = zip(*sorted(self.new_label_mapping_.items(),
                                         key=operator.itemgetter(1)))
             return np.append(self.classes_, sorted_new)
         else:

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -228,6 +228,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                                      for value in y[missing_mask]]
                 return out
             elif type(self.new_labels) in [int]:
+                # Update the new label mapping
+                self.new_label_mapping_.update(dict(zip(diff_new,
+                                                        [self.new_labels]
+                                                        * len(diff_new))))
+
                 # Find entries with new labels
                 missing_mask = np.in1d(y, diff_fit)
 
@@ -259,8 +264,24 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         self._check_fitted()
 
+        if type(self.new_labels) in [int]:
+            warnings.warn('When ``new_labels`` uses an integer '
+                          're-labeling strategy, the ``inverse_transform`` '
+                          'is not necessarily one-to-one mapping; any '
+                          'labels not present during initial ``fit`` will '
+                          'not be mapped.',
+                          UserWarning)
+
         y = np.asarray(y)
-        return self.get_classes()[y]
+        try:
+            return self.get_classes()[y]
+        except IndexError:
+            # Raise exception
+            num_classes = len(self.get_classes())
+            raise ValueError("Classes were passed to ``inverse_transform`` "
+                             "with integer new_labels strategy ``fit``-time: "
+                             "{0}"
+                             .format(np.setdiff1d(y, range(num_classes))))
 
 
 class LabelBinarizer(BaseEstimator, TransformerMixin):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -76,7 +76,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder()
+    LabelEncoder(new_labels=None)
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -89,7 +89,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder()
+    LabelEncoder(new_labels=None)
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -57,14 +57,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     Parameters
     ----------
 
-    new_labels : string, optional (default: "raise")
-        Determines how to handle new labels, i.e., data
-        not seen in the training domain.
-
-        - If ``"raise"``, then raise ValueError.
-        - If ``"update"``, then re-map the new labels to
-          classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If an integer value is passed, then re-label with this value.
+    new_labels : Int, optional (default: None)
+          re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
           taken if a non-negative value is passed to not accidentally
           intersect.  Additionally, ``inverse_transform`` will fail for a
@@ -82,7 +76,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder()
     >>> le.classes_
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
@@ -95,7 +89,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_labels='raise')
+    LabelEncoder()
     >>> list(le.classes_)
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
@@ -105,10 +99,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, new_labels="raise"):
+    def __init__(self, new_labels=None):
         # Check new_labels parameter
-        if (new_labels not in ["update", "raise"] and
-            type(new_labels) is not int):
+        if new_labels is not None and type(new_labels) is not int:
                 raise ValueError("Value of argument `new_labels`={0} is "
                                  "unknown and not an "
                                  "integer.".format(new_labels))
@@ -172,25 +165,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
             # Get the new labels
             unseen = np.setdiff1d(classes, self.classes_)
 
-            # If we are mapping new labels, get "new" ID and change in copy.
-            if self.new_labels == "update":
-                # Update the new label mapping
-
-                # XXX there is a more efficient way to do this by inserting
-                # new labels into the sorted .classes_
-                self.classes_ = np.unique(np.concatenate((np.asarray(y),
-                                                         self.classes_)))
-            elif type(self.new_labels) is int:
-                # Update the new label mapping
+            if type(self.new_labels) is int:
                 ret = np.searchsorted(self.classes_, y)
                 ret[np.in1d(y, unseen)] = self.new_labels
-
-                # XXX there is a more efficient way to do this by inserting
-                # new labels into the sorted .classes_
-                self.classes_ = np.unique(np.concatenate((np.asarray(y),
-                                                         self.classes_)))
                 return ret
-            elif self.new_labels == "raise":
+            elif self.new_labels is None:
                 raise ValueError("y contains new label(s): %s" % str(unseen))
             else:
                 # Raise on invalid argument.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -107,7 +107,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     def __init__(self, classes=None, new_labels=None):
         if classes is not None:
-            self.classes_ = classes
+            self.classes_ = np.asarray(classes)
 
         if new_labels is not None and type(new_labels) is not int:
                 raise ValueError("Value of argument `new_labels`={0} is "

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -145,7 +145,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self.classes_, y = np.unique(y, return_inverse=True)
         return y
 
-    def transform(self, y):
+    def transform(self, y, classes=None):
         """Transform labels to normalized encoding.
 
         Parameters
@@ -153,20 +153,27 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y : array-like of shape [n_samples]
             Target values.
 
+        classes : array-like, optional (default: None)
+            List of unique sorted labels to encode the target data against.
+            If None the LabelEncoder must have already been fit and the unique
+            labels from the fit will be used.
+
         Returns
         -------
         y : array-like of shape [n_samples]
         """
-        self._check_fitted()
+        if classes is None:
+            self._check_fitted()
+            classes = self.classes_
 
-        classes = np.unique(y)
-        _check_numpy_unicode_bug(classes)
-        if len(np.intersect1d(classes, self.classes_)) < len(classes):
+        y_classes = np.unique(y)
+        _check_numpy_unicode_bug(y_classes)
+        if len(np.intersect1d(y_classes, classes)) < len(y_classes):
             # Get the new labels
-            unseen = np.setdiff1d(classes, self.classes_)
+            unseen = np.setdiff1d(y_classes, classes)
 
             if type(self.new_labels) is int:
-                ret = np.searchsorted(self.classes_, y)
+                ret = np.searchsorted(classes, y)
                 ret[np.in1d(y, unseen)] = self.new_labels
                 return ret
             elif self.new_labels is None:
@@ -176,7 +183,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 raise ValueError("Value of argument `new_labels`={0} is "
                                  "unknown.".format(self.new_labels))
 
-        return np.searchsorted(self.classes_, y)
+        return np.searchsorted(classes, y)
 
     def inverse_transform(self, y):
         """Transform labels back to original encoding.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -4,13 +4,13 @@
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Hamzeh Alsalhi <ha258@cornell.edu>
+#          Michael Bommarito <michael@bommaritollc.com>
 # License: BSD 3 clause
 
 from collections import defaultdict
 import itertools
 import array
 import warnings
-import operator
 
 import operator
 import numpy as np
@@ -65,7 +65,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         - If ``"raise"``, then raise ValueError.
         - If ``"update"``, then re-map the new labels to
           classes ``[N, ..., N+m-1]``, where ``m`` is the number of new labels.
-        - If an integer value is passed, then use re-label with this value.
+        - If an integer value is passed, then re-label with this value.
           N.B. that default values are in [0, 1, ...], so caution should be
           taken if a non-negative value is passed to not accidentally
           intersect.
@@ -85,8 +85,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit([1, 2, 2, 6])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
-    >>> le.classes_
+    LabelEncoder(new_labels='raise')
+    >>> le.get_classes()
     array([1, 2, 6])
     >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
     array([0, 0, 1, 2]...)
@@ -98,8 +98,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     >>> le = preprocessing.LabelEncoder()
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
-    LabelEncoder(new_label_class=-1, new_labels='raise')
-    >>> list(le.classes_)
+    LabelEncoder(new_labels='raise')
+    >>> list(le.get_classes())
     ['amsterdam', 'paris', 'tokyo']
     >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
     array([2, 2, 1]...)

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -187,10 +187,6 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
                 return ret
             elif self.new_labels is None:
                 raise ValueError("y contains new label(s): %s" % str(unseen))
-            else:
-                # Raise on invalid argument.
-                raise ValueError("Value of argument `new_labels`={0} is "
-                                 "unknown.".format(self.new_labels))
 
         return np.searchsorted(classes, y)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -12,7 +12,6 @@ import itertools
 import array
 import warnings
 
-import operator
 import numpy as np
 import scipy.sparse as sp
 
@@ -108,9 +107,11 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
     def __init__(self, new_labels="raise"):
         # Check new_labels parameter
-        if new_labels not in ["update", "raise"] and type(new_labels) is not int:
-            raise ValueError("Value of argument `new_labels`={0} is unknown "
-                             "and not an integer.".format(new_labels))
+        if (new_labels not in ["update", "raise"] and
+            type(new_labels) is not int):
+                raise ValueError("Value of argument `new_labels`={0} is "
+                                 "unknown and not an "
+                                 "integer.".format(new_labels))
         self.new_labels = new_labels
 
     def _check_fitted(self):
@@ -505,7 +506,8 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
         allow for fitting to classes independently of the transform operation
     """
     if not isinstance(y, list):
-        # XXX Workaround that will be removed when list of list format is dropped
+        # XXX Workaround that will be removed when list of list format is
+        # dropped
         y = check_array(y, accept_sparse='csr', ensure_2d=False)
     if neg_label >= pos_label:
         raise ValueError("neg_label={0} must be strictly less than "

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,16 +210,6 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
-def test_label_encoder_get_classes():
-    """Test LabelEncoder's get_classes method."""
-    le = LabelEncoder(new_labels="update")
-    le.fit([1, 1, 4, 5, -1, 0])
-    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
-    assert_array_equal(le.classes_, le.classes_)
-    le.transform([10])
-    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5, 10])
-
-
 def test_label_encoder_new_label_update():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels="update")
@@ -229,33 +219,33 @@ def test_label_encoder_new_label_update():
                        [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]),
                        ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "_"]),
+    # Unseen label "d"
+    assert_array_equal(le.transform(["b", "c", "d"]),
                        [1, 2, 3])
-    assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
-    assert_array_equal(le.transform(["_", "z", "a"]),
+    assert_array_equal(le.classes_, ["a", "b", "c", "d"])
+    assert_array_equal(le.transform(["d", "z", "a"]),
                        [3, 4, 0])
     assert_array_equal(le.inverse_transform([3, 4, 0]),
-                       ["_", "z", "a"])
+                       ["d", "z", "a"])
 
 
-def test_label_encoder_new_label_replace():
-    """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels=-99)
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, -99])
-    assert_warns(UserWarning, le.inverse_transform, [2, 1, 0])
+# def test_label_encoder_new_label_replace():
+#     """Test LabelEncoder's transform on new labels"""
+#     le = LabelEncoder(new_labels=-99)
+#     le.fit(["a", "b", "b", "c"])
+#     assert_array_equal(le.classes_, ["a", "b", "c"])
+#     assert_array_equal(le.transform(["a", "a", "c"]),
+#                        [0, 0, 2])
+#     assert_array_equal(le.inverse_transform([2, 1, 0]),
+#                        ["c", "b", "a"])
+#     assert_array_equal(le.transform(["b", "c", "d"]),
+#                        [1, 2, -99])
+#     assert_warns(UserWarning, le.inverse_transform, [2, 1, 0])
 
 
 def test_label_encoder_new_label_arg():
-    """Test LabelEncoder's  new_labels argument handling"""
-    le = LabelEncoder(new_labels="xyz")
-    assert_raises(ValueError, le.fit, ["a", "b", "b", "c"])
+    """Test LabelEncoder's new_labels argument handling"""
+    assert_raises(ValueError, LabelEncoder, "xyz")
 
 
 def test_label_encoder_fit_transform():
@@ -274,6 +264,9 @@ def test_label_encoder_errors():
     le = LabelEncoder()
     assert_raises(ValueError, le.transform, [])
     assert_raises(ValueError, le.inverse_transform, [])
+
+    # Fail on unrecognized vlaue for the 'new_label' parameter 
+    assert_raises(ValueError, LabelEncoder, "xyz")
 
 
 def test_sparse_output_multilabel_binarizer():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -215,10 +215,9 @@ def test_label_encoder_get_classes():
     le = LabelEncoder(new_labels="update")
     le.fit([1, 1, 4, 5, -1, 0])
     assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
-    assert_array_equal(le.classes_, le.get_classes())
+    assert_array_equal(le.classes_, le.classes_)
     le.transform([10])
-    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
-    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5, 10])
 
 
 def test_label_encoder_new_label_update():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -220,6 +220,15 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.transform(["b", "c", "d"]), [1, 2, -99])
 
 
+def test_label_encoder_classes_parameter():
+    """Test LabelEncoder's classes parameter"""
+    le = LabelEncoder(classes=["a", "b", "c"], new_labels=None)
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["c", "a", "b", "c"],), [2, 0, 1, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]), ["c", "b", "a"])
+    assert_raises(ValueError, le.transform, ["b", "c", "d"])
+
+
 def test_label_encoder_transform_classes_parameter():
     """Test LabelEncoder's transform using the classes parameter"""
     le = LabelEncoder(new_labels=None)
@@ -248,8 +257,8 @@ def test_label_encoder_errors():
     le = LabelEncoder()
     assert_raises(ValueError, le.transform, [])
     assert_raises(ValueError, le.inverse_transform, [])
-    # Fail on unrecognized vlaue for the 'new_label' parameter
-    assert_raises(ValueError, LabelEncoder, "xyz")
+    # Fail on unrecognized value for the 'new_label' parameter
+    assert_raises(ValueError, LabelEncoder, new_labels="xyz")
 
 
 def test_sparse_output_multilabel_binarizer():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -229,18 +229,15 @@ def test_label_encoder_new_label_update():
                        ["d", "z", "a"])
 
 
-# def test_label_encoder_new_label_replace():
-#     """Test LabelEncoder's transform on new labels"""
-#     le = LabelEncoder(new_labels=-99)
-#     le.fit(["a", "b", "b", "c"])
-#     assert_array_equal(le.classes_, ["a", "b", "c"])
-#     assert_array_equal(le.transform(["a", "a", "c"]),
-#                        [0, 0, 2])
-#     assert_array_equal(le.inverse_transform([2, 1, 0]),
-#                        ["c", "b", "a"])
-#     assert_array_equal(le.transform(["b", "c", "d"]),
-#                        [1, 2, -99])
-#     assert_warns(UserWarning, le.inverse_transform, [2, 1, 0])
+def test_label_encoder_new_label_replace():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels=-99)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]), [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]), ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]), [1, 2, -99])
+    assert_array_equal(le.inverse_transform([3, 1, 0]), ["d", "b", "a"])
 
 
 def test_label_encoder_new_label_arg():
@@ -264,7 +261,6 @@ def test_label_encoder_errors():
     le = LabelEncoder()
     assert_raises(ValueError, le.transform, [])
     assert_raises(ValueError, le.inverse_transform, [])
-
     # Fail on unrecognized vlaue for the 'new_label' parameter 
     assert_raises(ValueError, LabelEncoder, "xyz")
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -240,11 +240,6 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.inverse_transform([3, 1, 0]), ["d", "b", "a"])
 
 
-def test_label_encoder_new_label_arg():
-    """Test LabelEncoder's new_labels argument handling"""
-    assert_raises(ValueError, LabelEncoder, "xyz")
-
-
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()
@@ -261,7 +256,7 @@ def test_label_encoder_errors():
     le = LabelEncoder()
     assert_raises(ValueError, le.transform, [])
     assert_raises(ValueError, le.inverse_transform, [])
-    # Fail on unrecognized vlaue for the 'new_label' parameter 
+    # Fail on unrecognized vlaue for the 'new_label' parameter
     assert_raises(ValueError, LabelEncoder, "xyz")
 
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -235,6 +235,8 @@ def test_label_encoder_new_label_update():
     assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
     assert_array_equal(le.transform(["_", "z", "a"]),
                        [3, 4, 0])
+    assert_array_equal(le.inverse_transform([3, 4, 0]),
+                       ["_", "z", "a"])
 
 
 def test_label_encoder_new_label_replace():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -220,6 +220,18 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.transform(["b", "c", "d"]), [1, 2, -99])
 
 
+def test_label_encoder_transform_classes_parameter():
+    """Test LabelEncoder's transform using the classes parameter"""
+    le = LabelEncoder(new_labels=None)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["d", "f", "e", "e"],
+                                    classes=["d", "e", "f"]),
+                       [0, 2, 1, 1])
+    assert_array_equal(le.inverse_transform([2, 1, 0]), ["c", "b", "a"])
+    assert_raises(ValueError, le.transform, ["b", "c", "d"])
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,25 +210,6 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
-def test_label_encoder_new_label_update():
-    """Test LabelEncoder's transform on new labels"""
-    le = LabelEncoder(new_labels="update")
-    le.fit(["a", "b", "b", "c"])
-    assert_array_equal(le.classes_, ["a", "b", "c"])
-    assert_array_equal(le.transform(["a", "a", "c"]),
-                       [0, 0, 2])
-    assert_array_equal(le.inverse_transform([2, 1, 0]),
-                       ["c", "b", "a"])
-    # Unseen label "d"
-    assert_array_equal(le.transform(["b", "c", "d"]),
-                       [1, 2, 3])
-    assert_array_equal(le.classes_, ["a", "b", "c", "d"])
-    assert_array_equal(le.transform(["d", "z", "a"]),
-                       [3, 4, 0])
-    assert_array_equal(le.inverse_transform([3, 4, 0]),
-                       ["d", "z", "a"])
-
-
 def test_label_encoder_new_label_replace():
     """Test LabelEncoder's transform on new labels"""
     le = LabelEncoder(new_labels=-99)
@@ -237,7 +218,6 @@ def test_label_encoder_new_label_replace():
     assert_array_equal(le.transform(["a", "a", "c"]), [0, 0, 2])
     assert_array_equal(le.inverse_transform([2, 1, 0]), ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "d"]), [1, 2, -99])
-    assert_array_equal(le.inverse_transform([3, 1, 0]), ["d", "b", "a"])
 
 
 def test_label_encoder_fit_transform():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -250,6 +250,7 @@ def test_label_encoder_new_label_replace():
                        ["c", "b", "a"])
     assert_array_equal(le.transform(["b", "c", "d"]),
                        [1, 2, -99])
+    assert_warns(UserWarning, le.inverse_transform, [2, 1, 0])
 
 
 def test_label_encoder_new_label_arg():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -210,6 +210,52 @@ def test_label_encoder():
     assert_raises(ValueError, le.transform, [0, 6])
 
 
+def test_label_encoder_get_classes():
+    """Test LabelEncoder's get_classes method."""
+    le = LabelEncoder(new_labels="update")
+    le.fit([1, 1, 4, 5, -1, 0])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.classes_, le.get_classes())
+    le.transform([10])
+    assert_array_equal(le.classes_, [-1, 0, 1, 4, 5])
+    assert_array_equal(le.get_classes(), [-1, 0, 1, 4, 5, 10])
+
+
+def test_label_encoder_new_label_update():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels="update")
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "_"]),
+                       [1, 2, 3])
+    assert_array_equal(le.get_classes(), ["a", "b", "c", "_"])
+    assert_array_equal(le.transform(["_", "z", "a"]),
+                       [3, 4, 0])
+
+
+def test_label_encoder_new_label_replace():
+    """Test LabelEncoder's transform on new labels"""
+    le = LabelEncoder(new_labels=-99)
+    le.fit(["a", "b", "b", "c"])
+    assert_array_equal(le.classes_, ["a", "b", "c"])
+    assert_array_equal(le.transform(["a", "a", "c"]),
+                       [0, 0, 2])
+    assert_array_equal(le.inverse_transform([2, 1, 0]),
+                       ["c", "b", "a"])
+    assert_array_equal(le.transform(["b", "c", "d"]),
+                       [1, 2, -99])
+
+
+def test_label_encoder_new_label_arg():
+    """Test LabelEncoder's  new_labels argument handling"""
+    le = LabelEncoder(new_labels="xyz")
+    assert_raises(ValueError, le.fit, ["a", "b", "b", "c"])
+
+
 def test_label_encoder_fit_transform():
     """Test fit_transform"""
     le = LabelEncoder()


### PR DESCRIPTION
This is a pull request to adopt the work done by @mjbommar at #3483

This PR intends to make preprocessing.LabelEncoder more friendly for production/pipeline usage by adding a new_labels constructor argument.

Instead of always raising ValueError for unseen/new labels in transform, LabelEncoder may be initialized with new_labels as:
- [x] None: current behavior, i.e., raise ValueError; to remain default behavior
- [x] ~~"update": update classes with new IDs [N, ..., N+m-1] for m new labels and assign~~
- [x] an integer value: set newly seen labels to have fixed value corresponding to this integer value
- [x] Add classes parameter to transform function
- [x] Classes parameter during initilization
