### PR TITLE
[MRG] Matern kernel

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -883,6 +883,7 @@ See the :ref:`metrics` section of the user guide for further details.
    metrics.pairwise.pairwise_kernels
    metrics.pairwise.polynomial_kernel
    metrics.pairwise.rbf_kernel
+   metrics.pairwise.matern_kernel
    metrics.pairwise_distances
    metrics.pairwise_distances_argmin
    metrics.pairwise_distances_argmin_min

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -123,6 +123,62 @@ between two vectors. This kernel is defined as:
 where ``x`` and ``y`` are the input vectors. If :math:`\gamma = \sigma^{-2}`
 the kernel is known as the Gaussian kernel of variance :math:`\sigma^2`.
 
+Matérn kernel
+-------------
+The function :func:`matern_kernel` is a generalization of the RBF kernel. It has
+an additional parameter :math:`\nu` (set via the keyword coef0) which controls
+the smoothness of the resulting function. The general functional form of a
+Matérn is given by
+
+.. math::
+
+    k(d) = \sigma^2\frac{1}{\Gamma(\nu)2^{\nu-1}}\Bigg(\gamma\sqrt{2\nu} d\Bigg)^\nu K_\nu\Bigg(\gamma\sqrt{2\nu} d\Bigg),
+
+where :math:`d=\| x-y \|` and ``x`` and ``y`` are the input vectors. 
+
+As :math:`\nu\rightarrow\infty`, the Matérn kernel converges to the RBF kernel.
+When :math:`\nu = 1/2`, the Matérn kernel becomes identical to the absolute
+exponential kernel, i.e.,
+
+.. math::
+    k(d) = \sigma^2 \exp \Bigg(-\gamma d \Bigg) \quad \quad \nu= \tfrac{1}{2}
+
+In particular, :math:`\nu = 3/2`:
+
+.. math::
+    k(d) = \sigma^2 \Bigg(1 + \gamma \sqrt{3} d \Bigg) \exp \Bigg(-\gamma \sqrt{3}d \Bigg) \quad \quad \nu= \tfrac{3}{2}
+
+and :math:`\nu = 5/2`:
+
+.. math::
+    k(d) = \sigma^2 \Bigg(1 + \gamma \sqrt{5}d +\frac{5}{3} \gamma^2d^2 \Bigg) \exp \Bigg(-\gamma \sqrt{5}d \Bigg) \quad \quad \nu= \tfrac{5}{2}
+
+are popular choices for learning functions that are not infinitely
+differentiable (as assumed by the RBF kernel) but at least once (:math:`\nu =
+3/2`) or twice differentiable (:math:`\nu = 5/2`).
+
+The following example illustrates how the Matérn kernel's covariance decreases
+with increasing dissimilarity of the two inputs for different values of coef0
+(the parameter :math:`\nu` of the Matérn kernel):
+
+.. figure:: ../auto_examples/metrics/images/plot_matern_kernel_001.png
+    :target: ../auto_examples/metrics/plot_matern_kernel.html
+    :align: center
+
+The flexibility of controlling the smoothness of the learned function via coef0
+allows adapting to the properties of the true underlying functional relation.
+The following example shows that support vector regression with Matérn kernel
+with smaller values of coef0 can better approximate a discontinuous 
+step-function:
+
+.. figure:: ../auto_examples/svm/images/plot_svm_matern_kernel_001.png
+    :target: ../auto_examples/svm/plot_svm_matern_kernel.html
+    :align: center
+
+See Rasmussen and Williams 2006, pp84 for further details regarding the
+different variants of the Matérn kernel.
+
+
 Chi-squared kernel
 ------------------
 The chi-squared kernel is a very popular choice for training non-linear SVMs in
@@ -171,4 +227,9 @@ The chi squared kernel is most commonly used on histograms (bags) of visual word
       categories: A comprehensive study
       International Journal of Computer Vision 2007
       http://eprints.pascal-network.org/archive/00002309/01/Zhang06-IJCV.pdf
+
+    * Rasmussen, C. E. and Williams, C.
+      Gaussian Processes for Machine Learning
+      The MIT Press, 2006
+      http://www.gaussianprocess.org/gpml/chapters/
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,10 @@ New features
      for fixed user-provided cross-validation folds.
      By `untom <https://github.com/untom>`_.
 
