### PR TITLE
[MRG] DOC, FIX: Support Python 2 and 3 in gen_rst.py

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -42,7 +42,7 @@ try:
     execfile
 except NameError:
     def execfile(filename, global_vars=None, local_vars=None):
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
             code = compile(f.read(), filename, 'exec')
             exec(code, global_vars, local_vars)
 
@@ -426,7 +426,7 @@ carousel_thumbs = {'plot_classifier_comparison_001.png': (1, 600),
 def extract_docstring(filename, ignore_heading=False):
     """ Extract a module-level docstring, if any
     """
-    lines = open(filename).readlines()
+    lines = open(filename, encoding='utf-8').readlines()
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
@@ -522,7 +522,7 @@ Examples
 def extract_line_count(filename, target_dir):
     # Extract the line count of a file
     example_file = os.path.join(target_dir, filename)
-    lines = open(example_file).readlines()
+    lines = open(example_file, encoding='utf-8').readlines()
     start_row = 0
     if lines and lines[0].startswith('#!'):
         lines.pop(0)
@@ -954,7 +954,8 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
     f.flush()
 
     # save variables so we can later add links to the documentation
-    example_code_obj = identify_names(open(example_file).read())
+    example_code_obj = \
+        identify_names(open(example_file, encoding='utf-8').read())
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle'
         with open(codeobj_fname, 'wb') as fid:

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -20,6 +20,7 @@ import gzip
 import posixpath
 import subprocess
 from textwrap import dedent
+from sklearn.externals import six
 
 
 # Try Python 2 first, otherwise load from Python 3
@@ -426,7 +427,10 @@ carousel_thumbs = {'plot_classifier_comparison_001.png': (1, 600),
 def extract_docstring(filename, ignore_heading=False):
     """ Extract a module-level docstring, if any
     """
-    lines = open(filename, encoding='utf-8').readlines()
+    if six.PY2:
+        lines = open(filename).readlines()
+    else:
+        lines = open(filename, encoding='utf-8').readlines()    
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
@@ -522,7 +526,10 @@ Examples
 def extract_line_count(filename, target_dir):
     # Extract the line count of a file
     example_file = os.path.join(target_dir, filename)
-    lines = open(example_file, encoding='utf-8').readlines()
+    if six.PY2:
+        lines = open(example_file).readlines()
+    else:
+        lines = open(example_file, encoding='utf-8').readlines()    
     start_row = 0
     if lines and lines[0].startswith('#!'):
         lines.pop(0)
@@ -954,8 +961,11 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
     f.flush()
 
     # save variables so we can later add links to the documentation
-    example_code_obj = \
-        identify_names(open(example_file, encoding='utf-8').read())
+    if six.PY2:
+        example_code_obj = identify_names(open(example_file).read())
+    else:
+        example_code_obj = \
+            identify_names(open(example_file, encoding='utf-8').read())    
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle'
         with open(codeobj_fname, 'wb') as fid:


### PR DESCRIPTION
The encoding (if not specified) used by `open` in Python is platform dependent. On my Windows machine it is `cp1251`, so I had troubles building docs with the example gallery because of that (some examples contain non-ASCII characters.) 

I think setting it explicitly to `utf-8` is a good thing.
