### PR TITLE
[MRG] FIX: Fix bug in computing full tree when n_clusters is large

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -214,6 +214,12 @@ Bug fixes
       l2 regularization and large learning rate values).
       By `Olivier Grisel`_
 
+    - When `compute_full_tree` is set to "auto", the full tree is
+      built when n_clusters is high and is early stopped when n_clusters is
+      low, while the behavor should be vice-versa in
+      :class:`cluster.AgglomerativeClustering` (and friends).
+      This has been fixed By `Manoj Kumar`_
+
 API changes summary
 -------------------
 

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -689,7 +689,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             # Early stopping is likely to give a speed up only for
             # a large number of clusters. The actual threshold
             # implemented here is heuristic
-            compute_full_tree = self.n_clusters > max(100, .02 * n_samples)
+            compute_full_tree = self.n_clusters < max(100, .02 * n_samples)
         n_clusters = self.n_clusters
         if compute_full_tree:
             n_clusters = None


### PR DESCRIPTION
There was a bug where compute_full_tree was set to True when `n_clusters` greater than 100 or 0.02 \* n_samples. It should be reverse, the tree should not be computed fully when n_clusters is very large, since it spoils the purpose.
