### PR TITLE
[MRG + 2] Refactor kneighbors_graph and radius_neighbors_graph (et.al)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -280,6 +280,11 @@ Bug fixes
       when using unsorted ``labels`` in the multi-label setting.
       By `Andreas Müller`_.
 
+    - Avoid skipping the first nearest neighbor in the methods ``radius_neighbors``,
+      ``kneighbors``, ``kneighbors_graph`` and ``radius_neighbors_graph`` in
+      :class:`sklearn.neighbors.NearestNeighbors` and family, when the query
+      data is not the same as fit data. By `Manoj Kumar`_.
+
 API changes summary
 -------------------
 
@@ -341,6 +346,17 @@ API changes summary
     - Input data validation was refactored for more consistent input
       validation. The ``check_arrays`` function was replaced by ``check_array``
       and ``check_X_y``. By `Andreas Müller`_.
+
+    - Allow ``X=None`` in the methods ``radius_neighbors``, ``kneighbors``,
+      ``kneighbors_graph`` and ``radius_neighbors_graph`` in
+      :class:`sklearn.neighbors.NearestNeighbors` and family. If set to None,
+      then for every sample this avoids setting the sample itself as the
+      first nearest neighbor. By `Manoj Kumar`_.
+
+    - Add parameter ``include_self`` in :func:`neighbors.kneighbors_graph`
+      and :func:`neighbors.radius_neighbors_graph` which has to be explicitly
+      set by the user. If set to True, then the sample itself is considered
+      as the first nearest neighbor.
 
 .. _changes_0_15_2:
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -313,8 +313,8 @@ class KNeighborsMixin(object):
         else:
             query_is_train = True
             X = self._fit_X
-            # Include an extra neighbor in order to avoid marking the sample
-            # itself as the first neighbor.
+            # Include an extra neighbor to account for the sample itself being
+            # returned, which is removed later
             n_neighbors += 1
 
         train_size = self._fit_X.shape[0]
@@ -469,7 +469,7 @@ class KNeighborsMixin(object):
 class RadiusNeighborsMixin(object):
     """Mixin for radius-based neighbors searches"""
 
