### PR TITLE
[MRG] Prediction variance in bagging-based regressors

### DIFF
--- a/examples/gaussian_process/plot_gp_probabilistic_classification_after_regression.py
+++ b/examples/gaussian_process/plot_gp_probabilistic_classification_after_regression.py
@@ -65,8 +65,7 @@ x1, x2 = np.meshgrid(np.linspace(- lim, lim, res),
 xx = np.vstack([x1.reshape(x1.size), x2.reshape(x2.size)]).T
 
 y_true = g(xx)
-y_pred, MSE = gp.predict(xx, eval_MSE=True)
-sigma = np.sqrt(MSE)
+y_pred, sigma = gp.predict(xx, with_std=True)
 y_true = y_true.reshape((res, res))
 y_pred = y_pred.reshape((res, res))
 sigma = sigma.reshape((res, res))

--- a/examples/gaussian_process/plot_gp_regression.py
+++ b/examples/gaussian_process/plot_gp_regression.py
@@ -52,7 +52,7 @@ X = np.atleast_2d([1., 3., 5., 6., 7., 8.]).T
 y = f(X).ravel()
 
 # Mesh the input space for evaluations of the real function, the prediction and
-# its MSE
+# its standard deviation
 x = np.atleast_2d(np.linspace(0, 10, 1000)).T
 
 # Instanciate a Gaussian Process model
@@ -62,12 +62,11 @@ gp = GaussianProcess(corr='cubic', theta0=1e-2, thetaL=1e-4, thetaU=1e-1,
 # Fit to data using Maximum Likelihood Estimation of the parameters
 gp.fit(X, y)
 
-# Make the prediction on the meshed x-axis (ask for MSE as well)
-y_pred, MSE = gp.predict(x, eval_MSE=True)
-sigma = np.sqrt(MSE)
+# Make the prediction on the meshed x-axis (ask for standard deviation as well)
+y_pred, sigma = gp.predict(x, with_std=True)
 
 # Plot the function, the prediction and the 95% confidence interval based on
-# the MSE
+# the standard deviation
 fig = pl.figure()
 pl.plot(x, f(x), 'r:', label=u'$f(x) = x\,\sin(x)$')
 pl.plot(X, y, 'r.', markersize=10, label=u'Observations')
@@ -93,7 +92,7 @@ noise = np.random.normal(0, dy)
 y += noise
 
 # Mesh the input space for evaluations of the real function, the prediction and
-# its MSE
+# its standard deviation
 x = np.atleast_2d(np.linspace(0, 10, 1000)).T
 
 # Instanciate a Gaussian Process model
@@ -105,12 +104,11 @@ gp = GaussianProcess(corr='squared_exponential', theta0=1e-1,
 # Fit to data using Maximum Likelihood Estimation of the parameters
 gp.fit(X, y)
 
-# Make the prediction on the meshed x-axis (ask for MSE as well)
-y_pred, MSE = gp.predict(x, eval_MSE=True)
-sigma = np.sqrt(MSE)
+# Make the prediction on the meshed x-axis (ask for standard deviation as well)
+y_pred, sigma = gp.predict(x, with_std=True)
 
 # Plot the function, the prediction and the 95% confidence interval based on
-# the MSE
+# the standard deviation
 fig = pl.figure()
 pl.plot(x, f(x), 'r:', label=u'$f(x) = x\,\sin(x)$')
 pl.errorbar(X.ravel(), y, dy, fmt='r.', markersize=10, label=u'Observations')

--- a/examples/plot_predictive_standard_deviation.py
+++ b/examples/plot_predictive_standard_deviation.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+==============================================================
+Comparison of predictive distributions of different regressors
+==============================================================
+
+A simple one-dimensional regression problem adressed by three different
+regressors:
+
+1. A Gaussian Process
+2. A Random Forest
+3. A Bagging-based Regressor
+
+The regressors are fitted based on noisy observations where the magnitude of
+the noise at the different training point varies and is known. Plotted are
+both the mean and the pointwise 95% confidence interval of the predictions.
+
+This example is based on the example gaussian_process/plot_gp_regression.py.
+
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+import numpy as np
+from sklearn.gaussian_process import GaussianProcess
+from sklearn.ensemble import RandomForestRegressor, BaggingRegressor
+from matplotlib import pyplot as pl
+
+np.random.seed(1)
+
+
+def f(x):
+    """The function to predict."""
+    return x * np.sin(x)
+
+X = np.linspace(0.1, 9.9, 20)
+X = np.atleast_2d(X).T
+
+# Observations and noise
+y = f(X).ravel()
+dy = 0.5 + 1.0 * np.random.random(y.shape)
+noise = np.random.normal(0, dy)
+y += noise
+
+# Mesh the input space for evaluations of the real function, the prediction and
+# its standard deviation
+x = np.atleast_2d(np.linspace(0, 10, 1000)).T
+
+regrs = {"gaussian_process": GaussianProcess(corr='squared_exponential',
+                                             theta0=1e-1, thetaL=1e-3,
+                                             thetaU=1, nugget=(dy / y) ** 2,
+                                             random_start=100),
+         "random_forest": RandomForestRegressor(n_estimators=250),
+         "bagging": BaggingRegressor(n_estimators=250)}
+
+
+# Plot predictive distributions of different regressors
+fig = pl.figure()
+colors = {"gaussian_process": 'b', "random_forest": 'g', "bagging": 'c'}
+for name, regr in regrs.items():
+    regr.fit(X, y)
+
+    # Make the prediction on the meshed x-axis (ask for standard deviation
+    # as well)
+    y_pred, sigma = regr.predict(x, with_std=True)
+
+    # Plot 95% confidence interval based on the predictive standard deviation
+    pl.plot(x, y_pred, colors[name], label=name)
+    pl.fill(np.concatenate([x, x[::-1]]),
+            np.concatenate([y_pred - 1.9600 * sigma,
+                           (y_pred + 1.9600 * sigma)[::-1]]),
+            alpha=.3, fc=colors[name], ec='None')
+
+# Plot the function and the observations
+pl.plot(x, f(x), 'r:', label=u'$f(x) = x\,\sin(x)$')
+pl.errorbar(X.ravel(), y, dy, fmt='r.', markersize=10, label=u'Observations')
+pl.xlabel('$x$')
+pl.ylabel('$f(x)$')
+pl.ylim(-10, 20)
+pl.legend(loc='upper left')
+
+pl.show()

--- a/examples/plot_predictive_standard_deviation.py
+++ b/examples/plot_predictive_standard_deviation.py
@@ -6,7 +6,7 @@ r"""
 Comparison of predictive distributions of different regressors
 ==============================================================
 
-A simple one-dimensional regression problem adressed by three different
+A simple one-dimensional, noisy regression problem adressed by three different
 regressors:
 
 1. A Gaussian Process
@@ -14,11 +14,14 @@ regressors:
 3. A Bagging-based Regressor
 
 The regressors are fitted based on noisy observations where the magnitude of
-the noise at the different training point varies and is known. Plotted are
+the noise at the different training point is constant and known. Plotted are
 both the mean and the pointwise 95% confidence interval of the predictions.
+The mean predictions are evaluated on noise-less test data using the mean-
+squared-error. The mean log probabilities of the noise-less test data are used
+to evaluate the predictive distributions (a normal distribution with the
+predicted mean and standard deviation) of the three regressors.
 
 This example is based on the example gaussian_process/plot_gp_regression.py.
-
 """
 print(__doc__)
 
@@ -26,8 +29,10 @@ print(__doc__)
 # Licence: BSD 3 clause
 
 import numpy as np
+from scipy.stats import norm
 from sklearn.gaussian_process import GaussianProcess
 from sklearn.ensemble import RandomForestRegressor, BaggingRegressor
+from sklearn.metrics import mean_squared_error
 from matplotlib import pyplot as pl
 
 np.random.seed(1)
@@ -42,7 +47,7 @@ X = np.atleast_2d(X).T
 
 # Observations and noise
 y = f(X).ravel()
-dy = 0.5 + 1.0 * np.random.random(y.shape)
+dy = np.ones_like(y)
 noise = np.random.normal(0, dy)
 y += noise
 
@@ -50,23 +55,40 @@ y += noise
 # its standard deviation
 x = np.atleast_2d(np.linspace(0, 10, 1000)).T
 
-regrs = {"gaussian_process": GaussianProcess(corr='squared_exponential',
+regrs = {"Gaussian Process": GaussianProcess(corr='squared_exponential',
                                              theta0=1e-1, thetaL=1e-3,
                                              thetaU=1, nugget=(dy / y) ** 2,
                                              random_start=100),
-         "random_forest": RandomForestRegressor(n_estimators=250),
-         "bagging": BaggingRegressor(n_estimators=250)}
+         "Random Forest": RandomForestRegressor(n_estimators=250),
+         "Bagging": BaggingRegressor(n_estimators=250)}
 
 
 # Plot predictive distributions of different regressors
 fig = pl.figure()
-colors = {"gaussian_process": 'b', "random_forest": 'g', "bagging": 'c'}
+# Plot the function and the observations
+pl.plot(x, f(x), 'r', label=u'$f(x) = x\,\sin(x)$')
+pl.fill(np.concatenate([x, x[::-1]]),
+        np.concatenate([f(x) - 1.9600, (f(x) + 1.9600)[::-1]]),
+        alpha=.3, fc='r', ec='None')
+pl.plot(X.ravel(), y, 'ko', zorder=5, label=u'Observations')
+# Plot predictive distibutions of GP and Bagging
+colors = {"Gaussian Process": 'b', "Bagging": 'g'}
+mse = {}
+log_pdf_loss = {}
 for name, regr in regrs.items():
     regr.fit(X, y)
 
     # Make the prediction on the meshed x-axis (ask for standard deviation
     # as well)
     y_pred, sigma = regr.predict(x, with_std=True)
+
+    # Compute mean-squared error and log predictive loss
+    mse[name] = mean_squared_error(f(x), y_pred)
+    log_pdf_loss[name] = \
+        norm(y_pred, sigma).logpdf(f(x)).mean()
+
+    if name == "Random Forest":  # Skip because RF is very similar to Bagging
+        continue
 
     # Plot 95% confidence interval based on the predictive standard deviation
     pl.plot(x, y_pred, colors[name], label=name)
@@ -75,12 +97,27 @@ for name, regr in regrs.items():
                            (y_pred + 1.9600 * sigma)[::-1]]),
             alpha=.3, fc=colors[name], ec='None')
 
-# Plot the function and the observations
-pl.plot(x, f(x), 'r:', label=u'$f(x) = x\,\sin(x)$')
-pl.errorbar(X.ravel(), y, dy, fmt='r.', markersize=10, label=u'Observations')
+
 pl.xlabel('$x$')
 pl.ylabel('$f(x)$')
 pl.ylim(-10, 20)
 pl.legend(loc='upper left')
+
+print "Mean-squared error of predictors on 1000 equidistant noise-less test " \
+    "datapoints:\n\tRandom Forest: %.2f\n\tBagging: %.2f" \
+    "\n\tGaussian Process: %.2f" \
+    % (mse["Random Forest"], mse["Bagging"], mse["Gaussian Process"])
+
+print "Mean log-probability of 1000 equidistant noise-less test datapoints " \
+    "under the (normal) predictive distribution of the predictors, i.e., " \
+    "log N(y_true| y_pred_mean, y_pred_std) [less is better]:"\
+    "\n\tRandom Forest: %.2f\n\tBagging: %.2f\n\tGaussian Process: %.2f" \
+    % (log_pdf_loss["Random Forest"], log_pdf_loss["Bagging"],
+       log_pdf_loss["Gaussian Process"])
+
+print "In summary, the mean predictions of the Gaussian Process are slightly "\
+    "better than those of Random Forest and Bagging. The predictive " \
+    "distributions (taking into account also the predictive variance) " \
+    "of the Gaussian Process are considerably better."
 
 pl.show()

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -795,7 +795,8 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
 
         The predicted regression target of an input sample is computed as the
         mean predicted regression targets of the estimators in the ensemble.
-        Optionally, the standard deviation is computed in addition.
+        Optionally, the standard deviation of the predictions of the ensemble's
+        estimators is computed in addition.
 
         Parameters
         ----------
@@ -804,8 +805,8 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
             they are supported by the base estimator.
 
         with_std : boolean, optional, default=False
-            When True, the standard deviation of predictions across the
-            ensemble is returned in addition to the mean.
+            When True, the standard deviation of the predictions of the
+            ensemble's estimators is returned in addition to the mean.
 
         Returns
         -------
@@ -813,7 +814,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
             The mean of the predicted values.
 
         y_std : array of shape = [n_samples], optional (if with_std == True)
-            The standard deviation of the predicted values.
+            The standard deviation of the ensemble's predicted values.
         """
         # Check data
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -812,7 +812,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
         y_mean : array of shape = [n_samples]
             The mean of the predicted values.
 
-        y_std : array of shape = [n_samples]
+        y_std : array of shape = [n_samples], optional (if with_std == True)
             The standard deviation of the predicted values.
         """
         # Check data

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -827,9 +827,10 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
                 self.estimators_[starts[i]:starts[i + 1]],
                 self.estimators_features_[starts[i]:starts[i + 1]],
                 X)
