### PR TITLE
[MRG+1] Fixes #3644

### DIFF
--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -362,7 +362,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
         else:
             norms_squared = None
         return orthogonal_mp_gram(G, Xy, n_nonzero_coefs, tol, norms_squared,
-                                  copy_Gram=copy_X, copy_Xy=False)
+                                  copy_Gram=copy_X, copy_Xy=False, return_path=return_path)
 
     if return_path:
         coef = np.zeros((X.shape[1], y.shape[1], X.shape[1]))

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -171,6 +171,15 @@ def test_omp_path():
     assert_array_almost_equal(path[:, :, -1], last)
 
 
+def test_omp_return_path_prop_with_gram():
+    path = orthogonal_mp(X, y, n_nonzero_coefs=5, return_path=True, 
+            precompute=True)
+    last = orthogonal_mp(X, y, n_nonzero_coefs=5, return_path=False,
+            precompute=True)
+    assert_equal(path.shape, (n_features, n_targets, 5))
+    assert_array_almost_equal(path[:, :, -1], last)
+
+
 def test_omp_cv():
     # FIXME: This test is unstable on Travis, see issue #3190 for more detail.
     check_skip_travis()


### PR DESCRIPTION
Added `return_path` parameter while calling `orthogonal_mp_gram` to propagate the same.

@agramfort @MechCoder
