### PR TITLE
DOC: Remove extra # from url in fit.

### DIFF
--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -478,7 +478,7 @@ class DPGMM(GMM):
         For a full derivation and description of the algorithm see
         doc/modules/dp-derivation.rst
         or
-        http://scikit-learn.org/stable/modules/dp-derivation.html#
+        http://scikit-learn.org/stable/modules/dp-derivation.html
 
         A initialization step is performed before entering the em
         algorithm. If you want to avoid this step, set the keyword


### PR DESCRIPTION
The extra # messes with the rst parser which produces an invalid URL where the ".html" suffix is missing.
