### PR TITLE
[MRG+1] Various docstring fixes for web docs

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -556,7 +556,7 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
 
         Returns
         -------
-        y: array of shape = [n_samples] or [n_samples, n_outputs]
+        y : array of shape = [n_samples] or [n_samples, n_outputs]
             The predicted values.
         """
         # Check data
@@ -1288,7 +1288,7 @@ class RandomTreesEmbedding(BaseForest):
         If not None then ``max_depth`` will be ignored.
         Note: this parameter is tree-specific.
 
-    sparse_output: bool, optional (default=True)
+    sparse_output : bool, optional (default=True)
         Whether or not to return a sparse CSR matrix, as default behavior,
         or to return a dense array compatible with dense pipeline operators.
 
@@ -1393,7 +1393,7 @@ class RandomTreesEmbedding(BaseForest):
 
         Returns
         -------
-        X_transformed: sparse matrix, shape=(n_samples, n_out)
+        X_transformed : sparse matrix, shape=(n_samples, n_out)
             Transformed dataset.
         """
         # ensure_2d=False because there are actually unit test checking we fail
@@ -1424,7 +1424,7 @@ class RandomTreesEmbedding(BaseForest):
 
         Returns
         -------
-        X_transformed: sparse matrix, shape=(n_samples, n_out)
+        X_transformed : sparse matrix, shape=(n_samples, n_out)
             Transformed dataset.
         """
         return self.one_hot_encoder_.transform(self.apply(X))

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -203,7 +203,7 @@ class LossFunction(six.with_metaclass(ABCMeta, object)):
             The residuals (usually the negative gradient).
         y_pred : np.ndarray, shape=(n,):
             The predictions.
-        sample_weight np.ndarray, shape=(n,):
+        sample_weight : np.ndarray, shape=(n,):
             The weight of each sample.
         """
         # compute leaf for each sample in ``X``.
@@ -1534,7 +1534,7 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
         Returns
         -------
-        y: array of shape = [n_samples]
+        y : array of shape = [n_samples]
             The predicted values.
         """
         return self.decision_function(X).ravel()

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -598,7 +598,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
         combination of L1 and L2.
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If ``False``, the
         data is assumed to be already centered.
 
@@ -619,7 +619,7 @@ class ElasticNet(LinearModel, RegressorMixin):
     copy_X : boolean, optional, default True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    tol: float, optional
+    tol : float, optional
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
@@ -629,7 +629,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
 
-    positive: bool, optional
+    positive : bool, optional
         When set to ``True``, forces the coefficients to be positive.
 
     selection : str, default 'cyclic'
@@ -961,7 +961,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
     path_params : dictionary
         Parameters passed to the path function
 
-    alphas: array-like, optional
+    alphas : array-like, optional
         Array of float that is used for cross-validation. If not
         provided, computed using 'path'
 
@@ -975,7 +975,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
         The order of the arrays expected by the path function to
         avoid memory copies
 
-    dtype: a numpy dtype or None
+    dtype : a numpy dtype or None
         The dtype of the arrays expected by the path function to
         avoid memory copies
     """
@@ -1261,10 +1261,10 @@ class LassoCV(LinearModelCV, RegressorMixin):
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter: int, optional
+    max_iter : int, optional
         The maximum number of iterations
 
-    tol: float, optional
+    tol : float, optional
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -85,22 +85,22 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     verbose : int (default=0)
         Controls output verbosity.
 
-    return_path: bool, (optional=True)
+    return_path : bool, (optional=True)
         If ``return_path==True`` returns the entire path, else returns only the
         last point of the path.
 
     Returns
     --------
-    alphas: array, shape: [n_alphas + 1]
+    alphas : array, shape: [n_alphas + 1]
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter``, ``n_features`` or the
         number of nodes in the path with ``alpha >= alpha_min``, whichever
         is smaller.
 
-    active: array, shape [n_alphas]
+    active : array, shape [n_alphas]
         Indices of active variables at the end of the path.
 
-    coefs: array, shape (n_features, n_alphas + 1)
+    coefs : array, shape (n_features, n_alphas + 1)
         Coefficients along the path
 
     n_iter : int
@@ -486,7 +486,7 @@ class Lars(LinearModel, RegressorMixin):
     copy_X : boolean, optional, default True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    eps: float, optional
+    eps : float, optional
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
@@ -909,7 +909,7 @@ class LarsCV(Lars):
         Number of CPUs to use during the cross validation. If ``-1``, use
         all the CPUs
 
-    eps: float, optional
+    eps : float, optional
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems.
@@ -1067,7 +1067,7 @@ class LassoLarsCV(LarsCV):
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter: integer, optional
+    max_iter : integer, optional
         Maximum number of iterations to perform.
 
     cv : cross-validation generator, optional
@@ -1082,7 +1082,7 @@ class LassoLarsCV(LarsCV):
         Number of CPUs to use during the cross validation. If ``-1``, use
         all the CPUs
 