-    def radius_neighbors(self, X, radius=None, return_distance=True):
+    def radius_neighbors(self, X=None, radius=None, return_distance=True):
         """Finds the neighbors within a given radius of a point or points.
 
         Returns indices of and distances to the neighbors of each point.
@@ -477,7 +477,10 @@ class RadiusNeighborsMixin(object):
         Parameters
         ----------
         X : array-like, last dimension same as that of fit data
-            The new point or points
+            The new point or points.
+            If not provided, X is assumed to be the same as the fit
+            data. In this case, for each data point in X, the first nearest
+            neighbor is NOT the data point itself.
 
         radius : float
             Limiting distance of neighbors to return.
@@ -501,13 +504,17 @@ class RadiusNeighborsMixin(object):
         class from an array representing our data set and ask who's
         the closest point to [1,1,1]
 
+        >>> import numpy as np
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
         >>> from sklearn.neighbors import NearestNeighbors
         >>> neigh = NearestNeighbors(radius=1.6)
         >>> neigh.fit(samples) # doctest: +ELLIPSIS
         NearestNeighbors(algorithm='auto', leaf_size=30, ...)
-        >>> print(neigh.radius_neighbors([1., 1., 1.])) # doctest: +ELLIPSIS
-        (array([[ 1.5,  0.5]]...), array([[1, 2]]...)
+        >>> rng = neigh.radius_neighbors([1., 1., 1.])
+        >>> print(np.asarray(rng[0][0])) # doctest: +ELLIPSIS
+        [ 1.5  0.5]
+        >>> print(np.asarray(rng[1][0])) # doctest: +ELLIPSIS
+        [1 2]
 
         The first array returned contains the distances to all points which
         are closer than 1.6, while the second array returned contains their
@@ -524,11 +531,17 @@ class RadiusNeighborsMixin(object):
         if self._fit_method is None:
             raise NotFittedError("Must fit neighbors before querying.")
 
-        X = check_array(X, accept_sparse='csr')
+        if X is not None:
+            query_is_train = False
+            X = check_array(X, accept_sparse='csr')
+        else:
+            query_is_train = True
+            X = self._fit_X
 
         if radius is None:
             radius = self.radius
 
+        n_samples = X.shape[0]
         if self._fit_method == 'brute':
             # for efficiency, use squared euclidean distances
             if self.effective_metric_ == 'euclidean':
@@ -539,30 +552,28 @@ class RadiusNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X,
                                           self.effective_metric_,
                                           **self.effective_metric_params_)
-            neigh_ind = [np.where(d < radius)[0] for d in dist]
 
-            # if there are the same number of neighbors for each point,
-            # we can do a normal array.  Otherwise, we return an object
-            # array with elements that are numpy arrays
-            try:
-                neigh_ind = np.asarray(neigh_ind, dtype=int)
-                dtype_F = float
-            except ValueError:
-                neigh_ind = np.asarray(neigh_ind, dtype='object')
-                dtype_F = object
+            neigh_ind_list = [np.where(d < radius)[0] for d in dist]
+
+            # See https://github.com/numpy/numpy/issues/5456
+            # if you want to understand why this is initialized this way.
+            neigh_ind = np.empty(n_samples, dtype='object')
+            neigh_ind[:] = neigh_ind_list
+            dist_array = np.empty(n_samples, dtype='object')
 
             if return_distance:
                 if self.effective_metric_ == 'euclidean':
-                    dist = np.array([np.sqrt(d[neigh_ind[i]])
-                                     for i, d in enumerate(dist)],
-                                    dtype=dtype_F)
+                    dist_list = [np.sqrt(d[neigh_ind[i]])
+                        for i, d in enumerate(dist)]
                 else:
-                    dist = np.array([d[neigh_ind[i]]
-                                     for i, d in enumerate(dist)],
-                                    dtype=dtype_F)
-                return dist, neigh_ind
+                    dist_list = [d[neigh_ind[i]]
+                        for i, d in enumerate(dist)]
+                dist_array[:] = dist_list
+
+                results = dist_array, neigh_ind
             else:
-                return neigh_ind
+                results = neigh_ind
+
         elif self._fit_method in ['ball_tree', 'kd_tree']:
             if issparse(X):
                 raise ValueError(
@@ -571,12 +582,32 @@ class RadiusNeighborsMixin(object):
             results = self._tree.query_radius(X, radius,
                                               return_distance=return_distance)
             if return_distance:
-                ind, dist = results
-                return dist, ind
-            else:
-                return results
+                results = results[::-1]
         else:
             raise ValueError("internal: _fit_method not recognized")
+
+        if not query_is_train:
+            return results
+        else:
+            if return_distance:
+                dist, neigh_ind = results
+            else:
+                neigh_ind = results
+
+            for ind, ind_neighbor in enumerate(neigh_ind):
+                mask = ind_neighbor != ind
+                # Corner case if the number of duplicates is more than the number
+                # of neighbors, then mask the first neighbor.
+                if np.all(mask):
+                    mask[0] = False
+
+                neigh_ind[ind] = ind_neighbor[mask]
+                if return_distance:
+                    dist[ind] = dist[ind][mask]
+
+            if return_distance:
+                return dist, neigh_ind
+            return neigh_ind
 
     def radius_neighbors_graph(self, X, radius=None, mode='connectivity'):
         """Computes the (weighted) graph of Neighbors for points in X
