### PR TITLE
[MRG+1] don't set trailing "_" attrs in __init__

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -49,8 +49,7 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
 
         # Don't instantiate estimators now! Parameters of base_estimator might
         # still change. Eg., when grid-searching with the nested object syntax.
-        # This needs to be filled by the derived classes.
-        self.estimators_ = []
+        # self.estimators_ needs to be filled by the derived classes in fit.
 
     def _validate_estimator(self, default=None):
         """Check the estimator and the n_estimator attribute, set the

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -225,7 +225,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
 
         random_state = check_random_state(self.random_state)
 
-        if not self.warm_start:
+        if not self.warm_start or not hasattr(self, "estimators_"):
             # Free allocated memory, if any
             self.estimators_ = []
 
@@ -292,7 +292,8 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
         -------
         feature_importances_ : array, shape = [n_features]
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
+        if (getattr(self, "estimators_", None) is None
+                or len(self.estimators_) == 0):
             raise ValueError("Estimator not fitted, "
                              "call `fit` before `feature_importances_`.")
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -710,8 +710,6 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         self.max_leaf_nodes = max_leaf_nodes
         self.warm_start = warm_start
 
-        self.estimators_ = np.empty((0, 0), dtype=np.object)
-
     def _fit_stage(self, i, X, y, y_pred, sample_weight, sample_mask,
                    criterion, splitter, random_state):
         """Fit another stage of ``n_classes_`` trees to the boosting model. """
@@ -1037,7 +1035,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
     def _init_decision_function(self, X):
         """Check input and compute prediction of ``init``. """
-        if self.estimators_ is None or len(self.estimators_) == 0:
+
+        if len(getattr(self, "estimators_", [])) == 0:
             raise ValueError("Estimator not fitted, call `fit` "
                              "before making predictions`.")
         if X.shape[1] != self.n_features:
@@ -1109,7 +1108,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         -------
         feature_importances_ : array, shape = [n_features]
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
+        if len(getattr(self, "estimators_", [])) == 0:
             raise ValueError("Estimator not fitted, "
                              "call `fit` before `feature_importances_`.")
 

--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -119,7 +119,7 @@ def partial_dependence(gbrt, target_variables, grid=None, X=None,
     """
     if not isinstance(gbrt, BaseGradientBoosting):
         raise ValueError('gbrt has to be an instance of BaseGradientBoosting')
-    if gbrt.estimators_.shape[0] == 0:
+    if len(getattr(gbrt, "estimators_", [])) == 0:
         raise ValueError('Call %s.fit before partial_dependence' %
                          gbrt.__class__.__name__)
     if (grid is None and X is None) or (grid is not None and X is not None):

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -678,7 +678,6 @@ class ElasticNet(LinearModel, RegressorMixin):
                  random_state=None, selection='cyclic'):
         self.alpha = alpha
         self.l1_ratio = l1_ratio
-        self.coef_ = None
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.precompute = precompute
@@ -687,7 +686,6 @@ class ElasticNet(LinearModel, RegressorMixin):
         self.tol = tol
         self.warm_start = warm_start
         self.positive = positive
-        self.intercept_ = 0.0
         self.random_state = random_state
         self.selection = selection
 
@@ -742,7 +740,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         if self.selection not in ['cyclic', 'random']:
             raise ValueError("selection should be either random or cyclic.")
 
-        if not self.warm_start or self.coef_ is None:
+        if not self.warm_start or getattr(self, "coef_", None) is None:
             coef_ = np.zeros((n_targets, n_features), dtype=np.float64,
                              order='F')
         else:
@@ -1612,7 +1610,6 @@ class MultiTaskElasticNet(Lasso):
                  warm_start=False, random_state=None, selection='cyclic'):
         self.l1_ratio = l1_ratio
         self.alpha = alpha
-        self.coef_ = None
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.max_iter = max_iter
@@ -1786,7 +1783,6 @@ class MultiTaskLasso(MultiTaskElasticNet):
                  copy_X=True, max_iter=1000, tol=1e-4, warm_start=False,
                  random_state=None, selection='cyclic'):
         self.alpha = alpha
