### PR TITLE
[MRG+1] DBSCAN: faster, weighted samples, and sparse input

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -150,6 +150,9 @@ Enhancements
 
    - Sparse support for :func:`paired_distances`. By `Joel Nothman`_.
 
+   - DBSCAN now supports sparse input and sample weights, and should be
+     faster in general. By `Joel Nothman`_.
+
 Documentation improvements
 ..........................
 

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -23,20 +23,20 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
 
     Parameters
     ----------
-    X: array [n_samples, n_samples] or [n_samples, n_features]
-        Array of distances between samples, or a feature array.
-        The array is treated as a feature array unless the metric is given as
-        'precomputed'.
+    X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
+            array of shape (n_samples, n_samples)
+        A feature array, or array of distances between samples if
+        ``metric='precomputed'``.
 
-    eps: float, optional
+    eps : float, optional
         The maximum distance between two samples for them to be considered
         as in the same neighborhood.
 
-    min_samples: int, optional
+    min_samples : int, optional
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point.
 
-    metric: string, or callable
+    metric : string, or callable
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
         the options allowed by metrics.pairwise.pairwise_distances for its
@@ -44,18 +44,18 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
         If metric is "precomputed", X is assumed to be a distance matrix and
         must be square.
 
-    algorithm: {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
         See NearestNeighbors module documentation for details.
 
-    leaf_size: int, optional (default = 30)
+    leaf_size : int, optional (default = 30)
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
 
-    p: float, optional
+    p : float, optional
         The power of the Minkowski metric to be used to calculate distance
         between points.
 
@@ -65,12 +65,12 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
         negative weight may inhibit its eps-neighbor from being core.
         Note that weights are absolute, and default to 1.
 
-    random_state: numpy.RandomState, optional
+    random_state : numpy.RandomState, optional
         The generator used to initialize the centers. Defaults to numpy.random.
 
     Returns
     -------
-    core_samples: array [n_core_samples]
+    core_samples : array [n_core_samples]
         Indices of core samples.
 
     labels : array [n_samples]
@@ -99,7 +99,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     random_state = check_random_state(random_state)
 
     # Calculate neighborhood for all samples. This leaves the original point
-    # in, which needs to be considered later (i.e. point i is the
+    # in, which needs to be considered later (i.e. point i is in the
     # neighborhood of point i. While True, its useless information)
     if metric == 'precomputed':
         D = pairwise_distances(X, metric=metric)
@@ -218,10 +218,10 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
         Parameters
         ----------
-        X: array (n_samples, n_samples) or (n_samples, n_features)
-            Array of distances between samples, or a feature array.
-            The array is treated as a feature array unless the metric is
-            given as 'precomputed'.
+        X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
+                array of shape (n_samples, n_samples)
+            A feature array, or array of distances between samples if
+            ``metric='precomputed'``.
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with weight greater
             than ``min_samples`` is automatically a core sample; a sample with
@@ -239,10 +239,10 @@ class DBSCAN(BaseEstimator, ClusterMixin):
 
         Parameters
         ----------
-        X: array (n_samples, n_samples) or (n_samples, n_features)
-            Array of distances between samples, or a feature array.
-            The array is treated as a feature array unless the metric is
-            given as 'precomputed'.
+        X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
+                array of shape (n_samples, n_samples)
+            A feature array, or array of distances between samples if
+            ``metric='precomputed'``.
         sample_weight : array, shape (n_samples,), optional
             Weight of each sample, such that a sample with weight greater
             than ``min_samples`` is automatically a core sample; a sample with

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..base import BaseEstimator, ClusterMixin
 from ..metrics import pairwise_distances
-from ..utils import check_random_state
+from ..utils import check_random_state, check_array
 from ..neighbors import NearestNeighbors
 
 
@@ -83,7 +83,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     if not eps > 0.0:
         raise ValueError("eps must be positive.")
 
-    X = np.asarray(X)
+    X = check_array(X, accept_sparse='csr')
 
     # If index order not given, create random order.
     random_state = check_random_state(random_state)
@@ -211,7 +211,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         params: dict
             Overwrite keywords from __init__.
         """
-        X = np.asarray(X)
+        X = check_array(X, accept_sparse='csr')
         clust = dbscan(X, **self.get_params())
         self.core_sample_indices_, self.labels_ = clust
         self.components_ = X[self.core_sample_indices_].copy()

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -233,3 +233,26 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         self.core_sample_indices_, self.labels_ = clust
         self.components_ = X[self.core_sample_indices_].copy()
         return self
+
+    def fit_predict(self, X, y=None, sample_weight=None):
+        """Performs clustering on X and returns cluster labels.
+
+        Parameters
+        ----------
+        X: array (n_samples, n_samples) or (n_samples, n_features)
+            Array of distances between samples, or a feature array.
+            The array is treated as a feature array unless the metric is
+            given as 'precomputed'.
+        sample_weight : array, shape (n_samples,), optional
+            Weight of each sample, such that a sample with weight greater
+            than ``min_samples`` is automatically a core sample; a sample with
+            negative weight may inhibit its eps-neighbor from being core.
+            Note that weights are absolute, and default to 1.
+
+        Returns
+        -------
+        y : ndarray, shape (n_samples,)
+            cluster labels
+        """
+        self.fit(X, sample_weight=sample_weight)
+        return self.labels_

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -10,8 +10,11 @@ from numpy.testing import assert_raises
 from scipy.spatial import distance
 from scipy import sparse
 
-from sklearn.utils.testing import assert_equal, assert_array_equal
-from sklearn.cluster.dbscan_ import DBSCAN, dbscan
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.cluster.dbscan_ import DBSCAN
+from sklearn.cluster.dbscan_ import dbscan
 from .common import generate_clustered_data
 from sklearn.metrics.pairwise import pairwise_distances
 
@@ -169,3 +172,60 @@ def test_pickle():
     obj = DBSCAN()
     s = pickle.dumps(obj)
     assert_equal(type(pickle.loads(s)), obj.__class__)
+
+
+def test_weighted_dbscan():
+    sample_weight = np.random.randint(0, 5, X.shape[0])
+
+    # ensure sample_weight is validated
+    assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2])
+    assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2, 3, 4])
+
+    # ensure sample_weight has an effect
+    assert_array_equal([], dbscan([[0], [1]], sample_weight=None,
+                                  min_samples=5)[0])
+    assert_array_equal([], dbscan([[0], [1]], sample_weight=[5, 5],
+                                  min_samples=5)[0])
+    assert_array_equal([0], dbscan([[0], [1]], sample_weight=[6, 5],
+                                   min_samples=5)[0])
+    assert_array_equal([0, 1], dbscan([[0], [1]], sample_weight=[6, 6],
+                                      min_samples=5)[0])
+
+    # points within eps of each other:
+    assert_array_equal([0, 1], dbscan([[0], [1]], eps=1.5,
+                                      sample_weight=[5, 1], min_samples=5)[0])
+    # and effect of non-positive and non-integer sample_weight:
+    assert_array_equal([], dbscan([[0], [1]], sample_weight=[5, 0],
+                                  eps=1.5, min_samples=5)[0])
+    assert_array_equal([0, 1], dbscan([[0], [1]], sample_weight=[5, 0.1],
+                                      eps=1.5, min_samples=5)[0])
+    assert_array_equal([0, 1], dbscan([[0], [1]], sample_weight=[6, 0],
+                                      eps=1.5, min_samples=5)[0])
+    assert_array_equal([], dbscan([[0], [1]], sample_weight=[6, -1],
+                                  eps=1.5, min_samples=5)[0])
+
+    # for non-negative sample_weight, cores should be identical to repetition
+    core1, label1 = dbscan(X, sample_weight=sample_weight, random_state=42)
+    assert_equal(len(label1), len(X))
+
+    X_repeated = np.repeat(X, sample_weight, axis=0)
+    core_repeated, label_repeated = dbscan(X_repeated)
+    core_repeated_mask = np.zeros(X_repeated.shape[0], dtype=bool)
+    core_repeated_mask[core_repeated] = True
+    core_mask = np.zeros(X.shape[0], dtype=bool)
+    core_mask[core1] = True
+    assert_array_equal(np.repeat(core_mask, sample_weight), core_repeated_mask)
+
+    # sample_weight should work with precomputed distance matrix
+    D = pairwise_distances(X)
+    core3, label3 = dbscan(D, sample_weight=sample_weight,
+                           metric='precomputed', random_state=42)
+    assert_array_equal(core1, core3)
+    assert_array_equal(label1, label3)
+
+    # sample_weight should work with estimator
+    est = DBSCAN(random_state=42).fit(X, sample_weight=sample_weight)
+    core4 = est.core_sample_indices_
+    label4 = est.labels_
+    assert_array_equal(core1, core4)
+    assert_array_equal(label1, label4)

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -8,8 +8,9 @@ import numpy as np
 from numpy.testing import assert_raises
 
 from scipy.spatial import distance
+from scipy import sparse
 
-from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_equal, assert_array_equal
 from sklearn.cluster.dbscan_ import DBSCAN, dbscan
 from .common import generate_clustered_data
 from sklearn.metrics.pairwise import pairwise_distances
@@ -63,6 +64,15 @@ def test_dbscan_feature():
 
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_2, n_clusters)
+
+
+def test_dbscan_sparse():
+    core_sparse, labels_sparse = dbscan(sparse.lil_matrix(X), eps=.8,
+                                        min_samples=10, random_state=0)
+    core_dense, labels_dense = dbscan(X, eps=.8, min_samples=10,
+                                      random_state=0)
+    assert_array_equal(core_dense, core_sparse)
+    assert_array_equal(labels_dense, labels_sparse)
 
 
 def test_dbscan_callable():

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -229,3 +229,10 @@ def test_weighted_dbscan():
     label4 = est.labels_
     assert_array_equal(core1, core4)
     assert_array_equal(label1, label4)
+
+    est = DBSCAN(random_state=42)
+    label5 = est.fit_predict(X, sample_weight=sample_weight)
+    core5 = est.core_sample_indices_
+    assert_array_equal(core1, core5)
+    assert_array_equal(label1, label5)
+    assert_array_equal(label1, est.labels_)

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -175,8 +175,6 @@ def test_pickle():
 
 
 def test_weighted_dbscan():
-    sample_weight = np.random.randint(0, 5, X.shape[0])
-
     # ensure sample_weight is validated
     assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2])
     assert_raises(ValueError, dbscan, [[0], [1]], sample_weight=[2, 3, 4])
@@ -205,11 +203,13 @@ def test_weighted_dbscan():
                                   eps=1.5, min_samples=5)[0])
 
     # for non-negative sample_weight, cores should be identical to repetition
+    rng = np.random.RandomState(42)
+    sample_weight = rng.randint(0, 5, X.shape[0])
     core1, label1 = dbscan(X, sample_weight=sample_weight, random_state=42)
     assert_equal(len(label1), len(X))
 
     X_repeated = np.repeat(X, sample_weight, axis=0)
-    core_repeated, label_repeated = dbscan(X_repeated)
+    core_repeated, label_repeated = dbscan(X_repeated, random_state=42)
     core_repeated_mask = np.zeros(X_repeated.shape[0], dtype=bool)
     core_repeated_mask[core_repeated] = True
     core_mask = np.zeros(X.shape[0], dtype=bool)


### PR DESCRIPTION
DBSCAN now supports sparse matrix input, and weighted samples (a compact representation of density when duplicate points exist; also useful when weighting is possible for BIRCH's global clustering).

I have also vectorized the implementation. This reduces the cluster comparison toy examples under DBSCAN from ~.6s each to .02s each on my machine.

(This could be sped up further by allowing a dual-tree radius_neighbors lookup that reuses the computed tree. The toy examples have `n_features=2`, so neighbor calculation does not take up as much of the overall time as it might otherwise.)
