### PR TITLE
[MRG+1] FIX heisenfailure in test_lasso_lars_path_length

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -202,7 +202,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
         alpha[0] = C / n_samples
         if alpha[0] <= alpha_min:  # early stopping
-            if not (abs(alpha[0] - alpha_min) < tiny):
+            if not (abs(alpha[0] - alpha_min) < 10 * tiny32):
                 # interpolation factor 0 <= ss < 1
                 if n_iter > 0:
                     # In the first iteration, all alphas are zero, the formula


### PR DESCRIPTION
Tentative fix for #3370: random failure under Python 32 bit and Windows.

The failure is very rare so I am not 100% sure that this fixes it. Appveyor will tell over time. In the mean time I do a PR here to have travis check that this does not cause a failure in some other test.
