### PR TITLE
Lower memory usage of spectral_embedding.

### DIFF
--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -239,6 +239,8 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         # orders-of-magnitude speedup over simply using keyword which='LA'
         # in standard mode.
         try:
+            # We are computing the opposite of the laplacian inplace so as
+            # to spare a memory allocation of a possibly very large array
             laplacian *= -1
             lambdas, diffusion_map = eigsh(laplacian, k=n_components,
                                            sigma=1.0, which='LM',
@@ -247,8 +249,9 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         except RuntimeError:
             # When submatrices are exactly singular, an LU decomposition
             # in arpack fails. We fallback to lobpcg
-            laplacian *= -1
             eigen_solver = "lobpcg"
+            # Revert the laplacian to its opposite to have lobpcg work
+            laplacian *= -1
 
     if eigen_solver == 'amg':
         # Use AMG to get a preconditioner and speed up the eigenvalue

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -239,7 +239,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         # orders-of-magnitude speedup over simply using keyword which='LA'
         # in standard mode.
         try:
-            laplacian = -laplacian
+            laplacian *= -1
             lambdas, diffusion_map = eigsh(laplacian, k=n_components,
                                            sigma=1.0, which='LM',
                                            tol=eigen_tol)
@@ -247,7 +247,7 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         except RuntimeError:
             # When submatrices are exactly singular, an LU decomposition
             # in arpack fails. We fallback to lobpcg
-            laplacian = -laplacian
+            laplacian *= -1
             eigen_solver = "lobpcg"
 
     if eigen_solver == 'amg':

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -239,13 +239,15 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
         # orders-of-magnitude speedup over simply using keyword which='LA'
         # in standard mode.
         try:
-            lambdas, diffusion_map = eigsh(-laplacian, k=n_components,
+            laplacian = -laplacian
+            lambdas, diffusion_map = eigsh(laplacian, k=n_components,
                                            sigma=1.0, which='LM',
                                            tol=eigen_tol)
             embedding = diffusion_map.T[n_components::-1] * dd
         except RuntimeError:
             # When submatrices are exactly singular, an LU decomposition
             # in arpack fails. We fallback to lobpcg
+            laplacian = -laplacian
             eigen_solver = "lobpcg"
 
     if eigen_solver == 'amg':


### PR DESCRIPTION
When calling eigsh, -laplacian is given as an argument. Both laplacian
and -laplacian are thus in memory. By assigning -laplacian to laplacian,
the extra copy is freed. This copy is not needed by the end of the
function call. The memory reclaimed is therefore available for the eigsh
call. In case of a RuntimeError, the laplacian is reverted to its old
value to process lobpcg as usual.
