### PR TITLE
[MRG+1] FIX warning check in test_affinities

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -11,11 +11,12 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_equal, clean_warning_registry
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_warns_message
 
 from sklearn.cluster import SpectralClustering, spectral_clustering
 from sklearn.cluster.spectral import spectral_embedding
@@ -138,15 +139,10 @@ def test_affinities():
                       centers=[[1, 1], [-1, -1]], cluster_std=0.01
                       )
     # nearest neighbors affinity
-    clean_warning_registry()
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always", UserWarning)
-        sp = SpectralClustering(n_clusters=2, affinity='nearest_neighbors',
-                                random_state=0)
-        labels = sp.fit(X).labels_
-        assert_equal(adjusted_rand_score(y, labels), 1)
-    assert_true(re.search(r'\bnot fully connected\b',
-                          str(warning_list[0].message)))
+    sp = SpectralClustering(n_clusters=2, affinity='nearest_neighbors',
+                            random_state=0)
+    assert_warns_message(UserWarning, 'not fully connected', sp.fit, X)
+    assert_equal(adjusted_rand_score(y, sp.labels_), 1)
 
     sp = SpectralClustering(n_clusters=2, gamma=2, random_state=0)
     labels = sp.fit(X).labels_


### PR DESCRIPTION
Tentative PR to see if this fixes the travis failures on `test_affinities` such as this one:

https://travis-ci.org/scikit-learn/scikit-learn/jobs/37830488

I cannot reproduce it on my local Python 2.7 so it's a shot in the dark.
