### PR TITLE
[MRG+1] Add a more memory efficient version of DictVectorizer

### DIFF
--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -1,4 +1,5 @@
-# Author: Lars Buitinck <L.J.Buitinck@uva.nl>
+# Authors: Lars Buitinck <L.J.Buitinck@uva.nl>
+#          Dan Blanchard <dblanchard@ets.org>
 # License: BSD 3 clause
 
 from array import array
@@ -49,6 +50,9 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     sparse: boolean, optional.
         Whether transform should produce scipy.sparse matrices.
         True by default.
+    sort: boolean, optional.
+        Whether feature_names_ and vocabulary_ should be sorted when fitting.
+        True by default.
 
     Attributes
     ----------
@@ -81,10 +85,12 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
       encoded as columns of integers.
     """
 
-    def __init__(self, dtype=np.float64, separator="=", sparse=True):
+    def __init__(self, dtype=np.float64, separator="=", sparse=True,
+                 sort=True):
         self.dtype = dtype
         self.separator = separator
         self.sparse = sparse
+        self.sort = sort
 
     def fit(self, X, y=None):
         """Learn a list of feature name -> indices mappings.
@@ -101,24 +107,32 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         self
         """
         # collect all the possible feature names
-        feature_names = set()
+        self.feature_names_ = []
+        self.vocabulary_ = {}
+
+        vocab = self.vocabulary_
+
         for x in X:
             for f, v in six.iteritems(x):
                 if isinstance(v, six.string_types):
                     f = "%s%s%s" % (f, self.separator, v)
-                feature_names.add(f)
+                if f not in vocab:
+                    self.feature_names_.append(f)
+                    if not self.sort:
+                        vocab[f] = len(vocab)
 
-        # sort the feature names to define the mapping
-        feature_names = sorted(feature_names)
-        self.vocabulary_ = dict((f, i) for i, f in enumerate(feature_names))
-        self.feature_names_ = feature_names
+        if self.sort:
+            self.feature_names_.sort()
+            self.vocabulary_ = dict((f, i) for i, f in
+                                    enumerate(self.feature_names_))
 
         return self
 
     def fit_transform(self, X, y=None):
         """Learn a list of feature name -> indices mappings and transform X.
 
-        Like fit(X) followed by transform(X).
+        Like fit(X) followed by transform(X), but does not require
+        materializing X in memory.
 
         Parameters
         ----------
@@ -131,15 +145,73 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         -------
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
-
-        Notes
-        -----
-        Because this method requires two passes over X, it materializes X in
-        memory.
         """
-        X = _tosequence(X)
-        self.fit(X)
-        return self.transform(X)
+        # Sanity check: Python's array has no way of explicitly requesting the
+        # signed 32-bit integers that scipy.sparse needs, so we use the next
+        # best thing: typecode "i" (int). However, if that gives larger or
+        # smaller integers than 32-bit ones, np.frombuffer screws up.
+        assert array("i").itemsize == 4, (
+            "sizeof(int) != 4 on your platform; please report this at"
+            " https://github.com/scikit-learn/scikit-learn/issues and"
+            " include the output from platform.platform() in your bug report")
+
+        self.vocabulary_ = {}
+        self.feature_names_ = []
+
+        dtype = self.dtype
+        vocab = self.vocabulary_
+
+        # Process everything as sparse regardless of setting
+        X = [X] if isinstance(X, Mapping) else X
+
+        indices = array("i")
+        indptr = array("i", [0])
+        # XXX we could change values to an array.array as well, but it
+        # would require (heuristic) conversion of dtype to typecode...
+        values = []
+
+        # collect all the possible feature names and build sparse matrix at
+        # same time
+        for x in X:
+            for f, v in six.iteritems(x):
+                if isinstance(v, six.string_types):
+                    f = "%s%s%s" % (f, self.separator, v)
+                    v = 1
+                if f not in vocab:
+                    vocab[f] = len(vocab)
+                    self.feature_names_.append(f)
+                indices.append(vocab[f])
+                values.append(dtype(v))
+
+            indptr.append(len(indices))
+
+        if len(indptr) == 1:
+            raise ValueError("Sample sequence X is empty.")
+
+        if len(indices) > 0:
+            # workaround for bug in older NumPy:
+            # http://projects.scipy.org/numpy/ticket/1943
+            indices = np.frombuffer(indices, dtype=np.intc)
+        indptr = np.frombuffer(indptr, dtype=np.intc)
+        shape = (len(indptr) - 1, len(vocab))
+
+        result_matrix = sp.csr_matrix((values, indices, indptr),
+                                      shape=shape, dtype=dtype)
+
+        # Sort everything if asked
+        if self.sort:
+            self.feature_names_.sort()
+            map_index = np.empty(len(self.feature_names_), dtype=np.int32)
+            for new_val, f in enumerate(self.feature_names_):
+                map_index[new_val] = self.vocabulary_[f]
+                self.vocabulary_[f] = new_val
+            result_matrix = result_matrix[:, map_index]
+
+        # Convert to dense if asked
+        if not self.sparse:
+            result_matrix = result_matrix.todense()
+
+        return result_matrix
 
     def inverse_transform(self, X, dict_type=dict):
         """Transform array or sparse matrix X back to feature mappings.