@@ -620,13 +651,16 @@ class RadiusNeighborsMixin(object):
         --------
         kneighbors_graph
         """
-        X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
+        # radius_neighbors does the None handling.
+        if X is not None:
+            X = check_array(X, accept_sparse='csr')
+            n_samples1 = X.shape[0]
+        else:
+            n_samples1 = self._fit_X.shape[0]
 
+        n_samples2 = self._fit_X.shape[0]
         if radius is None:
             radius = self.radius
-
-        n_samples1 = X.shape[0]
-        n_samples2 = self._fit_X.shape[0]
 
         # construct CSR matrix representation of the NN graph
         if mode == 'connectivity':

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -255,11 +255,10 @@ class KNeighborsMixin(object):
 
         Parameters
         ----------
-        X : array-like, last dimension same as that of fit data or None.
-            The new point.
-            If not provided, X is assumed to be the same as the fit
-            data. In this case, for each data point in X, the first nearest
-            neighbor is NOT the data point itself.
+        X : array-like, last dimension same as that of fit data, optional
+            The query point or points.
+            If not provided, neighbors of each indexed point are returned.
+            In this case, the query point is not considered its own neighbor.
 
         n_neighbors : int
             Number of neighbors to get (default is the value
@@ -390,17 +389,16 @@ class KNeighborsMixin(object):
                 return dist, neigh_ind
             return neigh_ind
 
-
     def kneighbors_graph(self, X=None, n_neighbors=None,
                          mode='connectivity'):
         """Computes the (weighted) graph of k-Neighbors for points in X
 
         Parameters
         ----------
-        X : array-like, last dimension same as that of fit data or None.
-            If not provided, X is assumed to be the same as the fit
-            data. In this case, for each data point in X, the first nearest
-            neighbor is NOT the data point itself.
+        X : array-like, last dimension same as that of fit data, optional
+            The query point or points.
+            If not provided, neighbors of each indexed point are returned.
+            In this case, the query point is not considered its own neighbor.
 
         n_neighbors : int
             Number of neighbors for each sample.
@@ -454,7 +452,8 @@ class KNeighborsMixin(object):
             A_ind = self.kneighbors(X, n_neighbors, return_distance=False)
 
         elif mode == 'distance':
-            A_data, A_ind = self.kneighbors(X, n_neighbors, return_distance=True)
+            A_data, A_ind = self.kneighbors(
+                X, n_neighbors, return_distance=True)
             A_data = np.ravel(A_data)
 
         else:
@@ -462,9 +461,8 @@ class KNeighborsMixin(object):
                 'Unsupported mode, must be one of "connectivity" '
                 'or "distance" but got "%s" instead' % mode)
 
-        kneighbors_graph = csr_matrix((
-            A_data, A_ind.ravel(), A_indptr),
-            shape=(n_samples1, n_samples2))
+        kneighbors_graph = csr_matrix((A_data, A_ind.ravel(), A_indptr),
+                                      shape=(n_samples1, n_samples2))
 
         return kneighbors_graph
 
@@ -479,11 +477,10 @@ class RadiusNeighborsMixin(object):
 
         Parameters
         ----------
-        X : array-like, last dimension same as that of fit data
-            The new point or points.
-            If not provided, X is assumed to be the same as the fit
-            data. In this case, for each data point in X, the first nearest
-            neighbor is NOT the data point itself.
+        X : array-like, (n_samples, n_features), optional
+            The query point or points.
+            If not provided, neighbors of each indexed point are returned.
+            In this case, the query point is not considered its own neighbor.
 
         radius : float
             Limiting distance of neighbors to return.
@@ -567,10 +564,10 @@ class RadiusNeighborsMixin(object):
             if return_distance:
                 if self.effective_metric_ == 'euclidean':
                     dist_list = [np.sqrt(d[neigh_ind[i]])
-                        for i, d in enumerate(dist)]
+                                 for i, d in enumerate(dist)]
                 else:
                     dist_list = [d[neigh_ind[i]]
-                        for i, d in enumerate(dist)]
+                                 for i, d in enumerate(dist)]
                 dist_array[:] = dist_list
 
                 results = dist_array, neigh_ind
@@ -611,7 +608,7 @@ class RadiusNeighborsMixin(object):
                 return dist, neigh_ind
             return neigh_ind
 
