### PR TITLE
code for issue #3749 - change the format of displayed results in classification_report

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1117,7 +1117,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='weighted',
 
 
 def classification_report(y_true, y_pred, labels=None, target_names=None,
-                          sample_weight=None):
+                          sample_weight=None, digits=2):
     """Build a text report showing the main classification metrics
 
     Parameters
@@ -1136,6 +1136,8 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    digits : number of digits for formatting output floating point values
 
     Returns
     -------
@@ -1172,7 +1174,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
         target_names = ['%s' % l for l in labels]
     else:
         width = max(len(cn) for cn in target_names)
-        width = max(width, len(last_line_heading))
+        width = max(width, len(last_line_heading), digits)
 
     headers = ["precision", "recall", "f1-score", "support"]
     fmt = '%% %ds' % width  # first column: class name
@@ -1192,7 +1194,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     for i, label in enumerate(labels):
         values = [target_names[i]]
         for v in (p[i], r[i], f1[i]):
-            values += ["{0:0.2f}".format(v)]
+            values += ["{0:0.{1}f}".format(v, digits)]
         values += ["{0}".format(s[i])]
         report += fmt % tuple(values)
 
@@ -1203,7 +1205,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     for v in (np.average(p, weights=s),
               np.average(r, weights=s),
               np.average(f1, weights=s)):
-        values += ["{0:0.2f}".format(v)]
+        values += ["{0:0.{1}f}".format(v, digits)]
     values += ['{0}'.format(np.sum(s))]
     report += fmt % tuple(values)
     return report


### PR DESCRIPTION
Made a simple enhancement for issue #3749, adding digits to the optional arguments to the classification_report function with default value of 2 (matches previous hard coded value). Allows user to print out the floating values with whatever precision they want in the format.

No unit test added at this time, I will work on that once I've figured out the testing setup using Nose. Any suggestions for test would be welcome.
