### PR TITLE
Fix the issue #3745, the code book generation for OutputCodeClassifier

### DIFF
--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -226,15 +226,15 @@ effect to bagging. The maximum value for ``code_size`` is
 ``2^(n_classes-1)-1 / n_classes`` as suggested by [1]_, since the codes with
 all 0 or 1, and the complement of existing codes need to be excluded.
 
-The ``coding_strategy`` attribute allows the user the select the strategy to
+The ``strategy`` attribute allows the user the select the strategy to
 code the classes. Two strategies are supported currently: (1) ``"random"``,
 a random ``n_classes x int(n_classes * code_size)`` matrix is generated, and
 entries > 0.5 are set to be 1 and the rest to be 0 or -1; (2)
-``"opt_column_selection"``, random subsets of the exhaustive code are sampled,
+``"max_hamming"``, random subsets of the exhaustive code are sampled,
 and the one with the largest Hamming distance is chosen.
 
 The ``max_iter`` attribute is used when
-``coding_strategy="opt_column_selection"`` allows the user to generate a code
+``strategy="max_hamming"`` allows the user to generate a code
 book with most separation between classes from several randomly generated
 subsets of the exhaustive code book.
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -200,9 +200,9 @@ matrix which keeps track of the location/code of each class is called the
 code book. The code size is the dimensionality of the aforementioned space.
 Intuitively, each class should be represented by a code as unique as
 possible and a good code book should be designed to optimize classification
-accuracy. In this implementation, we simply use a randomly-generated code
-book as advocated in [2]_ although more elaborate methods may be added in the
-future.
+accuracy. In this implementation, we randomly generate subset of the exhaustive
+codes, suggested in [1]_ multiple times and pick up the one with most
+separation between different classes.
 
 At fitting time, one binary classifier per bit in the code book is fitted.
 At prediction time, the classifiers are used to project new points in the
@@ -222,7 +222,13 @@ one-vs-the-rest. In this case, some classifiers will in theory correct for
 the mistakes made by other classifiers, hence the name "error-correcting".
 In practice, however, this may not happen as classifier mistakes will
 typically be correlated. The error-correcting output codes have a similar
-effect to bagging.
+effect to bagging. The maximum value for ``code_size`` is
+``2^(n_classes-1)-1 / n_classes`` as suggested by [1]_, since the codes with
+all 0 or 1, and the complement of existing codes need to be excluded.
+
+The ``max_iter`` attribute allows the user to generate a code book with most
+separation between classes from several randomly generated subsets of the
+exhaustive code book.
 
 
 Multiclass learning
@@ -236,14 +242,14 @@ Below is an example of multiclass learning using Output-Codes::
   >>> iris = datasets.load_iris()
   >>> X, y = iris.data, iris.target
   >>> clf = OutputCodeClassifier(LinearSVC(random_state=0),
-  ...                            code_size=2, random_state=0)
+  ...                            code_size=1, max_iter=5, random_state=0)
   >>> clf.fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-         0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1,
-         1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+         0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+         1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1,
          1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-         2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 1, 1, 2, 2, 2,
+         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2,
          2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
 
 .. topic:: References:

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -230,11 +230,11 @@ The ``strategy`` attribute allows the user the select the strategy to
 code the classes. Two strategies are supported currently: (1) ``"random"``,
 a random ``n_classes x int(n_classes x code_size)`` matrix is generated, and
 entries > 0.5 are set to be 1 and the rest to be 0 or -1; (2)
-``"max_hamming"``, random subsets of the exhaustive code are sampled,
+``"iter_hamming"``, random subsets of the exhaustive code are sampled,
 and the one with the largest Hamming distance is chosen.
 
 The ``max_iter`` attribute is used when
-``strategy="max_hamming"`` allows the user to generate a code
+``strategy="iter_hamming"`` allows the user to generate a code
 book with most separation between classes from several randomly generated
 subsets of the exhaustive code book.
 
