### PR TITLE
[MRG+1] Removed n_jobs parameter from the fit method and added it to constructor

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -45,7 +45,7 @@ and will store the coefficients :math:`w` of the linear model in its
     >>> from sklearn import linear_model
     >>> clf = linear_model.LinearRegression()
     >>> clf.fit ([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
-    LinearRegression(copy_X=True, fit_intercept=True, normalize=False)
+    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=1, normalize=False)
     >>> clf.coef_
     array([ 0.5,  0.5])
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -175,8 +175,7 @@ Linear models: :math:`y = X\beta + \epsilon`
     >>> from sklearn import linear_model
     >>> regr = linear_model.LinearRegression()
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
-    LinearRegression(copy_X=True, fit_intercept=True, n_jobs =1,
-                     normalize=False)
+    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=1, normalize=False)
     >>> print(regr.coef_)
     [   0.30349955 -237.63931533  510.53060544  327.73698041 -814.13170937
       492.81458798  102.84845219  184.60648906  743.51961675   76.09517222]

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -175,7 +175,8 @@ Linear models: :math:`y = X\beta + \epsilon`
     >>> from sklearn import linear_model
     >>> regr = linear_model.LinearRegression()
     >>> regr.fit(diabetes_X_train, diabetes_y_train)
-    LinearRegression(copy_X=True, fit_intercept=True, normalize=False)
+    LinearRegression(copy_X=True, fit_intercept=True, n_jobs =1,
+                     normalize=False)
     >>> print(regr.coef_)
     [   0.30349955 -237.63931533  510.53060544  327.73698041 -814.13170937
       492.81458798  102.84845219  184.60648906  743.51961675   76.09517222]

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -99,6 +99,8 @@ API changes summary
       and pass these to their distance metric. This will no longer be supported
       in scikit-learn 0.18; use the ``metric_params`` argument instead.
 
+    - `n_jobs` parameter of the fit method shifted to the constructor of the
+       LinearRegression class.
 
 .. _changes_0_15_2:
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -355,10 +355,10 @@ class LinearRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
+        warnings.warn("The n_jobs parameter has been moved from the fit"
+                      " method to the LinearRegression class constructor",
+                      DeprecationWarning, stacklevel=2)
         if n_jobs != 1:
-            warnings.warn("The n_jobs parameter has been moved from the fit"
-                          " method to the LinearRegression class constructor",
-                          DeprecationWarning, stacklevel=2)
             n_jobs = n_jobs
         else:
             n_jobs = self.n_jobs

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -355,13 +355,13 @@ class LinearRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        if self.n_jobs != 1:
-            n_jobs = self.n_jobs
         if n_jobs != 1:
             warnings.warn("The n_jobs parameter has been moved from the fit"
                           " method to the LinearRegression class constructor",
                           DeprecationWarning, stacklevel=2)
             n_jobs_ = n_jobs
+        else:
+            n_jobs_ = self.n_jobs
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
         y = np.asarray(y)
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -355,13 +355,13 @@ class LinearRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        warnings.warn("The n_jobs parameter has been moved from the fit"
-                      " method to the LinearRegression class constructor",
-                      DeprecationWarning, stacklevel=2)
-        if n_jobs != 1:
-            self.n_jobs = n_jobs
-        else:
+        if self.n_jobs != 1:
             n_jobs = self.n_jobs
+        if n_jobs != 1:
+            warnings.warn("The n_jobs parameter has been moved from the fit"
+                          " method to the LinearRegression class constructor",
+                          DeprecationWarning, stacklevel=2)
+            n_jobs_ = n_jobs
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
         y = np.asarray(y)
 
@@ -375,7 +375,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                 self.residues_ = out[3]
             else:
                 # sparse_lstsq cannot handle y with shape (M, K)
