### PR TITLE
 Use correct savefig arguments in gen_rst.py

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -881,8 +881,16 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                 for fig_mngr in fig_managers:
                     # Set the fig_num figure as the current figure as we can't
                     # save a figure that's not the current figure.
-                    plt.figure(fig_mngr.num)
-                    plt.savefig(image_path % fig_mngr.num)
+                    fig = plt.figure(fig_mngr.num)
+                    kwargs = {}
+                    to_rgba = matplotlib.colors.colorConverter.to_rgba
+                    for attr in ['facecolor', 'edgecolor']:
+                        fig_attr = getattr(fig, 'get_' + attr)()
+                        default_attr = matplotlib.rcParams['figure.' + attr]
+                        if to_rgba(fig_attr) != to_rgba(default_attr):
+                            kwargs[attr] = fig_attr
+
+                    fig.savefig(image_path % fig_mngr.num, **kwargs)
                     figure_list.append(image_fname % fig_mngr.num)
             except:
                 print(80 * '_')


### PR DESCRIPTION
Only pass facecolor/edgecolor arguments to savefig when they are different
than rcParams['figure.facecolor']/rcParams['figure.edgecolor']
From nilearn
