### PR TITLE
[MRG+1] DOC A few fixes in the docstrings of all classifiers.

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -191,7 +191,7 @@ class BaseEstimator(object):
 
         Parameters
         ----------
-        deep: boolean, optional
+        deep : boolean, optional
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -24,7 +24,7 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     Parameters
     ----------
     X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
-            array of shape (n_samples, n_samples)
+array of shape (n_samples, n_samples)
         A feature array, or array of distances between samples if
         ``metric='precomputed'``.
 
@@ -219,7 +219,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
-                array of shape (n_samples, n_samples)
+array of shape (n_samples, n_samples)
             A feature array, or array of distances between samples if
             ``metric='precomputed'``.
         sample_weight : array, shape (n_samples,), optional
@@ -240,7 +240,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         Parameters
         ----------
         X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
-                array of shape (n_samples, n_samples)
+array of shape (n_samples, n_samples)
             A feature array, or array of distances between samples if
             ``metric='precomputed'``.
         sample_weight : array, shape (n_samples,), optional

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -25,8 +25,8 @@ from sklearn.cluster import AgglomerativeClustering, FeatureAgglomeration
 from sklearn.cluster.hierarchical import (_hc_cut, _TREE_BUILDERS,
                                           linkage_tree)
 from sklearn.feature_extraction.image import grid_to_graph
-from sklearn.metrics.pairwise import PAIRED_DISTANCES, cosine_distances,\
-    manhattan_distances
+from sklearn.metrics.pairwise import (
+        PAIRED_DISTANCES, cosine_distances, manhattan_distances)
 from sklearn.metrics.cluster import normalized_mutual_info_score
 from sklearn.neighbors.graph import kneighbors_graph
 from sklearn.cluster._hierarchical import average_merge, max_merge

