### PR TITLE
[MRG+1] fixes to check_scoring and regression tests. 

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -186,7 +186,8 @@ Bug fixes
       By `Joel Nothman`_
 
     - The ``scoring`` attribute of grid-search and cross-validation methods is no longer
-     ignored when a :class:`grid_search.GridSearchCV` is given as a base estimator. 
+     ignored when a :class:`grid_search.GridSearchCV` is given as a base estimator or
+     the base estimator doesn't have predict.
 
     - The function :func:`hierarchical.ward_tree` now returns the children in
       the same order for both the structured and unstructured versions. By

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -178,6 +178,15 @@ Documentation improvements
 
 Bug fixes
 .........
+    - Metaestimators now support ducktyping for the presence of ``decision_function``,
+      ``predict_proba`` and other methods. This fixes behavior of
+      :class:`grid_search.GridSearchCV`,
+      :class:`grid_search.RandomizedSearchCV`, :class:`pipeline.Pipeline`,
+      :class:`feature_selection.RFE`, :class:`feature_selection.RFECV` when nested.
+      By `Joel Nothman`_
+
+    - The ``scoring`` attribute of grid-search and cross-validation methods is no longer
+     ignored when a :class:`grid_search.GridSearchCV` is given as a base estimator. 
 
     - The function :func:`hierarchical.ward_tree` now returns the children in
       the same order for both the structured and unstructured versions. By

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -231,20 +231,16 @@ def check_scoring(estimator, scoring=None, allow_none=False,
     if not hasattr(estimator, 'fit'):
         raise TypeError("estimator should a be an estimator implementing "
                         "'fit' method, %r was passed" % estimator)
-    elif hasattr(estimator, 'predict') and has_scoring:
+    elif has_scoring:
         return get_scorer(scoring)
     elif hasattr(estimator, 'score'):
         return _passthrough_scorer
-    elif not has_scoring:
-        if allow_none:
+    elif allow_none:
             return None
+    else:
         raise TypeError(
             "If no scoring is specified, the estimator passed should "
             "have a 'score' method. The estimator %r does not." % estimator)
-    else:
-        raise TypeError(
-            "The estimator passed should have a 'score' or a 'predict' "
-            "method. The estimator %r does not." % estimator)
 
 
 def make_scorer(score_func, greater_is_better=True, needs_proba=False,

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -236,7 +236,7 @@ def check_scoring(estimator, scoring=None, allow_none=False,
     elif hasattr(estimator, 'score'):
         return _passthrough_scorer
     elif allow_none:
-            return None
+        return None
     else:
         raise TypeError(
             "If no scoring is specified, the estimator passed should "

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -12,7 +12,8 @@ from sklearn.utils.testing import assert_not_equal
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
                              log_loss, precision_score, recall_score)
 from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.scorer import check_scoring
+from sklearn.metrics.scorer import (check_scoring, _PredictScorer,
+                                    _passthrough_scorer)
 from sklearn.metrics import make_scorer, get_scorer, SCORERS
 from sklearn.svm import LinearSVC
 from sklearn.cluster import KMeans
@@ -82,6 +83,7 @@ def test_check_scoring():
     estimator = EstimatorWithFitAndScore()
     estimator.fit([[1]], [1])
     scorer = check_scoring(estimator)
+    assert_true(scorer is _passthrough_scorer)
     assert_almost_equal(scorer(estimator, [[1]], [1]), 1.0)
 
     estimator = EstimatorWithFitAndPredict()
@@ -94,10 +96,8 @@ def test_check_scoring():
     assert_almost_equal(scorer(estimator, [[1]], [1]), 1.0)
 
     estimator = EstimatorWithFit()
-    pattern = (r"The estimator passed should have a 'score'"
-               r" or a 'predict' method\. The estimator .* does not\.")
-    assert_raises_regexp(TypeError, pattern, check_scoring, estimator,
-                         "accuracy")
+    scorer = check_scoring(estimator, "accuracy")
+    assert_true(isinstance(scorer, _PredictScorer))
 
     estimator = EstimatorWithFit()
     scorer = check_scoring(estimator, allow_none=True)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -3,12 +3,14 @@ import pickle
 import numpy as np
 
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_not_equal
 
+from sklearn.base import BaseEstimator
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
                              log_loss, precision_score, recall_score)
 from sklearn.metrics.cluster import adjusted_rand_score
@@ -16,6 +18,7 @@ from sklearn.metrics.scorer import (check_scoring, _PredictScorer,
                                     _passthrough_scorer)
 from sklearn.metrics import make_scorer, get_scorer, SCORERS
 from sklearn.svm import LinearSVC
+from sklearn.pipeline import make_pipeline
 from sklearn.cluster import KMeans
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import Ridge, LogisticRegression
@@ -48,7 +51,7 @@ class EstimatorWithoutFit(object):
     pass
 
 
-class EstimatorWithFit(object):
+class EstimatorWithFit(BaseEstimator):
     """Dummy estimator to test check_scoring"""
     def fit(self, X, y):
         return self
@@ -71,6 +74,12 @@ class EstimatorWithFitAndPredict(object):
 
     def predict(self, X):
         return self.y
+
+
+class DummyScorer(object):
+    """Dummy scorer that always returns 1."""
+    def __call__(self, est, X, y):
+        return 1
 
 
 def test_check_scoring():
@@ -102,6 +111,26 @@ def test_check_scoring():
     estimator = EstimatorWithFit()
     scorer = check_scoring(estimator, allow_none=True)
     assert_true(scorer is None)
+
+
+def test_check_scoring_gridsearchcv():
+    # test that check_scoring works on GridSearchCV and pipeline.
+    # slightly redundant non-regression test.
+
+    grid = GridSearchCV(LinearSVC(), param_grid={'C': [.1, 1]})
+    scorer = check_scoring(grid, "f1")
+    assert_true(isinstance(scorer, _PredictScorer))
+
+    pipe = make_pipeline(LinearSVC())
+    scorer = check_scoring(pipe, "f1")
+    assert_true(isinstance(scorer, _PredictScorer))
+
+    # check that cross_val_score definitely calls the scorer
+    # and doesn't make any assumptions about the estimator apart from having a
+    # fit.
+    scores = cross_val_score(EstimatorWithFit(), [[1], [2], [3]], [1, 0, 1],
+                             scoring=DummyScorer())
+    assert_array_equal(scores, 1)
 
 
 def test_make_scorer():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -40,7 +40,8 @@ from sklearn.grid_search import (GridSearchCV, RandomizedSearchCV,
 from sklearn.svm import LinearSVC, SVC
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.cluster import KMeans, SpectralClustering
+from sklearn.cluster import KMeans
+from sklearn.neighbors import KernelDensity
 from sklearn.metrics import f1_score
 from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_auc_score
@@ -512,14 +513,18 @@ def test_unsupervised_grid_search():
     assert_equal(grid_search.best_params_["n_clusters"], 4)
 
 
-def test_bad_estimator():
-    # test grid-search with clustering algorithm which doesn't support
-    # "predict"
-    sc = SpectralClustering()
-    grid_search = GridSearchCV(sc, param_grid=dict(gamma=[.1, 1, 10]),
-                               scoring='ari')
-    assert_raise_message(TypeError, "'score' or a 'predict'", grid_search.fit,
-                         [[1]])
+def test_gridsearch_no_predict():
+    # test grid-search with an estimator without predict.
+    # slight duplication of a test from KDE
+    def custom_scoring(estimator, X):
+        return estimator.score(X) + 3
+    X, _ = make_blobs(cluster_std=.1, random_state=1,
+                      centers=[[0, 1], [1, 0], [0, 0]])
+    search = GridSearchCV(KernelDensity(),
+                          param_grid=dict(bandwidth=[.01, .1, 1, 10]),
+                          scoring=custom_scoring)
+    search.fit(X)
+    assert_equal(search.best_params_['bandwidth'], .1)
 
 
 def test_param_sampler():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -19,7 +19,6 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_false, assert_true
-from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -517,15 +516,15 @@ def test_gridsearch_no_predict():
     # test grid-search with an estimator without predict.
     # slight duplication of a test from KDE
     def custom_scoring(estimator, X):
-        return estimator.score(X) + 1000
+        return 42 if estimator.bandwidth == .1 else 0
     X, _ = make_blobs(cluster_std=.1, random_state=1,
                       centers=[[0, 1], [1, 0], [0, 0]])
     search = GridSearchCV(KernelDensity(),
-                          param_grid=dict(bandwidth=[.01, .1, 1, 10]),
+                          param_grid=dict(bandwidth=[.01, .1, 1]),
                           scoring=custom_scoring)
     search.fit(X)
     assert_equal(search.best_params_['bandwidth'], .1)
-    assert_greater(search.best_score_, 1000)
+    assert_equal(search.best_score_, 42)
 
 
 def test_param_sampler():

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -19,10 +19,10 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_false, assert_true
+from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
@@ -517,7 +517,7 @@ def test_gridsearch_no_predict():
     # test grid-search with an estimator without predict.
     # slight duplication of a test from KDE
     def custom_scoring(estimator, X):
-        return estimator.score(X) + 3
+        return estimator.score(X) + 1000
     X, _ = make_blobs(cluster_std=.1, random_state=1,
                       centers=[[0, 1], [1, 0], [0, 0]])
     search = GridSearchCV(KernelDensity(),
@@ -525,6 +525,7 @@ def test_gridsearch_no_predict():
                           scoring=custom_scoring)
     search.fit(X)
     assert_equal(search.best_params_['bandwidth'], .1)
+    assert_greater(search.best_score_, 1000)
 
 
 def test_param_sampler():


### PR DESCRIPTION
This changes the behavior of `check_scoring`.
If scoring is provided, it MUST be used. Also, a scorer might not need predict, so that check is dropped.
Fixes remaining issues from #3848 and #2853.
