### PR TITLE
TST fix test failure due to warning registry

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_equal, clean_warning_registry
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
@@ -138,7 +138,6 @@ def test_affinities():
                       centers=[[1, 1], [-1, -1]], cluster_std=0.01
                       )
     # nearest neighbors affinity
-    clean_warning_registry()
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", UserWarning)
         sp = SpectralClustering(n_clusters=2, affinity='nearest_neighbors',


### PR DESCRIPTION
Partially reverts cd7b43ccf97c2333380d0b3f5701d579ee8837c8. I must admit I've no clue what's going on; the patch looked good, and only 2.6 fails.
