### PR TITLE
Fix usability issue in metrics.classification_report.

### DIFF
--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -2041,7 +2041,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
                                                   sample_weight=sample_weight)
 
     for i, label in enumerate(labels):
-        values = [target_names[i]]
+        values = [target_names[label]]
         for v in (p[i], r[i], f1[i]):
             values += ["{0:0.2f}".format(v)]
         values += ["{0}".format(s[i])]


### PR DESCRIPTION
Fix usability issue in metrics.classification_report.
In following codes, 'class 0' and 'class 1' will be printed, while 'class 0' and 'class 2' are expected.

``` python
y_true = [0, 0, 2, 0, 0]
y_pred = [0, 2, 2, 0, 0]
target_names = ['class 0', 'class 1', 'class 2']
print(metrics.classification_report(y_true, y_pred, target_names=target_names))

== console ==
             precision    recall  f1-score   support

    class 0       1.00      0.75      0.86         4
    class 1       0.50      1.00      0.67         1

avg / total       0.90      0.80      0.82         5
```

In real world, we don't know which label will be included in y_true or y_pred, since those may come from random subset using KFold. So include all the label names in 'target_names' is safer and more intuitive.
