### PR TITLE
Show estimated end time for GBM verbose output

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -645,9 +645,6 @@ class VerboseReporter(object):
     If ``verbose==1`` output is printed once in a while (when iteration mod
     verbose_mod is zero).; if larger than 1 then output is printed for
     each update.
-
-    If ``verbose==-1``, as above, but the estimated end time is also printed;
-    if less than -1 then output is printed for each update.
     """
 
     def __init__(self, verbose):
@@ -661,11 +658,8 @@ class VerboseReporter(object):
         if est.subsample < 1:
             header_fields.append('OOB Improve')
             verbose_fmt.append('{oob_impr:>16.4f}')
-        header_fields.append('Remaining Time')
-        verbose_fmt.append('{remaining_time:>16s}')
-        if self.verbose < 0:
-            header_fields.append('End Time')
-            verbose_fmt.append('{end_time:>16s}')
+        header_fields.extend(['Remaining Time', 'End Time'])
+        verbose_fmt.extend(['{remaining_time:>16s}', '{end_time:>16s}'])
 
         # print the header line
         print(('%10s ' + '%16s ' *
@@ -687,7 +681,9 @@ class VerboseReporter(object):
             remaining_time = ((est.n_estimators - (j + 1)) *
                               (time() - self.start_time) / float(i + 1))
             end_time = strftime("%d %b %H:%M", localtime(time() + remaining_time))
-            if remaining_time > 60:
+            if remaining_time > 3600:
+                remaining_time = '{0:.2f}h'.format(remaining_time / 3600.0)
+            elif remaining_time > 60:
                 remaining_time = '{0:.2f}m'.format(remaining_time / 60.0)
             else:
                 remaining_time = '{0:.2f}s'.format(remaining_time)
@@ -696,7 +692,7 @@ class VerboseReporter(object):
                                           oob_impr=oob_impr,
                                           remaining_time=remaining_time,
                                           end_time=end_time))
-            if abs(self.verbose) == 1 and ((i + 1) // (self.verbose_mod * 10) > 0):
+            if self.verbose == 1 and ((i + 1) // (self.verbose_mod * 10) > 0):
                 # adjust verbose frequency (powers of 10)
                 self.verbose_mod *= 10
 
@@ -1045,7 +1041,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
                 # no need to fancy index w/ no subsampling
                 self.train_score_[i] = loss_(y, y_pred, sample_weight)
 
-            if self.verbose != 0:
+            if self.verbose > 0:
                 verbose_reporter.update(i, self)
 
             if monitor is not None:
@@ -1229,8 +1225,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     verbose : int, default: 0
         Enable verbose output. If 1 then it prints progress and performance
         once in a while (the more trees the lower the frequency). If greater
-        than 1 then it prints progress and performance for every tree. If
-        negative, the estimated end time is also printed.
+        than 1 then it prints progress and performance for every tree.
 
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit
@@ -1508,8 +1503,7 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     verbose : int, default: 0
         Enable verbose output. If 1 then it prints progress and performance
         once in a while (the more trees the lower the frequency). If greater
-        than 1 then it prints progress and performance for every tree. If
-        negative, the estimated end time is also printed.
+        than 1 then it prints progress and performance for every tree.
 
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 from __future__ import division
 from abc import ABCMeta, abstractmethod
 from warnings import warn
-from time import time
+from time import time, strftime, localtime
 
 import numbers
 import numpy as np
@@ -645,6 +645,9 @@ class VerboseReporter(object):
     If ``verbose==1`` output is printed once in a while (when iteration mod
     verbose_mod is zero).; if larger than 1 then output is printed for
     each update.
+
+    If ``verbose==-1``, as above, but the estimated end time is also printed;
+    if less than -1 then output is printed for each update.
     """
 
     def __init__(self, verbose):
@@ -660,6 +663,9 @@ class VerboseReporter(object):
             verbose_fmt.append('{oob_impr:>16.4f}')
         header_fields.append('Remaining Time')
         verbose_fmt.append('{remaining_time:>16s}')
