### PR TITLE
gen_rst informs file with missing documentation

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -453,7 +453,7 @@ def extract_docstring(filename, ignore_heading=False):
                         first_par = ((first_par[:95] + '...')
                                      if len(first_par) > 95 else first_par)
                     else:
-			raise ValueError("Docstring not found by gallery.\n"
+                        raise ValueError("Docstring not found by gallery.\n"
                                          "Please check the layout of your"
                                          " example file:\n {}\n and make sure"
                                          " it's correct".format(filename))

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -453,9 +453,10 @@ def extract_docstring(filename, ignore_heading=False):
                         first_par = ((first_par[:95] + '...')
                                      if len(first_par) > 95 else first_par)
                     else:
-                        raise ValueError("Docstring not found by gallery",
-                                         "Please check your example's layout",
-                                         " and make sure it's correct")
+			raise ValueError("Docstring not found by gallery.\n"
+                                         "Please check the layout of your"
+                                         " example file:\n {}\n and make sure"
+                                         " it's correct".format(filename))
                 else:
                     first_par = paragraphs[0]
 


### PR DESCRIPTION
When porting this file to a new repository, I realized it does not specify which script in the examples does not match the docstring layout.
