### PR TITLE
MRG+1: Add cross_val_predict function

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -176,6 +176,7 @@ Classes
 
    cross_validation.train_test_split
    cross_validation.cross_val_score
+   cross_validation.cross_val_predict
    cross_validation.permutation_test_score
    cross_validation.check_cv
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -152,15 +152,18 @@ The function :func:`cross_val_predict` has a similar interface to
 :func:`cross_val_score`, but returns, for each element in the input, the
 prediction that was obtained for that element when it was in the test set. Only
 cross-validation strategies that assign all elements to a test set exactly once
-can be used (otherwise, an exception is raise).
+can be used (otherwise, an exception is raised).
 
-These prediction then be used to evalute the classifier::
+These prediction can then be used to evalute the classifier::
 
   >>> predicted = cross_validation.cross_val_predict(clf, iris.data,
   ...                                                iris.target, cv=10)
   >>> metrics.accuracy_score(iris.target, predicted) # doctest: +ELLIPSIS
   0.97...
 
+Note that the result of this computation may be slightly different from those
+obtained using :func:`cross_val_score` as the elements are grouped in different
+ways.
 
 The available cross validation iterators are introduced in the following
 section.

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -144,6 +144,24 @@ validation iterator instead, for instance::
   ...                                                     # doctest: +ELLIPSIS
   array([ 0.97...,  0.97...,  1.        ])
 
+
+Obtaining predictions by cross-validation
+-----------------------------------------
+
+The function :func:`cross_val_predict` has a similar interface to
+:func:`cross_val_score`, but returns, for each element in the input, the
+prediction that was obtained for that element when it was in the test set. Only
+cross-validation strategies that assign all elements to a test set exactly once
+can be used (otherwise, an exception is raise).
+
+These prediction then be used to evalute the classifier::
+
+  >>> predicted = cross_validation.cross_val_predict(clf, iris.data,
+  ...                                                iris.target, cv=10)
+  >>> metrics.accuracy_score(iris.target, predicted) # doctest: +ELLIPSIS
+  0.97...
+
+
 The available cross validation iterators are introduced in the following
 section.
 
@@ -182,6 +200,7 @@ section.
     * :ref:`example_feature_selection_plot_rfe_with_cross_validation.py`,
     * :ref:`example_model_selection_grid_search_digits.py`,
     * :ref:`example_model_selection_grid_search_text_feature_extraction.py`,
+    * :ref:`example_plot_cv_predict.py`,
 
 Cross validation iterators
 ==========================

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,9 @@ New features
      and :class:`SGDRegressor <linear_model.SGDRegressor>` By
      `Danny Sullivan`_.
 
+   - Added :func:`cross_val_predict <cross_validation.cross_val_predict>`
+     function which computes cross-validated estimates. By `Luis Pedro Coelho`_
+
 
 Enhancements
 ............
@@ -3034,3 +3037,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Ian Gilmore: https://github.com/agileminor
 
 .. _Aaron Staple: https://github.com/staple
+
+.. _Luis Pedro Coelho: http://luispedro.org

--- a/examples/plot_cv_predict.py
+++ b/examples/plot_cv_predict.py
@@ -1,0 +1,28 @@
+"""
+====================================
+Plotting Cross-Validated Predictions
+====================================
+
+This example shows how to use `cross_val_predict` to visualize prediction
+errors.
+
+"""
+from sklearn import datasets
+from sklearn.cross_validation import cross_val_predict
+from sklearn import linear_model
+import matplotlib.pyplot as plt
+
+lr = linear_model.LinearRegression()
+boston = datasets.load_boston()
+y = boston.target
+
+# cross_val_predict returns an array of the same size as `y` where each entry
+# is a prediction obtained by cross validated:
+predicted = cross_val_predict(lr, boston.data, y, cv=10)
+
+fig,ax = plt.subplots()
+ax.scatter(y, predicted)
+ax.plot([y.min(), y.max()], [y.min(), y.max()], 'k--', lw=4)
+ax.set_xlabel('Measured')
+ax.set_ylabel('Predicted')
+fig.show()

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -41,6 +41,7 @@ __all__ = ['Bootstrap',
            'StratifiedShuffleSplit',
            'check_cv',
            'cross_val_score',
+           'cross_val_prediction',
            'permutation_test_score',
            'train_test_split']
 
