### PR TITLE
BUG: Correct check for local import

### DIFF
--- a/sklearn/__check_build/__init__.py
+++ b/sklearn/__check_build/__init__.py
@@ -18,7 +18,7 @@ def raise_build_error(e):
     # directory to help debugging on the mailing list.
     local_dir = os.path.split(__file__)[0]
     msg = STANDARD_MSG
-    if local_dir == "sklearn/check_build":
+    if local_dir == "sklearn/__check_build":
         # Picking up the local install: this will work only if the
         # install is an 'inplace build'
         msg = INPLACE_MSG


### PR DESCRIPTION
With the move of the `check_build` directory to `__check_build` in  cd7404706 the comparison for displaying the error message indicating a import from the source tree that has not been build inplace was incorrect.  This fixes this bug so that the **INPLACE_MSG** is displayed in these cases.
