### PR TITLE
[MRG+2] DOC narrative docs for grid search's robustness to failure

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -61,8 +61,6 @@ evaluated and the best combination is retained.
 
 .. currentmodule:: sklearn.grid_search
 
-.. _gridsearch_scoring:
-
 .. topic:: Examples:
 
     - See :ref:`example_model_selection_grid_search_digits.py` for an example of
@@ -130,53 +128,60 @@ increasing ``n_iter`` will always lead to a finer search.
 Tips for parameter search
 =========================
 
-.. topic:: Specifying an objective metric
+.. _gridsearch_scoring:
 
-  By default, parameter search uses the ``score`` function of the estimator
-  to evaluate a parameter setting. These are the
-  :func:`sklearn.metrics.accuracy_score` for classification and
-  :func:`sklearn.metrics.r2_score` for regression.  For some applications,
-  other scoring functions are better suited (for example in unbalanced
-  classification, the accuracy score is often uninformative). An alternative
-  scoring function can be specified via the ``scoring`` parameter to
-  :class:`GridSearchCV`, :class:`RandomizedSearchCV` and many of the
-  specialized cross-validation tools described below.
-  See :ref:`scoring_parameter` for more details.
+Specifying an objective metric
+------------------------------
 
-.. topic:: Composite estimators and parameter spaces
+By default, parameter search uses the ``score`` function of the estimator
+to evaluate a parameter setting. These are the
+:func:`sklearn.metrics.accuracy_score` for classification and
+:func:`sklearn.metrics.r2_score` for regression.  For some applications,
+other scoring functions are better suited (for example in unbalanced
+classification, the accuracy score is often uninformative). An alternative
+scoring function can be specified via the ``scoring`` parameter to
+:class:`GridSearchCV`, :class:`RandomizedSearchCV` and many of the
+specialized cross-validation tools described below.
+See :ref:`scoring_parameter` for more details.
 
-   :ref:`pipeline` describes building composite estimators whose
-   parameter space can be searched with these tools.
+Composite estimators and parameter spaces
+-----------------------------------------
 
-.. topic:: Model selection: development and evaluation
+:ref:`pipeline` describes building composite estimators whose
+parameter space can be searched with these tools.
 
-  Model selection by evaluating various parameter settings can be seen as a way
-  to use the labeled data to "train" the parameters of the grid.
+Model selection: development and evaluation
+-------------------------------------------
 
-  When evaluating the resulting model it is important to do it on
-  held-out samples that were not seen during the grid search process:
-  it is recommended to split the data into a **development set** (to
-  be fed to the ``GridSearchCV`` instance) and an **evaluation set**
-  to compute performance metrics.
+Model selection by evaluating various parameter settings can be seen as a way
+to use the labeled data to "train" the parameters of the grid.
 
-  This can be done by using the :func:`cross_validation.train_test_split`
-  utility function.
+When evaluating the resulting model it is important to do it on
+held-out samples that were not seen during the grid search process:
+it is recommended to split the data into a **development set** (to
+be fed to the ``GridSearchCV`` instance) and an **evaluation set**
+to compute performance metrics.
 
-.. topic:: Parallelism
+This can be done by using the :func:`cross_validation.train_test_split`
+utility function.
 
-  :class:`GridSearchCV` and :class:`RandomizedSearchCV` evaluate each parameter
-  setting independently.  Computations can be run in parallel if your OS
-  supports it, by using the keyword ``n_jobs=-1``. See function signature for
-  more details.
+Parallelism
+-----------
 
-.. topic:: Robustness to failure
+:class:`GridSearchCV` and :class:`RandomizedSearchCV` evaluate each parameter
+setting independently.  Computations can be run in parallel if your OS
+supports it, by using the keyword ``n_jobs=-1``. See function signature for
+more details.
 
