### PR TITLE
[MRG] Pretty decision trees - tree.export_graphviz()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,12 @@ Enhancements
    - Added ``stratify`` option to :func:`cross_validation.train_test_split` for stratified splitting.
      By Miroslav Batchkarov.
 
+   - The :func:`tree.export_graphviz` function now supports aesthetic
+     improvements for :class:`tree.DecisionTreeClassifier` and 
+     :class:`tree.DecisionTreeRegressor`, including options for coloring nodes
+     by their majority class or impurity, showing variable names, and using
+     node proportions instead of raw sample counts. By `Trevor Stephens`_.
+
 Bug fixes
 .........
 

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -7,15 +7,63 @@ This module defines export functions for decision trees.
 #          Brian Holt <bdholt1@gmail.com>
 #          Noel Dawe <noel@dawe.me>
 #          Satrajit Gosh <satrajit.ghosh@gmail.com>
+#          Trevor Stephens <trev.stephens@gmail.com>
 # Licence: BSD 3 clause
+
+import numpy as np
 
 from ..externals import six
 
 from . import _tree
 
 
-def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
-                    max_depth=None):
+def _color_brew(n):
+    """Generate n colors with equally spaced hues.
+
+    Parameters
+    ----------
+    n : int
+        The number of colors required.
+
+    Returns
+    -------
+    color_list : list, length n
+        List of n tuples of form (R, G, B) being the components of each color.
+    """
+    color_list = []
+
+    # Initialize saturation & value; calculate chroma & value shift
+    s, v = 0.75, 0.9
+    c = s * v
+    m = v - c
+
+    for h in np.arange(25, 385, 360./n).astype(int):
+        # Calculate some intermediate values
+        h_bar = h / 60.
+        x = c * (1 - abs((h_bar % 2) - 1))
+        # Initialize RGB with same hue & chroma as our color
+        rgb = [(c, x, 0),
+               (x, c, 0),
+               (0, c, x),
+               (0, x, c),
+               (x, 0, c),
+               (c, 0, x),
+               (c, x, 0)]
+        r, g, b = rgb[int(h_bar)]
+        # Shift the initial RGB values to match value and store
+        rgb = [(int(255 * (r + m))),
+               (int(255 * (g + m))),
+               (int(255 * (b + m)))]
+        color_list.append(rgb)
+
+    return color_list
+
+
+def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
+                    feature_names=None, class_names=None, label='all',
+                    filled=False, leaves_parallel=False, impurity=True,
+                    node_ids=False, proportion=False, rotate=False,
+                    rounded=False, special_characters=False):
     """Export a decision tree in DOT format.
 
     This function generates a GraphViz representation of the decision tree,
@@ -36,12 +84,51 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
     out_file : file object or string, optional (default="tree.dot")
         Handle or name of the output file.
 
-    feature_names : list of strings, optional (default=None)
-        Names of each of the features.
-
     max_depth : int, optional (default=None)
         The maximum depth of the representation. If None, the tree is fully
         generated.
+
+    feature_names : list of strings, optional (default=None)
+        Names of each of the features.
+
+    class_names : list of strings, bool or None, optional (default=None)
+        Names of each of the target classes in ascending numerical order.
+        Only relevant for classification and not supported for multi-output.
+        If ``True``, shows a symbolic representation of the class name.
+
+    label : {'all', 'root', 'none'}, optional (default='all')
+        Whether to show informative labels for impurity, etc.
+        Options include 'all' to show at every node, 'root' to show only at
+        the top root node, or 'none' to not show at any node.
+
+    filled : bool, optional (default=False)
+        When set to ``True``, paint nodes to indicate majority class for
+        classification, extremity of values for regression, or purity of node
+        for multi-output.
+
+    leaves_parallel : bool, optional (default=False)
+        When set to ``True``, draw all leaf nodes at the bottom of the tree.
+
+    impurity : bool, optional (default=True)
+        When set to ``True``, show the impurity at each node.
+
+    node_ids : bool, optional (default=False)
+        When set to ``True``, show the ID number on each node.
+
+    proportion : bool, optional (default=False)
+        When set to ``True``, change the display of 'values' and/or 'samples'
+        to be proportions and percentages respectively.
+
+    rotate : bool, optional (default=False)
+        When set to ``True``, orient tree left to right rather than top-down.
+
+    rounded : bool, optional (default=False)
+        When set to ``True``, draw node boxes with rounded corners and use
+        Helvetica fonts instead of Times-Roman.
+
+    special_characters : bool, optional (default=False)
+        When set to ``False``, ignore special characters for PostScript
+        compatibility.
 
     Examples
     --------
@@ -55,32 +142,137 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
     >>> tree.export_graphviz(clf,
     ...     out_file='tree.dot')                # doctest: +SKIP
     """