-    eps: float, optional
+    eps : float, optional
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems.
@@ -1152,7 +1152,7 @@ class LassoLarsIC(LassoLars):
 
     Parameters
     ----------
-    criterion: 'bic' | 'aic'
+    criterion : 'bic' | 'aic'
         The type of criterion to use.
 
     fit_intercept : boolean
@@ -1174,11 +1174,11 @@ class LassoLarsIC(LassoLars):
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter: integer, optional
+    max_iter : integer, optional
         Maximum number of iterations to perform. Can be used for
         early stopping.
 
-    eps: float, optional
+    eps : float, optional
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -356,7 +356,7 @@ def _multinomial_loss_grad_hess(w, X, Y, alpha, sample_weight):
         (n_classes * (n_features + 1),)
         Ravelled gradient of the multinomial loss.
 
-    hessp: callable
+    hessp : callable
         Function that takes in a vector input of shape (n_classes * n_features)
         or (n_classes * (n_features + 1)) and returns matrix-vector product
         with hessian.

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -271,29 +271,29 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
 
     Parameters
     ----------
-    X: array, shape (n_samples, n_features)
+    X : array, shape (n_samples, n_features)
         Input data. Columns are assumed to have unit norm.
 
-    y: array, shape (n_samples,) or (n_samples, n_targets)
+    y : array, shape (n_samples,) or (n_samples, n_targets)
         Input targets
 
-    n_nonzero_coefs: int
+    n_nonzero_coefs : int
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol: float
+    tol : float
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    precompute: {True, False, 'auto'},
+    precompute : {True, False, 'auto'},
         Whether to perform precomputations. Improves performance when n_targets
         or n_samples is very large.
 
-    copy_X: bool, optional
+    copy_X : bool, optional
         Whether the design matrix X must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    return_path: bool, optional. Default: False
+    return_path : bool, optional. Default: False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
@@ -302,7 +302,7 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
 
     Returns
     -------
-    coef: array, shape (n_features,) or (n_features, n_targets)
+    coef : array, shape (n_features,) or (n_features, n_targets)
         Coefficients of the OMP solution. If `return_path=True`, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
@@ -405,32 +405,32 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
 
     Parameters
     ----------
-    Gram: array, shape (n_features, n_features)
+    Gram : array, shape (n_features, n_features)
         Gram matrix of the input data: X.T * X
 
-    Xy: array, shape (n_features,) or (n_features, n_targets)
+    Xy : array, shape (n_features,) or (n_features, n_targets)
         Input targets multiplied by X: X.T * y
 
-    n_nonzero_coefs: int
+    n_nonzero_coefs : int
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol: float
+    tol : float
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    norms_squared: array-like, shape (n_targets,)
+    norms_squared : array-like, shape (n_targets,)
         Squared L2 norms of the lines of y. Required if tol is not None.
 
-    copy_Gram: bool, optional
+    copy_Gram : bool, optional
         Whether the gram matrix must be copied by the algorithm. A false
         value is only helpful if it is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    copy_Xy: bool, optional
+    copy_Xy : bool, optional
         Whether the covariance vector Xy must be copied by the algorithm.
         If False, it may be overwritten.
 
-    return_path: bool, optional. Default: False
+    return_path : bool, optional. Default: False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
@@ -439,7 +439,7 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
 
     Returns
     -------
-    coef: array, shape (n_features,) or (n_features, n_targets)
+    coef : array, shape (n_features,) or (n_features, n_targets)
         Coefficients of the OMP solution. If `return_path=True`, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
@@ -606,7 +606,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
 
         Returns
         -------
