### PR TITLE
[MRG+1] Fix doc signature mismatch

### DIFF
--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -100,11 +100,14 @@ class _CFNode(object):
         Threshold needed for a new subcluster to enter a CFSubcluster.
 
     branching_factor : int
-       Maximum number of CF subclusters in each node.
+        Maximum number of CF subclusters in each node.
 
     is_leaf : bool
         We need to know if the CFNode is a leaf or not, in order to
         retrieve the final subclusters.
+
+    n_features : int
+        The number of features.
 
     Attributes
     ----------
@@ -248,10 +251,6 @@ class _CFSubcluster(object):
     linear_sum : ndarray, shape (n_features,), optional
         Sample. This is kept optional to allow initialization of empty
         subclusters.
-
-    index : int, optional
-        Index of the array in the original data. This enables to
-        retrieve the final subclusters.
 
     Attributes
     ----------

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -178,7 +178,16 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         must be square.
     random_state : numpy.RandomState, optional
         The generator used to shuffle the samples. Defaults to numpy.random.
-
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+        The algorithm to be used by the NearestNeighbors module
+        to compute pointwise distances and find nearest neighbors.
+        See NearestNeighbors module documentation for details.
+    leaf_size : int, optional (default = 30)
+        Leaf size passed to BallTree or cKDTree. This can affect the speed
+        of the construction and query, as well as the memory required
+        to store the tree. The optimal value depends
+        on the nature of the problem.
+ 
     Attributes
     ----------
     core_sample_indices_ : array, shape = [n_core_samples]

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -888,7 +888,6 @@ class Ward(AgglomerativeClustering):
         when varying the number of clusters and using caching, it may
         be advantageous to compute the full tree.
 
-
     Attributes
     ----------
     labels_ : array [n_features]
@@ -960,6 +959,11 @@ class WardAgglomeration(AgglomerationTransform, Ward):
         useful only when specifying a connectivity matrix. Note also that
         when varying the number of cluster and using caching, it may
         be advantageous to compute the full tree.
+
+    pooling_func : callable, default=np.mean
+        This combines the values of agglomerated features into a single
+        value, and should accept an array of shape [M, N] and the keyword
+        argument `axis=1`, and reduce it to an array of size [M].
 
     Attributes
     ----------

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -685,6 +685,16 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
+    verbose : int, default 0
+        Verbosity mode.
+
+    copy_x : boolean, default True
+        When pre-computing distances it is more numerically accurate to center
+        the data first.  If copy_x is True, then the original data is not
+        modified.  If False, the original data is modified, and put back before
+        the function returns, but small numerical differences may be introduced
+        by subtracting and then adding the data mean.
+
     Attributes
     ----------
     cluster_centers_ : array, [n_clusters, n_features]
@@ -918,8 +928,14 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
         model will take longer to converge, but should converge in a
         better clustering.
 
-    verbose : bool, optional
+    verbose : bool, optional, default False
         Controls the verbosity.
+
+    compute_squared_diff : bool
+        If set to False, the squared diff computation is skipped.
+
+    old_center_buffer : int
+        Copy of old centers for monitoring convergence.
 
     Returns
     -------
@@ -1143,6 +1159,8 @@ class MiniBatchKMeans(KMeans):
         model will take longer to converge, but should converge in a
         better clustering.
 
+    verbose : boolean, optional
+        Verbosity mode.
 
     Attributes
     ----------

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -13,9 +13,10 @@ Seeding is performed using a binning technique for scalability.
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 
-from collections import defaultdict
 import numpy as np
+import warnings
 
+from collections import defaultdict
 from ..externals import six
 from ..utils import extmath, check_random_state, gen_batches
 from ..utils.validation import check_is_fitted
@@ -66,7 +67,8 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
 
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
-               min_bin_freq=1, cluster_all=True, max_iter=300):
+               min_bin_freq=1, cluster_all=True, max_iter=300,
+               max_iterations=None):
     """Perform mean shift clustering of data using a flat kernel.
 
     Parameters
@@ -122,6 +124,13 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     See examples/cluster/plot_meanshift.py for an example.
 
     """
+    # FIXME To be removed in 0.18
+    if max_iterations is not None:
+        warnings.warn("The `max_iterations` parameter has been renamed to "
+                      "`max_iter` from version 0.16. The `max_iterations` "
+                      "parameter will be removed in 0.18", DeprecationWarning)
+        max_iter = max_iterations
+
     if bandwidth is None:
         bandwidth = estimate_bandwidth(X)
     if seeds is None:

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -99,6 +99,15 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
        To speed up the algorithm, accept only those bins with at least
        min_bin_freq points as seeds. If not defined, set to 1.
 
