### PR TITLE
[MRG +1] Support metric='precomputed' in nearest neighbors

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -823,8 +823,8 @@ Enhancements
    - Add multi-output support to :class:`gaussian_process.GaussianProcess`
      by John Novak.
 
-   - Support for distance matrices (i.e. n_samples by n_samples) for
-     NearestNeighbor with algorithm='brute' by `Robert Layton`_.
+   - Support for precomputed distance matrices in nearest neighbor estimators
+     by `Robert Layton`_ and `Joel Nothman`_.
 
    - Norm computations optimized for NumPy 1.6 and later versions by
      `Lars Buitinck`_. In particular, the k-means algorithm no longer

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -823,6 +823,9 @@ Enhancements
    - Add multi-output support to :class:`gaussian_process.GaussianProcess`
      by John Novak.
 
+   - Support for distance matrices (i.e. n_samples by n_samples) for
+     NearestNeighbor with algorithm='brute' by `Robert Layton`_.
+
    - Norm computations optimized for NumPy 1.6 and later versions by
      `Lars Buitinck`_. In particular, the k-means algorithm no longer
      needs a temporary data structure the size of its input.

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -115,18 +115,14 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     # Calculate neighborhood for all samples. This leaves the original point
     # in, which needs to be considered later (i.e. point i is in the
     # neighborhood of point i. While True, its useless information)
-    if metric == 'precomputed':
-        D = pairwise_distances(X, metric=metric)
-        neighborhoods = np.empty(X.shape[0], dtype=object)
-        neighborhoods[:] = [np.where(x <= eps)[0] for x in D]
-    else:
-        neighbors_model = NearestNeighbors(radius=eps, algorithm=algorithm,
-                                           leaf_size=leaf_size,
-                                           metric=metric, p=p)
-        neighbors_model.fit(X)
-        # This has worst case O(n^2) memory complexity
-        neighborhoods = neighbors_model.radius_neighbors(X, eps,
-                                                         return_distance=False)
+
+    neighbors_model = NearestNeighbors(radius=eps, algorithm=algorithm,
+                                       leaf_size=leaf_size,
+                                       metric=metric, p=p)
+    neighbors_model.fit(X)
+    # This has worst case O(n^2) memory complexity
+    neighborhoods = neighbors_model.radius_neighbors(X, eps,
+                                                     return_distance=False)
 
     if sample_weight is None:
         n_neighbors = np.array([len(neighbors) for neighbors in neighborhoods])

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -298,10 +298,10 @@ def test_dbscan_core_samples_toy():
 def test_dbscan_precomputed_metric_with_degenerate_input_arrays():
     # see https://github.com/scikit-learn/scikit-learn/issues/4641 for
     # more details
-    X = np.ones((10, 2))
+    X = np.eye(10)
     labels = DBSCAN(eps=0.5, metric='precomputed').fit(X).labels_
     assert_equal(len(set(labels)), 1)
 
-    X = np.zeros((10, 2))
+    X = np.zeros((10, 10))
     labels = DBSCAN(eps=0.5, metric='precomputed').fit(X).labels_
     assert_equal(len(set(labels)), 1)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -950,7 +950,7 @@ PAIRWISE_DISTANCE_FUNCTIONS = {
     'l2': euclidean_distances,
     'l1': manhattan_distances,
     'manhattan': manhattan_distances,
-    'precomputed': lambda x: x
+    'precomputed': None,  # HACK: precomputed is always allowed, never called
 }
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -54,7 +54,7 @@ def _return_float_dtype(X, Y):
     return X, Y, dtype
 
 
