### PR TITLE
[MRG+1] change default to shuffle=True in SGDClassifier.

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -63,7 +63,7 @@ a linear algorithm, for example a linear SVM::
     SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
            eta0=0.0, fit_intercept=True, l1_ratio=0.15,
            learning_rate='optimal', loss='hinge', n_iter=5, n_jobs=1,
-           penalty='l2', power_t=0.5, random_state=None, shuffle=False,
+           penalty='l2', power_t=0.5, random_state=None, shuffle=True,
            verbose=0, warm_start=False)
     >>> clf.score(X_features, y)
     1.0

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1105,7 +1105,7 @@ This way, we can solve the XOR problem with a linear classifier::
            [1, 0, 1, 0],
            [1, 1, 0, 0],
            [1, 1, 1, 1]])
-    >>> clf = Perceptron(fit_intercept=False, n_iter=10).fit(X, y)
+    >>> clf = Perceptron(fit_intercept=False, n_iter=10, shuffle=False).fit(X, y)
     >>> clf.score(X, y)
     1.0
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -64,7 +64,7 @@ for the training samples::
     SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
            eta0=0.0, fit_intercept=True, l1_ratio=0.15,
            learning_rate='optimal', loss='hinge', n_iter=5, n_jobs=1,
-           penalty='l2', power_t=0.5, random_state=None, shuffle=False,
+           penalty='l2', power_t=0.5, random_state=None, shuffle=True,
            verbose=0, warm_start=False)
 
 
@@ -76,21 +76,21 @@ After being fitted, the model can then be used to predict new values::
 SGD fits a linear model to the training data. The member ``coef_`` holds
 the model parameters::
 
-    >>> clf.coef_
-    array([[ 9.91080278,  9.91080278]])
+    >>> clf.coef_                                         # doctest: +ELLIPSIS
+    array([[ 9.9...,  9.9...]])
 
 Member ``intercept_`` holds the intercept (aka offset or bias)::
 
     >>> clf.intercept_                                    # doctest: +ELLIPSIS
-    array([-9.990...])
+    array([-9.9...])
 
 Whether or not the model should use an intercept, i.e. a biased
 hyperplane, is controlled by the parameter ``fit_intercept``.
 
 To get the signed distance to the hyperplane use :meth:`SGDClassifier.decision_function`::
 
-    >>> clf.decision_function([[2., 2.]])
-    array([ 29.65318117])
+    >>> clf.decision_function([[2., 2.]])                 # doctest: +ELLIPSIS
+    array([ 29.6...])
 
 The concrete loss function can be set via the ``loss``
 parameter. :class:`SGDClassifier` supports the following loss functions:
@@ -110,8 +110,8 @@ Using ``loss="log"`` or ``loss="modified_huber"`` enables the
 :math:`P(y|x)` per sample :math:`x`::
 
     >>> clf = SGDClassifier(loss="log").fit(X, y)
-    >>> clf.predict_proba([[1., 1.]])
-    array([[ 0.0000005,  0.9999995]])
+    >>> clf.predict_proba([[1., 1.]])                      # doctest: +ELLIPSIS
+    array([[ 0.00...,  0.99...]])
 
 The concrete penalty can be set via the ``penalty`` parameter.
 SGD supports the following penalties:

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -351,7 +351,7 @@ classifier object into our pipeline::
   >>> text_clf = Pipeline([('vect', CountVectorizer()),
   ...                      ('tfidf', TfidfTransformer()),
   ...                      ('clf', SGDClassifier(loss='hinge', penalty='l2',
-  ...                                            alpha=1e-3, n_iter=5)),
+  ...                                            alpha=1e-3, n_iter=5, random_state=42)),
   ... ])
   >>> _ = text_clf.fit(twenty_train.data, twenty_train.target)
   >>> predicted = text_clf.predict(docs_test)
@@ -367,19 +367,20 @@ analysis of the results::
   ...                                         # doctest: +NORMALIZE_WHITESPACE
                           precision    recall  f1-score   support
   <BLANKLINE>
-             alt.atheism       0.94      0.82      0.87       319
-           comp.graphics       0.88      0.98      0.92       389
-                 sci.med       0.95      0.89      0.92       396
-  soc.religion.christian       0.90      0.95      0.92       398
+             alt.atheism       0.95      0.81      0.87       319
+           comp.graphics       0.88      0.97      0.92       389
+                 sci.med       0.94      0.90      0.92       396
+  soc.religion.christian       0.90      0.95      0.93       398
   <BLANKLINE>
              avg / total       0.92      0.91      0.91      1502
   <BLANKLINE>
 
   >>> metrics.confusion_matrix(twenty_test.target, predicted)
