### PR TITLE
[WIP] Kernel regression

### DIFF
--- a/examples/plot_kernel_regression.py
+++ b/examples/plot_kernel_regression.py
@@ -1,0 +1,79 @@
+"""
+========================================================================
+Comparison of kernel regression (KR) and support vector regression (SVR)
+========================================================================
+
+Toy example of 1D regression using kernel regression (KR) and support vector
+regression (SVR). KR provides an efficient way of selecting a kernel's
+bandwidth via leave-one-out cross-validation, which is considerably faster
+that an explicit grid-search as required by SVR. The main disadvantages are
+that it does not support regularization and is not robust to outliers.
+"""
+print(__doc__)
+
+import time
+
+import numpy as np
+from sklearn.svm import SVR
+from sklearn.grid_search import GridSearchCV
+from sklearn.learning_curve import learning_curve
+from sklearn.kernel_regression import KernelRegression
+import matplotlib.pyplot as plt
+
+np.random.seed(0)
+
+
+###############################################################################
+# Generate sample data
+X = np.sort(5 * np.random.rand(100, 1), axis=0)
+y = np.sin(X).ravel()
+
+###############################################################################
+# Add noise to targets
+y += 0.5 * (0.5 - np.random.rand(y.size))
+
+###############################################################################
+# Fit regression models
+svr = GridSearchCV(SVR(kernel='rbf'), cv=5,
+                   param_grid={"C": [1e-1, 1e0, 1e1, 1e2],
+                               "gamma": np.logspace(-2, 2, 10)})
+kr = KernelRegression(kernel="rbf", gamma=np.logspace(-2, 2, 10))
+t0 = time.time()
+y_svr = svr.fit(X, y).predict(X)
+print "SVR complexity and bandwidth selected and model fitted in %.3f s" \
+    % (time.time() - t0)
+t0 = time.time()
+y_kr = kr.fit(X, y).predict(X)
+print "KR including bandwith fitted in %.3f s" \
+    % (time.time() - t0)
+
+###############################################################################
+# Visualize models
+plt.scatter(X, y, c='k', label='data')
+plt.hold('on')
+plt.plot(X, y_kr, c='g', label='Kernel Regression')
+plt.plot(X, y_svr, c='r', label='SVR')
+plt.xlabel('data')
+plt.ylabel('target')
+plt.title('Kernel regression versus SVR')
+plt.legend()
+
+# Visualize learning curves
+plt.figure()
+train_sizes, train_scores_svr, test_scores_svr = \
+    learning_curve(svr, X, y, train_sizes=np.linspace(0.1, 1, 10),
+                   scoring="mean_squared_error", cv=10)
+train_sizes_abs, train_scores_kr, test_scores_kr = \
+    learning_curve(kr, X, y, train_sizes=np.linspace(0.1, 1, 10),
+                   scoring="mean_squared_error", cv=10)
+plt.plot(train_sizes, test_scores_svr.mean(1), 'o-', color="r",
+         label="SVR")
+plt.plot(train_sizes, test_scores_kr.mean(1), 'o-', color="g",
+         label="Kernel Regression")
+plt.yscale("symlog", linthreshy=1e-7)
+plt.ylim(-10, -0.01)
+plt.xlabel("Training size")
+plt.ylabel("Mean Squared Error")
+plt.title('Learning curves')
+plt.legend(loc="best")
+plt.show()

--- a/sklearn/kernel_regression.py
+++ b/sklearn/kernel_regression.py
@@ -11,7 +11,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 
 
 class KernelRegression(BaseEstimator, RegressorMixin):
-    """Nadaraya-Watson kernel regression with automatic bandwith selection.
+    """Nadaraya-Watson kernel regression with automatic bandwidth selection.
 
     This implements Nadaraya-Watson kernel regression with (optional) automatic
     bandwith selection of the kernel via leave-one-out cross-validation. Kernel
@@ -32,20 +32,6 @@ class KernelRegression(BaseEstimator, RegressorMixin):
         sklearn.metrics.pairwise. Ignored by other kernels. If a sequence of
         values is given, one of these values is selected which minimizes
         the mean-squared-error of leave-one-out cross-validation.
-
-
-    Attributes
-    ----------
-    components_ : array, shape (n_components, n_features)
-        Subset of training points used to construct the feature map.
-
-    component_indices_ : array, shape (n_components)
-        Indices of ``components_`` in the training set.
-
-    normalization_ : array, shape (n_components, n_components)
-        Normalization matrix needed for embedding.
-        Square root of the kernel matrix on ``components_``.
-
 
     See also
     --------