-    def radius_neighbors_graph(self, X, radius=None, mode='connectivity'):
+    def radius_neighbors_graph(self, X=None, radius=None, mode='connectivity'):
         """Computes the (weighted) graph of Neighbors for points in X
 
         Neighborhoods are restricted the points at a distance lower than
@@ -619,8 +616,10 @@ class RadiusNeighborsMixin(object):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Sample data
+        X : array-like, shape = [n_samples, n_features], optional
+            The query point or points.
+            If not provided, neighbors of each indexed point are returned.
+            In this case, the query point is not considered its own neighbor.
 
         radius : float
             Radius of neighborhoods.

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -320,7 +320,8 @@ class KNeighborsMixin(object):
         train_size = self._fit_X.shape[0]
         if n_neighbors > train_size:
             raise ValueError(
-                "Expected n_neighbors <= %d. Got %d" % (train_size, n_neighbors)
+                "Expected n_neighbors <= %d. Got %d" %
+                (train_size, n_neighbors)
             )
         n_samples, _ = X.shape
         sample_range = np.arange(n_samples)[:, None]
@@ -363,18 +364,19 @@ class KNeighborsMixin(object):
             return result
 
         else:
+            # If the query data is the same as the indexed data, we would like
+            # to ignore the first nearest neighbor of every sample, i.e
+            # the sample itself.
             if return_distance:
                 dist, neigh_ind = result
             else:
                 neigh_ind = result
 
-            # If the query data is the same as the indexed data, we would like
-            # to ignore the first nearest neighbor of every sample, i.e
-            # the sample itself.
             sample_mask = neigh_ind != sample_range
 
-            # Corner case: When the number of duplicates are more than the number
-            # of neighbors, the first NN will not be the sample, but a duplicate.
+            # Corner case: When the number of duplicates are more
+            # than the number of neighbors, the first NN will not
+            # be the sample, but a duplicate.
             # In that case mask the first duplicate.
             dup_gr_nbrs = np.all(sample_mask, axis=1)
             sample_mask[:, 0][dup_gr_nbrs] = False
@@ -383,7 +385,8 @@ class KNeighborsMixin(object):
                 neigh_ind[sample_mask], (n_samples, n_neighbors - 1))
 
             if return_distance:
-                dist = np.reshape(dist[sample_mask], (n_samples, n_neighbors - 1))
+                dist = np.reshape(
+                    dist[sample_mask], (n_samples, n_neighbors - 1))
                 return dist, neigh_ind
             return neigh_ind
 
@@ -589,6 +592,9 @@ class RadiusNeighborsMixin(object):
         if not query_is_train:
             return results
         else:
+            # If the query data is the same as the indexed data, we would like
+            # to ignore the first nearest neighbor of every sample, i.e
+            # the sample itself.
             if return_distance:
                 dist, neigh_ind = results
             else:
@@ -596,10 +602,6 @@ class RadiusNeighborsMixin(object):
 
             for ind, ind_neighbor in enumerate(neigh_ind):
                 mask = ind_neighbor != ind
-                # Corner case if the number of duplicates is more than the number
-                # of neighbors, then mask the first neighbor.
-                if np.all(mask):
-                    mask[0] = False
 
                 neigh_ind[ind] = ind_neighbor[mask]
                 if return_distance:
@@ -651,12 +653,8 @@ class RadiusNeighborsMixin(object):
         --------
         kneighbors_graph
         """
-        # radius_neighbors does the None handling.
         if X is not None:
-            X = check_array(X, accept_sparse='csr')
-            n_samples1 = X.shape[0]
-        else:
-            n_samples1 = self._fit_X.shape[0]
+            X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
 
         n_samples2 = self._fit_X.shape[0]
         if radius is None:
@@ -676,6 +674,7 @@ class RadiusNeighborsMixin(object):
                 'Unsupported mode, must be one of "connectivity", '
                 'or "distance" but got %s instead' % mode)
 
+        n_samples1 = A_ind.shape[0]
         n_neighbors = np.array([len(a) for a in A_ind])
         A_ind = np.concatenate(list(A_ind))
         if A_data is None:

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -4,6 +4,8 @@
 #
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
 
+import warnings
+
 from .base import KNeighborsMixin, RadiusNeighborsMixin
 from .unsupervised import NearestNeighbors
 
@@ -77,7 +79,13 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
             ).fit(X)
     else:
         _check_params(X, metric, p, metric_params)
