### PR TITLE
[MRG+2] ENH add coverage multilabel ranking metric

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -787,6 +787,7 @@ details.
    :toctree: generated/
    :template: function.rst
 
+   metrics.coverage_error
    metrics.label_ranking_average_precision_score
 
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -972,8 +972,8 @@ In multilabel learning, each sample can have any number of ground truth labels
 associated with it. The goal is to give high scores and better rank to
 the ground truth labels.
 
-Coverage
---------
+Coverage error
+--------------
 
 The :func:`coverage_error` function computes the average number of labels that
 have to be included in the final prediction such such that all true labels

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -977,19 +977,19 @@ Coverage
 
 The :func:`coverage_error` function computes the average number of labels that
 have to be included in the final prediction such such that all true labels
-are predicted. This is usefull if you want to know how many top-scored-labels
-you have to predict in average without missing any true one. The best and
-minimal coverage is thus the average number of true labels.
+are predicted. This is useful if you want to know how many top-scored-labels
+you have to predict in average without missing any true one. The best value
+of this metrics is thus the average number of true labels.
 
 Formally, given a binary indicator matrix of the ground truth labels
-:math:`y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}` and the
+:math:`y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}` and the
 score associated with each label
-:math:`\hat{f} \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}`,
+:math:`\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}`,
 the coverage is defined as
 
 .. math::
   coverage(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} rank_{ij}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij}
 
 with :math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -992,6 +992,8 @@ the coverage is defined as
     \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij}
 
 with :math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`.
+Given the rank definition, ties in ``y_scores`` are broken by giving the
+maximal rank that would have been assigned to all tied values.
 
 Here is a small example of usage of this function::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -972,6 +972,36 @@ In multilabel learning, each sample can have any number of ground truth labels
 associated with it. The goal is to give high scores and better rank to
 the ground truth labels.
 
+Coverage
+--------
+
+The :func:`coverage_error` function computes the average number of labels that
+have to be included in the final prediction such such that all true labels
+are predicted. This is usefull if you want to know how many top-scored-labels
+you have to predict in average without missing any true one. The best and
+minimal coverage is thus the average number of true labels.
+
+Formally, given a binary indicator matrix of the ground truth labels
+:math:`y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}` and the
+score associated with each label
+:math:`\hat{f} \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}`,
+the coverage is defined as
+
+.. math::
+  coverage(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} rank_{ij}
+
+with :math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`.
+
+Here is a small example of usage of this function::
+
+    >>> import numpy as np
+    >>> from sklearn.metrics import coverage_error
+    >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
+    >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
+    >>> coverage_error(y_true, y_score)
+    2.5
+
 Label ranking average precision
 -------------------------------
 
@@ -986,7 +1016,7 @@ score. This metric will yield better scores if you are able to give better rank
 to the labels associated with each sample. The obtained score is always strictly
 greater than 0, and the best value is 1. If there is exactly one relevant
 label per sample, label ranking average precision is equivalent to the `mean
-reciprocal rank <http://en.wikipedia.org/wiki/Mean_reciprocal_rank>`.
+reciprocal rank <http://en.wikipedia.org/wiki/Mean_reciprocal_rank>`_.
 
 Formally, given a binary indicator matrix of the ground truth labels
 :math:`y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}` and the

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,8 @@ New features
    - Add the :func:`metrics.label_ranking_average_precision_score` metrics. By
      `Arnaud Joly`_.
 
+   - Add the :func:`metrics.coverage_error` metrics. By `Arnaud Joly`_.
+
    - Added :class:`linear_model.LogisticRegressionCV`. By
      `Manoj Kumar`_, `Fabian Pedregosa`_, `Gael Varoquaux`_
      and `Alexandre Gramfort`_.

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -5,6 +5,7 @@ and pairwise metrics and distance computations.
 
 from .ranking import auc
 from .ranking import average_precision_score
+from .ranking import coverage_error
 from .ranking import label_ranking_average_precision_score
 from .ranking import precision_recall_curve
 from .ranking import roc_auc_score
