### PR TITLE
[MRG+1] Fix shuffle for arrays with ndim > 2

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -242,8 +242,8 @@ def resample(*arrays, **options):
             max_n_samples, n_samples))
 
     check_consistent_length(*arrays)
-    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False, allow_nd=True)
-              for x in arrays]
+    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False,
+                          allow_nd=True) for x in arrays]
 
     if replace:
         indices = random_state.randint(0, n_samples, size=(max_n_samples,))

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -179,6 +179,9 @@ def resample(*arrays, **options):
     random_state : int or RandomState instance
         Control the shuffling for reproducible behavior.
 
+    allow_nd : boolean, False by default
+        Allow the input arrays to have > 2 dimensions.
+
     Returns
     -------
     Sequence of resampled views of the collections. The original arrays are
@@ -225,6 +228,7 @@ def resample(*arrays, **options):
     random_state = check_random_state(options.pop('random_state', None))
     replace = options.pop('replace', True)
     max_n_samples = options.pop('n_samples', None)
+    allow_nd = options.pop('allow_nd', False)
     if options:
         raise ValueError("Unexpected kw arguments: %r" % options.keys())
 
@@ -241,8 +245,12 @@ def resample(*arrays, **options):
         raise ValueError("Cannot sample %d out of arrays with dim %d" % (
             max_n_samples, n_samples))
 
+    if not isinstance(allow_nd, bool):
+        raise ValueError("Parameter allow_nd expected to be <type 'bool'>,\
+                         was given %s" % type(allow_nd))
+
     check_consistent_length(*arrays)
-    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False)
+    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False, allow_nd=allow_nd)
               for x in arrays]
 
     if replace:
@@ -281,6 +289,9 @@ def shuffle(*arrays, **options):
     n_samples : int, None by default
         Number of samples to generate. If left to None this is
         automatically set to the first dimension of the arrays.
+
+    allow_nd : boolean, False by default
+        Allow the input arrays to have > 2 dimensions.
 
     Returns
     -------

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -179,9 +179,6 @@ def resample(*arrays, **options):
     random_state : int or RandomState instance
         Control the shuffling for reproducible behavior.
 
-    allow_nd : boolean, False by default
-        Allow the input arrays to have > 2 dimensions.
-
     Returns
     -------
     Sequence of resampled views of the collections. The original arrays are
@@ -228,7 +225,6 @@ def resample(*arrays, **options):
     random_state = check_random_state(options.pop('random_state', None))
     replace = options.pop('replace', True)
     max_n_samples = options.pop('n_samples', None)
-    allow_nd = options.pop('allow_nd', False)
     if options:
         raise ValueError("Unexpected kw arguments: %r" % options.keys())
 
@@ -245,12 +241,8 @@ def resample(*arrays, **options):
         raise ValueError("Cannot sample %d out of arrays with dim %d" % (
             max_n_samples, n_samples))
 
-    if not isinstance(allow_nd, bool):
-        raise ValueError("Parameter allow_nd expected to be <type 'bool'>,\
-                         was given %s" % type(allow_nd))
-
     check_consistent_length(*arrays)
-    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False, allow_nd=allow_nd)
+    arrays = [check_array(x, accept_sparse='csr', ensure_2d=False, allow_nd=True)
               for x in arrays]
 
     if replace:
@@ -289,9 +281,6 @@ def shuffle(*arrays, **options):
     n_samples : int, None by default
         Number of samples to generate. If left to None this is
         automatically set to the first dimension of the arrays.
-
-    allow_nd : boolean, False by default
-        Allow the input arrays to have > 2 dimensions.
 
     Returns
     -------

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -180,6 +180,4 @@ def test_safe_indexing_mock_pandas():
 
 def test_shuffle_on_ndim_equals_three():
     A = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])  # A.shape = (2,2,2)
-    B = shuffle(A, random_state=100)
-    # should be shuffled, and shouldn't raise a ValueError for dim > 2
-    assert_true(not (A == B).all())
+    shuffle(A)  # shouldn't raise a ValueError for dim = 3

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -179,6 +179,7 @@ def test_safe_indexing_mock_pandas():
 
 
 def test_shuffle_on_ndim_equals_three():
-    A = np.array([[[1,2],[3,4]],[[5,6],[7,8]]]) # A.shape = (2,2,2)
-    B = shuffle(A)
-    assert_true((A == B).all()) # should be shuffled, and shouldn't raise a ValueError for dim > 2
+    A = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])  # A.shape = (2,2,2)
+    B = shuffle(A, random_state=100)
+    # should be shuffled, and shouldn't raise a ValueError for dim > 2
+    assert_true(not (A == B).all())

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -14,6 +14,7 @@ from sklearn.utils import resample
 from sklearn.utils import safe_mask
 from sklearn.utils import column_or_1d
 from sklearn.utils import safe_indexing
+from sklearn.utils import shuffle
 from sklearn.utils.extmath import pinvh
 from sklearn.utils.mocking import MockDataFrame
 
@@ -175,3 +176,9 @@ def test_safe_indexing_mock_pandas():
     X_df_indexed = safe_indexing(X_df, inds)
     X_indexed = safe_indexing(X_df, inds)
     assert_array_equal(np.array(X_df_indexed), X_indexed)
+
+
+def test_shuffle_on_ndim_equals_three():
+    A = np.array([[[1,2],[3,4]],[[5,6],[7,8]]]) # A.shape = (2,2,2)
+    B = shuffle(A)
+    assert_true((A == B).all()) # should be shuffled, and shouldn't raise a ValueError for dim > 2


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/3694 by passing allow_nd=True into check_array within resample and shuffle, allowing shuffle and resample to work on arrays with ndim > 2. Also added a short test for shuffling an array with ndim = 3.
