### PR TITLE
[MRG+1] GaussianNB.partial_fit - Raise ValueError when there is a mismatch between target and classes argument

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -28,6 +28,7 @@ from .utils import check_X_y, check_array
 from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils.multiclass import _check_partial_fit_first_call
 from .externals import six
+from .utils.fixes import in1d
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB']
 
@@ -303,9 +304,18 @@ class GaussianNB(BaseNB):
             # Put epsilon back in each time
             self.sigma_[:, :] -= epsilon
 
-        class2idx = dict((cls, idx) for idx, cls in enumerate(self.classes_))
-        for y_i in np.unique(y):
-            i = class2idx[y_i]
+        classes = self.classes_
+        
+        unique_y = np.unique(y)
+        unique_y_in_classes = in1d(unique_y, classes)
+        
+        if not np.all(unique_y_in_classes):
+             raise ValueError(
+                     "The target label(s) %s in y do not exist in the "
+                     "initial classes %s" % (y[~unique_y_in_classes], classes))
+       
+        for y_i in unique_y:
+            i = classes.searchsorted(y_i)
             X_i = X[y == y_i, :]
             N_i = X_i.shape[0]
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -47,6 +47,10 @@ def test_gnb():
     y_pred_log_proba = clf.predict_log_proba(X)
     assert_array_almost_equal(np.log(y_pred_proba), y_pred_log_proba, 8)
 
+    # Test whether label mismatch between target y and classes raises
+    # an Error
+    # FIXME Remove this test once the more general partial_fit tests are merged
+    assert_raises(ValueError, GaussianNB().partial_fit, X, y, classes=[0, 1])
 
 def test_gnb_prior():
     """Test whether class priors are properly set. """


### PR DESCRIPTION
In `GaussianNB.partial_fit`, when there is a mismatch between the target labels (or classes) `y` and the `classes` argument, a `KeyError` was raised while attempting to access the `class2idx` ( refactored to `class_to_index` for readability ) with the mismatching key.

Sample code that reproduces this `KeyError`
`gnb.partial_fit(X = [[1,2], [-2,2]], y = [1,2], classes = [0,1])`
- Now a `ValueError` with a message explaining that is raised.
  `ValueError: The target label in y does not exist in the initial classes argument, classes=[0, 1]; The conflicting target label is 2`
- Added NRT to test the same.

@GaelVaroquaux Could you take a look at this?