-    def node_to_str(tree, node_id, criterion):
-        if not isinstance(criterion, six.string_types):
-            criterion = "impurity"
 
-        value = tree.value[node_id]
-        if tree.n_outputs == 1:
-            value = value[0, :]
-
-        if tree.children_left[node_id] == _tree.TREE_LEAF:
-            return "%s = %.4f\\nsamples = %s\\nvalue = %s" \
-                   % (criterion,
-                      tree.impurity[node_id],
-                      tree.n_node_samples[node_id],
-                      value)
+    def get_color(value):
+        # Find the appropriate color & intensity for a node
+        if colors['bounds'] is None:
+            # Classification tree
+            color = list(colors['rgb'][np.argmax(value)])
+            sorted_values = sorted(value, reverse=True)
+            alpha = int(255 * (sorted_values[0] - sorted_values[1]) /
+                        (1 - sorted_values[1]))
         else:
+            # Regression tree or multi-output
+            color = list(colors['rgb'][0])
+            alpha = int(255 * ((value - colors['bounds'][0]) /
+                               (colors['bounds'][1] - colors['bounds'][0])))
+
+        # Return html color code in #RRGGBBAA format
+        color.append(alpha)
+        hex_codes = [str(i) for i in range(10)]
+        hex_codes.extend(['a', 'b', 'c', 'd', 'e', 'f'])
+        color = [hex_codes[c // 16] + hex_codes[c % 16] for c in color]
+
+        return '#' + ''.join(color)
+
+    def node_to_str(tree, node_id, criterion):
+        # Generate the node content string
+
+        if tree.n_outputs == 1:
+            value = tree.value[node_id][0, :]
+        else:
+            value = tree.value[node_id]
+
+        # Should labels be shown?
+        labels = (label == 'root' and node_id == 0) or label == 'all'
+
+        # PostScript compatibility for special characters
+        if special_characters:
+            characters = ['&#35;', '<SUB>', '</SUB>', '&le;', '<br/>', '>']
+            node_string = '<'
+        else:
+            characters = ['#', '[', ']', '<=', '\\n', '"']
+            node_string = '"'
+
+        # Write node ID
+        if node_ids:
+            if labels:
+                node_string += 'node '
+            node_string += characters[0] + str(node_id) + characters[4]
+
+        # Write decision criteria
+        if tree.children_left[node_id] != _tree.TREE_LEAF:
+            # Always write node decision criteria, except for leaves
             if feature_names is not None:
                 feature = feature_names[tree.feature[node_id]]
             else:
-                feature = "X[%s]" % tree.feature[node_id]
+                feature = "X%s%s%s" % (characters[1],
+                                       tree.feature[node_id],
+                                       characters[2])
+            node_string += '%s %s %s%s' % (feature,
+                                           characters[3],
+                                           round(tree.threshold[node_id], 4),
+                                           characters[4])
 
-            return "%s <= %.4f\\n%s = %s\\nsamples = %s" \
-                   % (feature,
-                      tree.threshold[node_id],
-                      criterion,
-                      tree.impurity[node_id],
-                      tree.n_node_samples[node_id])
+        # Write impurity
+        if impurity:
+            if not isinstance(criterion, six.string_types):
+                criterion = "impurity"
+            if labels:
+                node_string += '%s = ' % criterion
+            node_string += (str(round(tree.impurity[node_id], 4)) +
+                            characters[4])
+
+        # Write node sample count
+        if labels:
+            node_string += 'samples = '
+        if proportion:
+            percent = (100. * tree.n_node_samples[node_id] /
+                       float(tree.n_node_samples[0]))
+            node_string += (str(round(percent, 1)) + '%' +
+                            characters[4])
+        else:
+            node_string += (str(tree.n_node_samples[node_id]) +
+                            characters[4])
+
+        # Write node class distribution / regression value
+        if proportion and tree.n_classes[0] != 1:
+            # For classification this will show the proportion of samples
+            value = value / tree.weighted_n_node_samples[node_id]
+        if labels:
+            node_string += 'value = '
+        if tree.n_classes[0] == 1:
+            # Regression
+            value_text = np.around(value, 4)
+        elif proportion:
+            # Classification
+            value_text = np.around(value, 2)
+        elif np.all(np.equal(np.mod(value, 1), 0)):
+            # Classification without floating-point weights
+            value_text = value.astype(int)
+        else:
+            # Classification with floating-point weights
+            value_text = np.around(value, 4)
+        # Strip whitespace
+        value_text = str(value_text.astype('S32')).replace("b'", "'")
+        value_text = value_text.replace("' '", ", ").replace("'", "")
+        if tree.n_classes[0] == 1 and tree.n_outputs == 1:
+            value_text = value_text.replace("[", "").replace("]", "")
+        value_text = value_text.replace("\n ", characters[4])
+        node_string += value_text + characters[4]
+
+        # Write node majority class
+        if (class_names is not None and
+                tree.n_classes[0] != 1 and
+                tree.n_outputs == 1):
+            # Only done for single-output classification trees
+            if labels:
+                node_string += 'class = '
+            if class_names is not True:
+                class_name = class_names[np.argmax(value)]
+            else:
+                class_name = "y%s%s%s" % (characters[1],
+                                          np.argmax(value),
+                                          characters[2])
+            node_string += class_name
+
+        # Clean up any trailing newlines
+        if node_string[-2:] == '\\n':
+            node_string = node_string[:-2]
+        if node_string[-5:] == '<br/>':
+            node_string = node_string[:-5]
+
+        return node_string + characters[5]
 
     def recurse(tree, node_id, criterion, parent=None, depth=0):
         if node_id == _tree.TREE_LEAF:
@@ -91,12 +283,56 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
 
         # Add node with description
         if max_depth is None or depth <= max_depth:
-            out_file.write('%d [label="%s", shape="box"] ;\n' %
-                           (node_id, node_to_str(tree, node_id, criterion)))
+
+            # Collect ranks for 'leaf' option in plot_options
+            if left_child == _tree.TREE_LEAF:
+                ranks['leaves'].append(str(node_id))
+            elif str(depth) not in ranks:
+                ranks[str(depth)] = [str(node_id)]
+            else:
+                ranks[str(depth)].append(str(node_id))
+
+            out_file.write('%d [label=%s'
+                           % (node_id,
+                              node_to_str(tree, node_id, criterion)))
+
+            if filled:
+                # Fetch appropriate color for node
+                if 'rgb' not in colors:
+                    # Initialize colors and bounds if required
+                    colors['rgb'] = _color_brew(tree.n_classes[0])
+                    if tree.n_outputs != 1:
+                        # Find max and min impurities for multi-output
+                        colors['bounds'] = (np.min(-tree.impurity),
+                                             np.max(-tree.impurity))
+                    elif tree.n_classes[0] == 1:
+                        # Find max and min values in leaf nodes for regression
+                        colors['bounds'] = (np.min(tree.value),
+                                             np.max(tree.value))
+                if tree.n_outputs == 1:
+                    node_val = (tree.value[node_id][0, :] /
+                                tree.weighted_n_node_samples[node_id])
+                    if tree.n_classes[0] == 1:
+                        # Regression
+                        node_val = tree.value[node_id][0, :]
+                else:
+                    # If multi-output color node by impurity
+                    node_val = -tree.impurity[node_id]
+                out_file.write(', fillcolor="%s"' % get_color(node_val))
+            out_file.write('] ;\n')
 
             if parent is not None:
                 # Add edge to parent
-                out_file.write('%d -> %d ;\n' % (parent, node_id))
+                out_file.write('%d -> %d' % (parent, node_id))
+                if parent == 0:
+                    # Draw True/False labels if parent is root node
+                    angles = np.array([45, -45]) * ((rotate - .5) * -2)
+                    out_file.write(' [labeldistance=2.5, labelangle=')
+                    if node_id == 1:
+                        out_file.write('%d, headlabel="True"]' % angles[0])
+                    else:
+                        out_file.write('%d, headlabel="False"]' % angles[1])
+                out_file.write(' ;\n')
 
             if left_child != _tree.TREE_LEAF:
                 recurse(tree, left_child, criterion=criterion, parent=node_id,
@@ -105,7 +341,13 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
                         depth=depth + 1)
 
         else:
-            out_file.write('%d [label="(...)", shape="box"] ;\n' % node_id)
+            ranks['leaves'].append(str(node_id))
+
+            out_file.write('%d [label="(...)"' % node_id)
+            if filled:
+                # color cropped nodes grey
+                out_file.write(', fillcolor="#C0C0C0"')
+            out_file.write('] ;\n' % node_id)
 
             if parent is not None:
                 # Add edge to parent
@@ -120,12 +362,46 @@ def export_graphviz(decision_tree, out_file="tree.dot", feature_names=None,
                 out_file = open(out_file, "wb")
             own_file = True
 
-        out_file.write("digraph Tree {\n")
+        # The depth of each node for plotting with 'leaf' option
+        ranks = {'leaves': []}
+        # The colors to render each node with
+        colors = {'bounds': None}
 
+        out_file.write('digraph Tree {\n')
+
+        # Specify node aesthetics
+        out_file.write('node [shape=box')
+        rounded_filled = []
+        if filled:
+            rounded_filled.append('filled')
+        if rounded:
+            rounded_filled.append('rounded')
+        if len(rounded_filled) > 0:
+            out_file.write(', style="%s", color="black"'
+                           % ", ".join(rounded_filled))
+        if rounded:
+            out_file.write(', fontname=helvetica')
+        out_file.write('] ;\n')
+
+        # Specify graph & edge aesthetics
+        if leaves_parallel:
+            out_file.write('graph [ranksep=equally, splines=polyline] ;\n')
+        if rounded:
+            out_file.write('edge [fontname=helvetica] ;\n')
+        if rotate:
+            out_file.write('rankdir=LR ;\n')
+
+        # Now recurse the tree and add node & edge attributes
         if isinstance(decision_tree, _tree.Tree):
             recurse(decision_tree, 0, criterion="impurity")
         else:
             recurse(decision_tree.tree_, 0, criterion=decision_tree.criterion)
+
+        # If required, draw leaf nodes at same depth as each other
+        if leaves_parallel:
+            for rank in sorted(ranks):
+                out_file.write("{rank=same ; " +
+                               "; ".join(r for r in ranks[rank]) + "} ;\n")
         out_file.write("}")
 
     finally:

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -5,15 +5,15 @@ Testing for export functions of decision trees (sklearn.tree.export).
 from numpy.testing import assert_equal
 from nose.tools import assert_raises
 
-from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree import export_graphviz
 from sklearn.externals.six import StringIO
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
 y = [-1, -1, -1, 1, 1, 1]
-T = [[-1, -1], [2, 2], [3, 2]]
-true_result = [-1, 1, 1]
+y2 = [[-1, 1], [-1, 2], [-1, 3], [1, 1], [1, 2], [1, 3]]
+w = [1, 1, 1, .5, .5, .5]
 
 
 def test_graphviz_toy():
@@ -28,16 +28,17 @@ def test_graphviz_toy():
     out = StringIO()
     export_graphviz(clf, out_file=out)
     contents1 = out.getvalue()
-    contents2 = "digraph Tree {\n" \
-                "0 [label=\"X[0] <= 0.0000\\ngini = 0.5\\n" \
-                "samples = 6\", shape=\"box\"] ;\n" \
-                "1 [label=\"gini = 0.0000\\nsamples = 3\\n" \
-                "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
-                "0 -> 1 ;\n" \
-                "2 [label=\"gini = 0.0000\\nsamples = 3\\n" \
-                "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
-                "0 -> 2 ;\n" \
-                "}"
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box] ;\n' \
+                '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
+                'value = [3, 3]"] ;\n' \
+                '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n' \
+                '0 -> 2 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="False"] ;\n' \
+                '}'
 
     assert_equal(contents1, contents2)
 
@@ -45,31 +46,167 @@ def test_graphviz_toy():
     out = StringIO()
     export_graphviz(clf, out_file=out, feature_names=["feature0", "feature1"])
     contents1 = out.getvalue()
-    contents2 = "digraph Tree {\n" \
-                "0 [label=\"feature0 <= 0.0000\\ngini = 0.5\\n" \
-                "samples = 6\", shape=\"box\"] ;\n" \
-                "1 [label=\"gini = 0.0000\\nsamples = 3\\n" \
-                "value = [ 3.  0.]\", shape=\"box\"] ;\n" \
-                "0 -> 1 ;\n" \
-                "2 [label=\"gini = 0.0000\\nsamples = 3\\n" \
-                "value = [ 0.  3.]\", shape=\"box\"] ;\n" \
-                "0 -> 2 ;\n" \
-                "}"
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box] ;\n' \
+                '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
+                'value = [3, 3]"] ;\n' \
+                '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n' \
+                '0 -> 2 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="False"] ;\n' \
+                '}'
+
+    assert_equal(contents1, contents2)
+
+    # Test with class_names
+    out = StringIO()
+    export_graphviz(clf, out_file=out, class_names=["yes", "no"])
+    contents1 = out.getvalue()
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box] ;\n' \
+                '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
+                'value = [3, 3]\\nclass = yes"] ;\n' \
+                '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]\\n' \
+                'class = yes"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]\\n' \
+                'class = no"] ;\n' \
+                '0 -> 2 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="False"] ;\n' \
+                '}'
+
+    assert_equal(contents1, contents2)
+
+    # Test plot_options
+    out = StringIO()
+    export_graphviz(clf, out_file=out, filled=True, impurity=False,
+                    proportion=True, special_characters=True, rounded=True)
+    contents1 = out.getvalue()
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box, style="filled, rounded", color="black", ' \
+                'fontname=helvetica] ;\n' \
+                'edge [fontname=helvetica] ;\n' \
+                '0 [label=<X<SUB>0</SUB> &le; 0.0<br/>samples = 100.0%<br/>' \
+                'value = [0.5, 0.5]>, fillcolor="#e5813900"] ;\n' \
+                '1 [label=<samples = 50.0%<br/>value = [1.0, 0.0]>, ' \
+                'fillcolor="#e58139ff"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label=<samples = 50.0%<br/>value = [0.0, 1.0]>, ' \
+                'fillcolor="#399de5ff"] ;\n' \
+                '0 -> 2 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="False"] ;\n' \
+                '}'
 
     assert_equal(contents1, contents2)
 
     # Test max_depth
     out = StringIO()
