### PR TITLE
[MRG] Fix boundary handling in radius_neighbors (issue #4072)

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -482,7 +482,7 @@ class RadiusNeighborsMixin(object):
                 dist = pairwise_distances(X, self._fit_X,
                                           self.effective_metric_,
                                           **self.effective_metric_params_)
-            neigh_ind = [np.where(d < radius)[0] for d in dist]
+            neigh_ind = [np.where(d <= radius)[0] for d in dist]
 
             # if there are the same number of neighbors for each point,
             # we can do a normal array.  Otherwise, we return an object

--- a/sklearn/neighbors/tests/test_approximate.py
+++ b/sklearn/neighbors/tests/test_approximate.py
@@ -201,6 +201,19 @@ def test_radius_neighbors():
     assert_true(np.all(np.less_equal(np.sort(distances_exact[0]),
                                      np.sort(distances_approx[0]))))
 
+    # Check that boundary handling is consistent with NearestNeighbors
+    X_train = np.array([[5.0, 5.0, 2.0], [21.0, 5.0, 5.0], [1.0, 1.0, 1.0]])
+
+    lshf = LSHForest(min_hash_match=0, n_candidates=6).fit(X_train)
+    nbrs = NearestNeighbors(algorithm='brute', metric='cosine').fit(X_train)
+
+    ind_approx = lshf.radius_neighbors([0.0, 0.0, 0.0], radius=1, return_distance=False)
+    ind_exact = nbrs.radius_neighbors([0.0, 0.0, 0.0], radius=1,  return_distance=False)
+    assert_array_equal(np.sort(ind_approx[0]), ind_exact[0])
+
+    ind_approx = lshf.radius_neighbors([0.0, 0.0, 0.0], radius=0.99, return_distance=False)
+    ind_exact = nbrs.radius_neighbors([0.0, 0.0, 0.0], radius=0.99,  return_distance=False)
+    assert_array_equal(np.sort(ind_approx[0]), ind_exact[0])
 
 def test_distances():
     """Checks whether returned neighbors are from closest to farthest."""

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -314,6 +314,21 @@ def test_radius_neighbors_classifier_zero_distance():
             assert_array_equal(correct_labels1, clf.predict(z1))
 
 
+def test_radius_neighbors_boundary_handling():
+    """ Test whether points lying on boundary are handled consistently """
+
+    X = np.array([[1.5], [3.0], [3.01]]) 
+    radius = 3.0
+
+    correct_neighbors = np.array([0, 1])
+
+    for algorithm in ALGORITHMS:
+         nbrs = neighbors.NearestNeighbors(radius=radius, 
+                                           algorithm=algorithm).fit(X) 
+         ind = nbrs.radius_neighbors([0.0], return_distance=False)
+         assert_array_equal(correct_neighbors, ind[0])
+
+
 def test_RadiusNeighborsClassifier_multioutput():
     """Test k-NN classifier on multioutput data"""
     rng = check_random_state(0)


### PR DESCRIPTION
Fixes #4072 

This PR makes the `radius_neighbors` for brute force to include points lying on boundary of chosen radius. This is the same behavior as the KD Tree and Ball Tree `radius_neighbors`. 
