### PR TITLE
[MRG+2] ENH: Patches Nearest Centroid for metric=manhattan for sparse and dense data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -119,6 +119,10 @@ Bug fixes
       estimator. It allows for instance to make bagging of a pipeline object.
       By `Arnaud Joly`_
 
+    - :class:`neighbors.NearestCentroid` now uses the median as the centroid
+      when metric is set to ``manhattan``. It was using the mean before.
+      By `Manoj Kumar`_
+
 API changes summary
 -------------------
 

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -102,7 +102,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
             raise ValueError('y has less than 2 classes')
 
         # Mask mapping each class to it's members.
-        self.centroids_ = np.zeros((n_classes, n_features), dtype=np.float64)
+        self.centroids_ = np.empty((n_classes, n_features), dtype=np.float64)
         # Number of clusters in each class.
         nk = np.zeros(n_classes)
 

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -88,8 +88,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
             Target values (integers)
         """
         X, y = check_X_y(X, y, ['csc'])
-        X_sparse = sp.issparse(X)
-        if X_sparse and self.shrink_threshold:
+        is_X_sparse = sp.issparse(X)
+        if is_X_sparse and self.shrink_threshold:
             raise ValueError("threshold shrinking not supported"
                              " for sparse input")
 
@@ -109,13 +109,13 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         for cur_class in y_ind:
             center_mask = y_ind == cur_class
             nk[cur_class] = np.sum(center_mask)
-            if X_sparse:
+            if is_X_sparse:
                 center_mask = np.where(center_mask)[0]
 
             # XXX: Update other averaging methods according to the metrics.
             if self.metric == "manhattan":
                 # NumPy does not calculate median of sparse matrices.
-                if not X_sparse:
+                if not is_X_sparse:
                     self.centroids_[cur_class] = np.median(X[center_mask], axis=0)
                 else:
                     self.centroids_[cur_class] = csc_row_median(X[center_mask])

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -94,7 +94,12 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         y : array, shape = [n_samples]
             Target values (integers)
         """
