### PR TITLE
[MRG + 2] ENH RobustScaler

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -145,6 +145,16 @@ full formula is::
 
     X_scaled = X_std / (max - min) + min
 
+
+Scaling data with outliers
+--------------------------
+If your data contains many outliers, scaling using the mean and variance
+of the data does sometimes not work very well. In these cases, you can use
+:func:`robust_scale` and :class:`RobustScaler` as drop-in replacements
+instead, which use more robust estimates for the center and range of your
+data.
+
+
 .. topic:: References:
 
   Further discussion on the importance of centering and scaling data is

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -100,6 +100,7 @@ of :class:`StandardScaler`.
 
 Scaling features to a range
 ---------------------------
+
 An alternative standardization is scaling features to
 lie between a given minimum and maximum value, often between zero and one.
 This can be achieved using :class:`MinMaxScaler`.
@@ -148,10 +149,11 @@ full formula is::
 
 Scaling data with outliers
 --------------------------
+
 If your data contains many outliers, scaling using the mean and variance
-of the data does sometimes not work very well. In these cases, you can use
+of the data is likely to not work very well. In these cases, you can use
 :func:`robust_scale` and :class:`RobustScaler` as drop-in replacements
-instead, which use more robust estimates for the center and range of your
+instead. They use more robust estimates for the center and range of your
 data.
 
 

--- a/examples/preprocessing/README.txt
+++ b/examples/preprocessing/README.txt
@@ -1,0 +1,6 @@
+.. _preprocessing_examples:
+
+Preprocessing
+------------
+
+Examples concerning the :mod:`sklearn.preprocessing` module.

--- a/examples/preprocessing/plot_robust_scaling.py
+++ b/examples/preprocessing/plot_robust_scaling.py
@@ -46,24 +46,28 @@ X_train[0, 0] = -1000  # a fairly large outlier
 
 
 # Scale data
-s = StandardScaler()
-Xtr_s = s.fit_transform(X_train)
-Xte_s = s.transform(X_test)
+standard_scaler = StandardScaler()
+Xtr_s = standard_scaler.fit_transform(X_train)
+Xte_s = standard_scaler.transform(X_test)
 