-  Some parameter settings may result in a failure to ``fit`` one or more folds
-  of the data.  By default, this will cause the entire search to fail, even if
-  some parameter settings could be fully evaluated. Setting ``error_score=0``
-  (or `=np.NaN`) will make the procedure robust to such failure, issuing a
-  warning and setting the score for that fold to 0 (or `NaN`), but completing
-  the search.
+Robustness to failure
+---------------------
+
+Some parameter settings may result in a failure to ``fit`` one or more folds
+of the data.  By default, this will cause the entire search to fail, even if
+some parameter settings could be fully evaluated. Setting ``error_score=0``
+(or `=np.NaN`) will make the procedure robust to such failure, issuing a
+warning and setting the score for that fold to 0 (or `NaN`), but completing
+the search.
 
 .. _alternative_cv:
 

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -29,16 +29,14 @@ A search consists of:
 - a cross-validation scheme; and
 - a :ref:`score function <gridsearch_scoring>`.
 
+Some models allow for specialized, efficient parameter search strategies,
+:ref:`outlined below <alternative_cv>`.
 Two generic approaches to sampling search candidates are provided in
 scikit-learn: for given values, :class:`GridSearchCV` exhaustively considers
 all parameter combinations, while :class:`RandomizedSearchCV` can sample a
 given number of candidates from a parameter space with a specified
-distribution.
-
-.. seealso
-
-   :ref:`pipeline` describes building composite estimators whose
-   parameter space can be searched with these tools.
+distribution. After describing these tools we detail
+:ref:`best practice <grid_search_tips>` applicable to both approaches.
 
 Exhaustive Grid Search
 ======================
@@ -61,35 +59,9 @@ The :class:`GridSearchCV` instance implements the usual estimator API: when
 "fitting" it on a dataset all the possible combinations of parameter values are
 evaluated and the best combination is retained.
 
-.. topic:: Model selection: development and evaluation
-
-  Model selection with ``GridSearchCV`` can be seen as a way to use the
-  labeled data to "train" the parameters of the grid.
-
-  When evaluating the resulting model it is important to do it on
-  held-out samples that were not seen during the grid search process:
-  it is recommended to split the data into a **development set** (to
-  be fed to the ``GridSearchCV`` instance) and an **evaluation set**
-  to compute performance metrics.
-
-  This can be done by using the :func:`cross_validation.train_test_split`
-  utility function.
-
 .. currentmodule:: sklearn.grid_search
 
 .. _gridsearch_scoring:
-
-Scoring functions for parameter search
---------------------------------------
-
-By default, :class:`GridSearchCV` uses the ``score`` function of the estimator
-to evaluate a parameter setting. These are the
-:func:`sklearn.metrics.accuracy_score` for classification and
-:func:`sklearn.metrics.r2_score` for regression.  For some applications, other
-scoring functions are better suited (for example in unbalanced classification,
-the accuracy score is often uninformative). An alternative scoring function
-can be specified via the ``scoring`` parameter to :class:`GridSearchCV`.  See
-:ref:`scoring_parameter` for more details.
 
 .. topic:: Examples:
 
@@ -101,12 +73,6 @@ can be specified via the ``scoring`` parameter to :class:`GridSearchCV`.  See
       extractor (n-gram count vectorizer and TF-IDF transformer) with a
       classifier (here a linear SVM trained with SGD with either elastic
       net or L2 penalty) using a :class:`pipeline.Pipeline` instance.
-
-.. note::
-
-  Computations can be run in parallel if your OS supports it, by using
-  the keyword ``n_jobs=-1``, see function signature for more details.
-
 
 Randomized Parameter Optimization
 =================================
@@ -159,6 +125,60 @@ increasing ``n_iter`` will always lead to a finer search.
       Random search for hyper-parameter optimization,
       The Journal of Machine Learning Research (2012)
 
