### PR TITLE
[MRG+1] kernel_ridge added to classes.rst

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -578,6 +578,25 @@ From text
    kernel_approximation.RBFSampler
    kernel_approximation.SkewedChi2Sampler
 
+.. _kernel_ridge_ref:
+
+:mod:`sklearn.kernel_ridge` Kernelized Ridge Regression
+========================================================
+
+.. automodule:: sklearn.kernel_ridge
+   :no-members:
+   :no-inherited-members:
+
+**User guide:** See the :ref:`kernel_ridge` section for further details.
+
+.. currentmodule:: sklearn
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   kernel_ridge.KernelRidge
+
 .. _lda_ref:
 
 :mod:`sklearn.lda`: Linear Discriminant Analysis


### PR DESCRIPTION
This is fixes an issue introduced in PR #3942, where I forgot adding the new kernel_ridge module to classes.rst