@@ -67,6 +68,7 @@ __all__ = [
     'completeness_score',
     'confusion_matrix',
     'consensus_score',
+    'coverage_error',
     'euclidean_distances',
     'explained_variance_score',
     'f1_score',

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -75,7 +75,7 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
     if y_type == "binary":
         return binary_metric(y_true, y_score, sample_weight=sample_weight)
 
-    check_consistent_length(y_true, y_score)
+    check_consistent_length(y_true, y_score, sample_weight)
     y_true = check_array(y_true)
     y_score = check_array(y_score)
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -624,7 +624,7 @@ def label_ranking_average_precision_score(y_true, y_score):
 def coverage_error(y_true, y_score, sample_weight=None):
     """Coverage error measure
 
-    Compute how fare we need to go through the ranked scores to cover all
+    Compute how far we need to go through the ranked scores to cover all
     true labels. The best value is equal to the average the number
     of labels in ``y_true` per sample.
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -622,11 +622,11 @@ def label_ranking_average_precision_score(y_true, y_score):
 
 
 def coverage_error(y_true, y_score):
-    """ Coverage error measure
+    """Coverage error measure
 
-    Compute how fare we need to go through the ranking scores to get all
+    Compute how fare we need to go through the ranked scores to cover all
     true labels. The best value is equal to the average the number
-    of labels in y_true per sample.
+    of labels in ``y_true` per sample.
 
     Parameters
     ----------
@@ -643,6 +643,12 @@ def coverage_error(y_true, y_score):
     Return
     ------
     coverage : float
+
+    References
+    ----------
+    .. [1] Tsoumakas, G., Katakis, I., & Vlahavas, I. (2010).
+           Mining multi-label data. In Data mining and knowledge discovery
+           handbook (pp. 667-685). Springer US.
 
     """
     y_true = check_array(y_true, ensure_2d=False)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -621,9 +621,6 @@ def label_ranking_average_precision_score(y_true, y_score):
     return out / n_samples
 
 
-    check_consistent_length(y_true, y_score)
-
-
 def coverage_error(y_true, y_score):
     """ Coverage error measure
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -656,7 +656,7 @@ def coverage_error(y_true, y_score, sample_weight=None):
     """
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)
-    check_consistent_length(y_true, y_score)
+    check_consistent_length(y_true, y_score, sample_weight)
 
     y_type = type_of_target(y_true)
     if y_type != "multilabel-indicator":

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -621,7 +621,7 @@ def label_ranking_average_precision_score(y_true, y_score):
     return out / n_samples
 
 
