### PR TITLE
[MRG] ENH use specific warning class for RP

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -42,6 +42,7 @@ from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
 from .utils.random import sample_without_replacement
 from .utils.validation import check_array
+from .utils import DataDimensionalityWarning
 
 
 __all__ = ["SparseRandomProjection",
@@ -364,7 +365,8 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
                     "The number of components is higher than the number of"
                     " features: n_features < n_components (%s < %s)."
                     "The dimensionality of the problem will not be reduced."
-                    % (n_features, self.n_components))
+                    % (n_features, self.n_components),
+                    DataDimensionalityWarning)
 
             self.n_components_ = self.n_components
 

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -20,6 +20,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
+from sklearn.utils import DataDimensionalityWarning
 
 all_sparse_random_matrix = [sparse_random_matrix]
 all_dense_random_matrix = [gaussian_random_matrix]
@@ -336,7 +337,7 @@ def test_warning_n_components_greater_than_n_features():
     data, _ = make_sparse_random_data(5, n_features, int(n_features / 4))
 
     for RandomProjection in all_RandomProjection:
-        assert_warns(UserWarning,
+        assert_warns(DataDimensionalityWarning,
                      RandomProjection(n_components=n_features + 1).fit, data)
 
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -417,5 +417,9 @@ def tosequence(x):
         return list(x)
 
 
-class ConvergenceWarning(Warning):
-    "Custom warning to capture convergence problems"
+class ConvergenceWarning(UserWarning):
+    """Custom warning to capture convergence problems"""
+
+
+class DataDimensionalityWarning(UserWarning):
+    """Custom warning to notify potential issues with data dimensionality"""


### PR DESCRIPTION
This is a followup to the discussion in #3856.

Using a custom warning class will make it possible to use RP for usage not related to dimensionality reduction without issuing a phony warning when we expect the number of components to be larger than the number of features.

An example of such generic usage of RP is LSH.