--- a/sklearn/covariance/__init__.py
+++ b/sklearn/covariance/__init__.py
@@ -6,11 +6,18 @@ Covariance estimation is closely related to the theory of Gaussian Graphical
 Models.
 """
 
-from .empirical_covariance_ import empirical_covariance, EmpiricalCovariance, \
-    log_likelihood
-from .shrunk_covariance_ import shrunk_covariance, ShrunkCovariance, \
-    ledoit_wolf, ledoit_wolf_shrinkage, \
-    LedoitWolf, oas, OAS
+from .empirical_covariance_ import (
+        empirical_covariance, EmpiricalCovariance, log_likelihood)
+
+from .shrunk_covariance_ import (
+        shrunk_covariance, 
+        ShrunkCovariance,
+        ledoit_wolf,
+        ledoit_wolf_shrinkage,
+        LedoitWolf, 
+        oas,
+        OAS)
+
 from .robust_covariance import fast_mcd, MinCovDet
 from .graph_lasso_ import graph_lasso, GraphLasso, GraphLassoCV
 from .outlier_detection import EllipticEnvelope

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -108,7 +108,7 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
     Attributes
     ----------
     `contamination` : float, 0. < contamination < 0.5
-      The amount of contamination of the data set, i.e. the proportion of \
+      The amount of contamination of the data set, i.e. the proportion of 
       outliers in the data set.
 
     location_ : array-like, shape (n_features,)

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -6,16 +6,25 @@
 
 import numpy as np
 
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_warns
-
 from sklearn import datasets
-from sklearn.covariance import empirical_covariance, EmpiricalCovariance, \
-    ShrunkCovariance, shrunk_covariance, \
-    LedoitWolf, ledoit_wolf, ledoit_wolf_shrinkage, OAS, oas
+
+from sklearn.utils.testing import (
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_raises,
+        assert_warns)
+
+from sklearn.covariance import (
+        empirical_covariance,
+        EmpiricalCovariance,
+        ShrunkCovariance,
+        shrunk_covariance,
+        LedoitWolf,
+        ledoit_wolf,
+        ledoit_wolf_shrinkage,
+        OAS,
+        oas)
 
 X = datasets.load_diabetes().data
 X_1d = X[:, 0]

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -787,7 +787,7 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
         normalized to unit norm.
 
     transform_algorithm : {'lasso_lars', 'lasso_cd', 'lars', 'omp', \
-    'threshold'}
+'threshold'}
         Algorithm used to transform the data:
         lars: uses the least angle regression method (linear_model.lars_path)
         lasso_lars: uses Lars to compute the Lasso solution
@@ -886,7 +886,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
         the estimated components are sparse.
 
     transform_algorithm : {'lasso_lars', 'lasso_cd', 'lars', 'omp', \
-    'threshold'}
+'threshold'}
         Algorithm used to transform the data
         lars: uses the least angle regression method (linear_model.lars_path)
         lasso_lars: uses Lars to compute the Lasso solution
@@ -1042,7 +1042,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         the estimated components are sparse.
 
     transform_algorithm : {'lasso_lars', 'lasso_cd', 'lars', 'omp', \
-    'threshold'}
+'threshold'}
         Algorithm used to transform the data.
         lars: uses the least angle regression method (linear_model.lars_path)
         lasso_lars: uses Lars to compute the Lasso solution

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -143,8 +143,8 @@ class PCA(BaseEstimator, TransformerMixin):
         Components with maximum variance.
 
     explained_variance_ratio_ : array, [n_components]
-        Percentage of variance explained by each of the selected components. \
-        k is not set then all components are stored and the sum of explained \
+        Percentage of variance explained by each of the selected components.
+        k is not set then all components are stored and the sum of explained
         variances is equal to 1.0
 
     mean_ : array, [n_features]
@@ -499,8 +499,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         Components with maximum variance.
 
     explained_variance_ratio_ : array, [n_components]
-        Percentage of variance explained by each of the selected components. \
-        k is not set then all components are stored and the sum of explained \
+        Percentage of variance explained by each of the selected components.
+        k is not set then all components are stored and the sum of explained
         variances is equal to 1.0
 
     mean_ : array, [n_features]

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -74,7 +74,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     array([[ 2.,  0.,  1.],
            [ 0.,  1.,  3.]])
     >>> v.inverse_transform(X) == \
-        [{'bar': 2.0, 'foo': 1.0}, {'baz': 1.0, 'foo': 3.0}]
+[{'bar': 2.0, 'foo': 1.0}, {'baz': 1.0, 'foo': 3.0}]
     True
     >>> v.transform({'foo': 4, 'unseen_feature': 3})
     array([[ 0.,  0.,  4.]])

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -166,7 +166,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
     Attributes
     ----------
     theta_ : array
-        Specified theta OR the best set of autocorrelation parameters (the \
+        Specified theta OR the best set of autocorrelation parameters (the
         sought maximizer of the reduced likelihood function).
 
     reduced_likelihood_function_value_ : array

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -264,7 +264,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
         Returns
         -------
         X_new : {array, sparse matrix}, \
-               shape = (n_samples, n_features * (2*sample_steps + 1))
+shape = (n_samples, n_features * (2*sample_steps + 1))
             Whether the return value is an array of sparse matrix depends on
             the type of the input X.
         """

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -538,7 +538,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         parameter vector (w in the cost function formula)
 
     sparse_coef_ : scipy.sparse matrix, shape = (n_features, 1) | \