-    export_graphviz(clf, out_file=out, max_depth=0)
+    export_graphviz(clf, out_file=out, max_depth=0, class_names=True)
     contents1 = out.getvalue()
-    contents2 = "digraph Tree {\n" \
-                "0 [label=\"X[0] <= 0.0000\\ngini = 0.5\\n" \
-                "samples = 6\", shape=\"box\"] ;\n" \
-                "1 [label=\"(...)\", shape=\"box\"] ;\n" \
-                "0 -> 1 ;\n" \
-                "2 [label=\"(...)\", shape=\"box\"] ;\n" \
-                "0 -> 2 ;\n" \
-                "}"
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box] ;\n' \
+                '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
+                'value = [3, 3]\\nclass = y[0]"] ;\n' \
+                '1 [label="(...)"] ;\n' \
+                '0 -> 1 ;\n' \
+                '2 [label="(...)"] ;\n' \
+                '0 -> 2 ;\n' \
+                '}'
+
+    assert_equal(contents1, contents2)
+
+    # Test max_depth with plot_options
+    out = StringIO()
+    export_graphviz(clf, out_file=out, max_depth=0, filled=True,
+                    node_ids=True)
+    contents1 = out.getvalue()
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box, style="filled", color="black"] ;\n' \
+                '0 [label="node #0\\nX[0] <= 0.0\\ngini = 0.5\\n' \
+                'samples = 6\\nvalue = [3, 3]", fillcolor="#e5813900"] ;\n' \
+                '1 [label="(...)", fillcolor="#C0C0C0"] ;\n' \
+                '0 -> 1 ;\n' \
+                '2 [label="(...)", fillcolor="#C0C0C0"] ;\n' \
+                '0 -> 2 ;\n' \
+                '}'
+
+    assert_equal(contents1, contents2)
+
+    # Test multi-output with weighted samples
+    clf = DecisionTreeClassifier(max_depth=2,
+                                 min_samples_split=1,
+                                 criterion="gini",
+                                 random_state=2)
+    clf = clf.fit(X, y2, sample_weight=w)
+
+    out = StringIO()
+    export_graphviz(clf, out_file=out, filled=True, impurity=False)
+    contents1 = out.getvalue()
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box, style="filled", color="black"] ;\n' \
+                '0 [label="X[0] <= 0.0\\nsamples = 6\\n' \
+                'value = [[3.0, 1.5, 0.0]\\n' \
+                '[1.5, 1.5, 1.5]]", fillcolor="#e5813900"] ;\n' \
+                '1 [label="X[1] <= -1.5\\nsamples = 3\\n' \
+                'value = [[3, 0, 0]\\n[1, 1, 1]]", ' \
+                'fillcolor="#e5813965"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label="samples = 1\\nvalue = [[1, 0, 0]\\n' \
+                '[0, 0, 1]]", fillcolor="#e58139ff"] ;\n' \
+                '1 -> 2 ;\n' \
+                '3 [label="samples = 2\\nvalue = [[2, 0, 0]\\n' \
+                '[1, 1, 0]]", fillcolor="#e581398c"] ;\n' \
+                '1 -> 3 ;\n' \
+                '4 [label="X[0] <= 1.5\\nsamples = 3\\n' \
+                'value = [[0.0, 1.5, 0.0]\\n[0.5, 0.5, 0.5]]", ' \
+                'fillcolor="#e5813965"] ;\n' \
+                '0 -> 4 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="False"] ;\n' \
+                '5 [label="samples = 2\\nvalue = [[0.0, 1.0, 0.0]\\n' \
+                '[0.5, 0.5, 0.0]]", fillcolor="#e581398c"] ;\n' \
+                '4 -> 5 ;\n' \
+                '6 [label="samples = 1\\nvalue = [[0.0, 0.5, 0.0]\\n' \
+                '[0.0, 0.0, 0.5]]", fillcolor="#e58139ff"] ;\n' \
+                '4 -> 6 ;\n' \
+                '}'
+
+    assert_equal(contents1, contents2)
+
+    # Test regression output with plot_options
+    clf = DecisionTreeRegressor(max_depth=3,
+                                min_samples_split=1,
+                                criterion="mse",
+                                random_state=2)
+    clf.fit(X, y)
+
+    out = StringIO()
+    export_graphviz(clf, out_file=out, filled=True, leaves_parallel=True,
+                    rotate=True, rounded=True)
+    contents1 = out.getvalue()
+    contents2 = 'digraph Tree {\n' \
+                'node [shape=box, style="filled, rounded", color="black", ' \
+                'fontname=helvetica] ;\n' \
+                'graph [ranksep=equally, splines=polyline] ;\n' \
+                'edge [fontname=helvetica] ;\n' \
+                'rankdir=LR ;\n' \
+                '0 [label="X[0] <= 0.0\\nmse = 1.0\\nsamples = 6\\n' \
+                'value = 0.0", fillcolor="#e581397f"] ;\n' \
+                '1 [label="mse = 0.0\\nsamples = 3\\nvalue = -1.0", ' \
+                'fillcolor="#e5813900"] ;\n' \
+                '0 -> 1 [labeldistance=2.5, labelangle=-45, ' \
+                'headlabel="True"] ;\n' \
+                '2 [label="mse = 0.0\\nsamples = 3\\nvalue = 1.0", ' \
+                'fillcolor="#e58139ff"] ;\n' \
+                '0 -> 2 [labeldistance=2.5, labelangle=45, ' \
+                'headlabel="False"] ;\n' \
+                '{rank=same ; 0} ;\n' \
+                '{rank=same ; 1; 2} ;\n' \
+                '}'
 
     assert_equal(contents1, contents2)
 
