### PR TITLE
[WIP] Adding tests for estimators implementing `partial_fit` and a few other related fixes / enhancements

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -361,7 +361,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         n_samples, n_features = X.shape
 
         self._validate_params()
-        _check_partial_fit_first_call(self, classes)
+        _check_partial_fit_first_call(self, y, classes)
 
         n_classes = self.classes_.shape[0]
 
@@ -374,8 +374,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
             self._allocate_parameter_mem(n_classes, n_features,
                                          coef_init, intercept_init)
         elif n_features != self.coef_.shape[-1]:
-            raise ValueError("Number of features %d does not match previous data %d."
-                             % (n_features, self.coef_.shape[-1]))
+            raise ValueError("Number of features %d does not match previous "
+                             "data %d." % (n_features, self.coef_.shape[-1]))
 
         self.loss_function = self._get_loss_function(loss)
         if self.t_ is None:
@@ -884,8 +884,8 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
             self._allocate_parameter_mem(1, n_features,
                                          coef_init, intercept_init)
         elif n_features != self.coef_.shape[-1]:
-            raise ValueError("Number of features %d does not match previous data %d."
-                             % (n_features, self.coef_.shape[-1]))
+            raise ValueError(("Number of features %d does not match previous "
+                              "data %d.") % (n_features, self.coef_.shape[-1]))
         if self.average > 0 and self.average_coef_ is None:
             self.average_coef_ = np.zeros(n_features,
                                           dtype=np.float64,

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -252,6 +252,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
             self.h_samples_ = np.zeros((self.batch_size, self.n_components))
 
         self._fit(X, self.random_state_)
+        return self
 
     def _fit(self, v_pos, rng):
         """Inner fit for one mini-batch.

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -44,11 +44,6 @@ def test_gnb():
     y_pred_log_proba = clf.predict_log_proba(X)
     assert_array_almost_equal(np.log(y_pred_proba), y_pred_log_proba, 8)
 
-    # Test whether label mismatch between target y and classes raises
-    # an Error
-    # FIXME Remove this test once the more general partial_fit tests are merged
-    assert_raises(ValueError, GaussianNB().partial_fit, X, y, classes=[0, 1])
-
 
 def test_gnb_prior():
     # Test whether class priors are properly set.

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -21,8 +21,7 @@ import numpy as np
 from ..externals.six import string_types
 
 from .validation import check_array
-
-from ..utils.fixes import bincount
+from .fixes import in1d, bincount
 
 
 def _unique_multiclass(y):
@@ -96,7 +95,8 @@ def unique_labels(*ys):
 
     # Check consistency for the indicator format
     if (label_type == "multilabel-indicator" and
-            len(set(check_array(y, ['csr', 'csc', 'coo']).shape[1] for y in ys)) > 1):
+            len(set(check_array(y, ['csr', 'csc', 'coo']).shape[1]
+                    for y in ys)) > 1):
         raise ValueError("Multi-label binary indicator input with "
                          "different numbers of labels")
 
@@ -317,7 +317,7 @@ def type_of_target(y):
         return 'multiclass' + suffix
 
 
-def _check_partial_fit_first_call(clf, classes=None):
+def _check_partial_fit_first_call(clf, y=None, classes=None):
     """Private helper function for factorizing common classes param logic
 
     Estimators that implement the ``partial_fit`` API need to be provided with
@@ -328,7 +328,7 @@ def _check_partial_fit_first_call(clf, classes=None):
 
     This function returns True if it detects that this was the first call to
     ``partial_fit`` on ``clf``. In that case the ``classes_`` attribute is also
-    set on ``clf``.
+    set on ``clf`` after validating against unique y labels.
 
     """
     if getattr(clf, 'classes_', None) is None and classes is None:
@@ -341,14 +341,25 @@ def _check_partial_fit_first_call(clf, classes=None):
                 raise ValueError(
                     "`classes=%r` is not the same as on last call "
                     "to partial_fit, was: %r" % (classes, clf.classes_))
-
         else:
             # This is the first call to partial_fit
+            if issparse(y):
+                raise ValueError("Sparse y is not supported.")
+
+            # Validate classes against unique labels in y
+            y_, classes_ = np.array(y), np.array(classes)
+            unique_y = np.unique(y_)
+            unique_y_in_classes = in1d(unique_y, classes_,
+                                       assume_unique=True)
+            if not np.all(unique_y_in_classes):
+                msg = ("The target label(s) %s in y do not exist in the"
+                       "initial classes %s" %
+                       (unique_y[~unique_y_in_classes], classes_))
+                raise ValueError(msg)
             clf.classes_ = unique_labels(classes)
             return True
 
-    # classes is None and clf.classes_ has already previously been set:
-    # nothing to do
+    # classes is None and clf.classes_ has already previously been set
     return False
 
 


### PR DESCRIPTION
Fixes #3896 

**New `partial_fit` tests:**
The below tests are based off @arjoly's [suggestion](https://github.com/scikit-learn/scikit-learn/issues/3896#issuecomment-64862823).
- [x] 1. General tests
  - Assert that `partial_fit` returns `self`. - Thanks @jnothman for [the suggestion.](https://github.com/scikit-learn/scikit-learn/issues/3896#issue-50330161)
  - Clone test... `assert clone(est).partial_fit == est.partial_fit`
- [x] 2. Check that an error is raised if the number of features changes.
- [x] 3. Estimator reset test
  - Check that doing `fit` after a set of `fit` / `partial_fit` restarts the estimator.
  - Assert that `partial_fit` and then `fit` with a different number of features works without raising any Exceptions... - Thanks @amueller for [the suggestion](https://github.com/scikit-learn/scikit-learn/pull/3907#issuecomment-68411916)
- [x] 4. Check if `partial_fit` does not overwrite the previous model.
  - Based on @jnothman [suggestion](https://github.com/scikit-learn/scikit-learn/pull/3907#issuecomment-68478630)
- [x] 5. Check that classifier handles correctly the classes argument in the `partial_fit`.
  - a. Check if mismatch between `classes` argument and `np.unique(y_i)` raises `ValueError`.
  - b. Check that error is raised if `classes` is not specified during first `partial_fit` call.
  - c. Check error is not raised if `classes` is not specified during subsequent calls.
- [x] Helper functions
  - `_validate_y_against_classes` - Check label mismatch between `y` and `classes` arg
  - `assert_same_model(X, est1, est2)`
  - `assert_not_same_model(X, est1, est2)`
    - Use `predict`, `transform`, `decision_function` and `predict_proba` to check equality of models.
  - In `sklearn.utils.estimator_checks` `_partial_fit` and `_fit` to use the appropriate parameters.
  - `assert_attributes_equal(est1, est2)`
  - `assert_attributes_not_equal(est1, est2)`
  - `assert_array_not_equal`

**Refs**
Also see #406 - This PR fixes 1st under not so easy for pfit-able estimators, via 3a ( of this PR )

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/3907)

<!-- Reviewable:end -->
