### PR TITLE
[MRG+1] Simplify sample_weight support in Ridge.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,9 @@ New features
      kernelized ridge regression.
      By `Mathieu Blondel`_ and `Jan Hendrik Metzen`_.
 
+   - All solvers in :class:`linear_model.Ridge` now support `sample_weight`.
+     By `Mathieu Blondel`_.
+
    - Added :class:`cross_validation.PredefinedSplit` cross-validation
      for fixed user-provided cross-validation folds.
      By `untom <https://github.com/untom>`_.

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -6,11 +6,11 @@
 
 import numpy as np
 
+from .base import BaseEstimator, RegressorMixin
+from .metrics.pairwise import pairwise_kernels
+from .linear_model.ridge import _solve_cholesky_kernel
 from .utils import check_X_y
-from sklearn.base import BaseEstimator, RegressorMixin
-from sklearn.metrics.pairwise import pairwise_kernels
-from sklearn.linear_model.ridge import _solve_cholesky_kernel
-from sklearn.utils.validation import check_is_fitted
+from .utils.validation import check_is_fitted
 
 
 class KernelRidge(BaseEstimator, RegressorMixin):

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -200,15 +200,10 @@ def _rescale_data(X, y, sample_weight):
     n_samples = X.shape[0]
     sample_weight = sample_weight * np.ones(n_samples)
     sample_weight = np.sqrt(sample_weight)
-    if sparse.issparse(X):
-        sw_matrix = sparse.dia_matrix((sample_weight, 0),
-                                      shape=(n_samples, n_samples))
-        X = safe_sparse_dot(sw_matrix, X)
-    else:
-        X = X.copy()
-        X *= sample_weight[:, np.newaxis]
-    y = y.copy()
-    y *= sample_weight[:, np.newaxis]
+    sw_matrix = sparse.dia_matrix((sample_weight, 0),
+                                  shape=(n_samples, n_samples))
+    X = safe_sparse_dot(sw_matrix, X)
+    y = safe_sparse_dot(sw_matrix, y)
     return X, y
 
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -89,23 +89,13 @@ def _solve_lsqr(X, y, alpha, max_iter=None, tol=1e-3):
     return coefs
 
 
-def _solve_cholesky(X, y, alpha, sample_weight=None):
+def _solve_cholesky(X, y, alpha):
     # w = inv(X^t X + alpha*Id) * X.T y
     n_samples, n_features = X.shape
     n_targets = y.shape[1]
 
-    has_sw = sample_weight is not None
-
-    if has_sw:
-        sample_weight = sample_weight * np.ones(n_samples)
-        sample_weight_matrix = sparse.dia_matrix((sample_weight, 0),
-            shape=(n_samples, n_samples))
-        weighted_X = safe_sparse_dot(sample_weight_matrix, X)
-        A = safe_sparse_dot(weighted_X.T, X, dense_output=True)
-        Xy = safe_sparse_dot(weighted_X.T, y, dense_output=True)
-    else:
-        A = safe_sparse_dot(X.T, X, dense_output=True)
-        Xy = safe_sparse_dot(X.T, y, dense_output=True)
+    A = safe_sparse_dot(X.T, X, dense_output=True)
+    Xy = safe_sparse_dot(X.T, y, dense_output=True)
 
     one_alpha = np.array_equal(alpha, len(alpha) * [alpha[0]])
 
@@ -137,6 +127,8 @@ def _solve_cholesky_kernel(K, y, alpha, sample_weight=None, copy=False):
         or sample_weight not in [1.0, None]
 
     if has_sw:
+        # Unlike other solvers, we need to support sample_weight directly
+        # because K might be a pre-computed kernel.
         sw = np.sqrt(np.atleast_1d(sample_weight))
         y = y * sw[:, np.newaxis]
         K *= np.outer(sw, sw)
@@ -201,6 +193,23 @@ def _deprecate_dense_cholesky(solver):
         solver = 'cholesky'
 
     return solver
