### PR TITLE
[MRG + 1] Fix KNeighborsRegressor and RadiusNeighborsRegressor returning NaN predi...

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -93,7 +93,8 @@ def _get_weights(dist, weights):
                 else:
                     dist[point_dist_i] = 1. / point_dist
         else:
-            dist = 1. / dist
+            with np.errstate(divide='ignore'):
+                dist = 1. / dist
             inf_mask = np.isinf(dist)
             inf_row = np.any(inf_mask, axis=1)
             dist[inf_row] = inf_mask[inf_row]

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -83,14 +83,20 @@ def _get_weights(dist, weights):
         # if user attempts to classify a point that was zero distance from one
         # or more training points, those training points are weighted as 1.0
         # and the other points as 0.0
-        for point_dist_i, point_dist in enumerate(dist):
-            # check if point_dist is iterable
-            # (ex: RadiusNeighborClassifier.predict may set an element of dist
-            # to 1e-6 to represent an 'outlier')
-            if hasattr(point_dist, '__contains__') and 0. in point_dist:
-                dist[point_dist_i] = (point_dist == 0.)
-            else:
-                dist[point_dist_i] = 1. / point_dist
+        if dist.dtype is np.dtype(object):
+            for point_dist_i, point_dist in enumerate(dist):
+                # check if point_dist is iterable
+                # (ex: RadiusNeighborClassifier.predict may set an element of dist
+                # to 1e-6 to represent an 'outlier')
+                if hasattr(point_dist, '__contains__') and 0. in point_dist:
+                    dist[point_dist_i] = point_dist == 0.
+                else:
+                    dist[point_dist_i] = 1. / point_dist
+        else:
+            dist = 1. / dist
+            inf_mask = np.isinf(dist)
+            inf_row = np.any(inf_mask, axis=1)
+            dist[inf_row] = inf_mask[inf_row]
         return dist
     elif callable(weights):
         return weights(dist)

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -80,8 +80,17 @@ def _get_weights(dist, weights):
     if weights in (None, 'uniform'):
         return None
     elif weights == 'distance':
-        with np.errstate(divide='ignore'):
-            dist = 1. / dist
+        # if user attempts to classify a point that was zero distance from one
+        # or more training points, those training points are weighted as 1.0
+        # and the other points as 0.0
+        for point_dist_i, point_dist in enumerate(dist):
+            # check if point_dist is iterable
+            # (ex: RadiusNeighborClassifier.predict may set an element of dist
+            # to 1e-6 to represent an 'outlier')
+            if hasattr(point_dist, '__contains__') and 0. in point_dist:
+                dist[point_dist_i] = (point_dist == 0.)
+            else:
+                dist[point_dist_i] = 1. / point_dist
         return dist
     elif callable(weights):
         return weights(dist)
@@ -268,7 +277,7 @@ class KNeighborsMixin(object):
         Returns
         -------
         dist : array
-            Array representing the lengths to point, only present if
+            Array representing the lengths to points, only present if
             return_distance=True
 
         ind : array

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -192,10 +192,6 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         weights = _get_weights(neigh_dist, self.weights)
         if weights is None:
             weights = np.ones_like(neigh_ind)
-        else:
-            # Some weights may be infinite (zero distance), which can cause
-            # downstream NaN values when used for normalization.
-            weights[np.isinf(weights)] = np.finfo('f').max
 
         all_rows = np.arange(X.shape[0])
         probabilities = []

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -314,6 +314,39 @@ def test_radius_neighbors_classifier_zero_distance():
             assert_array_equal(correct_labels1, clf.predict(z1))
 
 
+def test_neighbors_regressors_zero_distance():
+    """ Test radius-based regressor, when distance to a sample is zero. """
+
+    X = np.array([[1.0, 1.0], [1.0, 1.0], [2.0, 2.0], [2.5, 2.5]])
+    y = np.array([1.0, 1.5, 2.0, 0.0])
+    radius = 0.2
+    z = np.array([[1.1, 1.1], [2.0, 2.0]])
+
+    rnn_correct_labels = np.array([1.25, 2.0])
+
+    knn_correct_unif = np.array([1.25, 1.0])
+    knn_correct_dist = np.array([1.25, 2.0])
+
+    for algorithm in ALGORITHMS:
+        # we don't test for weights=_weight_func since user will be expected
+        # to handle zero distances themselves in the function.
+        for weights in ['uniform', 'distance']:
+            rnn = neighbors.RadiusNeighborsRegressor(radius=radius,
+                                                     weights=weights,
+                                                     algorithm=algorithm)
+            rnn.fit(X, y)
+            assert_array_almost_equal(rnn_correct_labels, rnn.predict(z))
+
+        for weights, corr_labels in zip(['uniform', 'distance'],
+                                        [knn_correct_unif, knn_correct_dist]):
+            knn = neighbors.KNeighborsRegressor(n_neighbors=2,
+                                                weights=weights,
+                                                algorithm=algorithm)
+            knn.fit(X, y)
+            assert_array_almost_equal(corr_labels, knn.predict(z))
+
+
+
 def test_RadiusNeighborsClassifier_multioutput():
     """Test k-NN classifier on multioutput data"""
     rng = check_random_state(0)


### PR DESCRIPTION
A  `KNeighborsRegressor` with distance weighting will predict `NaN` if the data to predict on happens to match a data point from the training set.  (This actually happened to me with some data from a Kaggle competition)

For example,

```
from sklearn import neighbors
import numpy as np

X = np.array([[1.0],[2.0],[3.0]])
y = np.array([1.0, 2.0, 3.0])

clf = neighbors.KNeighborsRegressor(n_neighbors=3, weights='distance')

clf.fit(X,y)
print(clf.predict([[1.0]]))
```

The output is `NaN`.  This seems like undesirable behavior.  I would have expected `pred` to be `1.0`.  In addition, `RadiusNeighborsRegressor` suffers from this problem.  

Note that the infinities are already handled properly by `KNeighborsClassifier` and `RadiusNeighborsClassifiers`.  For example,

```
from sklearn import neighbors
import numpy as np

X = np.array([[1.0],[2.0],[3.0]])
y = np.array([1, 0, 1])

clf = neighbors.KNeighborsClassifier(n_neighbors=3, weights='distance')

clf.fit(X,y)
print(clf.predict([[1.0]]))
```

This outputs `1` as expected.

This pull request is my proposed solution.  Note that if there are two points with distance=0, it chooses one of them, which is consistent with the warning given in the [KNeighborsRegressor docs](http://scikit-learn.org/dev/modules/generated/sklearn.neighbors.KNeighborsRegressor.html).

This is my first pull request for any project, so let me know if I'm doing something wrong!
