### PR TITLE
[MRG+1] MAINT: create ensure_symmetric utility function to check matrix symmetry

### DIFF
--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -11,7 +11,7 @@ import warnings
 
 from ..base import BaseEstimator
 from ..metrics import euclidean_distances
-from ..utils import check_random_state, check_array, ensure_symmetric
+from ..utils import check_random_state, check_array, check_symmetric
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
 from ..isotonic import IsotonicRegression
@@ -65,7 +65,7 @@ def _smacof_single(similarities, metric=True, n_components=2, init=None,
         Number of iterations run.
 
     """
-    similarities = ensure_symmetric(similarities, raise_exception=True)
+    similarities = check_symmetric(similarities, raise_exception=True)
 
     n_samples = similarities.shape[0]
     random_state = check_random_state(random_state)

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -11,7 +11,7 @@ import warnings
 
 from ..base import BaseEstimator
 from ..metrics import euclidean_distances
-from ..utils import check_random_state, check_array
+from ..utils import check_random_state, check_array, ensure_symmetric
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
 from ..isotonic import IsotonicRegression
@@ -65,14 +65,10 @@ def _smacof_single(similarities, metric=True, n_components=2, init=None,
         Number of iterations run.
 
     """
+    similarities = ensure_symmetric(similarities, raise_exception=True)
+
     n_samples = similarities.shape[0]
     random_state = check_random_state(random_state)
-
-    if similarities.shape[0] != similarities.shape[1]:
-        raise ValueError("similarities must be a square array (shape=%d)" %
-                         n_samples)
-    if not np.allclose(similarities, similarities.T):
-        raise ValueError("similarities must be symmetric")
 
     sim_flat = ((1 - np.tri(n_samples)) * similarities).ravel()
     sim_flat_w = sim_flat[sim_flat != 0]

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -13,7 +13,7 @@ from scipy.sparse.linalg import lobpcg
 
 from ..base import BaseEstimator
 from ..externals import six
-from ..utils import check_random_state, check_array, ensure_symmetric
+from ..utils import check_random_state, check_array, check_symmetric
 from ..utils.graph import graph_laplacian
 from ..utils.sparsetools import connected_components
 from ..utils.arpack import eigsh
@@ -183,7 +183,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
       Andrew V. Knyazev
       http://dx.doi.org/10.1137%2FS1064827500366124
     """
-    adjacency = ensure_symmetric(adjacency)
+    adjacency = check_symmetric(adjacency)
 
     try:
         from pyamg import smoothed_aggregation_solver

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -13,8 +13,7 @@ from scipy.sparse.linalg import lobpcg
 
 from ..base import BaseEstimator
 from ..externals import six
-from ..utils import check_random_state
-from ..utils.validation import check_array
+from ..utils import check_random_state, check_array, ensure_symmetric
 from ..utils.graph import graph_laplacian
 from ..utils.sparsetools import connected_components
 from ..utils.arpack import eigsh
@@ -184,6 +183,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
       Andrew V. Knyazev
       http://dx.doi.org/10.1137%2FS1064827500366124
     """
+    adjacency = ensure_symmetric(adjacency)
 
     try:
         from pyamg import smoothed_aggregation_solver
@@ -205,15 +205,6 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
     # Whether to drop the first eigenvector
     if drop_first:
         n_components = n_components + 1
-    # Check that the matrices given is symmetric
-    if ((not sparse.isspmatrix(adjacency) and
-         not np.all((adjacency - adjacency.T) < 1e-10)) or
-        (sparse.isspmatrix(adjacency) and
-         not np.all((adjacency - adjacency.T).data < 1e-10))):
-        warnings.warn("Graph adjacency matrix should be symmetric. "
-                      "Converted to be symmetric by average with its "
-                      "transpose.")
-        adjacency = .5 * (adjacency + adjacency.T)
 
     if not _graph_is_connected(adjacency):
         warnings.warn("Graph is not fully connected, spectral embedding"

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -213,7 +213,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         warnings.warn("Graph adjacency matrix should be symmetric. "
                       "Converted to be symmetric by average with its "
                       "transpose.")
-    adjacency = .5 * (adjacency + adjacency.T)
+        adjacency = .5 * (adjacency + adjacency.T)
 
     if not _graph_is_connected(adjacency):
         warnings.warn("Graph is not fully connected, spectral embedding"

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -12,7 +12,7 @@ from .validation import (as_float_array,
                          assert_all_finite, warn_if_not_float,
                          check_random_state, column_or_1d, check_array,
                          check_consistent_length, check_X_y, indexable,
-                         ensure_symmetric)
+                         check_symmetric)
 from .class_weight import compute_class_weight
 from ..externals.joblib import cpu_count
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -11,7 +11,8 @@ from .murmurhash import murmurhash3_32
 from .validation import (as_float_array,
                          assert_all_finite, warn_if_not_float,
                          check_random_state, column_or_1d, check_array,
-                         check_consistent_length, check_X_y, indexable)
+                         check_consistent_length, check_X_y, indexable,
+                         ensure_symmetric)
 from .class_weight import compute_class_weight
 from ..externals.joblib import cpu_count
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -406,16 +406,16 @@ def has_fit_parameter(estimator, parameter):
     return parameter in getargspec(estimator.fit)[0]
 
 
-def ensure_symmetric(array, tol=1E-10, raise_warning=True,
-                     raise_exception=False):
+def check_symmetric(array, tol=1E-10, raise_warning=True,
+                    raise_exception=False):
     """
-    Ensure that the array is symmetric two-dimensional array or sparse matrix,
+    Check that the array is symmetric two-dimensional array or sparse matrix,
     returning a symmetrized version and optionally raising a warning or
     exception if the input is not symmetric.
 
     Parameters
     ----------
-    array : object
+    array : nd-array or sparse matrix
         Input object to check / convert
     tol : float
         Absolute tolerance for equivalence of arrays. Default = 1E-10.
@@ -427,7 +427,9 @@ def ensure_symmetric(array, tol=1E-10, raise_warning=True,
     Returns
     -------
     array_sym : object
-        Symmetrized version of the input array
+        Symmetrized version of the input array, i.e. the average of array
+        and array.transpose(). If sparse, then duplicate entries are first
+        summed and zeros are eliminated.
     """
     if (array.ndim != 2) or (array.shape[0] != array.shape[1]):
         raise ValueError("array must be 2-dimensional and symmetric")
@@ -444,6 +446,10 @@ def ensure_symmetric(array, tol=1E-10, raise_warning=True,
         if raise_warning:
             warnings.warn("Array is not symmetric, and will be converted "
                           "to symmetric by average with its transpose.")
-        array = 0.5 * (array + array.T)
+        if sp.issparse(array):
+            conversion = 'to' + array.format
+            array = getattr(0.5 * (array + array.T), conversion)()
+        else:
+            array = 0.5 * (array + array.T)
 
     return array

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -416,7 +416,8 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
     Parameters
     ----------
     array : nd-array or sparse matrix
-        Input object to check / convert
+        Input object to check / convert. Must be two-dimensional and square,
+        otherwise a ValueError will be raised.
     tol : float
         Absolute tolerance for equivalence of arrays. Default = 1E-10.
     raise_warning : boolean (default=True)
@@ -426,13 +427,13 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
 
     Returns
     -------
-    array_sym : object
+    array_sym : ndarray or sparse matrix
         Symmetrized version of the input array, i.e. the average of array
         and array.transpose(). If sparse, then duplicate entries are first
         summed and zeros are eliminated.
     """
     if (array.ndim != 2) or (array.shape[0] != array.shape[1]):
-        raise ValueError("array must be 2-dimensional and symmetric")
+        raise ValueError("array must be 2-dimensional and square")
 
     if sp.issparse(array):
         diff = (array - array.T).data

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -408,10 +408,11 @@ def has_fit_parameter(estimator, parameter):
 
 def check_symmetric(array, tol=1E-10, raise_warning=True,
                     raise_exception=False):
-    """
-    Check that the array is symmetric two-dimensional array or sparse matrix,
-    returning a symmetrized version and optionally raising a warning or
-    exception if the input is not symmetric.
+    """Make sure that array is 2D, square and symmetric.
+
+    If the array is not symmetric, then a symmetrized version is returned.
+    Optionally, a warning or exception is raised if the matrix is not
+    symmetric.
 
     Parameters
     ----------
@@ -433,7 +434,8 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
         summed and zeros are eliminated.
     """
     if (array.ndim != 2) or (array.shape[0] != array.shape[1]):
-        raise ValueError("array must be 2-dimensional and square")
+        raise ValueError("array must be 2-dimensional and square. "
+                         "shape = {0}".format(array.shape))
 
     if sp.issparse(array):
         diff = (array - array.T).data

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -404,3 +404,46 @@ def has_fit_parameter(estimator, parameter):
 
     """
     return parameter in getargspec(estimator.fit)[0]
+
+
+def ensure_symmetric(array, tol=1E-10, raise_warning=True,
+                     raise_exception=False):
+    """
+    Ensure that the array is symmetric two-dimensional array or sparse matrix,
+    returning a symmetrized version and optionally raising a warning or
+    exception if the input is not symmetric.
+
+    Parameters
+    ----------
+    array : object
+        Input object to check / convert
+    tol : float
+        Absolute tolerance for equivalence of arrays. Default = 1E-10.
+    raise_warning : boolean (default=True)
+        If True then raise a warning if conversion is required.
+    raise_exception : boolean (default=False)
+        If True then raise an exception if array is not symmetric.
+
+    Returns
+    -------
+    array_sym : object
+        Symmetrized version of the input array
+    """
+    if (array.ndim != 2) or (array.shape[0] != array.shape[1]):
+        raise ValueError("array must be 2-dimensional and symmetric")
+
+    if sp.issparse(array):
+        diff = (array - array.T).data
+        symmetric = np.all(abs(diff) < tol)
+    else:
+        symmetric = np.allclose(array, array.T, atol=tol)
+
+    if not symmetric:
+        if raise_exception:
+            raise ValueError("Array must be symmetric")
+        if raise_warning:
+            warnings.warn("Array is not symmetric, and will be converted "
+                          "to symmetric by average with its transpose.")
+        array = 0.5 * (array + array.T)
+
+    return array


### PR DESCRIPTION
(first commit of this is from PR #4021)

This PR creates a utility function called `ensure_symmetric` which checks whether a matrix is symmetric. This also fixes a (possible?) bug in the validation check for `spectral_embedding`: it compares the absolute difference of the matrix with its transpose.