-  array([[261,  10,  12,  36],
-         [  5, 380,   2,   2],
-         [  7,  32, 353,   4],
-         [  6,  11,   4, 377]])
+  array([[258,  11,  15,  35],
+         [  4, 379,   3,   3],
+         [  5,  33, 355,   3],
+         [  5,  10,   4, 379]])
+
 
 As expected the confusion matrix shows that posts from the newsgroups
 on atheism and christian are more often confused for one another than
@@ -459,7 +460,7 @@ we can do::
   vect__ngram_range: (1, 1)
 
   >>> score                                              # doctest: +ELLIPSIS
-  0.902...
+  0.900...
 
 .. note:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -413,6 +413,12 @@ API changes summary
       data (less than 1 sample or less than 1 feature for 2D input).
       By `Olivier Grisel`_.
 
+
+    - The ``shuffle`` option of :class:`.linear_model.SGDClassifier`,
+      :class:`linear_model.SGDRegressor`, :class:`linear_model.Perceptron`,
+      :class:`linear_model.PassiveAgressiveClassivier` and
+      :class:`linear_model.PassiveAgressiveRegressor` now defaults to ``True``.
+
 .. _changes_0_15_2:
 
 0.15.2

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -15,17 +15,16 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     C : float
         Maximum step size (regularization). Defaults to 1.0.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=False
         Whether the intercept should be estimated or not. If False, the
-        data is assumed to be already centered. Defaults to True.
+        data is assumed to be already centered.
 
     n_iter : int, optional
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle : bool, optional
+    shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
-        Defaults to False.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -71,7 +70,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     """
     def __init__(self, C=1.0, fit_intercept=True,
-                 n_iter=5, shuffle=False, verbose=0, loss="hinge",
+                 n_iter=5, shuffle=True, verbose=0, loss="hinge",
                  n_jobs=1, random_state=None, warm_start=False):
         BaseSGDClassifier.__init__(self,
                                    penalty=None,
@@ -163,9 +162,8 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle : bool, optional
+    shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
-        Defaults to False.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -205,7 +203,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     K. Crammer, O. Dekel, J. Keshat, S. Shalev-Shwartz, Y. Singer - JMLR (2006)
 
     """
-    def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=False,
+    def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, loss="epsilon_insensitive",
                  epsilon=DEFAULT_EPSILON, random_state=None, class_weight=None,
                  warm_start=False):

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -26,9 +26,8 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
         The number of passes over the training data (aka epochs).
         Defaults to 5.
 
-    shuffle : bool, optional
+    shuffle : bool, optional, default True
         Whether or not the training data should be shuffled after each epoch.
-        Defaults to False.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -85,7 +84,7 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
     http://en.wikipedia.org/wiki/Perceptron and references therein.
     """
     def __init__(self, penalty=None, alpha=0.0001, fit_intercept=True,
-                 n_iter=5, shuffle=False, verbose=0, eta0=1.0, n_jobs=1,
+                 n_iter=5, shuffle=True, verbose=0, eta0=1.0, n_jobs=1,
                  random_state=0, class_weight=None, warm_start=False):
         super(Perceptron, self).__init__(loss="perceptron",
                                          penalty=penalty,

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -51,7 +51,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
     """Base class for SGD classification and regression."""
 
     def __init__(self, loss, penalty='l2', alpha=0.0001, C=1.0,
-                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, epsilon=0.1, random_state=None,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
                  warm_start=False, average=False):
@@ -331,7 +331,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
 
     @abstractmethod
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001, l1_ratio=0.15,
-                 fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
+                 fit_intercept=True, n_iter=5, shuffle=True, verbose=0,
                  epsilon=DEFAULT_EPSILON, n_jobs=1, random_state=None,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
                  class_weight=None, warm_start=False, average=False):
@@ -627,7 +627,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
-        Defaults to False.
+        Defaults to True.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -704,7 +704,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
             eta0=0.0, fit_intercept=True, l1_ratio=0.15,
             learning_rate='optimal', loss='hinge', n_iter=5, n_jobs=1,
-            penalty='l2', power_t=0.5, random_state=None, shuffle=False,
+            penalty='l2', power_t=0.5, random_state=None, shuffle=True,
             verbose=0, warm_start=False)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
@@ -716,7 +716,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     """
 
     def __init__(self, loss="hinge", penalty='l2', alpha=0.0001, l1_ratio=0.15,
-                 fit_intercept=True, n_iter=5, shuffle=False, verbose=0,
+                 fit_intercept=True, n_iter=5, shuffle=True, verbose=0,
                  epsilon=DEFAULT_EPSILON, n_jobs=1, random_state=None,
                  learning_rate="optimal", eta0=0.0, power_t=0.5,
                  class_weight=None, warm_start=False, average=False):
@@ -853,7 +853,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
 
     @abstractmethod
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
-                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, epsilon=DEFAULT_EPSILON, random_state=None,
                  learning_rate="invscaling", eta0=0.01, power_t=0.25,
                  warm_start=False, average=False):