-            (n_targets, n_features)
+(n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
     intercept_ : float | array, shape = (n_targets,)
@@ -769,7 +769,7 @@ class Lasso(ElasticNet):
         parameter vector (w in the cost function formula)
 
     sparse_coef_ : scipy.sparse matrix, shape = (n_features, 1) | \
-            (n_targets, n_features)
+(n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
     intercept_ : float | array, shape = (n_targets,)
@@ -1461,7 +1461,7 @@ class MultiTaskElasticNet(Lasso):
         Independent term in decision function.
 
     coef_ : array, shape = (n_tasks, n_features)
-        Parameter vector (W in the cost function formula). If a 1D y is \
+        Parameter vector (W in the cost function formula). If a 1D y is
         passed in at fit (non multi-task usage), ``coef_`` is then a 1D array
 
     n_iter_ : int

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -502,15 +502,15 @@ class Lars(LinearModel, RegressorMixin):
     Attributes
     ----------
     alphas_ : array, shape (n_alphas + 1,) | list of n_targets such arrays
-        Maximum of covariances (in absolute value) at each iteration. \
-        ``n_alphas`` is either ``n_nonzero_coefs`` or ``n_features``, \
+        Maximum of covariances (in absolute value) at each iteration.
+        ``n_alphas`` is either ``n_nonzero_coefs`` or ``n_features``,
         whichever is smaller.
 
     active_ : list, length = n_alphas | list of n_targets such lists
         Indices of active variables at the end of the path.
 
     coef_path_ : array, shape (n_features, n_alphas + 1) \
-        | list of n_targets such arrays
+| list of n_targets such arrays
         The varying values of the coefficients along the path. It is not
         present if the ``fit_path`` parameter is ``False``.
 
@@ -577,7 +577,7 @@ class Lars(LinearModel, RegressorMixin):
             Target values.
 
         Xy : array-like, shape (n_samples,) or (n_samples, n_targets), \
-                optional
+optional
             Xy = np.dot(X.T, y) that can be precomputed. It is useful
             only when the Gram matrix is precomputed.
 
@@ -717,9 +717,9 @@ class LassoLars(Lars):
     ----------
     alphas_ : array, shape (n_alphas + 1,) | list of n_targets such arrays
         Maximum of covariances (in absolute value) at each iteration. \
-        ``n_alphas`` is either ``max_iter``, ``n_features``, or the number of \
-        nodes in the path with correlation greater than ``alpha``, whichever \
-        is smaller.
+``n_alphas`` is either ``max_iter``, ``n_features``, or the number of \
+nodes in the path with correlation greater than ``alpha``, whichever \
+is smaller.
 
     active_ : list, length = n_alphas | list of n_targets such lists
         Indices of active variables at the end of the path.

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -51,7 +51,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     Attributes
     ----------
     coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
-            n_features]
+n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
@@ -191,7 +191,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     Attributes
     ----------
     coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
-            n_features]
+n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -61,7 +61,7 @@ class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
     Attributes
     ----------
     coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
-            n_features]
+n_features]
         Weights assigned to the features.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -271,8 +271,8 @@ class RandomizedLasso(BaseRandomizedLinearModel):
         Feature scores between 0 and 1.
 
     all_scores_ : array, shape = [n_features, n_reg_parameter]
-        Feature scores between 0 and 1 for all values of the regularization \
-        parameter. The reference article suggests ``scores_`` is the max of \
+        Feature scores between 0 and 1 for all values of the regularization
+        parameter. The reference article suggests ``scores_`` is the max of
         ``all_scores_``.
 
     Examples
@@ -439,11 +439,11 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
         Feature scores between 0 and 1.
 
     all_scores_ : array, shape = [n_features, n_reg_parameter]
-        Feature scores between 0 and 1 for all values of the regularization \
-        parameter. The reference article suggests ``scores_`` is the max \
+        Feature scores between 0 and 1 for all values of the regularization
+        parameter. The reference article suggests ``scores_`` is the max
         of ``all_scores_``.
 
-    Examples
+Examples
     --------
     >>> from sklearn.linear_model import RandomizedLogisticRegression
     >>> randomized_logistic = RandomizedLogisticRegression()

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -938,10 +938,10 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
     Attributes
     ----------
     cv_values_ : array, shape = [n_samples, n_alphas] or \
-        shape = [n_samples, n_targets, n_alphas], optional
-        Cross-validation values for each alpha (if `store_cv_values=True` and \
-        `cv=None`). After `fit()` has been called, this attribute will \
-        contain the mean squared errors (by default) or the values of the \
+[n_samples, n_targets, n_alphas], optional.
+        Cross-validation values for each alpha (if `store_cv_values=True` and
+        `cv=None`). After `fit()` has been called, this attribute will
+        contain the mean squared errors (by default) or the values of the
         `{loss,score}_func` function (if provided in the constructor).
 
     coef_ : array, shape = [n_features] or [n_targets, n_features]
