### PR TITLE
fix import error in lda.py

### DIFF
--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 from scipy import linalg
-from six import string_types
+from .externals.six import string_types
 
 from .base import BaseEstimator, TransformerMixin
 from .linear_model.base import LinearClassifierMixin


### PR DESCRIPTION
Fix import error in `python 3.4`environment.
when I run `from sklearn.lda import LDA` , got `ImportError: No module named 'six'`.
