### PR TITLE
DOC FIX: typo and minor update

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1024,7 +1024,7 @@ Regression metrics
 The :mod:`sklearn.metrics` module implements several loss, score, and utility
 functions to measure regression performance. Some of those have been enhanced
 to handle the multioutput case: :func:`mean_absolute_error`,
-:func:`mean_absolute_error` and :func:`r2_score`.
+:func:`mean_squared_error`, :func:`median_absolute_error` and :func:`r2_score`.
 
 
 Explained variance score


### PR DESCRIPTION
The documentation repeated `mean_absolute_error` twice, when (I assume) the second instance was supposed to refer to `mean_squared_error`, so I fixed that.

Also, it appears that `median_absolute_error` fits the criteria described in the sentence, so I added that function to the sentence.