@@ -972,6 +972,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
+
     alphas : numpy array of shape [n_alphas]
         Array of alpha values to try.
         Small positive values of alpha improve the conditioning of the
@@ -1004,11 +1005,11 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     Attributes
     ----------
     cv_values_ : array, shape = [n_samples, n_alphas] or \
-    shape = [n_samples, n_responses, n_alphas], optional
+shape = [n_samples, n_responses, n_alphas], optional
         Cross-validation values for each alpha (if `store_cv_values=True` and
-    `cv=None`). After `fit()` has been called, this attribute will contain \
-    the mean squared errors (by default) or the values of the \
-    `{loss,score}_func` function (if provided in the constructor).
+        `cv=None`). After `fit()` has been called, this attribute will contain
+        the mean squared errors (by default) or the values of the
+        `{loss,score}_func` function (if provided in the constructor).
 
     coef_ : array, shape = [n_features] or [n_targets, n_features]
         Weight vector(s).

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -589,8 +589,8 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     Parameters
     ----------
     loss : str, 'hinge', 'log', 'modified_huber', 'squared_hinge',\
-                'perceptron', or a regression loss: 'squared_loss', 'huber',\
-                'epsilon_insensitive', or 'squared_epsilon_insensitive'
+'perceptron', or a regression loss: 'squared_loss', 'huber',\
+'epsilon_insensitive', or 'squared_epsilon_insensitive'
         The loss function to be used. Defaults to 'hinge', which gives a
         linear SVM.
         The 'log' loss gives logistic regression, a probabilistic classifier.
@@ -685,7 +685,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     Attributes
     ----------
     coef_ : array, shape (1, n_features) if n_classes == 2 else (n_classes,\
-            n_features)
+n_features)
         Weights assigned to the features.
 
     intercept_ : array, shape (1,) if n_classes == 2 else (n_classes,)
@@ -1102,7 +1102,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
     Parameters
     ----------
     loss : str, 'squared_loss', 'huber', 'epsilon_insensitive', \
-                or 'squared_epsilon_insensitive'
+or 'squared_epsilon_insensitive'
         The loss function to be used. Defaults to 'squared_loss' which refers
         to the ordinary least squares fit. 'huber' modifies 'squared_loss' to
         focus less on getting outliers correct by switching from squared to

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -364,7 +364,7 @@ class MDS(BaseEstimator):
         Parameters
         ----------
         X : array, shape=[n_samples, n_features], or [n_samples, n_samples] \
-                if dissimilarity='precomputed'
+if dissimilarity='precomputed'
             Input data.
 
         init : {None or ndarray, shape (n_samples,)}, optional
@@ -381,7 +381,7 @@ class MDS(BaseEstimator):
         Parameters
         ----------
         X : array, shape=[n_samples, n_features], or [n_samples, n_samples] \
-                if dissimilarity='precomputed'
+if dissimilarity='precomputed'
             Input data.
 
         init : {None or ndarray, shape (n_samples,)}, optional

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -62,7 +62,7 @@ def _check_targets(y_true, y_pred):
     Returns
     -------
     type_true : one of {'multilabel-indicator', 'multilabel-sequences', \
-                        'multiclass', 'binary'}
+'multiclass', 'binary'}
         The type of the true target data, as output by
         ``utils.multiclass.type_of_target``
 