+    cluster_all : boolean, default True
+        If true, then all points are clustered, even those orphans that are
+        not within any kernel. Orphans are assigned to the nearest kernel.
+        If false, then orphans are given cluster label -1.
+
+    max_iterations : int, default 300
+        Maximum number of iterations, per seed point before the clustering
+        operation terminates (for that seed point), if has not converged yet.
+
     Returns
     -------
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -66,7 +66,7 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
 
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
-               min_bin_freq=1, cluster_all=True, max_iterations=300):
+               min_bin_freq=1, cluster_all=True, max_iter=300):
     """Perform mean shift clustering of data using a flat kernel.
 
     Parameters
@@ -104,7 +104,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         not within any kernel. Orphans are assigned to the nearest kernel.
         If false, then orphans are given cluster label -1.
 
-    max_iterations : int, default 300
+    max_iter : int, default 300
         Maximum number of iterations, per seed point before the clustering
         operation terminates (for that seed point), if has not converged yet.
 
@@ -134,7 +134,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     center_intensity_dict = {}
     nbrs = NearestNeighbors(radius=bandwidth).fit(X)
 
-    # For each seed, climb gradient until convergence or max_iterations
+    # For each seed, climb gradient until convergence or max_iter
     for my_mean in seeds:
         completed_iterations = 0
         while True:
@@ -146,9 +146,9 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                 break  # Depending on seeding strategy this condition may occur
             my_old_mean = my_mean  # save the old mean
             my_mean = np.mean(points_within, axis=0)
-            # If converged or at max_iterations, addS the cluster
+            # If converged or at max_iter, addS the cluster
             if (extmath.norm(my_mean - my_old_mean) < stop_thresh or
-                    completed_iterations == max_iterations):
+                    completed_iterations == max_iter):
                 center_intensity_dict[tuple(my_mean)] = len(points_within)
                 break
             completed_iterations += 1

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -260,28 +260,31 @@ class GraphLasso(EmpiricalCovariance):
 
     Parameters
     ----------
-    alpha : positive float, optional
+    alpha : positive float, default 0.01
         The regularization parameter: the higher alpha, the more
         regularization, the sparser the inverse covariance.
 
-    cov_init : 2D array (n_features, n_features), optional
-        The initial guess for the covariance.
-
-    mode : {'cd', 'lars'}
+    mode : {'cd', 'lars'}, default 'cd'
         The Lasso solver to use: coordinate descent or LARS. Use LARS for
         very sparse underlying graphs, where p > n. Elsewhere prefer cd
         which is more numerically stable.
 
-    tol : positive float, optional
+    tol : positive float, default 1e-4
         The tolerance to declare convergence: if the dual gap goes below
         this value, iterations are stopped.
 
-    max_iter : integer, optional
+    max_iter : integer, default 100
         The maximum number of iterations.
 
-    verbose : boolean, optional
+    verbose : boolean, default False
         If verbose is True, the objective function and dual gap are
         plotted at each iteration.
+
+    assume_centered : boolean, default False
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False, data are centered before computation.
 
     Attributes
     ----------
@@ -450,6 +453,13 @@ class GraphLassoCV(GraphLasso):
     verbose: boolean, optional
         If verbose is True, the objective function and duality gap are
         printed at each iteration.
+
+    assume_centered : Boolean
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False, data are centered before computation.
+
 
     Attributes
     ----------

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -59,6 +59,10 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         The random generator used. If an integer is given, it fixes the
         seed. Defaults to the global numpy random number generator.
 
+    cov_computation_method : callable, default empirical_covariance
+        The function which will be used to compute the covariance.
+        Must return shape (n_features, n_features)
+
     Returns
     -------
     location : array-like, shape (n_features,)
@@ -210,10 +214,16 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
         Maximum number of iterations for the c_step procedure.
         (2 is enough to be close to the final solution. "Never" exceeds 20).
 
-    random_state : integer or numpy.RandomState, optional
+    random_state : integer or numpy.RandomState, default None
         The random generator used. If an integer is given, it fixes the
         seed. Defaults to the global numpy random number generator.
 
+    cov_computation_method : callable, default empirical_covariance
+        The function which will be used to compute the covariance.
+        Must return shape (n_features, n_features)
+
+    verbose : boolean, default False
+        Control the output verbosity.
 
     See Also
     ---------
@@ -303,6 +313,10 @@ def fast_mcd(X, support_fraction=None,
         The generator used to randomly subsample. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
+
+    cov_computation_method : callable, default empirical_covariance
+        The function which will be used to compute the covariance.
+        Must return shape (n_features, n_features)
 
     Notes
     -----

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -66,12 +66,18 @@ class ShrunkCovariance(EmpiricalCovariance):
 
     Parameters
     ----------
-    store_precision : bool
+    store_precision : boolean, default True
         Specify if the estimated precision is stored
 
-    shrinkage : float, 0 <= shrinkage <= 1
+    shrinkage : float, 0 <= shrinkage <= 1, default 0.1
         Coefficient in the convex combination used for the computation
         of the shrunk estimate.
+
+    assume_centered : boolean, default False
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False, data are centered before computation.
 
     Attributes
     ----------
@@ -113,12 +119,6 @@ class ShrunkCovariance(EmpiricalCovariance):
             and n_features is the number of features.
 
         y : not used, present for API consistence purpose.
-
-        assume_centered : Boolean
-            If True, data are not centered before computation.
-            Useful to work with data whose mean is significantly equal to
-            zero but is not exactly zero.
-            If False, data are centered before computation.
 
         Returns
         -------

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -149,7 +149,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
     tol : non-negative real, default 1e-06
         The tolerance used in the iterative algorithm.
 
-    copy : boolean
+    copy : boolean, default True
         Whether the deflation should be done on a copy. Let the default
         value to True unless you don't care about side effects.
 
@@ -359,7 +359,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             Training vectors, where n_samples in the number of samples and
             q is the number of response variables.
 
-        copy : boolean
+        copy : boolean, default True
             Whether to copy X and Y, or perform in-place normalization.
 
         Returns
@@ -397,7 +397,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             Training vectors, where n_samples in the number of samples and
             p is the number of predictors.
 
-        copy : boolean
+        copy : boolean, default True
             Whether to copy X and Y, or perform in-place normalization.
 
         Notes
@@ -429,7 +429,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             Training vectors, where n_samples in the number of samples and
             q is the number of response variables.
 
-        copy : boolean
+        copy : boolean, default True
             Whether to copy X and Y, or perform in-place normalization.
 
         Returns
@@ -450,14 +450,6 @@ class PLSRegression(_PLS):
 
     Parameters
     ----------
-    X : array-like of predictors, shape = [n_samples, p]
-        Training vectors, where n_samples in the number of samples and
-        p is the number of predictors.
-
-    Y : array-like of response, shape = [n_samples, q] or [n_samples]
-        Training vectors, where n_samples in the number of samples and
-        q is the number of response variables.
-
     n_components : int, (default 2)
         Number of components to keep.
 
@@ -580,16 +572,6 @@ class PLSCanonical(_PLS):
 
     Parameters
     ----------
-    X : array-like of predictors, shape = [n_samples, p]
-        Training vectors, where n_samples is the number of samples and
-        p is the number of predictors.
-
-    Y : array-like of response, shape = [n_samples, q]
-        Training vectors, where n_samples is the number of samples and
-        q is the number of response variables.
-
-    n_components : int, number of components to keep. (default 2).
-
     scale : boolean, scale data? (default True)
 
     algorithm : string, "nipals" or "svd"
@@ -606,6 +588,8 @@ class PLSCanonical(_PLS):
     copy : boolean, default True
         Whether the deflation should be done on a copy. Let the default
         value to True unless you don't care about side effect
+
+    n_components : int, number of components to keep. (default 2).
 
     Attributes
     ----------
@@ -704,20 +688,14 @@ class PLSSVD(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    X : array-like of predictors, shape = [n_samples, p]
-        Training vector, where n_samples is the number of samples and
-        p is the number of predictors. X will be centered before any analysis.
+    n_components : int, default 2
+        Number of components to keep.
 
-    Y : array-like of response, shape = [n_samples, q]
-        Training vector, where n_samples is the number of samples and
-        q is the number of response variables. X will be centered before any
-        analysis.
+    scale : boolean, default True
+        Whether to scale X and Y.
 
-    n_components : int, (default 2).
-        number of components to keep.
-
-    scale : boolean, (default True)
-        whether to scale X and Y.
+    copy : boolean, default True
+        Whether to copy X and Y, or perform in-place computations.
 
     Attributes
     ----------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1327,7 +1327,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         The target variable to try to predict in the case of
         supervised learning.
 
-    scoring : callable
+    scorer : callable
         A scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -1161,7 +1161,7 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
     Parameters
     ----------
     dim: integer, optional (default=1)
-        The size of the random  (matrix to generate.
+        The size of the random matrix to generate.
 
     alpha: float between 0 and 1, optional (default=0.95)
         The probability that a coefficient is non zero (see notes).
@@ -1172,9 +1172,20 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    largest_coef : float between 0 and 1, optional (default=0.9)
+        The value of the largest coefficient.
+
+    smallest_coef : float between 0 and 1, optional (default=0.1)
+        The value of the smallest coefficient.
+
+    norm_diag : boolean, optional (default=False)
+        Whether to normalize the output matrix to make the leading diagonal
+        elements all 1
+
     Returns
     -------
-    prec: array of shape = [dim, dim]
+    prec : sparse matrix of shape (dim, dim)
+        The generated matrix.
 
     Notes
     -----
@@ -1204,10 +1215,12 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
     prec = np.dot(chol.T, chol)
 
     if norm_diag:
-        d = np.diag(prec)
+        # Form the diagonal vector into a row matrix
+        d = np.diag(prec).reshape(1, prec.shape[0])
         d = 1. / np.sqrt(d)
-        prec *= d
-        prec *= d[:, np.newaxis]
+
+        prec *= d 
+        prec *= d.T
 
     return prec
 

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -86,6 +86,7 @@ def _load_csv(F):
     ----------
     F : file object
         CSV file open in byte mode.
+
     Returns
     -------
     rec : np.ndarray

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -65,24 +65,24 @@ def load_svmlight_file(f, n_features=None, dtype=np.float64,
 
     Parameters
     ----------
-    f: {str, file-like, int}
+    f : {str, file-like, int}
         (Path to) a file to load. If a path ends in ".gz" or ".bz2", it will
         be uncompressed on the fly. If an integer is passed, it is assumed to
         be a file descriptor. A file-like or file descriptor will not be closed
         by this function. A file-like object must be opened in binary mode.
 
-    n_features: int or None
+    n_features : int or None
         The number of features to use. If None, it will be inferred. This
         argument is useful to load several files that are subsets of a
         bigger sliced dataset: each subset might not have examples of
         every feature, hence the inferred shape might vary from one
         slice to another.
 
-    multilabel: boolean, optional
+    multilabel : boolean, optional, default False
         Samples may have several labels each (see
         http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel.html)
 
-    zero_based: boolean or "auto", optional
+    zero_based : boolean or "auto", optional, default "auto"
         Whether column indices in f are zero-based (True) or one-based
         (False). If column indices are one-based, they are transformed to
         zero-based to match Python/NumPy conventions.
@@ -91,8 +91,12 @@ def load_svmlight_file(f, n_features=None, dtype=np.float64,
         are unfortunately not self-identifying. Using "auto" or True should
         always be safe.
 
-    query_id: boolean, defaults to False
+    query_id : boolean, default False
         If True, will return the query_id array for each file.
+
+    dtype : numpy data type, default np.float64
+        Data type of dataset to be loaded. This will be the data type of the
+        output numpy arrays ``X`` and ``y``.
 
     Returns
     -------
@@ -218,6 +222,10 @@ def load_svmlight_files(files, n_features=None, dtype=np.float64,
     query_id: boolean, defaults to False
         If True, will return the query_id array for each file.
 
+    dtype : numpy data type, default np.float64
+        Data type of dataset to be loaded. This will be the data type of the
+        output numpy arrays ``X`` and ``y``.
+ 
     Returns
     -------
     [X1, y1, ..., Xn, yn]

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -87,15 +87,16 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
 
         Parameters
         ----------
-        X: array-like, shape (n_samples, n_features)
+        X : array-like, shape (n_samples, n_features)
             Training data, where n_samples is the number of samples and
             n_features is the number of features.
 
         Returns
         -------
-        self: object
+        self : object
             Returns the instance itself.
         """
