### PR TITLE
Fix for issue 3815.

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -42,7 +42,6 @@ boston = datasets.load_boston()
 boston.data, boston.target = shuffle(boston.data, boston.target,
                                      random_state=rng)
 
-
 def test_classification_toy():
     """Check classification on a toy dataset."""
     for alg in ['SAMME', 'SAMME.R']:
@@ -246,6 +245,12 @@ def test_base_estimator():
 
     clf = AdaBoostRegressor(SVR(), random_state=0)
     clf.fit(X, y_regr)
+
+    # check that an empty discrete ensemble fails early
+    X_fail = [[1, 1], [1, 1], [1, 1], [1, 1]]
+    y_fail = ["foo", "bar", 1, 2]
+    clf = AdaBoostClassifier(SVC(), algorithm="SAMME")
+    assert_raises(ValueError, clf.fit, X_fail, y_fail)
 
 
 def test_sample_weight_missing():

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -546,6 +546,10 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         # Stop if the error is at least as bad as random guessing
         if estimator_error >= 1. - (1. / n_classes):
             self.estimators_.pop(-1)
+            if len(self.estimators_) == 0:
+                raise ValueError('BaseClassifier in AdaBoostClassifier '
+                                 'ensemble is worse than random, ensemble '
+                                 'can not be fit.')
             return None, None, None
 
         # Boost weight using multi-class AdaBoost SAMME alg


### PR DESCRIPTION
Discrete AdaBoostClassifier now fails early if the base classifier if worse than random.
