### PR TITLE
[MRG + 1] Fix problem with non positive definite covariance matrices in GMM

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -688,9 +688,10 @@ def _covar_mstep_full(gmm, X, responsibilities, weighted_X_sum, norm,
         post = responsibilities[:, c]
         # Underflow Errors in doing post * X.T are  not important
         np.seterr(under='ignore')
-        avg_cv = np.dot(post * X.T, X) / (post.sum() + 10 * EPS)
-        mu = gmm.means_[c][np.newaxis]
-        cv[c] = (avg_cv - np.dot(mu.T, mu) + min_covar * np.eye(n_features))
+        mu = gmm.means_[c]
+        diff = X - mu
+        avg_cv = np.dot(post * diff.T, diff) / (post.sum() + 10 * EPS)
+        cv[c] = avg_cv + min_covar * np.eye(n_features)
     return cv
 
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -686,11 +686,11 @@ def _covar_mstep_full(gmm, X, responsibilities, weighted_X_sum, norm,
     cv = np.empty((gmm.n_components, n_features, n_features))
     for c in range(gmm.n_components):
         post = responsibilities[:, c]
-        # Underflow Errors in doing post * X.T are  not important
-        np.seterr(under='ignore')
         mu = gmm.means_[c]
         diff = X - mu
-        avg_cv = np.dot(post * diff.T, diff) / (post.sum() + 10 * EPS)
+        with np.errstate(under='ignore'):
+            # Underflow Errors in doing post * X.T are  not important
+            avg_cv = np.dot(post * diff.T, diff) / (post.sum() + 10 * EPS)
         cv[c] = avg_cv + min_covar * np.eye(n_features)
     return cv
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -382,7 +382,7 @@ def check_positive_definite_covars(covariance_type):
 
 
 def test_positive_definite_covars():
-    """Check positive definiteness for all covariance types"""
+    # Check positive definiteness for all covariance types
     for covariance_type in ["full", "tied", "diag", "spherical"]:
         yield check_positive_definite_covars, covariance_type
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -337,23 +337,23 @@ def test_aic():
 def _test_positive_definite_covars(covariance_type):
     """ Test that covariance matrices do not become non positive definite
 
-Due to the accumulation of round-off errors, the computation of the covariance
-matrices during the learning phase could lead to non-positive definite
-covariance matrices. Namely the use of the formula:
+    Due to the accumulation of round-off errors, the computation of the
+    covariance  matrices during the learning phase could lead to non-positive
+    definite covariance matrices. Namely the use of the formula:
 
-.. math:: C = (\\sum_i w_i \\boldsymbol x_i \\boldsymbol x_i^T)
-          - \\boldsymbol \\mu \\boldsymbol \\mu^T
+    .. math:: C = (\\sum_i w_i \\boldsymbol x_i \\boldsymbol x_i^T)
+              - \\boldsymbol \\mu \\boldsymbol \\mu^T
 
-instead of:
+    instead of:
 
-.. math:: C = \\sum_i w_i (\\boldsymbol x_i - \\boldsymbol \\mu)
-              (\\boldsymbol x_i - \\boldsymbol \\mu)^T
+    .. math:: C = \\sum_i w_i (\\boldsymbol x_i - \\boldsymbol \\mu)
+                  (\\boldsymbol x_i - \\boldsymbol \\mu)^T
 
-while mathematically equivalent, was observed a ``LinAlgError`` exception,
-when computing a ``GMM`` with full covariance matrices and fixed mean.
+    while mathematically equivalent, was observed a ``LinAlgError`` exception,
+    when computing a ``GMM`` with full covariance matrices and fixed mean.
 
-This function ensures that some later optimization will not introduce the
-problem again.
+    This function ensures that some later optimization will not introduce the
+    problem again.
 """
     rng = np.random.RandomState(1)
     # we build a dataset with 2 2d component. The components are unbalanced
@@ -399,7 +399,6 @@ def test_positive_definite_covars_diag():
 def test_positive_definite_covars_spherical():
     """ Test that the spherical covariance matrices are positive definite """
     _test_positive_definite_covars("spherical")
-
 
 
 if __name__ == '__main__':

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -7,6 +7,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
+from sklearn.utils.testing import assert_greater
 
 rng = np.random.RandomState(0)
 
@@ -334,20 +335,19 @@ def test_aic():
         assert_true(np.abs(g.bic(X) - bic) / n_samples < bound)
 
 
-def _test_positive_definite_covars(covariance_type):
-    """ Test that covariance matrices do not become non positive definite
+def check_positive_definite_covars(covariance_type):
+    r""" Test that covariance matrices do not become non positive definite
 
     Due to the accumulation of round-off errors, the computation of the
     covariance  matrices during the learning phase could lead to non-positive
     definite covariance matrices. Namely the use of the formula:
 
-    .. math:: C = (\\sum_i w_i \\boldsymbol x_i \\boldsymbol x_i^T)
-              - \\boldsymbol \\mu \\boldsymbol \\mu^T
+    .. math:: C = (\sum_i w_i  x_i x_i^T)
+              - \mu \mu^T
 
     instead of:
 
-    .. math:: C = \\sum_i w_i (\\boldsymbol x_i - \\boldsymbol \\mu)
-                  (\\boldsymbol x_i - \\boldsymbol \\mu)^T
+    .. math:: C = \sum_i w_i (x_i - \mu)(x_i - \mu)^T
 
     while mathematically equivalent, was observed a ``LinAlgError`` exception,
     when computing a ``GMM`` with full covariance matrices and fixed mean.
@@ -364,12 +364,13 @@ def _test_positive_definite_covars(covariance_type):
     gmm = mixture.GMM(2, params="wc", covariance_type=covariance_type,
                       min_covar=1e-3)
 
-    # The following line can raise an exception with  full covariance matrices
-    # due to the use of the Cholesky decomposition when computing the density.
+    # This is a non-regression test for issue #2640. The following call used
+    # to trigger:
+    # numpy.linalg.linalg.LinAlgError: 2-th leading minor not positive definite
     gmm.fit(X)
 
     if covariance_type == "diag" or covariance_type == "spherical":
-        assert(gmm.covars_.min() > 0)
+        assert_greater(gmm.covars_.min(), 0)
     else:
         if covariance_type == "tied":
             covs = [gmm.covars_]
@@ -377,28 +378,13 @@ def _test_positive_definite_covars(covariance_type):
             covs = gmm.covars_
 
         for c in covs:
-            w, u = np.linalg.eigh(c)
-            assert(w.min() > 0)
+            assert_greater(np.linalg.det(c), 0)
 
 
-def test_positive_definite_covars_full():
-    """ Test that the full covariance matrices are positive definite """
-    _test_positive_definite_covars("full")
-
-
-def test_positive_definite_covars_tied():
-    """ Test that the tied covariance matrix is positive definite """
-    _test_positive_definite_covars("tied")
-
-
-def test_positive_definite_covars_diag():
-    """ Test that the diagonal covariance matrices are positive definite """
-    _test_positive_definite_covars("diag")
-
-
-def test_positive_definite_covars_spherical():
-    """ Test that the spherical covariance matrices are positive definite """
-    _test_positive_definite_covars("spherical")
+def test_positive_definite_covars():
+    """Check positive definiteness for all covariance types"""
+    for covariance_type in ["full", "tied", "diag", "spherical"]:
+        check_positive_definite_covars(covariance_type)
 
 
 if __name__ == '__main__':

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -334,6 +334,74 @@ def test_aic():
         assert_true(np.abs(g.bic(X) - bic) / n_samples < bound)
 
 
+def _test_positive_definite_covars(covariance_type):
+    """ Test that covariance matrices do not become non positive definite
+
+Due to the accumulation of round-off errors, the computation of the covariance
+matrices during the learning phase could lead to non-positive definite
+covariance matrices. Namely the use of the formula:
+
+.. math:: C = (\\sum_i w_i \\boldsymbol x_i \\boldsymbol x_i^T)
+          - \\boldsymbol \\mu \\boldsymbol \\mu^T
+
+instead of:
+
+.. math:: C = \\sum_i w_i (\\boldsymbol x_i - \\boldsymbol \\mu)
+              (\\boldsymbol x_i - \\boldsymbol \\mu)^T
+
+while mathematically equivalent, was observed a ``LinAlgError`` exception,
+when computing a ``GMM`` with full covariance matrices and fixed mean.
+
+This function ensures that some later optimization will not introduce the
+problem again.
+"""
+    rng = np.random.RandomState(1)
+    # we build a dataset with 2 2d component. The components are unbalanced
+    # (respective weights 0.9 and 0.1)
+    X = rng.randn(100, 2)
+    X[-10:] += (3, 3)  # Shift the 10 last points
+
+    gmm = mixture.GMM(2, params="wc", covariance_type=covariance_type,
+                      min_covar=1e-3)
+
+    # The following line can raise an exception with  full covariance matrices
+    # due to the use of the Cholesky decomposition when computing the density.
+    gmm.fit(X)
+
+    if covariance_type == "diag" or covariance_type == "spherical":
+        assert(gmm.covars_.min() > 0)
+    else:
+        if covariance_type == "tied":
+            covs = [gmm.covars_]
+        else:
+            covs = gmm.covars_
+
+        for c in covs:
+            w, u = np.linalg.eigh(c)
+            assert(w.min() > 0)
+
+
+def test_positive_definite_covars_full():
+    """ Test that the full covariance matrices are positive definite """
+    _test_positive_definite_covars("full")
+
+
+def test_positive_definite_covars_tied():
+    """ Test that the tied covariance matrix is positive definite """
+    _test_positive_definite_covars("tied")
+
+
+def test_positive_definite_covars_diag():
+    """ Test that the diagonal covariance matrices are positive definite """
+    _test_positive_definite_covars("diag")
+
+
+def test_positive_definite_covars_spherical():
+    """ Test that the spherical covariance matrices are positive definite """
+    _test_positive_definite_covars("spherical")
+
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -384,7 +384,7 @@ def check_positive_definite_covars(covariance_type):
 def test_positive_definite_covars():
     """Check positive definiteness for all covariance types"""
     for covariance_type in ["full", "tied", "diag", "spherical"]:
-        check_positive_definite_covars(covariance_type)
+        yield check_positive_definite_covars, covariance_type
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Due to round off errors, the formula used to compute the weighted covariance matrix may lead to matrices with large negative eigenvalues.

The formula is:
C = \sum_i w_i (x_i - \mu)(x_i - \mu)'                         (1)
C = (\sum_i w_i x_i x_i')  - \mu \mu'                           (2)

assuming \sum_i w_i = 1 and \mu = \sum_i w_i x_i

The second formula does not guarantee that C is positive definite.

The fix may have as a side effect to increase the memory consumption since a new array containing the difference (X - mu) is created and may take longer to compute.
