### PR TITLE
[MRG+1] ENH: Allow connectivity to be a callable in AgglomerativeClutering et.al

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -135,6 +135,10 @@ Enhancements
    - :func:`neighbors.kneighbors_graph` and :func:`radius_neighbors_graph`
      support non-Euclidean metrics. By `Manoj Kumar`_
 
+   - Parameter ``connectivity`` in :class:`cluster.AgglomerativeClustering`
+     and family now accept callables that return a connectivity matrix.
+     By `Manoj Kumar`_.
+
 Documentation improvements
 ..........................
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -525,15 +525,13 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     n_clusters : int, default=2
         The number of clusters to find.
 
-    connectivity : int, array-like, callable, optional
+    connectivity : array-like, callable, optional
         Connectivity matrix. Defines for each sample the neighboring
         samples following a given structure of the data.
         This can be a connectivity matrix itself, a callable that transforms
         the data into a connectivity matrix, such as derived from
-        kneighbors_graph or an integer. If an integer is provided, then
-        each sample point is connected to its connectivity nearest neighbors
-        in Euclidean space. Default is None, i.e, the hierarchical clustering
-        algorithm is unstructured.
+        kneighbors_graph. Default is None, i.e, the
+        hierarchical clustering algorithm is unstructured.
 
     affinity : string or callable, default: "euclidean"
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
@@ -636,10 +634,9 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         if self.connectivity is not None:
             if callable(self.connectivity):
                 connectivity = self.connectivity(X)
-            elif isinstance(connectivity, int):
-                connectivity = kneighbors_graph(
-                    X, n_neighbors=self.connectivity)
-            # Unnecessary check if an int is provided but we can live with it.
+            if not sparse.isspmatrix(connectivity) or not (
+                isinstance(connectivity, np.ndarray)):
+                connectivity = sparse.lil_matrix(connectivity)
             if (connectivity.shape[0] != X.shape[0] or
                     connectivity.shape[1] != X.shape[0]):
                 raise ValueError("`connectivity` does not have shape "
@@ -692,11 +689,13 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     n_clusters : int, default 2
         The number of clusters to find.
 
-    connectivity : sparse matrix, optional
+    connectivity : array-like, callable, optional
         Connectivity matrix. Defines for each feature the neighboring
         features following a given structure of the data.
-        Default is None, i.e, the hierarchical clustering algorithm is
-        unstructured.
+        This can be a connectivity matrix itself, a callable that transforms
+        the data into a connectivity matrix, such as derived from
+        kneighbors_graph. Default is None, i.e, the
+        hierarchical clustering algorithm is unstructured.
 
     affinity : string or callable, default "euclidean"
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
@@ -861,14 +860,13 @@ class WardAgglomeration(AgglomerationTransform, Ward):
     n_clusters : int or ndarray
         The number of clusters.
 
-    connectivity : int, array-like, callable, optional, default None
+    connectivity : array-like, callable, optional
         Connectivity matrix. Defines for each sample the neighboring
         samples following a given structure of the data.
-        This can be a connectivity matrix itself, a callable that returns
-        a connectivity matrix or an integer. If an integer is provided,
-        then a kneighbors_graph is used by default.
-        Default is None, i.e, the hierarchical clustering algorithm is
-        unstructured.
+        This can be a connectivity matrix itself, a callable that transforms
+        the data into a connectivity matrix, such as derived from
+        kneighbors_graph. Default is None, i.e, the
+        hierarchical clustering algorithm is unstructured.
 
     memory : Instance of joblib.Memory or string, optional
         Used to cache the output of the computation of the tree.

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -23,7 +23,6 @@ from ..utils.sparsetools import connected_components
 
 from . import _hierarchical
 from ._feature_agglomeration import AgglomerationTransform
-from ..neighbors.graph import kneighbors_graph
 from ..utils.fast_dict import IntFloatDict
 
 if sys.version_info[0] > 2:
@@ -525,10 +524,10 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     n_clusters : int, default=2
         The number of clusters to find.
 
-    connectivity : array-like, callable, optional
+    connectivity : array-like or callable, optional
         Connectivity matrix. Defines for each sample the neighboring
         samples following a given structure of the data.
-        This can be a connectivity matrix itself, a callable that transforms
+        This can be a connectivity matrix itself or a callable that transforms
         the data into a connectivity matrix, such as derived from
         kneighbors_graph. Default is None, i.e, the
         hierarchical clustering algorithm is unstructured.
@@ -634,13 +633,8 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         if self.connectivity is not None:
             if callable(self.connectivity):
                 connectivity = self.connectivity(X)
-            if not sparse.isspmatrix(connectivity) or not (
-                isinstance(connectivity, np.ndarray)):
-                connectivity = sparse.lil_matrix(connectivity)
-            if (connectivity.shape[0] != X.shape[0] or
-                    connectivity.shape[1] != X.shape[0]):
-                raise ValueError("`connectivity` does not have shape "
-                                 "(n_samples, n_samples)")
+            connectivity = check_array(
+                connectivity, accept_sparse=['csr', 'coo', 'lil'])
 
         n_samples = len(X)
         compute_full_tree = self.compute_full_tree
@@ -689,10 +683,10 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
     n_clusters : int, default 2
         The number of clusters to find.
 
-    connectivity : array-like, callable, optional
+    connectivity : array-like or callable, optional
         Connectivity matrix. Defines for each feature the neighboring
         features following a given structure of the data.
-        This can be a connectivity matrix itself, a callable that transforms
+        This can be a connectivity matrix itself or a callable that transforms
         the data into a connectivity matrix, such as derived from
         kneighbors_graph. Default is None, i.e, the
         hierarchical clustering algorithm is unstructured.
@@ -860,10 +854,10 @@ class WardAgglomeration(AgglomerationTransform, Ward):
     n_clusters : int or ndarray
         The number of clusters.
 
-    connectivity : array-like, callable, optional
+    connectivity : array-like or callable, optional
         Connectivity matrix. Defines for each sample the neighboring
         samples following a given structure of the data.
-        This can be a connectivity matrix itself, a callable that transforms
+        This can be a connectivity matrix itself or a callable that transforms
         the data into a connectivity matrix, such as derived from
         kneighbors_graph. Default is None, i.e, the
         hierarchical clustering algorithm is unstructured.

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -340,12 +340,9 @@ def test_connectivity_callable():
     aglc1 = AgglomerativeClustering(connectivity=connectivity)
     aglc2 = AgglomerativeClustering(
         connectivity=partial(kneighbors_graph, n_neighbors=3))
-    aglc3 = AgglomerativeClustering(connectivity=3)
     aglc1.fit(X)
     aglc2.fit(X)
-    aglc3.fit(X)
     assert_array_equal(aglc1.labels_, aglc2.labels_)
-    assert_array_equal(aglc2.labels_, aglc3.labels_)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/3851 (It was marked easy, but I went ahead and fixed it)

The current AgglomerativeClustering conditions connectivity on the input data, which is prevents the reuse of the model for different data (if connectivity is provided initially) and definitely not in a pipeline where the input data is modified (as pointed by @jnothman ).

This fixes it by allowing it to be an int or a callable. If an int, then the kneighbors_graph is used.