-def check_pairwise_arrays(X, Y):
+def check_pairwise_arrays(X, Y, precomputed=False):
     """ Set X and Y appropriately and checks inputs
 
     If Y is None, it is set as a pointer to X (i.e. not a copy).
@@ -65,13 +65,18 @@ def check_pairwise_arrays(X, Y):
     Specifically, this function first ensures that both X and Y are arrays,
     then checks that they are at least two dimensional while ensuring that
     their elements are floats. Finally, the function checks that the size
-    of the second dimension of the two arrays is equal.
+    of the second dimension of the two arrays is equal, or the equivalent
+    check for a precomputed distance matrix.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples_a, n_features)
 
     Y : {array-like, sparse matrix}, shape (n_samples_b, n_features)
+
+    precomputed : bool
+        True if X is to be treated as precomputed distances to the samples in
+        Y.
 
     Returns
     -------
@@ -90,7 +95,14 @@ def check_pairwise_arrays(X, Y):
     else:
         X = check_array(X, accept_sparse='csr', dtype=dtype)
         Y = check_array(Y, accept_sparse='csr', dtype=dtype)
-    if X.shape[1] != Y.shape[1]:
+
+    if precomputed:
+        if X.shape[1] != Y.shape[0]:
+            raise ValueError("Precomputed metric requires shape "
+                             "(n_queries, n_indexed). Got (%d, %d) "
+                             "for %d indexed." %
+                             (X.shape[0], X.shape[1], Y.shape[0]))
+    elif X.shape[1] != Y.shape[1]:
         raise ValueError("Incompatible dimension for X and Y matrices: "
                          "X.shape[1] == %d while Y.shape[1] == %d" % (
                              X.shape[1], Y.shape[1]))
@@ -1128,6 +1140,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
                          "callable" % (metric, _VALID_METRICS))
 
     if metric == "precomputed":
+        X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
         func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
@@ -1268,6 +1281,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
 
     """
     if metric == "precomputed":
+        X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif metric in PAIRWISE_KERNEL_FUNCTIONS:
         if filter_params:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -949,7 +949,9 @@ PAIRWISE_DISTANCE_FUNCTIONS = {
     'euclidean': euclidean_distances,
     'l2': euclidean_distances,
     'l1': manhattan_distances,
-    'manhattan': manhattan_distances, }
+    'manhattan': manhattan_distances,
+    'precomputed': lambda x: x
+}
 
 
 def distance_metrics():

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_true
 
 from sklearn.externals.six import iteritems
@@ -80,10 +81,6 @@ def test_pairwise_distances():
     assert_equal(S.shape[0], X.shape[0])
     assert_equal(S.shape[1], Y.shape[0])
     assert_array_almost_equal(S, S2)
-    # Tests that precomputed metric returns pointer to, and not copy of, X.
-    S = np.dot(X, X.T)
-    S2 = pairwise_distances(S, metric="precomputed")
-    assert_true(S is S2)
     # Test with sparse X and Y,
     # currently only supported for Euclidean, L1 and cosine.
     X_sparse = csr_matrix(X)
@@ -116,6 +113,38 @@ def test_pairwise_distances():
 
     # Test that a value error is raised if the metric is unkown
     assert_raises(ValueError, pairwise_distances, X, Y, metric="blah")
+
+
+def test_pairwise_precomputed():
+    for func in [pairwise_distances, pairwise_kernels]:
+        # Test correct shape
+        assert_raises_regexp(ValueError, '.* shape .*',
+                             func, np.zeros((5, 3)), metric='precomputed')
+        # with two args
+        assert_raises_regexp(ValueError, '.* shape .*',
+                             func, np.zeros((5, 3)), np.zeros((4, 4)),
+                             metric='precomputed')
+        # even if shape[1] agrees (although thus second arg is spurious)
+        assert_raises_regexp(ValueError, '.* shape .*',
+                             func, np.zeros((5, 3)), np.zeros((4, 3)),
+                             metric='precomputed')
+
+        # Test not copied (if appropriate dtype)
+        S = np.zeros((5, 5))
+        S2 = func(S, metric="precomputed")
+        assert_true(S is S2)
+        # with two args
+        S = np.zeros((5, 3))
+        S2 = func(S, np.zeros((3, 3)), metric="precomputed")
+        assert_true(S is S2)
+
+        # Test always returns float dtype
+        S = func(np.array([[1]], dtype='int'), metric='precomputed')
+        assert_equal('f', S.dtype.kind)
+
+        # Test converts list to array-like
+        S = func([[1]], metric='precomputed')
+        assert_true(isinstance(S, np.ndarray))
 
 
 def check_pairwise_parallel(func, metric, kwds):

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -139,7 +139,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise ValueError("unrecognized algorithm: '%s'" % algorithm)
 
         if algorithm == 'auto':
