### PR TITLE
[MRG] clarify RandomTreesEmbedding docstring

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -1250,10 +1250,12 @@ class RandomTreesEmbedding(BaseForest):
     An unsupervised transformation of a dataset to a high-dimensional
     sparse representation. A datapoint is coded according to which leaf of
     each tree it is sorted into. Using a one-hot encoding of the leaves,
-    this leads to a binary coding with as many ones as trees in the forest.
+    this leads to a binary coding with as many ones as there are trees in
+    the forest.
 
-    The dimensionality of the resulting representation is approximately
-    ``n_estimators * 2 ** max_depth``.
+    The dimensionality of the resulting representation is
+    ``n_out <= n_estimators * max_leaf_nodes``. If ``max_leaf_nodes == None``,
+    the number of leaf nodes is at most ``n_estimators * 2 ** max_depth``.
 
     Parameters
     ----------
@@ -1268,25 +1270,21 @@ class RandomTreesEmbedding(BaseForest):
 
     min_samples_split : integer, optional (default=2)
         The minimum number of samples required to split an internal node.
-        Note: this parameter is tree-specific.
 
     min_samples_leaf : integer, optional (default=1)
         The minimum number of samples in newly created leaves.  A split is
         discarded if after the split, one of the leaves would contain less then
         ``min_samples_leaf`` samples.
-        Note: this parameter is tree-specific.
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
         leaf node.
-        Note: this parameter is tree-specific.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
         Best nodes are defined as relative reduction in impurity.
         If None then unlimited number of leaf nodes.
         If not None then ``max_depth`` will be ignored.
-        Note: this parameter is tree-specific.
 
     sparse_output : bool, optional (default=True)
         Whether or not to return a sparse CSR matrix, as default behavior,


### PR DESCRIPTION
I noticed `n_out` was mentioned in some method docstrings, but never defined. Also, noting that parameters are tree-specific isn't necessary in a tree-specific ensemble :)

@glouppe @arjoly Care to give this a quick look?