-r = RobustScaler()
-Xtr_r = r.fit_transform(X_train)
-Xte_r = r.fit_transform(X_test)
+robust_scaler = RobustScaler()
+Xtr_r = robust_scaler.fit_transform(X_train)
+Xte_r = robust_scaler.fit_transform(X_test)
 
 
-# Plot data (note we zoom in to the data center, so the outlier
-# data point can't be seen in this plot).
-fig, ax = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
-ax[0].scatter(Xtr_s[:, 0], Xtr_s[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
-ax[1].scatter(Xtr_r[:, 0], Xtr_r[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
-ax[0].set_title("Training set after standard scaling")
-ax[1].set_title("Training set after robust scaling")
-ax[0].set_xlim(-3, 3)
-ax[0].set_ylim(-3, 3)
+# Plot data
+fig, ax = plt.subplots(1, 3, figsize=(12, 4))
+ax[0].scatter(X_train[:, 0], X_train[:, 1],
+              color=np.where(Y_train > 0, 'r', 'b'))
+ax[1].scatter(Xtr_s[:, 0], Xtr_s[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
+ax[2].scatter(Xtr_r[:, 0], Xtr_r[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
+ax[0].set_title("Unscaled data")
+ax[1].set_title("After standard scaling (zoomed in)")
+ax[2].set_title("After robust scaling (zoomed in)")
+# for the scaled data, we zoom in to the data center (outlier can't be seen!)
+for a in ax[1:]:
+    a.set_xlim(-3, 3)
+    a.set_ylim(-3, 3)
 plt.tight_layout()
 plt.show()
 

--- a/examples/preprocessing/plot_robust_scaling.py
+++ b/examples/preprocessing/plot_robust_scaling.py
@@ -29,11 +29,11 @@ from sklearn.preprocessing import StandardScaler, RobustScaler
 # Create training and test data
 np.random.seed(42)
 n_datapoints = 100
-C=[[0.9, 0.0],[0.0, 20.0]]
+Cov = [[0.9, 0.0], [0.0, 20.0]]
 mu1 = [100.0, -3.0]
 mu2 = [101.0, -3.0]
-X1 = np.random.multivariate_normal(mean=mu1, cov=C, size=n_datapoints)
-X2 = np.random.multivariate_normal(mean=mu2, cov=C, size=n_datapoints)
+X1 = np.random.multivariate_normal(mean=mu1, cov=Cov, size=n_datapoints)
+X2 = np.random.multivariate_normal(mean=mu2, cov=Cov, size=n_datapoints)
 Y_train = np.hstack([[-1]*n_datapoints, [1]*n_datapoints])
 X_train = np.vstack([X1, X2])
 

--- a/examples/preprocessing/plot_robust_scaling.py
+++ b/examples/preprocessing/plot_robust_scaling.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+=========================================================
+Robust Scaling on Toy Data
+=========================================================
+
+Making sure that each Feature has approximately the same scale can be a
+crucial preprocessing step. However, when data contains outliers,
+:class:`StandardScaler <sklearn.preprocessing.StandardScaler>` can often
+be mislead. In such cases, it is better to use a scaler that is robust
+against outliers.
+
+Here, we demonstrate this on a toy dataset, where one single datapoint
+is a large outlier.
+"""
+from __future__ import print_function
+print(__doc__)
+
+
+# Code source: Thomas Unterthiner
+# License: BSD 3 clause
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.preprocessing import StandardScaler, RobustScaler
+
+# Create training and test data
+np.random.seed(42)
+n_datapoints = 100
+C=[[0.9, 0.0],[0.0, 20.0]]
+mu1 = [100.0, -3.0]
+mu2 = [101.0, -3.0]
+X1 = np.random.multivariate_normal(mean=mu1, cov=C, size=n_datapoints)
+X2 = np.random.multivariate_normal(mean=mu2, cov=C, size=n_datapoints)
+Y_train = np.hstack([[-1]*n_datapoints, [1]*n_datapoints])
+X_train = np.vstack([X1, X2])
+
+X1 = np.random.multivariate_normal(mean=mu1, cov=C, size=n_datapoints)
+X2 = np.random.multivariate_normal(mean=mu2, cov=C, size=n_datapoints)
+Y_test = np.hstack([[-1]*n_datapoints, [1]*n_datapoints])
+X_test = np.vstack([X1, X2])
+
+X_train[0, 0] = -1000  # a fairly large outlier
+
+
+# Scale data
+s = StandardScaler()
+Xtr_s = s.fit_transform(X_train)
+Xte_s = s.transform(X_test)
+
+r = RobustScaler()
+Xtr_r = r.fit_transform(X_train)
+Xte_r = r.fit_transform(X_test)
+
+
+# Plot data (note we zoom in to the data center, so the outlier
+# data point can't be seen in this plot).
+fig, ax = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
+ax[0].scatter(Xtr_s[:, 0], Xtr_s[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
+ax[1].scatter(Xtr_r[:, 0], Xtr_r[:, 1], color=np.where(Y_train > 0, 'r', 'b'))
+ax[0].set_title("Training set after standard scaling")
+ax[1].set_title("Training set after robust scaling")
+ax[0].set_xlim(-3, 3)
+ax[0].set_ylim(-3, 3)
+plt.tight_layout()
+plt.show()
+
+
+# Classify using k-NN
+from sklearn.neighbors import KNeighborsClassifier
+
+knn = KNeighborsClassifier()
+knn.fit(Xtr_s, Y_train)
+acc_s = knn.score(Xte_s, Y_test)
+print("Testset accuracy using standard scaler: %.3f" % acc_s)
+knn.fit(Xtr_r, Y_train)
+acc_r = knn.score(Xte_r, Y_test)
+print("Testset accuracy using robust scaler:   %.3f" % acc_r)

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -7,11 +7,13 @@ from .data import Binarizer
 from .data import KernelCenterer
 from .data import MinMaxScaler
 from .data import Normalizer
+from .data import RobustScaler
 from .data import StandardScaler
 from .data import add_dummy_feature
 from .data import binarize
 from .data import normalize
 from .data import scale
+from .data import robust_scale
 from .data import OneHotEncoder
 
 from .data import PolynomialFeatures
@@ -33,11 +35,13 @@ __all__ = [
     'MinMaxScaler',
     'Normalizer',
     'OneHotEncoder',
+    'RobustScaler',
     'StandardScaler',
     'add_dummy_feature',
     'PolynomialFeatures',
     'binarize',
     'normalize',
     'scale',
+    'robust_scale',
     'label_binarize',
 ]

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -536,8 +536,6 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 elif self.axis == 0:
                     inplace_column_scale(X, 1.0 / self.scale_)
         else:
-            if self.copy:
-                X = X.copy()
             if self.with_centering:
                 X -= self.center_
             if self.with_scaling:
@@ -564,9 +562,6 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 else:
                     inplace_column_scale(X, self.scale_)
         else:
-            if self.copy:
-                X = X.copy()
-
             if self.with_scaling:
                 X *= self.scale_
             if self.with_centering:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -420,12 +420,6 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    interquartile_scale : float or string in  ["normal" (default), ],
-           The interquartile range is divided by this factor. If
-           `interquartile_scale` is "normal", the data is scaled so it
-           approximately reaches unit variance. This convergence assumes
-           Gaussian input data and will need a large number of samples.
-
     with_centering : boolean, True by default
         If True, center the data before scaling.
         This does not work (and will raise an exception) when attempted on
@@ -467,9 +461,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
     http://en.wikipedia.org/wiki/Interquartile_range
     """
 
-    def __init__(self, interquartile_scale="normal", with_centering=True,
-                 with_scaling=True, copy=True):
-        self.interquartile_scale = interquartile_scale
+    def __init__(self, with_centering=True, with_scaling=True, copy=True):
         self.with_centering = with_centering
         self.with_scaling = with_scaling
         self.copy = copy
@@ -510,21 +502,13 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         if sparse.issparse(X):
             raise TypeError("RobustScaler cannot be fitted on sparse inputs")
 
-        if not np.isreal(self.interquartile_scale):
-            if self.interquartile_scale != "normal":
-                raise ValueError("Unknown interquartile_scale value.")
-            else:
-                iqr_scale = 1.34898
-        else:
-            iqr_scale = self.interquartile_scale
-
         X = self._check_array(X, self.copy)
         if self.with_centering:
             self.center_ = np.median(X, axis=0)
 
         if self.with_scaling:
             q = np.percentile(X, (25, 75), axis=0)
-            self.scale_ = (q[1] - q[0]) / iqr_scale
+            self.scale_ = (q[1] - q[0])
             if np.isscalar(self.scale_):
                 if self.scale_ == 0:
                     self.scale_ = 1.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -529,7 +529,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                     self.scale_ = 1.
             else:
                 self.scale_[self.scale_ == 0.0] = 1.0
-                self.scale_[-np.isfinite(self.scale_)] = 1.0
+                self.scale_[~np.isfinite(self.scale_)] = 1.0
         return self
 
     def transform(self, X, y=None, copy=None):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -337,7 +337,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 X, axis=0, with_mean=self.with_mean, with_std=self.with_std)
             return self
 
-    def transform(self, X, y=None):
+    def transform(self, X, y=None, copy=None):
         """Perform standardization by centering and scaling
 
         Parameters
@@ -347,8 +347,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'std_')
 
-        X = check_array(X, accept_sparse='csr', copy=self.copy,
-                        ensure_2d=False)
+        copy = copy if copy is not None else self.copy
+        X = check_array(X, accept_sparse='csr', copy=copy, ensure_2d=False)
         if warn_if_not_float(X, estimator=self):
             X = X.astype(np.float)
         if sparse.issparse(X):
@@ -365,7 +365,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 X /= self.std_
         return X
 
-    def inverse_transform(self, X):
+    def inverse_transform(self, X, copy=None):
         """Scale back the data to the original representation
 
         Parameters
@@ -375,6 +375,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'std_')
 
+        copy = copy if copy is not None else self.copy
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
@@ -383,13 +384,13 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             if not sparse.isspmatrix_csr(X):
                 X = X.tocsr()
                 copy = False
-            if self.copy:
+            if copy:
                 X = X.copy()
             if self.std_ is not None:
                 inplace_column_scale(X, self.std_)
         else:
             X = np.asarray(X)
-            if self.copy:
+            if copy:
                 X = X.copy()
             if self.with_std:
                 X *= self.std_
@@ -532,7 +533,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 self.scale_[~np.isfinite(self.scale_)] = 1.0
         return self
 
-    def transform(self, X, y=None, copy=None):
+    def transform(self, X, y=None):
         """Center and scale the data
 
         Parameters
@@ -544,9 +545,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
             check_is_fitted(self, 'center_')
         if self.with_scaling:
             check_is_fitted(self, 'scale_')
-        if copy is None:
-            copy = self.copy
-        X = self._check_array(X, copy)
+        X = self._check_array(X, self.copy)
         if sparse.issparse(X):
             if self.with_scaling:
                 if X.shape[0] == 1:
@@ -554,7 +553,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 elif self.axis == 0:
                     inplace_column_scale(X, 1.0 / self.scale_)
         else:
-            if copy:
+            if self.copy:
                 X = X.copy()
             if self.with_centering:
                 X -= self.center_
@@ -562,7 +561,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 X /= self.scale_
         return X
 
-    def inverse_transform(self, X, copy=None):
+    def inverse_transform(self, X):
         """Scale back the data to the original representation
 
         Parameters
@@ -574,9 +573,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
             check_is_fitted(self, 'center_')
         if self.with_scaling:
             check_is_fitted(self, 'scale_')
-        if copy is None:
-            copy = self.copy
-        X = self._check_array(X, copy)
+        X = self._check_array(X, self.copy)
         if sparse.issparse(X):
             if self.with_scaling:
                 if X.shape[0] == 1:
@@ -584,7 +581,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 else:
                     inplace_column_scale(X, self.scale_)
         else:
-            if copy:
+            if self.copy:
                 X = X.copy()
 
             if self.with_scaling:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -397,6 +397,259 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         return X
 
 
+class RobustScaler(BaseEstimator, TransformerMixin):
+    """Standardize features by removing the median and scaling to IQR.
+
+    Centering and scaling happen independently on each feature (or each
+    sample, depending on the `axis` argument) by computing the relevant
+    statistics on the samples in the training set. Median and  interquartile
+    range are then stored to be used on later data using the `transform`
+    method.
+
+    Standardization of a dataset is a common requirement for many
+    machine learning estimators. Typically this is done by removing the mean
+    and scaling to unit variance. However, outliers can often influence the
+    sample mean / variance in a negative way. In such cases, the median and
+    the interquartile range often give better results.
+
+    Parameters
+    ----------
+    interquartile_scale: float or string in  ["normal" (default), ],
+           The interquartile range is divided by this factor. If
+           `interquartile_scale` is "normal", the data is scaled so it
+           approximately reaches unit variance. This converge assumes Gaussian
+           input data and will need a large number of samples.
+
+    with_centering : boolean, True by default
+        If True, center the data before scaling.
+        This does not work (and will raise an exception) when attempted on
+        sparse matrices, because centering them entails building a dense
+        matrix which in common use cases is likely to be too large to fit in
+        memory.
+
+    with_scaling : boolean, True by default
+        If True, scale the data to interquartile range.
+
+    copy : boolean, optional, default is True
+        If False, try to avoid a copy and do inplace scaling instead.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array or scipy.sparse CSR matrix, a copy may still be
+        returned.
+
+    Attributes
+    ----------
+    `center_` : array of floats
+        The median value for each feature in the training set, unless axis=1,
+        in which case it contains the median value for each sample
+
+    `scale_` : array of floats
+        The (scaled) interquartile range for each feature in the training set,
+        unless axis=1, in which case it contains the median value for each
+        sample.
+
+    See also
+    --------
+    :class:`sklearn.preprocessing.StandardScaler` to perform centering
+    and scaling using mean and variance.
+
+    :class:`sklearn.decomposition.RandomizedPCA` with `whiten=True`
+    to further remove the linear correlation across features.
+    """
+
+    def __init__(self, interquartile_scale="normal", with_centering=True,
+                 with_scaling=True, copy=True):
+        self.interquartile_scale = interquartile_scale
+        self.with_centering = with_centering
+        self.with_scaling = with_scaling
+        self.copy = copy
+
+    def _check_array(self, X, copy):
+        """Makes sure centering is not enabled for sparse matrices."""
+        X = check_array(X, accept_sparse=('csr', 'csc'),
+                        copy=copy, ensure_2d=False)
+        if warn_if_not_float(X, estimator=self):
+            X = X.astype(np.float)
+        if sparse.issparse(X):
+            if self.with_centering:
+                raise ValueError(
+                    "Cannot center sparse matrices: use `with_centering=False`"
+                    " instead. See docstring for motivation and alternatives.")
+        return X
+
+    def _handle_zeros_in_scale(self, scale):
+        ''' Makes sure that whenever scale is zero, we handle it correctly.
+
+        This happens in most scalers when we have constant features.'''
+        # if we are fitting on 1D arrays, scale might be a scalar
+        if np.isscalar(scale):
+            if scale == 0:
+                scale = 1.
+        elif isinstance(scale, np.ndarray):
+            scale[scale == 0.0] = 1.0
+            scale[-np.isfinite(scale)] = 1.0
+        return scale
+
+    def fit(self, X, y=None, copy=None):
+        """Compute the mean and std to be used for later scaling.
+
+        Parameters
+        ----------
+        X : array-like or CSR matrix with shape [n_samples, n_features]
+            The data used to compute the mean and standard deviation
+            used for later scaling along the features axis.
+        """
+        if sparse.issparse(X):
+            raise TypeError("RobustScaler cannot be fitted on sparse inputs")
+
+        if not np.isreal(self.interquartile_scale):
+            if self.interquartile_scale != "normal":
+                raise ValueError("Unknown interquartile_scale value.")
+            else:
+                iqr_scale = 1.34898
+        else:
+            iqr_scale = self.interquartile_scale
+
+        if copy is None:
+            copy = self.copy
+
+        self.center_ = None
+        self.scale_ = None
+        X = self._check_array(X, copy)
+        if self.with_centering:
+            self.center_ = np.median(X, axis=0)
+
+        if self.with_scaling:
+            q = np.percentile(X, (25, 75), axis=0)
+            self.scale_ = (q[1] - q[0]) / iqr_scale
+            if np.isscalar(self.scale_):
+                if self.scale_ == 0:
+                    self.scale_ = 1.
+            else:
+                self.scale_[self.scale_ == 0.0] = 1.0
+                self.scale_[-np.isfinite(self.scale_)] = 1.0
+        return self
+
+    def transform(self, X, y=None, copy=None):
+        """Perform standardization by centering and scaling
+
+        Parameters
+        ----------
+        X : array-like or CSR matrix.
+            The data used to scale along the specified axis.
+        """
+        if copy is None:
+            copy = self.copy
+        X = self._check_array(X, copy)
+        if sparse.issparse(X):
+            if self.with_scaling:
+                if X.shape[0] == 1:
+                    inplace_row_scale(X, 1.0 / self.scale_)
+                elif self.axis == 0:
+                    inplace_column_scale(X, 1.0 / self.scale_)
+        else:
+            if copy:
+                X = X.copy()
+            if self.with_centering:
+                X -= self.center_
+            if self.with_scaling:
+                X /= self.scale_
+        return X
+
+    def inverse_transform(self, X, copy=None):
+        """Scale back the data to the original representation
+
+        Parameters
+        ----------
+        X : array-like or CSR matrix.
+            The data used to scale along the specified axis.
+        """
+        if self.with_centering:
+            check_is_fitted(self, 'center_')
+        if self.with_scaling:
+            check_is_fitted(self, 'scale_')
+        if copy is None:
+            copy = self.copy
+        X = self._check_array(X, copy)
+        if sparse.issparse(X):
+            if self.with_scaling:
+                if X.shape[0] == 1:
+                    inplace_row_scale(X, self.scale_)
+                else:
+                    inplace_column_scale(X, self.scale_)
+        else:
+            if copy:
+                X = X.copy()
+
+            if self.with_scaling:
+                X *= self.scale_
+            if self.with_centering:
+                X += self.center_
+        return X
+
+
+def robust_scale(X, interquartile_scale="normal", axis=0, with_centering=True,
+                 with_scaling=True, copy=True):
+    """Standardize a dataset along any axis
+
+    Center to the median and component wise scale
+    according to the interquartile range.
+
+    Parameters
+    ----------
+    X : array-like or CSR matrix.
+        The data to center and scale.
+
+    interquartile_scale: float or string in  ["normal" (default), ],
+           The interquartile range is divided by this factor. If
+           `interquartile_scale` is "normal", the data is scaled so it
+           approximately reaches unit variance. This converge assumes Gaussian
+           input data and will need a large number of samples.
+
+    axis : int (0 by default)
+        axis used to compute the medians and IQR along. If 0,
+        independently scale each feature, otherwise (if 1) scale
+        each sample.
+
+    with_centering : boolean, True by default
+        If True, center the data before scaling.
+
+    with_scaling : boolean, True by default
+        If True, scale the data to unit variance (or equivalently,
+        unit standard deviation).
+
+    copy : boolean, optional, default is True
+        set to False to perform inplace row normalization and avoid a
+        copy (if the input is already a numpy array or a scipy.sparse
+        CSR matrix and if axis is 1).
+
+    Notes
+    -----
+    This implementation will refuse to center scipy.sparse matrices
+    since it would make them non-sparse and would potentially crash the
+    program with memory exhaustion problems.
+
+    Instead the caller is expected to either set explicitly
+    `with_centering=False` (in that case, only variance scaling will be
+    performed on the features of the CSR matrix) or to call `X.toarray()`
+    if he/she expects the materialized dense array to fit in memory.
+
+    To avoid memory copy the caller should pass a CSR matrix.
+
+    See also
+    --------
+    :class:`sklearn.preprocessing.RobustScaler` to perform centering and
+    scaling using the ``Transformer`` API (e.g. as part of a preprocessing
+    :class:`sklearn.pipeline.Pipeline`)
+    """
+    s = RobustScaler(interquartile_scale=interquartile_scale,
+                     with_centering=with_centering, with_scaling=with_scaling,
+                     copy=copy)
+    if axis == 0:
+        return s.fit_transform(X)
+    else:
+        return s.fit_transform(X.T).T
+
+
 class PolynomialFeatures(BaseEstimator, TransformerMixin):
     """Generate polynomial and interaction features.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -457,6 +457,8 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     Notes
     -----
+    See examples/preprocessing/plot_robust_scaling.py for an example.
+
     http://en.wikipedia.org/wiki/Median_(statistics)
     http://en.wikipedia.org/wiki/Interquartile_range
     """

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -402,9 +402,9 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 class RobustScaler(BaseEstimator, TransformerMixin):
     """Scale features using statistics that are robust to outliers.
 
-    This Scaler removes the median and and scales the data according to
+    This Scaler removes the median and scales the data according to
     the Interquartile Range (IQR). The IQR is the range between the 1st
-    quartile (25th quantile) and the and 3rd quartile (75th quantile).
+    quartile (25th quantile) and the 3rd quartile (75th quantile).
 
     Centering and scaling happen independently on each feature (or each
     sample, depending on the `axis` argument) by computing the relevant

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -335,7 +335,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 X, axis=0, with_mean=self.with_mean, with_std=self.with_std)
             return self
 
-    def transform(self, X, y=None, copy=None):
+    def transform(self, X, y=None):
         """Perform standardization by centering and scaling
 
         Parameters
@@ -345,8 +345,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'std_')
 
-        copy = copy if copy is not None else self.copy
-        X = check_array(X, accept_sparse='csr', copy=copy, ensure_2d=False)
+        X = check_array(X, accept_sparse='csr', copy=self.copy,
+                        ensure_2d=False)
         if warn_if_not_float(X, estimator=self):
             X = X.astype(np.float)
         if sparse.issparse(X):
@@ -363,7 +363,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
                 X /= self.std_
         return X
 
-    def inverse_transform(self, X, copy=None):
+    def inverse_transform(self, X):
         """Scale back the data to the original representation
 
         Parameters
@@ -373,7 +373,6 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         """
         check_is_fitted(self, 'std_')
 
-        copy = copy if copy is not None else self.copy
         if sparse.issparse(X):
             if self.with_mean:
                 raise ValueError(
@@ -382,13 +381,13 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             if not sparse.isspmatrix_csr(X):
                 X = X.tocsr()
                 copy = False
-            if copy:
+            if self.copy:
                 X = X.copy()
             if self.std_ is not None:
                 inplace_column_scale(X, self.std_)
         else:
             X = np.asarray(X)
-            if copy:
+            if self.copy:
                 X = X.copy()
             if self.with_std:
                 X *= self.std_
@@ -507,10 +506,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         else:
             iqr_scale = self.interquartile_scale
 
-        if copy is None:
-            copy = self.copy
-
-        X = self._check_array(X, copy)
+        X = self._check_array(X, self.copy)
         if self.with_centering:
             self.center_ = np.median(X, axis=0)
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -493,12 +493,12 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         return scale
 
     def fit(self, X, y=None):
-        """Compute the mean and quantiles to be used for scaling.
+        """Compute the median and quantiles to be used for scaling.
 
         Parameters
         ----------
         X : array-like with shape [n_samples, n_features]
-            The data used to compute the mean and standard deviation
+            The data used to compute the median and quantiles
             used for later scaling along the features axis.
         """
         if sparse.issparse(X):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -31,11 +31,13 @@ __all__ = [
     'MinMaxScaler',
     'Normalizer',
     'OneHotEncoder',
+    'RobustScaler',
     'StandardScaler',
     'add_dummy_feature',
     'binarize',
     'normalize',
     'scale',
+    'robust_scale',
 ]
 
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -577,8 +577,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         return X
 
 
-def robust_scale(X, interquartile_scale="normal", axis=0, with_centering=True,
-                 with_scaling=True, copy=True):
+def robust_scale(X, axis=0, with_centering=True, with_scaling=True, copy=True):
     """Standardize a dataset along any axis
 
     Center to the median and component wise scale
@@ -588,12 +587,6 @@ def robust_scale(X, interquartile_scale="normal", axis=0, with_centering=True,
     ----------
     X : array-like.
         The data to center and scale.
-
-    interquartile_scale : float or string in  ["normal" (default), ],
-           The interquartile range is divided by this factor. If
-           `interquartile_scale` is "normal", the data is scaled so it
-           approximately reaches unit variance. This convergence assumes
-           Gaussian input data and will need a large number of samples.
 
     axis : int (0 by default)
         axis used to compute the medians and IQR along. If 0,
@@ -631,8 +624,7 @@ def robust_scale(X, interquartile_scale="normal", axis=0, with_centering=True,
     scaling using the ``Transformer`` API (e.g. as part of a preprocessing
     :class:`sklearn.pipeline.Pipeline`)
     """
-    s = RobustScaler(interquartile_scale=interquartile_scale,
-                     with_centering=with_centering, with_scaling=with_scaling,
+    s = RobustScaler(with_centering=with_centering, with_scaling=with_scaling,
                      copy=copy)
     if axis == 0:
         return s.fit_transform(X)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -465,10 +465,8 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     def _check_array(self, X, copy):
         """Makes sure centering is not enabled for sparse matrices."""
-        X = check_array(X, accept_sparse=('csr', 'csc'),
+        X = check_array(X, accept_sparse=('csr', 'csc'), dtype=np.float,
                         copy=copy, ensure_2d=False)
-        if warn_if_not_float(X, estimator=self):
-            X = X.astype(np.float)
         if sparse.issparse(X):
             if self.with_centering:
                 raise ValueError(

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -414,11 +414,11 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    interquartile_scale: float or string in  ["normal" (default), ],
+    interquartile_scale : float or string in  ["normal" (default), ],
            The interquartile range is divided by this factor. If
            `interquartile_scale` is "normal", the data is scaled so it
-           approximately reaches unit variance. This converge assumes Gaussian
-           input data and will need a large number of samples.
+           approximately reaches unit variance. This convergence assumes
+           Gaussian input data and will need a large number of samples.
 
     with_centering : boolean, True by default
         If True, center the data before scaling.
@@ -489,12 +489,12 @@ class RobustScaler(BaseEstimator, TransformerMixin):
             scale[-np.isfinite(scale)] = 1.0
         return scale
 
-    def fit(self, X, y=None, copy=None):
-        """Compute the mean and std to be used for later scaling.
+    def fit(self, X, y=None):
+        """Compute the mean and quantiles to be used for scaling.
 
         Parameters
         ----------
-        X : array-like or CSR matrix with shape [n_samples, n_features]
+        X : array-like with shape [n_samples, n_features]
             The data used to compute the mean and standard deviation
             used for later scaling along the features axis.
         """
@@ -528,7 +528,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X, y=None, copy=None):
-        """Perform standardization by centering and scaling
+        """Center and scale the data
 
         Parameters
         ----------
@@ -598,14 +598,14 @@ def robust_scale(X, interquartile_scale="normal", axis=0, with_centering=True,
 
     Parameters
     ----------
-    X : array-like or CSR matrix.
+    X : array-like.
         The data to center and scale.
 
-    interquartile_scale: float or string in  ["normal" (default), ],
+    interquartile_scale : float or string in  ["normal" (default), ],
            The interquartile range is divided by this factor. If
            `interquartile_scale` is "normal", the data is scaled so it
-           approximately reaches unit variance. This converge assumes Gaussian
-           input data and will need a large number of samples.
+           approximately reaches unit variance. This convergence assumes
+           Gaussian input data and will need a large number of samples.
 
     axis : int (0 by default)
         axis used to compute the medians and IQR along. If 0,

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -439,13 +439,10 @@ class RobustScaler(BaseEstimator, TransformerMixin):
     Attributes
     ----------
     `center_` : array of floats
-        The median value for each feature in the training set, unless axis=1,
-        in which case it contains the median value for each sample
+        The median value for each feature in the training set.
 
     `scale_` : array of floats
-        The (scaled) interquartile range for each feature in the training set,
-        unless axis=1, in which case it contains the median value for each
-        sample.
+        The (scaled) interquartile range for each feature in the training set.
 
     See also
     --------
@@ -489,7 +486,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                 scale = 1.
         elif isinstance(scale, np.ndarray):
             scale[scale == 0.0] = 1.0
-            scale[-np.isfinite(scale)] = 1.0
+            scale[~np.isfinite(scale)] = 1.0
         return scale
 
     def fit(self, X, y=None):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -512,8 +512,6 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         if copy is None:
             copy = self.copy
 
-        self.center_ = None
-        self.scale_ = None
         X = self._check_array(X, copy)
         if self.with_centering:
             self.center_ = np.median(X, axis=0)
@@ -537,6 +535,10 @@ class RobustScaler(BaseEstimator, TransformerMixin):
         X : array-like or CSR matrix.
             The data used to scale along the specified axis.
         """
+        if self.with_centering:
+            check_is_fitted(self, 'center_')
+        if self.with_scaling:
+            check_is_fitted(self, 'scale_')
         if copy is None:
             copy = self.copy
         X = self._check_array(X, copy)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -399,7 +399,11 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
 
 class RobustScaler(BaseEstimator, TransformerMixin):
-    """Standardize features by removing the median and scaling to IQR.
+    """Scale features using statistics that are robust to outliers.
+
+    This Scaler removes the median and and scales the data according to
+    the Interquartile Range (IQR). The IQR is the range between the 1st
+    quartile (25th quantile) and the and 3rd quartile (75th quantile).
 
     Centering and scaling happen independently on each feature (or each
     sample, depending on the `axis` argument) by computing the relevant
@@ -455,6 +459,11 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     :class:`sklearn.decomposition.RandomizedPCA` with `whiten=True`
     to further remove the linear correlation across features.
+
+    Notes
+    -----
+    http://en.wikipedia.org/wiki/Median_(statistics)
+    http://en.wikipedia.org/wiki/Interquartile_range
     """
 
     def __init__(self, interquartile_scale="normal", with_centering=True,

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -472,7 +472,7 @@ def test_robust_scaler_2d_arrays():
 
 def test_robust_scaler_iris():
     X = iris.data
-    scaler = RobustScaler(interquartile_scale=1.0)
+    scaler = RobustScaler()
     X_trans = scaler.fit_transform(X)
     assert_array_almost_equal(np.median(X_trans, axis=0), 0)
     X_trans_inv = scaler.inverse_transform(X_trans)
@@ -484,34 +484,11 @@ def test_robust_scaler_iris():
 
 def test_robust_scale_axis1():
     X = iris.data
-    X_trans = robust_scale(X, interquartile_scale=1.0, axis=1)
+    X_trans = robust_scale(X, axis=1)
     assert_array_almost_equal(np.median(X_trans, axis=1), 0)
     q = np.percentile(X_trans, q=(25, 75), axis=1)
     iqr = q[1] - q[0]
     assert_array_almost_equal(iqr, 1)
-
-
-def test_robust_scaler_iqr_scale():
-    """Does iqr scaling achieve approximately std= 1 on Gaussian data?"""
-    rng = np.random.RandomState(42)
-    X = rng.randn(10000, 4)  # need lots of samples
-    scaler = RobustScaler()
-    X_trans = scaler.fit_transform(X)
-    assert_array_almost_equal(X_trans.std(axis=0), 1,  decimal=2)
-
-
-def test_robust_scale_iqr_errors():
-    """Check that invalid arguments yield ValueError"""
-    rng = np.random.RandomState(42)
-    X = rng.randn(4, 5)
-    assert_raises(ValueError, RobustScaler(interquartile_scale="foo").fit, X)
-    # TODO: for some reason assert_raise doesn't test this correctly
-    did_raise = False
-    try:
-        robust_scale(X, interquartile_scale="foo")
-    except ValueError:
-        did_raise = True
-    assert(did_raise)
 
 
 def test_robust_scaler_zero_variance_features():
@@ -520,7 +497,7 @@ def test_robust_scaler_zero_variance_features():
          [0., 1., -0.1],
          [0., 1., +1.1]]
 
-    scaler = RobustScaler(interquartile_scale=1.0)
+    scaler = RobustScaler()
     X_trans = scaler.fit_transform(X)
 
     # NOTE: for such a small sample size, what we expect in the third column

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -464,7 +464,7 @@ def test_robust_scaler_2d_arrays():
     X[:, 0] = 0.0  # first feature is always of zero
 
     scaler = RobustScaler()
-    X_scaled = scaler.fit(X).transform(X, copy=True)
+    X_scaled = scaler.fit(X).transform(X)
 
     assert_array_almost_equal(np.median(X_scaled, axis=0), 5 * [0.0])
     assert_array_almost_equal(X_scaled.std(axis=0)[0], 0)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -558,8 +558,6 @@ def test_warning_scaling_integers():
     assert_warns_message(UserWarning, w, scale, X)
     assert_warns_message(UserWarning, w, StandardScaler().fit, X)
     assert_warns_message(UserWarning, w, MinMaxScaler().fit, X)
-    assert_warns_message(UserWarning, w, robust_scale, X)
-    assert_warns_message(UserWarning, w, RobustScaler().fit, X)
 
 
 def test_normalizer_l1():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -25,6 +25,8 @@ from sklearn.preprocessing.data import OneHotEncoder
 from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler
+from sklearn.preprocessing.data import RobustScaler
+from sklearn.preprocessing.data import robust_scale
 from sklearn.preprocessing.data import add_dummy_feature
 from sklearn.preprocessing.data import PolynomialFeatures
 
@@ -455,6 +457,96 @@ def test_scale_function_without_centering():
     assert_array_almost_equal(X_csr_scaled_std, X_scaled.std(axis=0))
 
 
+def test_robust_scaler_2d_arrays():
+    """Test robust scaling of 2d array along first axis"""
+    rng = np.random.RandomState(0)
+    X = rng.randn(4, 5)
+    X[:, 0] = 0.0  # first feature is always of zero
+
+    scaler = RobustScaler()
+    X_scaled = scaler.fit(X).transform(X, copy=True)
+
+    assert_array_almost_equal(np.median(X_scaled, axis=0), 5 * [0.0])
+    assert_array_almost_equal(X_scaled.std(axis=0)[0], 0)
+
+
+def test_robust_scaler_iris():
+    X = iris.data
+    scaler = RobustScaler(interquartile_scale=1.0)
+    X_trans = scaler.fit_transform(X)
+    assert_array_almost_equal(np.median(X_trans, axis=0), 0)
+    X_trans_inv = scaler.inverse_transform(X_trans)
+    assert_array_almost_equal(X, X_trans_inv)
+    q = np.percentile(X_trans, q=(25, 75), axis=0)
+    iqr = q[1] - q[0]
+    assert_array_almost_equal(iqr, 1)
+
+
+def test_robust_scale_axis1():
+    X = iris.data
+    X_trans = robust_scale(X, interquartile_scale=1.0, axis=1)
+    assert_array_almost_equal(np.median(X_trans, axis=1), 0)
+    q = np.percentile(X_trans, q=(25, 75), axis=1)
+    iqr = q[1] - q[0]
+    assert_array_almost_equal(iqr, 1)
+
+
+def test_robust_scaler_iqr_scale():
+    """Does iqr scaling achieve approximately std= 1 on Gaussian data?"""
+    rng = np.random.RandomState(42)
+    X = rng.randn(10000, 4)  # need lots of samples
+    scaler = RobustScaler()
+    X_trans = scaler.fit_transform(X)
+    assert_array_almost_equal(X_trans.std(axis=0), 1,  decimal=2)
+
+
+def test_robust_scale_iqr_errors():
+    """Check that invalid arguments yield ValueError"""
+    rng = np.random.RandomState(42)
+    X = rng.randn(4, 5)
+    assert_raises(ValueError, RobustScaler(interquartile_scale="foo").fit, X)
+    # TODO: for some reason assert_raise doesn't test this correctly
+    did_raise = False
+    try:
+        robust_scale(X, interquartile_scale="foo")
+    except ValueError:
+        did_raise = True
+    assert(did_raise)
+
+
+def test_robust_scaler_zero_variance_features():
+    """Check min max scaler on toy data with zero variance features"""
+    X = [[0., 1., +0.5],
+         [0., 1., -0.1],
+         [0., 1., +1.1]]
+
+    scaler = RobustScaler(interquartile_scale=1.0)
+    X_trans = scaler.fit_transform(X)
+
+    # NOTE: for such a small sample size, what we expect in the third column
+    # depends HEAVILY on the method used to calculate quantiles. The values
+    # here were calculated to fit the quantiles produces by np.percentile
+    # using numpy 1.9 Calculating quantiles with
+    # scipy.stats.mstats.scoreatquantile or scipy.stats.mstats.mquantiles
+    # would yield very different results!
+    X_expected = [[0., 0., +0.0],
+                  [0., 0., -1.0],
+                  [0., 0., +1.0]]
+    assert_array_almost_equal(X_trans, X_expected)
+    X_trans_inv = scaler.inverse_transform(X_trans)
+    assert_array_almost_equal(X, X_trans_inv)
+
+    # make sure new data gets transformed correctly
+    X_new = [[+0., 2., 0.5],
+             [-1., 1., 0.0],
+             [+0., 1., 1.5]]
+    X_trans_new = scaler.transform(X_new)
+    X_expected_new = [[+0., 1., +0.],
+                      [-1., 0., -0.83333],
+                      [+0., 0., +1.66667]]
+    assert_array_almost_equal(X_trans_new, X_expected_new, decimal=3)
+
+
 def test_warning_scaling_integers():
     """Check warning when scaling integer data"""
     X = np.array([[1, 2, 0],
@@ -466,6 +558,8 @@ def test_warning_scaling_integers():
     assert_warns_message(UserWarning, w, scale, X)
     assert_warns_message(UserWarning, w, StandardScaler().fit, X)
     assert_warns_message(UserWarning, w, MinMaxScaler().fit, X)
+    assert_warns_message(UserWarning, w, robust_scale, X)
+    assert_warns_message(UserWarning, w, RobustScaler().fit, X)
 
 
 def test_normalizer_l1():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -515,7 +515,7 @@ def test_robust_scale_iqr_errors():
 
 
 def test_robust_scaler_zero_variance_features():
-    """Check min max scaler on toy data with zero variance features"""
+    """Check RobustScaler on toy data with zero variance features"""
     X = [[0., 1., +0.5],
          [0., 1., -0.1],
          [0., 1., +1.1]]


### PR DESCRIPTION
This PR adds `RobustScaler` and `robust_scale` as alternative to `StandardScaler` and `scale`. They use robust estimates of data center/scale (median & interquartile range), which will work better for data with outliers.

Most of this was discussed before in #2514 (and even older commits). I separated this out so it can be merged as-is.

I originally wanted to submit this only after #3639 was merged, but sending the PR now allows it to be discussed concurrently (if either this or #3639 get merged, I'll of course update the other commit).