-        self.coef_ = None
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.max_iter = max_iter

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -72,15 +72,6 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
 
         self._validate_params()
 
-        self.coef_ = None
-
-        if self.average > 0:
-            self.standard_coef_ = None
-            self.average_coef_ = None
-        # iteration count for learning rate schedule
-        # must not be int (e.g. if ``learning_rate=='optimal'``)
-        self.t_ = None
-
     def set_params(self, *args, **kwargs):
         super(BaseSGD, self).set_params(*args, **kwargs)
         self._validate_params()
@@ -346,7 +337,6 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                                                 warm_start=warm_start,
                                                 average=average)
         self.class_weight = class_weight
-        self.classes_ = None
         self.n_jobs = int(n_jobs)
 
     def _partial_fit(self, X, y, alpha, C,
@@ -367,7 +357,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                                                            self.classes_, y)
         sample_weight = self._validate_sample_weight(sample_weight, n_samples)
 
-        if self.coef_ is None or coef_init is not None:
+        if getattr(self, "coef_", None) is None or coef_init is not None:
             self._allocate_parameter_mem(n_classes, n_features,
                                          coef_init, intercept_init)
         elif n_features != self.coef_.shape[-1]:
@@ -375,7 +365,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                              % (n_features, self.coef_.shape[-1]))
 
         self.loss_function = self._get_loss_function(loss)
-        if self.t_ is None:
+        if getattr(self, "t_", None) is None:
             self.t_ = 1.0
 
         # delegate to concrete training procedure
@@ -395,7 +385,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
 
     def _fit(self, X, y, alpha, C, loss, learning_rate, coef_init=None,
              intercept_init=None, sample_weight=None):
-        if hasattr(self, "classes_"):
+        if getattr(self, "classes_", None) is not None:
             self.classes_ = None
 
         X, y = check_X_y(X, y, 'csr', dtype=np.float64, order="C")
@@ -405,7 +395,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         # np.unique sorts in asc order; largest class id is positive class
         classes = np.unique(y)
 
-        if self.warm_start and self.coef_ is not None:
+        if self.warm_start and getattr(self, "coef_", None) is not None:
             if coef_init is None:
                 coef_init = self.coef_
             if intercept_init is None:
@@ -421,7 +411,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
             self.average_intercept_ = None
 
         # Clear iteration count for multiple call to fit.
-        self.t_ = None
+        self.t_ = 1.0
 
         self._partial_fit(X, y, alpha, C, loss, learning_rate, self.n_iter,
                           classes, sample_weight, coef_init, intercept_init)
@@ -868,13 +858,13 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         # Allocate datastructures from input arguments
         sample_weight = self._validate_sample_weight(sample_weight, n_samples)
 
-        if self.coef_ is None:
+        if getattr(self, "coef_", None) is None:
             self._allocate_parameter_mem(1, n_features,
                                          coef_init, intercept_init)
         elif n_features != self.coef_.shape[-1]:
             raise ValueError("Number of features %d does not match previous data %d."
                              % (n_features, self.coef_.shape[-1]))
-        if self.average > 0 and self.average_coef_ is None:
+        if self.average > 0 and getattr(self, "average_coef_", None) is None:
             self.average_coef_ = np.zeros(n_features,
                                           dtype=np.float64,
                                           order="C")
@@ -914,7 +904,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
 
     def _fit(self, X, y, alpha, C, loss, learning_rate, coef_init=None,
              intercept_init=None, sample_weight=None):
-        if self.warm_start and self.coef_ is not None:
+        if self.warm_start and getattr(self, "coef_", None) is not None:
             if coef_init is None:
                 coef_init = self.coef_
             if intercept_init is None:
@@ -930,7 +920,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
             self.average_intercept_ = None
 
         # Clear iteration count for multiple call to fit.
