### PR TITLE
[MRG+1] Fix LARS on 32 bit Python that failed on Windows

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -266,7 +266,13 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             if diag < 1e-7:
                 # The system is becoming too ill-conditioned.
                 # We have degenerate vectors in our active set.
-                # We'll 'drop for good' the last regressor added
+                # We'll 'drop for good' the last regressor added.
+
+                # Note: this case is very rare. It is no longer triggered by the
+                # test suite. The `equality_tolerance` margin added in 0.16.0 to
+                # get early stopping to work consistently on all versions of
+                # Python including 32 bit Python under Windows seems to make it
+                # very difficult to trigger the 'drop for good' strategy.
                 warnings.warn('Regressors in active set degenerate. '
                               'Dropping a regressor, after %i iterations, '
                               'i.e. alpha=%.3e, '

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -185,6 +185,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 
     tiny = np.finfo(np.float).tiny  # to avoid division by 0 warning
     tiny32 = np.finfo(np.float32).tiny  # to avoid division by 0 warning
+    equality_tolerance = np.finfo(np.float32).eps
 
     while True:
         if Cov.size:
@@ -201,8 +202,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
             prev_coef = coefs[n_iter - 1]
 
         alpha[0] = C / n_samples
-        if alpha[0] <= alpha_min:  # early stopping
-            if not (abs(alpha[0] - alpha_min) < 10 * np.finfo(np.float32).eps):
+        if alpha[0] <= alpha_min + equality_tolerance:  # early stopping
+            if abs(alpha[0] - alpha_min) > equality_tolerance:
                 # interpolation factor 0 <= ss < 1
                 if n_iter > 0:
                     # In the first iteration, all alphas are zero, the formula

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -183,14 +183,9 @@ def test_no_path_all_precomputed():
 
 def test_singular_matrix():
     # Test when input is a singular matrix
-    # In this test the "drop for good strategy" of lars_path is necessary
-    # to give a good answer
     X1 = np.array([[1, 1.], [1., 1.]])
     y1 = np.array([1, 1])
-    in_warn_message = 'Dropping a regressor'
-    f = assert_warns_message
-    alphas, active, coef_path = f(ConvergenceWarning, in_warn_message,
-                                  linear_model.lars_path, X1, y1)
+    alphas, active, coef_path = linear_model.lars_path(X1, y1)
     assert_array_almost_equal(coef_path.T, [[0, 0], [1, 0]])
 
 
@@ -322,21 +317,16 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned():
     sigma = 0.2
     y += sigma * rng.rand(*y.shape)
     y = y.squeeze()
+    lars_alphas, _, lars_coef = linear_model.lars_path(X, y, method='lasso')
 
-    f = assert_warns_message
 
-    def in_warn_message(msg):
-        return 'Early stopping' in msg or 'Dropping a regressor' in msg
-    lars_alphas, _, lars_coef = f(ConvergenceWarning,
-                                  in_warn_message,
-                                  linear_model.lars_path, X, y, method='lasso')
+    _, lasso_coef2, _ = linear_model.lasso_path(X, y,
+                                                alphas=lars_alphas,
+                                                tol=1e-6,
+                                                fit_intercept=False)
 
+    # Check that the deprecated return_models=True yields the same coefs path
     with ignore_warnings():
-        _, lasso_coef2, _ = linear_model.lasso_path(X, y,
-                                                    alphas=lars_alphas,
-                                                    tol=1e-6,
-                                                    fit_intercept=False)
-
         lasso_coef = np.zeros((w.shape[0], len(lars_alphas)))
         iter_models = enumerate(linear_model.lasso_path(X, y,
                                                         alphas=lars_alphas,
@@ -351,10 +341,13 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned():
     np.testing.assert_array_almost_equal(lasso_coef, lasso_coef2, decimal=1)
 
 
-def test_lars_drop_for_good():
+def test_lasso_lars_vs_lasso_cd_ill_conditioned2():
     # Create an ill-conditioned situation in which the LARS has to go
     # far in the path to converge, and check that LARS and coordinate
     # descent give the same answers
+    # Note it used to be the case that Lars had to use the drop for good
+    # strategy for this but this is no longer the case with the
+    # equality_tolerance checks
     X = [[1e20,  1e20,  0],
          [-1e-32,  0,  0],
          [1,       1,  1]]
@@ -371,8 +364,7 @@ def test_lars_drop_for_good():
     lars_obj = objective_function(lars_coef_)
 
     coord_descent = linear_model.Lasso(alpha=alpha, tol=1e-10, normalize=False)
-    with ignore_warnings():
-        cd_coef_ = coord_descent.fit(X, y).coef_
+    cd_coef_ = coord_descent.fit(X, y).coef_
     cd_obj = objective_function(cd_coef_)
 
     assert_less(lars_obj, cd_obj * (1. + 1e-8))


### PR DESCRIPTION
FIX #3370: better LARS alpha path inequality checks for 32 bit support.

Finally fixed the failure reported by AppVeyor (ignore the upload failure, it's because I did not configure the secret key on my personal appveyor account):

  https://ci.appveyor.com/project/ogrisel/scikit-learn/build/job/3enuragixu8bh5r8

The drop for good strategy is no longer triggered by any test as a result of this fix. I did not repove the code for drop for good though.

Ping @fabianp @GaelVaroquaux
