### PR TITLE
[MRG+2.5] Add decision_function for OneVsOneClassifier.

### DIFF
--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -161,6 +161,11 @@ One-Vs-One
 
 :class:`OneVsOneClassifier` constructs one classifier per pair of classes.
 At prediction time, the class which received the most votes is selected.
+In the event of a tie (among two classes with an equal number of votes), it
+selects the class with the highest aggregate classification confidence by
+summing over the pair-wise classification confidence levels computed by the
+underlying binary classifiers.
+
 Since it requires to fit ``n_classes * (n_classes - 1) / 2`` classifiers,
 this method is usually slower than one-vs-the-rest, due to its
 O(n_classes^2) complexity. However, this method may be advantageous for
@@ -187,6 +192,12 @@ Below is an example of multiclass learning using OvO::
          1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
          2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
          2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
+
+
+.. topic:: References:
+
+    .. [1] "Pattern Recognition and Machine Learning. Springer",
+        Christopher M. Bishop, page 183, (First Edition)
 
 
 Error-Correcting Output-Codes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -152,6 +152,9 @@ Enhancements
 
    - Add ``n_iter_`` attribute to estimators that accept a ``max_iter`` attribute
      in their constructor. By `Manoj Kumar`_.
+  
+   - Added decision function for :class:`multiclass.OneVsOneClassifier`
+     By `Raghav R V`_ and `Kyle Beauchamp`_.
 
    - :func:`neighbors.kneighbors_graph` and :func:`radius_neighbors_graph`
      support non-Euclidean metrics. By `Manoj Kumar`_

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -43,10 +43,9 @@ from .base import MetaEstimatorMixin
 from .preprocessing import LabelBinarizer
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
-from .utils.validation import (
-        _num_samples,
-        check_consistent_length,
-        check_is_fitted)
+from .utils.validation import _num_samples
+from .utils.validation import check_consistent_length
+from .utils.validation import check_is_fitted
 from .utils import deprecated
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
@@ -120,7 +119,7 @@ def fit_ovr(estimator, X, y, n_jobs=1):
     lb : fitted LabelBinarizer
 
     """
-    ovr =  OneVsRestClassifier(estimator, n_jobs=n_jobs).fit(X, y)
+    ovr = OneVsRestClassifier(estimator, n_jobs=n_jobs).fit(X, y)
     return ovr.estimators_, ovr.label_binarizer_
 
 
@@ -179,6 +178,7 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
 
 class _ConstantPredictor(BaseEstimator):
+
     def fit(self, X, y):
         self.y_ = y
         return self
@@ -363,7 +363,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
-
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. This can only be used with estimators which implement the
@@ -424,7 +423,7 @@ def _fit_ovo_binary(estimator, X, y, i, j):
 @deprecated("fit_ovo is deprecated and will be removed in 0.18."
             "Use the OneVsOneClassifier instead.")
 def fit_ovo(estimator, X, y, n_jobs=1):
-    ovo =  OneVsOneClassifier(estimator, n_jobs=n_jobs).fit(X, y)
+    ovo = OneVsOneClassifier(estimator, n_jobs=n_jobs).fit(X, y)
     return ovo.estimators_, ovo.classes_
 
 
@@ -511,7 +510,11 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         return self
 
     def predict(self, X):
-        """Predict multi-class targets using underlying estimators.
+        """Estimate the best class label for each sample in X.
+        
+        This is implemented as ``argmax(decision_function(X), axis=1)`` which
+        will return the label of the class with most votes by estimators
+        predicting the outcome of a decision for each possible class pair.
 
         Parameters
         ----------
@@ -523,62 +526,52 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         y : numpy array of shape [n_samples]
             Predicted multi-class targets.
         """
-        check_is_fitted(self, 'estimators_')
-        n_samples = X.shape[0]
-        n_classes = self.classes_.shape[0]
-        votes = np.zeros((n_samples, n_classes))
-        scores = np.zeros((n_samples, n_classes))
-
-        k = 0
-        for i in range(n_classes):
-            for j in range(i + 1, n_classes):
-                pred = self.estimators_[k].predict(X)
-                score = _predict_binary(self.estimators_[k], X)
-                scores[:, i] -= score
-                scores[:, j] += score
-                votes[pred == 0, i] += 1
-                votes[pred == 1, j] += 1
-                k += 1
-
-        # find all places with maximum votes per sample
-        maxima = votes == np.max(votes, axis=1)[:, np.newaxis]
-
-        # if there are ties, use scores to break them
-        if np.any(maxima.sum(axis=1) > 1):
-            scores[~maxima] = -np.inf
-            prediction = scores.argmax(axis=1)
-        else:
-            prediction = votes.argmax(axis=1)
-        return self.classes_[prediction]
+        Y = self.decision_function(X)
+        return self.classes_[Y.argmax(axis=1)]
 
     def decision_function(self, X):
-        """Distance (votes) of the samples X to the separating hyperplanes.
+        """Decision function for the OneVsOneClassifier.
+
+        The decision values for the samples are computed by adding the 
+        normalized sum of pair-wise classification confidence levels to the
+        votes in order to disambiguate between the decision values when the
+        votes for all the classes are equal leading to a tie.
+
         Parameters
         ----------
         X : array-like, shape = [n_samples, n_features]
