### PR TITLE
[MRG+1] Test check_consistent_length and TypeError with ensemble arg

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -284,9 +284,9 @@ def test_check_consistent_length():
     check_consistent_length([1], (2,), np.array([3]), sp.csr_matrix((1, 2)))
     assert_raises_regexp(ValueError, 'inconsistent numbers of samples',
                          check_consistent_length, [1, 2], [1])
-    assert_raises_regexp(TypeError, 'got <type \'int\'>',
+    assert_raises_regexp(TypeError, 'got <\w+ \'int\'>',
                          check_consistent_length, [1, 2], 1)
-    assert_raises_regexp(TypeError, 'got <type \'object\'>',
+    assert_raises_regexp(TypeError, 'got <\w+ \'object\'>',
                          check_consistent_length, [1, 2], object())
     # XXX: Should this throw a TypeError?
     assert_raises(IndexError, check_consistent_length, [1, 2], np.array(1))

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1,23 +1,21 @@
 """Tests for input validation functions"""
 
 from tempfile import NamedTemporaryFile
+from itertools import product
+
 import numpy as np
 from numpy.testing import assert_array_equal, assert_warns
 import scipy.sparse as sp
 from nose.tools import assert_raises, assert_true, assert_false, assert_equal
-from itertools import product
 
+from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils import as_float_array, check_array, check_symmetric
-
 from sklearn.utils.estimator_checks import NotAnArray
-
 from sklearn.random_projection import sparse_random_matrix
-
 from sklearn.linear_model import ARDRegression
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.svm import SVR
-
 from sklearn.datasets import make_blobs
 from sklearn.utils import as_float_array, check_array
 from sklearn.utils.estimator_checks import NotAnArray
@@ -284,12 +282,15 @@ def test_check_consistent_length():
     check_consistent_length([1], [2], [3], [4], [5])
     check_consistent_length([[1, 2], [[1, 2]]], [1, 2], ['a', 'b'])
     check_consistent_length([1], (2,), np.array([3]), sp.csr_matrix((1, 2)))
-    assert_raises(ValueError, check_consistent_length, [1, 2], [1])
-    assert_raises(TypeError, check_consistent_length, [1, 2], 1)
-    assert_raises(TypeError, check_consistent_length, [1, 2], object())
+    assert_raises_regexp(ValueError, 'inconsistent numbers of samples',
+                         check_consistent_length, [1, 2], [1])
+    assert_raises_regexp(TypeError, 'got <type \'int\'>',
+                         check_consistent_length, [1, 2], 1)
+    assert_raises_regexp(TypeError, 'got <type \'object\'>',
+                         check_consistent_length, [1, 2], object())
     # XXX: Should this throw a TypeError?
     assert_raises(IndexError, check_consistent_length, [1, 2], np.array(1))
     # Despite ensembles having __len__ they must raise TypeError
-    assert_raises(TypeError, check_consistent_length,
-                  [1, 2], RandomForestRegressor())
-    # XXX: We should have a test with a string, but what is correct behaviour
+    assert_raises_regexp(TypeError, 'estimator', check_consistent_length,
+                         [1, 2], RandomForestRegressor())
+    # XXX: We should have a test with a string, but what is correct behaviour?

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -24,7 +24,8 @@ from sklearn.utils.estimator_checks import NotAnArray
 from sklearn.utils.validation import (
         NotFittedError,
         has_fit_parameter,
-        check_is_fitted)
+        check_is_fitted,
+        check_consistent_length)
 
 
 def test_as_float_array():
@@ -274,6 +275,21 @@ def test_check_is_fitted():
 
     ard.fit(*make_blobs())
     svr.fit(*make_blobs())
- 
+
     assert_equal(None, check_is_fitted(ard, "coef_"))
     assert_equal(None, check_is_fitted(svr, "support_"))
+
+
+def test_check_consistent_length():
+    check_consistent_length([1], [2], [3], [4], [5])
+    check_consistent_length([[1, 2], [[1, 2]]], [1, 2], ['a', 'b'])
+    check_consistent_length([1], (2,), np.array([3]), sp.csr_matrix((1, 2)))
+    assert_raises(ValueError, check_consistent_length, [1, 2], [1])
+    assert_raises(TypeError, check_consistent_length, [1, 2], 1)
+    assert_raises(TypeError, check_consistent_length, [1, 2], object())
+    # XXX: Should this throw a TypeError?
+    assert_raises(IndexError, check_consistent_length, [1, 2], np.array(1))
+    # Despite ensembles having __len__ they must raise TypeError
+    assert_raises(TypeError, check_consistent_length,
+                  [1, 2], RandomForestRegressor())
+    # XXX: We should have a test with a string, but what is correct behaviour

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -105,12 +105,14 @@ def _num_samples(x):
     """Return number of samples in array-like x."""
     if hasattr(x, 'fit'):
         # Don't get num_samples from an ensembles length!
-        raise TypeError('Expected dataset, but found estimator {0}'.format(x))
+        raise TypeError('Expected sequence or array-like, got '
+                        'estimator %s' % x)
     if not hasattr(x, '__len__') and not hasattr(x, 'shape'):
         if hasattr(x, '__array__'):
             x = np.asarray(x)
         else:
-            raise TypeError("Expected sequence or array-like, got %r" % x)
+            raise TypeError("Expected sequence or array-like, got %s" %
+                            type(x))
     return x.shape[0] if hasattr(x, 'shape') else len(x)
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -103,6 +103,9 @@ def _is_arraylike(x):
 
 def _num_samples(x):
     """Return number of samples in array-like x."""
+    if hasattr(x, 'fit'):
+        # Don't get num_samples from an ensembles length!
+        raise TypeError('Expected dataset, but found estimator {0}'.format(x))
     if not hasattr(x, '__len__') and not hasattr(x, 'shape'):
         if hasattr(x, '__array__'):
             x = np.asarray(x)
@@ -124,8 +127,8 @@ def check_consistent_length(*arrays):
 
     uniques = np.unique([_num_samples(X) for X in arrays if X is not None])
     if len(uniques) > 1:
-        raise ValueError("Found arrays with inconsistent numbers of samples: %s"
-                         % str(uniques))
+        raise ValueError("Found arrays with inconsistent numbers of samples: "
+                         "%s" % str(uniques))
 
 
 def indexable(*iterables):


### PR DESCRIPTION
#4081's code will now raise:

```
TypeError: Expected dataset, but found estimator RandomForestRegressor(bootstrap=True, criterion='mse', max_depth=None,
           max_features='auto', max_leaf_nodes=None, min_samples_leaf=1,
           min_samples_split=2, min_weight_fraction_leaf=0.0,
           n_estimators=10, n_jobs=1, oob_score=False, random_state=None,
           verbose=1, warm_start=False)
```

instead of 

```
ValueError: Found arrays with inconsistent numbers of samples: [10 17]
```
