### PR TITLE
[MRG] ENH: Return distances option for linkage_trees

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,8 @@ Enhancements
    - Add option ``return_distance`` in :func:`hierarchical.ward_tree`
      to return distances between nodes for both structured and unstructured
      versions of the algorithm. By `Matteo Visconti di Oleggio Castello`_.
+     The same option was added in :func:`hierarchical.linkage_tree`.
+     By `Manoj Kumar`_
 
    - Add support for sample weights in scorer objects.  Metrics with sample
      weight support will automatically benefit from it. By `Noel Dawe`_ and

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -358,6 +358,12 @@ def linkage_tree(X, connectivity=None, n_components=None,
         The parent of each node. Only returned when a connectivity matrix
         is specified, elsewhere 'None' is returned.
 
+    distances : ndarray, shape (n_nodes,)
+        Returned when return_distance is set to True.
+
+        distances[i] refers to the distance between children[i][0] and
+        children[i][1] when they are merged.
+
     See also
     --------
     ward_tree : hierarchical clustering with ward linkage

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -235,7 +235,7 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
     used_node = np.ones(n_nodes, dtype=bool)
     children = []
     if return_distance:
-        distances = []
+        distances = np.empty(n_nodes - n_samples)
 
     not_visited = np.empty(n_nodes, dtype=np.int8, order='C')
 
@@ -250,7 +250,7 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
         children.append((i, j))
         used_node[i] = used_node[j] = False
         if return_distance:  # store inertia value
-            distances.append(inert)
+            distances[k - n_samples] = inert
 
         # update the moments
         moments_1[k] = moments_1[i] + moments_1[j]
@@ -286,7 +286,7 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
 
     if return_distance:
         # 2 is scaling factor to compare w/ unstructured version
-        distances = np.sqrt(2. * np.array(distances))
+        distances = np.sqrt(2. * distances)
         return children, n_components, n_leaves, parent, distances
     else:
         return children, n_components, n_leaves, parent
@@ -294,7 +294,8 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
 
 # average and complete linkage
 def linkage_tree(X, connectivity=None, n_components=None,
-                 n_clusters=None, linkage='complete', affinity="euclidean"):
+                 n_clusters=None, linkage='complete', affinity="euclidean",
+                 return_distance=False):
     """Linkage agglomerative clustering based on a Feature matrix.
 
     The inertia matrix uses a Heapq-based representation.
@@ -336,6 +337,9 @@ def linkage_tree(X, connectivity=None, n_components=None,
     affinity : string or callable, optional, default: "euclidean".
         which metric to use. Can be "euclidean", "manhattan", or any
         distance know to paired distance (see metric.pairwise)
+
+    return_distance : bool, default False
+        whether or not to return the distances between the clusters.
 
     Returns
     -------
@@ -403,6 +407,10 @@ def linkage_tree(X, connectivity=None, n_components=None,
             X = X[i, j]
         out = hierarchy.linkage(X, method=linkage, metric=affinity)
         children_ = out[:, :2].astype(np.int)
+
+        if return_distance:
+            distances = out[:, 2]
+            return children_, 1, n_samples, None, distances
         return children_, 1, n_samples, None
 
     connectivity = _fix_connectivity(X, connectivity,
@@ -429,6 +437,8 @@ def linkage_tree(X, connectivity=None, n_components=None,
         assert n_clusters <= n_samples
         n_nodes = 2 * n_samples - n_clusters
 
+    if return_distance:
+        distances = np.empty(n_nodes - n_samples)
     # create inertia heap and connection matrix
     A = np.empty(n_nodes, dtype=object)
     inertia = list()
@@ -462,6 +472,11 @@ def linkage_tree(X, connectivity=None, n_components=None,
                 break
         i = edge.a
         j = edge.b
+
+        if return_distance:
+            # store distances
+            distances[k - n_samples] = edge.weight
+
         parent[i] = parent[j] = k
         children.append((i, j))
         # Keep track of the number of elements per cluster
@@ -484,10 +499,13 @@ def linkage_tree(X, connectivity=None, n_components=None,
 
     # Separate leaves in children (empty lists up to now)
     n_leaves = n_samples
-    children = np.array(children)  # return numpy array for efficient caching
 
+    # # return numpy array for efficient caching
+    children = np.array(children)[:, ::-1]
+
+    if return_distance:
+        return children, n_components, n_leaves, parent, distances
     return children, n_components, n_leaves, parent
-
 
 # Matching names to tree-building strategies
 def _complete_linkage(*args, **kwargs):

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -335,7 +335,8 @@ def test_ward_linkage_tree_return_distance():
 
         for linkage in ['average', 'complete']:
             structured_items = linkage_tree(
-                X, connectivity, linkage=linkage, return_distance=True)[-1]
+                X, connectivity=connectivity, linkage=linkage,
+                return_distance=True)[-1]
             unstructured_items = linkage_tree(
                 X, linkage=linkage, return_distance=True)[-1]
             structured_dist = structured_items[-1]
@@ -343,7 +344,8 @@ def test_ward_linkage_tree_return_distance():
             structured_children = structured_items[0]
             unstructured_children = unstructured_items[0]
             assert_array_almost_equal(structured_dist, unstructured_dist)
-            assert_array_almost_equal(structured_children, unstructured_children)
+            assert_array_almost_equal(
+                structured_children, unstructured_children)
 
     # test on the following dataset where we know the truth
     # taken from scipy/cluster/tests/hierarchy_test_data.py
@@ -360,6 +362,20 @@ def test_ward_linkage_tree_return_distance():
                                [6., 8., 9.10208346, 4.],
                                [7., 9., 24.7784379, 6.]])
 
+    linkage_X_complete = np.array(
+        [[3., 4., 0.36265956, 2.],
+         [1., 5., 1.77045373, 2.],
+         [0., 2., 2.55760419, 2.],
+         [6., 8., 6.96742194, 4.],
+         [7., 9., 18.77445997, 6.]])
+
+    linkage_X_average = np.array(
+        [[3., 4., 0.36265956, 2.],
+         [1., 5., 1.77045373, 2.],
+         [0., 2., 2.55760419, 2.],
+         [6., 8., 6.55832839, 4.],
+         [7., 9., 15.44089605, 6.]])
+
     n_samples, n_features = np.shape(X)
     connectivity_X = np.ones((n_samples, n_samples))
 
@@ -374,6 +390,23 @@ def test_ward_linkage_tree_return_distance():
     # check that the distances are correct
     assert_array_almost_equal(linkage_X_ward[:, 2], out_X_unstructured[4])
     assert_array_almost_equal(linkage_X_ward[:, 2], out_X_structured[4])
+
+    linkage_options = ['complete', 'average']
+    X_linkage_truth = [linkage_X_complete, linkage_X_average]
+    for (linkage, X_truth) in zip(linkage_options, X_linkage_truth):
+        out_X_unstructured = linkage_tree(
+            X, return_distance=True, linkage=linkage)
+        out_X_structured = linkage_tree(
+            X, connectivity=connectivity_X, linkage=linkage,
+            return_distance=True)
+
+        # check that the labels are the same
+        assert_array_equal(X_truth[:, :2], out_X_unstructured[0])
+        assert_array_equal(X_truth[:, :2], out_X_structured[0])
+
+        # check that the distances are correct
+        assert_array_almost_equal(X_truth[:, 2], out_X_unstructured[4])
+        assert_array_almost_equal(X_truth[:, 2], out_X_structured[4])
 
 
 def test_connectivity_fixing_non_lil():

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -396,6 +396,25 @@ def test_int_float_dict():
     average_merge(d, other, mask=np.ones(100, dtype=np.intp), n_a=1, n_b=1)
 
 
+def test_average_max_linkage_distances():
+    """Test that the linkage trees give same distance"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(20, 5)
+    connectivity = np.ones((20, 20))
+
+    for linkage in ['average', 'complete']:
+        structured_items = linkage_tree(
+            X, connectivity, linkage=linkage, return_distance=True)[-1]
+        unstructured_items = linkage_tree(
+            X, linkage=linkage, return_distance=True)[-1]
+        structured_dist = structured_items[-1]
+        unstructured_dist = unstructured_items[-1]
+        structured_children = structured_items[0]
+        unstructured_children = unstructured_items[0]
+        assert_array_almost_equal(structured_dist, unstructured_dist)
+        assert_array_almost_equal(structured_children, unstructured_children)
+
+
 if __name__ == '__main__':
     import nose
     nose.run(argv=['', __file__])

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -302,12 +302,11 @@ def test_ward_tree_children_order():
         assert_array_equal(out_unstructured[0], out_structured[0])
 
 
