### PR TITLE
[MRG + 2] make check_array convert object to float.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -377,6 +377,10 @@ API changes summary
     - `thresh` parameter is deprecated in favor of new `tol` parameter in
       :class:`GMM`. See `Enhancements` section for details. By `Hervé Bredin`_.
 
+    - Estimators will treat input with dtype object as numeric when possible.
+      By `Andreas Müller`_
+
+
 
 .. _changes_0_15_2:
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1146,7 +1146,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
     def _validate_y(self, y):
         self.n_classes_ = 1
-        if y.dtype is np.dtype(object):
+        if y.dtype.kind == 'O':
             y = y.astype(np.float64)
         # Default implementation
         return y

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -126,7 +126,7 @@ class PriorProbabilityEstimator(BaseEstimator):
     """
     def fit(self, X, y, sample_weight=None):
         if sample_weight is None:
-            sample_weight = np.ones_like(y, dtype=np.float)
+            sample_weight = np.ones_like(y, dtype=np.float64)
         class_counts = bincount(y, weights=sample_weight)
         self.priors = class_counts / class_counts.sum()
 
@@ -1146,7 +1146,8 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
     def _validate_y(self, y):
         self.n_classes_ = 1
-
+        if y.dtype is np.dtype(object):
+            y = y.astype(np.float64)
         # Default implementation
         return y
 

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -11,8 +11,8 @@ from scipy import linalg, optimize
 
 from ..base import BaseEstimator, RegressorMixin
 from ..metrics.pairwise import manhattan_distances
-from ..utils import check_random_state, check_array, check_consistent_length
-from ..utils.validation import  check_is_fitted
+from ..utils import check_random_state, check_array, check_X_y
+from ..utils.validation import check_is_fitted
 from . import regression_models as regression
 from . import correlation_models as correlation
 
@@ -264,12 +264,10 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         self.random_state = check_random_state(self.random_state)
 
         # Force data to 2D numpy.array
-        X = check_array(X)
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
         self.y_ndim_ = y.ndim
         if y.ndim == 1:
             y = y[:, np.newaxis]
-        check_consistent_length(X, y)
 
         # Check shapes of DOE & observations
         n_samples, n_features = X.shape
@@ -883,7 +881,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
                              "or array of length n_samples.")
 
         # Check optimizer
-        if not self.optimizer in self._optimizer_types:
+        if self.optimizer not in self._optimizer_types:
             raise ValueError("optimizer should be one of %s"
                              % self._optimizer_types)
 

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -25,7 +25,7 @@ from scipy import sparse
 from ..externals import six
 from ..externals.joblib import Parallel, delayed
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
-from ..utils import as_float_array, check_array
+from ..utils import as_float_array, check_array, check_X_y
 from ..utils.extmath import safe_sparse_dot
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
@@ -372,8 +372,8 @@ class LinearRegression(LinearModel, RegressorMixin):
             n_jobs_ = n_jobs
         else:
             n_jobs_ = self.n_jobs
-        X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                         y_numeric=True, multi_output=True)
 
         X, y, X_mean, y_mean, X_std = self._center_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X)

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -132,7 +132,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, dtype=np.float)
+        X, y = check_X_y(X, y, dtype=np.float64, y_numeric=True)
         X, y, X_mean, y_mean, X_std = self._center_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X)
         n_samples, n_features = X.shape
@@ -342,7 +342,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, dtype=np.float)
+        X, y = check_X_y(X, y, dtype=np.float64, y_numeric=True)
 
         n_samples, n_features = X.shape
         coef_ = np.zeros(n_features)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -627,7 +627,7 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         X, y = check_X_y(X, y, accept_sparse='csc', dtype=np.float64,
                          order='F', copy=self.copy_X and self.fit_intercept,
-                         multi_output=True)
+                         multi_output=True, y_numeric=True)
 
         X, y, X_mean, y_mean, X_std, precompute, Xy = \
             _pre_fit(X, y, None, self.precompute, self.normalize,

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -21,7 +21,7 @@ from scipy.linalg.lapack import get_lapack_funcs
 
 from .base import LinearModel
 from ..base import RegressorMixin
-from ..utils import arrayfuncs, as_float_array, check_array, check_X_y
+from ..utils import arrayfuncs, as_float_array, check_X_y
 from ..cross_validation import _check_cv as check_cv
 from ..utils import ConvergenceWarning
 from ..externals.joblib import Parallel, delayed
@@ -422,7 +422,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
                 for ii in idx:
                     for i in range(ii, n_active):
                         indices[i], indices[i + 1] = indices[i + 1], indices[i]
-                        Gram[i], Gram[i + 1] = swap(Gram[i], Gram[i+1])
+                        Gram[i], Gram[i + 1] = swap(Gram[i], Gram[i + 1])
                         Gram[:, i], Gram[:, i + 1] = swap(Gram[:, i],
                                                           Gram[:, i + 1])
 
@@ -589,8 +589,7 @@ class Lars(LinearModel, RegressorMixin):
         self : object
             returns an instance of self.
         """