@@ -274,3 +274,9 @@ Below is an example of multiclass learning using Output-Codes::
     .. [3] "The Elements of Statistical Learning",
         Hastie T., Tibshirani R., Friedman J., page 606 (second-edition)
         2008.
+
+    .. [4] "Reducing multiclass to binary: A unifying approach for margin
+       classifiers."
+       Allwein, Erin L., Robert E. Schapire, and Yoram Singer,
+       The Journal of Machine Learning Research 1: 113-141,
+       2001.

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -228,7 +228,7 @@ all 0 or 1, and the complement of existing codes need to be excluded.
 
 The ``strategy`` attribute allows the user the select the strategy to
 code the classes. Two strategies are supported currently: (1) ``"random"``,
-a random ``n_classes x int(n_classes * code_size)`` matrix is generated, and
+a random ``n_classes x int(n_classes x code_size)`` matrix is generated, and
 entries > 0.5 are set to be 1 and the rest to be 0 or -1; (2)
 ``"max_hamming"``, random subsets of the exhaustive code are sampled,
 and the one with the largest Hamming distance is chosen.

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -226,10 +226,17 @@ effect to bagging. The maximum value for ``code_size`` is
 ``2^(n_classes-1)-1 / n_classes`` as suggested by [1]_, since the codes with
 all 0 or 1, and the complement of existing codes need to be excluded.
 
-The ``max_iter`` attribute allows the user to generate a code book with most
-separation between classes from several randomly generated subsets of the
-exhaustive code book.
+The ``coding_strategy`` attribute allows the user the select the strategy to
+code the classes. Two strategies are supported currently: (1) ``"random"``,
+a random ``n_classes x int(n_classes * code_size)`` matrix is generated, and
+entries > 0.5 are set to be 1 and the rest to be 0 or -1; (2)
+``"opt_column_selection"``, random subsets of the exhaustive code are sampled,
+and the one with the largest Hamming distance is chosen.
 
+The ``max_iter`` attribute is used when
+``coding_strategy="opt_column_selection"`` allows the user to generate a code
+book with most separation between classes from several randomly generated
+subsets of the exhaustive code book.
 
 Multiclass learning
 -------------------