@@ -294,123 +366,3 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
                                                     key=itemgetter(1))]
 
         return self
-
-
-class UnsortedDictVectorizer(DictVectorizer):
-    '''
-    A DictVectorizer that does not require that feature_names_ is
-    is sorted.  This allows it to support calling fit_transform with
-    a generator, potentially freeing up lots of memory.
-    '''
-    
-    def fit(self, X, y=None):
-        """Learn a list of feature name -> indices mappings.
-
-        Parameters
-        ----------
-        X : Mapping or iterable over Mappings
-            Dict(s) or Mapping(s) from feature names (arbitrary Python
-            objects) to feature values (strings or convertible to dtype).
-        y : (ignored)
-
-        Returns
-        -------
-        self
-        
-        Notes
-        -----
-        Unlike the base DictVectorizer, this does not sort the list of
-        feature names, thereby eliminating the need to temporarily store 
-        them all twice.
-        """
-        # collect all the possible feature names
-        self.feature_names_ = []
-        self.vocabulary_ = {}
-        
-        vocab = self.vocabulary_
-        
-        for x in X:
-            for f, v in six.iteritems(x):
-                if isinstance(v, six.string_types):
-                    f = "%s%s%s" % (f, self.separator, v)
-                if f not in vocab:
-                    self.feature_names_.append(f)
-                    vocab[f] = len(vocab) 
-        return self
-
-    def fit_transform(self, X, y=None):
-        """Learn a list of feature name -> indices mappings and transform X.
-
-        Like fit(X) followed by transform(X).
-
-        Parameters
-        ----------
-        X : Mapping or iterable over Mappings
-            Dict(s) or Mapping(s) from feature names (arbitrary Python
-            objects) to feature values (strings or convertible to dtype).
-        y : (ignored)
-
-        Returns
-        -------
-        Xa : {array, sparse matrix}
-            Feature vectors; always 2-d.
-
-        Notes
-        -----
-        Unlike the base DictVectorizer, this method does not requires
-        two passes over X, so it does not materialize X in memory.
-        """
-        # Sanity check: Python's array has no way of explicitly requesting the
-        # signed 32-bit integers that scipy.sparse needs, so we use the next
-        # best thing: typecode "i" (int). However, if that gives larger or
-        # smaller integers than 32-bit ones, np.frombuffer screws up.
-        assert array("i").itemsize == 4, (
-            "sizeof(int) != 4 on your platform; please report this at"
-            " https://github.com/scikit-learn/scikit-learn/issues and"
-            " include the output from platform.platform() in your bug report")
-
-        self.vocabulary_ = {}
-        self.feature_names_ = []
-
-        dtype = self.dtype
-        vocab = self.vocabulary_
-
-        # Process everything as sparse regardless of setting
-        X = [X] if isinstance(X, Mapping) else X
-
-        indices = array("i")
-        indptr = array("i", [0])
-        # XXX we could change values to an array.array as well, but it
-        # would require (heuristic) conversion of dtype to typecode...
-        values = []
-
-        # collect all the possible feature names and build sparse matrix at
-        # same time
-        for x in X:
-            for f, v in six.iteritems(x):
-                if isinstance(v, six.string_types):
-                    f = "%s%s%s" % (f, self.separator, v)
-                    v = 1
-                if f not in vocab:
-                    vocab[f] = len(vocab)
-                    self.feature_names_.append(f)
-                indices.append(vocab[f])
-                values.append(dtype(v))
-
-            indptr.append(len(indices))
-
-        if len(indptr) == 1:
-            raise ValueError("Sample sequence X is empty.")
-
-        if len(indices) > 0:
-            # workaround for bug in older NumPy:
-            # http://projects.scipy.org/numpy/ticket/1943
-            indices = np.frombuffer(indices, dtype=np.intc)
-        indptr = np.frombuffer(indptr, dtype=np.intc)
-        shape = (len(indptr) - 1, len(vocab))
-
-        sparse_matrix = sp.csr_matrix((values, indices, indptr),
-                                      shape=shape, dtype=dtype)
-
-        # Convert to dense if asked
-        return sparse_matrix if self.sparse else sparse_matrix.todense()

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -117,6 +117,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
                 if isinstance(v, six.string_types):
                     f = "%s%s%s" % (f, self.separator, v)
                 if f not in vocab:
