### PR TITLE
[MRG+2] FIX: Modify test that tests state of warnings before and after assert_warns

### DIFF
--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -86,7 +86,9 @@ def test_assert_raise_message():
 
 # This class is inspired from numpy 1.7 with an alteration to check
 # the reset warning filters after calls to assert_warns.
-# This assert_warns behavior is specific to scikit-learn.
+# This assert_warns behavior is specific to scikit-learn because
+#`clean_warning_registry()` is called internally by assert_warns
+# and clears all previous filters.
 class TestWarns(unittest.TestCase):
     def test_warn(self):
         def f():
@@ -95,6 +97,8 @@ class TestWarns(unittest.TestCase):
 
         # Test that assert_warns is not impacted by externally set
         # filters and is reset internally.
+        # This is because `clean_warning_registry()` is called internally by
+        # assert_warns and clears all previous filters.
         warnings.simplefilter("ignore", UserWarning)
         assert_equal(assert_warns(UserWarning, f), 3)
 

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -84,7 +84,8 @@ def test_assert_raise_message():
                   _raise_ValueError, "test")
 
 
-# This class is taken from numpy 1.7
+# This class is inspired from numpy 1.7 with an alteration to check
+# the emptied warning filters after calls to assert_warns.
 class TestWarns(unittest.TestCase):
     def test_warn(self):
         def f():
@@ -92,6 +93,10 @@ class TestWarns(unittest.TestCase):
             return 3
 
         assert_equal(assert_warns(UserWarning, f), 3)
+
+        # Test that the warning registry is empty after assert_warns
+        assert_equal(sys.modules['warnings'].filters, [])
+
         assert_raises(AssertionError, assert_no_warnings, f)
         assert_equal(assert_no_warnings(lambda x: x, 1), 1)
 

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -85,13 +85,17 @@ def test_assert_raise_message():
 
 
 # This class is inspired from numpy 1.7 with an alteration to check
-# the emptied warning filters after calls to assert_warns.
+# the reset warning filters after calls to assert_warns.
+# This assert_warns behavior is specific to scikit-learn.
 class TestWarns(unittest.TestCase):
     def test_warn(self):
         def f():
             warnings.warn("yo")
             return 3
 
+        # Test that assert_warns is not impacted by externally set
+        # filters and is reset internally.
+        warnings.simplefilter("ignore", UserWarning)
         assert_equal(assert_warns(UserWarning, f), 3)
 
         # Test that the warning registry is empty after assert_warns

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -91,16 +91,9 @@ class TestWarns(unittest.TestCase):
             warnings.warn("yo")
             return 3
 
-        before_filters = sys.modules['warnings'].filters[:]
         assert_equal(assert_warns(UserWarning, f), 3)
-        after_filters = sys.modules['warnings'].filters
-
         assert_raises(AssertionError, assert_no_warnings, f)
         assert_equal(assert_no_warnings(lambda x: x, 1), 1)
-
-        # Check that the warnings state is unchanged
-        assert_equal(before_filters, after_filters,
-                     "assert_warns does not preserve warnings state")
 
     def test_warn_wrong_warning(self):
         def f():


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/3626

The warnings registry is cleared before and after every call to `assert_warns`. (https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/testing.py#L146) This is because there might be cases when the warning is logged and does not raise a warning in the subsequent call.

So I suggest we remove this "test" and there is no use testing this any more.