@@ -1141,7 +1141,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
 
     shuffle : bool, optional
         Whether or not the training data should be shuffled after each epoch.
-        Defaults to False.
+        Defaults to True.
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
@@ -1208,7 +1208,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
     SGDRegressor(alpha=0.0001, average=False, epsilon=0.1, eta0=0.01,
                  fit_intercept=True, l1_ratio=0.15, learning_rate='invscaling',
                  loss='squared_loss', n_iter=5, penalty='l2', power_t=0.25,
-                 random_state=None, shuffle=False, verbose=0, warm_start=False)
+                 random_state=None, shuffle=True, verbose=0, warm_start=False)
 
     See also
     --------
@@ -1216,7 +1216,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
 
     """
     def __init__(self, loss="squared_loss", penalty="l2", alpha=0.0001,
-                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=False,
+                 l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, epsilon=DEFAULT_EPSILON, random_state=None,
                  learning_rate="invscaling", eta0=0.01, power_t=0.25,
                  warm_start=False, average=False):

--- a/sklearn/linear_model/tests/test_passive_aggressive.py
+++ b/sklearn/linear_model/tests/test_passive_aggressive.py
@@ -113,7 +113,7 @@ def test_classifier_correctness():
             clf2 = PassiveAggressiveClassifier(C=1.0,
                                                loss=loss,
                                                fit_intercept=True,
-                                               n_iter=2)
+                                               n_iter=2, shuffle=False)
             clf2.fit(data, y_bin)
 
             assert_array_almost_equal(clf1.w, clf2.coef_.ravel(), decimal=2)
@@ -168,7 +168,7 @@ def test_regressor_correctness():
             reg2 = PassiveAggressiveRegressor(C=1.0,
                                               loss=loss,
                                               fit_intercept=True,
-                                              n_iter=2)
+                                              n_iter=2, shuffle=False)
             reg2.fit(data, y_bin)
 
             assert_array_almost_equal(reg1.w, reg2.coef_.ravel(), decimal=2)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -483,7 +483,7 @@ def test_ovo_ties():
     # not defaulting to the smallest label
     X = np.array([[1, 2], [2, 1], [-2, 1], [-2, -1]])
     y = np.array([2, 0, 1, 2])
-    multi_clf = OneVsOneClassifier(Perceptron())
+    multi_clf = OneVsOneClassifier(Perceptron(shuffle=False))
     ovo_prediction = multi_clf.fit(X, y).predict(X)
     ovo_decision = multi_clf.decision_function(X)
 
@@ -510,7 +510,7 @@ def test_ovo_ties2():
     # cycle through labels so that each label wins once
     for i in range(3):
         y = (y_ref + i) % 3
-        multi_clf = OneVsOneClassifier(Perceptron())
+        multi_clf = OneVsOneClassifier(Perceptron(shuffle=False))
         ovo_prediction = multi_clf.fit(X, y).predict(X)
         assert_equal(ovo_prediction[0], i % 3)
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -599,7 +599,7 @@ def check_classifiers_train(name, Classifier):
         assert_equal(y_pred.shape, (n_samples,))
         # training set performance
         if name not in ['BernoulliNB', 'MultinomialNB']:
-            assert_greater(accuracy_score(y, y_pred), 0.85)
+            assert_greater(accuracy_score(y, y_pred), 0.83)
 
         # raises error on malformed input for predict
         assert_raises(ValueError, classifier.predict, X.T)
@@ -791,6 +791,8 @@ def check_regressors_train(name, Regressor):
     if not hasattr(regressor, 'alphas') and hasattr(regressor, 'alpha'):
         # linear regressors need to set alpha, but not generalized CV ones
         regressor.alpha = 0.01
+    if name == 'PassiveAggressiveRegressor':
+        regressor.C = 0.01
 
     # raises error on malformed input for fit
     assert_raises(ValueError, regressor.fit, X, y[:-1])
@@ -809,6 +811,7 @@ def check_regressors_train(name, Regressor):
     # and furthermore assumes the presence of outliers, hence
     # skipped
     if name not in ('PLSCanonical', 'CCA', 'RANSACRegressor'):
+        print(regressor)
         assert_greater(regressor.score(X, y_), 0.5)
 
 
@@ -862,7 +865,7 @@ def check_class_weight_classifiers(name, Classifier):
         set_random_state(classifier)
         classifier.fit(X_train, y_train)
         y_pred = classifier.predict(X_test)
-        assert_greater(np.mean(y_pred == 0), 0.9)
+        assert_greater(np.mean(y_pred == 0), 0.89)
 
 
 def check_class_weight_auto_classifiers(name, Classifier, X_train, y_train,


### PR DESCRIPTION
See #3960.
Tests fail because they seem to rely on iris being sorted, which makes me question their validity somewhat. At least that is true for `test_large_regularization`.
