### PR TITLE
[MRG+2] Add NotFittedError class and fix all modules to raise uniform errors when not fitted

### DIFF
--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from ..base import TransformerMixin
 from ..utils import check_array
+from ..utils.validation import check_is_fitted
 
 import warnings
 
@@ -43,6 +44,8 @@ class AgglomerationTransform(TransformerMixin):
         Y : array, shape = [n_samples, n_clusters] or [n_clusters]
             The pooled values for each feature cluster.
         """
+        check_is_fitted(self, "labels_")
+
         if pooling_func is not None:
             warnings.warn("The pooling_func parameter is deprecated since 0.15 "
                           "and will be removed in 0.18. "
@@ -77,5 +80,7 @@ class AgglomerationTransform(TransformerMixin):
             A vector of size n_samples with the values of Xred assigned to
             each of the cluster of samples.
         """
+        check_is_fitted(self, "labels_")
+
         unil, inverse = np.unique(self.labels_, return_inverse=True)
         return Xred[..., inverse]

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import as_float_array, check_array
+from ..utils.validation import check_is_fitted
 from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
 
@@ -313,9 +314,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
         labels : array, shape (n_samples,)
             Index of the cluster each sample belongs to.
         """
-        if not hasattr(self, "cluster_centers_indices_"):
-            raise ValueError("Estimator is not fitted.")
-
+        check_is_fitted(self, "cluster_centers_indices_")
         if not hasattr(self, "cluster_centers_"):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -14,6 +14,7 @@ from ..base import TransformerMixin, ClusterMixin, BaseEstimator
 from ..externals.six.moves import xrange
 from ..utils import check_array
 from ..utils.extmath import row_norms, safe_sparse_dot
+from ..utils.validation import check_is_fitted, _is_fitted
 from .hierarchical import AgglomerativeClustering
 
 
@@ -511,14 +512,11 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
             return self._fit(X)
 
     def _check_fit(self, X):
-        is_fitted = hasattr(self, 'subcluster_centers_')
-
-        # Called by partial_fit, before fitting.
-        has_partial_fit = hasattr(self, 'partial_fit_')
-
         # Should raise an error if one does not fit before predicting.
-        if not has_partial_fit and not is_fitted:
-            raise ValueError("Fit training data before predicting")
+        m = "%(name)s clusterer is not yet fitted with the training data"
+        check_is_fitted(self, ['subcluster_centers_', 'partial_fit_'], m, any)
+
+        is_fitted = _is_fitted(self, 'subcluster_centers_')
 
         if is_fitted and X.shape[1] != self.subcluster_centers_.shape[1]:
             raise ValueError(

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -26,6 +26,7 @@ from ..utils import check_array
 from ..utils import check_random_state
 from ..utils import as_float_array
 from ..utils import gen_batches
+from ..utils.validation import check_is_fitted
 from ..utils.random import choice
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
@@ -764,10 +765,6 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
         return X
 
-    def _check_fitted(self):
-        if not hasattr(self, "cluster_centers_"):
-            raise AttributeError("Model has not been trained yet.")
-
     def fit(self, X, y=None):
         """Compute k-means clustering.
 
@@ -825,7 +822,8 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         X_new : array, shape [n_samples, k]
             X transformed in the new space.
         """
-        self._check_fitted()
+        check_is_fitted(self, 'cluster_centers_') 
+
         X = self._check_test_data(X)
         return self._transform(X)
 
@@ -850,7 +848,8 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         labels : array, shape [n_samples,]
             Index of the cluster each sample belongs to.
         """
-        self._check_fitted()
+        check_is_fitted(self, 'cluster_centers_') 
+
         X = self._check_test_data(X)
         x_squared_norms = row_norms(X, squared=True)
         return _labels_inertia(X, x_squared_norms, self.cluster_centers_)[0]
@@ -868,7 +867,8 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         score : float
             Opposite of the value of X on the K-means objective.
         """
-        self._check_fitted()
+        check_is_fitted(self, 'cluster_centers_') 
+
         X = self._check_test_data(X)
         x_squared_norms = row_norms(X, squared=True)
         return -_labels_inertia(X, x_squared_norms, self.cluster_centers_)[1]
@@ -1411,6 +1411,7 @@ class MiniBatchKMeans(KMeans):
         labels : array, shape [n_samples,]
             Index of the cluster each sample belongs to.
         """
-        self._check_fitted()
+        check_is_fitted(self, 'cluster_centers_') 
+
         X = self._check_test_data(X)
         return self._labels_inertia_minibatch(X)[0]

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from ..externals import six
 from ..utils import extmath, check_random_state, gen_batches
+from ..utils.validation import check_is_fitted
 from ..base import BaseEstimator, ClusterMixin
 from ..neighbors import NearestNeighbors
 from ..metrics.pairwise import pairwise_distances_argmin
@@ -330,4 +331,6 @@ class MeanShift(BaseEstimator, ClusterMixin):
         labels : array, shape [n_samples,]
             Index of the cluster each sample belongs to.
         """
+        check_is_fitted(self, "cluster_centers_")
+
         return pairwise_distances_argmin(X, self.cluster_centers_)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -168,11 +168,6 @@ def test_k_means_plus_plus_init():
     _check_fitted_model(km)
 
 
-def test_k_means_check_fitted():
-    km = KMeans(n_clusters=n_clusters, random_state=42)
-    assert_raises(AttributeError, km._check_fitted)
-
-
 def test_k_means_new_centers():
     # Explore the part of the code where a new center is reassigned
     X = np.array([[0, 0, 1, 1],

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -14,6 +14,7 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from scipy import linalg
 from ..utils import arpack
+from ..utils.validation import check_is_fitted
 
 __all__ = ['PLSCanonical', 'PLSRegression', 'PLSSVD']
 
@@ -365,6 +366,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         -------
         x_scores if Y is not given, (x_scores, y_scores) otherwise.
         """
+        check_is_fitted(self, 'x_mean_')
         # Normalize
         if copy:
             Xc = (np.asarray(X) - self.x_mean_) / self.x_std_
@@ -403,6 +405,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         This call requires the estimation of a p x q matrix, which may
         be an issue in high dimensional space.
         """
+        check_is_fitted(self, 'x_mean_')
         # Normalize
         if copy:
             Xc = (np.asarray(X) - self.x_mean_)
@@ -433,6 +436,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         -------
         x_scores if Y is not given, (x_scores, y_scores) otherwise.
         """
+        check_is_fitted(self, 'x_mean_')
         return self.fit(X, y, **fit_params).transform(X, y)
 
 
@@ -559,6 +563,7 @@ class PLSRegression(_PLS):
 
     @property
     def coefs(self):
+        check_is_fitted(self, 'coef_')
         DeprecationWarning("'coefs' attribute has been deprecated and will be "
                            "removed in version 0.17. Use 'coef_' instead")
         return self.coef_
@@ -773,6 +778,7 @@ class PLSSVD(BaseEstimator, TransformerMixin):
 
     def transform(self, X, Y=None):
         """Apply the dimension reduction learned on the train data."""
+        check_is_fitted(self, 'x_mean_')
         Xr = (X - self.x_mean_) / self.x_std_
         x_scores = np.dot(Xr, self.x_weights_)
         if Y is not None:

--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -14,6 +14,7 @@ from scipy import linalg
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
 from ..utils.extmath import fast_dot
+from ..utils.validation import check_is_fitted
 from ..externals import six
 from abc import ABCMeta, abstractmethod
 
@@ -123,6 +124,8 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
         >>> ipca.transform(X) # doctest: +SKIP
         """
+        check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)
+
         X = check_array(X)
         if self.mean_ is not None:
             X = X - self.mean_

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -19,6 +19,7 @@ from ..externals.joblib import Parallel, delayed, cpu_count
 from ..externals.six.moves import zip
 from ..utils import check_array, check_random_state, gen_even_slices
 from ..utils.extmath import randomized_svd, row_norms
+from ..utils.validation import check_is_fitted
 from ..linear_model import Lasso, orthogonal_mp_gram, LassoLars, Lars
 
 
@@ -749,6 +750,8 @@ class SparseCodingMixin(TransformerMixin):
             Transformed data
 
         """
+        check_is_fitted(self, 'components_') 
+
         # XXX : kwargs is not documented
         X = check_array(X)
         n_samples, n_features = X.shape

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -29,6 +29,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..externals.six.moves import xrange
 from ..utils import check_array, check_random_state
 from ..utils.extmath import fast_logdet, fast_dot, randomized_svd, squared_norm
+from ..utils.validation import check_is_fitted
 from ..utils import ConvergenceWarning
 
 
@@ -242,6 +243,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
             The latent variables of X.
         """
+        check_is_fitted(self, 'components_')
+
         X = check_array(X)
         Ih = np.eye(len(self.components_))
 
@@ -264,6 +267,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         cov : array, shape (n_features, n_features)
             Estimated covariance of data.
         """
