### PR TITLE
[MRG+1] LSHForest: sparse support and vectorised _find_longest_prefix_match

### DIFF
--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -333,7 +333,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
 
         Parameters
         ----------
-        X : array_like, shape (n_samples, n_features)
+        X : array_like or sparse (CSR) matrix, shape (n_samples, n_features)
             List of n_features-dimensional data points. Each row
             corresponds to a single data point.
 
@@ -392,7 +392,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
 
         Parameters
         ----------
-        X : array_like, shape (n_samples, n_features)
+        X : array_like or sparse (CSR) matrix, shape (n_samples, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single query.
 
@@ -441,7 +441,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
 
         Parameters
         ----------
-        X : array_like, shape (n_samples, n_features)
+        X : array_like or sparse (CSR) matrix, shape (n_samples, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single query.
 
@@ -491,7 +491,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
 
         Parameters
         ----------
-        X : array_like, shape (n_samples, n_features)
+        X : array_like or sparse (CSR) matrix, shape (n_samples, n_features)
             New data point to be inserted into the LSH Forest.
         """
         X = check_array(X, accept_sparse='csr')

--- a/sklearn/neighbors/tests/test_approximate.py
+++ b/sklearn/neighbors/tests/test_approximate.py
@@ -385,6 +385,8 @@ def test_graphs():
 
 
 def test_sparse_input():
+    # note: Fixed random state in sp.rand is not supported in older scipy.
+    #       The test should succeed regardless.
     X1 = sp.rand(50, 100)
     X2 = sp.rand(10, 100)
     forest_sparse = LSHForest(radius=1, random_state=0).fit(X1)

--- a/sklearn/neighbors/tests/test_approximate.py
+++ b/sklearn/neighbors/tests/test_approximate.py
@@ -385,8 +385,8 @@ def test_graphs():
 
 
 def test_sparse_input():
-    X1 = sp.rand(50, 100, random_state=0)
-    X2 = sp.rand(10, 100, random_state=1)
+    X1 = sp.rand(50, 100)
+    X2 = sp.rand(10, 100)
     forest_sparse = LSHForest(radius=1, random_state=0).fit(X1)
     forest_dense = LSHForest(radius=1, random_state=0).fit(X1.A)
 

--- a/sklearn/neighbors/tests/test_approximate.py
+++ b/sklearn/neighbors/tests/test_approximate.py
@@ -4,9 +4,10 @@ Locality Sensitive Hashing Forest module
 (sklearn.neighbors.LSHForest).
 """
 
-# Author: Maheshakya Wijewardena
+# Author: Maheshakya Wijewardena, Joel Nothman
 
 import numpy as np
+import scipy.sparse as sp
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
@@ -381,6 +382,28 @@ def test_graphs():
         assert_equal(kneighbors_graph.shape[1], n_samples)
         assert_equal(radius_neighbors_graph.shape[0], n_samples)
         assert_equal(radius_neighbors_graph.shape[1], n_samples)
+
+
+def test_sparse_input():
+    X1 = sp.rand(50, 100, random_state=0)
+    X2 = sp.rand(10, 100, random_state=1)
+    forest_sparse = LSHForest(radius=1, random_state=0).fit(X1)
+    forest_dense = LSHForest(radius=1, random_state=0).fit(X1.A)
+
+    d_sparse, i_sparse = forest_sparse.kneighbors(X2, return_distance=True)
+    d_dense, i_dense = forest_dense.kneighbors(X2.A, return_distance=True)
+    assert_array_equal(d_sparse, d_dense)
+    assert_array_equal(i_sparse, i_dense)
+
+    d_sparse, i_sparse = forest_sparse.radius_neighbors(X2,
+                                                        return_distance=True)
+    d_dense, i_dense = forest_dense.radius_neighbors(X2.A,
+                                                     return_distance=True)
+    assert_equal(d_sparse.shape, d_dense.shape)
+    for a, b in zip(d_sparse, d_dense):
+        assert_array_equal(a, b)
+    for a, b in zip(i_sparse, i_dense):
+        assert_array_equal(a, b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds sparse matrix support to `LSHForest`, vectorises calls to `hasher.transform`, and vectorises `_find_longest_prefix_match` over queries. These seem to speed things up a little, but the benchmark script does not provide very stable timings for me.

Some other query operations cannot be easily vectorised, such as gathering the set of candidates per query (which differ in cardinality). Unvectorised operations make sparse matrix calculations particularly inefficient (because extracting a single row is not especially cheap).
