### PR TITLE
DOC: COSMIT: Naive Bayes long url + PEP8 cleanup

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -298,8 +298,8 @@ class GaussianNB(BaseNB):
             self.class_count_ = np.zeros(n_classes)
         else:
             if X.shape[1] != self.theta_.shape[1]:
-                raise ValueError("Number of features %d does not match previous data %d." %
-                                 (X.shape[1], self.theta_.shape[1]))
+                msg = "Number of features %d does not match previous data %d."
+                raise ValueError(msg % (X.shape[1], self.theta_.shape[1]))
             # Put epsilon back in each time
             self.sigma_[:, :] -= epsilon
 
@@ -406,8 +406,8 @@ class BaseDiscreteNB(BaseNB):
             self.feature_count_ = np.zeros((n_effective_classes, n_features),
                                            dtype=np.float64)
         elif n_features != self.coef_.shape[1]:
-            raise ValueError("Number of features %d does not match previous data %d."
-                             % (n_features, self.coef_.shape[-1]))
+            msg = "Number of features %d does not match previous data %d."
+            raise ValueError(msg % (n_features, self.coef_.shape[-1]))
 
         Y = label_binarize(y, classes=self.classes_)
         if Y.shape[1] == 1:
@@ -569,8 +569,7 @@ class MultinomialNB(BaseDiscreteNB):
     ----------
     C.D. Manning, P. Raghavan and H. Schuetze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234-265.
-    http://nlp.stanford.edu/IR-book/html/htmledition/
-        naive-bayes-text-classification-1.html
+    http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html
     """
 
     def __init__(self, alpha=1.0, fit_prior=True, class_prior=None):


### PR DESCRIPTION
- Put long link to IR-book on its own line to make sure it renders as a
  correct link in the docs.
- Put long ValueError messages that were breaking PEP8 compliance of
  the file `naive_bayes.py` into temporary variables.

Signed-off-by: mr.Shu mr@shu.io

---

This pull request might not be necessary at all, but at least the change on line 572 is pretty important to me. It took me a while to realize what the URL should be by looking in here (http://scikit-learn.org/dev/modules/generated/sklearn.naive_bayes.MultinomialNB.html#sklearn.naive_bayes.MultinomialNB) and I also think this is just not right and shouldn't be left like that.

I understand that this breaks PEP8 (especially the line length rule) and there are ways how to get around that (http://stackoverflow.com/questions/14414878/how-do-i-break-a-link-in-a-rst-docstring-to-satisfy-pep8) but I believe this is precisely the case in which the following from the original PEP8 document applies: 

> But most importantly: know when to be inconsistent -- sometimes the style guide just doesn't apply. When in doubt, use your best judgment. Look at other examples and decide what looks best. And don't hesitate to ask!
> Two good reasons to break a particular rule:
> - When applying the rule would make the code less readable, even for someone who is used to reading code that follows the rules.