+        check_is_fitted(self, 'components_')
+
         cov = np.dot(self.components_.T, self.components_)
         cov.flat[::len(cov) + 1] += self.noise_variance_  # modify diag inplace
         return cov
@@ -276,6 +281,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         precision : array, shape (n_features, n_features)
             Estimated precision of data.
         """
+        check_is_fitted(self, 'components_')
+
         n_features = self.components_.shape[1]
 
         # handle corner cases first
@@ -308,6 +315,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         ll: array, shape (n_samples,)
             Log-likelihood of each sample under the current model
         """
+        check_is_fitted(self, 'components_')
+        
         Xr = X - self.mean_
         precision = self.get_precision()
         n_features = X.shape[1]

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -17,6 +17,7 @@ from ..externals import six
 from ..externals.six import moves
 from ..utils import check_array, as_float_array, check_random_state
 from ..utils.extmath import fast_dot
+from ..utils.validation import check_is_fitted
 
 __all__ = ['fastica', 'FastICA']
 
@@ -530,6 +531,8 @@ class FastICA(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        check_is_fitted(self, 'mixing_')
+
         X = check_array(X, copy=copy)
         if self.whiten:
             X -= self.mean_
@@ -551,6 +554,8 @@ class FastICA(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_features)
         """
+        check_is_fitted(self, 'mixing_')
+
         if copy:
             X = X.copy()
         X = fast_dot(X, self.mixing_.T)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import linalg
 
 from ..utils.arpack import eigsh
+from ..utils.validation import check_is_fitted, NotFittedError
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import KernelCenterer
 from ..metrics.pairwise import pairwise_kernels
@@ -240,6 +241,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         -------
         X_new: array-like, shape (n_samples, n_components)
         """
+        check_is_fitted(self, 'X_fit_')
+
         K = self._centerer.transform(self._get_kernel(X, self.X_fit_))
         return np.dot(K, self.alphas_ / np.sqrt(self.lambdas_))
 
@@ -259,7 +262,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         "Learning to Find Pre-Images", G BakIr et al, 2004.
         """
         if not self.fit_inverse_transform:
-            raise ValueError("Inverse transform was not fitted!")
+            raise NotFittedError("Inverse transform was not fitted.")
 
         K = self._get_kernel(X, self.X_transformed_fit_)
 

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -262,7 +262,9 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         "Learning to Find Pre-Images", G BakIr et al, 2004.
         """
         if not self.fit_inverse_transform:
-            raise NotFittedError("Inverse transform was not fitted.")
+            raise NotFittedError("The fit_inverse_transform parameter was not"
+                                 " set to True when instantiating and hence "
+                                 "the inverse transform is not available.")
 
         K = self._get_kernel(X, self.X_transformed_fit_)
 

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -20,6 +20,7 @@ from scipy.optimize import nnls
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_random_state, check_array
 from ..utils.extmath import randomized_svd, safe_sparse_dot, squared_norm
+from ..utils.validation import check_is_fitted
 
 
 def safe_vstack(Xs):
@@ -569,6 +570,8 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         data: array, [n_samples, n_components]
             Transformed data
         """
+        check_is_fitted(self, 'n_components_')
+
         X = check_array(X, accept_sparse='csc')
         Wt = np.zeros((self.n_components_, X.shape[0]))
         check_non_negative(X, "ProjectedGradientNMF.transform")

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -19,6 +19,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_random_state, as_float_array
 from ..utils import check_array
 from ..utils.extmath import fast_dot, fast_logdet, randomized_svd
+from ..utils.validation import check_is_fitted
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
@@ -380,6 +381,8 @@ class PCA(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
 
         """
+        check_is_fitted(self, 'mean_')
+
         X = check_array(X)
         if self.mean_ is not None:
             X = X - self.mean_
@@ -402,6 +405,8 @@ class PCA(BaseEstimator, TransformerMixin):
         -------
         X_original array-like, shape (n_samples, n_features)
         """
+        check_is_fitted(self, 'mean_')
+
         if self.whiten:
             return fast_dot(
                 X,
@@ -428,6 +433,8 @@ class PCA(BaseEstimator, TransformerMixin):
         ll: array, shape (n_samples,)
             Log-likelihood of each sample under the current model
         """
+        check_is_fitted(self, 'mean_')
+
         X = check_array(X)
         Xr = X - self.mean_
         n_features = X.shape[1]
@@ -619,6 +626,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
 
         """
+        check_is_fitted(self, 'mean_')
+
         X = check_array(X)
         if self.mean_ is not None:
             X = X - self.mean_
@@ -664,6 +673,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         If whitening is enabled, inverse_transform does not compute the
         exact inverse operation of transform.
         """
+        check_is_fitted(self, 'mean_')
+
         X_original = fast_dot(X, self.components_)
         if self.mean_ is not None:
             X_original = X_original + self.mean_

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -5,6 +5,7 @@
 import numpy as np
 
 from ..utils import check_random_state, check_array
+from ..utils.validation import check_is_fitted
 from ..linear_model import ridge_regression
 from ..base import BaseEstimator, TransformerMixin
 from .dict_learning import dict_learning, dict_learning_online
@@ -152,6 +153,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         X_new array, shape (n_samples, n_components)
             Transformed data.
         """
+        check_is_fitted(self, 'components_')
+
         X = check_array(X)
         ridge_alpha = self.ridge_alpha if ridge_alpha is None else ridge_alpha
         U = ridge_regression(self.components_.T, X.T, ridge_alpha,

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -10,7 +10,6 @@ import numbers
 import numpy as np
 from warnings import warn
 from abc import ABCMeta, abstractmethod
-from ..utils.validation import has_fit_parameter
 
 from ..base import ClassifierMixin, RegressorMixin
 from ..externals.joblib import Parallel, delayed
@@ -20,8 +19,10 @@ from ..metrics import r2_score, accuracy_score
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import check_random_state, check_X_y, check_array, column_or_1d
 from ..utils.random import sample_without_replacement
+from ..utils.validation import has_fit_parameter, check_is_fitted
 
 from .base import BaseEnsemble, _partition_estimators
+
 
 __all__ = ["BaggingClassifier",
            "BaggingRegressor"]
@@ -516,7 +517,8 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
         y : array of shape = [n_samples]
             The predicted classes.
         """
-        return self.classes_.take(np.argmax(self.predict_proba(X), axis=1),
+        predicted_probabilitiy = self.predict_proba(X)
+        return self.classes_.take((np.argmax(predicted_probabilitiy, axis=1)),
                                   axis=0)
 
     def predict_proba(self, X):
@@ -541,6 +543,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute `classes_`.
         """
+        check_is_fitted(self, "classes_")
         # Check data
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
 
@@ -586,6 +589,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
             The class log-probabilities of the input samples. The order of the
             classes corresponds to that in the attribute `classes_`.
         """
+        check_is_fitted(self, "classes_")
         if hasattr(self.base_estimator_, "predict_log_proba"):
             # Check data
             X = check_array(X)
@@ -639,6 +643,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
             cases with ``k == 1``, otherwise ``k==n_classes``.
 
         """
+        check_is_fitted(self, "classes_")
         # Trigger an exception if not supported
         if not hasattr(self.base_estimator_, "decision_function"):
             raise NotImplementedError
@@ -809,6 +814,7 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
         y : array of shape = [n_samples]
             The predicted values.
         """
+        check_is_fitted(self, "estimators_features_")
         # Check data
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -59,7 +59,7 @@ from ..tree import (DecisionTreeClassifier, DecisionTreeRegressor,
                     ExtraTreeClassifier, ExtraTreeRegressor)
 from ..tree._tree import DTYPE, DOUBLE
 from ..utils import check_random_state, check_array
-from ..utils.validation import DataConversionWarning
+from ..utils.validation import DataConversionWarning, check_is_fitted
 from .base import BaseEnsemble, _partition_estimators
 
 __all__ = ["RandomForestClassifier",
@@ -151,6 +151,8 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
             For each datapoint x in X and for each tree in the forest,
             return the index of the leaf x ends up in.
         """
+        check_is_fitted(self, 'n_outputs_')
+
         X = check_array(X, dtype=DTYPE, accept_sparse="csr")
         results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                            backend="threading")(
@@ -292,6 +294,8 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
         -------
         feature_importances_ : array, shape = [n_features]
         """
+        check_is_fitted(self, 'n_outputs_')
+
         if self.estimators_ is None or len(self.estimators_) == 0:
             raise ValueError("Estimator not fitted, "
                              "call `fit` before `feature_importances_`.")
@@ -408,6 +412,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
         y : array of shape = [n_samples] or [n_samples, n_outputs]
             The predicted classes.
         """
+        check_is_fitted(self, 'n_outputs_')
+
         # ensure_2d=False because there are actually unit test checking we fail
         # for 1d.
         X = check_array(X, ensure_2d=False, accept_sparse="csr")
@@ -447,6 +453,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute `classes_`.
         """
+        check_is_fitted(self, 'n_outputs_')
+
         # Check data
         X = check_array(X, dtype=DTYPE, accept_sparse="csr")
 
@@ -559,6 +567,8 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
         y : array of shape = [n_samples] or [n_samples, n_outputs]
             The predicted values.
         """
+        check_is_fitted(self, 'n_outputs_')
+
         # Check data
         X = check_array(X, dtype=DTYPE, accept_sparse="csr")
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1355,6 +1355,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         score = self.decision_function(X)
         try:
             return self.loss_._score_to_proba(score)
+        except NotFittedError as e:
+            raise
         except AttributeError:
             raise AttributeError('loss=%r does not support predict_proba' %
                                  self.loss)
@@ -1378,6 +1380,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         try:
             for score in self.staged_decision_function(X):
                 yield self.loss_._score_to_proba(score)
+        except NotFittedError as e:
+            raise
         except AttributeError:
             raise AttributeError('loss=%r does not support predict_proba' %
                                  self.loss)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -39,6 +39,7 @@ from ..utils import check_random_state, check_array, check_X_y, column_or_1d
 from ..utils import check_consistent_length
 from ..utils.extmath import logsumexp
 from ..utils.stats import _weighted_percentile
+from ..utils.validation import check_is_fitted, NotFittedError
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 
@@ -66,6 +67,8 @@ class QuantileEstimator(BaseEstimator):
             self.quantile = _weighted_percentile(y, sample_weight, self.alpha * 100.0)
 
     def predict(self, X):
+        check_is_fitted(self, 'quantile')
+
         y = np.empty((X.shape[0], 1), dtype=np.float64)
         y.fill(self.quantile)
         return y
@@ -80,6 +83,8 @@ class MeanEstimator(BaseEstimator):
             self.mean = np.average(y, weights=sample_weight)
 
     def predict(self, X):
+        check_is_fitted(self, 'mean')
+
         y = np.empty((X.shape[0], 1), dtype=np.float64)
         y.fill(self.mean)
         return y
@@ -103,6 +108,8 @@ class LogOddsEstimator(BaseEstimator):
         self.prior = self.scale * np.log(pos / neg)
 
     def predict(self, X):
+        check_is_fitted(self, 'prior')
+
         y = np.empty((X.shape[0], 1), dtype=np.float64)
         y.fill(self.prior)
         return y
@@ -124,6 +131,8 @@ class PriorProbabilityEstimator(BaseEstimator):
         self.priors = class_counts / class_counts.sum()
 
     def predict(self, X):
+        check_is_fitted(self, 'priors')
+
         y = np.empty((X.shape[0], self.priors.shape[0]), dtype=np.float64)
         y[:] = self.priors
         return y
@@ -143,6 +152,8 @@ class ZeroEstimator(BaseEstimator):
             self.n_classes = 1
 
     def predict(self, X):
+        check_is_fitted(self, 'n_classes')
+
         y = np.empty((X.shape[0], self.n_classes), dtype=np.float64)
         y.fill(0.0)
         return y
@@ -1038,8 +1049,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
     def _init_decision_function(self, X):
         """Check input and compute prediction of ``init``. """
         if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError("Estimator not fitted, call `fit` "
-                             "before making predictions`.")
+            raise NotFittedError("Estimator not fitted, call `fit`"
+                                 " before making predictions`.")
         if X.shape[1] != self.n_features:
             raise ValueError("X.shape[1] should be {0:d}, not {1:d}.".format(
                 self.n_features, X.shape[1]))
@@ -1110,8 +1121,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         feature_importances_ : array, shape = [n_features]
         """
         if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError("Estimator not fitted, "
-                             "call `fit` before `feature_importances_`.")
+            raise NotFittedError("Estimator not fitted, call `fit` before"
+                                 " `feature_importances_`.")
 
         total_sum = np.zeros((self.n_features, ), dtype=np.float64)
         for stage in self.estimators_:

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -21,8 +21,8 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.validation import DataConversionWarning, NotFittedError
-
+from sklearn.utils.validation import DataConversionWarning
+from sklearn.utils.validation import NotFittedError
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -21,7 +21,7 @@ from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.validation import DataConversionWarning
+from sklearn.utils.validation import DataConversionWarning, NotFittedError
 
 
 # toy sample
@@ -417,8 +417,8 @@ def test_staged_predict_proba():
     X_train, y_train = X[:200], y[:200]
     X_test, y_test = X[200:], y[200:]
     clf = GradientBoostingClassifier(n_estimators=20)
-    # test raise ValueError if not fitted
-    assert_raises(ValueError, lambda X: np.fromiter(
+    # test raise NotFittedError if not fitted
+    assert_raises(NotFittedError, lambda X: np.fromiter(
         clf.staged_predict_proba(X), dtype=np.float64), X_test)
 
     clf.fit(X_train, y_train)

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -39,7 +39,9 @@ from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE
 from ..utils import check_array, check_X_y, check_random_state
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import has_fit_parameter
+from sklearn.utils.validation import (
+        has_fit_parameter,
+        check_is_fitted)
 
 __all__ = [
     'AdaBoostClassifier',
@@ -160,10 +162,6 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 sample_weight /= sample_weight_sum
 
         return self
-
-    def _check_fitted(self):
-        if not hasattr(self, "estimators_"):
-            raise ValueError("call fit first")
 
     @abstractmethod
     def _boost(self, iboost, X, y, sample_weight):
@@ -657,7 +655,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
         """
-        self._check_fitted()
+        check_is_fitted(self, "n_classes_")
         X = self._validate_X_predict(X)
 
         n_classes = self.n_classes_
@@ -701,7 +699,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
         """
-        self._check_fitted()
+        check_is_fitted(self, "n_classes_")
         X = self._validate_X_predict(X)
 
         n_classes = self.n_classes_
@@ -751,6 +749,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             The class probabilities of the input samples. The order of
             outputs is the same of that of the `classes_` attribute.
         """
+        check_is_fitted(self, "n_classes_")
+        
         n_classes = self.n_classes_
         X = self._validate_X_predict(X)
 
@@ -1088,6 +1088,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         y : array of shape = [n_samples]
             The predicted regression values.
         """
+        check_is_fitted(self, "estimator_weights_")
         X = self._validate_X_predict(X)
 
         return self._get_median_predict(X, len(self.estimators_))
@@ -1113,7 +1114,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         y : generator of array, shape = [n_samples]
             The predicted regression values.
         """
-        self._check_fitted()
+        check_is_fitted(self, "estimator_weights_")
         X = self._validate_X_predict(X)
 
         for i, _ in enumerate(self.estimators_, 1):

--- a/sklearn/feature_selection/from_model.py
+++ b/sklearn/feature_selection/from_model.py
@@ -6,6 +6,7 @@ import numpy as np
 from ..base import TransformerMixin
 from ..externals import six
 from ..utils import safe_mask, check_array
+from ..utils.validation import NotFittedError, check_is_fitted
 
 
 class _LearntSelectorMixin(TransformerMixin):
@@ -43,21 +44,24 @@ class _LearntSelectorMixin(TransformerMixin):
         X_r : array of shape [n_samples, n_selected_features]
             The input samples with only the selected features.
         """
+        check_is_fitted(self, ('coef_', 'feature_importances_'), 
+                        all_or_any=any)
+
         X = check_array(X, 'csc')
         # Retrieve importance vector
         if hasattr(self, "feature_importances_"):
             importances = self.feature_importances_
 
         elif hasattr(self, "coef_"):
+            if self.coef_ is None:
+                msg = "This model is not fitted yet. Please call fit() first" 
+                raise NotFittedError(msg)
+
             if self.coef_.ndim == 1:
                 importances = np.abs(self.coef_)
-
             else:
                 importances = np.sum(np.abs(self.coef_), axis=0)
 
-        else:
-            raise ValueError("No `feature_importances_` or `coef_` on %r"
-                             % self)
         if len(importances) != X.shape[1]:
             raise ValueError("X has different number of features than"
                              " during model fitting.")

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -16,6 +16,7 @@ from ..preprocessing import LabelBinarizer
 from ..utils import (as_float_array, check_array, check_X_y, safe_sqr,
                      safe_mask)
 from ..utils.extmath import norm, safe_sparse_dot
+from ..utils.validation import check_is_fitted
 from .base import SelectorMixin
 
 
@@ -352,6 +353,8 @@ class SelectPercentile(_BaseFilter):
                              % self.percentile)
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         # Cater for NaNs
         if self.percentile == 100:
             return np.ones(len(self.scores_), dtype=np.bool)
@@ -409,6 +412,8 @@ class SelectKBest(_BaseFilter):
                              % self.k)
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         if self.k == 'all':
             return np.ones(self.scores_.shape, dtype=bool)
         elif self.k == 0:
@@ -452,6 +457,8 @@ class SelectFpr(_BaseFilter):
         self.alpha = alpha
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         return self.pvalues_ < self.alpha
 
 
@@ -485,6 +492,8 @@ class SelectFdr(_BaseFilter):
         self.alpha = alpha
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         alpha = self.alpha
         sv = np.sort(self.pvalues_)
         threshold = sv[sv < alpha * np.arange(len(self.pvalues_))].max()
@@ -517,6 +526,8 @@ class SelectFwe(_BaseFilter):
         self.alpha = alpha
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         return (self.pvalues_ < self.alpha / len(self.pvalues_))
 
 
@@ -582,6 +593,8 @@ class GenericUnivariateSelect(_BaseFilter):
         self._make_selector()._check_params(X, y)
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'scores_')
+
         selector = self._make_selector()
         selector.pvalues_ = self.pvalues_
         selector.scores_ = self.scores_

--- a/sklearn/feature_selection/variance_threshold.py
+++ b/sklearn/feature_selection/variance_threshold.py
@@ -6,6 +6,7 @@ from ..base import BaseEstimator
 from .base import SelectorMixin
 from ..utils import check_array
 from ..utils.sparsefuncs import mean_variance_axis
+from ..utils.validation import check_is_fitted
 
 
 class VarianceThreshold(BaseEstimator, SelectorMixin):
@@ -74,4 +75,6 @@ class VarianceThreshold(BaseEstimator, SelectorMixin):
         return self
 
     def _get_support_mask(self):
+        check_is_fitted(self, 'variances_')
+
         return self.variances_ > self.threshold

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -12,6 +12,7 @@ from scipy import linalg, optimize
 from ..base import BaseEstimator, RegressorMixin
 from ..metrics.pairwise import manhattan_distances
 from ..utils import check_random_state, check_array, check_consistent_length
+from ..utils.validation import  check_is_fitted
 from . import regression_models as regression
 from . import correlation_models as correlation
 
@@ -409,6 +410,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             An array with shape (n_eval, ) or (n_eval, n_targets) as with y,
             with the Mean Squared Error at x.
         """
+        check_is_fitted(self, "X")
 
         # Check input shapes
         X = check_array(X)
@@ -568,6 +570,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                 G
                         QR decomposition of the matrix Ft.
         """
+        check_is_fitted(self, "X")
 
         if theta is None:
             # Use built-in autocorrelation parameters

--- a/sklearn/hmm.py
+++ b/sklearn/hmm.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from .utils import check_random_state, deprecated
 from .utils.extmath import logsumexp
+from .utils.validation import check_is_fitted
 from .base import BaseEstimator
 from .mixture import (
     GMM, log_multivariate_normal_density, sample_gaussian,
@@ -762,6 +763,8 @@ class GaussianHMM(_BaseHMM):
     covars_ = property(_get_covars, _set_covars)
 
     def _compute_log_likelihood(self, obs):
+        check_is_fitted(self, '_means_')
+        
         return log_multivariate_normal_density(
             obs, self._means_, self._covars_, self._covariance_type)
 
@@ -1011,6 +1014,7 @@ class MultinomialHMM(_BaseHMM):
     emissionprob_ = property(_get_emissionprob, _set_emissionprob)
 
     def _compute_log_likelihood(self, obs):
+        check_is_fitted(self, 'emissionprob_')
         return self._log_emissionprob[:, obs].T
 
     def _generate_sample_from_state(self, state, random_state=None):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -17,6 +17,7 @@ from .base import BaseEstimator
 from .base import TransformerMixin
 from .utils import check_array, check_random_state, as_float_array
 from .utils.extmath import safe_sparse_dot
+from .utils.validation import check_is_fitted
 from .metrics.pairwise import pairwise_kernels
 
 
@@ -89,6 +90,8 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        check_is_fitted(self, 'random_weights_')
+
         X = check_array(X, accept_sparse='csr')
         projection = safe_sparse_dot(X, self.random_weights_)
         projection += self.random_offset_
@@ -173,6 +176,8 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
+        check_is_fitted(self, 'random_weights_')
+
         X = as_float_array(X, copy=True)
         X = check_array(X, copy=False)
         if (X < 0).any():
@@ -268,6 +273,9 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
             Whether the return value is an array of sparse matrix depends on
             the type of the input X.
         """
+        msg = ("%(name)s is not fitted. Call fit to set the parameters before"
+               " calling transform")
+        check_is_fitted(self, "sample_interval_", msg=msg)
 
         X = check_array(X, accept_sparse='csr')
         sparse = sp.issparse(X)
@@ -477,11 +485,13 @@ class Nystroem(BaseEstimator, TransformerMixin):
         X_transformed : array, shape=(n_samples, n_components)
             Transformed data.
         """
+        check_is_fitted(self, 'components_')
 
+        kernel_params = self._get_kernel_params()
         embedded = pairwise_kernels(X, self.components_,
                                     metric=self.kernel,
                                     filter_params=True,
-                                    **self._get_kernel_params())
+                                    **kernel_params)
         return np.dot(embedded, self.normalization_.T)
 
     def _get_kernel_params(self):

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -21,6 +21,7 @@ from .linear_model.base import LinearClassifierMixin
 from .covariance import ledoit_wolf, empirical_covariance, shrunk_covariance
 from .utils.multiclass import unique_labels
 from .utils import check_array, check_X_y
+from .utils.validation import check_is_fitted
 from .preprocessing import StandardScaler
 
 
@@ -441,6 +442,8 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
         X_new : array, shape (n_samples, n_components)
             Transformed data.
         """
+        check_is_fitted(self, ['xbar_', 'scalings_'], all_or_any=any)
+
         X = check_array(X)
         if self.solver == 'lsqr':
             raise NotImplementedError("transform not implemented for 'lsqr' "

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -29,6 +29,8 @@ from ..utils import as_float_array, check_array
 from ..utils.extmath import safe_sparse_dot
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
+from ..utils.validation import (
+        NotFittedError, _is_fitted, check_is_fitted)
 
 
 ###
@@ -132,6 +134,8 @@ class LinearModel(six.with_metaclass(ABCMeta, BaseEstimator)):
         C : array, shape = (n_samples,)
             Returns predicted values.
         """
+        check_is_fitted(self, "coef_")
+
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
         return safe_sparse_dot(X, self.coef_.T,
                                dense_output=True) + self.intercept_
@@ -189,6 +193,10 @@ class LinearClassifierMixin(ClassifierMixin):
             case, confidence score for self.classes_[1] where >0 means this
             class would be predicted.
         """
+        if not _is_fitted(self, 'coef_') or self.coef_ is None:
+            raise NotFittedError("This %(name)s instance is not fitted"
+                                 "yet"%{'name':type(self).__name__})
+
         X = check_array(X, accept_sparse='csr')
 
         n_features = self.coef_.shape[1]
@@ -258,8 +266,8 @@ class SparseCoefMixin(object):
         -------
         self: estimator
         """
-        if not hasattr(self, "coef_"):
-            raise ValueError("Estimator must be fitted before densifying.")
+        msg = "Estimator, %(name)s, must be fitted before densifying."
+        check_is_fitted(self, "coef_",  msg=msg)
         if sp.issparse(self.coef_):
             self.coef_ = self.coef_.toarray()
         return self
@@ -288,8 +296,8 @@ class SparseCoefMixin(object):
         -------
         self: estimator
         """
-        if not hasattr(self, "coef_"):
-            raise ValueError("Estimator must be fitted before sparsifying.")
+        msg = "Estimator, %(name)s, must be fitted before sparsifying."
+        check_is_fitted(self, "coef_",  msg=msg)
         self.coef_ = sp.csr_matrix(self.coef_)
         return self
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -29,8 +29,7 @@ from ..utils import as_float_array, check_array
 from ..utils.extmath import safe_sparse_dot
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
-from ..utils.validation import (
-        NotFittedError, _is_fitted, check_is_fitted)
+from ..utils.validation import NotFittedError, check_is_fitted
 
 
 ###
@@ -193,7 +192,7 @@ class LinearClassifierMixin(ClassifierMixin):
             case, confidence score for self.classes_[1] where >0 means this
             class would be predicted.
         """
-        if not _is_fitted(self, 'coef_') or self.coef_ is None:
+        if not hasattr(self, 'coef_') or self.coef_ is None:
             raise NotFittedError("This %(name)s instance is not fitted"
                                  "yet"%{'name':type(self).__name__})
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -22,6 +22,7 @@ from ..externals.joblib import Parallel, delayed
 from ..externals import six
 from ..externals.six.moves import xrange
 from ..utils.extmath import safe_sparse_dot
+from ..utils.validation import check_is_fitted
 from ..utils import ConvergenceWarning
 
 from . import cd_fast
@@ -688,6 +689,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         T : array, shape = (n_samples,)
             The predicted decision function
         """
+        check_is_fitted(self, 'n_iter_')
         if sparse.isspmatrix(X):
             return np.ravel(safe_sparse_dot(self.coef_, X.T, dense_output=True)
                             + self.intercept_)

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -21,6 +21,7 @@ from ..externals import six
 from ..externals.joblib import Memory, Parallel, delayed
 from ..utils import (as_float_array, check_random_state, check_X_y,
                      check_array, safe_mask, ConvergenceWarning)
+from ..utils.validation import check_is_fitted
 from .least_angle import lars_path, LassoLarsIC
 from .logistic import LogisticRegression
 
@@ -121,6 +122,8 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
 
     def get_support(self, indices=False):
         """Return a mask, or list, of the features/indices selected."""
+        check_is_fitted(self, 'scores_')
+
         mask = self.scores_ > self.selection_threshold
         return mask if not indices else np.where(mask)[0]
 

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -9,6 +9,7 @@ import numpy as np
 from ..base import BaseEstimator, MetaEstimatorMixin, RegressorMixin, clone
 from ..utils import check_random_state, check_array, check_consistent_length
 from ..utils.random import sample_without_replacement
+from ..utils.validation import check_is_fitted
 from .base import LinearRegression
 
 
@@ -351,6 +352,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         y : array, shape = [n_samples] or [n_samples, n_targets]
             Returns predicted values.
         """
+        check_is_fitted(self, 'estimator_')
+
         return self.estimator_.predict(X)
 
     def score(self, X, y):
@@ -371,4 +374,6 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         z : float
             Score of the prediction.
         """
+        check_is_fitted(self, 'estimator_')
+
         return self.estimator_.score(X, y)

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -18,6 +18,7 @@ from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import (check_array, check_random_state, check_X_y)
 from ..utils.extmath import safe_sparse_dot
 from ..utils.multiclass import _check_partial_fit_first_call
+from ..utils.validation import check_is_fitted
 from ..externals import six
 
 from .sgd_fast import plain_sgd, average_sgd
@@ -728,6 +729,8 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
             average=average)
 
     def _check_proba(self):
+        check_is_fitted(self, "t_")
+
         if self.loss not in ("log", "modified_huber"):
             raise AttributeError("probability estimates are not available for"
                                  " loss=%r" % self.loss)
@@ -990,6 +993,8 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
         array, shape (n_samples,)
            Predicted target values per element in X.
         """
+        check_is_fitted(self, ["t_", "coef_", "intercept_"], all_or_any=all)
+
         X = check_array(X, accept_sparse='csr')
 
         scores = safe_sparse_dot(X, self.coef_.T,

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -10,6 +10,7 @@ from scipy.sparse import eye, csr_matrix
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_random_state, check_array
 from ..utils.arpack import eigsh
+from ..utils.validation import check_is_fitted
 from ..neighbors import NearestNeighbors
 
 
@@ -667,6 +668,8 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
         Because of scaling performed by this method, it is discouraged to use
         it together with methods that are not scale-invariant (like SVMs)
         """
+        check_is_fitted(self, "nbrs_")
+
         X = check_array(X)
         ind = self.nbrs_.kneighbors(X, n_neighbors=self.n_neighbors,
                                     return_distance=False)

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -18,6 +18,7 @@ from scipy.spatial.distance import cdist
 from ..externals.six.moves import xrange
 from ..utils import check_random_state
 from ..utils.extmath import logsumexp, pinvh, squared_norm
+from ..utils.validation import check_is_fitted
 from .. import cluster
 from .gmm import GMM
 
@@ -242,6 +243,8 @@ class DPGMM(GMM):
             Posterior probabilities of each mixture component for each
             observation
         """
+        check_is_fitted(self, 'gamma_')
+
         X = np.asarray(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]
@@ -452,10 +455,11 @@ class DPGMM(GMM):
 
     def lower_bound(self, X, z):
         """returns a lower bound on model evidence based on X and membership"""
+        check_is_fitted(self, 'means_')
+        
         if self.covariance_type not in ['full', 'tied', 'diag', 'spherical']:
             raise NotImplementedError("This ctype is not implemented: %s"
                                       % self.covariance_type)
-
         X = np.asarray(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]
@@ -678,6 +682,8 @@ class VBGMM(DPGMM):
             Posterior probabilities of each mixture component for each
             observation
         """
+        check_is_fitted(self, 'gamma_')
+
         X = np.asarray(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -15,6 +15,7 @@ from scipy import linalg
 from ..base import BaseEstimator
 from ..utils import check_random_state
 from ..utils.extmath import logsumexp, pinvh
+from ..utils.validation import check_is_fitted
 from .. import cluster
 
 from sklearn.externals.six.moves import zip
@@ -296,6 +297,8 @@ class GMM(BaseEstimator):
             Posterior probabilities of each mixture component for each
             observation
         """
+        check_is_fitted(self, 'means_')
+
         X = np.asarray(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]
@@ -372,6 +375,8 @@ class GMM(BaseEstimator):
         X : array_like, shape (n_samples, n_features)
             List of samples
         """
+        check_is_fitted(self, 'means_')
+
         if random_state is None:
             random_state = self.random_state
         random_state = check_random_state(random_state)

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -27,8 +27,9 @@ from .preprocessing import label_binarize
 from .utils import check_X_y, check_array
 from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils.multiclass import _check_partial_fit_first_call
-from .externals import six
 from .utils.fixes import in1d
+from .utils.validation import check_is_fitted
+from .externals import six
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB']
 
@@ -332,6 +333,8 @@ class GaussianNB(BaseNB):
         return self
 
     def _joint_log_likelihood(self, X):
+        check_is_fitted(self, "classes_")
+
         X = check_array(X)
         joint_log_likelihood = []
         for i in range(np.size(self.classes_)):
@@ -604,6 +607,8 @@ class MultinomialNB(BaseDiscreteNB):
 
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""
+        check_is_fitted(self, "classes_")
+
         X = check_array(X, accept_sparse='csr')
         return (safe_sparse_dot(X, self.feature_log_prob_.T)
                 + self.class_log_prior_)
@@ -703,7 +708,8 @@ class BernoulliNB(BaseDiscreteNB):
 
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""
-
+        check_is_fitted(self, "classes_")
+        
         X = check_array(X, accept_sparse='csr')
 
         if self.binarize is not None:

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -20,6 +20,7 @@ from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from ..utils import check_X_y, check_array
 from ..utils.fixes import argpartition
 from ..utils.validation import DataConversionWarning
+from ..utils.validation import NotFittedError
 from ..externals import six
 
 
@@ -298,7 +299,7 @@ class KNeighborsMixin(object):
 
         """
         if self._fit_method is None:
-            raise ValueError("must fit neighbors before querying")
+            raise NotFittedError("Must fit neighbors before querying.")
 
         X = check_array(X, accept_sparse='csr')
 
@@ -463,9 +464,8 @@ class RadiusNeighborsMixin(object):
         For efficiency, `radius_neighbors` returns arrays of objects, where
         each object is a 1D array of indices or distances.
         """
-
         if self._fit_method is None:
-            raise ValueError("must fit neighbors before querying")
+            raise NotFittedError("Must fit neighbors before querying.")
 
         X = check_array(X, accept_sparse='csr')
 

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -16,7 +16,7 @@ from ..base import BaseEstimator, ClassifierMixin
 from ..externals.six.moves import xrange
 from ..metrics.pairwise import pairwise_distances
 from ..preprocessing import LabelEncoder
-from ..utils.validation import check_array, check_X_y
+from ..utils.validation import check_array, check_X_y, check_is_fitted
 from ..utils.sparsefuncs import csc_median_axis_0
 
 
@@ -182,8 +182,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         be the distance matrix between the data to be predicted and
         ``self.centroids_``.
         """
+        check_is_fitted(self, 'centroids_')
+
         X = check_array(X, accept_sparse='csr')
-        if not hasattr(self, "centroids_"):
-            raise AttributeError("Model has not been trained yet.")
         return self.classes_[pairwise_distances(
             X, self.centroids_, metric=self.metric).argmin(axis=1)]

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -22,6 +22,7 @@ from ..utils import issparse
 from ..utils.extmath import safe_sparse_dot
 from ..utils.extmath import log_logistic
 from ..utils.fixes import expit             # logistic function
+from ..utils.validation import check_is_fitted
 
 
 class BernoulliRBM(BaseEstimator, TransformerMixin):
@@ -116,6 +117,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         h : array, shape (n_samples, n_components)
             Latent representations of the data.
         """
+        check_is_fitted(self, "components_")
+
         X = check_array(X, accept_sparse='csr', dtype=np.float)
         return self._mean_hiddens(X)
 
@@ -206,6 +209,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         v_new : array-like, shape (n_samples, n_features)
             Values of the visible layer after one Gibbs step.
         """
+        check_is_fitted(self, "components_")
+
         rng = check_random_state(self.random_state)
         h_ = self._sample_hiddens(v, rng)
         v_ = self._sample_visibles(h_, rng)
@@ -295,6 +300,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         free energy on X, then on a randomly corrupted version of X, and
         returns the log of the logistic function of the difference.
         """
+        check_is_fitted(self, "components_")
+        
         v = check_array(X, accept_sparse='csr')
         rng = check_random_state(self.random_state)
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -19,6 +19,7 @@ from ..utils.fixes import combinations_with_replacement as combinations_w_r
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale, mean_variance_axis)
+from ..utils.validation import check_is_fitted
 
 zip = six.moves.zip
 map = six.moves.map
@@ -217,6 +218,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X : array-like with shape [n_samples, n_features]
             Input data that will be transformed.
         """
+        check_is_fitted(self, 'scale_')
+
         X = check_array(X, copy=self.copy, ensure_2d=False)
         X *= self.scale_
         X += self.min_
@@ -230,6 +233,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X : array-like with shape [n_samples, n_features]
             Input data that will be transformed.
         """
+        check_is_fitted(self, 'scale_')
+
         X = check_array(X, copy=self.copy, ensure_2d=False)
         X -= self.min_
         X /= self.scale_
@@ -337,6 +342,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         X : array-like with shape [n_samples, n_features]
             The data used to scale along the features axis.
         """
+        check_is_fitted(self, 'std_')
+
         copy = copy if copy is not None else self.copy
         X = check_array(X, accept_sparse='csr', copy=copy, ensure_2d=False)
         if warn_if_not_float(X, estimator=self):
@@ -363,6 +370,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         X : array-like with shape [n_samples, n_features]
             The data used to scale along the features axis.
         """
+        check_is_fitted(self, 'std_')
+
         copy = copy if copy is not None else self.copy
         if sparse.issparse(X):
             if self.with_mean:
@@ -482,6 +491,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
         """
+        check_is_fitted(self, 'powers_')
+
         X = check_array(X)
         n_samples, n_features = X.shape
 
@@ -764,6 +775,8 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         -------
         K_new : numpy array of shape [n_samples1, n_samples2]
         """
+        check_is_fitted(self, 'K_fit_all_')
+
         K = check_array(K)
         if copy:
             K = K.copy()

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -13,6 +13,7 @@ from ..utils import check_array
 from ..utils import as_float_array
 from ..utils.fixes import astype
 from ..utils.sparsefuncs import _get_median
+from ..utils.validation import check_is_fitted
 
 from ..externals import six
 
@@ -304,6 +305,9 @@ class Imputer(BaseEstimator, TransformerMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             The input data to complete.
         """
+        if self.axis == 0:
+            check_is_fitted(self, 'statistics_')
+
         # Copy just once
         X = as_float_array(X, copy=self.copy, force_all_finite=False)
 

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -13,6 +13,7 @@ import numpy as np
 from .base import BaseEstimator, ClassifierMixin
 from .externals.six.moves import xrange
 from .utils import check_array, check_X_y
+from .utils.validation import check_is_fitted
 
 __all__ = ['QDA']
 
@@ -141,6 +142,8 @@ class QDA(BaseEstimator, ClassifierMixin):
         return self
 
     def _decision_function(self, X):
+        check_is_fitted(self, 'classes_')
+
         X = check_array(X)
         norm2 = []
         for i in range(len(self.classes_)):

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -41,7 +41,7 @@ from .externals.six.moves import xrange
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
 from .utils.random import sample_without_replacement
-from .utils.validation import check_array
+from .utils.validation import check_array, NotFittedError
 from .utils import DataDimensionalityWarning
 
 
@@ -402,7 +402,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
         X = check_array(X, accept_sparse=['csr', 'csc'])
 
         if self.components_ is None:
-            raise ValueError('No random projection matrix had been fit.')
+            raise NotFittedError('No random projection matrix had been fit.')
 
         if X.shape[1] != self.components_.shape[1]:
             raise ValueError(

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -61,7 +61,7 @@ from ..base import BaseEstimator, ClassifierMixin
 from ..metrics.pairwise import rbf_kernel
 from ..utils.graph import graph_laplacian
 from ..utils.extmath import safe_sparse_dot
-from ..utils.validation import check_X_y
+from ..utils.validation import check_X_y, check_is_fitted
 from ..externals import six
 from ..neighbors.unsupervised import NearestNeighbors
 
@@ -168,6 +168,8 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
             Normalized probability distributions across
             class labels
         """
+        check_is_fitted(self, 'X_')
+
         if sparse.isspmatrix(X):
             X_2d = X
         else:

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -12,6 +12,7 @@ from ..preprocessing import LabelEncoder
 from ..utils import check_array, check_random_state, column_or_1d
 from ..utils import ConvergenceWarning, compute_class_weight
 from ..utils.extmath import safe_sparse_dot
+from ..utils.validation import check_is_fitted
 from ..externals import six
 
 
@@ -354,11 +355,12 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             Returns the decision function of the sample for each class
             in the model.
         """
+        # NOTE: _validate_for_predict contains check for is_fitted
+        # hence must be placed before any other attributes are used.
+        X = self._validate_for_predict(X)
         if self._sparse:
             raise NotImplementedError("Decision_function not supported for"
                                       " sparse SVM.")
-
-        X = self._validate_for_predict(X)
         X = self._compute_kernel(X)
 
         kernel = self.kernel
@@ -381,9 +383,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         return dec_func
 
     def _validate_for_predict(self, X):
-        if not hasattr(self, "support_"):
-            raise ValueError("This %s has not been fitted yet"
-                             % type(self).__name__)
+        check_is_fitted(self, 'support_')
+        
         X = check_array(X, accept_sparse='csr', dtype=np.float64, order="C")
         if self._sparse and not sp.isspmatrix(X):
             X = sp.csr_matrix(X)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -382,7 +382,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def _validate_for_predict(self, X):
         if not hasattr(self, "support_"):
-            raise ValueError("this %s has not been fitted yet"
+            raise ValueError("This %s has not been fitted yet"
                              % type(self).__name__)
         X = check_array(X, accept_sparse='csr', dtype=np.float64, order="C")
         if self._sparse and not sp.isspmatrix(X):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -16,7 +16,7 @@ from sklearn.externals.six import PY3
 from sklearn.externals.six.moves import zip
 from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
-from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater 
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import ignore_warnings
@@ -38,7 +38,9 @@ from sklearn.utils.estimator_checks import (
     check_regressors_pickle,
     check_transformer_sparse_data,
     check_transformer_pickle,
+    check_transformers_unfitted,
     check_estimators_nan_inf,
+    check_estimators_unfitted,
     check_classifiers_one_label,
     check_classifiers_train,
     check_classifiers_classes,
@@ -106,6 +108,7 @@ def test_transformers():
         if name not in ['AdditiveChi2Sampler', 'Binarizer', 'Normalizer']:
             # basic tests
             yield check_transformer, name, Transformer
+            yield check_transformers_unfitted, name, Transformer
 
 
 def test_estimators_nan_inf():
@@ -154,6 +157,8 @@ def test_classifiers():
 
             # test if classifiers can cope with y.shape = (n_samples, 1)
             yield check_classifiers_input_shapes, name, Classifier
+        # test if NotFittedError is raised
+        yield check_estimators_unfitted, name, Classifier
 
 
 def test_regressors():
@@ -171,6 +176,8 @@ def test_regressors():
         if name != 'CCA':
             # check that the regressor handles int input
             yield check_regressors_int, name, Regressor
+        # Test if NotFittedError is raised
+        yield check_estimators_unfitted, name, Regressor
 
 
 def test_configure():

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -26,6 +26,7 @@ from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_array, check_random_state
+from ..utils.validation import NotFittedError, check_is_fitted
 
 
 from ._tree import Criterion
@@ -320,7 +321,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         n_samples, n_features = X.shape
 
         if self.tree_ is None:
-            raise Exception("Tree not initialized. Perform a fit first")
+            raise NotFittedError("Tree not initialized. Perform a fit first")
 
         if self.n_features_ != n_features:
             raise ValueError("Number of features of the model must "
@@ -366,8 +367,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         feature_importances_ : array, shape = [n_features]
         """
         if self.tree_ is None:
-            raise ValueError("Estimator not fitted, "
-                             "call `fit` before `feature_importances_`.")
+            raise NotFittedError("Estimator not fitted, call `fit` before"
+                                 " `feature_importances_`.")
 
         return self.tree_.compute_feature_importances()
 
@@ -525,6 +526,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute `classes_`.
         """
+        check_is_fitted(self, 'n_outputs_')
         X = check_array(X, dtype=DTYPE, accept_sparse="csr")
         if issparse(X) and (X.indices.dtype != np.intc or
                             X.indptr.dtype != np.intc):
@@ -534,7 +536,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         n_samples, n_features = X.shape
 
         if self.tree_ is None:
-            raise Exception("Tree not initialized. Perform a fit first.")
+            raise NotFittedError("Tree not initialized. Perform a fit first.")
 
         if self.n_features_ != n_features:
             raise ValueError("Number of features of the model must "

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -31,7 +31,7 @@ from sklearn.random_projection import BaseRandomProjection
 from sklearn.feature_selection import SelectKBest
 from sklearn.svm.base import BaseLibSVM
 
-from sklearn.utils.validation import DataConversionWarning
+from sklearn.utils.validation import DataConversionWarning, NotFittedError
 from sklearn.cross_validation import train_test_split
 
 from sklearn.utils import shuffle
@@ -157,6 +157,17 @@ def check_transformer_data_not_an_array(name, Transformer):
     this_X = NotAnArray(X)
     this_y = NotAnArray(np.asarray(y))
     _check_transformer(name, Transformer, this_X, this_y)
+
+
+def check_transformers_unfitted(name, Transformer):
+    X, y = _boston_subset()
+
+    with warnings.catch_warnings(record=True):
+        transformer = Transformer()
+    if not hasattr(transformer, 'Transform'):
+        return
+
+    assert_raises(NotFittedError, transformer.transform, X)
 
 
 def _check_transformer(name, Transformer, X, y):
@@ -537,6 +548,25 @@ def check_classifiers_train(name, Classifier):
             assert_raises(ValueError, classifier.predict_proba, X.T)
             # raises error on malformed input for predict_proba
             assert_raises(ValueError, classifier.predict_proba, X.T)
+
+
+def check_estimators_unfitted(name, Estimator):
+    """Check if NotFittedError is raised when calling predict and related
+    functions"""
+
+    # Common test for Regressors as well as Classifiers
+    X, y = _boston_subset()
+
+    with warnings.catch_warnings(record=True):
+        est = Estimator()
+
+    assert_raises(NotFittedError, est.predict, X)
+    
+    if hasattr(est, 'decision_function'):
+        assert_raises(NotFittedError, est.decision_function, X)
+
+    if hasattr(est, 'predict_proba'):
+        assert_raises(NotFittedError, est.predict_proba, X)
 
 
 def check_classifiers_input_shapes(name, Classifier):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -981,7 +981,8 @@ def multioutput_estimator_convert_y_2d(name, y):
     return y
 
 
-def check_non_transformer_estimators_n_iter(name, estimator, multi_output=False):
+def check_non_transformer_estimators_n_iter(name, estimator, 
+                                            multi_output=False):
     # Check if all iterative solvers, run for more than one iteratiom
 
     iris = load_iris()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -164,8 +164,6 @@ def check_transformers_unfitted(name, Transformer):
 
     with warnings.catch_warnings(record=True):
         transformer = Transformer()
-    if not hasattr(transformer, 'Transform'):
-        return
 
     assert_raises(NotFittedError, transformer.transform, X)
 
@@ -561,12 +559,18 @@ def check_estimators_unfitted(name, Estimator):
         est = Estimator()
 
     assert_raises(NotFittedError, est.predict, X)
-    
+ 
+    if hasattr(est, 'predict'):
+        assert_raises(NotFittedError, est.predict, X)
+
     if hasattr(est, 'decision_function'):
         assert_raises(NotFittedError, est.decision_function, X)
 
     if hasattr(est, 'predict_proba'):
         assert_raises(NotFittedError, est.predict_proba, X)
+    
+    if hasattr(est, 'predict_log_proba'):
+        assert_raises(NotFittedError, est.predict_log_proba, X)
 
 
 def check_classifiers_input_shapes(name, Classifier):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -24,7 +24,6 @@ from sklearn.utils.estimator_checks import NotAnArray
 from sklearn.utils.validation import (
         NotFittedError,
         has_fit_parameter,
-        _is_fitted,
         check_is_fitted)
 
 
@@ -248,26 +247,10 @@ def test_check_symmetric():
             assert_array_equal(output, arr_sym)
 
 
-def test_is_fitted():
-    assert_raises(ValueError, _is_fitted, ARDRegression, "coef_")
-    assert_raises(ValueError, _is_fitted, SVR, "support_")
-
-    try:
-        assert_false(_is_fitted(ARDRegression(), "coef_"))
-        assert_false(_is_fitted(SVR(), "support_"))
-    except ValueError:
-        assert False, "_is_fitted check failed with incorrect result"
-
-    ard = ARDRegression().fit(*make_blobs())
-    svr = SVR().fit(*make_blobs())
-
-    assert_true(_is_fitted(ard, "coef_"))
-    assert_true(_is_fitted(svr, "support_"))
-
-
 def test_check_is_fitted():
+    # Check is ValueError raised when non estimator instance passed
     assert_raises(ValueError, check_is_fitted, ARDRegression, "coef_")
-    assert_raises(ValueError, check_is_fitted, SVR, "support_")
+    assert_raises(ValueError, check_is_fitted, "SVR", "support_")
 
     ard = ARDRegression()
     svr = SVR()
@@ -278,7 +261,7 @@ def test_check_is_fitted():
     except ValueError:
         assert False, "check_is_fitted failed with ValueError"
 
-    # NotFittedError is a subclass of ValueError and AttributeError
+    # NotFittedError is a subclass of both ValueError and AttributeError
     try:
         check_is_fitted(ard, "coef_", "Random message %(name)s, %(name)s")
     except ValueError as e:
@@ -291,6 +274,6 @@ def test_check_is_fitted():
 
     ard.fit(*make_blobs())
     svr.fit(*make_blobs())
-
+ 
     assert_equal(None, check_is_fitted(ard, "coef_"))
     assert_equal(None, check_is_fitted(svr, "support_"))

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -13,10 +13,19 @@ from sklearn.utils.estimator_checks import NotAnArray
 
 from sklearn.random_projection import sparse_random_matrix
 
+from sklearn.linear_model import ARDRegression
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.svm import SVR
-from sklearn.utils.validation import has_fit_parameter
+
+from sklearn.datasets import make_blobs
+from sklearn.utils import as_float_array, check_array
+from sklearn.utils.estimator_checks import NotAnArray
+from sklearn.utils.validation import (
+        NotFittedError,
+        has_fit_parameter,
+        _is_fitted,
+        check_is_fitted)
 
 
 def test_as_float_array():
@@ -201,6 +210,7 @@ def test_check_array():
     result = check_array(X_no_array)
     assert_true(isinstance(result, np.ndarray))
 
+
 def test_has_fit_parameter():
     assert_false(has_fit_parameter(KNeighborsClassifier, "sample_weight"))
     assert_true(has_fit_parameter(RandomForestRegressor, "sample_weight"))
@@ -236,3 +246,51 @@ def test_check_symmetric():
             assert_array_equal(output.toarray(), arr_sym)
         else:
             assert_array_equal(output, arr_sym)
+
+
+def test_is_fitted():
+    assert_raises(ValueError, _is_fitted, ARDRegression, "coef_")
+    assert_raises(ValueError, _is_fitted, SVR, "support_")
+
+    try:
+        assert_false(_is_fitted(ARDRegression(), "coef_"))
+        assert_false(_is_fitted(SVR(), "support_"))
+    except ValueError:
+        assert False, "_is_fitted check failed with incorrect result"
+
+    ard = ARDRegression().fit(*make_blobs())
+    svr = SVR().fit(*make_blobs())
+
+    assert_true(_is_fitted(ard, "coef_"))
+    assert_true(_is_fitted(svr, "support_"))
+
+
+def test_check_is_fitted():
+    assert_raises(ValueError, check_is_fitted, ARDRegression, "coef_")
+    assert_raises(ValueError, check_is_fitted, SVR, "support_")
+
+    ard = ARDRegression()
+    svr = SVR()
+
+    try:
+        assert_raises(NotFittedError, check_is_fitted, ard, "coef_")
+        assert_raises(NotFittedError, check_is_fitted, svr, "support_")
+    except ValueError:
+        assert False, "check_is_fitted failed with ValueError"
+
+    # NotFittedError is a subclass of ValueError and AttributeError
+    try:
+        check_is_fitted(ard, "coef_", "Random message %(name)s, %(name)s")
+    except ValueError as e:
+        assert_equal(str(e), "Random message ARDRegression, ARDRegression")
+
+    try:
+        check_is_fitted(svr, "support_", "Another message %(name)s, %(name)s")
+    except AttributeError as e:
+        assert_equal(str(e), "Another message SVR, SVR")
+
+    ard.fit(*make_blobs())
+    svr.fit(*make_blobs())
+
+    assert_equal(None, check_is_fitted(ard, "coef_"))
+    assert_equal(None, check_is_fitted(svr, "support_"))

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -30,10 +30,10 @@ class NonBLASDotWarning(UserWarning):
 
 
 class NotFittedError(ValueError, AttributeError):
-    """
-    Exception class to raise if estimator is used before fitting
+    """Exception class to raise if estimator is used before fitting
 
-    Inherits from both ValueError and AttributeError to help exception handling
+    This class inherits from both ValueError and AttributeError to help with
+    exception handling and backward compatibility.
     """
 
 
@@ -469,70 +469,42 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
     return array
 
 
-def _is_fitted(estimator, attributes, all_or_any=all):
-    """
-    Check if the estimator is fitted by verifying if the estimator has all
-    the passed attributes.
+def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
+    """Perform is_fitted validation for estimator.
+
+    Checks if the estimator is fitted by verifying the presence of 
+    "all_or_any" of the passed attributes and raises a NotFittedError with the
+    given message.
 
     Parameters
     ----------
-    estimator : An estimator instance or object, instance of BaseEstimator
-        estimator instance for which the check is performed. The estimator
-        class must inherit from BaseEstimator.
+    estimator : estimator instance.
+        estimator instance for which the check is performed.
 
     attributes : attribute name(s) given as string or a list/tuple of strings
         Eg. : ["coef_", "estimator_", ...], "coef_"
 
-    all_or_any : callable, {all, any}, optional, default all
-        Specify whether all or any of the given attributes must exist.
+    msg : string
+        The default error message is, "This %(name)s instance is not fitted
+        yet. Call 'fit' with appropriate arguments before using this method."
 
-    Return
-    ------
-    result : boolean
-        True if all the attributes exist, False otherwise
-
-    Example
-    -------
-    >>> from sklearn.svm import SVC
-    >>> _is_fitted(SVC(), "support_")
-    False
-    """
-    if not isinstance(estimator, BaseEstimator):
-        raise ValueError("Not an estimator inistance, %s"%(estimator))
-
-    if not isinstance(attributes, (list, tuple)):
-        attributes = [attributes]
-
-    return all_or_any([hasattr(estimator, attr) for attr in attributes])
-
-
-def check_is_fitted(estimator, attributes,
-                    msg="This %(name)s instance is not fitted yet.", 
-                    all_or_any=all):
-    """
-    Perform is_fitted validation for estimator
-
-    Check if the estimator is fitted by verifying if the estimator has all the
-    passed attributes and raises an AttributeError with the given message if
-    the estimator was not fitted.
-
-    Parameters
-    ----------
-    estimator : An estimator instance or object, instance of BaseEstimator
-        estimator instance for which the check is performed. The estimator
-        class must inherit from BaseEstimator.
-
-    attributes : attribute name(s) given as string or a list/tuple of strings
-        Eg. : ["coef_", "estimator_", ...], "coef_"
-
-    msg : string, optional, default "This %(name)s instance is not fitted yet."
         For custom messages if "%(name)s" is present in the message string,
         it is substituted for the estimator name.
 
         Eg. : "Estimator, %(name)s, must be fitted before sparsifying".
 
-    all_or_any : callable, {all, any}, optional, default all
+    all_or_any : callable, {all, any}, default all
         Specify whether all or any of the given attributes must exist.
     """
-    if not _is_fitted(estimator, attributes, all_or_any):
-        raise NotFittedError(msg%{'name':type(estimator).__name__})
+    if msg is None:
+        msg = ("This %(name)s instance is not fitted yet. Call 'fit' with "
+               "appropriate arguments before using this method.")
+
+    if not hasattr(estimator, 'fit'):
+        raise ValueError("%s is not an estimator instance." % (estimator))
+
+    if not isinstance(attributes, (list, tuple)):
+        attributes = [attributes]
+
+    if not all_or_any([hasattr(estimator, attr) for attr in attributes]):
+        raise NotFittedError(msg % {'name' : type(estimator).__name__})

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -494,7 +494,7 @@ def _is_fitted(estimator, attributes, all_or_any=all):
     Example
     -------
     >>> from sklearn.svm import SVC
-    >>> _is_fitted(SVC(), "coef_")
+    >>> _is_fitted(SVC(), "support_")
     False
     """
     if not isinstance(estimator, BaseEstimator):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -14,6 +14,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from ..externals import six
+from ..base import BaseEstimator
 from inspect import getargspec
 
 
@@ -26,6 +27,14 @@ warnings.simplefilter("always", DataConversionWarning)
 
 class NonBLASDotWarning(UserWarning):
     "A warning on implicit dispatch to numpy.dot"
+    pass
+
+class NotFittedError(ValueError, AttributeError):
+    """
+    Exception class to raise if estimator is used before fitting
+
+    Inherits from both ValueError and AttributeError to help exception handling
+    """
     pass
 
 
@@ -394,7 +403,7 @@ def check_random_state(seed):
                      ' instance' % seed)
 
 def has_fit_parameter(estimator, parameter):
-    """ Checks whether the estimator's fit method supports the given parameter.
+    """Checks whether the estimator's fit method supports the given parameter.
 
     Example
     -------
@@ -459,3 +468,72 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
             array = 0.5 * (array + array.T)
 
     return array
+
+
+def _is_fitted(estimator, attributes, all_or_any=all):
+    """
+    Check if the estimator is fitted by verifying if the estimator has all
+    the passed attributes.
+
+    Parameters
+    ----------
+    estimator : An estimator instance or object, instance of BaseEstimator
+        estimator instance for which the check is performed. The estimator
+        class must inherit from BaseEstimator.
+
+    attributes : attribute name(s) given as string or a list/tuple of strings
+        Eg. : ["coef_", "estimator_", ...], "coef_"
+
+    all_or_any : callable, {all, any}, optional, default all
+        Specify whether all or any of the given attributes must exist.
+
+    Return
+    ------
+    result : boolean
+        True if all the attributes exist, False otherwise
+
+    Example
+    -------
+    >>> from sklearn.svm import SVC
+    >>> _is_fitted(SVC(), "coef_")
+    False
+    """
+    if not isinstance(estimator, BaseEstimator):
+        raise ValueError("Not an estimator inistance, %s"%(estimator))
+
+    if not isinstance(attributes, (list, tuple)):
+        attributes = [attributes]
+
+    return all_or_any([hasattr(estimator, attr) for attr in attributes])
+
+
+def check_is_fitted(estimator, attributes,
+                    msg="This %(name)s instance is not fitted yet.", 
+                    all_or_any=all):
+    """
+    Perform is_fitted validation for estimator
+
+    Check if the estimator is fitted by verifying if the estimator has all the
+    passed attributes and raises an AttributeError with the given message if
+    the estimator was not fitted.
+
+    Parameters
+    ----------
+    estimator : An estimator instance or object, instance of BaseEstimator
+        estimator instance for which the check is performed. The estimator
+        class must inherit from BaseEstimator.
+
+    attributes : attribute name(s) given as string or a list/tuple of strings
+        Eg. : ["coef_", "estimator_", ...], "coef_"
+
+    msg : string, optional, default "This %(name)s instance is not fitted yet."
+        For custom messages if "%(name)s" is present in the message string,
+        it is substituted for the estimator name.
+
+        Eg. : "Estimator, %(name)s, must be fitted before sparsifying".
+
+    all_or_any : callable, {all, any}, optional, default all
+        Specify whether all or any of the given attributes must exist.
+    """
+    if not _is_fitted(estimator, attributes, all_or_any):
+        raise NotFittedError(msg%{'name':type(estimator).__name__})

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -27,7 +27,7 @@ warnings.simplefilter("always", DataConversionWarning)
 
 class NonBLASDotWarning(UserWarning):
     "A warning on implicit dispatch to numpy.dot"
-    pass
+
 
 class NotFittedError(ValueError, AttributeError):
     """
@@ -35,7 +35,6 @@ class NotFittedError(ValueError, AttributeError):
 
     Inherits from both ValueError and AttributeError to help exception handling
     """
-    pass
 
 
 # Silenced by default to reduce verbosity. Turn on at runtime for


### PR DESCRIPTION
Fixes #3627 and #3601
- [x] Add `util.validation.NotFittedError`
- [x] Add `check_is_fitted` to raise `NotFittedError` when the given attribute(s) aren't available in the passed estimator instance.
  `check_is_fitted` will also simply return the result if the `raise_error` parameter is set to `False`.
- [x] Refactor existing modules to use `check_is_fitted`
- [x] Add tests to ensure all the unfitted estimators {regressors, classifiers, transformers} raise `NotFittedError` when predict ( or related methods are called ).
  Thanks to @jnothman for [this](https://github.com/jnothman/scikit-learn/compare/scikit-learn:master...jnothman:unfitted-error)
- [x] Run smoke test and fix all modules which do not currently raise an error, when `predict` like methods are called before `fit`-ing
- [x] Make travis happy.

The `check_is_fitted` should behave more ideally after #3937 is merged...