@@ -319,7 +319,7 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True,
     In the multilabel case with binary label indicators:
 
     >>> jaccard_similarity_score(np.array([[0, 1], [1, 1]]),\
-        np.ones((2, 2)))
+np.ones((2, 2)))
     0.75
     """
 
@@ -618,8 +618,8 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
 
     Returns
     -------
-    fbeta_score : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+    fbeta_score : float (if average is not None) or array of float, shape = \
+[n_unique_labels]
         F-beta score of the positive class in binary classification or weighted
         average of the F-beta score of each class for the multiclass task.
 
@@ -781,17 +781,17 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
 
     Returns
     -------
-    precision: float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+    precision: float (if average is not None) or array of float, shape = \
+[n_unique_labels]
 
-    recall: float (if average is not None) or array of float, , shape =\
-        [n_unique_labels]
+    recall: float (if average is not None) or array of float, , shape = \
+[n_unique_labels]
 
-    fbeta_score: float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+    fbeta_score: float (if average is not None) or array of float, shape = \
+[n_unique_labels]
 
-    support: int (if average is not None) or array of int, shape =\
-        [n_unique_labels]
+    support: int (if average is not None) or array of int, shape = \
+[n_unique_labels]
         The number of occurrences of each label in ``y_true``.
 
     References
@@ -1020,8 +1020,8 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
 
     Returns
     -------
-    precision : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+    precision : float (if average is not None) or array of float, shape = \
+[n_unique_labels]
         Precision of the positive class in binary classification or weighted
         average of the precision of each class for the multiclass task.
 
@@ -1103,8 +1103,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
     Returns
     -------
-    recall : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
+    recall : float (if average is not None) or array of float, shape = \
+[n_unique_labels]
         Recall of the positive class in binary classification or weighted
         average of the recall of each class for the multiclass task.
 

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -32,7 +32,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     Parameters
     ----------
     X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+[n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
     labels : array, shape = [n_samples]
@@ -117,7 +117,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     Parameters
     ----------
     X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+[n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
     labels : array, shape = [n_samples]

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -451,7 +451,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     >>> manhattan_distances(2, 3)#doctest:+ELLIPSIS
     array([[ 1.]])
     >>> manhattan_distances([[1, 2], [3, 4]],\
-         [[1, 2], [0, 3]])#doctest:+ELLIPSIS
+[[1, 2], [0, 3]])#doctest:+ELLIPSIS
     array([[ 0.,  2.],
            [ 4.,  4.]])
     >>> import numpy as np
@@ -986,7 +986,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
     Parameters
     ----------
     X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+[n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
     Y : array [n_samples_b, n_features]
@@ -1146,7 +1146,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     Parameters
     ----------
     X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
-             [n_samples_a, n_features] otherwise
+[n_samples_a, n_features] otherwise
         Array of pairwise kernels between samples, or a feature array.
 
     Y : array [n_samples_b, n_features]

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -579,7 +579,9 @@ class MultinomialNB(BaseDiscreteNB):
     ----------
     C.D. Manning, P. Raghavan and H. Schuetze (2008). Introduction to
     Information Retrieval. Cambridge University Press, pp. 234-265.
-    http://nlp.stanford.edu/IR-book/html/htmledition/naive-bayes-text-classification-1.html
+
+    http://nlp.stanford.edu/IR-book/html/htmledition/\
+naive-bayes-text-classification-1.html
     """
 
     def __init__(self, alpha=1.0, fit_prior=True, class_prior=None):

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -12,10 +12,10 @@ import numpy as np
 from scipy import stats
 from ..utils.extmath import weighted_mode
 
-from .base import \
-    _check_weights, _get_weights, \
-    NeighborsBase, KNeighborsMixin,\
-    RadiusNeighborsMixin, SupervisedIntegerMixin
+from .base import (
+        _check_weights, _get_weights,
+        NeighborsBase, KNeighborsMixin,
+        RadiusNeighborsMixin, SupervisedIntegerMixin)
 from ..base import ClassifierMixin
 from ..utils import check_array
 

--- a/sklearn/svm/__init__.py
+++ b/sklearn/svm/__init__.py
@@ -10,8 +10,8 @@ The :mod:`sklearn.svm` module includes Support Vector Machine algorithms.
 #         of their respective owners.
 # License: BSD 3 clause (C) INRIA 2010
 
-from .classes import SVC, NuSVC, SVR, NuSVR, OneClassSVM, LinearSVC, \
-	LinearSVR
+from .classes import (
+        SVC, NuSVC, SVR, NuSVR, OneClassSVM, LinearSVC, LinearSVR)
 from .bounds import l1_min_c
 from . import libsvm, liblinear, libsvm_sparse
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from .base import _fit_liblinear, BaseSVC, BaseLibSVM
 from ..base import BaseEstimator, RegressorMixin