+
 
     def transform(self, X, y=None):
         """Apply dimensionality reduction to X.

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -28,15 +28,19 @@ def _gs_decorrelation(w, W, j):
 
     Parameters
     ----------
-    w: array of shape(n), to be orthogonalized
+    w : ndarray of shape(n)
+        Array to be orthogonalized
 
-    W: array of shape(p, n), null space definition
+    W : ndarray of shape(p, n)
+        Null space definition
 
-    j: int < p
+    j : int < p
+        The no of (from the first) rows of Null space W wrt which w is
+        orthogonalized.
 
-    caveats
-    -------
-    assumes that W is orthogonal
+    Notes
+    -----
+    Assumes that W is orthogonal
     w changed in place
     """
     w -= np.dot(np.dot(w, W[:j].T), W[:j])

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -93,13 +93,10 @@ def _initialize_nmf(X, n_components, variant=None, eps=1e-6,
         Initial guesses for solving X ~= WH such that
         the number of columns in W is n_components.
 
-    Remarks
-    -------
-
-    This implements the algorithm described in
-    C. Boutsidis, E. Gallopoulos: SVD based
-    initialization: A head start for nonnegative
-    matrix factorization - Pattern Recognition, 2008
+    References
+    ----------
+    C. Boutsidis, E. Gallopoulos: SVD based initialization: A head start for 
+    nonnegative matrix factorization - Pattern Recognition, 2008
 
     http://tinyurl.com/nndsvd
     """
@@ -204,12 +201,10 @@ def _nls_subproblem(V, W, H, tol, max_iter, sigma=0.01, beta=0.1):
     n_iter : int
         The number of iterations done by the algorithm.
 
-    Reference
-    ---------
-
-    C.-J. Lin. Projected gradient methods
-    for non-negative matrix factorization. Neural
-    Computation, 19(2007), 2756-2779.
+    References
+    ----------
+    C.-J. Lin. Projected gradient methods for non-negative matrix factorization.
+    Neural Computation, 19(2007), 2756-2779.
     http://www.csie.ntu.edu.tw/~cjlin/nmf/
 
     """

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -31,13 +31,13 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
     Parameters
     ----------
     spectrum: array of shape (n)
-        data spectrum
-    rank: int,
-        tested rank value
-    n_samples: int,
-        number of samples
-    dim: int,
-        embedding/empirical dimension
+        Data spectrum.
+    rank: int
+        Tested rank value.
+    n_samples: int
+        Number of samples.
+    n_features: int
+        Number of features.
 
     Returns
     -------

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -206,16 +206,24 @@ class LossFunction(six.with_metaclass(ABCMeta, object)):
         ----------
         tree : tree.Tree
             The tree object.
-        X : np.ndarray, shape=(n, m)
+        X : ndarray, shape=(n, m)
             The data array.
-        y : np.ndarray, shape=(n,)
+        y : ndarray, shape=(n,)
             The target labels.
-        residual : np.ndarray, shape=(n,)
+        residual : ndarray, shape=(n,)
             The residuals (usually the negative gradient).
-        y_pred : np.ndarray, shape=(n,):
+        y_pred : ndarray, shape=(n,)
             The predictions.
-        sample_weight : np.ndarray, shape=(n,):
+        sample_weight : ndarray, shape=(n,)
             The weight of each sample.
+        sample_mask : ndarray, shape=(n,)
+            The sample mask to be used.
+        learning_rate : float, default=0.1
+            learning rate shrinks the contribution of each tree by 
+            `learning_rate`.
+        k : int, default 0
+            The index of the estimator being updated.
+
         """
         # compute leaf for each sample in ``X``.
         terminal_regions = tree.apply(X)
@@ -312,8 +320,8 @@ class HuberLossFunction(RegressionLossFunction):
 
     M-Regression proposed in Friedman 2001.
 
-    See
-    ---
+    References
+    ----------
     J. Friedman, Greedy Function Approximation: A Gradient Boosting
     Machine, The Annals of Statistics, Vol. 29, No. 5, 2001.
     """
@@ -575,8 +583,8 @@ class ExponentialLoss(ClassificationLossFunction):
 
     Same loss as AdaBoost.
 
-    See
-    ---
+    References
+    ----------
     Greg Ridgeway, Generalized Boosted Models: A guide to the gbm package, 2007
     """
     def __init__(self, n_classes):

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -15,12 +15,14 @@ import functools
 import time
 import threading
 import itertools
+
 try:
     import cPickle as pickle
 except:
     import pickle
 
 from ._multiprocessing_helpers import mp
+
 if mp is not None:
     from .pool import MemmapingPool
     from multiprocessing.pool import ThreadPool
@@ -192,13 +194,13 @@ class Parallel(Logger):
 
         Parameters
         -----------
-        n_jobs: int
+        n_jobs : int
             The number of jobs to use for the computation. If -1 all CPUs
             are used. If 1 is given, no parallel computing code is used
             at all, which is useful for debugging. For n_jobs below -1,
             (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all
             CPUs but one are used.
-        backend: str or None
+        backend : str or None
             Specify the parallelization backend implementation.
             Supported backends are:
               - "multiprocessing" used by default, can induce some
@@ -211,16 +213,16 @@ class Parallel(Logger):
                 explicitly releases the GIL (for instance a Cython loop wrapped
                 in a "with nogil" block or an expensive call to a library such
                 as NumPy).
-        verbose: int, optional
+        verbose : int, optional
             The verbosity level: if non zero, progress messages are
             printed. Above 50, the output is sent to stdout.
             The frequency of the messages increases with the verbosity level.
             If it more than 10, all iterations are reported.
-        pre_dispatch: {'all', integer, or expression, as in '3*n_jobs'}
+        pre_dispatch : {'all', integer, or expression, as in '3*n_jobs'}
             The amount of jobs to be pre-dispatched. Default is 'all',
             but it may be memory consuming, for instance if each job
             involves a lot of a data.
-        temp_folder: str, optional
+        temp_folder : str, optional
             Folder to be used by the pool for memmaping large arrays
             for sharing memory with worker processes. If None, this will try in
             order:
@@ -231,12 +233,16 @@ class Parallel(Logger):
               with TMP, TMPDIR or TEMP environment variables, typically /tmp
               under Unix operating systems.
             Only active when backend="multiprocessing".
-        max_nbytes int, str, or None, optional, 100e6 (100MB) by default
+        max_nbytes : int, str, or None, optional, 100e6 (100MB) by default
             Threshold on the size of arrays passed to the workers that
             triggers automated memory mapping in temp_folder. Can be an int
             in Bytes, or a human-readable string, e.g., '1M' for 1 megabyte.
             Use None to disable memmaping of large arrays.
             Only active when backend="multiprocessing".
+        mmap_mode : 'r', 'r+' or 'c'
+            Mode for the created memmap datastructure. See the documentation of
+            numpy.memmap for more details. Note: 'w+' is coerced to 'r+'
+            automatically to avoid zeroing the data on unpickling.
 
         Notes
         -----

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -37,7 +37,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    dtype : NumPy type, optional
+    dtype : numpy type, optional
         The type of feature values. Passed to scipy.sparse matrix constructors
         as the dtype argument. Do not set this to bool, np.boolean or any
         unsigned integer type.
@@ -50,7 +50,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         The feature_name is hashed to find the appropriate column for the
         feature. The value's sign might be flipped in the output (but see
         non_negative, below).
-    non_negative : boolean, optional
+    non_negative : boolean, optional, default np.float64
         Whether output matrices should contain non-negative values only;
         effectively calls abs on the matrix prior to returning it.
         When True, output values can be interpreted as frequencies.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -984,6 +984,10 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         X : sparse matrix, [n_samples, n_features]
             a matrix of term/token counts
 
+        copy : boolean, default True
+            Whether to copy X and operate on the copy or perform in-place
+            operations.
+
         Returns
         -------
         vectors : sparse matrix, [n_samples, n_features]
@@ -1275,6 +1279,10 @@ class TfidfVectorizer(CountVectorizer):
         ----------
         raw_documents : iterable
             an iterable which yields either str, unicode or file objects
+
+        copy : boolean, default True
+            Whether to copy X and operate on the copy or perform in-place
+            operations.
 
         Returns
         -------

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -57,6 +57,9 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         Useful for doing grid searches when an `RFE` object is passed as an
         argument to, e.g., a `sklearn.grid_search.GridSearchCV` object.
 
+    verbose : int, default=0
+        Controls verbosity of output.
+
     Attributes
     ----------
     n_features_ : int
@@ -66,8 +69,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         The mask of selected features.
 
     ranking_ : array of shape [n_features]
-        The feature ranking, such that `ranking_[i]` corresponds to the \
-        ranking position of the i-th feature. Selected (i.e., estimated \
+        The feature ranking, such that `ranking_[i]` corresponds to the
+        ranking position of the i-th feature. Selected (i.e., estimated
         best) features are assigned rank 1.
 
     estimator_ : object

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -17,9 +17,9 @@ def absolute_exponential(theta, d):
     Absolute exponential autocorrelation model.
     (Ornstein-Uhlenbeck stochastic process)::
 
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i| )
-                                          i = 1
+                                          n
+        theta, d --> r(theta, d) = exp(  sum  - theta_i * |d_i| )
+                                        i = 1
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def absolute_exponential(theta, d):
         An array with shape 1 (isotropic) or n (anisotropic) giving the
         autocorrelation parameter(s).
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.
@@ -59,9 +59,9 @@ def squared_exponential(theta, d):
     Squared exponential correlation model (Radial Basis Function).
     (Infinitely differentiable stochastic process, very smooth)::
 
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * (dx_i)^2 )
-                                          i = 1
+                                          n
+        theta, d --> r(theta, d) = exp(  sum  - theta_i * (d_i)^2 )
+                                        i = 1
 
     Parameters
     ----------
@@ -69,7 +69,7 @@ def squared_exponential(theta, d):
         An array with shape 1 (isotropic) or n (anisotropic) giving the
         autocorrelation parameter(s).
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.
@@ -103,9 +103,9 @@ def generalized_exponential(theta, d):
     (Useful when one does not know the smoothness of the function to be
     predicted.)::
 
-                                            n
-        theta, dx --> r(theta, dx) = exp(  sum  - theta_i * |dx_i|^p )
-                                          i = 1
+                                          n
+        theta, d --> r(theta, d) = exp(  sum  - theta_i * |d_i|^p )
+                                        i = 1
 
     Parameters
     ----------
@@ -113,7 +113,7 @@ def generalized_exponential(theta, d):
         An array with shape 1+1 (isotropic) or n+1 (anisotropic) giving the
         autocorrelation parameter(s) (theta, p).
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.
@@ -152,17 +152,17 @@ def pure_nugget(theta, d):
     Spatial independence correlation model (pure nugget).
     (Useful when one wants to solve an ordinary least squares problem!)::
 
-                                             n
-        theta, dx --> r(theta, dx) = 1 if   sum |dx_i| == 0
-                                           i = 1
-                                     0 otherwise
+                                           n
+        theta, d --> r(theta, d) = 1 if   sum |d_i| == 0
+                                         i = 1
+                                   0 otherwise
 
     Parameters
     ----------
     theta : array_like
         None.
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.
@@ -188,9 +188,9 @@ def cubic(theta, d):
     """
     Cubic correlation model::
 
-        theta, dx --> r(theta, dx) =
+        theta, d --> r(theta, d) =
           n
-        prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
+         prod max(0, 1 - 3(theta_j*d_ij)^2 + 2(theta_j*d_ij)^3) ,  i = 1,...,m
         j = 1
 
     Parameters
@@ -199,7 +199,7 @@ def cubic(theta, d):
         An array with shape 1 (isotropic) or n (anisotropic) giving the
         autocorrelation parameter(s).
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.
@@ -238,7 +238,7 @@ def linear(theta, d):
     """
     Linear correlation model::
 
-        theta, dx --> r(theta, dx) =
+        theta, d --> r(theta, d) =
               n
             prod max(0, 1 - theta_j*d_ij) ,  i = 1,...,m
             j = 1
@@ -249,7 +249,7 @@ def linear(theta, d):
         An array with shape 1 (isotropic) or n (anisotropic) giving the
         autocorrelation parameter(s).
 
-    dx : array_like
+    d : array_like
         An array with shape (n_eval, n_features) giving the componentwise
         distances between locations x and x' at which the correlation model
         should be evaluated.

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -158,6 +158,12 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
     n_components : int, optional
         Number of components (< n_classes - 1) for dimensionality reduction.
 
+    store_covariance : bool, optional
+        Additionally compute class covariance matrix (default False).
+
+    tol : float, optional
+        Threshold used for rank estimation in SVD solver.
+
     Attributes
     ----------
     coef_ : array, shape (n_features,) or (n_classes, n_features)
@@ -391,6 +397,12 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
 
         y : array, shape (n_samples,)
             Target values.
+
+        store_covariance : bool, optional
+            Additionally compute class covariance matrix (default False).
+
+        tol : float, optional
+            Threshold used for rank estimation.
         """
         if store_covariance:
             warnings.warn("'store_covariance' was moved to the __init__()"

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -318,7 +318,8 @@ class LinearRegression(LinearModel, RegressorMixin):
     copy_X : boolean, optional, default True
         If True, X will be copied; else, it may be overwritten.
 
-    n_jobs : The number of jobs to use for the computation.
+    n_jobs : int, optional, default 1
+        The number of jobs to use for the computation.
         If -1 all CPUs are used. This will only provide speedup for
         n_targets > 1 and sufficient large problems.
 
@@ -355,8 +356,14 @@ class LinearRegression(LinearModel, RegressorMixin):
         ----------
         X : numpy array or sparse matrix of shape [n_samples,n_features]
             Training data
+
         y : numpy array of shape [n_samples, n_targets]
             Target values
+
+        n_jobs : int, optional, default 1
+            The number of jobs to use for the computation.
+            If -1 all CPUs are used. This will only provide speedup for
+            n_targets > 1 and sufficiently large problems.
 
         Returns
         -------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -170,6 +170,9 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     positive : bool, default False
         If set to True, forces coefficients to be positive.
 
+    return_n_iter : bool
+        whether to return the number of iterations or not.
+
     Returns
     -------
     alphas : array, shape (n_alphas,)
@@ -1186,6 +1189,17 @@ class LassoCV(LinearModelCV, RegressorMixin):
         a random feature to update. Useful only when selection is set to
         'random'.
 
+    fit_intercept : boolean, default True
+        whether to calculate the intercept for this model. If set
+        to false, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    normalize : boolean, optional, default False
+        If ``True``, the regressors X will be normalized before regression.
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
+
     Attributes
     ----------
     alpha_ : float
@@ -1311,6 +1325,17 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
         The seed of the pseudo random number generator that selects
         a random feature to update. Useful only when selection is set to
         'random'.
+
+    fit_intercept : boolean
+        whether to calculate the intercept for this model. If set
+        to false, no intercept will be used in calculations
+        (e.g. data is expected to be already centered).
+
+    normalize : boolean, optional, default False
+        If ``True``, the regressors X will be normalized before regression.
+
+    copy_X : boolean, optional, default True
+        If ``True``, X will be copied; else, it may be overwritten.
 
     Attributes
     ----------

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -85,9 +85,12 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     verbose : int (default=0)
         Controls output verbosity.
 
-    return_path : bool, (optional=True)
+    return_path : bool, optional (default=True)
         If ``return_path==True`` returns the entire path, else returns only the
         last point of the path.
+
+    return_n_iter : bool, optional (default=False)
+        Whether to return the number of iterations.
 
     Returns
     --------
@@ -1248,15 +1251,18 @@ class LassoLarsIC(LassoLars):
     def fit(self, X, y, copy_X=True):
         """Fit the model using X, y as training data.
 
-        parameters
+        Parameters
         ----------
-        x : array-like, shape (n_samples, n_features)
+        X : array-like, shape (n_samples, n_features)
             training data.
 
         y : array-like, shape (n_samples,)
             target values.
+    
+        copy_X : boolean, optional, default True
+            If ``True``, X will be copied; else, it may be overwritten.
 
-        returns
+        Returns
         -------
         self : object
             returns an instance of self.

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -770,6 +770,11 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         the entire probability distribution. Works only for the 'lbfgs'
         solver.
 
+    copy : bool, default True
+        Whether or not to produce a copy of the data. Setting this to
+        True will be useful in cases, when ``_log_reg_scoring_path`` is called
+        repeatedly with the same data, as y is modified along the path.
+
     Returns
     -------
     coefs : ndarray, shape (n_cs, n_features) or (n_cs, n_features + 1)

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -132,10 +132,6 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         intercept_init : array, shape = [n_classes]
             The initial intercept to warm-start the optimization.
 
-        sample_weight : array-like, shape = [n_samples], optional
-            Weights applied to individual samples.
-            If not provided, uniform weights are assumed.
-
         Returns
         -------
         self : returns an instance of self.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -771,8 +771,7 @@ class _RidgeGCV(LinearModel):
         cv_values = np.zeros((n_samples * n_y, len(self.alphas)))
         C = []
 
-        scorer = check_scoring(self, scoring=self.scoring, allow_none=True,
-                               score_overrides_loss=True)
+        scorer = check_scoring(self, scoring=self.scoring, allow_none=True)
         error = scorer is None
 
         for i, alpha in enumerate(self.alphas):

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -140,10 +140,10 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
     adjacency : array-like or sparse matrix, shape: (n_samples, n_samples)
         The adjacency matrix of the graph to embed.
 
-    n_components : integer, optional
+    n_components : integer, optional, default 8
         The dimension of the projection subspace.
 
-    eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}, default None
         The eigenvalue decomposition strategy to use. AMG requires pyamg
         to be installed. It can be faster on very large, sparse problems,
         but may also lead to instabilities.
@@ -163,6 +163,9 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         connected graph, but for spectral clustering, this should be kept as
         False to retain the first eigenvector.
 
+    norm_laplacian : bool, optional, default=True
+        If True, then compute normalized Laplacian.
+ 
     Returns
     -------
     embedding : array, shape=(n_samples, n_components)

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -56,6 +56,9 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    binary_metric : callable, returns shape [n_classes]
+        The binary metric function to use.
+
     Returns
     -------
     score : float or array of shape [n_classes]

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -242,7 +242,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
         can be changed for fine-tuning. The larger the number, the larger the
         memory usage.
 
-    metric : string or callable
+    metric : string or callable, default 'euclidean'
         metric to use for distance computation. Any metric from scikit-learn
         or scipy.spatial.distance can be used.
 
@@ -270,6 +270,9 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
 
     metric_kwargs : dict, optional
         Keyword arguments to pass to specified metric function.
+
+    axis : int, optional, default 1
+        Axis along which the argmin and distances are to be computed.
 
     Returns
     -------
@@ -355,7 +358,11 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
 
     Parameters
     ==========
-    X, Y : array-like
+    X : array-like
+        Arrays containing points. Respective shapes (n_samples1, n_features)
+        and (n_samples2, n_features)
+
+    Y : array-like
         Arrays containing points. Respective shapes (n_samples1, n_features)
         and (n_samples2, n_features)
 
@@ -394,6 +401,9 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
 
     metric_kwargs : dict
         keyword arguments to pass to specified metric function.
+
+    axis : int, optional, default 1
+        Axis along which the argmin and distances are to be computed.
 
     Returns
     =======
@@ -597,7 +607,11 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
     Parameters
     ----------
-    X, Y : ndarray (n_samples, n_features)
+    X : ndarray (n_samples, n_features)
+        Array 1 for distance computation.
+
+    Y : ndarray (n_samples, n_features)
+        Array 2 for distance computation.
 
     metric : string or callable
         The metric to use when calculating distance between instances in a
@@ -667,11 +681,13 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Parameters
     ----------
-    X : array of shape (n_samples_1, n_features)
+    X : ndarray of shape (n_samples_1, n_features)
 
-    Y : array of shape (n_samples_2, n_features)
+    Y : ndarray of shape (n_samples_2, n_features)
 
-    degree : int
+    coef0 : int, default 1
+
+    degree : int, default 3
 
     Returns
     -------
@@ -696,11 +712,11 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
     Parameters
     ----------
-    X : array of shape (n_samples_1, n_features)
+    X : ndarray of shape (n_samples_1, n_features)
 
-    Y : array of shape (n_samples_2, n_features)
+    Y : ndarray of shape (n_samples_2, n_features)
 
-    degree : int
+    coef0 : int, default 1
 
     Returns
     -------

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -201,8 +201,7 @@ def _passthrough_scorer(estimator, *args, **kwargs):
     return estimator.score(*args, **kwargs)
 
 
-def check_scoring(estimator, scoring=None, allow_none=False,
-                  score_overrides_loss=False):
+def check_scoring(estimator, scoring=None, allow_none=False):
     """Determine scorer from user options.
 
     A TypeError will be thrown if the estimator cannot be scored.

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -127,34 +127,39 @@ class DPGMM(GMM):
 
     Parameters
     ----------
-    n_components: int, optional
-        Number of mixture components. Defaults to 1.
+    n_components: int, default 1
+        Number of mixture components.
 
-    covariance_type: string, optional
+    covariance_type: string, default 'diag'
         String describing the type of covariance parameters to
         use.  Must be one of 'spherical', 'tied', 'diag', 'full'.
-        Defaults to 'diag'.
 
-    alpha: float, optional
+    alpha: float, default 1
         Real number representing the concentration parameter of
         the dirichlet process. Intuitively, the Dirichlet Process
         is as likely to start a new cluster for a point as it is
         to add that point to a cluster with alpha elements. A
         higher alpha means more clusters, as the expected number
-        of clusters is ``alpha*log(N)``. Defaults to 1.
+        of clusters is ``alpha*log(N)``.
 
-    thresh : float, optional
+    thresh : float, default 1e-2
         Convergence threshold.
-    n_iter : int, optional
+
+    n_iter : int, default 10
         Maximum number of iterations to perform before convergence.
-    params : string, optional
+
+    params : string, default 'wmc' 
         Controls which parameters are updated in the training
         process.  Can contain any combination of 'w' for weights,
-        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
-    init_params : string, optional
+        'm' for means, and 'c' for covars.
+
+    init_params : string, default 'wmc' 
         Controls which parameters are updated in the initialization
         process.  Can contain any combination of 'w' for weights,
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+
+    verbose : boolean, default False
+        Controls output verbosity.
 
     Attributes
     ----------
@@ -595,21 +600,37 @@ class VBGMM(DPGMM):
 
     Parameters
     ----------
-    n_components: int, optional
-        Number of mixture components. Defaults to 1.
+    n_components: int, default 1
+        Number of mixture components.
 
-    covariance_type: string, optional
+    covariance_type: string, default 'diag'
         String describing the type of covariance parameters to
         use.  Must be one of 'spherical', 'tied', 'diag', 'full'.
-        Defaults to 'diag'.
 
-    alpha: float, optional
+    alpha: float, default 1
         Real number representing the concentration parameter of
         the dirichlet distribution. Intuitively, the higher the
         value of alpha the more likely the variational mixture of
-        Gaussians model will use all components it can. Defaults
-        to 1.
+        Gaussians model will use all components it can.
 
+    thresh : float, default 1e-2
+        Convergence threshold.
+
+    n_iter : int, default 10
+        Maximum number of iterations to perform before convergence.
+
+    params : string, default 'wmc'
+        Controls which parameters are updated in the training
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.
+
+    init_params : string, default 'wmc'
+        Controls which parameters are updated in the initialization
+        process.  Can contain any combination of 'w' for weights,
+        'm' for means, and 'c' for covars.  Defaults to 'wmc'.
+
+    verbose : boolean, default False
+        Controls output verbosity.
 
     Attributes
     ----------

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -69,7 +69,7 @@ def sample_gaussian(mean, covar, covariance_type='diag', n_samples=1,
     mean : array_like, shape (n_features,)
         Mean of the distribution.
 
-    covars : array_like, optional
+    covar : array_like, optional
         Covariance of the distribution. The shape depends on `covariance_type`:
             scalar if 'spherical',
             (n_features) if 'diag',

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -42,6 +42,32 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
+ 
+    metric : string or callable, default 'minkowski'
+        metric to use for distance computation. Any metric from scikit-learn
+        or scipy.spatial.distance can be used.
+
+        If metric is a callable function, it is called on each
+        pair of instances (rows) and the resulting value recorded. The callable
+        should take two arrays as input and return one value indicating the
+        distance between them. This works for Scipy's metrics, but is less
+        efficient than passing the metric name as a string.
+
+        Distance matrices are not supported.
+
+        Valid values for metric are:
+
+        - from scikit-learn: ['cityblock', 'cosine', 'euclidean', 'l1', 'l2',
+          'manhattan']
+
+        - from scipy.spatial.distance: ['braycurtis', 'canberra', 'chebyshev',
+          'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski',
+          'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto',
+          'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath',
+          'sqeuclidean', 'yule']
+
+        See the documentation for scipy.spatial.distance for details on these
+        metrics.
 
     metric_params: dict, optional (default = None)
         additional keyword arguments for the metric function.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -86,7 +86,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix and if axis is 1).
@@ -165,7 +165,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
     feature_range: tuple (min, max), default=(0, 1)
         Desired range of transformed data.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         Set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array).
 
@@ -275,7 +275,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         If False, try to avoid a copy and do inplace scaling instead.
         This is not guaranteed to always work inplace; e.g. if the data is
         not a NumPy array or scipy.sparse CSR matrix, a copy may still be
@@ -520,7 +520,7 @@ def normalize(X, norm='l2', axis=1, copy=True):
         axis used to normalize the data along. If 1, independently normalize
         each sample, otherwise (if 0) normalize each feature.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix and if axis is 1).
