### PR TITLE
[MRG] FIX update sklearn.__all__ to include all end-user submodules

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -36,14 +36,19 @@ if __SKLEARN_SETUP__:
 else:
     from . import __check_build
     from .base import clone
+    __check_build  # avoid flakes unused variable error
 
-    __all__ = ['cross_validation', 'cluster', 'covariance',
-               'datasets', 'decomposition', 'feature_extraction',
-               'feature_selection', 'semi_supervised',
-               'gaussian_process', 'grid_search', 'hmm', 'lda', 'linear_model',
-               'metrics', 'mixture', 'naive_bayes', 'neighbors', 'pipeline',
-               'preprocessing', 'qda', 'svm', 'clone',
-               'cross_decomposition', 'isotonic']
+    __all__ = ['cluster', 'covariance', 'cross_decomposition',
+               'cross_validation', 'datasets', 'decomposition', 'dummy',
+               'ensemble', 'externals', 'feature_extraction',
+               'feature_selection', 'gaussian_process', 'grid_search', 'hmm',
+               'isotonic', 'kernel_approximation', 'lda', 'learning_curve',
+               'linear_model', 'manifold', 'metrics', 'mixture', 'multiclass',
+               'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
+               'preprocessing', 'qda', 'random_projection', 'semi_supervised',
+               'svm', 'tree',
+               # Non-modules:
+               'clone']
 
 
 def setup_module(module):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -17,7 +17,9 @@ from sklearn.externals.six.moves import zip
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import all_estimators
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import SkipTest
+from sklearn.utils.testing import ignore_warnings
 
 import sklearn
 from sklearn.base import (ClassifierMixin, RegressorMixin,
@@ -285,12 +287,14 @@ def test_estimators_overwrite_params():
                 yield check_estimators_overwrite_params, name, Estimator
 
 
+@ignore_warnings
 def test_import_all_consistency():
     # Smoke test to check that any name in a __all__ list is actually defined
     # in the namespace of the module or package.
     pkgs = pkgutil.walk_packages(path=sklearn.__path__, prefix='sklearn.',
                                  onerror=lambda _: None)
-    for importer, modname, ispkg in pkgs:
+    submods = [modname for _, modname, _ in pkgs]
+    for modname in submods + ['sklearn']:
         if ".tests." in modname:
             continue
         package = __import__(modname, fromlist="dummy")
@@ -299,6 +303,15 @@ def test_import_all_consistency():
                 raise AttributeError(
                     "Module '{0}' has no attribute '{1}'".format(
                         modname, name))
+
+
+def test_root_import_all_completeness():
+    EXCEPTIONS = ('utils', 'tests', 'base', 'setup')
+    for _, modname, _ in pkgutil.walk_packages(path=sklearn.__path__,
+                                               onerror=lambda _: None):
+        if '.' in modname or modname.startswith('_') or modname in EXCEPTIONS:
+            continue
+        assert_in(modname, sklearn.__all__)
 
 
 def test_sparsify_estimators():


### PR DESCRIPTION
`sklearn.__all__` appears to have been populated with something like the following in mind:

``` python
from sklearn import *
iris = datasets.load_iris()
clf = linear_model.LogisticRegression().fit(iris.data, iris.target)
```

This PR fixes #3615 which notes that **all** is not up-to-date. This PR adds a test to ensure that the list is maintained, while making exceptions explicit. `test_import_all_consistency` is extended to ensure that the entire contents of `sklearn.__all__` is (not only complete but) valid.