+   - Added :func:`metrics.pairwise.matern_kernel`, a kernel where the
+     smoothness of the learned function can be controlled.
+     By `Jan Hendrik Metzen`_.
+
 
 Enhancements
 ............

--- a/examples/metrics/README.txt
+++ b/examples/metrics/README.txt
@@ -1,0 +1,6 @@
+.. _metrics_examples:
+
+Metrics
+-------
+
+Examples concerning the :mod:`sklearn.metrics` module.

--- a/examples/metrics/plot_matern_kernel.py
+++ b/examples/metrics/plot_matern_kernel.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+============================================================================
+Matern kernel: influence of coef0 on kernel covariance
+============================================================================
+
+The example shows how the kernel covariance decreases with increasing
+dissimilarity of the two inputs for different values of coef0 (the parameter
+"nu" of the Matern kernel)
+
+See Rasmussen and Williams 2006, pp84 for details regarding the different
+variants of the Matern kernel.
+
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+
+import numpy as np
+
+from sklearn.metrics.pairwise import matern_kernel
+
+import matplotlib.pyplot as plt
+
+d = np.linspace(-4, 4, 500)[:, None]
+
+for coef0 in [0.5, 1.5, 2.5, np.inf]:
+	K = matern_kernel(d, [[0.0]], gamma=1, coef0=coef0)
+	plt.plot(d[:, 0], K[:, 0], label=coef0)
+
+plt.xlabel("distance")
+plt.ylabel("covariance")
+plt.yscale("log")
+plt.ylim(1e-3, 1e0)
+plt.legend(title="coef0")
+plt.show()

--- a/examples/metrics/plot_matern_kernel.py
+++ b/examples/metrics/plot_matern_kernel.py
@@ -22,15 +22,15 @@ print(__doc__)
 
 import numpy as np
 
-from sklearn.metrics.pairwise import matern_kernel
-
 import matplotlib.pyplot as plt
+
+from sklearn.metrics.pairwise import matern_kernel
 
 d = np.linspace(-4, 4, 500)[:, None]
 
 for coef0 in [0.5, 1.5, 2.5, np.inf]:
-	K = matern_kernel(d, [[0.0]], gamma=1, coef0=coef0)
-	plt.plot(d[:, 0], K[:, 0], label=coef0)
+    K = matern_kernel(d, [[0.0]], gamma=1, coef0=coef0)
+    plt.plot(d[:, 0], K[:, 0], label=coef0)
 
 plt.xlabel("distance")
 plt.ylabel("covariance")

--- a/examples/svm/plot_svm_matern_kernel.py
+++ b/examples/svm/plot_svm_matern_kernel.py
@@ -10,7 +10,7 @@ Support Vector Regression with four different variants of the Matern kernel
 is compared on a (discontinuous) step-function:
  * The Matern kernel for coef0==1.5, learning a once differentiable function
  * The Matern kernel for coef0==2.5, learning a twice differentiable function
- * The Matern kernel for coef0==3.5, learning a three-times differentiable 
+ * The Matern kernel for coef0==3.5, learning a three-times differentiable
    function
  * The absolute-exponential kernel which corresponds to a Matern kernel
    with coef0==0.5
@@ -31,10 +31,12 @@ print(__doc__)
 from functools import partial
 
 import numpy as np
+
+import matplotlib.pyplot as plt
+
 from sklearn.svm import NuSVR
 from sklearn.metrics.pairwise import matern_kernel
 
-import matplotlib.pyplot as plt
 
 np.random.seed(0)
 

--- a/examples/svm/plot_svm_matern_kernel.py
+++ b/examples/svm/plot_svm_matern_kernel.py
@@ -10,7 +10,7 @@ Support Vector Regression with four different variants of the Matern kernel
 is compared on a (discontinuous) step-function:
  * The Matern kernel for coef0==1.5, learning a once differentiable function
  * The Matern kernel for coef0==2.5, learning a twice differentiable function
- * The Matern kernel for coef0==3.5, learning a three-rimes differentiable 
+ * The Matern kernel for coef0==3.5, learning a three-times differentiable 
    function
  * The absolute-exponential kernel which corresponds to a Matern kernel
    with coef0==0.5

