### PR TITLE
[MRG] FIX: Thresholded Nearest Centroid fails with non-encoded y

### DIFF
--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -98,6 +98,16 @@ def test_pickle():
                        " after pickling (classification).")
 
 
+def test_shrinkage_threshold_decoded_y():
+    clf = NearestCentroid(shrink_threshold=0.01)
+    y_ind = np.asarray(y)
+    y_ind[y_ind == -1] = 0
+    clf.fit(X, y_ind)
+    centroid_encoded = clf.centroids_
+    clf.fit(X, y)
+    assert_array_equal(centroid_encoded, clf.centroids_)
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()


### PR DESCRIPTION
Minimal code:

```
X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
y = ["r", "r", "r", "b", "b", "b"]
clf = NearestCentroid(shrink_threshold=0.01)
clf.fit(X, y)
IndexError: arrays used as indices must be of integer (or boolean) type
```
