### PR TITLE
[MRG+1] reverted css to fix display bug in documentation, example page

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -499,8 +499,7 @@ def generate_example_rst(app):
     <style type="text/css">
     div#sidebarbutton {
         /* hide the sidebar collapser, while ensuring vertical arrangement */
-        width: 0px;
-        overflow: hidden;
+        display: none;
     }
     </style>
 


### PR DESCRIPTION
Revert change introduced by @jnothman in 
https://github.com/scikit-learn/scikit-learn/commit/937f36cba77f18af7b37f0798f76aaeaed0b02d8
causing a big empty space in the documentation, on the example page, after the first example

@jnothman, was this line changed to fix another bug somewhere?
