### PR TITLE
[MRG+1] fix RBFSampler's incorrect bandwidth

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,13 @@ Bug fixes
       appropriate error message and suggests a work around.
       By `Danny Sullivan`_.
 
+    - :class:`RBFSampler <kernel_approximation.RBFSampler>` with ``gamma=g``
+      formerly approximated :func:`rbf_kernel <metrics.pairwise.rbf_kernel>`
+      with ``gamma=g/2.``; the definition of ``gamma`` is now consistent,
+      which may substantially change your results if you use a fixed value.
+      (If you cross-validated over ``gamma``, it probably doesn't matter
+      too much.) By `Dougal Sutherland`_.
+
 
 API changes summary
 -------------------
@@ -2965,3 +2972,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Nikolay Mayorov: https://github.com/nmayorov
 
 .. _Jatin Shah: http://jatinshah.org/
+
+.. _Dougal Sutherland: https://github.com/dougalsutherland

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -69,7 +69,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         random_state = check_random_state(self.random_state)
         n_features = X.shape[1]
 
-        self.random_weights_ = (np.sqrt(self.gamma) * random_state.normal(
+        self.random_weights_ = (np.sqrt(2 * self.gamma) * random_state.normal(
             size=(n_features, self.n_components)))
 
         self.random_offset_ = random_state.uniform(0, 2 * np.pi,

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -4,6 +4,7 @@ from scipy.sparse import csr_matrix
 from sklearn.utils.testing import assert_array_equal, assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_array_almost_equal, assert_raises
+from sklearn.utils.testing import assert_less_equal
 
 from sklearn.metrics.pairwise import kernel_metrics
 from sklearn.kernel_approximation import RBFSampler
@@ -121,7 +122,11 @@ def test_rbf_sampler():
     Y_trans = rbf_transform.transform(Y)
     kernel_approx = np.dot(X_trans, Y_trans.T)
 
-    assert_array_almost_equal(kernel, kernel_approx, 1)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)  # close to unbiased
+    np.abs(error, out=error)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
 
 
 def test_input_validation():


### PR DESCRIPTION
`RBFSampler` is missing a factor of 2 in variance of the Gaussian to sample from. The original paper talks about the kernel `exp(1/(2 σ^2) ||x-y||^2)` Fourier-transforming into a Gaussian with variance `1/σ^2`; the current code has `exp(ɣ ||x-y||^2)` (incorrectly) Fourier-transforming to a Gaussian with variance `ɣ`.

Demonstration: here's the value of the RBF kernel between 0 and 1 for varying values of `gamma`, via `rbf_kernel`, `RBFSampler(gamma)`, and `RBFSampler(2 * gamma)` (using lots of components):
![](https://i.imgur.com/1z4Fk4u.png).

The reason `test_rbf_sampler` works is because the test is too loose, and it happens to be somewhat close at the values tested:
![](https://i.imgur.com/97fsDz5.png)
(x is true value, y is the approximated value). I just upped the number of Monte Carlo samples and increased it to 2 decimals, giving this new scatterplot:
![](http://i.imgur.com/4KnURsY.png)
This demonstrates that `assert_array_almost_equal` isn't really the right tool for testing Monte Carlo approximators like this (we can still only use 2 decimals in this test, with 10k samples). Instead, there should probably be a helper function to test that the mean absolute difference is fairly small, and also a looser bound on the max difference...or something.

Here's [a notebook](http://nbviewer.ipython.org/gist/dougalsutherland/11fd9895924c3c1aed19) that makes these pictures.

(This probably won't dramatically change anyone's practical results with `RBFSampler`, since effectively you're just cross-validating over a set of `gamma` values that are double the ones you thought you were cross-validating over. But if people were picking `gamma` based on an exact evaluation on a subset or from some other external source, their they'd be using a substantially different kernel than they thought they were.)
