### PR TITLE
[MRG]Fix nearly zero division

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -52,16 +52,17 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
         mean_ = None
 
     if with_std:
-        is_all_elems_equal = lambda arr: arr.size > 0 and all(arr == arr.take(0))
+        is_all_elems_equal = lambda arr: np.unique(arr).size == 1
 
         std_ = Xr.std(axis=0)
         if isinstance(std_, np.ndarray) and std_.size > 0:
             std_[std_ == 0.0] = 1.0
 
-            old_std_ = std_
             is_equal_matrix = np.apply_along_axis(lambda col: is_all_elems_equal(col), 0, Xr)
             std_with_flag = np.vstack([std_.ravel(), is_equal_matrix.ravel()])
             replace_to_one = lambda std_and_flag: 1.0 if std_and_flag[1] else std_and_flag[0]  # arg:(std_, flag)
+            
+            old_std_ = std_
             std_ = np.apply_along_axis(replace_to_one, 0, std_with_flag)
             std_.shape = old_std_.shape
         elif std_ == 0. or is_all_elems_equal(X):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -16,6 +16,7 @@ from ..utils import check_array
 from ..utils import warn_if_not_float
 from ..utils.extmath import row_norms
 from ..utils.fixes import combinations_with_replacement as combinations_w_r
+from ..utils.fixes import isclose
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale, mean_variance_axis)
@@ -38,6 +39,19 @@ __all__ = [
 ]
 
 
+def _replace_nearly_value(X, base, replace_to):
+    """Fit close value to avoid division by nearly zero.
+    """
+    def _fit(scalar):
+        if isclose(scalar, base):
+            return replace_to
+        else:
+            return scalar
+
+    otypes = [np.float64]*X.ndim
+    return np.vectorize(_fit, otypes=otypes)(X)
+
+
 def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
     """Compute mean and std deviation for centering, scaling.
 
@@ -53,10 +67,7 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
 
     if with_std:
         std_ = Xr.std(axis=0)
-        if isinstance(std_, np.ndarray):
-            std_[std_ == 0.0] = 1.0
-        elif std_ == 0.:
-            std_ = 1.
+        std_ = _replace_nearly_value(std_, base=0, replace_to=1)
     else:
         std_ = None
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -38,7 +38,6 @@ __all__ = [
 ]
 
 
-
 def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
     """Compute mean and std deviation for centering, scaling.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -42,14 +42,15 @@ __all__ = [
 def _replace_nearly_value(X, base, replace_to):
     """Fit close value to avoid division by nearly zero.
     """
-    def _fit(scalar):
-        if isclose(scalar, base):
+    def _replace(value):
+        if isclose(value, base):
             return replace_to
         else:
-            return scalar
+            return value
 
+    X = np.asarray(X)
     otypes = [np.float64]*X.ndim
-    return np.vectorize(_fit, otypes=otypes)(X)
+    return np.vectorize(_replace, otypes=otypes)(X)
 
 
 def _mean_and_std(X, axis=0, with_mean=True, with_std=True):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1,5 +1,5 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
-#          Mathieu Blondel <mathieu@mblondel.org>
+# Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: BSD 3 clause
@@ -52,7 +52,7 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
         mean_ = None
 
     if with_std:
-        is_all_elems_equal = lambda arr:arr.size > 0 and all(arr == arr.take(0))
+        is_all_elems_equal = lambda arr: arr.size > 0 and all(arr == arr.take(0))
 
         std_ = Xr.std(axis=0)
         if isinstance(std_, np.ndarray) and std_.size > 0:
@@ -61,7 +61,7 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
             old_std_ = std_
             is_equal_matrix = np.apply_along_axis(lambda col: is_all_elems_equal(col), 0, Xr)
             std_with_flag = np.vstack([std_.ravel(), is_equal_matrix.ravel()])
-            replace_to_one = lambda std_and_flag: 1.0 if std_and_flag[1] else std_and_flag[0] # arg:(std_, flag)
+            replace_to_one = lambda std_and_flag: 1.0 if std_and_flag[1] else std_and_flag[0]  # arg:(std_, flag)
             std_ = np.apply_along_axis(replace_to_one, 0, std_with_flag)
             std_.shape = old_std_.shape
         elif std_ == 0. or is_all_elems_equal(X):
@@ -452,6 +452,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <example_linear_model_plot_polynomial_interpolation.py>`
     """
+
     def __init__(self, degree=2, interaction_only=False, include_bias=True):
         self.degree = degree
         self.interaction_only = interaction_only
@@ -473,8 +474,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         """
         n_samples, n_features = check_array(X).shape
         self.powers_ = self._power_matrix(n_features, self.degree,
-                                          self.interaction_only,
-                                          self.include_bias)
+            self.interaction_only,
+            self.include_bias)
         return self
 
     def transform(self, X, y=None):
@@ -975,8 +976,9 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
     sklearn.feature_extraction.FeatureHasher : performs an approximate one-hot
       encoding of dictionary items or strings.
     """
+
     def __init__(self, n_values="auto", categorical_features="all",
-                 dtype=np.float, sparse=True):
+            dtype=np.float, sparse=True):
         self.n_values = n_values
         self.categorical_features = categorical_features
         self.dtype = dtype
@@ -1029,11 +1031,11 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         column_indices = (X + indices[:-1]).ravel()
         row_indices = np.repeat(np.arange(n_samples, dtype=np.int32),
-                                n_features)
+            n_features)
         data = np.ones(n_samples * n_features)
         out = sparse.coo_matrix((data, (row_indices, column_indices)),
-                                shape=(n_samples, indices[-1]),
-                                dtype=self.dtype).tocsr()
+            shape=(n_samples, indices[-1]),
+            dtype=self.dtype).tocsr()
 
         if self.n_values == 'auto':
             mask = np.array(out.sum(axis=0)).ravel() != 0
@@ -1050,7 +1052,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         efficient. See fit for the parameters, transform for the return value.
         """
         return _transform_selected(X, self._fit_transform,
-                                   self.categorical_features, copy=True)
+            self.categorical_features, copy=True)
 
     def _transform(self, X):
         """Assumes X contains only categorical features."""
@@ -1070,11 +1072,11 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         column_indices = (X + indices[:-1]).ravel()
         row_indices = np.repeat(np.arange(n_samples, dtype=np.int32),
-                                n_features)
+            n_features)
         data = np.ones(n_samples * n_features)
         out = sparse.coo_matrix((data, (row_indices, column_indices)),
-                                shape=(n_samples, indices[-1]),
-                                dtype=self.dtype).tocsr()
+            shape=(n_samples, indices[-1]),
+            dtype=self.dtype).tocsr()
         if self.n_values == 'auto':
             out = out[:, self.active_features_]
 
@@ -1094,4 +1096,4 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
             Transformed input.
         """
         return _transform_selected(X, self._transform,
-                                   self.categorical_features, copy=True)
+            self.categorical_features, copy=True)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -52,10 +52,10 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
         mean_ = None
 
     if with_std:
-        is_all_elems_equal = lambda arr:all(arr == arr.take(0))
+        is_all_elems_equal = lambda arr:arr.size > 0 and all(arr == arr.take(0))
 
         std_ = Xr.std(axis=0)
-        if isinstance(std_, np.ndarray):
+        if isinstance(std_, np.ndarray) and std_.size > 0:
             std_[std_ == 0.0] = 1.0
 
             old_std_ = std_

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1,5 +1,5 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
-# Mathieu Blondel <mathieu@mblondel.org>
+#          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 # License: BSD 3 clause
@@ -61,7 +61,7 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
             is_equal_matrix = np.apply_along_axis(lambda col: is_all_elems_equal(col), 0, Xr)
             std_with_flag = np.vstack([std_.ravel(), is_equal_matrix.ravel()])
             replace_to_one = lambda std_and_flag: 1.0 if std_and_flag[1] else std_and_flag[0]  # arg:(std_, flag)
-            
+
             old_std_ = std_
             std_ = np.apply_along_axis(replace_to_one, 0, std_with_flag)
             std_.shape = old_std_.shape
@@ -453,7 +453,6 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <example_linear_model_plot_polynomial_interpolation.py>`
     """
-
     def __init__(self, degree=2, interaction_only=False, include_bias=True):
         self.degree = degree
         self.interaction_only = interaction_only
@@ -475,8 +474,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         """
         n_samples, n_features = check_array(X).shape
         self.powers_ = self._power_matrix(n_features, self.degree,
-            self.interaction_only,
-            self.include_bias)
+                                          self.interaction_only,
+                                          self.include_bias)
         return self
 
     def transform(self, X, y=None):