--- a/examples/classification/plot_digits_multiclass.py
+++ b/examples/classification/plot_digits_multiclass.py
@@ -1,0 +1,139 @@
+"""
+===========================
+Multi-class classification
+===========================
+
+An example show how to use the different encoding methods in scikit-learn for
+multi-class problem, for example, a hand-written digits recognition. And a
+comparison is conducted among different encoding methods in scikit-learn:
+(1) Using the label_binarizer in SVC; (2) OneVsOneClassifier;
+(3) OneVsRestClassifier; (4) OutputCodeClassifer with two strategy, 'random'
+and 'iter_hamming'.
+
+"""
+print(__doc__)
+
+# Author: Qichao Que <que@cse.ohio-state.edu>
+# License: BSD 3 clause
+
+# Import timing, plotting and scientific python libarary.
+from matplotlib import pyplot as plt
+import numpy as np
+import time
+
+# Import datasets, classifiers, and performance metrics
+from sklearn.svm import SVC
+from sklearn import datasets, metrics
+from sklearn import multiclass
+from sklearn.metrics.pairwise import pairwise_distances
+
+# Load the digits dataset
+digits = datasets.load_digits()
+
+# Split the dataset in to training and testing data
+train_X = digits.data[:1000]
+train_y = digits.target[:1000]
+test_X = digits.data[1000:]
+test_y = digits.target[1000:]
+
+# Using label_binarizer built-in SVC
+c = SVC(gamma=0.001)
+s = time.time()
+c.fit(train_X, train_y)
+pred = c.predict(test_X)
+e = time.time()
+time_svc = e - s
+error_svc = np.sum((test_y != pred).astype(np.int)) / test_y.shape[0]
+print('Error for SVC: %.3f%%' % error_svc * 100)
+
+# Using OneVsRestClassifier
+c1 = multiclass.OneVsRestClassifier(c)
+s = time.time()
+c1.fit(train_X, train_y)
+pred = c1.predict(test_X)
+e = time.time()
+time_ovr = e - s
+error_ovr = np.sum((test_y != pred).astype(np.int)) / test_y.shape[0]
+print('Error for SVC using OneVsRest Code: %.3f%%' % error_ovr * 100)
+
+# Using OneVsOneClassifier
+c1 = multiclass.OneVsOneClassifier(c)
+s = time.time()
+c1.fit(train_X, train_y)
+pred = c1.predict(test_X)
+e = time.time()
+time_ovo = e - s
+error_ovo = np.sum((test_y != pred).astype(np.int)) / test_y.shape[0]
+print('Error for SVC using OneVsOne Code: %.3f%%' % error_ovo * 100)
+
+# constants for OutputCodeClassifier
+max_iter = 50
+repeat = 20
+code_size = [0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0]
+
+# Using OutputCodeClassifier with strategy 'iter_hamming'
+error_ecoc_iter_hamming = np.zeros((len(code_size), repeat))
+random_state = np.random.RandomState(0)
+time_ecoc_iter_hamming = np.zeros((len(code_size), repeat))
+for j, cs in enumerate(code_size):
+  for i in range(repeat):
+    c1 = multiclass.OutputCodeClassifier(c, max_iter=max_iter, code_size=cs,
+                                         strategy="iter_hamming",
+                                         random_state=random_state)
+    s = time.time()
+    c1.fit(train_X, train_y)
+    pred = c1.predict(test_X)
+    e = time.time()
+    time_ecoc_iter_hamming[j, i] = e - s
+    error_ecoc_iter_hamming[j, i] = np.sum((test_y != pred).astype(np.int)) / test_y.shape[0]
+mean_error_ecoc_iter_hamming = np.mean(error_ecoc_iter_hamming, axis=1)
+print('Error for SVC using Output Code with iter_hamming strategy: ')
+print(mean_error_ecoc_iter_hamming)
+
+# Using OutputCodeClassifier with strategy 'random'
+error_ecoc_random = np.zeros((len(code_size), repeat))
+random_state = np.random.RandomState(0)
+time_ecoc_random = np.zeros((len(code_size), repeat))
+for j, cs in enumerate(code_size):
+  for i in range(repeat):
+    c1 = multiclass.OutputCodeClassifier(c, max_iter=max_iter, code_size=cs,
+                                         strategy="random",
+                                         random_state=random_state)
+    s = time.time()
+    c1.fit(train_X, train_y)
+    pred = c1.predict(test_X)
+    e = time.time()
+    time_ecoc_random[j, i] = e-s
+    error_ecoc_random[j, i] = np.sum((test_y!=pred).astype(np.int))/test_y.shape[0]
+mean_error_ecoc_random = np.mean(error_ecoc_random, axis=1)
+print('Error for SVC using Output Code with random strategy:')
+print(mean_error_ecoc_random)
+
+plt.figure(1)
+# Plot Result, the classification error using different encoding strategy.
+plt.subplot(121)
+plt.plot(1, error_svc, 'b', marker='+', label='SVC')
+plt.plot(1, error_ovo, 'r', marker='o', label='OneVsOne')
+plt.plot(1, error_ovr, 'g', marker='*', label='OneVsRest')
+plt.plot(code_size, np.mean(error_ecoc_iter_hamming, axis=1), '-c', marker='x',
+         label='OC-iter_hamming')
+plt.plot(code_size, np.mean(error_ecoc_random, axis=1), '-k', marker='s',
+         label='OC-random')
+plt.legend()
+plt.xlabel('code_size')
+plt.ylabel('Classification Error')
+
+# Plot the timing results as well.
+plt.subplot(122)
+plt.plot(1, time_svc, 'b', marker='+', label='SVC')
+plt.plot(1, time_ovo, 'r', marker='o', label='OneVsOne')
+plt.plot(1, time_ovr, 'g', marker='*', label='OneVsRest')
+plt.plot(code_size, np.mean(time_ecoc_iter_hamming, axis=1), '-c', marker='x',
+         label='iter_hamming')
+plt.plot(code_size, np.mean(time_ecoc_random, axis=1), '-k', marker='s',
+         label='random')
+plt.xlabel('code_size')
+plt.ylabel('Running time')
+plt.legend()
+
+plt.show()

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -601,7 +601,7 @@ def _random_code_book(n_classes, random_state, code_size):
     return code_book
 
  