--- a/sklearn/kernel_regression.py
+++ b/sklearn/kernel_regression.py
@@ -1,0 +1,112 @@
+"""The :mod:`sklearn.kernel_regressor` module implements the Kernel Regressor.
+"""
+# Author: Jan Hendrik Metzen <janmetzen@mailbox.de>
+#
+# License: BSD 3 clause
+
+import numpy as np
+
+from sklearn.metrics.pairwise import pairwise_kernels
+from sklearn.base import BaseEstimator, RegressorMixin
+
+
+class KernelRegression(BaseEstimator, RegressorMixin):
+    """Nadaraya-Watson kernel regression with automatic bandwith selection.
+
+    This implements Nadaraya-Watson kernel regression with (optional) automatic
+    bandwith selection of the kernel via leave-one-out cross-validation. Kernel
+    regression is a simple non-parametric kernelized technique for learning
+    a non-linear relationship between input variable(s) and a target variable.
+
+    Parameters
+    ----------
+    kernel : string or callable, default="rbf"
+        Kernel map to be approximated. A callable should accept two arguments
+        and the keyword arguments passed to this object as kernel_params, and
+        should return a floating point number.
+
+    gamma : float, default=None
+        Gamma parameter for the RBF ("bandwidth"), polynomial,
+        exponential chi2 and sigmoid kernels. Interpretation of the default
+        value is left to the kernel; see the documentation for
+        sklearn.metrics.pairwise. Ignored by other kernels. If a sequence of
+        values is given, one of these values is selected which minimizes
+        the mean-squared-error of leave-one-out cross-validation.
+
+
+    Attributes
+    ----------
+    components_ : array, shape (n_components, n_features)
+        Subset of training points used to construct the feature map.
+
+    component_indices_ : array, shape (n_components)
+        Indices of ``components_`` in the training set.
+
+    normalization_ : array, shape (n_components, n_components)
+        Normalization matrix needed for embedding.
+        Square root of the kernel matrix on ``components_``.
+
+
+    See also
+    --------
+
+    sklearn.metrics.pairwise.kernel_metrics : List of built-in kernels.
+    """
+
+    def __init__(self, kernel="rbf", gamma=None):
+        self.kernel = kernel
+        self.gamma = gamma
+
+    def fit(self, X, y):
+        """Fit the model
+
+        Parameters
+        ----------
+        X : array-like of shape = [n_samples, n_features]
+            The training input samples.
+
+        y : array-like, shape = [n_samples]
+            The target values
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.X = X
+        self.y = y
+
+        if hasattr(self.gamma, "__iter__"):
+            self.gamma = self._optimize_gamma(self.gamma)
+
+        return self
+
+    def predict(self, X):
+        """Predict target values for X.
+
+        Parameters
+        ----------
+        X : array-like of shape = [n_samples, n_features]
+            The input samples.
+
+        Returns
+        -------
+        y : array of shape = [n_samples]
+            The predicted target value.
+        """
+        K = pairwise_kernels(self.X, X, metric=self.kernel, gamma=self.gamma)
+        return (K * self.y[:, None]).sum(axis=0) / K.sum(axis=0)
+
+    def _optimize_gamma(self, gamma_values):
+        # Select specific value of gamma from the range of given gamma_values
+        # by minimizing mean-squared error in leave-one-out cross validation
+        mse = np.empty_like(gamma_values, dtype=np.float)
+        for i, gamma in enumerate(gamma_values):
+            K = pairwise_kernels(self.X, self.X, metric=self.kernel,
+                                 gamma=gamma)
+            np.fill_diagonal(K, 0)  # leave-one-out
+            Ky = K * self.y[:, np.newaxis]
+            y_pred = Ky.sum(axis=0) / K.sum(axis=0)
+            mse[i] = ((y_pred - self.y) ** 2).mean()
+
+        return gamma_values[np.nanargmin(mse)]


### PR DESCRIPTION
Implementation of Nadaraya-Watson kernel regression with automatic bandwidth selection.

This simple algorithm is suited as a baseline for more complex algorithms, particularly in cases where the size of the training set is large compared to number of dimensions. An advantage of this algorithm is that it allows efficient bandwidth selection via leave-one-out cross-validation. This PR includes an example comparing kernel regression with SVR on a simple 1D toy dataset:

![figure_1](https://cloud.githubusercontent.com/assets/1116263/4668304/37ff234c-5564-11e4-99f9-9e526e1cd2c5.png)

![figure_2](https://cloud.githubusercontent.com/assets/1116263/4668310/401355a8-5564-11e4-85cd-410788904d08.png)

Potential future extensions of this could include metric learning for kernel regression (http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.117.7080)

Any opinions on whether this is interesting for sklearn?
