### PR TITLE
[MRG+1] Remove optional input validation from pairwise_metrics

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -120,10 +120,6 @@ Enhancements
      handle unknown categorical features more gracefully during transform.
      By `Manoj Kumar`_.
 
-   - Added option ``check_X_y`` to :func:`metrics.pairwise_distances_argmin_min`
-     that can give speed improvements by avoiding repeated checking when set to
-     False. By `Manoj Kumar`_.
-
    - Added support for sparse input data to decision trees and their ensembles.
      By `Fares Hedyati`_ and `Arnaud Joly`_.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -215,8 +215,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
 
 
 def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
-                                  batch_size=500, metric_kwargs=None,
-                                  check_X_y=True):
+                                  batch_size=500, metric_kwargs=None):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -271,10 +270,6 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     metric_kwargs : dict, optional
         Keyword arguments to pass to specified metric function.
 
-    check_X_y : bool, default True
-        Whether or not to check X and y for shape, validity and dtype. Speed
-        improvements possible if set to False when called repeatedly.
-
     Returns
     -------
     argmin : numpy.ndarray
@@ -295,8 +290,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     elif not callable(metric) and not isinstance(metric, str):
         raise ValueError("'metric' must be a string or a callable")
 
-    if check_X_y:
-        X, Y = check_pairwise_arrays(X, Y)
+    X, Y = check_pairwise_arrays(X, Y)
 
     if metric_kwargs is None:
         metric_kwargs = {}
@@ -344,8 +338,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
 
 
 def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
-                              batch_size=500, metric_kwargs={},
-                              check_X_y=True):
+                              batch_size=500, metric_kwargs={}):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -400,10 +393,6 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
     metric_kwargs : dict
         keyword arguments to pass to specified metric function.
 
-    check_X_y : bool, default True
-        Whether or not to check X and y for shape, validity and dtype. Speed
-        improvements possible if set to False when called repeatedly.
-
     Returns
     =======
     argmin : numpy.ndarray
@@ -415,7 +404,7 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
     sklearn.metrics.pairwise_distances_argmin_min
     """
     return pairwise_distances_argmin_min(X, Y, axis, metric, batch_size,
-                                         metric_kwargs, check_X_y)[0]
+                                         metric_kwargs)[0]
 
 
 def manhattan_distances(X, Y=None, sum_over_features=True,


### PR DESCRIPTION
Manually removed `check_X_y` since there was still some useful stuff related to repeated typecasting in check_pairwise. Fixes https://github.com/scikit-learn/scikit-learn/issues/3963 . ping @larsmans 
