### PR TITLE
[WIP] Refactor scaler code

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -72,7 +72,7 @@ This class is hence suitable for use in the early steps of a
 :class:`sklearn.pipeline.Pipeline`::
 
   >>> scaler = preprocessing.StandardScaler().fit(X)
-  >>> scaler
+  >>> scaler                                        # doctest: +NORMALIZE_WHITESPACE
   StandardScaler(copy=True, with_mean=True, with_std=True)
 
   >>> scaler.mean_                                      # doctest: +ELLIPSIS
@@ -132,11 +132,11 @@ applied to be consistent with the transformation performed on the train data::
 It is possible to introspect the scaler attributes to find about the exact
 nature of the transformation learned on the training data::
 
-  >>> min_max_scaler.scale_                             # doctest: +ELLIPSIS
-  array([ 0.5       ,  0.5       ,  0.33...])
+  >>> min_max_scaler.scale_                             # doctest: +NORMALIZE_WHITESPACE
+  array([ 0.5       ,  0.5       ,  0.33333333])
 
   >>> min_max_scaler.min_                               # doctest: +ELLIPSIS
-  array([ 0.        ,  0.5       ,  0.33...])
+  array([ 0.        ,  0.5       ,  0.33333333])
 
 If :class:`MinMaxScaler` is given an explicit ``feature_range=(min, max)`` the
 full formula is::

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -330,10 +330,10 @@ def make_pipeline(*steps):
     --------
     >>> from sklearn.naive_bayes import GaussianNB
     >>> from sklearn.preprocessing import StandardScaler
+    >>> from sklearn.pipeline import make_pipeline
     >>> make_pipeline(StandardScaler(), GaussianNB())    # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(steps=[('standardscaler',
-                     StandardScaler(copy=True, with_mean=True, with_std=True)),
-                    ('gaussiannb', GaussianNB())])
+        Pipeline(steps=[('standardscaler', StandardScaler(copy=True,
+                 with_mean=True, with_std=True)), ('gaussiannb', GaussianNB())])
 
     Returns
     -------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -231,11 +231,20 @@ class MinMaxScaler(BaseScaler):
         self.scalefactor_ = data_range / (feature_range[1] - feature_range[0])
         self.center_ = data_min - feature_range[0] * self.scalefactor_
 
-        self.scale_ = (feature_range[1] - feature_range[0]) / data_range
-        self.min_ = feature_range[0] - data_min * self.scale_
-        self.data_range = data_range
-        self.data_min = data_min
+        # pre 0.17-
+        self._scale = (feature_range[1] - feature_range[0]) / data_range
+        self._min = feature_range[0] - data_min * self.scale_
         return self
+
+    @property
+    def min_(self):
+        check_is_fitted(self, 'center_')
+        return self._min
+
+    @property
+    def scale_(self):
+        check_is_fitted(self, 'scalefactor_')
+        return self._scale
 
 
 class StandardScaler(BaseScaler):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -274,10 +274,7 @@ def test_scaler_without_centering():
     X_csc_scaled = scaler_csr.transform(X_csc, copy=True)
     assert_false(np.any(np.isnan(X_csc_scaled.data)))
 
-    assert_equal(scaler.mean_, scaler_csr.mean_)
     assert_array_almost_equal(scaler.std_, scaler_csr.std_)
-
-    assert_equal(scaler.mean_, scaler_csc.mean_)
     assert_array_almost_equal(scaler.std_, scaler_csc.std_)
 
     assert_array_almost_equal(
@@ -343,10 +340,7 @@ def test_scaler_int():
         X_csc_scaled = scaler_csr.transform(X_csc, copy=True)
     assert_false(np.any(np.isnan(X_csc_scaled.data)))
 
-    assert_equal(scaler.mean_, scaler_csr.mean_)
     assert_array_almost_equal(scaler.std_, scaler_csr.std_)
-
-    assert_equal(scaler.mean_, scaler_csc.mean_)
     assert_array_almost_equal(scaler.std_, scaler_csc.std_)
 
     assert_array_almost_equal(
@@ -440,9 +434,6 @@ def test_scale_function_without_centering():
     # test csc has same outcome
     X_csc_scaled = scale(X_csr.tocsc(), with_mean=False)
     assert_array_almost_equal(X_scaled, X_csc_scaled.toarray())
-
-    # raises value error on axis != 0
-    assert_raises(ValueError, scale, X_csr, with_mean=False, axis=1)
 
     assert_array_almost_equal(X_scaled.mean(axis=0),
                               [0., -0.01, 2.24, -0.35, -0.78], 2)


### PR DESCRIPTION
This PR refactors the scalers in `preprocessing` to use a common baseclass (`BaseScaler`). This is done to share some common functionality / avoid code duplication. This PR is part of a series of PR that split up #2514 , and other PRs in this series intend to introduce new scalers that will make use of `BaseScaler` (e.g. a scaler that uses robust statistics).

There is one issues with this PR that needs to be discussed:

All scalers (both the existing ones and the one's I'm going to introduce) do center the data and then scale it to fall into some range. So in essence, all layers do

```
(x - some_centering_statistic) / some_scaling_statistic
```

for each feature-column x.  The existing scalers already have attributes that expose their centering/scaling statistic, however those are not uniformly named.  I propose that the  `StandardScaler.mean_`/`StandardScaler.std_`/`MinMaxScaler.scale_` and `MinMaxScaler.min_` properties are being deprecated and replaced with `*.center_`/`*.scale_`, and the `with_mean`/`with_std` constructer arguments be renamed to `with_centering`/`with_scaling`.

@larsmans already said back in #2514 that he is against renaming the `mean_`/`std_` attributes, since the scaler API should be stable. An additional problem is that my proposal would change the meaning of `MinMaxScaler.scale_` (as the previous implementation used a slightly different math to arrive at the same scaling result).   This will of course break user code that uses `MinMaxScaler.scale_` and relies on its current implementation.  (NOTE: I had overlooked this when proposing #2514 and just noticed it when preparing this PR)

There are several ways to deal with this:
- don't expose the new `scale_`/`center_` arguments in StandardScaler/MinMaxScaler, and just keep the old `mean_`/`std_`/`scale_` arguments.
- deprecate `mean_`/`std_` and remove them after a few releases. Print a warning   whenever a user uses `scale_` on `MinMaxScaler` that the value has changed.
- ???

I would really appreciate any input on what the right thing to do here is!

_NOTE:_ As side-effect of this PR, `StandardScaler` and `MinMaxScaler` gain the ability to scale on other rows/samples instead of just columns/features (i.e., it is possible to use `axis=1`). However, no tests for this new functionality is included in this PR. This is because I intend to send another PR tomorrow that refactors the tests in this module (and adds the tests for `axis = 1`). I just thought that splitting up the tests makes it easier to review the changes (but I can add that other PR to this one if you wish).
