### PR TITLE
Spelling in heading newgroups -> newsgroups

### DIFF
--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -64,7 +64,7 @@ For instance::
     % python fetch_data.py
 
 
-Loading the 20 newgroups dataset
+Loading the 20 newsgroups dataset
 --------------------------------
 
 The dataset is called "Twenty Newsgroups". Here is the official


### PR DESCRIPTION
The section title is "newgroups", this fixes it so that it matches the rest of the document.