+        if self.verbose < 0:
+            header_fields.append('End Time')
+            verbose_fmt.append('{end_time:>16s}')
 
         # print the header line
         print(('%10s ' + '%16s ' *
@@ -680,6 +686,7 @@ class VerboseReporter(object):
             oob_impr = est.oob_improvement_[j] if do_oob else 0
             remaining_time = ((est.n_estimators - (j + 1)) *
                               (time() - self.start_time) / float(i + 1))
+            end_time = strftime("%d %b %H:%M", localtime(time() + remaining_time))
             if remaining_time > 60:
                 remaining_time = '{0:.2f}m'.format(remaining_time / 60.0)
             else:
@@ -687,8 +694,9 @@ class VerboseReporter(object):
             print(self.verbose_fmt.format(iter=j + 1,
                                           train_score=est.train_score_[j],
                                           oob_impr=oob_impr,
-                                          remaining_time=remaining_time))
-            if self.verbose == 1 and ((i + 1) // (self.verbose_mod * 10) > 0):
+                                          remaining_time=remaining_time,
+                                          end_time=end_time))
+            if abs(self.verbose) == 1 and ((i + 1) // (self.verbose_mod * 10) > 0):
                 # adjust verbose frequency (powers of 10)
                 self.verbose_mod *= 10
 
@@ -1037,7 +1045,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
                 # no need to fancy index w/ no subsampling
                 self.train_score_[i] = loss_(y, y_pred, sample_weight)
 
-            if self.verbose > 0:
+            if self.verbose != 0:
                 verbose_reporter.update(i, self)
 
             if monitor is not None:
@@ -1221,7 +1229,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     verbose : int, default: 0
         Enable verbose output. If 1 then it prints progress and performance
         once in a while (the more trees the lower the frequency). If greater
-        than 1 then it prints progress and performance for every tree.
+        than 1 then it prints progress and performance for every tree. If
+        negative, the estimated end time is also printed.
 
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit
@@ -1499,7 +1508,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     verbose : int, default: 0
         Enable verbose output. If 1 then it prints progress and performance
         once in a while (the more trees the lower the frequency). If greater
-        than 1 then it prints progress and performance for every tree.
+        than 1 then it prints progress and performance for every tree. If
+        negative, the estimated end time is also printed.
 
     warm_start : bool, default: False
         When set to ``True``, reuse the solution of the previous call to fit

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -617,6 +617,31 @@ def test_verbose_output():
     assert_equal(10 + 9, n_lines)
 
 
+def test_verbose_output_with_end():
+    """Check verbose=-1 does not cause error. """
+    from sklearn.externals.six.moves import cStringIO as StringIO
+    import sys
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
+                                     verbose=-1, subsample=0.8)
+    clf.fit(X, y)
+    verbose_output = sys.stdout
+    sys.stdout = old_stdout
+
+    # check output
+    verbose_output.seek(0)
+    header = verbose_output.readline().rstrip()
+    # with OOB
+    true_header = ' '.join(['%10s'] + ['%16s'] * 4) % (
+        'Iter', 'Train Loss', 'OOB Improve', 'Remaining Time', 'End Time')
+    assert_equal(true_header, header)
+
+    n_lines = sum(1 for l in verbose_output.readlines())
+    # one for 1-10 and then 9 for 20-100
+    assert_equal(10 + 9, n_lines)
+
+
 def test_more_verbose_output():
     """Check verbose=2 does not cause error. """
     from sklearn.externals.six.moves import cStringIO as StringIO
@@ -635,6 +660,31 @@ def test_more_verbose_output():
     # no OOB
     true_header = ' '.join(['%10s'] + ['%16s'] * 2) % (
         'Iter', 'Train Loss', 'Remaining Time')
+    assert_equal(true_header, header)
+
+    n_lines = sum(1 for l in verbose_output.readlines())
+    # 100 lines for n_estimators==100
+    assert_equal(100, n_lines)
+
+
+def test_more_verbose_output_with_end():
+    """Check verbose=-2 does not cause error. """
+    from sklearn.externals.six.moves import cStringIO as StringIO
+    import sys
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
+                                     verbose=-2)
+    clf.fit(X, y)
+    verbose_output = sys.stdout
+    sys.stdout = old_stdout
+
+    # check output
+    verbose_output.seek(0)
+    header = verbose_output.readline().rstrip()
+    # no OOB
+    true_header = ' '.join(['%10s'] + ['%16s'] * 3) % (
+        'Iter', 'Train Loss', 'Remaining Time', 'End Time')
     assert_equal(true_header, header)
 
     n_lines = sum(1 for l in verbose_output.readlines())

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -608,31 +608,6 @@ def test_verbose_output():
     verbose_output.seek(0)
     header = verbose_output.readline().rstrip()
     # with OOB
