### PR TITLE
[MRG + 1] FIX backward compatibility.

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1726,16 +1726,24 @@ def train_test_split(*arrays, **options):
     random_state = options.pop('random_state', None)
     dtype = options.pop('dtype', None)
     if dtype is not None:
-        warnings.warn("dtype option is ignored and will be removed in 0.18.")
+        warnings.warn("dtype option is ignored and will be removed in 0.18.",
+                      DeprecationWarning)
 
-    force_arrays = options.pop('force_arrays', False)
+    allow_nd = options.pop('allow_nd', None)
+    allow_lists = options.pop('allow_lists', None)
+
+    if allow_lists is not None:
+        warnings.warn("The allow_lists option is deprecated and will be "
+                      "assumed True in 0.18 and removed.", DeprecationWarning)
+
     if options:
         raise TypeError("Invalid parameters passed: %s" % str(options))
-    if force_arrays:
-        warnings.warn("The force_arrays option is deprecated and will be "
-                      "removed in 0.18.", DeprecationWarning)
-        arrays = [check_array(x, 'csr', ensure_2d=False,
-                              force_all_finite=False) if x is not None else x
+    if allow_nd is not None:
+        warnings.warn("The allow_nd option is deprecated and will be "
+                      "assumed True in 0.18 and removed.", DeprecationWarning)
+    if allow_lists is False or allow_nd is False:
+        arrays = [check_array(x, 'csr', allow_nd=allow_nd,
+                              force_all_finite=False, ensure_2d=False) if x is not None else x
                   for x in arrays]
 
     if test_size is None and train_size is None:

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -653,7 +653,7 @@ def test_train_test_split():
     X = np.arange(100).reshape((10, 10))
     X_s = coo_matrix(X)
     y = range(10)
-    split = cval.train_test_split(X, X_s, y, force_arrays=True)
+    split = cval.train_test_split(X, X_s, y, allow_lists=False)
     X_train, X_test, X_s_train, X_s_test, y_train, y_test = split
     assert_array_equal(X_train, X_s_train.toarray())
     assert_array_equal(X_test, X_s_test.toarray())
@@ -691,7 +691,7 @@ def train_test_split_mock_pandas():
     X_train, X_test = cval.train_test_split(X_df)
     assert_true(isinstance(X_train, MockDataFrame))
     assert_true(isinstance(X_test, MockDataFrame))
-    X_train_arr, X_test_arr = cval.train_test_split(X_df, force_arrays=True)
+    X_train_arr, X_test_arr = cval.train_test_split(X_df, allow_lists=False)
     assert_true(isinstance(X_train_arr, np.ndarray))
     assert_true(isinstance(X_test_arr, np.ndarray))
 


### PR DESCRIPTION
`force_arrays` was never in a release, `allow_nd` was a legal option to `train_test_split` that raises an error in master. Same goes for `allow_lists`.

Apparently I messed this up when I did the input validation refactoring.