--- a/examples/svm/plot_svm_matern_kernel.py
+++ b/examples/svm/plot_svm_matern_kernel.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+r"""
+============================================================================
+Support Vector Regression: comparing different variants of Matern kernel
+============================================================================
+
+Support Vector Regression with four different variants of the Matern kernel
+is compared on a (discontinuous) step-function:
+ * The Matern kernel for coef0==1.5, learning a once differentiable function
+ * The Matern kernel for coef0==2.5, learning a twice differentiable function
+ * The Matern kernel for coef0==3.5, learning a three-rimes differentiable 
+   function
+ * The absolute-exponential kernel which corresponds to a Matern kernel
+   with coef0==0.5
+ * The squared-exponential (RBF) kernel which corresponds to a Matern kernel
+   for the limit of coef0 becoming infinitely large
+
+See Rasmussen and Williams 2006, pp84 for details regarding the different
+variants of the Matern kernel.
+
+The example shows that smaller values of coef0 can better approximate the
+discontinuous step-function.
+"""
+print(__doc__)
+
+# Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# Licence: BSD 3 clause
+
+from functools import partial
+
+import numpy as np
+from sklearn.svm import NuSVR
+from sklearn.metrics.pairwise import matern_kernel
+
+import matplotlib.pyplot as plt
+
+np.random.seed(0)
+
+# Train SVR with RBF and Matern kernels and plot resulting
+# predictions
+x = np.random.uniform(0, 10, 50)
+y = (x < 5)
+
+svr_rbf = NuSVR(nu=0.25, C=1e2, kernel="rbf", gamma=0.25)
+svr_matern0_5 = NuSVR(nu=0.25, C=1e2,
+                      kernel=partial(matern_kernel, coef0=0.5, gamma=0.25))
+svr_matern1_5 = NuSVR(nu=0.25, C=1e2,
+                      kernel=partial(matern_kernel, coef0=1.5, gamma=0.25))
+svr_matern2_5 = NuSVR(nu=0.25, C=1e2,
+                      kernel=partial(matern_kernel, coef0=2.5, gamma=0.25))
+svr_matern3_5 = NuSVR(nu=0.25, C=1e2,
+                      kernel=partial(matern_kernel, coef0=3.5, gamma=0.25))
+
+svr_rbf.fit(x[:, None], y)
+svr_matern0_5.fit(x[:, None], y)
+svr_matern1_5.fit(x[:, None], y)
+svr_matern2_5.fit(x[:, None], y)
+svr_matern3_5.fit(x[:, None], y)
+
+xp = np.linspace(0, 10, 100)
+plt.scatter(x, y, c='k', s=25, zorder=10)
+plt.plot(xp, xp < 5, label="True", c='k')
+plt.plot(xp, svr_rbf.predict(xp[:, None]), label="RBF", c='g')
+plt.plot(xp, svr_matern0_5.predict(xp[:, None]), label="Matern(0.5)", c='m')
+plt.plot(xp, svr_matern1_5.predict(xp[:, None]), label="Matern(1.5)", c='r')
+plt.plot(xp, svr_matern2_5.predict(xp[:, None]), label="Matern(2.5)", c='c')
+plt.plot(xp, svr_matern3_5.predict(xp[:, None]), label="Matern(3.5)", c='b')
+plt.legend(loc='best', title="kernel")
+plt.xlabel("input")
+plt.ylabel("target")
+plt.show()

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -24,7 +24,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     n_components: int or None
         Number of components. If None, all non-zero components are kept.
 
-    kernel: "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "precomputed"
+    kernel: "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "matern" |
+            "precomputed"
         Kernel.
         Default: "linear"
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -11,6 +11,7 @@
 # License: BSD 3 clause
 
 import itertools
+import math
 
 import numpy as np
 from scipy.spatial import distance
@@ -508,11 +509,9 @@ def cosine_distances(X, Y=None):
 
     Parameters
     ----------
-    X : array_like, sparse matrix
-        with shape (n_samples_X, n_features).
+    X : array_like, sparse matrix, shape (n_samples_X, n_features).
 