+.. _grid_search_tips:
+
+Tips for parameter search
+=========================
+
+.. topic:: Specifying an objective metric
+
+  By default, parameter search uses the ``score`` function of the estimator
+  to evaluate a parameter setting. These are the
+  :func:`sklearn.metrics.accuracy_score` for classification and
+  :func:`sklearn.metrics.r2_score` for regression.  For some applications,
+  other scoring functions are better suited (for example in unbalanced
+  classification, the accuracy score is often uninformative). An alternative
+  scoring function can be specified via the ``scoring`` parameter to
+  :class:`GridSearchCV`, :class:`RandomizedSearchCV` and many of the
+  specialized cross-validation tools described below.
+  See :ref:`scoring_parameter` for more details.
+
+.. topic:: Composite estimators and parameter spaces
+
+   :ref:`pipeline` describes building composite estimators whose
+   parameter space can be searched with these tools.
+
+.. topic:: Model selection: development and evaluation
+
+  Model selection by evaluating various parameter settings can be seen as a way
+  to use the labeled data to "train" the parameters of the grid.
+
+  When evaluating the resulting model it is important to do it on
+  held-out samples that were not seen during the grid search process:
+  it is recommended to split the data into a **development set** (to
+  be fed to the ``GridSearchCV`` instance) and an **evaluation set**
+  to compute performance metrics.
+
+  This can be done by using the :func:`cross_validation.train_test_split`
+  utility function.
+
+.. topic:: Parallelism
+
+  :class:`GridSearchCV` and :class:`RandomizedSearchCV` evaluate each parameter
+  setting independently.  Computations can be run in parallel if your OS
+  supports it, by using the keyword ``n_jobs=-1``. See function signature for
+  more details.
+
+.. topic:: Robustness to failure
+
+  Some parameter settings may result in a failure to ``fit`` one or more folds
+  of the data.  By default, this will cause the entire search to fail, even if
+  some parameter settings could be fully evaluated. Setting ``error_score=0``
+  (or `=np.NaN`) will make the procedure robust to such failure, issuing a
+  warning and setting the score for that fold to 0 (or `NaN`), but completing
+  the search.
+
+.. _alternative_cv:
 
 Alternatives to brute force parameter search
 ============================================

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -25,7 +25,7 @@ In particular, the combination of kernel map approximations with
 Since there has not been much empirical work using approximate embeddings, it
 is advisable to compare results against exact kernel methods when possible.
 
-.. seealso
+.. seealso::
 
    :ref:`polynomial_regression` for an exact polynomial transformation.
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -677,7 +677,6 @@ def test_grid_search_allows_nans():
     GridSearchCV(p, {'classifier__foo_param': [1, 2, 3]}, cv=2).fit(X, y)
 
 
-
 class FailingClassifier(BaseEstimator):
     """Classifier that raises a ValueError on fit()"""
 
@@ -717,6 +716,14 @@ def test_grid_search_failing_classifier():
     # Ensure that grid scores were set to zero as required for those fits
     # that are expected to fail.
     assert all(np.all(this_point.cv_validation_scores == 0.0)
+               for this_point in gs.grid_scores_
+               if this_point.parameters['parameter'] ==
+               FailingClassifier.FAILING_PARAMETER)
+
+    gs = GridSearchCV(clf, [{'parameter': [0, 1, 2]}], scoring='accuracy',
+                      refit=False, error_score=float('nan'))
+    assert_warns(FitFailedWarning, gs.fit, X, y)
+    assert all(np.all(np.isnan(this_point.cv_validation_scores))
                for this_point in gs.grid_scores_
                if this_point.parameters['parameter'] ==
                FailingClassifier.FAILING_PARAMETER)


### PR DESCRIPTION
A fairly minor doc and test improvement. The `error_score` parameter in grid search wasn't mentioned in narrative docs.

I realised there were a number of best practice tips associated with parameter search, not specific to `GridSearchCV` or `RandomizedSearchCV`.

![3 2 grid search searching for estimator parameters scikit-learn 0 16-git documentation 4](https://cloud.githubusercontent.com/assets/78827/5199242/315ca3a6-75ae-11e4-9f99-212d6b0bbabf.png)
