### PR TITLE
Fixes ovr in the binary classifier case

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -54,6 +54,7 @@ __all__ = [
     "OutputCodeClassifier",
 ]
 
+
 def _fit_binary(estimator, X, y, classes=None):
     """Fit a single binary estimator."""
     unique_y = np.unique(y)
@@ -299,17 +300,17 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         else:
             thresh = .5
 
+        n_samples = _num_samples(X)
         if self.label_binarizer_.y_type_ == "multiclass":
-            maxima = np.empty(X.shape[0], dtype=float)
+            maxima = np.empty(n_samples, dtype=float)
             maxima.fill(-np.inf)
-            argmaxima = np.zeros(X.shape[0], dtype=int)
+            argmaxima = np.zeros(n_samples, dtype=int)
             for i, e in enumerate(self.estimators_):
                 pred = _predict_binary(e, X)
                 np.maximum(maxima, pred, out=maxima)
                 argmaxima[maxima == pred] = i
             return self.label_binarizer_.classes_[np.array(argmaxima.T)]
         else:
-            n_samples = _num_samples(X)
             indices = array.array('i')
             indptr = array.array('i', [0])
             for e in self.estimators_:
@@ -346,6 +347,11 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         # Y[i,j] gives the probability that sample i has the label j.
         # In the multi-label case, these are not disjoint.
         Y = np.array([e.predict_proba(X)[:, 1] for e in self.estimators_]).T
+
+        if len(self.estimators_) == 1:
+            # Only one estimator, but we still want to return probabilities
+            # for two classes.
+            Y = np.concatenate((Y, (1 - Y)), 1)
 
         if not self.multilabel_:
             # Then, probabilities should be normalized to 1.

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -27,7 +27,7 @@ from sklearn.metrics import recall_score
 
 from sklearn.preprocessing import LabelBinarizer
 
-from sklearn.svm import LinearSVC
+from sklearn.svm import LinearSVC, SVC
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import (LinearRegression, Lasso, ElasticNet, Ridge,
                                   Perceptron, LogisticRegression)
@@ -186,19 +186,29 @@ def test_ovr_binary():
 
     classes = set("eggs spam".split())
 
-    for base_clf in (MultinomialNB(), LinearSVC(random_state=0),
-                     LinearRegression(), Ridge(),
-                     ElasticNet()):
-
+    def conduct_test(base_clf, test_predict_proba=False):
         clf = OneVsRestClassifier(base_clf).fit(X, y)
         assert_equal(set(clf.classes_), classes)
         y_pred = clf.predict(np.array([[0, 0, 4]]))[0]
         assert_equal(set(y_pred), set("eggs"))
 
+        if test_predict_proba:
+            probabilities = clf.predict_proba(np.array([[0, 0, 4]]))
+            assert_equal(2, len(probabilities[0]))
+
         # test input as label indicator matrix
         clf = OneVsRestClassifier(base_clf).fit(X, Y)
         y_pred = clf.predict([[3, 0, 0]])[0]
         assert_equal(y_pred, 1)
+
+    for base_clf in (LinearSVC(random_state=0), LinearRegression(),
+                     Ridge(), ElasticNet()):
+        conduct_test(base_clf)
+
+    for base_clf in (MultinomialNB(), SVC(probability=True),
+                     LogisticRegression()):
+        conduct_test(base_clf, True)
+
 
 @ignore_warnings
 def test_ovr_multilabel():


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/3700. Also allows feature arrays (rather than just numpy arrays) in the multiclass case (already supported in the binary case), and adds a test for the number of probabilities returned from predict_proba in test_ovr_binary.
