### PR TITLE
Fix interpretation of parameter train_size (test_size) in cross_validation.Bootstrap

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -689,7 +689,7 @@ class Bootstrap(object):
             n_iter = n_bootstraps
         self.n_iter = n_iter
         if (isinstance(train_size, numbers.Real) and train_size >= 0.0
-                and train_size <= 1.0):
+                and train_size < 1.0):
             self.train_size = int(ceil(train_size * n))
         elif isinstance(train_size, numbers.Integral):
             self.train_size = train_size
@@ -700,7 +700,7 @@ class Bootstrap(object):
             raise ValueError("train_size=%d should not be larger than n=%d" %
                              (self.train_size, n))
 
-        if isinstance(test_size, numbers.Real) and 0.0 <= test_size <= 1.0:
+        if isinstance(test_size, numbers.Real) and 0.0 <= test_size < 1.0:
             self.test_size = int(ceil(test_size * n))
         elif isinstance(test_size, numbers.Integral):
             self.test_size = test_size


### PR DESCRIPTION
Bootstrap can now return train/test sets with only one 1 example.
Before, train_size=1 indicated entire set (100%). Now, train_size=1 results in train set with one example.