+
+
+def _rescale_data(X, y, sample_weight):
+    """Rescale data so as to support sample_weight"""
+    n_samples = X.shape[0]
+    sample_weight = sample_weight * np.ones(n_samples)
+    sample_weight = np.sqrt(sample_weight)
+    if sparse.issparse(X):
+        sw_matrix = sparse.dia_matrix((sample_weight, 0),
+                                      shape=(n_samples, n_samples))
+        X = safe_sparse_dot(sw_matrix, X)
+    else:
+        X = X.copy()
+        X *= sample_weight[:, np.newaxis]
+    y = y.copy()
+    y *= sample_weight[:, np.newaxis]
+    return X, y
 
 
 def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
@@ -307,11 +316,8 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         if np.atleast_1d(sample_weight).ndim > 1:
             raise ValueError("Sample weights must be 1D array or scalar")
 
-        if solver != "cholesky":
-            warnings.warn("sample_weight and class_weight not"
-                          " supported in %s, fall back to "
-                          "cholesky." % solver)
-            solver = 'cholesky'
+        # Sample weight can be implemented via a simple rescaling.
+        X, y = _rescale_data(X, y, sample_weight)
 
     # There should be either 1 or n_targets penalties
     alpha = np.asarray(alpha).ravel()
@@ -336,8 +342,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         if n_features > n_samples:
             K = safe_sparse_dot(X, X.T, dense_output=True)
             try:
-                dual_coef = _solve_cholesky_kernel(K, y, alpha,
-                                                         sample_weight)
+                dual_coef = _solve_cholesky_kernel(K, y, alpha)
 
                 coef = safe_sparse_dot(X.T, dual_coef, dense_output=True).T
             except linalg.LinAlgError:
@@ -346,7 +351,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
         else:
             try:
-                coef = _solve_cholesky(X, y, alpha, sample_weight)
+                coef = _solve_cholesky(X, y, alpha)
             except linalg.LinAlgError:
                 # use SVD solver if matrix is singular
                 solver = 'svd'

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -539,41 +539,6 @@ def test_ridgecv_store_cv_values():
     assert_equal(r.cv_values_.shape, (n_samples, n_responses, n_alphas))
 
 
-def test_ridge_sample_weights_in_feature_space():
-    """Check that Cholesky solver in feature space applies sample_weights
-    correctly.
-    """
-
-    rng = np.random.RandomState(42)
-
-    n_samples_list = [5, 6, 7] * 2
-    n_features_list = [7, 6, 5] * 2
-    n_targets_list = [1, 1, 1, 2, 2, 2]
-    noise = 1.
-    alpha = 2.
-    alpha = np.atleast_1d(alpha)
-
-    for n_samples, n_features, n_targets in zip(n_samples_list,
-                                                n_features_list,
-                                                n_targets_list):
-        X = rng.randn(n_samples, n_features)
-        beta = rng.randn(n_features, n_targets)
-        Y = X.dot(beta)
-        Y_noisy = Y + rng.randn(*Y.shape) * np.sqrt((Y ** 2).sum(0)) * noise
-
-        K = X.dot(X.T)
-        sample_weights = 1. + (rng.randn(n_samples) ** 2) * 10
-
-        coef_sample_space = _solve_cholesky_kernel(K, Y_noisy, alpha,
-                                         sample_weight=sample_weights)
-
-        coef_feature_space = _solve_cholesky(X, Y_noisy, alpha,
-                                         sample_weight=sample_weights)
-
-        assert_array_almost_equal(X.T.dot(coef_sample_space),
-                                  coef_feature_space.T)
-
-
 def test_raises_value_error_if_sample_weights_greater_than_1d():
     """Sample weights must be either scalar or 1D"""
 


### PR DESCRIPTION
I simplified the code by doing the rescaling upfront. This allows to support sample_weight in all solvers and fixes the long-standing bug #1190. Ping @eickenberg, @fabianp, @agramfort 