-                outs = Parallel(n_jobs)(
+                outs = Parallel(n_jobs = n_jobs_)(
                     delayed(lsqr)(X, y[:, j].ravel())
                     for j in range(y.shape[1]))
                 self.coef_ = np.vstack(out[0] for out in outs)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -310,6 +310,10 @@ class LinearRegression(LinearModel, RegressorMixin):
     copy_X : boolean, optional, default True
         If True, X will be copied; else, it may be overwritten.
 
+    n_jobs : The number of jobs to use for the computation.
+        If -1 all CPUs are used. This will only provide speedup for
+        n_targets > 1 and sufficient large problems.
+
     Attributes
     ----------
     coef_ : array, shape (n_features, ) or (n_targets, n_features)
@@ -328,10 +332,11 @@ class LinearRegression(LinearModel, RegressorMixin):
 
     """
 
-    def __init__(self, fit_intercept=True, normalize=False, copy_X=True):
+    def __init__(self, fit_intercept=True, normalize=False, copy_X=True, n_jobs=1):
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.copy_X = copy_X
+        self.n_jobs = n_jobs
 
     def fit(self, X, y, n_jobs=1):
         """
@@ -343,9 +348,6 @@ class LinearRegression(LinearModel, RegressorMixin):
             Training data
         y : numpy array of shape [n_samples, n_targets]
             Target values
-        n_jobs : The number of jobs to use for the computation.
-            If -1 all CPUs are used. This will only provide speedup for
-            n_targets > 1 and sufficient large problems
 
         Returns
         -------
@@ -364,7 +366,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                 self.residues_ = out[3]
             else:
                 # sparse_lstsq cannot handle y with shape (M, K)
-                outs = Parallel(n_jobs=n_jobs)(
+                outs = Parallel(n_jobs=self.n_jobs)(
                     delayed(lsqr)(X, y[:, j].ravel())
                     for j in range(y.shape[1]))
                 self.coef_ = np.vstack(out[0] for out in outs)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -359,7 +359,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                       " method to the LinearRegression class constructor",
                       DeprecationWarning, stacklevel=2)
         if n_jobs != 1:
-            n_jobs = n_jobs
+            self.n_jobs = n_jobs
         else:
             n_jobs = self.n_jobs
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -340,7 +340,7 @@ class LinearRegression(LinearModel, RegressorMixin):
         self.copy_X = copy_X
         self.n_jobs = n_jobs
 
-    def fit(self, X, y, n_jobs):
+    def fit(self, X, y, n_jobs=1):
         """
         Fit linear model.
 
@@ -355,10 +355,13 @@ class LinearRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        if n_jobs:
+        if n_jobs != 1:
             warnings.warn("The n_jobs parameter has been moved from the fit"
                           " method to the LinearRegression class constructor",
                           DeprecationWarning, stacklevel=2)
+            n_jobs = n_jobs
+        else:
+            n_jobs = self.n_jobs
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
         y = np.asarray(y)
 
@@ -372,7 +375,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                 self.residues_ = out[3]
             else:
                 # sparse_lstsq cannot handle y with shape (M, K)
-                outs = Parallel(n_jobs=self.n_jobs)(
+                outs = Parallel(n_jobs)(
                     delayed(lsqr)(X, y[:, j].ravel())
                     for j in range(y.shape[1]))
                 self.coef_ = np.vstack(out[0] for out in outs)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -375,7 +375,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                 self.residues_ = out[3]
             else:
                 # sparse_lstsq cannot handle y with shape (M, K)
-                outs = Parallel(n_jobs = n_jobs_)(
+                outs = Parallel(n_jobs=n_jobs_)(
                     delayed(lsqr)(X, y[:, j].ravel())
                     for j in range(y.shape[1]))
                 self.coef_ = np.vstack(out[0] for out in outs)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -15,6 +15,7 @@ Generalized Linear models.
 from __future__ import division
 from abc import ABCMeta, abstractmethod
 import numbers
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -332,13 +333,14 @@ class LinearRegression(LinearModel, RegressorMixin):
 
     """
 
-    def __init__(self, fit_intercept=True, normalize=False, copy_X=True, n_jobs=1):
+    def __init__(self, fit_intercept=True, normalize=False, copy_X=True,
+                 n_jobs=1):
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.copy_X = copy_X
         self.n_jobs = n_jobs
 
-    def fit(self, X, y, n_jobs=1):
+    def fit(self, X, y, n_jobs):
         """
         Fit linear model.
 
@@ -353,6 +355,10 @@ class LinearRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
+        if n_jobs:
+            warnings.warn("The n_jobs parameter has been moved from the fit"
+                          " method to the LinearRegression class constructor",
+                          DeprecationWarning, stacklevel=2)
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
         y = np.asarray(y)
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -41,10 +41,18 @@ def test_linear_regression():
     assert_array_almost_equal(clf.intercept_, [0])
     assert_array_almost_equal(clf.predict(X), [0])
 
+
+def test_linear_regression_n_jobs():
+    """
+    Test for the n_jobs parameter on the fit method and the constructor
+    """
+    X = [[1], [2]]
+    Y = [1, 2]
     clf = LinearRegression()
     clf_fit = clf.fit(X, Y, 4)
     assert_equal (clf_fit.n_jobs, clf.n_jobs)
-    assert_equal(clf.n_jobs, 4)
+    assert_equal(clf.n_jobs, 1)
+
 
 def test_fit_intercept():
     """

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -41,6 +41,10 @@ def test_linear_regression():
     assert_array_almost_equal(clf.intercept_, [0])
     assert_array_almost_equal(clf.predict(X), [0])
 
+    clf = LinearRegression()
+    clf_fit = clf.fit(X, Y, 4)
+    assert_equal (clf_fit.n_jobs, clf.n_jobs)
+    assert_equal(clf.n_jobs, 4)
 
 def test_fit_intercept():
     """

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -50,7 +50,7 @@ def test_linear_regression_n_jobs():
     Y = [1, 2]
     clf = LinearRegression()
     clf_fit = clf.fit(X, Y, 4)
-    assert_equal (clf_fit.n_jobs, clf.n_jobs)
+    assert_equal(clf_fit.n_jobs, clf.n_jobs)
     assert_equal(clf.n_jobs, 1)
 
 


### PR DESCRIPTION
Fixes #3672 
@arjoly I have deprecated the n_jobs parameter from the `fit` method and added it to the constructor. I was not certain as to how to add the deprecation warning though as i am new to this community, could you please tell me how to add that? I will patch that up in the new commit along with the tests if needed Thank you!
