### PR TITLE
Altering precision_recall_fscore_support docstring

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -742,7 +742,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         The strength of recall versus precision in the F-score.
 
     labels : array
-        Integer array of labels.
+        Sorted array of labels.
 
     pos_label : str or int, 1 by default
         If ``average`` is not ``None`` and the classification target is binary,


### PR DESCRIPTION
If the labels are unsorted and precision_recall_fscore_support is used with multilabel classifications it will raise an exception. E.g.:

```
sklearn.metrics.precision_recall_fscore_support(
    [(1,2)],
    [(3,4)],
    labels=[4, 1, 2, 3]
)
```

raises

```
/usr/local/lib/python2.7/dist-packages/sklearn/metrics/classification.pyc in precision_recall_fscore_support(y_true, y_pred, beta, labels, pos_label, average, warn_for, sample_weight)
    945     elif label_order is not None:
    946         indices = np.searchsorted(labels, label_order)
--> 947         precision = precision[indices]
    948         recall = recall[indices]
    949         f_score = f_score[indices]

IndexError: index 4 is out of bounds for size 4
```

Also, AFAICT the labels do not need to be integers.
