### PR TITLE
[MRG+1] Store KL divergence after optimization in t-SNE

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -366,6 +366,9 @@ class TSNE(BaseEstimator):
     training_data_ : array-like, shape (n_samples, n_features)
         Stores the training data.
 
+    kl_divergence_ : float
+        Kullback-Leibler divergence after optimization.
+
     Examples
     --------
 
@@ -433,9 +436,10 @@ class TSNE(BaseEstimator):
         else:
             if self.verbose:
                 print("[t-SNE] Computing pairwise distances...")
-            
+
             if self.metric == "euclidean":
-                distances = pairwise_distances(X, metric=self.metric, squared=True)
+                distances = pairwise_distances(X, metric=self.metric,
+                                               squared=True)
             else:
                 distances = pairwise_distances(X, metric=self.metric)
 
@@ -479,31 +483,33 @@ class TSNE(BaseEstimator):
 
         # Early exaggeration
         P *= self.early_exaggeration
-        params, error, it = _gradient_descent(
+        params, kl_divergence, it = _gradient_descent(
             _kl_divergence, params, it=0, n_iter=50, momentum=0.5,
             min_grad_norm=0.0, min_error_diff=0.0,
             learning_rate=self.learning_rate, verbose=self.verbose,
             args=[P, alpha, n_samples, self.n_components])
-        params, error, it = _gradient_descent(
+        params, kl_divergence, it = _gradient_descent(
             _kl_divergence, params, it=it + 1, n_iter=100, momentum=0.8,
             min_grad_norm=0.0, min_error_diff=0.0,
             learning_rate=self.learning_rate, verbose=self.verbose,
             args=[P, alpha, n_samples, self.n_components])
         if self.verbose:
-            print("[t-SNE] Error after %d iterations with early "
-                  "exaggeration: %f" % (it + 1, error))
+            print("[t-SNE] KL divergence after %d iterations with early "
+                  "exaggeration: %f" % (it + 1, kl_divergence))
 
         # Final optimization
         P /= self.early_exaggeration
-        params, error, it = _gradient_descent(
+        params, kl_divergence, it = _gradient_descent(
             _kl_divergence, params, it=it + 1, n_iter=self.n_iter,
             momentum=0.8, learning_rate=self.learning_rate,
             verbose=self.verbose, args=[P, alpha, n_samples,
                                         self.n_components])
         if self.verbose:
-            print("[t-SNE] Error after %d iterations: %f" % (it + 1, error))
+            print("[t-SNE] Error after %d iterations: %f"
+                  % (it + 1, kl_divergence))
 
         X_embedded = params.reshape(n_samples, self.n_components)
+        self.kl_divergence_ = kl_divergence
 
         return X_embedded
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -2,6 +2,7 @@ import sys
 from sklearn.externals.six.moves import cStringIO as StringIO
 import numpy as np
 import scipy.sparse as sp
+from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_less
@@ -13,6 +14,7 @@ from sklearn.manifold.t_sne import _gradient_descent
 from sklearn.manifold.t_sne import trustworthiness
 from sklearn.manifold.t_sne import TSNE
 from sklearn.manifold._utils import _binary_search_perplexity
+from sklearn.datasets import make_blobs
 from scipy.optimize import check_grad
 from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
@@ -166,6 +168,20 @@ def test_preserve_trustworthiness_approximately():
                             decimal=1)
 
 
+def test_optimization_minimizes_kl_divergence():
+    """t-SNE should give a lower KL divergence with more iterations."""
+    random_state = check_random_state(0)
+    X, _ = make_blobs(n_features=3, random_state=random_state)
+    kl_divergences = []
+    for n_iter in [200, 250, 300]:
+        tsne = TSNE(n_components=2, perplexity=10, learning_rate=100.0,
+                    n_iter=n_iter, random_state=0)
+        tsne.fit_transform(X)
+        kl_divergences.append(tsne.kl_divergence_)
+    assert_less_equal(kl_divergences[1], kl_divergences[0])
+    assert_less_equal(kl_divergences[2], kl_divergences[1])
+
+
 def test_fit_csr_matrix():
     """X can be a sparse matrix."""
     random_state = check_random_state(0)
@@ -259,7 +275,6 @@ def test_verbose():
 def test_chebyshev_metric():
     """t-SNE should allow metrics that cannot be squared (issue #3526)."""
     random_state = check_random_state(0)
-    tsne = TSNE(verbose=2, metric="chebyshev")
+    tsne = TSNE(metric="chebyshev")
     X = random_state.randn(5, 2)
     tsne.fit_transform(X)
-


### PR DESCRIPTION
This PR is based on #3422 from @joker0x5F5F and fixes [this issue](http://datascience.stackexchange.com/questions/762) which unfortunately has not been reported here ;)

Additionally, I renamed the `error_` to `kl_divergence_` because error is a term that might confuse users (maybe cost would be a better name?) and added a test that requires the attribute `TSNE.kl_divergence_`.
