### PR TITLE
[MRG  + 1] Fix preprocessing.scale for arrays with near zero ratio variance/max

### DIFF
--- a/sklearn/preprocessing/_weights.py
+++ b/sklearn/preprocessing/_weights.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ..utils.fixes import bincount
 
+
 def _balance_weights(y):
     """Compute sample weights such that the class distribution of y becomes
        balanced.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -149,10 +149,11 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
             # concerned feature is efficient, for instance by its mean or
             # maximum.
             if not np.allclose(mean_1, 0):
-                warnings.warn(
-                    "Centering failed. Dataset may contain too "
-                    "large values. You may need to prescale "
-                    "your features.")
+                warnings.warn("Numerical issues were encountered "
+                              "and might not be solved. Dataset may "
+                              "contain too large values. You may need "
+                              "to prescale your features.")
+                Xr -= mean_1
         if with_std:
             Xr /= std_
             if with_mean:
@@ -1108,7 +1109,9 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         # We use only those catgorical features of X that are known using fit.
         # i.e lesser than n_values_ using mask.
         # This means, if self.handle_unknown is "ignore", the row_indices and
-        # col_indices corresponding to the unknown categorical feature are ignored.
+        # col_indices corresponding to the unknown categorical feature are
+        # ignored.
+
         mask = (X < self.n_values_).ravel()
         if np.any(~mask):
             if self.handle_unknown not in ['error', 'ignore']:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -150,6 +150,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
             # maximum.
             if not np.allclose(mean_1, 0):
                 warnings.warn("Numerical issues were encountered "
+                              "when centering the data "
                               "and might not be solved. Dataset may "
                               "contain too large values. You may need "
                               "to prescale your features.")
@@ -165,6 +166,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
                 # substract the mean again:
                 if not np.allclose(mean_2, 0):
                     warnings.warn("Numerical issues were encountered "
+                                  "when scaling the data "
                                   "and might not be solved. The standard "
                                   "deviation of the data is probably "
                                   "very close to 0. ")

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -6,6 +6,7 @@
 
 from itertools import chain, combinations
 import numbers
+import warnings
 
 import numpy as np
 from scipy import sparse
@@ -17,6 +18,7 @@ from ..utils import warn_if_not_float
 from ..utils.extmath import row_norms
 from ..utils.fixes import (combinations_with_replacement as combinations_w_r,
                            bincount)
+from ..utils.fixes import isclose
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale, mean_variance_axis)
@@ -56,7 +58,7 @@ def _mean_and_std(X, axis=0, with_mean=True, with_std=True):
     if with_std:
         std_ = Xr.std(axis=0)
         if isinstance(std_, np.ndarray):
-            std_[std_ == 0.0] = 1.0
+            std_[std_ == 0.] = 1.0
         elif std_ == 0.:
             std_ = 1.
     else:
@@ -140,8 +142,32 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
         Xr = np.rollaxis(X, axis)
         if with_mean:
             Xr -= mean_
+            mean_1 = Xr.mean(axis=0)
+            # Verify that mean_1 is 'close to zero'. If X contains very
+            # large values, mean_1 can also be very large, due to a lack of
+            # precision of mean_. In this case, a pre-scaling of the
+            # concerned feature is efficient, for instance by its mean or
+            # maximum.
+            if not np.allclose(mean_1, 0):
+                raise ValueError(
+                    "Centering failed. Dataset may contain too "
+                    "large values. You may need to prescale "
+                    "your features.")
         if with_std:
             Xr /= std_
+            if with_mean:
+                mean_2 = Xr.mean(axis=0)
+                # If mean_2 is not 'close to zero', it comes from the fact that
+                # std_ is very small so that mean_2 = mean_1/std_ > 0, even if
+                # mean_1 was close to zero. The problem is thus essentially due
+                # to the lack of precision of mean_. A solution is then to
+                # substract the mean again:
+                if not np.allclose(mean_2, 0):
+                    warnings.warn("Numerical issues were encountered "
+                                  "and might not be solved. The standard "
+                                  "deviation of the data is probably "
+                                  "very close to 0. ")
+                    Xr -= mean_2
     return X
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -149,7 +149,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
             # concerned feature is efficient, for instance by its mean or
             # maximum.
             if not np.allclose(mean_1, 0):
-                raise ValueError(
+                warnings.warn(
                     "Centering failed. Dataset may contain too "
                     "large values. You may need to prescale "
                     "your features.")

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -100,6 +100,9 @@ def test_scaler_1d():
     X = np.ones(5)
     assert_array_equal(scale(X, with_mean=False), X)
 
+    # np.log(1e-5) is taken because of its length/precision,
+    # so that np.mean(X) and np.std(X) are then not precise enough
+    # to allow an easy standardization.
     X = np.zeros(8) + np.log(1e-5)
     assert_array_almost_equal(scale(X), np.zeros(8))
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -100,6 +100,9 @@ def test_scaler_1d():
     X = np.ones(5)
     assert_array_equal(scale(X, with_mean=False), X)
 
+
+def test_standard_scaler_numerical_stability():
+    """Test numerical stability of scaling"""
     # np.log(1e-5) is taken because of its length/precision,
     # so that np.mean(X) and np.std(X) are then not precise enough
     # to allow an easy standardization.
@@ -114,12 +117,12 @@ def test_scaler_1d():
         assert_array_almost_equal(scale(X), np.zeros(22))
     w = "standard deviation of the data is probably very close to 0"
     assert_warns_message(UserWarning, w, scale, X)
-    
+
     X = np.ones(10.) * 1e-100
     clean_warning_registry()
     with warnings.catch_warnings(record=True):
         assert_array_almost_equal(scale(X), np.zeros(10))
-    
+
     X = np.ones(10.) * 1e100
     clean_warning_registry()
     with warnings.catch_warnings(record=True):
@@ -127,7 +130,7 @@ def test_scaler_1d():
         assert_array_almost_equal(scale(X, with_std=False), np.zeros(10))
     w = "Dataset may contain too large values"
     assert_warns_message(UserWarning, w, scale, X)
-    
+
     X = np.arange(10.) * 1e100
     Y = np.arange(10.) * 1e-100
     clean_warning_registry()

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -105,11 +105,19 @@ def test_scaler_1d():
 
     X = np.zeros(22) + np.log(1e-5)
     assert_array_almost_equal(scale(X), np.zeros(22))
+    w = "standard deviation of the data is probably very close to 0"
+    assert_warns_message(UserWarning, w, scale, X)
 
     X = np.ones(10.) * 1e-100
     assert_array_almost_equal(scale(X), np.zeros(10))
 
-    X = np.arange(10.)
+    X = np.ones(10.) * 1e100
+    assert_array_almost_equal(scale(X), np.zeros(10))
+    assert_array_almost_equal(scale(X, with_std=False), np.zeros(10))
+    w = "Dataset may contain too large values"
+    assert_warns_message(UserWarning, w, scale, X)
+
+    X = np.arange(10.) * 1e100
     Y = np.arange(10.) * 1e-100
     assert_array_almost_equal(scale(X), scale(Y))
 
@@ -844,7 +852,7 @@ def test_one_hot_encoder_unknown_transform():
     oh.fit(X)
     assert_array_equal(
         oh.transform(y).toarray(),
-        np.array([[ 0.,  0.,  0.,  0.,  1.,  0.,  0.]])
+        np.array([[0.,  0.,  0.,  0.,  1.,  0.,  0.]])
         )
 
     # Raise error if handle_unknown is neither ignore or error.

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -104,25 +104,35 @@ def test_scaler_1d():
     # so that np.mean(X) and np.std(X) are then not precise enough
     # to allow an easy standardization.
     X = np.zeros(8) + np.log(1e-5)
-    assert_array_almost_equal(scale(X), np.zeros(8))
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(scale(X), np.zeros(8))
 
     X = np.zeros(22) + np.log(1e-5)
-    assert_array_almost_equal(scale(X), np.zeros(22))
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(scale(X), np.zeros(22))
     w = "standard deviation of the data is probably very close to 0"
     assert_warns_message(UserWarning, w, scale, X)
-
+    
     X = np.ones(10.) * 1e-100
-    assert_array_almost_equal(scale(X), np.zeros(10))
-
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(scale(X), np.zeros(10))
+    
     X = np.ones(10.) * 1e100
-    assert_array_almost_equal(scale(X), np.zeros(10))
-    assert_array_almost_equal(scale(X, with_std=False), np.zeros(10))
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(scale(X), np.zeros(10))
+        assert_array_almost_equal(scale(X, with_std=False), np.zeros(10))
     w = "Dataset may contain too large values"
     assert_warns_message(UserWarning, w, scale, X)
-
+    
     X = np.arange(10.) * 1e100
     Y = np.arange(10.) * 1e-100
-    assert_array_almost_equal(scale(X), scale(Y))
+    clean_warning_registry()
+    with warnings.catch_warnings(record=True):
+        assert_array_almost_equal(scale(X), scale(Y))
 
 
 def test_scaler_2d_arrays():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -100,6 +100,19 @@ def test_scaler_1d():
     X = np.ones(5)
     assert_array_equal(scale(X, with_mean=False), X)
 
+    X = np.zeros(8) + np.log(1e-5)
+    assert_array_almost_equal(scale(X), np.zeros(8))
+
+    X = np.zeros(22) + np.log(1e-5)
+    assert_array_almost_equal(scale(X), np.zeros(22))
+
+    X = np.ones(10.) * 1e-100
+    assert_array_almost_equal(scale(X), np.zeros(10))
+
+    X = np.arange(10.)
+    Y = np.arange(10.) * 1e-100
+    assert_array_almost_equal(scale(X), scale(Y))
+
 
 def test_scaler_2d_arrays():
     """Test scaling of 2d array along first axis"""
@@ -736,6 +749,7 @@ def test_one_hot_encoder_sparse():
     # test negative input to transform
     enc.fit([[0], [1]])
     assert_raises(ValueError, enc.transform, [[0], [-1]])
+
 
 def test_one_hot_encoder_dense():
     """check for sparse=False"""


### PR DESCRIPTION
Fix #3722, prolongating #3725.