-        X = check_array(X)
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, y_numeric=True, multi_output=True)
         n_features = X.shape[1]
 
         X, y, X_mean, y_mean, X_std = self._center_data(X, y,
@@ -1268,8 +1267,7 @@ class LassoLarsIC(LassoLars):
             returns an instance of self.
         """
         self.fit_path = True
-        X = check_array(X)
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
 
         X, y, Xmean, ymean, Xstd = LinearModel._center_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -529,7 +529,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                              "dual=False, got dual=%s" % dual)
     # Preprocessing.
     X = check_array(X, accept_sparse='csr', dtype=np.float64)
-    y = check_array(y, ensure_2d=False, copy=copy)
+    y = check_array(y, ensure_2d=False, copy=copy, dtype=None)
     _, n_features = X.shape
     check_consistent_length(X, y)
     classes = np.unique(y)
@@ -1318,7 +1318,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                                  "the primal form.")
 
         X = check_array(X, accept_sparse='csr', dtype=np.float64)
-        y = check_array(y, ensure_2d=False)
+        y = check_array(y, ensure_2d=False, dtype=None)
 
         if self.multi_class not in ['ovr', 'multinomial']:
             raise ValueError("multi_class backend should be either "

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -609,8 +609,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         self : object
             returns an instance of self.
         """
-        X = check_array(X)
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
         n_features = X.shape[1]
 
         X, y, X_mean, y_mean, X_std, Gram, Xy = \
@@ -805,7 +804,7 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
         self : object
             returns an instance of self.
         """
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, y_numeric=True)
         X = as_float_array(X, copy=False, force_all_finite=False)
         cv = check_cv(self.cv, X, y, classifier=False)
         max_iter = (min(max(int(0.1 * X.shape[1]), 5), X.shape[1])

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -88,7 +88,7 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
         self : object
             Returns an instance of self.
         """
-        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'])
+        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], y_numeric=True)
         X = as_float_array(X, copy=False)
         n_samples, n_features = X.shape
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -378,7 +378,8 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
         self.solver = solver
 
     def fit(self, X, y, sample_weight=None):
-        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float, multi_output=True)
+        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float,
+                         multi_output=True, y_numeric=True)
 
         if ((sample_weight is not None) and
                 np.atleast_1d(sample_weight).ndim > 1):
@@ -743,7 +744,8 @@ class _RidgeGCV(LinearModel):
         -------
         self : Returns self.
         """
-        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float, multi_output=True)
+        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float,
+                         multi_output=True, y_numeric=True)
 
         n_samples, n_features = X.shape
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -464,7 +464,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
     if not isinstance(y, list):
         # XXX Workaround that will be removed when list of list format is
         # dropped
-        y = check_array(y, accept_sparse='csr', ensure_2d=False)
+        y = check_array(y, accept_sparse='csr', ensure_2d=False, dtype=None)
     if neg_label >= pos_label:
         raise ValueError("neg_label={0} must be strictly less than "
                          "pos_label={1}.".format(neg_label, pos_label))

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -29,6 +29,7 @@ from sklearn.cluster.bicluster import BiclusterMixin
 from sklearn.cross_validation import train_test_split
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
+    check_dtype_object,
     check_parameters_default_constructible,
     check_estimator_sparse_data,
     check_estimators_dtypes,
@@ -96,6 +97,7 @@ def test_non_meta_estimators():
         if name not in CROSS_DECOMPOSITION:
             yield check_estimators_dtypes, name, Estimator
             yield check_fit_score_takes_y, name, Estimator
+            yield check_dtype_object, name, Estimator
 
         if name not in CROSS_DECOMPOSITION + ['SpectralEmbedding']:
             # SpectralEmbedding is non-deterministic,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -151,6 +151,7 @@ def check_estimator_sparse_data(name, Estimator):
 
 
 def check_dtype_object(name, Estimator):
+    # check that estimators treat dtype object as numeric if possible
     rng = np.random.RandomState(0)
     X = rng.rand(40, 10).astype(object)
     y = (X[:, 0] * 4).astype(np.int)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -294,7 +294,7 @@ def check_array(array, accept_sparse=None, dtype="numeric", order=None, copy=Fal
         if ensure_2d:
             array = np.atleast_2d(array)
         if dtype == "numeric":
-            if getattr(array, "dtype", None) is np.dtype(object):
+            if hasattr(array, "dtype") and array.dtype.kind == "O":
                 # if input is object, convert to float.
                 dtype = np.float64
             else:
@@ -398,7 +398,7 @@ def check_X_y(X, y, accept_sparse=None, dtype="numeric", order=None, copy=False,
     else:
         y = column_or_1d(y, warn=True)
         _assert_all_finite(y)
-    if y_numeric and y.dtype is np.dtype(object):
+    if y_numeric and y.dtype.kind == 'O':
         y = y.astype(np.float64)
 
     check_consistent_length(X, y)


### PR DESCRIPTION
- [x] add tests
- [ ] ~~think about people passing strings as objects to SVM with callable kernel~~ Not too concerned about this any more. Maybe @larsmans can comment?
- [x] think about what to do with y

The problem with y is that for regressors we might want to convert y to float, whereas for classifiers we map any unique objects to ints anyhow, so object is fine. Fixes #4006, #3142 and #4055.