-            for i in range(n_jobs))[0]
+            for i in range(n_jobs))
 
         # Reduce
+        all_y_hat = np.array(all_y_hat).reshape(self.n_estimators, -1)
         y_mean = np.mean(all_y_hat, axis=0)
         if with_std:
             return y_mean, np.std(all_y_hat, axis=0)

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -795,6 +795,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
 
         The predicted regression target of an input sample is computed as the
         mean predicted regression targets of the estimators in the ensemble.
+        Optionally, the standard deviation is computed in addition.
 
         Parameters
         ----------
@@ -803,15 +804,13 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
             they are supported by the base estimator.
 
         with_std : boolean, optional, default=False
-            A boolean specifying whether the standard deviation of the
-            predictions is evaluated or not.
-            Default assumes with_std = False and evaluates only the mean
-            prediction.
+            When True, the standard deviation of predictions across the
+            ensemble is returned in addition to the mean.
 
         Returns
         -------
-        y : array of shape = [n_samples]
-            The predicted values.
+        y_mean : array of shape = [n_samples]
+            The mean of the predicted values.
 
         y_std : array of shape = [n_samples]
             The standard deviation of the predicted values.
@@ -831,11 +830,11 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
             for i in range(n_jobs))[0]
 
         # Reduce
-        y_hat = np.mean(all_y_hat, axis=0)
+        y_mean = np.mean(all_y_hat, axis=0)
         if with_std:
-            return y_hat, np.std(all_y_hat, axis=0)
+            return y_mean, np.std(all_y_hat, axis=0)
         else:
-            return y_hat
+            return y_mean
 
     def _validate_estimator(self):
         """Check the estimator and set the base_estimator_ attribute."""

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -528,7 +528,8 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
 
         The predicted regression target of an input sample is computed as the
         mean predicted regression targets of the trees in the forest.
-        Optionally, the standard deviation is computed in addition.
+        Optionally, the standard deviation of the predictions of the ensemble's
+        estimators is computed in addition.
 
         Parameters
         ----------
@@ -536,8 +537,8 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
             The input samples.
 
         with_std : boolean, optional, default=False
-            When True, the standard deviation of predictions across the
-            ensemble is returned in addition to the mean.
+            When True, the standard deviation of the predictions of the
+            ensemble's estimators is returned in addition to the mean.
 
         Returns
         -------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -544,7 +544,7 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
         y_mean: array of shape = [n_samples] or [n_samples, n_outputs]
             The mean of the predicted values.
 
-        y_std : array of shape = [n_samples]
+        y_std : array of shape = [n_samples], optional (if with_std == True)
             The standard deviation of the predicted values.
         """
         # Check data

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -528,6 +528,7 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
 
         The predicted regression target of an input sample is computed as the
         mean predicted regression targets of the trees in the forest.
+        Optionally, the standard deviation is computed in addition.
 
         Parameters
         ----------
@@ -535,15 +536,13 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
             The input samples.
 
         with_std : boolean, optional, default=False
-            A boolean specifying whether the standard deviation of the
-            predictions is evaluated or not.
-            Default assumes with_std = False and evaluates only the mean
-            prediction.
+            When True, the standard deviation of predictions across the
+            ensemble is returned in addition to the mean.
 
         Returns
         -------
-        y: array of shape = [n_samples] or [n_samples, n_outputs]
-            The predicted values.
+        y_mean: array of shape = [n_samples] or [n_samples, n_outputs]
+            The mean of the predicted values.
 
         y_std : array of shape = [n_samples]
             The standard deviation of the predicted values.
@@ -562,11 +561,11 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
             delayed(_parallel_helper)(e, 'predict', X)
             for e in self.estimators_)
 
-        y_hat = np.mean(all_y_hat, axis=0)
+        y_mean = np.mean(all_y_hat, axis=0)
         if with_std:
-            return y_hat, np.std(all_y_hat, axis=0)
+            return y_mean, np.std(all_y_hat, axis=0)
         else:
-            return y_hat
+            return y_mean
 
     def _set_oob_score(self, X, y):
         n_samples = y.shape[0]

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -399,10 +399,8 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             time.
 
         with_std : boolean, optional, default=False
-            A boolean specifying whether the standard deviation of the
-            predictions is evaluated or not.
-            Default assumes with_std = False and evaluates only the mean
-            prediction.
+            When True, the standard deviation of predictions across the
+            ensemble is returned in addition to the mean.
 
         Returns
         -------

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -33,11 +33,11 @@ def test_1d(regr=regression.constant, corr=correlation.squared_exponential,
     gp = GaussianProcess(regr=regr, corr=corr, beta0=beta0,
                          theta0=1e-2, thetaL=1e-4, thetaU=1e-1,
                          random_start=random_start, verbose=False).fit(X, y)
-    y_pred, MSE = gp.predict(X, eval_MSE=True)
-    y2_pred, MSE2 = gp.predict(X2, eval_MSE=True)
+    y_pred, y_std = gp.predict(X, with_std=True)
+    _, y_std2 = gp.predict(X2, with_std=True)
 
-    assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.)
-                and np.allclose(MSE2, 0., atol=10))
+    assert_true(np.allclose(y_pred, y) and np.allclose(y_std ** 2, 0.)
+                and np.allclose(y_std2 ** 2, 0., atol=10))
 
 
 def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
@@ -67,12 +67,12 @@ def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
                          thetaU=thetaU,
                          random_start=random_start, verbose=False)
     gp.fit(X, y)
-    y_pred, MSE = gp.predict(X, eval_MSE=True)
+    y_pred, y_std = gp.predict(X, with_std=True)
 
-    assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.))
+    assert_true(np.allclose(y_pred, y) and np.allclose(y_std ** 2, 0.))
 
-    assert_true(np.all(gp.theta_ >= thetaL)) # Lower bounds of hyperparameters
-    assert_true(np.all(gp.theta_ <= thetaU)) # Upper bounds of hyperparameters
+    assert_true(np.all(gp.theta_ >= thetaL))  # Lower bounds of hyperparameters
+    assert_true(np.all(gp.theta_ <= thetaU))  # Upper bounds of hyperparameters
 
 
 def test_2d_2d(regr=regression.constant, corr=correlation.squared_exponential,
@@ -100,9 +100,9 @@ def test_2d_2d(regr=regression.constant, corr=correlation.squared_exponential,
                          thetaU=[1e-1] * 2,
                          random_start=random_start, verbose=False)
     gp.fit(X, y)
-    y_pred, MSE = gp.predict(X, eval_MSE=True)
+    y_pred, y_std = gp.predict(X, with_std=True)
 
-    assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.))
+    assert_true(np.allclose(y_pred, y) and np.allclose(y_std ** 2, 0.))
 
 
 @raises(ValueError)


### PR DESCRIPTION
This addresses issue  #3271. The main points are
- Option with_std added to method predict of BaggingRegressor and RandomForestRegressor. If True, the standard deviation of the predictions is returned in addition to the mean
- Added option with_std to GaussianProcess.predict() and deprecated eval_MSE, which returned the predictive variance
- Added one example comparing the predictive distributions of the three methods.

Please also check the planned deprecation path of the parameter eval_MSE in GaussianProcess
