### PR TITLE
[MRG] DOC fix layout: ensure stable width of documentwrapper

### DIFF
--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -726,15 +726,6 @@ div.docstringWrapper p {
     border-width: 1px;
 }
 
-.class,
-.function {
-	clear: both
-}
-
-.documentwrapper {
-	position: absolute;  /* Internal floats are separate to external */
-}
-
 .section:after {
     clear: both;
 }


### PR DESCRIPTION
Fixes bugs described at https://github.com/scikit-learn/scikit-learn/commit/937f36cba77f18af7b37f0798f76aaeaed0b02d8#commitcomment-8720925

I've only tested this by looking at BallTree (which is affected particularly because of its lack of content) and a class with examples. Both issues seem to be fixed (and I have no idea why I originally made those CSS changes).
