### PR TITLE
[MRG] Raise an error when sparse matrix is supplied to predict in KNeighborsClassifier

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -328,6 +328,10 @@ class KNeighborsMixin(object):
             else:
                 return neigh_ind
         elif self._fit_method in ['ball_tree', 'kd_tree']:
+            if issparse(X):
+                raise ValueError(
+                    "%s does not work with sparse matrices. Densify the data, "
+                    "or set algorithm='brute'" % self._fit_method)
             result = self._tree.query(X, n_neighbors,
                                       return_distance=return_distance)
             return result
@@ -503,6 +507,10 @@ class RadiusNeighborsMixin(object):
             else:
                 return neigh_ind
         elif self._fit_method in ['ball_tree', 'kd_tree']:
+            if issparse(X):
+                raise ValueError(
+                    "%s does not work with sparse matrices. Densify the data, "
+                    "or set algorithm='brute'" % self._fit_method)
             results = self._tree.query_radius(X, radius,
                                               return_distance=return_distance)
             if return_distance:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -857,6 +857,17 @@ def test_metric_params_interface():
                  metric_params={'p': 3})
 
 
+def test_predict_sparse_ball_kd_tree():
+    rng = np.random.RandomState(0)
+    X = rng.rand(5, 5)
+    y = rng.randint(0, 2, 5)
+    nbrs1 = neighbors.KNeighborsClassifier(1, algorithm='kd_tree')
+    nbrs2 = neighbors.KNeighborsRegressor(1, algorithm='ball_tree')
+    for model in [nbrs1, nbrs2]:
+        model.fit(X, y)
+        assert_raises(ValueError, model.predict, csr_matrix(X))
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/pull/3802

There might be cases when I predict on sparse data, after fitting on dense data (the centroids). Is it okay to densify the sparse matrix supplied to the predict method (with a warning), or should I just resort to using algorithm="brute" over here, https://github.com/scikit-learn/scikit-learn/pull/3802/files#diff-1741ad6b05f1eb0fd71af8bad0e001c7R484