-        X, y = check_X_y(X, y, ['csc'])
+        # If X is sparse and the metric is "manhattan", store it in a csc
+        # format is easier to calculate the median.
+        if self.metric == 'manhattan':
+            X, y = check_X_y(X, y, ['csc'])
+        else:
+            X, y = check_X_y(X, y, ['csr', 'csc'])
         is_X_sparse = sp.issparse(X)
         if is_X_sparse and self.shrink_threshold:
             raise ValueError("threshold shrinking not supported"

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -32,6 +32,11 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         feature array. If metric is a string or callable, it must be one of
         the options allowed by metrics.pairwise.pairwise_distances for its
         metric parameter.
+        The centroids for the samples corresponding to each class is the point
+        from which the sum of the distances (according to the metric) of all
+        samples that belong to that particular class are minimized.
+        If the "manhattan" metric is provided, this centroid is the median and
+        for all other metrics, the centroid is now set to be the mean.
     shrink_threshold : float, optional (default = None)
         Threshold for shrinking centroids to remove features.
 

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -8,6 +8,7 @@ Nearest Centroid Classification
 #
 # License: BSD 3 clause
 
+import warnings
 import numpy as np
 from scipy import sparse as sp
 
@@ -126,6 +127,11 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
                 else:
                     self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
             else:
+                if self.metric != 'euclidean':
+                    warnings.warn("Averaging for metrics other than "
+                                  "euclidean and manhattan not supported. "
+                                  "The average is set to be the mean."
+                                  )
                 self.centroids_[cur_class] = X[center_mask].mean(axis=0)
 
         if self.shrink_threshold:

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -16,7 +16,7 @@ from ..externals.six.moves import xrange
 from ..metrics.pairwise import pairwise_distances
 from ..preprocessing import LabelEncoder
 from ..utils.validation import check_array, check_X_y
-from ..utils.sparsefuncs import csc_row_median
+from ..utils.sparsefuncs import csc_median_axis_0
 
 
 class NearestCentroid(BaseEstimator, ClassifierMixin):
@@ -37,6 +37,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         samples that belong to that particular class are minimized.
         If the "manhattan" metric is provided, this centroid is the median and
         for all other metrics, the centroid is now set to be the mean.
+
     shrink_threshold : float, optional (default = None)
         Threshold for shrinking centroids to remove features.
 
@@ -123,7 +124,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
                 if not is_X_sparse:
                     self.centroids_[cur_class] = np.median(X[center_mask], axis=0)
                 else:
-                    self.centroids_[cur_class] = csc_row_median(X[center_mask])
+                    self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
             else:
                 self.centroids_[cur_class] = X[center_mask].mean(axis=0)
 

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -125,6 +125,17 @@ def test_predict_translated_data():
     assert_array_equal(y_init, y_translate)
 
 
+def test_manhattan_metric():
+    """Test the manhattan metric."""
+
+    clf = NearestCentroid(metric='manhattan')
+    clf.fit(X, y)
+    dense_centroid = clf.centroids_
+    clf.fit(X_csr, y)
+    assert_array_equal(clf.centroids_, dense_centroid)
+    assert_array_equal(dense_centroid, [[-1, -1], [1, 1]])
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -12,6 +12,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
 from ..utils import as_float_array
 from ..utils.fixes import astype
+from ..utils.sparsefuncs import _get_median
 
 from ..externals import six
 
@@ -29,34 +30,6 @@ def _get_mask(X, value_to_mask):
         return np.isnan(X)
     else:
         return X == value_to_mask
-
-
-def _get_median(data, n_zeros):
-    """Compute the median of data with n_zeros additional zeros.
-
-    This function is used to support sparse matrices; it modifies data in-place
-    """
-    n_elems = len(data) + n_zeros
-    if not n_elems:
-        return np.nan
-    n_negative = np.count_nonzero(data < 0)
-    middle, is_odd = divmod(n_elems, 2)
-    data.sort()
-
-    if is_odd:
-        return _get_elem_at_rank(middle, data, n_negative, n_zeros)
-
-    return (_get_elem_at_rank(middle - 1, data, n_negative, n_zeros) +
-            _get_elem_at_rank(middle, data, n_negative, n_zeros)) / 2.
-
-
-def _get_elem_at_rank(rank, data, n_negative, n_zeros):
-    """Find the value in data augmented with n_zeros for the given rank"""
-    if rank < n_negative:
-        return data[rank]
-    if rank - n_negative < n_zeros:
-        return 0
-    return data[rank - n_zeros]
 
 
 def _most_frequent(array, extra_value, n_repeat):

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -348,7 +348,8 @@ def count_nonzero(X, axis=None, sample_weight=None):
 def csc_row_median(csc):
     """
     Find the median across axis 0 of a CSC matrix.
-    Equivalent to doing np.median(X, axis=0)
+    Wrapper aound the _get_median function in imputer and is equivalent
+    to doing np.median(X, axis=0)
 
     Parameters
     ----------
@@ -361,55 +362,20 @@ def csc_row_median(csc):
         Median. 
 
     """
+    from ..preprocessing.imputation import _get_median
+
     if not isinstance(csc, sp.csc_matrix):
-        warnings.warn("Non CSC matix passed. Will convert to CSC format.")
-        csc = sp.csc_matrix(csc)
+        raise TypeError("Expected matrix of CSC format, got %s" % csc.format)
 
     indptr = csc.indptr
     n_samples, n_features = csc.shape
-
-    # Highly likely that the median of a sparse matrix is zero.
-    # Remains zero if the if/else conditions are not checked below.
     median = np.zeros(n_features)
 
     for f_ind, ptr in enumerate(indptr[:-1]):
-        sorted_nonzero = np.sort(csc.data[ptr: indptr[f_ind + 1]])
-        nz = n_samples - sorted_nonzero.size
-        zero_ind = np.searchsorted(sorted_nonzero, 0)
-        neg_idx = sorted_nonzero[: zero_ind]
-        pos_idx = sorted_nonzero[zero_ind: ]
-        odd = n_samples % 2
-        mid_ind = n_samples // 2
 
-        if odd:
-            # Number of negative terms is greater then (n_features + 1) / 2
-            # which implies the median is negative.
-            if zero_ind > mid_ind:
-                median[f_ind] = sorted_nonzero[mid_ind]
-
-            # The sum of the negative terms and the number of zeros is less
-            # than the (n_features + 1) / 2 which implies the median is positive.
-            elif zero_ind + nz <= mid_ind:
-                median[f_ind] = pos_idx[mid_ind - nz - neg_idx.size]
-
-        else:
-            # The first two conditions are highly unlikely.
-            # When the n_features / 2 is the last negative term and
-            # (n_features / 2) + 1 is zero.
-            if zero_ind == mid_ind:
-                median[f_ind] = neg_idx[-1] / 2.
-
-            # When the n_features / 2 is zero and (n_features / 2) + 1
-            # is the first positive term.
-            elif neg_idx.size + nz == mid_ind:
-                median[f_ind] = pos_idx[0] / 2.
-
-            # Same comments as for the odd case.
-            elif zero_ind > mid_ind:
-                median[f_ind] = (sorted_nonzero[mid_ind - 1] +
-                                 sorted_nonzero[mid_ind]) / 2.
-            elif zero_ind + nz < mid_ind:
-                npz = mid_ind - nz - neg_idx.size
-                median[f_ind] = (pos_idx[npz - 1] + pos_idx[npz]) / 2.
+        # Prevent modifying csc in place
+        data = np.copy(csc.data[ptr: indptr[f_ind + 1]])
+        nz = n_samples - data.size
+        median[f_ind] = _get_median(data, nz)
 
     return median

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -4,7 +4,6 @@
 # License: BSD 3 clause
 import scipy.sparse as sp
 import numpy as np
-import warnings
 
 from .fixes import sparse_min_max
 from .sparsefuncs_fast import csr_mean_variance_axis0 as _csr_mean_var_axis0
@@ -373,7 +372,7 @@ def _get_elem_at_rank(rank, data, n_negative, n_zeros):
     return data[rank - n_zeros]
 
 
-def csc_row_median(X):
+def csc_median_axis_0(X):
     """Find the median across axis 0 of a CSC matrix.
     It is equivalent to doing np.median(X, axis=0).
 
@@ -395,10 +394,10 @@ def csc_row_median(X):
     n_samples, n_features = X.shape
     median = np.zeros(n_features)
 
-    for f_ind, ptr in enumerate(indptr[:-1]):
+    for f_ind, (start, end) in enumerate(zip(indptr[:-1], indptr[1:])):
 
         # Prevent modifying X in place
-        data = np.copy(X.data[ptr: indptr[f_ind + 1]])
+        data = np.copy(X.data[start: end])
         nz = n_samples - data.size
         median[f_ind] = _get_median(data, nz)
 

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -384,7 +384,7 @@ def csc_row_median(X):
 
     Returns
     -------
-    median : ndarray, shape = (n_features,)
+    median : ndarray, shape (n_features,)
         Median. 
 
     """

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -389,3 +389,6 @@ def test_csc_row_median():
     X = [[0, -2], [-1, -5], [1, -3]]
     csc = sp.csc_matrix(X)
     assert_array_equal(csc_row_median(csc), np.array([0., -3]))
+
+    # Test that it raises an Error for non-csc matrices.
+    assert_raises(TypeError, csc_row_median, sp.csr_matrix(X))

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -10,7 +10,7 @@ from sklearn.utils.sparsefuncs import (mean_variance_axis,
                                        inplace_row_scale,
                                        inplace_swap_row, inplace_swap_column,
                                        min_max_axis,
-                                       count_nonzero, csc_row_median)
+                                       count_nonzero, csc_median_axis_0)
 from sklearn.utils.sparsefuncs_fast import assign_rows_csr
 from sklearn.utils.testing import assert_raises
 
