### PR TITLE
[MRG+1] FIX Isotonic Regression for duplicate minimal value

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -316,6 +316,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
                              .format(self.out_of_bounds))
 
         if self.out_of_bounds == "clip":
+            # XXX: Address scipy issue 4304 by adding a tiny value to 
+            # self.X_min_ during clipping
             T = np.clip(T, self.X_min_ + np.finfo(float).resolution,
                         self.X_max_)
         return self.f_(T)

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -316,7 +316,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
                              .format(self.out_of_bounds))
 
         if self.out_of_bounds == "clip":
-            T = np.clip(T, self.X_min_, self.X_max_)
+            T = np.clip(T, self.X_min_ + np.finfo(float).resolution,
+                        self.X_max_)
         return self.f_(T)
 
     def fit_transform(self, X, y, sample_weight=None):

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -245,6 +245,15 @@ def test_isotonic_regression_pickle():
     np.testing.assert_array_equal(ir.predict(x), ir2.predict(x))
 
 
+def test_isotonic_duplicate_min_entry():
+    x = [0, 0, 1]
+    y = [0, 0, 1]
+
+    ir = IsotonicRegression(increasing=True, out_of_bounds="clip")
+    ir.fit(x, y)
+    all_predictions_finite = np.all(np.isfinite(ir.predict(x)))
+    assert_true(all_predictions_finite)
+
 if __name__ == "__main__":
     import nose
     nose.run(argv=['', __file__])


### PR DESCRIPTION
Fixes an issue of Isotonic Regression when the minimal value of fitting is duplicated, e.g.:

```
ir = IsotonicRegression(increasing=True, out_of_bounds="clip")
ir.fit([0, 0, 1], [0, 0, 1])
ir.predict([0])
```

would return `nan` (see test_isotonic_duplicate_min_entry). The deeper reason for this seems to be in interpolate.interp1d. This issue is fixed by clipping not to minimal value observed in fitting but to minimal value + np.finfo(float).resolution.