-            alg_check = 'ball_tree'
+            if metric == 'precomputed':
+                alg_check = 'brute'
+            else:
+                alg_check = 'ball_tree'
         else:
             alg_check = algorithm
 
@@ -236,8 +239,9 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         if self._fit_method == 'auto':
             # A tree approach is better for small number of neighbors,
             # and KDTree is generally faster when available
-            if (self.n_neighbors is None
-                    or self.n_neighbors < self._fit_X.shape[0] // 2):
+            if ((self.n_neighbors is None or
+                 self.n_neighbors < self._fit_X.shape[0] // 2) and
+                    self.metric != 'precomputed'):
                 if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
                 else:
@@ -568,6 +572,10 @@ class RadiusNeighborsMixin(object):
         else:
             query_is_train = True
             X = self._fit_X
+
+        if self.effective_metric_ == 'precomputed' and \
+           X.shape[0] != X.shape[1]:
+            raise ValueError("Precomputed metric requires a square matrix.")
 
         if radius is None:
             radius = self.radius

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -319,6 +319,12 @@ class KNeighborsMixin(object):
         if self._fit_method is None:
             raise NotFittedError("Must fit neighbors before querying.")
 
+        X = check_array(X, accept_sparse='csr')
+
+        if self.effective_metric_ == 'precomputed' and \
+           X.shape[0] != X.shape[1]:
+            raise ValueError("Precomputed metric requires a square matrix.")
+
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -275,7 +275,8 @@ class KNeighborsMixin(object):
 
         Parameters
         ----------
-        X : array-like, last dimension same as that of fit data, optional
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
             The query point or points.
             If not provided, neighbors of each indexed point are returned.
             In this case, the query point is not considered its own neighbor.
@@ -326,8 +327,9 @@ class KNeighborsMixin(object):
         X = check_array(X, accept_sparse='csr')
 
         if self.effective_metric_ == 'precomputed' and \
-           X.shape[0] != X.shape[1]:
-            raise ValueError("Precomputed metric requires a square matrix.")
+           X.shape[1] != self._fit_X.shape[0]:
+            raise ValueError("Precomputed metric requires shape "
+                             "(n_queries, n_indexed).")
 
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
@@ -422,7 +424,8 @@ class KNeighborsMixin(object):
 
         Parameters
         ----------
-        X : array-like, last dimension same as that of fit data, optional
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
             The query point or points.
             If not provided, neighbors of each indexed point are returned.
             In this case, the query point is not considered its own neighbor.
@@ -574,8 +577,9 @@ class RadiusNeighborsMixin(object):
             X = self._fit_X
 
         if self.effective_metric_ == 'precomputed' and \
-           X.shape[0] != X.shape[1]:
-            raise ValueError("Precomputed metric requires a square matrix.")
+           X.shape[1] != self._fit_X.shape[0]:
+            raise ValueError("Precomputed metric requires shape "
+                             "(n_queries, n_indexed).")
 
         if radius is None:
             radius = self.radius
@@ -731,7 +735,8 @@ class SupervisedFloatMixin(object):
         Parameters
         ----------
         X : {array-like, sparse matrix, BallTree, KDTree}
-            Training data. If array or matrix, shape = [n_samples, n_features]
+            Training data. If array or matrix, shape [n_samples, n_features],
+            or [n_samples, n_samples] if metric='precomputed'.
 
         y : {array-like, sparse matrix}
             Target values, array of float values, shape = [n_samples]
@@ -750,7 +755,8 @@ class SupervisedIntegerMixin(object):
         Parameters
         ----------
         X : {array-like, sparse matrix, BallTree, KDTree}
-            Training data. If array or matrix, shape = [n_samples, n_features]
+            Training data. If array or matrix, shape [n_samples, n_features],
+            or [n_samples, n_samples] if metric='precomputed'.
 
         y : {array-like, sparse matrix}
             Target values of shape = [n_samples] or [n_samples, n_outputs]
@@ -791,6 +797,7 @@ class UnsupervisedMixin(object):
         Parameters
         ----------
         X : {array-like, sparse matrix, BallTree, KDTree}
-            Training data. If array or matrix, shape = [n_samples, n_features]
+            Training data. If array or matrix, shape [n_samples, n_features],
+            or [n_samples, n_samples] if metric='precomputed'.
         """
         return self._fit(X)

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -326,11 +326,6 @@ class KNeighborsMixin(object):
 
         X = check_array(X, accept_sparse='csr')
 
-        if self.effective_metric_ == 'precomputed' and \
-           X.shape[1] != self._fit_X.shape[0]:
-            raise ValueError("Precomputed metric requires shape "
-                             "(n_queries, n_indexed).")
-
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
 
@@ -575,11 +570,6 @@ class RadiusNeighborsMixin(object):
         else:
             query_is_train = True
             X = self._fit_X
-
-        if self.effective_metric_ == 'precomputed' and \
-           X.shape[1] != self._fit_X.shape[0]:
-            raise ValueError("Precomputed metric requires shape "
-                             "(n_queries, n_indexed).")
 
         if radius is None:
             radius = self.radius

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -264,6 +264,11 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                              % self.algorithm)
         return self
 
+    @property
+    def _pairwise(self):
+        # For cross-validation routines to split data correctly
+        return self.metric == 'precomputed'
+
 
 class KNeighborsMixin(object):
     """Mixin for k-neighbors searches"""

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -329,8 +329,6 @@ class KNeighborsMixin(object):
         if self._fit_method is None:
             raise NotFittedError("Must fit neighbors before querying.")
 
-        X = check_array(X, accept_sparse='csr')
-
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -127,8 +127,9 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
 
         Parameters
         ----------
-        X : array of shape [n_samples, n_features]
-            A 2-D array representing the test points.
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
+            Test samples.
 
         Returns
         -------
@@ -169,8 +170,9 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
 
         Parameters
         ----------
-        X : array, shape = (n_samples, n_features)
-            A 2-D array representing the test points.
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
+            Test samples.
 
         Returns
         -------
@@ -323,8 +325,9 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
         Parameters
         ----------
-        X : array of shape [n_samples, n_features]
-            A 2-D array representing the test points.
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
+            Test samples.
 
         Returns
         -------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -124,8 +124,9 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
         Parameters
         ----------
-        X : array of shape [n_samples, n_features]
-            A 2-D array representing the test points.
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
+            Test samples.
 
         Returns
         -------
@@ -261,8 +262,9 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
         Parameters
         ----------
-        X : array of shape [n_samples, n_features]
-            A 2-D array representing the test points.
+        X : array-like, shape (n_query, n_features), \
+                or (n_query, n_indexed) if metric == 'precomputed'
+            Test samples.
 
         Returns
         -------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -124,8 +124,8 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
         Parameters
         ----------
-        X : array or matrix, shape = [n_samples, n_features]
-
+        X : array of shape [n_samples, n_features]
+            A 2-D array representing the test points.
 
         Returns
         -------
@@ -261,7 +261,8 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
         Parameters
         ----------
-        X : array or matrix, shape = [n_samples, n_features]
+        X : array of shape [n_samples, n_features]
+            A 2-D array representing the test points.
 
         Returns
         -------

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1,9 +1,11 @@
 from itertools import product
+import pickle
 
 import numpy as np
 from scipy.sparse import (bsr_matrix, coo_matrix, csc_matrix, csr_matrix,
                           dok_matrix, lil_matrix)
 
+from sklearn import metrics
 from sklearn.cross_validation import train_test_split
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -98,6 +100,32 @@ def test_unsupervised_inputs():
 
         assert_array_almost_equal(dist1, dist2)
         assert_array_almost_equal(ind1, ind2)
+
+
+def test_unsupervisd_knn_distance():
+    """Tests unsupervised NearestNeighbors with a distance matrix."""
+    X = rng.random_sample((3, 4))  # Must not be square for tests below.
+    D = metrics.pairwise_distances(X, metric='euclidean')
+    # As a feature matrix (n_samples by n_features)
+    nbrs_X = neighbors.NearestNeighbors(n_neighbors=3)
+    nbrs_X.fit(X)
+    dist_X, ind_X = nbrs_X.kneighbors(X)
+    # As a dense distance matrix (n_samples by n_samples)
+    nbrs_D = neighbors.NearestNeighbors(n_neighbors=3, algorithm='brute',
+                                        metric='precomputed')
+    nbrs_D.fit(D)
+    dist_D, ind_D = nbrs_D.kneighbors(D)
+    # Assert that they give the same neighbors
+    assert_array_almost_equal(dist_X, dist_D)
+    assert_array_almost_equal(ind_X, ind_D)
+    # Test pickling
+    pickled_classifier = pickle.dumps(nbrs_D)
+    unpickled_classifier = pickle.loads(pickled_classifier)
+    unpickled_dist_D, unpickled_ind_D = unpickled_classifier.kneighbors(D)
+    assert_array_almost_equal(unpickled_dist_D, dist_D)
+    assert_array_almost_equal(unpickled_ind_D, ind_D)
+    # Must raise a ValueError if the matrix is not square
+    assert_raises(ValueError, nbrs_D.kneighbors, X)  # X is not square
 
 
 def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,
@@ -942,8 +970,7 @@ def test_non_euclidean_kneighbors():
         nbrs_graph = neighbors.radius_neighbors_graph(
             X, radius, metric=metric).toarray()
         nbrs1 = neighbors.NearestNeighbors(metric=metric, radius=radius).fit(X)
-        assert_array_equal(nbrs_graph,
-                           nbrs1.radius_neighbors_graph(X).toarray())
+        assert_array_equal(nbrs_graph, nbrs1.radius_neighbors_graph(X).A)
 
     # Raise error when wrong parameters are supplied,
     X_nbrs = neighbors.NearestNeighbors(3, metric='manhattan')

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -102,30 +102,41 @@ def test_unsupervised_inputs():
         assert_array_almost_equal(ind1, ind2)
 
 
-def test_unsupervisd_knn_distance():
+def test_unsupervised_precomputed():
     """Tests unsupervised NearestNeighbors with a distance matrix."""
     X = rng.random_sample((3, 4))  # Must not be square for tests below.
     D = metrics.pairwise_distances(X, metric='euclidean')
-    # As a feature matrix (n_samples by n_features)
-    nbrs_X = neighbors.NearestNeighbors(n_neighbors=3)
-    nbrs_X.fit(X)
-    dist_X, ind_X = nbrs_X.kneighbors(X)
-    # As a dense distance matrix (n_samples by n_samples)
-    nbrs_D = neighbors.NearestNeighbors(n_neighbors=3, algorithm='brute',
-                                        metric='precomputed')
-    nbrs_D.fit(D)
-    dist_D, ind_D = nbrs_D.kneighbors(D)
-    # Assert that they give the same neighbors
-    assert_array_almost_equal(dist_X, dist_D)
-    assert_array_almost_equal(ind_X, ind_D)
-    # Test pickling
-    pickled_classifier = pickle.dumps(nbrs_D)
-    unpickled_classifier = pickle.loads(pickled_classifier)
-    unpickled_dist_D, unpickled_ind_D = unpickled_classifier.kneighbors(D)
-    assert_array_almost_equal(unpickled_dist_D, dist_D)
-    assert_array_almost_equal(unpickled_ind_D, ind_D)
-    # Must raise a ValueError if the matrix is not square
-    assert_raises(ValueError, nbrs_D.kneighbors, X)  # X is not square
+    for method in ['kneighbors', 'radius_neighbors']:
+        # As a feature matrix (n_samples by n_features)
+        nbrs_X = neighbors.NearestNeighbors(n_neighbors=3)
+        nbrs_X.fit(X)
+        dist_X, ind_X = getattr(nbrs_X, method)(X)
+
+        # As a dense distance matrix (n_samples by n_samples)
+        nbrs_D = neighbors.NearestNeighbors(n_neighbors=3, algorithm='brute',
+                                            metric='precomputed')
+        nbrs_D.fit(D)
+        dist_D, ind_D = getattr(nbrs_D, method)(D)
+        assert_array_almost_equal(dist_X, dist_D)
+        assert_array_almost_equal(ind_X, ind_D)
+
+        # Check auto works too
+        nbrs_D = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
+                                            metric='precomputed')
+        nbrs_D.fit(D)
+        dist_D, ind_D = getattr(nbrs_D, method)(D)
+        assert_array_almost_equal(dist_X, dist_D)
+        assert_array_almost_equal(ind_X, ind_D)
+
+        # Test pickling to ensure lambda didn't get stored
+        pickled_nbrs = pickle.dumps(nbrs_D)
+        unpickled_nbrs = pickle.loads(pickled_nbrs)
+        unpickled_dist_D, unpickled_ind_D = getattr(unpickled_nbrs, method)(D)
+        assert_array_almost_equal(unpickled_dist_D, dist_D)
+        assert_array_almost_equal(unpickled_ind_D, ind_D)
+
+        # Must raise a ValueError if the matrix is not square
+        assert_raises(ValueError, getattr(nbrs_D, method), X)
 
 
 def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -133,6 +133,12 @@ def test_precomputed():
         assert_array_almost_equal(dist_X, dist_D)
         assert_array_almost_equal(ind_X, ind_D)
 
+        # Check X=None in prediction
+        dist_X, ind_X = getattr(nbrs_X, method)(None)
+        dist_D, ind_D = getattr(nbrs_D, method)(None)
+        assert_array_almost_equal(dist_X, dist_D)
+        assert_array_almost_equal(ind_X, ind_D)
+
         # Must raise a ValueError if the matrix is not of correct shape
         assert_raises(ValueError, getattr(nbrs_D, method), X)
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -6,7 +6,7 @@ from scipy.sparse import (bsr_matrix, coo_matrix, csc_matrix, csr_matrix,
                           dok_matrix, lil_matrix)
 
 from sklearn import metrics
-from sklearn.cross_validation import train_test_split
+from sklearn.cross_validation import train_test_split, cross_val_score
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
@@ -148,6 +148,21 @@ def test_precomputed():
         est.metric = 'precomputed'
         pred_D = est.fit(DXX, target).predict(DYX)
         assert_array_almost_equal(pred_X, pred_D)
+
+
+def test_precomputed_cross_validation():
+    # Ensure array is split correctly
+    rng = np.random.RandomState(0)
+    X = rng.rand(20, 2)
+    D = pairwise_distances(X, metric='euclidean')
+    y = rng.randint(3, size=20)
+    for Est in (neighbors.KNeighborsClassifier,
+                neighbors.RadiusNeighborsClassifier,
+                neighbors.KNeighborsRegressor,
+                neighbors.RadiusNeighborsRegressor):
+        metric_score = cross_val_score(Est(), X, y)
+        precomp_score = cross_val_score(Est(metric='precomputed'), D, y)
+        assert_array_equal(metric_score, precomp_score)
 
 
 def test_unsupervised_radius_neighbors(n_samples=20, n_features=5,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -133,13 +133,6 @@ def test_precomputed():
         assert_array_almost_equal(dist_X, dist_D)
         assert_array_almost_equal(ind_X, ind_D)
 
-        # Test pickling to ensure lambda didn't get stored
-        pickled_nbrs = pickle.dumps(nbrs_D)
-        restored_nbrs = pickle.loads(pickled_nbrs)
-        restored_dist_D, restored_ind_D = getattr(restored_nbrs, method)(DYX)
-        assert_array_almost_equal(restored_dist_D, dist_D)
-        assert_array_almost_equal(restored_ind_D, ind_D)
-
         # Must raise a ValueError if the matrix is not of correct shape
         assert_raises(ValueError, getattr(nbrs_D, method), X)
 


### PR DESCRIPTION
This fixes up #2532 (sorry to not offer the changes back there, @robertlayton: the rebase was too messy with my changes to validation in sklearn.metrics.pairwise) to handle queries that differ from the index data. This case is a little awkward in that the index data doesn't matter, but really should be supported for `KNNClassifier` et al.)

This also provides stronger validation to precomputed metrics in `pairwise_{distances,kernels}