@@ -369,7 +369,7 @@ def test_csc_row_median():
     X = rng.rand(100, 50)
     dense_median = np.median(X, axis=0)
     csc = sp.csc_matrix(X)
-    sparse_median = csc_row_median(csc)
+    sparse_median = csc_median_axis_0(csc)
     assert_array_equal(sparse_median, dense_median)
 
     # Test that it gives the same output when X is sparse
@@ -379,16 +379,16 @@ def test_csc_row_median():
     X[ind] = -X[ind]
     csc = sp.csc_matrix(X)
     dense_median = np.median(X, axis=0)
-    sparse_median = csc_row_median(csc)
+    sparse_median = csc_median_axis_0(csc)
     assert_array_equal(sparse_median, dense_median)
 
     # Test for toy data.
     X = [[0, -2], [-1, -1], [1, 0], [2, 1]]
     csc = sp.csc_matrix(X)
-    assert_array_equal(csc_row_median(csc), np.array([0.5, -0.5]))
+    assert_array_equal(csc_median_axis_0(csc), np.array([0.5, -0.5]))
     X = [[0, -2], [-1, -5], [1, -3]]
     csc = sp.csc_matrix(X)
-    assert_array_equal(csc_row_median(csc), np.array([0., -3]))
+    assert_array_equal(csc_median_axis_0(csc), np.array([0., -3]))
 
     # Test that it raises an Error for non-csc matrices.