-def test_ward_tree_distance():
-    """
-    Check that children are ordered in the same way for both structured and
-    unstructured versions of ward_tree.
-    """
-    # test on five random datasets
+def test_ward_linkage_tree_return_distance():
+    """Test return_distance option on linkage and ward trees"""
+
+    # test that return_distance when set true, gives same
+    # output on both structured and unstructured clustering.
     n, p = 10, 5
     rng = np.random.RandomState(0)
 
@@ -333,6 +332,18 @@ def test_ward_tree_distance():
         dist_structured = out_structured[-1]
 
         assert_array_almost_equal(dist_unstructured, dist_structured)
+
+        for linkage in ['average', 'complete']:
+            structured_items = linkage_tree(
+                X, connectivity, linkage=linkage, return_distance=True)[-1]
+            unstructured_items = linkage_tree(
+                X, linkage=linkage, return_distance=True)[-1]
+            structured_dist = structured_items[-1]
+            unstructured_dist = unstructured_items[-1]
+            structured_children = structured_items[0]
+            unstructured_children = unstructured_items[0]
+            assert_array_almost_equal(structured_dist, unstructured_dist)
+            assert_array_almost_equal(structured_children, unstructured_children)
 
     # test on the following dataset where we know the truth
     # taken from scipy/cluster/tests/hierarchy_test_data.py
@@ -394,25 +405,6 @@ def test_int_float_dict():
     # Complete smoke test
     max_merge(d, other, mask=np.ones(100, dtype=np.intp), n_a=1, n_b=1)
     average_merge(d, other, mask=np.ones(100, dtype=np.intp), n_a=1, n_b=1)
-
-
-def test_average_max_linkage_distances():
-    """Test that the linkage trees give same distance"""
-    rng = np.random.RandomState(0)
-    X = rng.randn(20, 5)
-    connectivity = np.ones((20, 20))
-
-    for linkage in ['average', 'complete']:
-        structured_items = linkage_tree(
-            X, connectivity, linkage=linkage, return_distance=True)[-1]
-        unstructured_items = linkage_tree(
-            X, linkage=linkage, return_distance=True)[-1]
-        structured_dist = structured_items[-1]
-        unstructured_dist = unstructured_items[-1]
-        structured_children = structured_items[0]
-        unstructured_children = unstructured_items[0]
-        assert_array_almost_equal(structured_dist, unstructured_dist)
-        assert_array_almost_equal(structured_children, unstructured_children)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the lines of https://github.com/scikit-learn/scikit-learn/pull/3158 . Also a micro optimization for the `ward_tree` option, by preallocating the distance array.