@@ -588,7 +588,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
     norm : 'l1' or 'l2', optional ('l2' by default)
         The norm to use to normalize each non zero sample.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix).
@@ -645,7 +645,7 @@ def binarize(X, threshold=0.0, copy=True):
         Feature values below or equal to this are replaced by 0, above it by 1.
         Threshold may not be less than 0 for operations on sparse matrices.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         set to False to perform inplace binarization and avoid a copy
         (if the input is already a numpy array or a scipy.sparse CSR / CSC
         matrix and if axis is 1).
@@ -695,7 +695,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
         Feature values below or equal to this are replaced by 0, above it by 1.
         Threshold may not be less than 0 for operations on sparse matrices.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default True
         set to False to perform inplace binarization and avoid a copy (if
         the input is already a numpy array or a scipy.sparse CSR matrix).
 
@@ -770,6 +770,9 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         ----------
         K : numpy array of shape [n_samples1, n_samples2]
             Kernel matrix.
+
+        copy : boolean, optional, default True
+            Set to False to perform inplace computation.
 
         Returns
         -------

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -96,6 +96,9 @@ class QDA(BaseEstimator, ClassifierMixin):
         store_covariances : boolean
             If True the covariance matrices are computed and stored in the
             `self.covariances_` attribute.
+        
+        tol : float, optional, default 1.0e-4
+            Threshold used for rank estimation.
         """
         X, y = check_X_y(X, y)
         self.classes_, y = np.unique(y, return_inverse=True)

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -96,6 +96,9 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         Convergence tolerance: threshold to consider the system at steady
         state
 
+    n_neighbors : integer > 0
+        Parameter for knn kernel
+ 
     """
 
     def __init__(self, kernel='rbf', gamma=20, n_neighbors=7,
@@ -271,16 +274,16 @@ class LabelPropagation(BaseLabelPropagation):
         String identifier for kernel function to use.
         Only 'rbf' and 'knn' kernels are currently supported..
     gamma : float
-      parameter for rbf kernel
+        Parameter for rbf kernel
     n_neighbors : integer > 0
-      parameter for knn kernel
+        Parameter for knn kernel
     alpha : float
-      clamping factor
+        Clamping factor
     max_iter : float
-      change maximum number of iterations allowed
+        Change maximum number of iterations allowed
     tol : float
-      Convergence tolerance: threshold to consider the system at steady
-      state
+        Convergence tolerance: threshold to consider the system at steady
+        state
 
     Attributes
     ----------

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -717,6 +717,12 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         hinge loss, 'lr' is the Logistic loss and 'ei' is the epsilon-insensitive
         loss.
 
+    epsilon : float, optional (default=0.1)
+        Epsilon parameter in the epsilon-insensitive loss function. Note
+        that the value of this parameter depends on the scale of the target
+        variable y. If unsure, set epsilon=0.
+
+
     Returns
     -------
     coef_ : ndarray, shape (n_features, n_features + 1)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -168,7 +168,7 @@ def resample(*arrays, **options):
 
     Parameters
     ----------
-    `*arrays` : sequence of arrays or scipy.sparse matrices with same shape[0]
+    *arrays : sequence of arrays or scipy.sparse matrices with same shape[0]
 
     replace : boolean, True by default
         Implements resampling with replacement. If False, this will implement
@@ -183,8 +183,10 @@ def resample(*arrays, **options):
 
     Returns
     -------
-    Sequence of resampled views of the collections. The original arrays are
-    not impacted.
+    resampled_arrays : sequence of arrays or scipy.sparse matrices with same \
+    shape[0]
+        Sequence of resampled views of the collections. The original arrays are 
+        not impacted.
 
     Examples
     --------
@@ -275,7 +277,7 @@ def shuffle(*arrays, **options):
 
     Parameters
     ----------
-    `*arrays` : sequence of arrays or scipy.sparse matrices with same shape[0]
+    *arrays : sequence of arrays or scipy.sparse matrices with same shape[0]
 
     random_state : int or RandomState instance
         Control the shuffling for reproducible behavior.
@@ -286,8 +288,10 @@ def shuffle(*arrays, **options):
 
     Returns
     -------
-    Sequence of shuffled views of the collections. The original arrays are
-    not impacted.
+    shuffled_arrays : sequence of arrays or scipy.sparse matrices with same \
+    shape[0]
+        Sequence of shuffled views of the collections. The original arrays are
+        not impacted.
 
     Examples
     --------
@@ -335,6 +339,10 @@ def safe_sqr(X, copy=True):
     Parameters
     ----------
     X : array like, matrix, sparse matrix
+
+    copy : boolean, optional, default True
+        Whether to create a copy of X and operate on it or to perform
+        inplace computation (default behaviour).
 
     Returns
     -------

--- a/sklearn/utils/_scipy_sparse_lsqr_backport.py
+++ b/sklearn/utils/_scipy_sparse_lsqr_backport.py
@@ -126,7 +126,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         Right-hand side vector ``b``.
     damp : float
         Damping coefficient.
-    atol, btol : float
+    atol, btol : float, default 1.0e-8
         Stopping tolerances. If both are 1.0e-9 (say), the final
         residual norm should be accurate to about 9 digits.  (The
         final x will usually have fewer correct digits, depending on

--- a/sklearn/utils/arpack.py
+++ b/sklearn/utils/arpack.py
@@ -1062,23 +1062,17 @@ def _eigs(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
 
     Parameters
     ----------
-    A : An N x N matrix, array, sparse matrix, or LinearOperator representing
-        the operation A * x, where A is a real or complex square matrix.
-    k : integer
+    A : An N x N matrix, array, sparse matrix, or LinearOperator representing \
+    the operation A * x, where A is a real or complex square matrix.
+
+    k : int, default 6
         The number of eigenvalues and eigenvectors desired.
         `k` must be smaller than N. It is not possible to compute all
         eigenvectors of a matrix.
 
-    Returns
-    -------
-    w : array
-        Array of k eigenvalues.
-    v : array
-        An array of `k` eigenvectors.
-        ``v[:, i]`` is the eigenvector corresponding to the eigenvalue w[i].
+    return_eigenvectors : boolean, default True
+        Whether to return the eigenvectors along with the eigenvalues.
 
-    Other Parameters
-    ----------------
     M : An N x N matrix, array, sparse matrix, or LinearOperator representing
         the operation M*x for the generalized eigenvalue problem
           ``A * x = w * M * x``
@@ -1092,6 +1086,7 @@ def _eigs(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
         iterative solver for a general linear operator.  Alternatively,
         the user can supply the matrix or operator Minv, which gives
         x = Minv * b = M^-1 * b
+
     sigma : real or complex
         Find eigenvalues near sigma using shift-invert mode.  This requires
         an operator to compute the solution of the linear system
@@ -1111,11 +1106,14 @@ def _eigs(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
             w'[i] = 1/2i * [ 1/(w[i]-sigma) - 1/(w[i]-conj(sigma)) ]
          * If A is complex,
             w'[i] = 1/(w[i]-sigma)
+
     v0 : array
         Starting vector for iteration.
+
     ncv : integer
         The number of Lanczos vectors generated
         `ncv` must be greater than `k`; it is recommended that ``ncv > 2*k``.
+
     which : string ['LM' | 'SM' | 'LR' | 'SR' | 'LI' | 'SI']
         Which `k` eigenvectors and eigenvalues to find:
          - 'LM' : largest magnitude
@@ -1128,19 +1126,33 @@ def _eigs(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
         (see discussion in 'sigma', above).  ARPACK is generally better
         at finding large values than small values.  If small eigenvalues are
         desired, consider using shift-invert mode for better performance.
+
     maxiter : integer
         Maximum number of Arnoldi update iterations allowed
+
     tol : float
         Relative accuracy for eigenvalues (stopping criterion)
         The default value of 0 implies machine precision.
+
     return_eigenvectors : boolean
         Return eigenvectors (True) in addition to eigenvalues
+
     Minv : N x N matrix, array, sparse matrix, or linear operator
         See notes in M, above.
+        
     OPinv : N x N matrix, array, sparse matrix, or linear operator
         See notes in sigma, above.
     OPpart : 'r' or 'i'.
         See notes in sigma, above
+
+    Returns
+    -------
+    w : array
+        Array of k eigenvalues.
+
+    v : array
+        An array of `k` eigenvectors.
+        ``v[:, i]`` is the eigenvector corresponding to the eigenvalue w[i].
 
     Raises
     ------
@@ -1287,16 +1299,6 @@ def _eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
         `k` must be smaller than N. It is not possible to compute all
         eigenvectors of a matrix.
 
-    Returns
-    -------
-    w : array
-        Array of k eigenvalues
-    v : array
-       An array of k eigenvectors
-       The v[i] is the eigenvector corresponding to the eigenvector w[i]
-
-    Other Parameters
-    ----------------
     M : An N x N matrix, array, sparse matrix, or linear operator representing
         the operation M * x for the generalized eigenvalue problem
           ``A * x = w * M * x``.
@@ -1337,7 +1339,7 @@ def _eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
         it is recommended that ncv > 2*k
     which : string ['LM' | 'SM' | 'LA' | 'SA' | 'BE']
         If A is a complex hermitian matrix, 'BE' is invalid.
-        Which `k` eigenvectors and eigenvalues to find:
+        Which `k` eigenvectors and eigenvalues to find
          - 'LM' : Largest (in magnitude) eigenvalues
          - 'SM' : Smallest (in magnitude) eigenvalues
          - 'LA' : Largest (algebraic) eigenvalues
@@ -1380,6 +1382,14 @@ def _eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None, ncv=None,
         The choice of mode will affect which eigenvalues are selected by
         the keyword 'which', and can also impact the stability of
         convergence (see [2] for a discussion)
+
+    Returns
+    -------
+    w : array
+        Array of k eigenvalues
+    v : array
+        An array of k eigenvectors
+        The v[i] is the eigenvector corresponding to the eigenvector w[i]
 
     Raises
     ------

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -423,12 +423,21 @@ def pinvh(a, cond=None, rcond=None, lower=True):
     ----------
     a : array, shape (N, N)
         Real symmetric or complex hermetian matrix to be pseudo-inverted
-    cond, rcond : float or None
+
+    cond : float or None, default None
         Cutoff for 'small' eigenvalues.
         Singular values smaller than rcond * largest_eigenvalue are considered
         zero.
 
         If None or -1, suitable machine precision is used.
+
+    rcond : float or None, default None (deprecated)
+        Cutoff for 'small' eigenvalues.
+        Singular values smaller than rcond * largest_eigenvalue are considered
+        zero.
+
+        If None or -1, suitable machine precision is used.
+ 
     lower : boolean
         Whether the pertinent array data is taken from the lower or upper
         triangle of a. (Default: lower)
@@ -529,9 +538,10 @@ def svd_flip(u, v, u_based_decision=True):
 
     Parameters
     ----------
-    u, v : arrays
-        The output of `linalg.svd` or `sklearn.utils.extmath.randomized_svd`,
-        with matching inner dimensions so one can compute `np.dot(u * s, v)`.
+    u, v : ndarray
+        u and v are the output of `linalg.svd` or 
+        `sklearn.utils.extmath.randomized_svd`, with matching inner dimensions
+        so one can compute `np.dot(u * s, v)`.
 
     u_based_decision : boolean, (default=True)
         If True, use the columns of u as the basis for sign flipping. Otherwise,

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -62,7 +62,7 @@ def unique_labels(*ys):
 
     Parameters
     ----------
-    ys : array-likes,
+    *ys : array-likes,
 
     Returns
     -------
@@ -361,8 +361,8 @@ def class_distribution(y, sample_weight=None):
     sample_weight : array-like of shape = (n_samples,), optional
         Sample weights.
 
-    Return
-    ------
+    Returns
+    -------
     classes : list of size n_outputs of arrays of size (n_classes,)
         List of classes for each column.
 

--- a/sklearn/utils/random.py
+++ b/sklearn/utils/random.py
@@ -224,8 +224,8 @@ def random_choice_csc(n_samples, classes, class_probability=None,
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    Return
-    ------
+    Returns
+    -------
     random_matrix : sparse csc matrix of size (n_samples, n_outputs)
 
     """

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -25,10 +25,10 @@ def inplace_csr_column_scale(X, scale):
 
     Parameters
     ----------
-    X: CSR matrix with shape (n_samples, n_features)
+    X : CSR matrix with shape (n_samples, n_features)
         Matrix to normalize using the variance of the features.
 
-    scale: float array with shape (n_features,)
+    scale : float array with shape (n_features,)
         Array of precomputed feature-wise values to use for scaling.
     """
     assert scale.shape[0] == X.shape[1]
@@ -43,11 +43,11 @@ def inplace_csr_row_scale(X, scale):
 
     Parameters
     ----------
-    X: CSR sparse matrix, shape (n_samples, n_features)
-    matrix to be scaled.
+    X : CSR sparse matrix, shape (n_samples, n_features)
+        Matrix to be scaled.
 
-    scale: float array with shape (n_samples,)
-    Array of precomputed sample-wise values to use for scaling.
+    scale : float array with shape (n_samples,)
+        Array of precomputed sample-wise values to use for scaling.
     """
     assert scale.shape[0] == X.shape[0]
     X.data *= np.repeat(scale, np.diff(X.indptr))
@@ -122,11 +122,11 @@ def inplace_row_scale(X, scale):
 
     Parameters
     ----------
-    X: CSR or CSC sparse matrix, shape (n_samples, n_features)
-    matrix to be scaled.
+    X : CSR or CSC sparse matrix, shape (n_samples, n_features)
+        Matrix to be scaled.
 
-    scale: float array with shape (n_features,)
-    Array of precomputed sample-wise values to use for scaling.
+    scale : float array with shape (n_features,)
+        Array of precomputed sample-wise values to use for scaling.
     """
     if isinstance(X, sp.csc_matrix):
         inplace_csr_column_scale(X.T, scale)

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -16,16 +16,16 @@ def _rankdata(a, method="average"):
     method : str, optional
         The method used to assign ranks to tied elements.
         The options are 'max'.
+        'max': The maximum of the ranks that would have been assigned
+              to all the tied values is assigned to each value.
 
-            'max': The maximum of the ranks that would have been assigned
-                  to all the tied values is assigned to each value.
     Returns
     -------
     ranks : ndarray
         An array of length equal to the size of a, containing rank scores.
 
-    Note
-    ----
+    Notes
+    -----
     We only backport the 'max' method
 
     """

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -403,14 +403,22 @@ def fake_mldata(columns_dict, dataname, matfile, ordering=None):
 
     Parameters
     ----------
-    columns_dict: contains data as
-                  columns_dict[column_name] = array of data
-    dataname: name of data set
-    matfile: file-like object or file name
-    ordering: list of column_names, determines the ordering in the data set
+    columns_dict : dict, keys=str, values=ndarray
+        Contains data as columns_dict[column_name] = array of data.
 
-    Note: this function transposes all arrays, while fetch_mldata only
-    transposes 'data', keep that into account in the tests.
+    dataname : string
+        Name of data set.
+
+    matfile : string or file object
+        The file name string or the file-like object of the output file.
+
+    ordering : list, default None
+        List of column_names, determines the ordering in the data set.
+
+    Notes
+    -----
+    This function transposes all arrays, while fetch_mldata only transposes
+    'data', keep that into account in the tests.
     """
     datasets = dict(columns_dict)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -76,6 +76,9 @@ def as_float_array(X, copy=True, force_all_finite=True):
         If True, a copy of X will be created. If False, a copy may still be
         returned if X's dtype is not a floating point type.
 
+    force_all_finite : boolean (default=True)
+        Whether to raise an error on np.inf and np.nan in X.
+
     Returns
     -------
     XT : {array, sparse matrix}
@@ -118,7 +121,7 @@ def check_consistent_length(*arrays):
 
     Parameters
     ----------
-    arrays : list or tuple of input objects.
+    *arrays : list or tuple of input objects.
         Objects that will be checked for consistent length.
     """
 
@@ -137,7 +140,7 @@ def indexable(*iterables):
 
     Parameters
     ----------
-    iterables : lists, dataframes, arrays, sparse matrices
+    *iterables : lists, dataframes, arrays, sparse matrices
         List of objects to ensure sliceability.
     """
     result = []
@@ -350,6 +353,9 @@ def column_or_1d(y, warn=False):
     ----------
     y : array-like
 
+    warn : boolean, default False
+       To control display of warnings. 
+
     Returns
     -------
     y : array
@@ -404,8 +410,8 @@ def check_random_state(seed):
 def has_fit_parameter(estimator, parameter):
     """Checks whether the estimator's fit method supports the given parameter.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sklearn.svm import SVC
     >>> has_fit_parameter(SVC(), "sample_weight")
     True


### PR DESCRIPTION
Fixes #2062 
- [x] Make all docstrings match with signatures. ( 120 / 120 )
- [x] Rename invalid sections to valid numpydoc defined sections
  - `Caveats` --> `Notes`
  - `Reference` --> `References`
  - `Example` --> `Examples` etc...
- [x] Cross check and scavenge #2084 for reviews / improvised docstrings etc...
- [x] Replace `FIXME` ( in docstring ) with relevant text...

~~Consistently remove `optional` across all docstrings and specify the `default` value directly...~~

@jnothman @amueller @NelleV Kindly take a look... 