-    Y : array_like, sparse matrix (optional)
-        with shape (n_samples_Y, n_features).
+    Y : array_like, sparse matrix (optional), shape (n_samples_Y, n_features).
 
     Returns
     -------
@@ -613,10 +612,10 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
     Parameters
     ----------
-    X : ndarray (n_samples, n_features)
+    X : array, shape (n_samples, n_features)
         Array 1 for distance computation.
 
-    Y : ndarray (n_samples, n_features)
+    Y : array, shape (n_samples, n_features)
         Array 2 for distance computation.
 
     metric : string or callable
@@ -631,7 +630,7 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
     Returns
     -------
-    distances : ndarray (n_samples, )
+    distances : array, shape (n_samples, )
 
     Examples
     --------
@@ -667,13 +666,13 @@ def linear_kernel(X, Y=None):
 
     Parameters
     ----------
-    X : array of shape (n_samples_1, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : array of shape (n_samples_2, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     Returns
     -------
-    Gram matrix : array of shape (n_samples_1, n_samples_2)
+    Gram matrix : array, shape (n_samples_X, n_samples_Y)
     """
     X, Y = check_pairwise_arrays(X, Y)
     return safe_sparse_dot(X, Y.T, dense_output=True)
@@ -687,9 +686,9 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Parameters
     ----------
-    X : ndarray of shape (n_samples_1, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : ndarray of shape (n_samples_2, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     coef0 : int, default 1
 
@@ -697,7 +696,7 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Returns
     -------
-    Gram matrix : array of shape (n_samples_1, n_samples_2)
+    Gram matrix : array, shape (n_samples_X, n_samples_Y)
     """
     X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
@@ -718,15 +717,15 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
     Parameters
     ----------
-    X : ndarray of shape (n_samples_1, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : ndarray of shape (n_samples_2, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     coef0 : int, default 1
 
     Returns
     -------
-    Gram matrix: array of shape (n_samples_1, n_samples_2)
+    Gram matrix: array, shape (n_samples_X, n_samples_Y)
     """
     X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
@@ -749,15 +748,15 @@ def rbf_kernel(X, Y=None, gamma=None):
 
     Parameters
     ----------
-    X : array of shape (n_samples_X, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : array of shape (n_samples_Y, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     gamma : float
 
     Returns
     -------
-    kernel_matrix : array of shape (n_samples_X, n_samples_Y)
+    kernel_matrix : array, shape (n_samples_X, n_samples_Y)
     """
     X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
@@ -785,19 +784,19 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
 
     Parameters
     ----------
-    X : array of shape (n_samples_X, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : array of shape (n_samples_Y, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     gamma : float
 
     coef0 : float>0.0 (the parameter nu)
         The parameter nu controlling the smoothness of the learned function.
-        The smaller coef0, the less smooth the approximated function is. 
-        For nu=inf, the kernel becomes equivalent to the RBF kernel and for 
-        nu=0.5 to the absolute exponential kernel. Important intermediate 
-        values are nu=1.5 (once differentiable functions) and nu=2.5 
-        (twice differentiable functions). Note that values of nu not in 
+        The smaller coef0, the less smooth the approximated function is.
+        For nu=inf, the kernel becomes equivalent to the RBF kernel and for
+        nu=0.5 to the absolute exponential kernel. Important intermediate
+        values are nu=1.5 (once differentiable functions) and nu=2.5
+        (twice differentiable functions). Note that values of nu not in
         [0.5, 1.5, 2.5, inf] incur a considerably higher computational cost
         (appr. 10 times higher) since they require to evaluate the modified
         Bessel function.
@@ -805,7 +804,7 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
 
     Returns
     -------
-    kernel_matrix : array of shape (n_samples_X, n_samples_Y)
+    kernel_matrix : array, shape (n_samples_X, n_samples_Y)
     """
     if coef0 == np.inf:  # fall back to rbf-kernel
         return rbf_kernel(X, Y, gamma)
@@ -819,17 +818,17 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
     K = euclidean_distances(X, Y, squared=False)
     if coef0 == 0.5:
         K *= -gamma
-        np.exp(K, K) # exponentiate K in-place
+        np.exp(K, K)  # exponentiate K in-place
     elif coef0 == 1.5:
-        K *= np.sqrt(3) * gamma
-        K = (1 + K) * np.exp(-K)
+        K *= math.sqrt(3) * gamma
+        K = (1. + K) * np.exp(-K)
     elif coef0 == 2.5:
-        K *= np.sqrt(5) * gamma
-        K = (1 + K + K ** 2 / 3.0) * np.exp(-K)
+        K *= math.sqrt(5) * gamma
+        K = (1. + K + K ** 2 / 3.0) * np.exp(-K)
     else:  # general case; expensive to evaluate
         K[K == 0.0] += np.finfo(float).eps  # strict zeros would result in nan
-        tmp = (np.sqrt(2 * coef0) * gamma * K)
-        K[:] = (2 ** (1 - coef0)) / scipy.special.gamma(coef0)
+        tmp = (math.sqrt(2 * coef0) * gamma * K)
+        K.fill((2 ** (1. - coef0)) / scipy.special.gamma(coef0))
         K *= tmp ** coef0
         K *= scipy.special.kv(coef0, tmp)
     return K
@@ -847,16 +846,13 @@ def cosine_similarity(X, Y=None):
 
     Parameters
     ----------
-    X : array_like, sparse matrix
-        with shape (n_samples_X, n_features).
+    X : array_like, sparse matrix, shape (n_samples_X, n_features).
 
-    Y : array_like, sparse matrix (optional)
-        with shape (n_samples_Y, n_features).
+    Y : array_like, sparse matrix (optional), shape (n_samples_Y, n_features).
 
     Returns
     -------
-    kernel matrix : array
-        An array with shape (n_samples_X, n_samples_Y).
+    kernel matrix : array, shape (n_samples_X, n_samples_Y).
     """
     # to avoid recursive import
 
@@ -894,13 +890,13 @@ def additive_chi2_kernel(X, Y=None):
 
     Parameters
     ----------
-    X : array-like of shape (n_samples_X, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : array of shape (n_samples_Y, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     Returns
     -------
-    kernel_matrix : array of shape (n_samples_X, n_samples_Y)
+    kernel_matrix : array, shape (n_samples_X, n_samples_Y)
 
     References
     ----------
@@ -947,16 +943,16 @@ def chi2_kernel(X, Y=None, gamma=1.):
 
     Parameters
     ----------
-    X : array-like of shape (n_samples_X, n_features)
+    X : array, shape (n_samples_X, n_features)
 
-    Y : array of shape (n_samples_Y, n_features)
+    Y : array, shape (n_samples_Y, n_features)
 
     gamma : float, default=1.
         Scaling parameter of the chi2 kernel.
 
     Returns
     -------
-    kernel_matrix : array of shape (n_samples_X, n_samples_Y)
+    kernel_matrix : array, shape (n_samples_X, n_samples_Y)
 
     References
     ----------
@@ -1111,11 +1107,11 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
 
     Parameters
     ----------
-    X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+    X : array, shape (n_samples_a, n_samples_a) if metric == "precomputed", \
+                     (n_samples_a, n_features) otherwise
         Array of pairwise distances between samples, or a feature array.
 
-    Y : array [n_samples_b, n_features]
+    Y : array, shape (n_samples_b, n_features)
         A second feature array only if X has shape [n_samples_a, n_features].
 
     metric : string, or callable
@@ -1146,7 +1142,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
 
     Returns
     -------
-    D : array [n_samples_a, n_samples_a] or [n_samples_a, n_samples_b]
+    D : array, shape (n_samples_a, n_samples_a) or (n_samples_a, n_samples_b)
         A distance matrix D such that D_{i, j} is the distance between the
         ith and jth vectors of the given matrix X, if Y is None.
         If Y is not None, then D_{i, j} is the distance between the ith array
@@ -1212,6 +1208,7 @@ def kernel_metrics():
       'rbf'             sklearn.pairwise.rbf_kernel
       'sigmoid'         sklearn.pairwise.sigmoid_kernel
       'cosine'          sklearn.pairwise.cosine_similarity
+      'matern'          sklearn.pairwise.matern_kernel
       ===============   ========================================
     """
     return PAIRWISE_KERNEL_FUNCTIONS
@@ -1247,12 +1244,12 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     kernel between the arrays from both X and Y.
 
     Valid values for metric are::
-        ['rbf', 'sigmoid', 'polynomial', 'poly', 'linear', 'cosine']
+        ['rbf', 'sigmoid', 'polynomial', 'poly', 'linear', 'cosine', 'matern']
 
     Parameters
     ----------
-    X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+    X : array, shape (n_samples_a, n_samples_a) if metric == "precomputed", \
+                     (n_samples_a, n_features) otherwise
         Array of pairwise kernels between samples, or a feature array.
 
     Y : array [n_samples_b, n_features]
@@ -1286,7 +1283,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
 
     Returns
     -------
-    K : array [n_samples_a, n_samples_a] or [n_samples_a, n_samples_b]
+    K : array, shape (n_samples_a, n_samples_a) or (n_samples_a, n_samples_b)
         A kernel matrix K such that K_{i, j} is the kernel between the
         ith and jth vectors of the given matrix X, if Y is None.
         If Y is not None, then K_{i, j} is the kernel between the ith array

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -827,7 +827,7 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
         K *= np.sqrt(5) * gamma
         K = (1 + K + K ** 2 / 3.0) * np.exp(-K)
     else:  # general case; expensive to evaluate
-        K[K == 0.0] += 1e-10  # strict zeros would result in nan
+        K[K == 0.0] += np.finfo(float).eps  # strict zeros would result in nan
         tmp = (np.sqrt(2 * coef0) * gamma * K)
         K[:] = (2 ** (1 - coef0)) / scipy.special.gamma(coef0)
         K *= tmp ** coef0

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -775,7 +775,7 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
     The class of Matern kernels is a generalization of the RBF and
     absolute exponential kernel parameterized by an additional parameter
     coef0 (commonly denoted as nu in the literature). The smaller coef0,
-    the less smooth the approximated function is. For nu->inf, the kernel
+    the less smooth the approximated function is. For nu=inf, the kernel
     becomes equivalent to the RBF kernel and for nu=0.5 to the absolute
     exponential kernel. Important intermediate values are nu=1.5 (once
     differentiable functions) and nu=2.5 (twice differentiable functions).
@@ -791,7 +791,17 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
 
     gamma : float
 
-    coef0 : float in [0.5, 1.5, 2.5, inf]
+    coef0 : float>0.0 (the parameter nu)
+        The parameter nu controlling the smoothness of the learned function.
+        The smaller coef0, the less smooth the approximated function is. 
+        For nu=inf, the kernel becomes equivalent to the RBF kernel and for 
+        nu=0.5 to the absolute exponential kernel. Important intermediate 
+        values are nu=1.5 (once differentiable functions) and nu=2.5 
+        (twice differentiable functions). Note that values of nu not in 
+        [0.5, 1.5, 2.5, inf] incur a considerably higher computational cost
+        (appr. 10 times higher) since they require to evaluate the modified
+        Bessel function.
+
 
     Returns
     -------
@@ -799,6 +809,8 @@ def matern_kernel(X, Y=None, gamma=None, coef0=1.5):
     """
     if coef0 == np.inf:  # fall back to rbf-kernel
         return rbf_kernel(X, Y, gamma)
+    elif coef0 <= 0.0:
+        raise ValueError("coef0 of Matérn kernel must be strictly positive.")
 
     X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:


### PR DESCRIPTION
Add Matern kernel to the kernels in pairwise.py.

The Matern kernel (https://en.wikipedia.org/wiki/Mat%C3%A9rn_covariance_function and Rasmussen and Williams 2006, pp84) is a generalization of the RBF and the absolute exponential kernel with an additional hyperparemeter nu, which allows interpolating between these two (RBF: nu=inf, absolute exponential: nu=0.5). In contrast to the RBF kernel, it makes less strict assumptions on the smoothness of the function to be learned. This is shown in an example for a step-function for different values of nu:

![figure_0](https://cloud.githubusercontent.com/assets/1116263/5189587/64c46cb2-74df-11e4-9b94-684e9751bc78.png)

TODOs:
- [x] support for arbitrary values of nu (coef0)
- [x] tests