+
         Returns
         -------
-        D : array-like, shape = [n_samples, n_class * (n_class-1) / 2]
-            Returns the decision function of the sample for each class
-            in the model.
+        Y : array-like, shape = [n_samples, n_classes]
         """
-        if not hasattr(self, "estimators_"):
-            raise ValueError("The object hasn't been fitted yet!")
+        check_is_fitted(self, 'estimators_')
 
-        # Predict decision function (votes) using the one-vs-one strategy.
         n_samples = X.shape[0]
         n_classes = self.classes_.shape[0]
         votes = np.zeros((n_samples, n_classes))
+        sum_of_confidences = np.zeros((n_samples, n_classes))
 
         k = 0
         for i in range(n_classes):
             for j in range(i + 1, n_classes):
                 pred = self.estimators_[k].predict(X)
+                confidence_levels_ij = _predict_binary(self.estimators_[k], X)
+                sum_of_confidences[:, i] -= confidence_levels_ij
+                sum_of_confidences[:, j] += confidence_levels_ij
                 votes[pred == 0, i] += 1
                 votes[pred == 1, j] += 1
                 k += 1
 
-        return votes
+        max_confidences = sum_of_confidences.max()
+        min_confidences = sum_of_confidences.min()
+
+        if max_confidences == min_confidences:
+            return votes
+
+        # Scale the sum_of_confidences to [-0.4, 0.4] and add it with votes
+        return votes + sum_of_confidences * \
+               (0.4 / max(abs(max_confidences), abs(min_confidences)))
 
 
 @deprecated("fit_ecoc is deprecated and will be removed in 0.18."
@@ -611,8 +604,8 @@ def fit_ecoc(estimator, X, y, code_size=1.5, random_state=None, n_jobs=1):
     code_book_ : numpy array of shape [n_classes, code_size]
         Binary array containing the code of each class.
     """
-    ecoc =  OutputCodeClassifier(estimator, random_state=random_state,
-                                 n_jobs=n_jobs).fit(X, y)
+    ecoc = OutputCodeClassifier(estimator, random_state=random_state,
+                                n_jobs=n_jobs).fit(X, y)
     return ecoc.estimators_, ecoc.classes_, ecoc.code_book_
 
 
@@ -620,7 +613,7 @@ def fit_ecoc(estimator, X, y, code_size=1.5, random_state=None, n_jobs=1):
             "Use the OutputCodeClassifier instead.")
 def predict_ecoc(estimators, classes, code_book, X):
     """Make predictions using the error-correcting output-code strategy."""
-    ecoc =  OutputCodeClassifier(clone(estimators[0]))
+    ecoc = OutputCodeClassifier(clone(estimators[0]))
     ecoc.classes_ = classes
     ecoc.estimators_ = estimators
     ecoc.code_book_ = code_book

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -551,6 +551,35 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             prediction = votes.argmax(axis=1)
         return self.classes_[prediction]
 
+    def decision_function(self, X):
+        """Distance (votes) of the samples X to the separating hyperplanes.
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+        Returns
+        -------
+        D : array-like, shape = [n_samples, n_class * (n_class-1) / 2]
+            Returns the decision function of the sample for each class
+            in the model.
+        """
+        if not hasattr(self, "estimators_"):
+            raise ValueError("The object hasn't been fitted yet!")
+
+        # Predict decision function (votes) using the one-vs-one strategy.
+        n_samples = X.shape[0]
+        n_classes = self.classes_.shape[0]
+        votes = np.zeros((n_samples, n_classes))
+
+        k = 0
+        for i in range(n_classes):
+            for j in range(i + 1, n_classes):
+                pred = self.estimators_[k].predict(X)
+                votes[pred == 0, i] += 1
+                votes[pred == 1, j] += 1
+                k += 1
+
+        return votes
+
 
 @deprecated("fit_ecoc is deprecated and will be removed in 0.18."
             "Use the OutputCodeClassifier instead.")


### PR DESCRIPTION
Adding `decision_function` support for the `OneVsOneClassifier`.

This is based off of #1548 and addresses #1523.
- [x] Implement the `decision_function` for `OneVsOneClassifier` 

decision_function returns `votes + scores * (0.4 / max(|scores.max(axis=None)|, |scores.min(axis=None)|))`

As a corner case, when both max and min are same, it simply returns `votes`.
- [x] Add tests for ovo decision function
- Tests `decision_function(X).argmax(axis=1) == predict(X)`
- Tests `decision_function(X).shape == (n_samples, n_classes)`
- Tests `np.round(decision_function(X)) == separately_computed_votes`
- Tests `computed_scores = (decision_function(X) - np.round(decision_function(X)) ) * upscale_factor_derived_from_computed_scores`
- [x] Incorporate the `decision_function` output in `test_ovo_ties`
  `ovo_ties` test requires `votes` to assert tie and `scores` to assert if the prediction breaks ties using aggregated decision scores. Both `votes` and `scores` ( individual ) were separately computed till now. These are modified to use `decision_function`
- `votes = round(decision_values)`
- `scaled_aggregated_scores = decision_values - votes`

@arjoly, @amueller, @mblondel  Pl. review when you find time!