@@ -977,9 +976,8 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
     sklearn.feature_extraction.FeatureHasher : performs an approximate one-hot
       encoding of dictionary items or strings.
     """
-
     def __init__(self, n_values="auto", categorical_features="all",
-            dtype=np.float, sparse=True):
+                 dtype=np.float, sparse=True):
         self.n_values = n_values
         self.categorical_features = categorical_features
         self.dtype = dtype
@@ -1032,11 +1030,11 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         column_indices = (X + indices[:-1]).ravel()
         row_indices = np.repeat(np.arange(n_samples, dtype=np.int32),
-            n_features)
+                                n_features)
         data = np.ones(n_samples * n_features)
         out = sparse.coo_matrix((data, (row_indices, column_indices)),
-            shape=(n_samples, indices[-1]),
-            dtype=self.dtype).tocsr()
+                                shape=(n_samples, indices[-1]),
+                                dtype=self.dtype).tocsr()
 
         if self.n_values == 'auto':
             mask = np.array(out.sum(axis=0)).ravel() != 0
@@ -1053,7 +1051,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         efficient. See fit for the parameters, transform for the return value.
         """
         return _transform_selected(X, self._fit_transform,
-            self.categorical_features, copy=True)
+                                   self.categorical_features, copy=True)
 
     def _transform(self, X):
         """Assumes X contains only categorical features."""
@@ -1073,11 +1071,11 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         column_indices = (X + indices[:-1]).ravel()
         row_indices = np.repeat(np.arange(n_samples, dtype=np.int32),
-            n_features)
+                                n_features)
         data = np.ones(n_samples * n_features)
         out = sparse.coo_matrix((data, (row_indices, column_indices)),
-            shape=(n_samples, indices[-1]),
-            dtype=self.dtype).tocsr()
+                                shape=(n_samples, indices[-1]),
+                                dtype=self.dtype).tocsr()
         if self.n_values == 'auto':
             out = out[:, self.active_features_]
 
@@ -1097,4 +1095,4 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
             Transformed input.
         """
         return _transform_selected(X, self._transform,
-            self.categorical_features, copy=True)
+                                   self.categorical_features, copy=True)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -99,6 +99,10 @@ def test_scaler_1d():
     X = np.ones(5)
     assert_array_equal(scale(X, with_mean=False), X)
 
+    X = np.zeros(22) + np.log(1e-5)
+    X_scaled = scale(X)
+    assert_array_almost_equal(X_scaled.mean(axis=0), 0.0)
+
 
 def test_scaler_2d_arrays():
     """Test scaling of 2d array along first axis"""


### PR DESCRIPTION
fixes #3722
- separate "reset zero to 1.0" function from `_mean_and_std()`
- add  `_replace_nearly_value()` function
  - with`isclose()`, "nealy" zero values also replaced to 1.0
- add floating point error testcase