@@ -1074,6 +1075,137 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
 
 ##############################################################################
+def cross_val_prediction(estimator, X, y=None, cv=None, n_jobs=1,
+                         verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+    """Evaluate a score by cross-validation
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit' and 'predict'
+        The object to use to fit the data.
+
+    X : array-like
+        The data to fit. Can be, for example a list, or an array at least 2d.
+
+    y : array-like, optional, default: None
+        The target variable to try to predict in the case of
+        supervised learning.
+
+    cv : cross-validation generator or int, optional, default: None
+        A cross-validation generator to use. If int, determines
+        the number of folds in StratifiedKFold if y is binary
+        or multiclass and estimator is a classifier, or the number
+        of folds in KFold otherwise. If None, it is equivalent to cv=3.
+        Note that this function does not makes sense when elements are included
+        in multiple test sets.
+
+    n_jobs : integer, optional
+        The number of CPUs to use to do the computation. -1 means
+        'all CPUs'.
+
+    verbose : integer, optional
+        The verbosity level.
+
+    fit_params : dict, optional
+        Parameters to pass to the fit method of the estimator.
+
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+
+            - An int, giving the exact number of total jobs that are
+              spawned
+
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    Returns
+    -------
+    preds : ndarray
+        This is the result of calling 'predict'
+    """
+    X, y = indexable(X, y)
+
+    cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
+    # We clone the estimator to make sure that all the folds are
+    # independent, and that it is pickle-able.
+    parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
+                        pre_dispatch=pre_dispatch)
+    preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
+                                                      train, test, verbose,
+                                                      fit_params)
+                            for train, test in cv)
+    if y is not None:
+        preds = np.empty_like(y)
+        for p, loc in preds_blocks:
+            preds[loc] = p
+    else:
+        preds = [None for _ in X]
+        for ps, loc in preds_blocks:
+            for p, ell in zip(ps, loc):
+                preds[ell] = p
+        preds = np.array(preds)
+    return preds
+
+
+def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
+    """Fit estimator and predict values for a given dataset split.
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit' and 'predict'
+        The object to use to fit the data.
+
+    X : array-like of shape at least 2D
+        The data to fit.
+
+    y : array-like, optional, default: None
+        The target variable to try to predict in the case of
+        supervised learning.
+
+    train : array-like, shape = (n_train_samples,)
+        Indices of training samples.
+
+    test : array-like, shape = (n_test_samples,)
+        Indices of test samples.
+
+    verbose : integer
+        The verbosity level.
+
+    fit_params : dict or None
+        Parameters that will be passed to ``estimator.fit``.
+
+    Returns
+    -------
+    preds : sequence
+        Result of calling 'estimator.predict'
+
+    test : array-like
+        This is the value of the test parameter
+    """
+    # Adjust length of sample weights
+    n_samples = _num_samples(X)
+    fit_params = fit_params if fit_params is not None else {}
+    fit_params = dict([(k, np.asarray(v)[train]
+                       if hasattr(v, '__len__') and len(v) == n_samples else v)
+                       for k, v in fit_params.items()])
+
+    X_train, y_train = _safe_split(estimator, X, y, train)
+    X_test, _ = _safe_split(estimator, X, y, test, train)
+
+    if y_train is None:
+        estimator.fit(X_train, **fit_params)
+    else:
+        estimator.fit(X_train, y_train, **fit_params)
+    preds = estimator.predict(X_test)
+    return preds, test
 
 
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1166,10 +1166,10 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
         The target variable to try to predict in the case of
         supervised learning.
 
-    train : array-like, shape = (n_train_samples,)
+    train : array-like, shape (n_train_samples,)
         Indices of training samples.
 
-    test : array-like, shape = (n_test_samples,)
+    test : array-like, shape (n_test_samples,)
         Indices of test samples.
 
     verbose : integer
