### PR TITLE
Fix RFE n_features minimum value #3812

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -126,11 +126,11 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             n_features_to_select = self.n_features_to_select
 
         if 0.0 < self.step < 1.0:
-            step = int(self.step * n_features)
+            step = int(max(1, self.step * n_features))       
         else:
             step = int(self.step)
         if step <= 0:
-            step = 1
+            raise ValueError("Step must be >0")
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -104,6 +104,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.step = step
         self.estimator_params = estimator_params
         self.verbose = verbose
+        self._n_features_to_remove = None
 
     def fit(self, X, y):
         """Fit the RFE model and then the underlying estimator on the selected
@@ -126,11 +127,12 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             n_features_to_select = self.n_features_to_select
 
         if 0.0 < self.step < 1.0:
-            step = int(self.step * n_features)
+            self._n_features_to_remove = int(self.step * n_features)
         else:
-            step = int(self.step)
-        if step <= 0:
-            raise ValueError("Step must be >0")
+            self._n_features_to_remove = int(self.step)
+
+        if self._n_features_to_remove <= 0:
+            self._n_features_to_remove = 1
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
@@ -156,7 +158,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             ranks = np.ravel(ranks)
 
             # Eliminate the worse features
-            threshold = min(step, np.sum(support_) - n_features_to_select)
+            threshold = min(self._n_features_to_remove, 
+                            np.sum(support_) - n_features_to_select)
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -104,7 +104,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.step = step
         self.estimator_params = estimator_params
         self.verbose = verbose
-        self._n_features_to_remove = None
 
     def fit(self, X, y):
         """Fit the RFE model and then the underlying estimator on the selected
@@ -127,12 +126,11 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             n_features_to_select = self.n_features_to_select
 
         if 0.0 < self.step < 1.0:
-            self._n_features_to_remove = int(self.step * n_features)
+            step = int(self.step * n_features)
         else:
-            self._n_features_to_remove = int(self.step)
-
-        if self._n_features_to_remove <= 0:
-            self._n_features_to_remove = 1
+            step = int(self.step)
+        if step <= 0:
+            step = 1
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
@@ -158,8 +156,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             ranks = np.ravel(ranks)
 
             # Eliminate the worse features
-            threshold = min(self._n_features_to_remove, 
-                            np.sum(support_) - n_features_to_select)
+            threshold = min(step, np.sum(support_) - n_features_to_select)
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
 
@@ -375,3 +372,4 @@ class RFECV(RFE, MetaEstimatorMixin):
         # here, the scores are normalized by len(cv)
         self.grid_scores_ = scores / len(cv)
         return self
+

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -8,9 +8,9 @@ from nose.tools import assert_equal
 from scipy import sparse
 
 from sklearn.feature_selection.rfe import RFE, RFECV
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, make_friedman1
 from sklearn.metrics import zero_one_loss
-from sklearn.svm import SVC
+from sklearn.svm import SVC, SVR
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
 
@@ -111,3 +111,27 @@ def test_rfecv():
                   scoring=test_scorer)
     rfecv.fit(X, y)
     assert_array_equal(rfecv.grid_scores_, np.ones(len(rfecv.grid_scores_)))
+
+
+def test_rfe_min_step():
+    
+    X, y = make_friedman1(n_samples=50, n_features=10, random_state=0)
+    estimator = SVR(kernel="linear")
+    selector = RFE(estimator, step=0.01)
+    sel = selector.fit(X,y)
+
+    # Test when floor(step * n_features) <= 0
+    assert_equal(sel._n_features_to_remove, 1)
+
+    selector = RFE(estimator, step=0.20)
+    sel = selector.fit(X,y)
+
+    # Test when step is between (0,1) and floor(step * n_features) > 0
+    assert_equal(sel._n_features_to_remove, 2)
+
+    selector = RFE(estimator, step=5)
+    sel = selector.fit(X,y)
+
+    # Test when step is an integer
+    assert_equal(sel._n_features_to_remove, 5)
+

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -115,23 +115,23 @@ def test_rfecv():
 
 def test_rfe_min_step():
     
-    X, y = make_friedman1(n_samples=50, n_features=10, random_state=0)
+    n_features = 10
+    X, y = make_friedman1(n_samples=50, n_features=n_features, random_state=0)
+    n_samples, n_features = X.shape
     estimator = SVR(kernel="linear")
-    selector = RFE(estimator, step=0.01)
-    sel = selector.fit(X,y)
 
     # Test when floor(step * n_features) <= 0
-    assert_equal(sel._n_features_to_remove, 1)
-
-    selector = RFE(estimator, step=0.20)
+    selector = RFE(estimator, step=0.01)
     sel = selector.fit(X,y)
+    assert_equal(sel.support_.sum(), n_features // 2)
 
     # Test when step is between (0,1) and floor(step * n_features) > 0
-    assert_equal(sel._n_features_to_remove, 2)
-
-    selector = RFE(estimator, step=5)
+    selector = RFE(estimator, step=0.20)
     sel = selector.fit(X,y)
+    assert_equal(sel.support_.sum(), n_features // 2)
 
     # Test when step is an integer
-    assert_equal(sel._n_features_to_remove, 5)
+    selector = RFE(estimator, step=5)
+    sel = selector.fit(X,y)
+    assert_equal(sel.support_.sum(), n_features // 2)
 


### PR DESCRIPTION
In RFE class the step value was just rounded down. 

```
step = int(self.step * n_features)
```

This was a problem when the number of features was small because step was 0 and it was raising an exception.

```
ValueError: Step must be >0
```

With the following fix we still keep the rounding down (so as not to change behavior too much) but do a minimum with 1. **step = [1, n_features-1]**

Fixed issue https://github.com/scikit-learn/scikit-learn/issues/3812