@@ -79,8 +216,13 @@ def test_graphviz_errors():
     clf = DecisionTreeClassifier(max_depth=3, min_samples_split=1)
     clf.fit(X, y)
 
+    # Check feature_names error
     out = StringIO()
     assert_raises(IndexError, export_graphviz, clf, out, feature_names=[])
+
+    # Check class_names error
+    out = StringIO()
+    assert_raises(IndexError, export_graphviz, clf, out, class_names=[])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As mentioned in #3643 this enhancement is intended to make the output of tree.export_graphviz more aesthetically pleasing as inspired by [fancyRpartPlot](http://blog.revolutionanalytics.com/2013/06/plotting-classification-and-regression-trees-with-plotrpart.html) in R. Colour brewing is done manually so the only additional import required is `numpy`, and output is still pure dot format. 

Enhancements include:
- Drawing leaf nodes at the base of the tree for clarity
- Colours indicating how the node classification is 'leaning', including multi-class
- Percentage samples shown in node instead of raw number of samples
- Percentage per class shown for all nodes, not just leaves

Standard output, omitting the new `pretty` and `simple` flags, should result in the exact same graphical output from Graphviz as the incumbent version, though the dot code has been altered slightly for simplicity given the new more complicated node representation for `pretty`.

A few examples using the Titanic survivor dataset:

