### PR TITLE
[MRG] support sample_weight in silhouette_score

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from sklearn import datasets
-from sklearn.metrics.cluster.unsupervised import silhouette_score
-from sklearn.metrics import pairwise_distances
+from .... import datasets
+from ..unsupervised import silhouette_score, silhouette_samples
+from ... import pairwise_distances
 from sklearn.utils.testing import assert_false, assert_almost_equal
 from sklearn.utils.testing import assert_raises_regexp
 
@@ -44,8 +44,8 @@ def test_no_nan():
     # Note that there is only one sample in cluster 0. This used to cause the
     # silhouette_score to return nan (see bug #960).
     labels = np.array([1, 0, 1, 1, 1])
-    # The distance matrix doesn't actually matter.
-    D = np.random.RandomState(0).rand(len(labels), len(labels))
+    # The distance matrix needs only be a valid distance matrix
+    D = pairwise_distances(np.random.RandomState(0).rand(len(labels), 2))
     silhouette = silhouette_score(D, labels, metric='precomputed')
     assert_false(np.isnan(silhouette))
 
@@ -68,3 +68,45 @@ def test_correct_labelsize():
                          'Number of labels is %d\. Valid values are 2 '
                          'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)
+
+
+def test_paper_example():
+    lower = [5.58,
+             7.00, 6.50,
+             7.08, 7.00, 3.83,
+             4.83, 5.08, 8.17, 5.83,
+             2.17, 5.75, 6.67, 6.92, 4.92,
+             6.42, 5.00, 5.58, 6.00, 4.67, 6.42,
+             3.42, 5.50, 6.42, 6.42, 5.00, 3.92, 6.17,
+             2.50, 4.92, 6.25, 7.33, 4.50, 2.25, 6.33, 2.75,
+             6.08, 6.67, 4.25, 2.67, 6.00, 6.17, 6.17, 6.92, 6.17,
+             5.25, 6.83, 4.50, 3.75, 5.75, 5.42, 6.08, 5.83, 6.67, 3.67,
+             4.75, 3.00, 6.08, 6.67, 5.00, 5.58, 4.83, 6.17, 5.67, 6.50, 6.92]
+    D = np.zeros((12, 12))
+    D[np.tril_indices(12, -1)] = lower
+    D += D.T
+
+    names = ['BEL', 'BRA', 'CHI', 'CUB', 'EGY', 'FRA', 'IND', 'ISR', 'USA',
+             'USS', 'YUG', 'ZAI']
+
+    labels1 = [1, 1, 2, 2, 1, 1, 2, 1, 1, 2, 2, 1]
+    labels2 = [1, 2, 3, 3, 1, 1, 2, 1, 1, 3, 3, 2]
+
+    expected1 = {'USA': .43, 'BEL': .39, 'FRA': .35, 'ISR': .30, 'BRA': .22,
+                 'EGY': .20, 'ZAI': .19, 'CUB': .40, 'USS': .34, 'CHI': .33,
+                 'YUG': .26, 'IND': -.04}
+    score1 = .28
+    expected2 = {'USA': .47, 'FRA': .44, 'BEL': .42, 'ISR': .37, 'EGY': .02,
+                 'ZAI': .28, 'BRA': .25, 'IND': .17, 'CUB': .48, 'USS': .44,
+                 'YUG': .31, 'CHI': .31}
+    score2 = .33
+
+    for labels, expected, score in [(labels1, expected1, score1),
+                                    (labels2, expected2, score2)]:
+        expected = [expected[name] for name in names]
+        assert_almost_equal(expected, silhouette_samples(D, np.array(labels),
+                                                         metric='precomputed'),
+                            decimal=2)
+        assert_almost_equal(score, silhouette_score(D, np.array(labels),
+                                                    metric='precomputed'),
+                            decimal=2)

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -110,3 +110,22 @@ def test_paper_example():
         assert_almost_equal(score, silhouette_score(D, np.array(labels),
                                                     metric='precomputed'),
                             decimal=2)
+
+
+def test_sample_weight():
+    n_samples = 10
+    rng = np.random.RandomState(0)
+    X = rng.rand(n_samples, 2)
+    sample_weight = rng.randint(3, size=n_samples)
+    # Ensure both the 0 and multiple cases are handled
+    assert np.any(sample_weight == 2)
+    assert np.any(sample_weight == 0)
+    y = rng.randint(2, size=n_samples)
+    X_repeated = np.repeat(X, sample_weight, axis=0)
+    y_repeated = np.repeat(y, sample_weight, axis=0)
+    repeated_input = silhouette_samples(X_repeated, y_repeated)
+    weighed_s = silhouette_samples(X, y, sample_weight=sample_weight)
+    repeated_output = np.repeat(weighed_s, sample_weight, axis=0)
+    assert_almost_equal(repeated_input, repeated_output)
+    assert_almost_equal(silhouette_score(X_repeated, y_repeated),
+                        silhouette_score(X, y, sample_weight=sample_weight))


### PR DESCRIPTION
I sought `sample_weight` in `silhouette_score`, to account for multiple points that are merged into one when calculating average distances. Hacking it into the current implementation resulted in a very slow solution. Thus this PR also rewrites the implementation, yielding something that's a bit slower than the solution at master, but supports `sample_weight`.

I've also added tests for correctness which I haven't otherwise found in the code.
