### PR TITLE
[MRG] MAINT remove deprecated loss in gradient boosting

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -631,8 +631,6 @@ LOSS_FUNCTIONS = {'ls': LeastSquaresError,
                   'lad': LeastAbsoluteError,
                   'huber': HuberLossFunction,
                   'quantile': QuantileLossFunction,
-                  'bdeviance': BinomialDeviance,
-                  'mdeviance': MultinomialDeviance,
                   'deviance': None,    # for both, multinomial and binomial
                   'exponential': ExponentialLoss,
                   }
@@ -781,10 +779,6 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         if (self.loss not in self._SUPPORTED_LOSS
                 or self.loss not in LOSS_FUNCTIONS):
             raise ValueError("Loss '{0:s}' not supported. ".format(self.loss))
-
-        if self.loss in ('mdeviance', 'bdeviance'):
-            warn(("Loss '{0:s}' is deprecated as of version 0.14. "
-                 "Use 'deviance' instead. ").format(self.loss))
 
         if self.loss == 'deviance':
             loss_class = (MultinomialDeviance
@@ -1276,7 +1270,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     Elements of Statistical Learning Ed. 2, Springer, 2009.
     """
 
-    _SUPPORTED_LOSS = ('deviance', 'mdeviance', 'bdeviance', 'exponential')
+    _SUPPORTED_LOSS = ('deviance', 'exponential')
 
     def __init__(self, loss='deviance', learning_rate=0.1, n_estimators=100,
                  subsample=1.0, min_samples_split=2,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -642,25 +642,6 @@ def test_more_verbose_output():
     assert_equal(100, n_lines)
 
 
-def test_warn_deviance():
-    """Test if mdeviance and bdeviance give deprecated warning. """
-    for loss in ('bdeviance', 'mdeviance'):
-        clean_warning_registry()
-        with warnings.catch_warnings(record=True) as w:
-            # This will raise a DataConversionWarning that we want to
-            # "always" raise, elsewhere the warnings gets ignored in the
-            # later tests, and the tests that check for this warning fail
-            warnings.simplefilter("always", DataConversionWarning)
-            clf = GradientBoostingClassifier(loss=loss)
-            try:
-                clf.fit(X, y)
-            except:
-                # mdeviance will raise ValueError because only 2 classes
-                pass
-            # deprecated warning for bdeviance and mdeviance
-            assert len(w) == 1
-
-
 def test_warm_start():
     """Test if warm start equals fit. """
     X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)


### PR DESCRIPTION
There is no mention to the version where this will be removed. However, I still think that it should be removed.