-    assert_raises(TypeError, csc_row_median, sp.csr_matrix(X))
+    assert_raises(TypeError, csc_median_axis_0, sp.csr_matrix(X))

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -10,7 +10,7 @@ from sklearn.utils.sparsefuncs import (mean_variance_axis,
                                        inplace_row_scale,
                                        inplace_swap_row, inplace_swap_column,
                                        min_max_axis,
-                                       count_nonzero)
+                                       count_nonzero, csc_row_median)
 from sklearn.utils.sparsefuncs_fast import assign_rows_csr
 from sklearn.utils.testing import assert_raises
 
@@ -359,3 +359,33 @@ def test_count_nonzero():
 
     assert_raises(TypeError, count_nonzero, X_csc)
     assert_raises(ValueError, count_nonzero, X_csr, axis=2)
+
+
+def test_csc_row_median():
+    """Test csc_row_median actually calculates the median."""
+
+    # Test that it gives the same output when X is dense.
+    rng = np.random.RandomState(0)
+    X = rng.rand(100, 50)
+    dense_median = np.median(X, axis=0)
+    csc = sp.csc_matrix(X)
+    sparse_median = csc_row_median(csc)
+    assert_array_equal(sparse_median, dense_median)
+
+    # Test that it gives the same output when X is sparse
+    X = rng.rand(51, 100)
+    X[X < 0.7] = 0.0
+    ind = rng.randint(0, 50, 10)
+    X[ind] = -X[ind]
+    csc = sp.csc_matrix(X)
+    dense_median = np.median(X, axis=0)
+    sparse_median = csc_row_median(csc)
+    assert_array_equal(sparse_median, dense_median)
+
+    # Test for toy data.
+    X = [[0, -2], [-1, -1], [1, 0], [2, 1]]
+    csc = sp.csc_matrix(X)
+    assert_array_equal(csc_row_median(csc), np.array([0.5, -0.5]))
+    X = [[0, -2], [-1, -5], [1, -3]]
+    csc = sp.csc_matrix(X)
+    assert_array_equal(csc_row_median(csc), np.array([0., -3]))


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/743

I have also added a utility for calculating the median of csc sparse matrices, since NumPy does not handle it and it is not a trivial one-liner.
