### PR TITLE
[MRG+1] FIX consensus score on non-square similarity matrices

### DIFF
--- a/sklearn/metrics/cluster/bicluster.py
+++ b/sklearn/metrics/cluster/bicluster.py
@@ -82,4 +82,4 @@ def consensus_score(a, b, similarity="jaccard"):
     indices = linear_assignment(1. - matrix)
     n_a = len(a[0])
     n_b = len(b[0])
-    return np.trace(matrix[:, indices[:, 1]]) / max(n_a, n_b)
+    return matrix[indices[:, 0], indices[:, 1]].sum() / max(n_a, n_b)

--- a/sklearn/metrics/cluster/tests/test_bicluster.py
+++ b/sklearn/metrics/cluster/tests/test_bicluster.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_equal, assert_almost_equal
 
 from sklearn.metrics.cluster.bicluster import _jaccard
 from sklearn.metrics import consensus_score
@@ -34,3 +34,17 @@ def test_consensus_score():
     assert_equal(consensus_score((a, a), (a, b)), 0)
     assert_equal(consensus_score((b, b), (a, b)), 0)
     assert_equal(consensus_score((b, b), (b, a)), 0)
+
+
+def test_consensus_score_issue2445():
+    ''' Different number of biclusters in A and B'''
+    a_rows = np.array([[True, True, False, False],
+                       [False, False, True, True],
+                       [False, False, False, True]])
+    a_cols = np.array([[True, True, False, False],
+                       [False, False, True, True],
+                       [False, False, False, True]])
+    idx = [0, 2]
+    s = consensus_score((a_rows, a_cols), (a_rows[idx], a_cols[idx]))
+    # B contains 2 of the 3 biclusters in A, so score should be 2/3
+    assert_almost_equal(s, 2.0/3.0)


### PR DESCRIPTION
This PR fixes #2445: When similarity matrices are non-square, the `bicluster.consensus_score` gave wrong results. 