-    return X.kneighbors_graph(X._fit_X, n_neighbors, mode=mode)
+    if mode == "connectivity":
+        warnings.warn("The behavior of marking each sample itself as the "
+                      "first nearest neighbor will be changed in 0.18",
+                      FutureWarning)
+        return X.kneighbors_graph(
+            X._fit_X, n_neighbors=n_neighbors, mode=mode)
+    return X.kneighbors_graph(X=None, n_neighbors=n_neighbors, mode=mode)
 
 
 def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -81,7 +81,8 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
         _check_params(X, metric, p, metric_params)
     if mode == "connectivity":
         warnings.warn("The behavior of marking each sample itself as the "
-                      "first nearest neighbor will be changed in 0.18",
+                      "first nearest neighbor has been deprecated since 0.16 "
+                      "and will be removed in 0.18",
                       FutureWarning)
         return X.kneighbors_graph(
             X._fit_X, n_neighbors=n_neighbors, mode=mode)
@@ -149,4 +150,11 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
             ).fit(X)
     else:
         _check_params(X, metric, p, metric_params)
-    return X.radius_neighbors_graph(X._fit_X, radius, mode)
+
+    if mode == "connectivity":
+        warnings.warn("The behavior of marking each sample itself as the "
+                      "first nearest neighbor has been deprecated since 0.16 "
+                      "and will be removed in 0.18",
+                      FutureWarning)
+        return X.radius_neighbors_graph(X._fit_X, radius, mode)
+    return X.radius_neighbors_graph(None, radius, mode)

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -26,11 +26,12 @@ def _query_include_self(X, include_self, mode):
     """Return the query based on include_self param"""
     # Done to preserve backward compatibility.
     if include_self is None:
-        warnings.warn(
-            "include_self will be set to False, i.e the first NN of each "
-            "sample will not be the sample itself unless explicitly set "
-            "from version 0.18", DeprecationWarning)
         if mode == "connectivity":
+            warnings.warn(
+                "include_self will be set to False, i.e the first NN of each "
+                "sample will not be the sample itself unless explicitly set "
+                "from version 0.18. Set include_self=True is this is "
+                "not sought.", DeprecationWarning)
             query = X._fit_X
         else:
             query = None
@@ -65,10 +66,11 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
         The default distance is 'euclidean' ('minkowski' metric with the p
         param equal to 2.)
 
-    include_self: bool, default None
+    include_self: bool, default backward-compatible.
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. The default behavior will be changed to False from
-        version 0.18.
+        itself. This is set to True for mode='connectivity' and False
+        for mode='distance' to preserve backward compatibilty. This will be
+        set to False from version 0.18.
 
     p : int, default 2
         Power parameter for the Minkowski metric. When p = 1, this is
@@ -137,8 +139,9 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
 
     include_self: bool, default None
         Whether or not to mark each sample as the first nearest neighbor to
-        itself. The default behavior will be changed to False from
-        version 0.18.
+        itself. This is set to True for mode='connectivity' and False
+        for mode='distance' to preserve backward compatibilty. This will be
+        set to False from version 0.18.
 
     p : int, default 2
         Power parameter for the Minkowski metric. When p = 1, this is

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -913,18 +913,27 @@ def test_kneighbors_graph_nearest_neighbors():
         nn.fit(X)
 
         # Do not do anything special to duplicates.
+        test_data = [[0], [1]]
         assert_array_equal(
-            nn.kneighbors_graph([[0], [1]]).A,
-            np.array([[1., 0.], [0., 1.]]))
+            nn.kneighbors_graph(test_data).A, [[1., 0.], [0., 1.]])
+        dist, ind = nn.kneighbors([[0], [1]])
+        assert_array_equal(dist, [[0], [0]])
+        assert_array_equal(ind, [[0], [1]])
 
