### PR TITLE
Implemented the H-Measure metric for binary classification.

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -752,6 +752,7 @@ details.
    metrics.confusion_matrix
    metrics.f1_score
    metrics.fbeta_score
+   metrics.h_measure_score
    metrics.hamming_loss
    metrics.hinge_loss
    metrics.jaccard_similarity_score

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -10,6 +10,7 @@ from .ranking import label_ranking_average_precision_score
 from .ranking import precision_recall_curve
 from .ranking import roc_auc_score
 from .ranking import roc_curve
+from .ranking import h_measure_score
 
 from .classification import accuracy_score
 from .classification import classification_report
@@ -72,6 +73,7 @@ __all__ = [
     'f1_score',
     'fbeta_score',
     'get_scorer',
+    'h_measure_score',
     'hamming_loss',
     'hinge_loss',
     'homogeneity_completeness_v_measure',

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -726,7 +726,7 @@ def h_measure_score(y_true, y_score, pos_label=None, alpha=None, beta=None):
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> h_measure_score(y_true, y_scores)
-    0.3413064705639679
+    0.5
 
     """
     

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -730,6 +730,14 @@ def h_measure_score(y_true, y_score, pos_label=None, alpha=None, beta=None):
 
     """
     
+    if len(np.unique(y_true)) != 2:
+        raise ValueError("Only one class present in y_true. ROC AUC score "
+                         "is not defined in that case.")
+    
+    check_consistent_length(y_true, y_score)
+    y_true = column_or_1d(y_true)
+    y_score = column_or_1d(y_score)
+    
     # ensure binary classification if pos_label is not specified
     classes = np.unique(y_true)
     if (pos_label is None and
@@ -746,6 +754,14 @@ def h_measure_score(y_true, y_score, pos_label=None, alpha=None, beta=None):
     y_true = (y_true == pos_label)
     
     fpr, tpr, thres = roc_curve(y_true, y_score, 1)
+    
+    if fpr[0] != 0 or tpr[0] != 0:
+        fpr = np.concatenate([[0], fpr])
+        tpr = np.concatenate([[0], tpr])
+    
+    if fpr[-1] != 1 or tpr[-1] != 1:
+        fpr = np.concatenate([fpr, [1]])
+        tpr = np.concatenate([tpr, [1]])
 
     # We estimate the priors of the two classes
     pi_1 = np.true_divide(np.sum(y_true), len(y_true))

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -29,6 +29,7 @@ from sklearn.metrics import label_ranking_average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
+from sklearn.metrics import h_measure_score
 
 from sklearn.metrics.base import UndefinedMetricWarning
 
@@ -897,3 +898,39 @@ def test_coverage_tie_handling():
     assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.5]]), 3)
     assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 3)
     assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)
+
+
+
+def test_h_measure():
+    y_true = [0, 1]
+    y_score = [0, 1]
+    h_measure = h_measure_score(y_true, y_score)
+    assert_almost_equal(h_measure, 1.)
+
+    y_true = [0, 1]
+    y_score = [1, 0]
+    h_measure = h_measure_score(y_true, y_score)
+    assert_almost_equal(h_measure, 0.)
+
+    y_true = [1, 0]
+    y_score = [1, 1]
+    h_measure = h_measure_score(y_true, y_score)
+    assert_almost_equal(h_measure, 0.)
+
+    y_true = [1, 0]
+    y_score = [1, 0]
+    h_measure = h_measure_score(y_true, y_score)
+    assert_almost_equal(h_measure, 1.)
+
+    y_true = [1, 0]
+    y_score = [0.5, 0.5]
+    h_measure = h_measure_score(y_true, y_score)
+    assert_almost_equal(h_measure, 0.)
+
+    y_true = [0, 0]
+    y_score = [0.25, 0.75]
+    assert_raises(ValueError, h_measure_score, y_true, y_score)
+
+    y_true = [1, 1]
+    y_score = [0.25, 0.75]
+    assert_raises(ValueError, h_measure_score, y_true, y_score)


### PR DESCRIPTION
Hi,

I added an implementation of the H-Measure, an alternative performance metric to the AUC for binary classifiers.

The AUC uses different misclassification costs (false positive - false negative) for different classifiers, which means it effectively compares different things when used on two different classifiers even on the same problem/dataset (see the following paper for proof: http://engr.case.edu/ray_soumya/mlrg/measuring_performance_hand.mlj09.pdf). The H-Measure solves this issue by explicitly specifying the relative costs of false positives and false negatives as a probability distribution.

This new method uses a beta distribution with parameters alpha and beta for the relative misclassification costs, and its implementation follows the paper mentioned above. If the parameters alpha and beta are not provided then the default distribution will be the one explained in the following paper:
http://arxiv.org/pdf/1202.2564v2.pdf

This new method was added to the metrics module in ranking.py. More information on the H-Measure can be found at the following website: http://www.hmeasure.net/

Kind regards,

 Borja
