### PR TITLE
Corrected two bugs related to 'tied' covariance_type in mixture.GMM(), a...

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -573,13 +573,8 @@ def _log_multivariate_normal_density_spherical(X, means, covars):
 
 def _log_multivariate_normal_density_tied(X, means, covars):
     """Compute Gaussian log-density at X for a tied model"""
-    n_samples, n_dim = X.shape
-    icv = pinvh(covars)
-    lpr = -0.5 * (n_dim * np.log(2 * np.pi) + np.log(linalg.det(covars) + 0.1)
-                  + np.sum(X * np.dot(X, icv), 1)[:, np.newaxis]
-                  - 2 * np.dot(np.dot(X, icv), means.T)
-                  + np.sum(means * np.dot(means, icv), 1))
-    return lpr
+    cv = np.tile(covars,(means.shape[0],1,1))
+    return _log_multivariate_normal_density_full(X, means, cv)
 
 
 def _log_multivariate_normal_density_full(X, means, covars, min_covar=1.e-7):
@@ -697,11 +692,11 @@ def _covar_mstep_full(gmm, X, responsibilities, weighted_X_sum, norm,
 def _covar_mstep_tied(gmm, X, responsibilities, weighted_X_sum, norm,
                       min_covar):
     # Eq. 15 from K. Murphy, "Fitting a Conditional Linear Gaussian
+    # Distribution"
     n_features = X.shape[1]
     avg_X2 = np.dot(X.T, X)
     avg_means2 = np.dot(gmm.means_.T, weighted_X_sum)
-    return (avg_X2 - avg_means2 + min_covar * np.eye(n_features)) / X.shape[0]
-
+    return (avg_X2 - avg_means2) / X.shape[0] + min_covar * np.eye(n_features) 
 
 _covar_mstep_funcs = {'spherical': _covar_mstep_spherical,
                       'diag': _covar_mstep_diag,

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -316,6 +316,24 @@ def test_n_parameters():
         assert_true(g._n_parameters() == n_params[cv_type])
 
 
+def test_1d_1component():
+    """
+    Test all of the covariance_types return the same BIC score for
+    1-dimensional, 1 compoenet fits.
+    """
+    n_samples, n_dim, n_components = 100, 1, 1
+    X = rng.randn(n_samples, n_dim)
+    g_full = mixture.GMM(n_components=n_components, covariance_type='full',
+                         random_state=rng, min_covar=1e-7, n_iter=1)
+    g_full.fit(X)
+    g_full_bic = g_full.bic(X)
+    for cv_type in ['tied', 'diag', 'spherical']:
+        g = mixture.GMM(n_components=n_components, covariance_type=cv_type,
+                        random_state=rng, min_covar=1e-7, n_iter=1)
+        g.fit(X)
+        assert_array_almost_equal(g.bic(X), g_full_bic)
+
+
 def test_aic():
     """ Test the aic and bic criteria"""
     n_samples, n_dim, n_components = 50, 3, 2


### PR DESCRIPTION
...dded test, closes #4036

The first bug was with the Gaussian log-density calculation for the 'tied' covariance_type.
Rather than fix this equation I reformatted the covars data structure so that it could be fed
into the 'full' covariance_type log-density calculation. It might be a tiny bit slower but I think
it is better to have the least amount of potentially redundant code as this should minimize
the potential for such errors.

The second bug I fixed was related to the _covar_mstep_tied() function, only the first part
of the equation should be divided by X.shape[0].