-    true_header = ' '.join(['%10s'] + ['%16s'] * 3) % (
-        'Iter', 'Train Loss', 'OOB Improve', 'Remaining Time')
-    assert_equal(true_header, header)
-
-    n_lines = sum(1 for l in verbose_output.readlines())
-    # one for 1-10 and then 9 for 20-100
-    assert_equal(10 + 9, n_lines)
-
-
-def test_verbose_output_with_end():
-    """Check verbose=-1 does not cause error. """
-    from sklearn.externals.six.moves import cStringIO as StringIO
-    import sys
-    old_stdout = sys.stdout
-    sys.stdout = StringIO()
-    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
-                                     verbose=-1, subsample=0.8)
-    clf.fit(X, y)
-    verbose_output = sys.stdout
-    sys.stdout = old_stdout
-
-    # check output
-    verbose_output.seek(0)
-    header = verbose_output.readline().rstrip()
-    # with OOB
     true_header = ' '.join(['%10s'] + ['%16s'] * 4) % (
         'Iter', 'Train Loss', 'OOB Improve', 'Remaining Time', 'End Time')
     assert_equal(true_header, header)
@@ -650,31 +625,6 @@ def test_more_verbose_output():
     sys.stdout = StringIO()
     clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
                                      verbose=2)
-    clf.fit(X, y)
-    verbose_output = sys.stdout
-    sys.stdout = old_stdout
-
-    # check output
-    verbose_output.seek(0)
-    header = verbose_output.readline().rstrip()
-    # no OOB
-    true_header = ' '.join(['%10s'] + ['%16s'] * 2) % (
-        'Iter', 'Train Loss', 'Remaining Time')
-    assert_equal(true_header, header)
-
-    n_lines = sum(1 for l in verbose_output.readlines())
-    # 100 lines for n_estimators==100
-    assert_equal(100, n_lines)
-
-
-def test_more_verbose_output_with_end():
-    """Check verbose=-2 does not cause error. """
-    from sklearn.externals.six.moves import cStringIO as StringIO
-    import sys
-    old_stdout = sys.stdout
-    sys.stdout = StringIO()
-    clf = GradientBoostingClassifier(n_estimators=100, random_state=1,
-                                     verbose=-2)
     clf.fit(X, y)
     verbose_output = sys.stdout
     sys.stdout = old_stdout


### PR DESCRIPTION
I have often checked in on bigger GBM models (eg 2000 trees) to find the `verbose=1` output telling me that there was still several hundred minutes remaining from the 1000 tree marker. Without an anchoring time stamp this left me with little idea of whether the update posted hours ago and I was nearly done, or if I was possibly only half way through.

This PR adds an estimated end time to the output if the user enters a negative verbosity. `-1` gives the 'occasional' update and `-2` every tree as before but with the end time shown as well. Old output still stands if using positive numbers or zero. Not sure how people will feel about the negative verbosity implementation, but I think this will be helpful for large datasets and/or big ensembles.

Quick example output for 20 trees:

```
clf = GradientBoostingClassifier(n_estimators=20, learning_rate=0.05, max_depth=6, verbose=-1, random_state=415)
clf.fit(train_x, train_y)

  Iter       Train Loss   Remaining Time         End Time 
     1           1.2427            5.95m     31 Oct 15:36
     2           1.2053            5.34m     31 Oct 15:35
     3           1.1716            4.58m     31 Oct 15:35
     4           1.1409            3.75m     31 Oct 15:34
     5           1.1131            3.18m     31 Oct 15:34
     6           1.0873            2.75m     31 Oct 15:33
     7           1.0640            2.42m     31 Oct 15:33
     8           1.0423            2.13m     31 Oct 15:33
     9           1.0227            1.88m     31 Oct 15:33
    10           1.0041            1.65m     31 Oct 15:33
    20           0.8781            0.00s     31 Oct 15:32
```
