### PR TITLE
[MRG+2] : Bug fix in computing the dataset_centroid in NearestCentroid

### DIFF
--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -108,6 +108,23 @@ def test_shrinkage_threshold_decoded_y():
     assert_array_equal(centroid_encoded, clf.centroids_)
 
 
+def test_predict_translated_data():
+    """Test that NearestCentroid gives same results on translated data"""
+
+    rng = np.random.RandomState(0)
+    X = rng.rand(50, 50)
+    y = rng.randint(0, 3, 50)
+    noise = rng.rand(50)
+    clf = NearestCentroid(shrink_threshold=0.1)
+    clf.fit(X, y)
+    y_init = clf.predict(X)
+    clf = NearestCentroid(shrink_threshold=0.1)
+    X_noise = X + noise
+    clf.fit(X_noise, y)
+    y_translate = clf.predict(X_noise)
+    assert_array_equal(y_init, y_translate)
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()


### PR DESCRIPTION
Continuation of work in https://github.com/scikit-learn/scikit-learn/pull/3746. 
There is a bug in L111 of the current code, where the mean of the first feature is taken as the centroid.

A bit more of minor numpy vectorization and code optimizations were added. I also added a test to verify the behavior that fails in master. 
