### PR TITLE
[MRG] DOC: Minor Improvement to `children_ attribute` in AgglomerativeClustering

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -125,12 +125,11 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None):
     -------
     children : 2D array, shape (n_nodes, 2)
         The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A value `i` greater than or equal to
-        `n_samples` is a non-leaf node and has children
-        `children_[i - n_samples]`.
-        The index refers to the height when two nodes are merged.
-        For instance, children_[0] refers to the nodes that were closest to
-        each other and hence were merged first and so on.
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_samples` is a non-leaf
+        node and has children `children_[i - n_samples]`. Alternatively
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_samples + i`
 
     n_components : int
         The number of connected components in the graph.
@@ -301,12 +300,11 @@ def linkage_tree(X, connectivity=None, n_components=None,
     -------
     children : 2D array, shape (n_nodes, 2)
         The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A value `i` greater than or equal to
-        `n_samples` is a non-leaf node and has children
-        `children_[i - n_samples]`.
-        The index refers to the height when two nodes are merged.
-        For instance, children_[0] refers to the nodes that were closest to
-        each other and hence were merged first and so on.
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_samples` is a non-leaf
+        node and has children `children_[i - n_samples]`. Alternatively
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_samples + i`
 
     n_components : int
         The number of connected components in the graph.
@@ -589,12 +587,11 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
 
     children_ : array-like, shape (n_nodes, 2)
         The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A value `i` greater than or equal to
-        `n_samples` is a non-leaf node and has children
-        `children_[i - n_samples]`.
-        The index refers to the height when two nodes are merged.
-        For instance, children_[0] refers to the nodes that were closest to
-        each other and hence were merged first and so on.
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_samples` is a non-leaf
+        node and has children `children_[i - n_samples]`. Alternatively
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_samples + i`
 
     """
 
@@ -749,13 +746,12 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         The estimated number of connected components in the graph.
 
     children_ : array-like, shape (n_nodes, 2)
-        The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A value `i` greater than or equal to
-        `n_samples` is a non-leaf node and has children
-        `children_[i - n_features]`.
-        The index refers to the height when two nodes are merged.
-        For instance, children_[0] refers to the nodes that were closest to
-        each other and hence were merged first and so on.
+        The children of each non-leaf node. Values less than `n_features`
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_features` is a non-leaf
+        node and has children `children_[i - n_features]`. Alternatively
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_features + i`
     """
 
     def fit(self, X, y=None, **params):
@@ -892,13 +888,12 @@ class WardAgglomeration(AgglomerationTransform, Ward):
     Attributes
     ----------
     children_ : array-like, shape (n_nodes, 2)
-        The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A value `i` greater than or equal to
-        `n_samples` is a non-leaf node and has children
-        `children_[i - n_features]`.
-        The index refers to the height when two nodes are merged.
-        For instance, children_[0] refers to the nodes that were closest to
-        each other and hence were merged first and so on.
+        The children of each non-leaf node. Values less than `n_features`
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_features` is a non-leaf
+        node and has children `children_[i - n_features]`. Alternatively
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_features + i`
 
     labels_ : array [n_features]
         cluster labels for each feature

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -124,9 +124,13 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None):
     Returns
     -------
     children : 2D array, shape (n_nodes, 2)
-        The children of each non-leaf node. Values less than `n_samples` refer
-        to leaves of the tree. A greater value `i` indicates a node with
-        children `children[i - n_samples]`.
+        The children of each non-leaf node. Values less than `n_samples`
+        refer to leaves of the tree. A value `i` greater than or equal to
+        `n_samples` is a non-leaf node and has children
+        `children_[i - n_samples]`.
+        The index refers to the height when two nodes are merged.
+        For instance, children_[0] refers to the nodes that were closest to
+        each other and hence were merged first and so on.
 
     n_components : int
         The number of connected components in the graph.
@@ -296,9 +300,13 @@ def linkage_tree(X, connectivity=None, n_components=None,
     Returns
     -------
     children : 2D array, shape (n_nodes, 2)
-        The children of each non-leaf node. Values less than `n_samples` refer
-        to leaves of the tree. A greater value `i` indicates a node with
-        children `children[i - n_samples]`.
+        The children of each non-leaf node. Values less than `n_samples`
+        refer to leaves of the tree. A value `i` greater than or equal to
+        `n_samples` is a non-leaf node and has children
+        `children_[i - n_samples]`.
+        The index refers to the height when two nodes are merged.
+        For instance, children_[0] refers to the nodes that were closest to
+        each other and hence were merged first and so on.
 
     n_components : int
         The number of connected components in the graph.
@@ -579,10 +587,15 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     n_components_ : int
         The estimated number of connected components in the graph.
 
-    children_ : array-like, shape = [n_nodes, 2]
+    children_ : array-like, shape (n_nodes, 2)
         The children of each non-leaf node. Values less than `n_samples`
-        refer to leaves of the tree. A greater value `i` indicates a node with
-        children `children_[i - n_samples]`.
+        refer to leaves of the tree. A value `i` greater than or equal to
+        `n_samples` is a non-leaf node and has children
+        `children_[i - n_samples]`.
+        The index refers to the height when two nodes are merged.
+        For instance, children_[0] refers to the nodes that were closest to
+        each other and hence were merged first and so on.
+
     """
 
     def __init__(self, n_clusters=2, affinity="euclidean",
@@ -736,9 +749,13 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         The estimated number of connected components in the graph.
 
     children_ : array-like, shape (n_nodes, 2)
-        The children of each non-leaf node. Values less than `n_features`
-        refer to leaves of the tree. A greater value `i` indicates a node with
-        children `children_[i - n_features]`.
+        The children of each non-leaf node. Values less than `n_samples`
+        refer to leaves of the tree. A value `i` greater than or equal to
+        `n_samples` is a non-leaf node and has children
+        `children_[i - n_features]`.
+        The index refers to the height when two nodes are merged.
+        For instance, children_[0] refers to the nodes that were closest to
+        each other and hence were merged first and so on.
     """
 
     def fit(self, X, y=None, **params):
@@ -813,7 +830,7 @@ class Ward(AgglomerativeClustering):
     n_components_ : int
         The estimated number of connected components in the graph.
 
-    children_ : array-like, shape = [n_nodes, 2]
+    children_ : array-like, shape (n_nodes, 2)
         The children of each non-leaf node. Values less than `n_samples`
         refer to leaves of the tree. A greater value `i` indicates a node with
         children `children_[i - n_samples]`.
@@ -874,10 +891,14 @@ class WardAgglomeration(AgglomerationTransform, Ward):
 
     Attributes
     ----------
-    children_ : array-like, shape = [n_nodes, 2]
-        The children of each non-leaf node. Values less than `n_samples` refer
-        to leaves of the tree. A greater value `i` indicates a node with
-        children `children_[i - n_samples]`.
+    children_ : array-like, shape (n_nodes, 2)
+        The children of each non-leaf node. Values less than `n_samples`
+        refer to leaves of the tree. A value `i` greater than or equal to
+        `n_samples` is a non-leaf node and has children
+        `children_[i - n_features]`.
+        The index refers to the height when two nodes are merged.
+        For instance, children_[0] refers to the nodes that were closest to
+        each other and hence were merged first and so on.
 
     labels_ : array [n_features]
         cluster labels for each feature


### PR DESCRIPTION
I'm sorry if this was obvious, but I had trouble in finding that it worked out this way without reading the code.

ping @agramfort 
