### PR TITLE
[MRG] Change loss names for LinearSVC and LinearSVR

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -743,8 +743,9 @@ with a svm classifier in a binary class problem::
   >>> est = svm.LinearSVC(random_state=0)
   >>> est.fit(X, y)
   LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-       intercept_scaling=1, loss='l2', max_iter=1000, multi_class='ovr',
-       penalty='l2', random_state=0, tol=0.0001, verbose=0)
+       intercept_scaling=1, loss='squared_hinge', max_iter=1000,
+       multi_class='ovr', penalty='l2', random_state=0, tol=0.0001,
+       verbose=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
   >>> pred_decision  # doctest: +ELLIPSIS
   array([-2.18...,  2.36...,  0.09...])
@@ -760,8 +761,9 @@ with a svm classifier in a multiclass problem::
   >>> est = svm.LinearSVC()
   >>> est.fit(X, Y)
   LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-       intercept_scaling=1, loss='l2', max_iter=1000, multi_class='ovr',
-       penalty='l2', random_state=None, tol=0.0001, verbose=0)
+       intercept_scaling=1, loss='squared_hinge', max_iter=1000,
+       multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
+       verbose=0)
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
   >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -129,8 +129,9 @@ two classes, only one model is trained::
     >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y) # doctest: +NORMALIZE_WHITESPACE
     LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-    intercept_scaling=1, loss='l2', max_iter=1000, multi_class='ovr',
-    penalty='l2', random_state=None, tol=0.0001, verbose=0)
+         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
+         multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
+         verbose=0)
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
     4

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -715,7 +715,7 @@ def test_count_vectorizer_pipeline_grid_selection():
 
     parameters = {
         'vect__ngram_range': [(1, 1), (1, 2)],
-        'svc__loss': ('l1', 'l2')
+        'svc__loss': ('hinge', 'squared_hinge')
     }
 
     # find the best parameters for both the feature extraction and the

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1452,8 +1452,9 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> est = svm.LinearSVC(random_state=0)
     >>> est.fit(X, y)
     LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='l2', max_iter=1000, multi_class='ovr',
-         penalty='l2', random_state=0, tol=0.0001, verbose=0)
+         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
+         multi_class='ovr', penalty='l2', random_state=0, tol=0.0001,
+         verbose=0)
     >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
     >>> pred_decision  # doctest: +ELLIPSIS
     array([-2.18...,  2.36...,  0.09...])
@@ -1467,8 +1468,9 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     >>> est = svm.LinearSVC()
     >>> est.fit(X, Y)
     LinearSVC(C=1.0, class_weight=None, dual=True, fit_intercept=True,
-         intercept_scaling=1, loss='l2', max_iter=1000, multi_class='ovr',
-         penalty='l2', random_state=None, tol=0.0001, verbose=0)
+         intercept_scaling=1, loss='squared_hinge', max_iter=1000,
+         multi_class='ovr', penalty='l2', random_state=None, tol=0.0001,
+         verbose=0)
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
     >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from .base import _fit_liblinear, BaseSVC, BaseLibSVM
@@ -25,9 +26,10 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     C : float, optional (default=1.0)
         Penalty parameter C of the error term.
 
-    loss : string, 'l1' or 'l2' (default='l2')
-        Specifies the loss function. 'l1' is the hinge loss (standard SVM)
-        while 'l2' is the squared hinge loss.
+    loss : string, 'hinge' or 'squared_hinge' (default='squared_hinge')
+        Specifies the loss function. 'hinge' is the standard SVM loss
+        (used e.g. by the SVC class) while 'squared_hinge' is the 
+        square of the hinge loss.
 
     penalty : string, 'l1' or 'l2' (default='l2')
         Specifies the norm used in the penalization. The 'l2'