+                    self.feature_names_.append(f)
                     vocab[f] = len(vocab)
 
         if self.sort:

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -208,7 +208,10 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         # Convert to dense if asked
         if not self.sparse:
-            result_matrix = result_matrix.todense()
+            temp_array = np.empty(result_matrix.shape,
+                                  dtype=result_matrix.dtype)
+            result_matrix.todense(out=temp_array)
+            result_matrix = temp_array
 
         return result_matrix
 

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -208,10 +208,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         # Convert to dense if asked
         if not self.sparse:
-            temp_array = np.empty(result_matrix.shape,
-                                  dtype=result_matrix.dtype)
-            result_matrix.todense(out=temp_array)
-            result_matrix = temp_array
+            result_matrix = np.asarray(result_matrix.todense())
 
         return result_matrix
 

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -208,7 +208,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
 
         # Convert to dense if asked
         if not self.sparse:
-            result_matrix = np.asarray(result_matrix.todense())
+            result_matrix = result_matrix.toarray()
 
         return result_matrix
 

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -117,9 +117,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
                 if isinstance(v, six.string_types):
                     f = "%s%s%s" % (f, self.separator, v)
                 if f not in vocab:
-                    self.feature_names_.append(f)
-                    if not self.sort:
-                        vocab[f] = len(vocab)
+                    vocab[f] = len(vocab)
 
         if self.sort:
             self.feature_names_.sort()
@@ -178,8 +176,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
                     f = "%s%s%s" % (f, self.separator, v)
                     v = 1
                 if f not in vocab:
-                    vocab[f] = len(vocab)
                     self.feature_names_.append(f)
+                    vocab[f] = len(vocab)
                 indices.append(vocab[f])
                 values.append(dtype(v))
 

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -42,8 +42,6 @@ def test_dictvectorizer():
                     if sort:
                         assert_equal(v.feature_names_,
                                      sorted(v.feature_names_))
-                        assert_equal(list(v.vocabulary_.items()),
-                                     sorted(v.vocabulary_.items()))
 
 
 def test_feature_selection():

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -1,4 +1,5 @@
-# Author: Lars Buitinck <L.J.Buitinck@uva.nl>
+# Authors: Lars Buitinck <L.J.Buitinck@uva.nl>
+#          Dan Blanchard <dblanchard@ets.org>
 # License: BSD 3 clause
 
 from random import Random
@@ -20,19 +21,29 @@ def test_dictvectorizer():
 
     for sparse in (True, False):
         for dtype in (int, np.float32, np.int16):
-            v = DictVectorizer(sparse=sparse, dtype=dtype)
-            X = v.fit_transform(D)
+            for sort in (True, False):
+                for iterable in (True, False):
+                    v = DictVectorizer(sparse=sparse, dtype=dtype, sort=sort)
+                    X = v.fit_transform(iter(D) if iterable else D)
 
-            assert_equal(sp.issparse(X), sparse)
-            assert_equal(X.shape, (3, 5))
-            assert_equal(X.sum(), 14)
-            assert_equal(v.inverse_transform(X), D)
+                    assert_equal(sp.issparse(X), sparse)
+                    assert_equal(X.shape, (3, 5))
+                    assert_equal(X.sum(), 14)
+                    assert_equal(v.inverse_transform(X), D)
 
-            if sparse:
-                # CSR matrices can't be compared for equality
-                assert_array_equal(X.A, v.transform(D).A)
-            else:
-                assert_array_equal(X, v.transform(D))
+                    if sparse:
+                        # CSR matrices can't be compared for equality
+                        assert_array_equal(X.A, v.transform(iter(D) if iterable
+                                                            else D).A)
+                    else:
+                        assert_array_equal(X, v.transform(iter(D) if iterable
+                                                          else D))
+
+                    if sort:
+                        assert_equal(v.feature_names_,
+                                     sorted(v.feature_names_))
+                        assert_equal(list(v.vocabulary_.items()),
+                                     sorted(v.vocabulary_.items()))
 
 
 def test_feature_selection():


### PR DESCRIPTION
When loading really large files for SKLL, I found that temporarily storing a list of dictionaries to pass to DictVectorizer was frequently using up huge amounts of memory.  With `UnsortedDictVectorizer`, you can call `fit_transform` with a generator, and not have to waste the temporary space.

This sub-class also overrides `fit` so that the feature names are not sorted in that case either for consistency.

I would have just modified the `DictVectorizer` class to no longer sort the list of feature names, but I didn't want to break anyone's code that somehow relied on that.
