### PR TITLE
[MRG] remove useless warning in Random Projections

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -28,7 +28,6 @@ The main theoretical result behind the efficiency of random projection is the
 # License: BSD 3 clause
 
 from __future__ import division
-import warnings
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
@@ -358,13 +357,6 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
             if self.n_components <= 0:
                 raise ValueError("n_components must be greater than 0, got %s"
                                  % self.n_components_)
-
-            elif self.n_components > n_features:
-                warnings.warn(
-                    "The number of components is higher than the number of"
-                    " features: n_features < n_components (%s < %s)."
-                    "The dimensionality of the problem will not be reduced."
-                    % (n_features, self.n_components))
 
             self.n_components_ = self.n_components
 

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -19,7 +19,6 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_warns
 
 all_sparse_random_matrix = [sparse_random_matrix]
 all_dense_random_matrix = [gaussian_random_matrix]
@@ -329,15 +328,6 @@ def test_correct_RandomProjection_dimensions_embedding():
             assert_equal(rp.components_.shape, (100, n_features))
             assert_less(rp.components_.nnz, 115)  # close to 1% density
             assert_less(85, rp.components_.nnz)  # close to 1% density
-
-
-def test_warning_n_components_greater_than_n_features():
-    n_features = 20
-    data, _ = make_sparse_random_data(5, n_features, int(n_features / 4))
-
-    for RandomProjection in all_RandomProjection:
-        assert_warns(UserWarning,
-                     RandomProjection(n_components=n_features + 1).fit, data)
 
 
 def test_works_with_sparse_data():


### PR DESCRIPTION
While RP is often used for dimensionality reduction, it's not necessarily the case. For instance the LSH pull request #3304 is using it internally to bucket the data.

Furthermore, if the user calls it with a fixed number of components (instead of using the "auto" mode that computes `n_components` based on the number of samples and the `eps` of the JL lemma), the users probably know what he/she is is doing so the warning is useless.

Therefore I think we should remove this warning.
