### PR TITLE
[MRG] Connect only required components in fixing the connectivity matrix

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -67,19 +67,18 @@ def _fix_connectivity(X, connectivity, n_components=None,
                       "stopping the tree early." % n_components,
                       stacklevel=2)
         # XXX: Can we do without completing the matrix?
-        for i in xrange(n_components):
+        for i in xrange(1, n_components):
             idx_i = np.where(labels == i)[0]
             Xi = X[idx_i]
-            for j in xrange(i):
-                idx_j = np.where(labels == j)[0]
-                Xj = X[idx_j]
-                D = pairwise_distances(Xi, Xj, metric=affinity)
-                ii, jj = np.where(D == np.min(D))
-                ii = ii[0]
-                jj = jj[0]
-                connectivity[idx_i[ii], idx_j[jj]] = True
-                connectivity[idx_j[jj], idx_i[ii]] = True
-        n_components = 1
+            j = i - 1
+            idx_j = np.where(labels == j)[0]
+            Xj = X[idx_j]
+            D = pairwise_distances(Xi, Xj, metric=affinity)
+            ii, jj = np.where(D == np.min(D))
+            ii = ii[0]
+            jj = jj[0]
+            connectivity[idx_i[ii], idx_j[jj]] = True
+            connectivity[idx_j[jj], idx_i[ii]] = True
 
     return connectivity
 


### PR DESCRIPTION
This is the beginning of some minor optimisations as I'm working through the agglomerative code. The previous code in fixing the connectivity matrix, looped through all components to complete the connectivity matrix.

For example, if there are 3 components, it connects, 1 - 0 , 2 - 1, 2 - 0, 3 - 2, 3 - 1, 3 - 0
Is it not sufficient to connect 1 - 0, 2 - 1 and 3 - 2, to make sure all components are connected? Sorry if this PR was out of place.
