### PR TITLE
[MRG+1] FIX: Make sure LogRegCV with solver=liblinear works with sparse matrices

### DIFF
--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -418,7 +418,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             raise ValueError("newton-cg and lbfgs solvers support only "
                              "dual=False, got dual=%s" % dual)
     # Preprocessing.
-    X = check_array(X, accept_sparse='csc', dtype=np.float64)
+    X = check_array(X, accept_sparse='csr', dtype=np.float64)
     y = check_array(y, ensure_2d=False, copy=copy)
     _, n_features = X.shape
     check_consistent_length(X, y)
@@ -1190,7 +1190,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                 raise ValueError("newton-cg and lbfgs solvers support only "
                                  "the primal form.")
 
-        X = check_array(X, accept_sparse='csc', dtype=np.float64)
+        X = check_array(X, accept_sparse='csr', dtype=np.float64)
         y = check_array(y, ensure_2d=False)
 
         if self.multi_class not in ['ovr', 'multinomial']:

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
-from scipy import linalg, optimize
+from scipy import linalg, optimize, sparse
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -532,3 +532,11 @@ def test_liblinear_decision_function_zero():
     # Dummy data such that the decision function becomes zero.
     X = np.zeros((5, 5))
     assert_array_equal(clf.predict(X), np.zeros(5))
+
+
+def test_liblinear_logregcv_sparse():
+    """Test LogRegCV with solver='liblinear' works for sparse matrices"""
+
+    X, y = make_classification(n_samples=10, n_features=5)
+    clf = LogisticRegressionCV(solver='liblinear')
+    clf.fit(sparse.csr_matrix(X), y)


### PR DESCRIPTION
The function `csr_set_problem` assumes X to be of `csr` format. More specifically, accessing `X.indptr[0] - 1` to get `n_samples` in the function creates huge problems. This fixes it.
