### PR TITLE
[MRG] Refactor ParameterGrid to use OrderedDict to keep the parameters sorted alphabetically.

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -770,7 +770,7 @@ def test_vectorizer_pipeline_grid_selection():
     assert_equal(grid_search.best_score_, 1.0)
     best_vectorizer = grid_search.best_estimator_.named_steps['vect']
     assert_equal(best_vectorizer.ngram_range, (1, 1))
-    assert_equal(best_vectorizer.norm, 'l2')
+    assert_equal(best_vectorizer.norm, 'l1')
     assert_false(best_vectorizer.fixed_vocabulary_)
 
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -30,6 +30,7 @@ from .utils.validation import _num_samples, indexable
 from .utils.metaestimators import if_delegate_has_method
 from .metrics.scorer import check_scoring
 
+from collections import OrderedDict
 
 __all__ = ['GridSearchCV', 'ParameterGrid', 'fit_grid_point',
            'ParameterSampler', 'RandomizedSearchCV']
@@ -79,7 +80,8 @@ class ParameterGrid(object):
             # wrap dictionary in a singleton list to support either dict
             # or list of dicts
             param_grid = [param_grid]
-        self.param_grid = param_grid
+        # Use OrderedDict to ensure keys are sorted for reproducibility
+        self.param_grid = [OrderedDict(d) for d in param_grid]
 
     def __iter__(self):
         """Iterate over the points in the grid.
@@ -91,8 +93,7 @@ class ParameterGrid(object):
             allowed values.
         """
         for p in self.param_grid:
-            # Always sort the keys of a dictionary, for reproducibility
-            items = sorted(p.items())
+            items = p.items()
             if not items:
                 yield {}
             else:


### PR DESCRIPTION
See #4017 and #3267

Performance of `OrderedDict` based `ParameterGrid` is similar to that of normal `dict` based one.

@amueller @larsmans 
