### PR TITLE
[MRG+2] Added sample weight support to confusion matrix.

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -17,6 +17,7 @@ the lower the better
 #          Noel Dawe <noel@dawe.me>
 #          Jatin Shah <jatindshah@gmail.com>
 #          Saurabh Jha <saurabh.jhaa@gmail.com>
+#          Bernardo Stein <bernardovstein@gmail.com>
 # License: BSD 3 clause
 
 from __future__ import division
@@ -178,7 +179,7 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def confusion_matrix(y_true, y_pred, labels=None):
+def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     """Compute confusion matrix to evaluate the accuracy of a classification
 
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
@@ -201,6 +202,8 @@ def confusion_matrix(y_true, y_pred, labels=None):
         If none is given, those that appear at least once
         in ``y_true`` or ``y_pred`` are used in sorted order.
 
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
 
     Returns
     -------
@@ -239,6 +242,11 @@ def confusion_matrix(y_true, y_pred, labels=None):
     else:
         labels = np.asarray(labels)
 
+    if sample_weight is None:
+        sample_weight = np.ones(y_true.shape[0], dtype=np.int)
+    else:
+        sample_weight = np.asarray(sample_weight)
+
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
     # convert yt, yp into index
@@ -249,8 +257,10 @@ def confusion_matrix(y_true, y_pred, labels=None):
     ind = np.logical_and(y_pred < n_labels, y_true < n_labels)
     y_pred = y_pred[ind]
     y_true = y_true[ind]
+    # also eliminate weights of eliminated items
+    sample_weight = sample_weight[ind]
 
-    CM = coo_matrix((np.ones(y_true.shape[0], dtype=np.int), (y_true, y_pred)),
+    CM = coo_matrix((sample_weight, (y_true, y_pred)),
                     shape=(n_labels, n_labels)
                     ).toarray()
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -247,6 +247,8 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     else:
         sample_weight = np.asarray(sample_weight)
 
+    check_consistent_length(sample_weight, y_true, y_pred)
+
     n_labels = labels.size
     label_to_ind = dict((y, x) for x, y in enumerate(labels))
     # convert yt, yp into index

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -515,13 +515,15 @@ def test_confusion_matrix_sample_weight():
     """Test confusion matrix - case with sample_weight"""
     y_true, y_pred, _ = make_prediction(binary=False)
 
-    weights = [0.1] * 25 + [0.2] * 25 + [0.3] * 25
+    weights = [.1] * 25 + [.2] * 25 + [.3] * 25
 
     cm = confusion_matrix(y_true, y_pred, sample_weight=weights)
 
-    assert_array_almost_equal(cm, [[4.1, 0.8, 0.1],
-                                   [0.8, 0.5, 5.0],
-                                   [0.0, 0.3, 3.4]])
+    true_cm = (.1 * confusion_matrix(y_true[:25], y_pred[:25]) +
+              .2 * confusion_matrix(y_true[25:50], y_pred[25:50]) +
+              .3 * confusion_matrix(y_true[50:], y_pred[50:]))
+
+    assert_array_almost_equal(cm, true_cm)
 
 
 def test_confusion_matrix_multiclass_subset_labels():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -511,6 +511,19 @@ def test_confusion_matrix_multiclass():
          string_type=True)
 
 
+def test_confusion_matrix_sample_weight():
+    """Test confusion matrix - case with sample_weight"""
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    weights = [0.1] * 25 + [0.2] * 25 + [0.3] * 25
+
+    cm = confusion_matrix(y_true, y_pred, sample_weight=weights)
+
+    assert_array_almost_equal(cm, [[4.1, 0.8, 0.1],
+                                   [0.8, 0.5, 5.0],
+                                   [0.0, 0.3, 3.4]])
+
+
 def test_confusion_matrix_multiclass_subset_labels():
     # Test confusion matrix - multi-class case with subset of labels
     y_true, y_pred, _ = make_prediction(binary=False)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -360,7 +360,13 @@ NOT_SYMMETRIC_METRICS = [
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
     "cohen_kappa_score",
-    "confusion_matrix",
+    "confusion_matrix", # Left this one here because the tests in this file do
+                        # not work for confusion_matrix, as its output is a
+                        # matrix instead of a number. Testing of
+                        # confusion_matrix with sample_weight is in
+                        # test_classification.py
+    "hamming_loss",
+    "matthews_corrcoef_score",
     "median_absolute_error",
 ]
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -365,8 +365,6 @@ METRICS_WITHOUT_SAMPLE_WEIGHT = [
                         # matrix instead of a number. Testing of
                         # confusion_matrix with sample_weight is in
                         # test_classification.py
-    "hamming_loss",
-    "matthews_corrcoef_score",
     "median_absolute_error",
 ]
 


### PR DESCRIPTION
Added a sample_weight parameter inside confusion_matrix which
will be used to build the confusion matrix. If not present, it
will default to np.ones() of size equal to the number of samples.
Tests were created in test_classification.py instead of
test_common.py.