-from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin, \
-    LinearModel
+from ..linear_model.base import (
+        LinearClassifierMixin, SparseCoefMixin, LinearModel)
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_array, check_X_y
 
@@ -41,7 +41,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     tol : float, optional (default=1e-4)
         Tolerance for stopping criteria
 
-    multi_class: string, 'ovr' or 'crammer_singer' (default='ovr')
+    multi_class : string, 'ovr' or 'crammer_singer' (default='ovr')
         Determines the multi-class strategy if `y` contains more than
         two classes.
         `ovr` trains n_classes one-vs-rest classifiers, while `crammer_singer`
@@ -90,12 +90,12 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     Attributes
     ----------
     coef_ : array, shape = [n_features] if n_classes == 2 \
-            else [n_classes, n_features]
+else [n_classes, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
-        `coef_` is a readonly property derived from `raw_coef_` that \
-        follows the internal memory layout of liblinear.
+        `coef_` is a readonly property derived from `raw_coef_` that
+         follows the internal memory layout of liblinear.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.
@@ -259,11 +259,11 @@ class LinearSVR(LinearModel, RegressorMixin):
     Attributes
     ----------
     coef_ : array, shape = [n_features] if n_classes == 2 \
-            else [n_classes, n_features]
+else [n_classes, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
 
-        `coef_` is a readonly property derived from `raw_coef_` that \
+        `coef_` is a readonly property derived from `raw_coef_` that
         follows the internal memory layout of liblinear.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
@@ -420,12 +420,12 @@ class SVC(BaseSVC):
         number of support vector for each class.
 
     dual_coef_ : array, shape = [n_class-1, n_SV]
-        Coefficients of the support vector in the decision function. \
-        For multiclass, coefficient for all 1-vs-1 classifiers. \
-        The layout of the coefficients in the multiclass case is somewhat \
-        non-trivial. See the section about multi-class classification in the \
+        Coefficients of the support vector in the decision function.
+        For multiclass, coefficient for all 1-vs-1 classifiers.
+        The layout of the coefficients in the multiclass case is somewhat
+        non-trivial. See the section about multi-class classification in the
         SVM section of the User Guide for details.
-
+ 
     coef_ : array, shape = [n_class-1, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of linear kernel.
@@ -544,10 +544,10 @@ class NuSVC(BaseSVC):
         number of support vector for each class.
 
     dual_coef_ : array, shape = [n_class-1, n_SV]
-        Coefficients of the support vector in the decision function. \
-        For multiclass, coefficient for all 1-vs-1 classifiers. \
-        The layout of the coefficients in the multiclass case is somewhat \
-        non-trivial. See the section about multi-class classification in \
+        Coefficients of the support vector in the decision function.
+        For multiclass, coefficient for all 1-vs-1 classifiers.
+        The layout of the coefficients in the multiclass case is somewhat
+        non-trivial. See the section about multi-class classification in
         the SVM section of the User Guide for details.
 
     coef_ : array, shape = [n_class-1, n_features]

--- a/sklearn/utils/sparsetools/_graph_validation.py
+++ b/sklearn/utils/sparsetools/_graph_validation.py
@@ -2,8 +2,11 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from scipy.sparse import csr_matrix, isspmatrix, isspmatrix_csc
-from ._graph_tools import csgraph_to_dense, csgraph_from_dense,\
-    csgraph_masked_from_dense, csgraph_from_masked
+from ._graph_tools import (
+        csgraph_to_dense,
+        csgraph_from_dense,
+        csgraph_masked_from_dense,
+        csgraph_from_masked)
 
 DTYPE = np.float64
 


### PR DESCRIPTION
- [x] Make the multiple lines in docstring appear without any extra spaces in between the two words where multilines are separated by `\` at the end of 1st line.

**docstring**
Before : 

```
    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,            n_features]
```

After : 

```
    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes, n_features]
```

**html**
No change
- [x] Refactor a few multiline imports to make them look neater.

A very minor PR, @jnothman could you take a look...