-        self: object
+        self : object
             returns an instance of self.
         """
         X = check_array(X)

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -15,26 +15,26 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     C : float
         Maximum step size (regularization). Defaults to 1.0.
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    n_iter: int, optional
+    n_iter : int, optional
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle: bool, optional
+    shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
         Defaults to False.
 
-    random_state: int seed, RandomState instance, or None (default)
+    random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
         shuffling the data.
 
-    verbose: integer, optional
+    verbose : integer, optional
         The verbosity level
 
-    n_jobs: integer, optional
+    n_jobs : integer, optional
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation. -1 means 'all CPUs'. Defaults
         to 1.
@@ -50,8 +50,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
-    n_features]
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
+            n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
@@ -155,27 +155,27 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     C : float
         Maximum step size (regularization). Defaults to 1.0.
 
-    epsilon: float
+    epsilon : float
         If the difference between the current prediction and the correct label
         is below this threshold, the model is not updated.
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    n_iter: int, optional
+    n_iter : int, optional
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle: bool, optional
+    shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
         Defaults to False.
 
-    random_state: int seed, RandomState instance, or None (default)
+    random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
         shuffling the data.
 
-    verbose: integer, optional
+    verbose : integer, optional
         The verbosity level
 
     loss : string, optional
@@ -190,8 +190,8 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
-    n_features]
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
+            n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -18,26 +18,26 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
         Constant that multiplies the regularization term if regularization is
         used. Defaults to 0.0001
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    n_iter: int, optional
+    n_iter : int, optional
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle: bool, optional
+    shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
         Defaults to False.
 
-    random_state: int seed, RandomState instance, or None (default)
+    random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
         shuffling the data.
 
-    verbose: integer, optional
+    verbose : integer, optional
         The verbosity level
 
-    n_jobs: integer, optional
+    n_jobs : integer, optional
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation. -1 means 'all CPUs'. Defaults
         to 1.
@@ -45,7 +45,7 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
     eta0 : double
         Constant by which the updates are multiplied. Defaults to 1.
 
-    class_weight : dict, {class_label : weight} or "auto" or None, optional
+    class_weight : dict, {class_label: weight} or "auto" or None, optional
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes
@@ -60,8 +60,8 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
 
     Attributes
     ----------
-    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,
-    n_features]
+    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
+            n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -385,7 +385,7 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
     n_resampling : int, optional, default=200
         Number of randomized models.
 
-    selection_threshold: float, optional, default=0.25
+    selection_threshold : float, optional, default=0.25
         The score above which features should be selected.
 
     fit_intercept : boolean, optional, default=True

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -240,16 +240,16 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
         All three solvers support both dense and sparse data.
 
-    tol: float
+    tol : float
         Precision of the solution.
 
-    verbose: int
+    verbose : int
         Verbosity level. Setting verbose > 0 will display additional information
         depending on the solver used.
 
     Returns
     -------
-    coef: array, shape = [n_features] or [n_targets, n_features]
+    coef : array, shape = [n_features] or [n_targets, n_features]
         Weight vector(s).
 
     Notes
@@ -888,7 +888,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
 
     Parameters
     ----------
-    alphas: numpy array of shape [n_alphas]
+    alphas : numpy array of shape [n_alphas]
         Array of alpha values to try.
         Small positive values of alpha improve the conditioning of the
         problem and reduce the variance of the estimates.
@@ -972,7 +972,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas: numpy array of shape [n_alphas]
+    alphas : numpy array of shape [n_alphas]
         Array of alpha values to try.
         Small positive values of alpha improve the conditioning of the
         problem and reduce the variance of the estimates.

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -605,27 +605,27 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
         Defaults to 0.15.
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    n_iter: int, optional
+    n_iter : int, optional
         The number of passes over the training data (aka epochs). The number
         of iterations is set to 1 if using partial_fit.
         Defaults to 5.
 
-    shuffle: bool, optional
+    shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
         Defaults to False.
 
-    random_state: int seed, RandomState instance, or None (default)
+    random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
         shuffling the data.
 
-    verbose: integer, optional
+    verbose : integer, optional
         The verbosity level
 
-    epsilon: float
+    epsilon : float
         Epsilon in the epsilon-insensitive loss functions; only if `loss` is
         'huber', 'epsilon_insensitive', or 'squared_epsilon_insensitive'.
         For 'huber', determines the threshold at which it becomes less
@@ -633,7 +633,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
         For epsilon-insensitive, any differences between the current prediction
         and the correct label are ignored if they are less than this threshold.
 
-    n_jobs: integer, optional
+    n_jobs : integer, optional
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation. -1 means 'all CPUs'. Defaults
         to 1.
@@ -652,7 +652,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     power_t : double
         The exponent for inverse scaling learning rate [default 0.5].
 
-    class_weight : dict, {class_label : weight} or "auto" or None, optional
+    class_weight : dict, {class_label: weight} or "auto" or None, optional
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes
@@ -673,8 +673,8 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     Attributes
     ----------
-    coef_ : array, shape (1, n_features) if n_classes == 2 else (n_classes,
-    n_features)
+    coef_ : array, shape (1, n_features) if n_classes == 2 else (n_classes,\
+            n_features)
         Weights assigned to the features.
 
     intercept_ : array, shape (1,) if n_classes == 2 else (n_classes,)
@@ -1114,7 +1114,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
         Defaults to 0.15.
 
-    fit_intercept: bool
+    fit_intercept : bool
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
@@ -1123,18 +1123,18 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
         of iterations is set to 1 if using partial_fit.
         Defaults to 5.
 
-    shuffle: bool, optional
+    shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
         Defaults to False.
 
-    random_state: int seed, RandomState instance, or None (default)
+    random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
         shuffling the data.
 
-    verbose: integer, optional
+    verbose : integer, optional
         The verbosity level.
 
-    epsilon: float
+    epsilon : float
         Epsilon in the epsilon-insensitive loss functions; only if `loss` is
         'huber', 'epsilon_insensitive', or 'squared_epsilon_insensitive'.
         For 'huber', determines the threshold at which it becomes less


### PR DESCRIPTION
Various fixes to get proper formatting (bold, continuation lines & rendering of dicts basically) for the web API docs. Just looked at the `ensemble` and `linear_model` modules so far, but will try to find time to review others in a later PR. Motivated by noticing a lot of formatting problems on http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html