+        test_data = [[2], [1]]
         assert_array_equal(
-            nn.kneighbors_graph([[2], [1]]).A,
-            np.array([[0., 1.], [0., 1.]]))
+            nn.kneighbors_graph(test_data).A, [[0., 1.], [0., 1.]])
+        dist, ind = nn.kneighbors(test_data)
+        assert_array_equal(dist, [[1], [0]])
+        assert_array_equal(ind, [[1], [1]])
 
         # Avoid marking sample to itself when X is None
         assert_array_equal(
             nn.kneighbors_graph().A,
             np.array([[0., 1.], [1., 0.]]))
+        dist, ind = nn.kneighbors()
+        assert_array_equal(dist, [[1], [1]])
+        assert_array_equal(ind, [[1], [0]])
 
         # Do not do anything special to duplicates.
         kng = nn.kneighbors_graph([[0], [1]], mode='distance')
@@ -956,6 +965,9 @@ def test_kneighbors_graph_nearest_neighbors():
         X = np.ones((3, 1))
         nn = neighbors.NearestNeighbors(n_neighbors=1)
         nn.fit(X)
+        dist, ind = nn.kneighbors()
+        assert_array_equal(dist, np.zeros((3, 1)))
+        assert_array_equal(ind, [[1], [0], [1]])
 
         kng = nn.kneighbors_graph(mode='distance')
         assert_array_equal(

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -895,12 +895,57 @@ def test_non_euclidean_kneighbors():
     # Raise error when wrong parameters are supplied,
     X_nbrs = neighbors.NearestNeighbors(3, metric='manhattan')
     X_nbrs.fit(X)
-    assert_raises(ValueError, neighbors.kneighbors_graph, X_nbrs, 3,
+    assert_raises(ValueError, neighbors.kneighbors_graph, None, 3,
                   metric='euclidean')
     X_nbrs = neighbors.NearestNeighbors(radius=radius, metric='manhattan')
     X_nbrs.fit(X)
-    assert_raises(ValueError, neighbors.radius_neighbors_graph, X_nbrs,
+    assert_raises(ValueError, neighbors.radius_neighbors_graph, None,
                   radius, metric='euclidean')
+
+
+def test_kneighbors_graph_nearest_neighbors():
+    """Test kneighbors_graph method in NearestNeighbors"""
+    for algorithm in ["kd_tree", "ball_tree", "brute"]:
+
+        nn = neighbors.NearestNeighbors(n_neighbors=1, algorithm=algorithm)
+
+        X = [[0], [1]]
+        nn.fit(X)
+
+        # Do not do anything special to duplicates.
+        assert_array_equal(
+            nn.kneighbors_graph([[0], [1]]).A,
+            np.array([[1., 0.], [0., 1.]]))
+
+        assert_array_equal(
+            nn.kneighbors_graph([[2], [1]]).A,
+            np.array([[0., 1.], [0., 1.]]))
+
+        # Avoid marking sample to itself when X is None
+        assert_array_equal(
+            nn.kneighbors_graph().A,
+            np.array([[0., 1.], [1., 0.]]))
+
+        # Do not do anything special to duplicates.
+        assert_array_equal(
+            nn.kneighbors_graph([[0], [1]], mode='distance').A,
+            np.array([[0., 0.], [0., 0.]]))
+
+        assert_array_equal(
+            nn.kneighbors_graph([[2], [1]], mode='distance').A,
+            np.array([[0., 1.], [0., 0.]]))
+
+        # Avoid marking sample to itself when X is None
+        assert_array_equal(
+            nn.kneighbors_graph(mode='distance').A,
+            np.array([[0., 1.], [1., 0.]]))
+
+        X = [[0, 1], [0, 1], [1, 1]]
+        nn = neighbors.NearestNeighbors(n_neighbors=2, algorithm=algorithm)
+        nn.fit(X)
+        assert_array_equal(
+            nn.kneighbors_graph().A,
+            np.array([[0., 1., 1.], [1., 0., 1.], [1., 1., 0]]))
 
 
 if __name__ == '__main__':

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -927,18 +927,23 @@ def test_kneighbors_graph_nearest_neighbors():
             np.array([[0., 1.], [1., 0.]]))
 
         # Do not do anything special to duplicates.
+        kng = nn.kneighbors_graph([[0], [1]], mode='distance')
         assert_array_equal(
-            nn.kneighbors_graph([[0], [1]], mode='distance').A,
+            kng.A,
             np.array([[0., 0.], [0., 0.]]))
+        assert_array_equal(kng.data, [0., 0.])
+        assert_array_equal(kng.indices, [0, 1])
 
         assert_array_equal(
             nn.kneighbors_graph([[2], [1]], mode='distance').A,
             np.array([[0., 1.], [0., 0.]]))
 
         # Avoid marking sample to itself when X is None
+        kng = nn.kneighbors_graph(mode='distance')
         assert_array_equal(
-            nn.kneighbors_graph(mode='distance').A,
-            np.array([[0., 1.], [1., 0.]]))
+            kng.A, np.array([[0., 1.], [1., 0.]]))
+        assert_array_equal(kng.data, [1., 1.])
+        assert_array_equal(kng.indices, [1, 0])
 
         X = [[0, 1], [0, 1], [1, 1]]
         nn = neighbors.NearestNeighbors(n_neighbors=2, algorithm=algorithm)
@@ -946,6 +951,20 @@ def test_kneighbors_graph_nearest_neighbors():
         assert_array_equal(
             nn.kneighbors_graph().A,
             np.array([[0., 1., 1.], [1., 0., 1.], [1., 1., 0]]))
+
+        # Mask the first duplicates when n_duplicates > n_neighbors.
+        X = np.ones((3, 1))
+        nn = neighbors.NearestNeighbors(n_neighbors=1)
+        nn.fit(X)
+
+        kng = nn.kneighbors_graph(mode='distance')
+        assert_array_equal(
+            kng.A, np.zeros((3, 3)))
+        assert_array_equal(kng.data, np.zeros(3))
+        assert_array_equal(kng.indices, [1., 0., 1.])
+        assert_array_equal(
+            nn.kneighbors_graph().A,
+            np.array([[0., 1., 0.], [1., 0., 0.], [0., 1., 0.]]))
 
 
 if __name__ == '__main__':

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -74,6 +74,7 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
 
     Examples
     --------
+      >>> import numpy as np
       >>> from sklearn.neighbors import NearestNeighbors
       >>> samples = [[0, 0, 2], [1, 0, 0], [0, 0, 1]]
 
@@ -85,8 +86,9 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
       ... #doctest: +ELLIPSIS
       array([[2, 0]]...)
 
-      >>> neigh.radius_neighbors([0, 0, 1.3], 0.4, return_distance=False)
-      array([[2]])
+      >>> rng = neigh.radius_neighbors([0, 0, 1.3], 0.4, return_distance=False)
+      >>> np.asarray(rng[0][0])
+      array(2)
 
     See also
     --------


### PR DESCRIPTION
Following the discussion in https://github.com/scikit-learn/scikit-learn/pull/4019 this PR
1. Allows X to be None in `neighbors.kneighbors` which skips the first neighbor in both distance and connectivity mode.
2. Do not do anything special in other cases.

```
In [2]: knn = NearestNeighbors(n_neighbors=1).fit([[0], [1]])
In [3]: knn.kneighbors_graph([[0], [1]]).toarray()
Out[3]: 
array([[ 1.,  0.],
       [ 0.,  1.]])
In [5]: knn.kneighbors_graph([[2], [1]]).toarray()
Out[5]: 
array([[ 0.,  1.],
       [ 0.,  1.]])
In [8]: knn.kneighbors_graph().toarray()
Out[8]: 
array([[ 0.,  1.],
       [ 1.,  0.]])
In [6]: knn.kneighbors_graph([[2], [1]], mode='distance').toarray()
Out[6]: 
array([[ 0.,  1.],
       [ 0.,  0.]])
In [7]: knn.kneighbors_graph([[0], [1]], mode='distance').toarray()
Out[7]: 
array([[ 0.,  0.],
       [ 0.,  0.]])
In [9]: knn.kneighbors_graph(mode='distance').toarray()
Out[9]: 
array([[ 0.,  1.],
       [ 1.,  0.]])
```

Also, a happy 2015 to everyone!