-        self.t_ = None
+        self.t_ = 1.0
 
         return self._partial_fit(X, y, alpha, C, loss, learning_rate,
                                  self.n_iter, sample_weight,
@@ -1007,7 +997,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         penalty_type = self._get_penalty_type(self.penalty)
         learning_rate_type = self._get_learning_rate_type(learning_rate)
 
-        if self.t_ is None:
+        if getattr(self, "t_", None) is None:
             self.t_ = 1.0
 
         random_state = check_random_state(self.random_state)

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -92,11 +92,11 @@ class Isomap(BaseEstimator, TransformerMixin):
         self.max_iter = max_iter
         self.path_method = path_method
         self.neighbors_algorithm = neighbors_algorithm
-        self.nbrs_ = NearestNeighbors(n_neighbors=n_neighbors,
-                                      algorithm=neighbors_algorithm)
 
     def _fit_transform(self, X):
         X = check_array(X)
+        self.nbrs_ = NearestNeighbors(n_neighbors=self.n_neighbors,
+                                      algorithm=self.neighbors_algorithm)
         self.nbrs_.fit(X)
         self.training_data_ = self.nbrs_._fit_X
         self.kernel_pca_ = KernelPCA(n_components=self.n_components,

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -244,12 +244,6 @@ class GMM(BaseEstimator):
         if n_init < 1:
             raise ValueError('GMM estimation requires at least one run')
 
-        self.weights_ = np.ones(self.n_components) / self.n_components
-
-        # flag to indicate exit status of fit() method: converged (True) or
-        # n_iter reached (False)
-        self.converged_ = False
-
     def _get_covars(self):
         """Covariance parameters for each mixture component.
         The shape depends on `cvtype`::

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -296,9 +296,6 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
         self.dense_output = dense_output
         self.random_state = random_state
 
-        self.components_ = None
-        self.n_components_ = None
-
     @abstractmethod
     def _make_random_matrix(n_components, n_features):
         """ Generate the random projection matrix
@@ -358,7 +355,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
         else:
             if self.n_components <= 0:
                 raise ValueError("n_components must be greater than 0, got %s"
-                                 % self.n_components_)
+                                 % self.n_components)
 
             elif self.n_components > n_features:
                 warnings.warn(
@@ -401,7 +398,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         X = check_array(X, accept_sparse=['csr', 'csc'])
 
-        if self.components_ is None:
+        if getattr(self, "components_", None) is None:
             raise ValueError('No random projection matrix had been fit.')
 
         if X.shape[1] != self.components_.shape[1]:
@@ -585,7 +582,6 @@ class SparseRandomProjection(BaseRandomProjection):
             random_state=random_state)
 
         self.density = density
-        self.density_ = None
 
     def _make_random_matrix(self, n_components, n_features):
         """ Generate the random projection matrix

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -50,6 +50,7 @@ from sklearn.utils.estimator_checks import (
     check_class_weight_auto_linear_classifier,
     check_estimators_overwrite_params,
     check_estimators_partial_fit_n_features,
+    check_no_fit_attributes_set_in_init,
     check_cluster_overwrite_params,
     check_sparsify_binary_classifier,
     check_sparsify_multiclass_classifier,
@@ -294,6 +295,54 @@ def test_estimators_overwrite_params():
                 # FIXME!
                 # in particular GaussianProcess!
                 yield check_estimators_overwrite_params, name, Estimator
+
+
+# These are the known trailing-_ properties on current estimators.
+#
+# Such properties cause hasattr(estimator, "param_") to return True even if
+# fit has not yet been called, making it harder to check whether the estimator
+# has been properly fitted to data, but we allow these for backwards compat.
+#
+# If you're sure you need to add such a property, list it here.
+_KNOWN_PROPERTIES = {
+    'AdaBoostClassifier': ['feature_importances_'],
+    'AdaBoostRegressor': ['feature_importances_'],
+    'BernoulliNB': ['coef_', 'intercept_'],
+    'DecisionTreeClassifier': ['feature_importances_'],
+    'DecisionTreeRegressor': ['feature_importances_'],
+    'ElasticNet': ['sparse_coef_'],
+    'ExtraTreeClassifier': ['feature_importances_'],
+    'ExtraTreeRegressor': ['feature_importances_'],
+    'ExtraTreesClassifier': ['feature_importances_'],
+    'ExtraTreesRegressor': ['feature_importances_'],
+    'GradientBoostingClassifier': ['feature_importances_'],
+    'GradientBoostingRegressor': ['feature_importances_'],
+    'Lasso': ['sparse_coef_'],
+    'MultinomialNB': ['coef_', 'intercept_'],
+    'MultiTaskLasso': ['sparse_coef_'],
+    'MultiTaskElasticNet': ['sparse_coef_'],
+    'NuSVC': ['coef_'],
+    'NuSVR': ['coef_'],
+    'OneClassSVM': ['coef_'],
+    'RandomForestClassifier': ['feature_importances_'],
+    'RandomForestRegressor': ['feature_importances_'],
+    'RidgeClassifier': ['classes_'],
+    'RidgeClassifierCV': ['classes_'],
+    'SpectralBiclustering': ['biclusters_'],
+    'SpectralCoclustering': ['biclusters_'],
+    'SVC': ['coef_'],
+    'SVR': ['coef_'],
+    'TfidfVectorizer': ['idf_'],
+}
+
+
+def test_no_fit_attributes_set_in_init():
+    # Assert that estimators do not set fit attributes (ending in "_")
+    # at initialization time.
+    for name, Estimator in all_estimators():
+        if name not in ['_BaseHMM', "GaussianHMM", "GMMHMM", 'MultinomialHMM']:
+            yield (check_no_fit_attributes_set_in_init,
+                   name, Estimator, _KNOWN_PROPERTIES.get(name, []))
 
 
 @ignore_warnings

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -91,14 +91,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         self.random_state = random_state
         self.max_leaf_nodes = max_leaf_nodes
 
-        self.n_features_ = None
-        self.n_outputs_ = None
-        self.classes_ = None
-        self.n_classes_ = None
-
-        self.tree_ = None
-        self.max_features_ = None
-
     def fit(self, X, y, sample_weight=None, check_input=True):
         """Build a decision tree from the training set (X, y).
 
@@ -365,7 +357,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         -------
         feature_importances_ : array, shape = [n_features]
         """
-        if self.tree_ is None:
+        if getattr(self, "tree_", None) is None:
             raise ValueError("Estimator not fitted, "
                              "call `fit` before `feature_importances_`.")
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import META_ESTIMATORS
@@ -802,6 +803,22 @@ def check_estimators_overwrite_params(name, Estimator):
                      "Estimator %s changes its parameter %s"
                      " from %s to %s during fit."
                      % (name, k, v, new_params[k]))
+
+
+def check_no_fit_attributes_set_in_init(name, Estimator, allowed_properties):
+    """Check that Estimator.__init__ doesn't set trailing-_ attributes.
+
+    allowed_properties is a set of attribute names that are allowed to be
+    on the Estimator class as properties.
+    """
+    estimator = Estimator()
+    for attr in dir(estimator):
+        if attr.endswith("_") and not attr.startswith("_"):
+            assert_true(hasattr(Estimator, attr),
+                        "%s set by __init__ in %s" % (attr, name))
+            assert_true(isinstance(getattr(Estimator, attr), property),
+                        "attribute %s on %s not a property" % (attr, name))
+            assert_in(attr, allowed_properties)
 
 
 def check_cluster_overwrite_params(name, Clustering):


### PR DESCRIPTION
As I said over at gh-3627, 

> we need to fix all the `__init__`s that set final-underscore attributes. Some of them set those to None or similar values. [...] we should do a systematic search of the codebase and introduce a smoke test.

I did just that.

Note: code uses `getattr(self, "someattr_", None) is None` instead of `hasattr`, in an attempt to be backwards compatible with pickled estimators that have these attributes. I'm not sure how important that is (who would pickle before fit?) and unpickling is not tested.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/3937)

<!-- Reviewable:end -->
