### PR TITLE
[MRG+1] FIX: Bug in RFECV when step is not 1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -157,6 +157,9 @@ Documentation improvements
 Bug fixes
 .........
 
+    - :class:`feature_selection.RFECV` now correctly handles cases when
+      ``step`` is not equal to 1. By `Nikolay Mayorov`_
+
     - The :class:`decomposition.PCA` now undoes whitening in its
      ``inverse_transform``. Also, its ``components_`` now always have unit
      length. By Michael Eickenberg.

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -112,6 +112,20 @@ def test_rfecv():
     rfecv.fit(X, y)
     assert_array_equal(rfecv.grid_scores_, np.ones(len(rfecv.grid_scores_)))
 
+    # Same as the first two tests, but with step=2
+    rfecv = RFECV(estimator=SVC(kernel="linear"), step=2, cv=5)
+    rfecv.fit(X, y)
+    assert_equal(len(rfecv.grid_scores_), 6)
+    assert_equal(len(rfecv.ranking_), X.shape[1])
+    X_r = rfecv.transform(X)
+    assert_array_equal(X_r, iris.data)
+
+    rfecv_sparse = RFECV(estimator=SVC(kernel="linear"), step=2, cv=5)
+    X_sparse = sparse.csr_matrix(X)
+    rfecv_sparse.fit(X_sparse, y)
+    X_r_sparse = rfecv_sparse.transform(X_sparse)
+    assert_array_equal(X_r_sparse.toarray(), iris.data)
+
 
 def test_rfe_min_step():
     
@@ -134,4 +148,3 @@ def test_rfe_min_step():
     selector = RFE(estimator, step=5)
     sel = selector.fit(X,y)
     assert_equal(sel.support_.sum(), n_features // 2)
-


### PR DESCRIPTION
Hi!

This patch fixes the bug with computation of the final `n_features_to_select` when `step` is not equal to 1. Everything should be clear from the code.

Please review.