no flags:

![full_new](https://cloud.githubusercontent.com/assets/5210848/4514716/0a8c122a-4b88-11e4-92dd-78f78bbfcee9.png)

`pretty`:

![full_pretty](https://cloud.githubusercontent.com/assets/5210848/4514717/154df71e-4b88-11e4-9d09-b763ebe63763.png)

`pretty` & `simple`:

![full_pretty_simple](https://cloud.githubusercontent.com/assets/5210848/4514718/20512c9e-4b88-11e4-88f7-6eb78fabec4d.png)

`pretty` & `max_depth`:

![cropped_pretty](https://cloud.githubusercontent.com/assets/5210848/4514721/3957a330-4b88-11e4-9544-78f68cab3da5.png)

It has been moderately tested on pure `tree.DecisionTreeClassifier` objects, though I am well aware that regression needs work and will fail if attempted with the new flags (though the standard output still appears to be functional).

To be discussed:
- How to represent colours for regression... I'm thinking a diverging colour scheme with white for the median or mean of the two most extreme values in the leaves should work well.
- Should the text and graphical options be broken out further? Something like `show_major_class`, `use_colours`, `use_percentages`, etc., or some perhaps discarded. I based the options off the R package, that's not meant to imply that this is the state of the art, just the best I've stumbled across.
- Should the base implementation even be maintained? The extra sub-tree recursion per node is a little expensive, but it's just a single tree... And seeing what each node is voting towards gives more intuitive information than the error coefficients alone. It even appears that this used to be standard output from the examples [here](http://scikit-learn.org/stable/modules/tree.html#tree)

Other options that might be useful:
- Left to right orientation for use in reports?
- Anything else you can think of? Though Graphviz is a little limited in what you can pull off
- Welcome any other suggestions / gotchas