-def coverage_error(y_true, y_score):
+def coverage_error(y_true, y_score, sample_weight=None):
     """Coverage error measure
 
     Compute how fare we need to go through the ranked scores to cover all
@@ -645,7 +645,7 @@ def coverage_error(y_true, y_score):
 
     Return
     ------
-    coverage : float
+    coverage_error : float
 
     References
     ----------
@@ -670,4 +670,4 @@ def coverage_error(y_true, y_score):
     coverage = (y_score >= y_min_relevant).sum(axis=1)
     coverage = coverage.filled(0)
 
-    return coverage.mean()
+    return np.average(coverage, weights=sample_weight)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -628,6 +628,9 @@ def coverage_error(y_true, y_score):
     true labels. The best value is equal to the average the number
     of labels in ``y_true` per sample.
 
+    Ties in `y_scores` are broken by giving maximal rank that would have
+    been assigned to all tied values.
+
     Parameters
     ----------
     y_true : array, shape = [n_samples, n_labels]

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -619,3 +619,49 @@ def label_ranking_average_precision_score(y_true, y_score):
         out += np.divide(L, rank, dtype=float).mean()
 
     return out / n_samples
+
+
+    check_consistent_length(y_true, y_score)
+
+
+def coverage_error(y_true, y_score):
+    """ Coverage error measure
+
+    Compute how fare we need to go through the ranking scores to get all
+    true labels. The best value is equal to the average the number
+    of labels in y_true per sample.
+
+    Parameters
+    ----------
+    y_true : array, shape = [n_samples, n_labels]
+        True binary labels in binary indicator format.
+
+    y_score : array, shape = [n_samples, n_labels]
+        Target scores, can either be probability estimates of the positive
+        class, confidence values, or binary decisions.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Return
+    ------
+    coverage : float
+
+    """
+    y_true = check_array(y_true, ensure_2d=False)
+    y_score = check_array(y_score, ensure_2d=False)
+    check_consistent_length(y_true, y_score)
+
+    y_type = type_of_target(y_true)
+    if y_type != "multilabel-indicator":
+        raise ValueError("{0} format is not supported".format(y_type))
+
+    if y_true.shape != y_score.shape:
+        raise ValueError("y_true and y_score have different shape")
+
+    y_score_mask = np.ma.masked_array(y_score, mask=np.logical_not(y_true))
+    y_min_relevant = y_score_mask.min(axis=1).reshape((-1, 1))
+    coverage = (y_score >= y_min_relevant).sum(axis=1)
+    coverage = coverage.filled(0)
+
+    return coverage.mean()

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -333,7 +333,6 @@ METRICS_WITHOUT_SAMPLE_WEIGHT = [
     "hamming_loss",
     "matthews_corrcoef_score",
     "median_absolute_error",
-    "coverage_error",
 ]
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -976,6 +976,11 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                 err_msg="%s sample_weight is not invariant "
                         "under scaling" % name)
 
+    # Check that if sample_weight.shape[0] != y_true.shape[0], it raised an
+    # error
+    assert_raises(Exception, metric, y1, y2,
+                  sample_weight=np.hstack([sample_weight, sample_weight]))
+
 
 def test_sample_weight_invariance(n_samples=50):
     random_state = check_random_state(0)
@@ -1052,3 +1057,5 @@ def test_sample_weight_invariance(n_samples=50):
         else:
             yield (check_sample_weight_invariance, name, metric, y_true,
                    y_pred)
+
+

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -26,6 +26,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import confusion_matrix
+from sklearn.metrics import coverage_error
 from sklearn.metrics import explained_variance_score
 from sklearn.metrics import f1_score
 from sklearn.metrics import fbeta_score
@@ -139,6 +140,8 @@ CLASSIFICATION_METRICS = {
 }
 
 THRESHOLDED_METRICS = {
+    "coverage_error": coverage_error,
+
     "log_loss": log_loss,
     "unnormalized_log_loss": partial(log_loss, normalize=False),
 
@@ -191,6 +194,8 @@ METRIC_UNDEFINED_MULTICLASS = [
 
     "roc_auc_score", "micro_roc_auc", "weighted_roc_auc",
     "macro_roc_auc",  "samples_roc_auc",
+
+    "coverage_error",
 ]
 
 # Metrics with an "average" argument
@@ -255,6 +260,8 @@ THRESHOLDED_MULTILABEL_METRICS = [
     "average_precision_score", "weighted_average_precision_score",
     "samples_average_precision_score", "micro_average_precision_score",
     "macro_average_precision_score",
+
+    "coverage_error",
 ]
 
 # Classification metrics with  "multilabel-indicator" and
@@ -326,6 +333,7 @@ METRICS_WITHOUT_SAMPLE_WEIGHT = [
     "hamming_loss",
     "matthews_corrcoef_score",
     "median_absolute_error",
+    "coverage_error",
 ]
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -881,21 +881,6 @@ def test_coverage_error():
     assert_almost_equal(coverage_error([[1, 1, 0]], [[0.5, 0.75, 0.25]]), 2)
     assert_almost_equal(coverage_error([[1, 1, 1]], [[0.5, 0.75, 0.25]]), 3)
 
-    # Tie handling
-    assert_almost_equal(coverage_error([[0, 0]], [[0.5, 0.5]]), 0)
-    assert_almost_equal(coverage_error([[1, 0]], [[0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1]], [[0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[1, 1]], [[0.5, 0.5]]), 2)
-
-    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.25, 0.5, 0.5]]), 0)
-    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)
-
     # Non trival case
     assert_almost_equal(coverage_error([[0, 1, 0], [1, 1, 0]],
                                        [[0.1, 10., -3], [0, 1, 3]]),
@@ -909,18 +894,18 @@ def test_coverage_error():
                                        [[0.1, 10, -3], [3, 1, 3], [0, 2, 0]]),
                         (1 + 3 + 3) / 3.)
 
-    # Raise value error if not appropriate format
-    assert_raises(ValueError, coverage_error, [0, 1, 0], [0.25, 0.3, 0.2])
-    assert_raises(ValueError, coverage_error, [0, 1, 2],
-                  [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
-    assert_raises(ValueError, coverage_error, [(0), (1), (2)],
-                  [[0.25, 0.75, 0.0], [0.7, 0.3, 0.0], [0.8, 0.2, 0.0]])
 
-    # Check that that y_true.shape != y_score.shape raise the proper exception
-    assert_raises(ValueError, coverage_error, [[0, 1], [0, 1]], [0 , 1])
-    assert_raises(ValueError, coverage_error, [[0, 1], [0, 1]], [[0 , 1]])
-    assert_raises(ValueError, coverage_error, [[0, 1], [0, 1]], [[0] , [1]])
+def test_coverage_tie_handling():
+    assert_almost_equal(coverage_error([[0, 0]], [[0.5, 0.5]]), 0)
+    assert_almost_equal(coverage_error([[1, 0]], [[0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[0, 1]], [[0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 1]], [[0.5, 0.5]]), 2)
 
-    assert_raises(ValueError, coverage_error, [[0, 1]], [[0 , 1], [0, 1]])
-    assert_raises(ValueError, coverage_error, [[0], [1]], [[0 , 1], [0, 1]])
-    assert_raises(ValueError, coverage_error, [[0, 1], [0, 1]], [[0] , [1]])
+    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.25, 0.5, 0.5]]), 0)
+    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.5]]), 3)
+    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.5]]), 3)
+    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 3)
+    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)


### PR DESCRIPTION
This pr adds the coverage multilabel ranking metric in scikit-learn.

It's very useful as it carries a lot of intuition on your estimator performance. This is the average number of ~~true~~ labels that you need to predict in order to avoid missing any true one given your y_score matrix.

@jnothman Do you see an easy way to make this works with sparse csc `y_true`?