-def _max_hamming_code_book(n_classes, random_state, code_size, max_iter):
+def _iter_hamming_code_book(n_classes, random_state, code_size, max_iter):
     """Randomly sample subsets of exhaustive code for n_classes, and choose
        the one gives the largest hamming distances.
     """
@@ -672,7 +672,7 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         than 0. Each iteration, a random code will be generated and the old 
         code will be replaced only when the total Hamming distance between 
         code words increases.
-        This parameter will be used when the strategy is "max_hamming"
+        This parameter will be used when the strategy is "iter_hamming"
 
     random_state : numpy.RandomState, optional
         The generator used to initialize the codebook. Defaults to
@@ -684,16 +684,16 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         useful for debugging. For n_jobs below -1, (n_cpus + 1 + n_jobs) are
         used. Thus for n_jobs = -2, all CPUs but one are used.
 
-    strategy : str, {'auto', 'random', 'max_hamming'}, optional, default: "auto"
+    strategy : str, {'auto', 'random', 'iter_hamming'}, optional, default: "auto"
         The strategy to generate a code book for all classes. Three options are
         avalable currently: 
         
         (1) "random": randomly generate a n_class x int(n_class*code_size)
             matrix, and set entries > 0.5 to be 1, the rest to be 0 or -1; 
-        (2) "max_hamming": select subset of exhaustive code book mutiple times
+        (2) "iter_hamming": select subset of exhaustive code book mutiple times
             randomly, and choose the one gives the largest hamming distances
             between classes.
-        (3) "auto": use "max_hamming" if the code_size is in the valid range
+        (3) "auto": use "iter_hamming" if the code_size is in the valid range
             for it; otherwise, "random" strategy will be used.
 
     Attributes
@@ -725,11 +725,11 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
        Hastie T., Tibshirani R., Friedman J., page 606 (second-edition)
        2008.
 