@@ -141,7 +143,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
 
     """
 
-    def __init__(self, penalty='l2', loss='l2', dual=True, tol=1e-4, C=1.0,
+    def __init__(self, penalty='l2', loss='squared_hinge', dual=True, tol=1e-4, C=1.0,
                  multi_class='ovr', fit_intercept=True, intercept_scaling=1,
                  class_weight=None, verbose=0, random_state=None, max_iter=1000):
         self.penalty = penalty
@@ -180,11 +182,20 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
         self.classes_ = np.unique(y)
+
+        if self.loss in ('l1', 'l2'):
+            # convert for backwards compatibility
+            loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(self.loss)
+            warnings.warn("loss='l1' (resp. loss='l2') is deprecated and will" +
+                          "be removed before version 1.0. Please use loss='hinge'" +
+                          "(resp. loss='squared_hinge') instead", DeprecationWarning)
+        else:
+            loss = self.loss
         self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
             X, y, self.C, self.fit_intercept, self.intercept_scaling,
             self.class_weight, self.penalty, self.dual, self.verbose,
             self.max_iter, self.tol, self.random_state, self.multi_class,
-            self.loss
+            loss
             )
 
         if self.multi_class == "crammer_singer" and len(self.classes_) == 2:
@@ -212,7 +223,8 @@ class LinearSVR(LinearModel, RegressorMixin):
         Penalty parameter C of the error term. The penalty is a squared
         l2 penalty. The bigger this parameter, the less regularization is used.
 
-    loss : string, 'l1' or 'l2' (default='l2')
+    loss : string, 'epsilon_insensitive' or 'squared_epsilon_insensitive' 
+           (default='epsilon_insensitive')
         Specifies the loss function. 'l1' is the epsilon-insensitive loss
         (standard SVR) while 'l2' is the squared epsilon-insensitive loss.
 
@@ -288,9 +300,9 @@ class LinearSVR(LinearModel, RegressorMixin):
         various loss functions and regularization regimes.
     """
 
-    def __init__(self, epsilon=0.0, tol=1e-4, C=1.0, loss='l1', fit_intercept=True,
-                 intercept_scaling=1., dual=True, verbose=0, random_state=None,
-                 max_iter=1000):
+    def __init__(self, epsilon=0.0, tol=1e-4, C=1.0, loss='epsilon_insensitive', 
+                 fit_intercept=True, intercept_scaling=1., dual=True, verbose=0, 
+                 random_state=None, max_iter=1000):
         self.tol = tol
         self.C = C
         self.epsilon = epsilon
@@ -324,11 +336,11 @@ class LinearSVR(LinearModel, RegressorMixin):
                              % self.C)
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
-        loss = {'l1': 'ei', 'l2': 'se'}.get(self.loss)
+        penalty = 'l2' # SVR only accepts L2 penalty
         self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
             X, y, self.C, self.fit_intercept, self.intercept_scaling,
-            None, 'l2', self.dual, self.verbose,
-            self.max_iter, self.tol, self.random_state, loss=loss,
+            None, penalty, self.dual, self.verbose,
+            self.max_iter, self.tol, self.random_state, loss=self.loss,
             epsilon=self.epsilon)
         self.coef_ = self.coef_.ravel()
 
@@ -687,6 +699,9 @@ class SVR(BaseLibSVM, RegressorMixin):
         Support Vector Machine for regression implemented using libsvm
         using a parameter to control the number of support vectors.
 
+    LinearSVR
+        Scalable Linear Support Vector Machine for regression
+        implemented using liblinear.
     """
     def __init__(self, kernel='rbf', degree=3, gamma=0.0, coef0=0.0, tol=1e-3,
                  C=1.0, epsilon=0.1, shrinking=True, cache_size=200,

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -459,14 +459,15 @@ def test_linearsvc_parameters():
     """
     # generate list of possible parameter combinations
     params = [(dual, loss, penalty) for dual in [True, False]
-              for loss in ['l1', 'l2', 'lr'] for penalty in ['l1', 'l2']]
+              for loss in ['hinge', 'squared_hinge', 'logistic_regression']
+              for penalty in ['l1', 'l2']]
 
     X, y = make_classification(n_samples=5, n_features=5)
 
     for dual, loss, penalty in params:
         clf = svm.LinearSVC(penalty=penalty, loss=loss, dual=dual)
-        if (loss == 'l1' and penalty == 'l1') or (
-            loss == 'l1' and penalty == 'l2' and not dual) or (
+        if (loss == 'hinge' and penalty == 'l1') or (
+            loss == 'hinge' and penalty == 'l2' and not dual) or (
             penalty == 'l1' and dual):
             assert_raises(ValueError, clf.fit, X, y)
         else:
@@ -486,7 +487,7 @@ def test_linearsvc():
     assert_array_almost_equal(clf.intercept_, [0], decimal=3)
 
     # the same with l1 penalty
-    clf = svm.LinearSVC(penalty='l1', dual=False, random_state=0).fit(X, Y)
+    clf = svm.LinearSVC(penalty='l1', loss='l2', dual=False, random_state=0).fit(X, Y)
     assert_array_equal(clf.predict(T), true_result)
 
     # l2 penalty with dual formulation


### PR DESCRIPTION
the names are now consistent across methods and with the SGD module

In LinearSVC:
   'l1' -> 'hinge'
   'l2' -> 'squared_hinge'
In LinearSVR:
   'l1' -> 'epsilon_insensitive'
   'l2' -> 'squared_epsilon_insensitive'