@@ -1327,10 +1327,10 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         A scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    train : array-like, shape = (n_train_samples,)
+    train : array-like, shape (n_train_samples,)
         Indices of training samples.
 
-    test : array-like, shape = (n_test_samples,)
+    test : array-like, shape (n_test_samples,)
         Indices of test samples.
 
     verbose : integer
@@ -1610,7 +1610,7 @@ def permutation_test_score(estimator, X, y, cv=None,
     score : float
         The true score without permuting targets.
 
-    permutation_scores : array, shape = [n_permutations]
+    permutation_scores : array, shape [n_permutations]
         The scores obtained for each permutations.
 
     pvalue : float

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -41,7 +41,7 @@ __all__ = ['Bootstrap',
            'StratifiedShuffleSplit',
            'check_cv',
            'cross_val_score',
-           'cross_val_prediction',
+           'cross_val_predict',
            'permutation_test_score',
            'train_test_split']
 
@@ -1075,9 +1075,9 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
 
 ##############################################################################
-def cross_val_prediction(estimator, X, y=None, cv=None, n_jobs=1,
+def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                          verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
-    """Evaluate a score by cross-validation
+    """Generate cross-validated estimates for each input data point
 
     Parameters
     ----------
@@ -1096,7 +1096,7 @@ def cross_val_prediction(estimator, X, y=None, cv=None, n_jobs=1,
         the number of folds in StratifiedKFold if y is binary
         or multiclass and estimator is a classifier, or the number
         of folds in KFold otherwise. If None, it is equivalent to cv=3.
-        Note that this function does not makes sense when elements are included
+        Note that this function does not make sense when elements are included
         in multiple test sets.
 
     n_jobs : integer, optional

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1096,8 +1096,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
         the number of folds in StratifiedKFold if y is binary
         or multiclass and estimator is a classifier, or the number
         of folds in KFold otherwise. If None, it is equivalent to cv=3.
-        Note that this function does not make sense when elements are included
-        in multiple test sets.
+        This generator must include all elements in the test set exactly once.
+        Otherwise, a ValueError is raised.
 
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1610,7 +1610,7 @@ def permutation_test_score(estimator, X, y, cv=None,
     score : float
         The true score without permuting targets.
 
-    permutation_scores : array, shape [n_permutations]
+    permutation_scores : array, shape (n_permutations,)
         The scores obtained for each permutations.
 
     pvalue : float

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1076,7 +1076,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
 ##############################################################################
 def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
-                         verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
     Parameters
@@ -1145,7 +1145,7 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     p = np.concatenate([p for p, _ in preds_blocks])
     locs = np.concatenate([loc for _, loc in preds_blocks])
     if not _check_is_partition(locs, X.shape[0]):
-        raise ValueError('cross_val_predict only works well for partitions of the data')
+        raise ValueError('cross_val_predict only works for partitions')
     preds = p.copy()
     preds[locs] = p
     return preds

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1144,6 +1144,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                             for train, test in cv)
     p = np.concatenate([p for p, _ in preds_blocks])
     locs = np.concatenate([loc for _, loc in preds_blocks])
+    if not _check_is_partition(locs, X.shape[0]):
+        raise ValueError('cross_val_predict only works well for partitions of the data')
     preds = p.copy()
     preds[locs] = p
     return preds
@@ -1200,6 +1202,30 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
         estimator.fit(X_train, y_train, **fit_params)
     preds = estimator.predict(X_test)
     return preds, test
+
+
+def _check_is_partition(locs, n):
+    """Check whether locs is a reordering of the array np.arange(n)
+
+    Parameters
+    ----------
+    locs : ndarray
+        integer array to test
+    n : int
+        number of expected elements
+
+    Returns
+    -------
+    is_partition : bool
+        True iff sorted(locs) is range(n)
+    """
+    if len(locs) != n:
+        return False
+    hit = np.zeros(n, bool)
+    hit[locs] = True
+    if not np.all(hit):
+        return False
+    return True
 
 
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1142,16 +1142,10 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                                                       train, test, verbose,
                                                       fit_params)
                             for train, test in cv)
-    if y is not None:
-        preds = np.empty_like(y)
-        for p, loc in preds_blocks:
-            preds[loc] = p
-    else:
-        preds = [None for _ in X]
-        for ps, loc in preds_blocks:
-            for p, ell in zip(ps, loc):
-                preds[ell] = p
-        preds = np.array(preds)
+    p = np.concatenate([p for p, _ in preds_blocks])
+    locs = np.concatenate([loc for _, loc in preds_blocks])
+    preds = p.copy()
+    preds[locs] = p
     return preds
 
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -7,6 +7,7 @@ from scipy.sparse import coo_matrix
 from scipy import stats
 
 from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
@@ -1036,3 +1037,19 @@ def test_cross_val_predict():
 
     preds = cval.cross_val_predict(KMeans(), X)
     assert_equal(len(preds), len(y))
+
+    def bad_cv():
+        for i in range(4):
+            yield np.array([0,1,2,3]), np.array([4,5,6,7,8])
+
+    assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
+
+
+def test_check_is_partition():
+    p = np.arange(100)
+    assert_true(cval._check_is_partition(p, 100))
+    assert_false(cval._check_is_partition(np.delete(p, 23), 100))
+
+    p[0] = 23
+    assert_false(cval._check_is_partition(p, 100))
+

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1021,5 +1021,18 @@ def test_cross_val_predict():
     preds = cval.cross_val_predict(est, X, y)
     assert_equal(len(preds), len(y))
 
+
+    cv = cval.LeaveOneOut(len(y))
+    preds = cval.cross_val_predict(est, X, y, cv=cv)
+    assert_equal(len(preds), len(y))
+
+
+    Xsp = X.copy()
+    Xsp *= (Xsp > np.median(Xsp))
+    Xsp = coo_matrix(Xsp)
+    preds = cval.cross_val_predict(est, Xsp, y)
+    assert_array_almost_equal(len(preds), len(y))
+
+
     preds = cval.cross_val_predict(KMeans(), X)
     assert_equal(len(preds), len(y))

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1005,14 +1005,14 @@ def test_cross_val_score_multilabel():
 
 def test_cross_val_predict():
     boston = load_boston()
-    X,y = boston.data, boston.target
+    X, y = boston.data, boston.target
     cv = cval.KFold(len(boston.target))
 
     est = Ridge()
 
     # Naive loop (should be same as cross_val_predict):
     preds2 = np.zeros_like(y)
-    for train,test in cv:
+    for train, test in cv:
         est.fit(X[train], y[train])
         preds2[test] = est.predict(X[test])
 
@@ -1022,11 +1022,9 @@ def test_cross_val_predict():
     preds = cval.cross_val_predict(est, X, y)
     assert_equal(len(preds), len(y))
 
-
     cv = cval.LeaveOneOut(len(y))
     preds = cval.cross_val_predict(est, X, y, cv=cv)
     assert_equal(len(preds), len(y))
-
 
     Xsp = X.copy()
     Xsp *= (Xsp > np.median(Xsp))
@@ -1034,13 +1032,12 @@ def test_cross_val_predict():
     preds = cval.cross_val_predict(est, Xsp, y)
     assert_array_almost_equal(len(preds), len(y))
 
-
     preds = cval.cross_val_predict(KMeans(), X)
     assert_equal(len(preds), len(y))
 
     def bad_cv():
         for i in range(4):
-            yield np.array([0,1,2,3]), np.array([4,5,6,7,8])
+            yield np.array([0, 1, 2, 3]), np.array([4, 5, 6, 7, 8])
 
     assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
 
@@ -1052,4 +1049,3 @@ def test_check_is_partition():
 
     p[0] = 23
     assert_false(cval._check_is_partition(p, 100))
-

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1012,7 +1012,7 @@ def test_cross_val_predict():
     preds2 = np.zeros_like(y)
     for train,test in cv:
         est.fit(X[train], y[train])
-        preds2[test] = est.predict(X[test])
+        preds2[test] = est.predict(X[test]).astype(preds2.dtype)
 
     preds = cval.cross_val_predict(est, X, y, cv=cv)
     assert_array_almost_equal(preds, preds2)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1000,6 +1000,7 @@ def test_cross_val_score_multilabel():
     assert_almost_equal(score_macro, [1, 1/2, 3/4, 1/2, 1/4])
     assert_almost_equal(score_samples, [1, 1/2, 3/4, 1/2, 1/4])
 
+
 def test_cross_val_predict():
     iris = load_iris()
     X,y = iris.data, iris.target
@@ -1007,17 +1008,17 @@ def test_cross_val_predict():
 
     est = Ridge()
 
-    # Naive loop (should be same as cross_val_prediction): 
+    # Naive loop (should be same as cross_val_predict):
     preds2 = np.zeros_like(y)
     for train,test in cv:
         est.fit(X[train], y[train])
         preds2[test] = est.predict(X[test])
-        
-    preds = cval.cross_val_prediction(est, X, y, cv=cv)
+
+    preds = cval.cross_val_predict(est, X, y, cv=cv)
     assert_array_almost_equal(preds, preds2)
 
-    preds = cval.cross_val_prediction(est, X, y)
+    preds = cval.cross_val_predict(est, X, y)
     assert_equal(len(preds), len(y))
 
-    preds = cval.cross_val_prediction(KMeans(), X)
+    preds = cval.cross_val_predict(KMeans(), X)
     assert_equal(len(preds), len(y))

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -23,6 +23,7 @@ from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 from sklearn import cross_validation as cval
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_regression
+from sklearn.datasets import load_boston
 from sklearn.datasets import load_digits
 from sklearn.datasets import load_iris
 from sklearn.metrics import accuracy_score
@@ -1002,9 +1003,9 @@ def test_cross_val_score_multilabel():
 
 
 def test_cross_val_predict():
-    iris = load_iris()
-    X,y = iris.data, iris.target
-    cv = cval.KFold(len(iris.target))
+    boston = load_boston()
+    X,y = boston.data, boston.target
+    cv = cval.KFold(len(boston.target))
 
     est = Ridge()
 
@@ -1012,7 +1013,7 @@ def test_cross_val_predict():
     preds2 = np.zeros_like(y)
     for train,test in cv:
         est.fit(X[train], y[train])
-        preds2[test] = est.predict(X[test]).astype(preds2.dtype)
+        preds2[test] = est.predict(X[test])
 
     preds = cval.cross_val_predict(est, X, y, cv=cv)
     assert_array_almost_equal(preds, preds2)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -36,6 +36,7 @@ from sklearn.externals.six.moves import zip
 from sklearn.linear_model import Ridge
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.svm import SVC
+from sklearn.cluster import KMeans
 
 from sklearn.preprocessing import Imputer, LabelBinarizer
 from sklearn.pipeline import Pipeline
@@ -998,3 +999,25 @@ def test_cross_val_score_multilabel():
     assert_almost_equal(score_micro, [1, 1/2, 3/4, 1/2, 1/3])
     assert_almost_equal(score_macro, [1, 1/2, 3/4, 1/2, 1/4])
     assert_almost_equal(score_samples, [1, 1/2, 3/4, 1/2, 1/4])
+
+def test_cross_val_predict():
+    iris = load_iris()
+    X,y = iris.data, iris.target
+    cv = cval.KFold(len(iris.target))
+
+    est = Ridge()
+
+    # Naive loop (should be same as cross_val_prediction): 
+    preds2 = np.zeros_like(y)
+    for train,test in cv:
+        est.fit(X[train], y[train])
+        preds2[test] = est.predict(X[test])
+        
+    preds = cval.cross_val_prediction(est, X, y, cv=cv)
+    assert_array_almost_equal(preds, preds2)
+
+    preds = cval.cross_val_prediction(est, X, y)
+    assert_equal(len(preds), len(y))
+
+    preds = cval.cross_val_prediction(KMeans(), X)
+    assert_equal(len(preds), len(y))


### PR DESCRIPTION
This function returns the cross-validated prediction for each element in
the input data (i.e., the prediction that is made when that object is in
the test set).

This is a loop that I keep writing over and over again, so I feel it should
be part of scikit-learn. Additionally, this uses joblib to take advantage of
multiple CPUs