-    .. [4] "Error-correcting ouput codes library,"
-       Escalera, Sergio, Oriol Pujol, and Petia Radeva, 
-       The Journal of Machine Learning Research 11, page 661-664,
-       2010.
-
+    .. [4] "Reducing multiclass to binary: A unifying approach for margin
+       classifiers", 
+       Allwein, Erin L., Robert E. Schapire, and Yoram Singer,
+       The Journal of Machine Learning Research 1: 113-141,
+       2001.
     """
 
     def __init__(self, estimator, code_size=1, max_iter=10,
@@ -773,14 +773,14 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             if n_code_words > max_code_size or np.power(2, n_code_words) < n_classes:
                 self.code_book_ = _random_code_book(n_classes, random_state, n_code_words)
             else:
-                self.code_book_ = _max_hamming_code_book(n_classes,
+                self.code_book_ = _iter_hamming_code_book(n_classes,
                                                                  random_state,
                                                                  n_code_words,
                                                                  self.max_iter)
         elif self.strategy == "random":
             self.code_book_ = _random_code_book(n_classes, random_state, n_code_words)
-        elif self.strategy == "max_hamming":
-            self.code_book_ = _max_hamming_code_book(n_classes,
+        elif self.strategy == "iter_hamming":
+            self.code_book_ = _iter_hamming_code_book(n_classes,
                                                              random_state,
                                                              n_code_words,
                                                              self.max_iter)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -632,11 +632,9 @@ def _iter_hamming_code_book(n_classes, random_state, code_size, max_iter):
         tmp_code_book = (p[:, None] + max_code_size+1 &
                          (1 << np.arange(n_classes-1, -1, -1)) > 0
                         ).astype(int).T
-        # The code distance is sum of hamming distances between columns and
-        # rows.
+        # The code distance is sum of hamming distances between rows.
         tmp_code_distance = np.sum(pairwise_distances(
-            tmp_code_book, metric='hamming')) + np.sum(pairwise_distances(
-            tmp_code_book.T, metric='hamming'))
+            tmp_code_book, metric='hamming'))
         if tmp_code_distance > best_code_distance:
             best_code_distance = tmp_code_distance
             best_code_book = tmp_code_book

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -490,8 +490,8 @@ def test_code_book_functions():
     random_state = np.random
     random_state.seed(0)
     code_book = _random_code_book(3, random_state, 10000)
-    proportion_of_1 = np.sum((code_book==1).astype(int))/30000
-    assert_true(proportion_of_1 > 0.45 and proportion_of_1 < 0.55)
+    proportion_of_1 = np.sum((code_book==1).astype(int)) * 1.0 / 30000
+    assert_true(proportion_of_1 > 0.48 and proportion_of_1 < 0.52)
     code_book = _max_hamming_code_book(5, random_state, 15, 10)
     assert_equal(5, code_book.shape[0])
     assert_equal(15, code_book.shape[1])

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -487,11 +487,15 @@ def test_ovo_string_y():
 def test_ecoc_exceptions():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
     assert_raises(ValueError, ecoc.predict, [])
-    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=3)
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
+                                coding_strategy="abc")
+    assert_raises(ValueError, ecoc.fit, [], [])
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=1.5,
+                                coding_strategy="opt_column_selection")
+    assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2]))
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01,
+                                coding_strategy="opt_column_selection")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
-    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01)
-    assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
-
 
 def test_ecoc_fit_predict():
     # A classifier which implements decision_function.
@@ -505,6 +509,26 @@ def test_ecoc_fit_predict():
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 1)
 
+def test_ecoc_coding_strategy():
+    # For irsi dataset, code_size=1.5 will use random_code_book
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
+                                code_size=1.5, random_state=0)
+    ecoc.fit(iris.data, iris.target).predict(iris.data)
+    assert_equal(len(ecoc.estimators_), int(n_classes * 1.5))
+
+    # Set the coding_strategy to be "random"
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
+                                code_size=1.5, random_state=0,
+                                coding_strategy="random")
+    ecoc.fit(iris.data, iris.target).predict(iris.data)
+    assert_equal(len(ecoc.estimators_), int(n_classes * 1.5))
+
+    # Set the coding_strategy to be "opt_column_selection"
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
+                                code_size=1.0, random_state=0,
+                                coding_strategy="opt_column_selection")
+    ecoc.fit(iris.data, iris.target).predict(iris.data)
+    assert_equal(len(ecoc.estimators_), n_classes * 1)
 
 def test_ecoc_gridsearch():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -508,8 +508,7 @@ def test_ecoc_exceptions():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=1.5,
                                 strategy="iter_hamming")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2]))
-    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01,
-                                strategy="iter_hamming")
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01)
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
 
 def test_ecoc_fit_predict():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -13,6 +13,8 @@ from sklearn.utils.testing import assert_greater
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.multiclass import OutputCodeClassifier
+from sklearn.multiclass import random_code_book
+from sklearn.multiclass import max_hamming_code_book
 
 from sklearn.multiclass import fit_ovr
 from sklearn.multiclass import fit_ovo
@@ -483,18 +485,27 @@ def test_ovo_string_y():
     ovo.fit(X, y)
     assert_array_equal(y, ovo.predict(X))
 
+def test_code_book_functions():
+    random_state = np.random
+    random_state.seed(0)
+    code_book = random_code_book(3, random_state, 3)
+    correct_code_book = np.array([[1., 1., 1.], [1., 0., 1.], [0., 1., 1.]])
+    assert_almost_equal(correct_code_book, code_book) 
+    code_book = max_hamming_code_book(5, random_state, 15, 10)
+    assert_equal(5, code_book.shape[0])
+    assert_equal(15, code_book.shape[1])
 
 def test_ecoc_exceptions():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
     assert_raises(ValueError, ecoc.predict, [])
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
-                                coding_strategy="abc")
+                                strategy="abc")
     assert_raises(ValueError, ecoc.fit, [], [])
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=1.5,
-                                coding_strategy="opt_column_selection")
+                                strategy="max_hamming")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2]))
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01,
-                                coding_strategy="opt_column_selection")
+                                strategy="max_hamming")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
 
 def test_ecoc_fit_predict():
@@ -509,24 +520,24 @@ def test_ecoc_fit_predict():
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 1)
 
-def test_ecoc_coding_strategy():
+def test_ecoc_strategy():
     # For irsi dataset, code_size=1.5 will use random_code_book
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
                                 code_size=1.5, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), int(n_classes * 1.5))
 
-    # Set the coding_strategy to be "random"
+    # Set the strategy to be "random"
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
                                 code_size=1.5, random_state=0,
-                                coding_strategy="random")
+                                strategy="random")
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), int(n_classes * 1.5))
 
-    # Set the coding_strategy to be "opt_column_selection"
+    # Set the strategy to be "max_hamming"
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
                                 code_size=1.0, random_state=0,
-                                coding_strategy="opt_column_selection")
+                                strategy="max_hamming")
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 1)
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -16,7 +16,7 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.multiclass import OutputCodeClassifier
 from sklearn.multiclass import _random_code_book
-from sklearn.multiclass import _max_hamming_code_book
+from sklearn.multiclass import _iter_hamming_code_book
 
 from sklearn.multiclass import fit_ovr
 from sklearn.multiclass import fit_ovo
@@ -495,7 +495,7 @@ def test_code_book_functions():
     proportion_of_1 = np.sum((code_book==1).astype(int)) * 1.0 / 30000
     assert_greater(proportion_of_1, 0.48)
     assert_less(proportion_of_1, 0.52)
-    code_book = _max_hamming_code_book(5, random_state, 15, 10)
+    code_book = _iter_hamming_code_book(5, random_state, 15, 10)
     assert_equal(5, code_book.shape[0])
     assert_equal(15, code_book.shape[1])
 
@@ -506,10 +506,10 @@ def test_ecoc_exceptions():
                                 strategy="abc")
     assert_raises(ValueError, ecoc.fit, [], [])
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=1.5,
-                                strategy="max_hamming")
+                                strategy="iter_hamming")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2]))
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01,
-                                strategy="max_hamming")
+                                strategy="iter_hamming")
     assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
 
 def test_ecoc_fit_predict():
@@ -538,21 +538,21 @@ def test_ecoc_strategy():
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), int(n_classes * 1.5))
 
-    # Set the strategy to be "max_hamming"
+    # Set the strategy to be "iter_hamming"
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
                                 code_size=1.0, random_state=0,
-                                strategy="max_hamming")
+                                strategy="iter_hamming")
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ecoc.estimators_), n_classes * 1)
 
-def test_max_hamming_code_book():
+def test_iter_hamming_code_book():
     # Test the the code could be improved using larger max_iter 
     random_state = np.random.RandomState(0)
-    dist0 = np.sum(pairwise_distances(_max_hamming_code_book(5, random_state,
+    dist0 = np.sum(pairwise_distances(_iter_hamming_code_book(5, random_state,
                                                             10, 1),
                                       metric='hamming'))
     random_state = np.random.RandomState(0)
-    dist1 = np.sum(pairwise_distances(_max_hamming_code_book(5, random_state,
+    dist1 = np.sum(pairwise_distances(_iter_hamming_code_book(5, random_state,
                                                             10, 2),
                                       metric='hamming')) 
     assert_greater_equal(dist0, dist1);

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -487,19 +487,23 @@ def test_ovo_string_y():
 def test_ecoc_exceptions():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
     assert_raises(ValueError, ecoc.predict, [])
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=3)
+    assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=0.01)
+    assert_raises(ValueError, ecoc.fit, [], np.array([0, 1, 2, 3]))
 
 
 def test_ecoc_fit_predict():
     # A classifier which implements decision_function.
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),
-                                code_size=2, random_state=0)
+                                code_size=1, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
-    assert_equal(len(ecoc.estimators_), n_classes * 2)
+    assert_equal(len(ecoc.estimators_), n_classes * 1)
 
     # A classifier which implements predict_proba.
-    ecoc = OutputCodeClassifier(MultinomialNB(), code_size=2, random_state=0)
+    ecoc = OutputCodeClassifier(MultinomialNB(), code_size=1, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
-    assert_equal(len(ecoc.estimators_), n_classes * 2)
+    assert_equal(len(ecoc.estimators_), n_classes * 1)
 
 
 def test_ecoc_gridsearch():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -10,6 +10,8 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater_equal
+from sklearn.utils.testing import assert_less
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.multiclass import OutputCodeClassifier
@@ -491,7 +493,8 @@ def test_code_book_functions():
     random_state.seed(0)
     code_book = _random_code_book(3, random_state, 10000)
     proportion_of_1 = np.sum((code_book==1).astype(int)) * 1.0 / 30000
-    assert_true(proportion_of_1 > 0.48 and proportion_of_1 < 0.52)
+    assert_greater(proportion_of_1, 0.48)
+    assert_less(proportion_of_1, 0.52)
     code_book = _max_hamming_code_book(5, random_state, 15, 10)
     assert_equal(5, code_book.shape[0])
     assert_equal(15, code_book.shape[1])
@@ -544,17 +547,15 @@ def test_ecoc_strategy():
 
 def test_max_hamming_code_book():
     # Test the the code could be improved using larger max_iter 
-    random_state = np.random
-    random_state.seed(0)
+    random_state = np.random.RandomState(0)
     dist0 = np.sum(pairwise_distances(_max_hamming_code_book(5, random_state,
                                                             10, 1),
                                       metric='hamming'))
-    random_state = np.random
-    random_state.seed(0)
+    random_state = np.random.RandomState(0)
     dist1 = np.sum(pairwise_distances(_max_hamming_code_book(5, random_state,
                                                             10, 2),
                                       metric='hamming')) 
-    assert_true(dist0 >= dist1);
+    assert_greater_equal(dist0, dist1);
 
 def test_ecoc_gridsearch():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0),

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -491,7 +491,7 @@ def test_code_book_functions():
     random_state.seed(0)
     code_book = _random_code_book(3, random_state, 10000)
     proportion_of_1 = np.sum((code_book==1).astype(int))/30000
-    assert_true(proportion_of_1 > 0.48 and proportion_of_1 < 0.52)
+    assert_true(proportion_of_1 > 0.45 and proportion_of_1 < 0.55)
     code_book = _max_hamming_code_book(5, random_state, 15, 10)
     assert_equal(5, code_book.shape[0])
     assert_equal(15, code_book.shape[1])


### PR DESCRIPTION
- Change the process of generating output code for OutputCodeClassifier. The process is to draw subsets of the exhaustive code book, see [1], multiple times and pick the one that give largest hamming distances between classes.
- Change the default value of code_size from 1.5 to 1. 1.5 is problematic. For example when n_classes = 3, the size of exhaustive code book is 3, so 1.5 for code_size is not possible.
- Add test case.
- Update the document.

[1] Thomas G. Dietterich, Ghulum Bakiri. Solving Multiclass Learning Problems via Error-Correcting Output Codes
