### PR TITLE
[MRG+2] Adding sample_weight support to matthews_corrcoef metric.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,9 @@ Enhancements
    - :class:`multiclass.OneVsOneClassifier` and :class:`multiclass.OneVsRestClassifier`
      now support ``partial_fit``. By `Asish Panda`_ and `Philipp Dowling`_.
 
+   - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
+     By `Jatin Shah`_ and `Raghav R V`_.
+
 Bug fixes
 .........
 
@@ -3925,7 +3928,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Matteo Visconti di Oleggio Castello: http://www.mvdoc.me
 
-.. _Raghav R V: https://github.com/ragv
+.. _Raghav R V: https://github.com/rvraghav93
 
 .. _Trevor Stephens: http://trevorstephens.com/
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -187,25 +187,40 @@ ALL_METRICS.update(REGRESSION_METRICS)
 # When you add a new metric or functionality, check if a general test
 # is already written.
 
-# Metric undefined with "binary" or "multiclass" input
-METRIC_UNDEFINED_MULTICLASS = [
-    "samples_f0.5_score", "samples_f1_score", "samples_f2_score",
-    "samples_precision_score", "samples_recall_score",
+# Those metrics don't support binary inputs
+METRIC_UNDEFINED_BINARY = [
+    "samples_f0.5_score",
+    "samples_f1_score",
+    "samples_f2_score",
+    "samples_precision_score",
+    "samples_recall_score",
+    "coverage_error",
 
-    # Those metrics don't support multiclass outputs
-    "average_precision_score", "weighted_average_precision_score",
-    "micro_average_precision_score", "macro_average_precision_score",
+    "roc_auc_score",
+    "micro_roc_auc",
+    "weighted_roc_auc",
+    "macro_roc_auc",
+    "samples_roc_auc",
+
+    "average_precision_score",
+    "weighted_average_precision_score",
+    "micro_average_precision_score",
+    "macro_average_precision_score",
     "samples_average_precision_score",
 
-    "label_ranking_average_precision_score",
-
-    "roc_auc_score", "micro_roc_auc", "weighted_roc_auc",
-    "macro_roc_auc",  "samples_roc_auc",
-
-    "coverage_error",
-    "brier_score_loss",
     "label_ranking_loss",
+    "label_ranking_average_precision_score",
 ]
+
+# Those metrics don't support multiclass inputs
+METRIC_UNDEFINED_MULTICLASS = [
+    "brier_score_loss",
+    "matthews_corrcoef_score",
+]
+
+# Metric undefined with "binary" or "multiclass" input
+METRIC_UNDEFINED_BINARY_MULTICLASS = set(METRIC_UNDEFINED_BINARY).union(
+    set(METRIC_UNDEFINED_MULTICLASS))
 
 # Metrics with an "average" argument
 METRICS_WITH_AVERAGING = [
@@ -346,7 +361,6 @@ NOT_SYMMETRIC_METRICS = [
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
     "cohen_kappa_score",
     "confusion_matrix",
-    "matthews_corrcoef_score",
     "median_absolute_error",
 ]
 
@@ -359,10 +373,9 @@ def test_symmetry():
     y_pred = random_state.randint(0, 2, size=(20, ))
 
     # We shouldn't forget any metrics
-    assert_equal(set(SYMMETRIC_METRICS).union(NOT_SYMMETRIC_METRICS,
-                                              THRESHOLDED_METRICS,
-                                              METRIC_UNDEFINED_MULTICLASS),
-                 set(ALL_METRICS))
+    assert_equal(set(SYMMETRIC_METRICS).union(
+        NOT_SYMMETRIC_METRICS, THRESHOLDED_METRICS,
+        METRIC_UNDEFINED_BINARY_MULTICLASS), set(ALL_METRICS))
 
     assert_equal(
         set(SYMMETRIC_METRICS).intersection(set(NOT_SYMMETRIC_METRICS)),
@@ -390,7 +403,7 @@ def test_sample_order_invariance():
     y_true_shuffle, y_pred_shuffle = shuffle(y_true, y_pred, random_state=0)
 
     for name, metric in ALL_METRICS.items():
-        if name in METRIC_UNDEFINED_MULTICLASS:
+        if name in METRIC_UNDEFINED_BINARY_MULTICLASS:
             continue
 
         assert_almost_equal(metric(y_true, y_pred),
@@ -457,7 +470,7 @@ def test_format_invariance_with_1d_vectors():
     y2_row = np.reshape(y2_1d, (1, -1))
 
     for name, metric in ALL_METRICS.items():
-        if name in METRIC_UNDEFINED_MULTICLASS:
+        if name in METRIC_UNDEFINED_BINARY_MULTICLASS:
             continue
 
         measure = metric(y1, y2)
@@ -532,7 +545,7 @@ def test_invariance_string_vs_numbers_labels():
     labels_str = ["eggs", "spam"]
 
     for name, metric in CLASSIFICATION_METRICS.items():
-        if name in METRIC_UNDEFINED_MULTICLASS:
+        if name in METRIC_UNDEFINED_BINARY_MULTICLASS:
             continue
 
         measure_with_number = metric(y1, y2)
@@ -613,7 +626,8 @@ def check_single_sample_multioutput(name):
 
 def test_single_sample():
     for name in ALL_METRICS:
-        if name in METRIC_UNDEFINED_MULTICLASS or name in THRESHOLDED_METRICS:
+        if (name in METRIC_UNDEFINED_BINARY_MULTICLASS or
+                name in THRESHOLDED_METRICS):
             # Those metrics are not always defined with one sample
             # or in multiclass classification
             continue
@@ -915,9 +929,9 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                                  sample_weight=sample_weight.tolist())
     assert_almost_equal(
         weighted_score, weighted_score_list,
-        err_msg="Weighted scores for array and list sample_weight input are "
-                "not equal (%f != %f) for %s" % (
-                    weighted_score, weighted_score_list, name))
+        err_msg=("Weighted scores for array and list "
+                 "sample_weight input are not equal (%f != %f) for %s") % (
+                     weighted_score, weighted_score_list, name))
 
     # check that integer weights is the same as repeated samples
     repeat_weighted_score = metric(
@@ -963,14 +977,14 @@ def check_sample_weight_invariance(name, metric, y1, y2):
 def test_sample_weight_invariance(n_samples=50):
     random_state = check_random_state(0)
 
-    # binary output
+    # binary
     random_state = check_random_state(0)
     y_true = random_state.randint(0, 2, size=(n_samples, ))
     y_pred = random_state.randint(0, 2, size=(n_samples, ))
     y_score = random_state.random_sample(size=(n_samples,))
     for name in ALL_METRICS:
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
-                name in METRIC_UNDEFINED_MULTICLASS):
+                name in METRIC_UNDEFINED_BINARY):
             continue
         metric = ALL_METRICS[name]
         if name in THRESHOLDED_METRICS:
@@ -985,7 +999,7 @@ def test_sample_weight_invariance(n_samples=50):
     y_score = random_state.random_sample(size=(n_samples, 5))
     for name in ALL_METRICS:
         if (name in METRICS_WITHOUT_SAMPLE_WEIGHT or
-                name in METRIC_UNDEFINED_MULTICLASS):
+                name in METRIC_UNDEFINED_BINARY_MULTICLASS):
             continue
         metric = ALL_METRICS[name]
         if name in THRESHOLDED_METRICS:


### PR DESCRIPTION
Partially fixes #3450 

Based on Jatin Shah's implementation of wcorrcoeff [here](https://github.com/scikit-learn/scikit-learn/issues/3450#issuecomment-51236631).

@jatinshah Have credited you in the what's new entry. Thanks!

Should there be any tests?
