### PR TITLE
make utils.check_symmetric future-proof

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -214,6 +214,7 @@ def test_check_symmetric():
     arr_asym = np.array([[0, 2], [0, 2]])
 
     test_arrays = {'dense': arr_asym,
+                   'dok': sp.dok_matrix(arr_asym),
                    'csr': sp.csr_matrix(arr_asym),
                    'csc': sp.csc_matrix(arr_asym),
                    'coo': sp.coo_matrix(arr_asym),

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -438,8 +438,11 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
                          "shape = {0}".format(array.shape))
 
     if sp.issparse(array):
-        diff = (array - array.T).data
-        symmetric = np.all(abs(diff) < tol)
+        diff = array - array.T
+        # only csr, csc, and coo have `data` attribute
+        if diff.format not in ['csr', 'csc', 'coo']:
+            diff = diff.tocsr()
+        symmetric = np.all(abs(diff.data) < tol)
     else:
         symmetric = np.allclose(array, array.T, atol=tol)
 


### PR DESCRIPTION
Two things:
- convert to CSR, CSC, COO if necessary
- add `dok` input to tests, which was left out previously
