### PR TITLE
[WIP] ENH Multilabel confusion matrix

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -16,6 +16,7 @@ from .ranking import roc_curve
 from .classification import accuracy_score
 from .classification import classification_report
 from .classification import cohen_kappa_score
+from .classification import binarized_multilabel_confusion_matrix
 from .classification import confusion_matrix
 from .classification import f1_score
 from .classification import fbeta_score
@@ -70,6 +71,7 @@ __all__ = [
     'classification_report',
     'cluster',
     'completeness_score',
+    'binarized_multilabel_confusion_matrix',
     'confusion_matrix',
     'consensus_score',
     'coverage_error',

--- a/sklearn/metrics/metrics.py
+++ b/sklearn/metrics/metrics.py
@@ -1,0 +1,34 @@
+import warnings
+warnings.warn("sklearn.metrics.metrics is deprecated and will be removed in "
+              "0.18. Please import from sklearn.metrics",
+              DeprecationWarning)
+
+
+from .ranking import auc
+from .ranking import average_precision_score
+from .ranking import label_ranking_average_precision_score
+from .ranking import precision_recall_curve
+from .ranking import roc_auc_score
+from .ranking import roc_curve
+
+from .classification import accuracy_score
+from .classification import classification_report
+from .classification import binarized_multilabel_confusion_matrix
+from .classification import confusion_matrix
+from .classification import f1_score
+from .classification import fbeta_score
+from .classification import hamming_loss
+from .classification import hinge_loss
+from .classification import jaccard_similarity_score
+from .classification import log_loss
+from .classification import matthews_corrcoef
+from .classification import precision_recall_fscore_support
+from .classification import precision_score
+from .classification import recall_score
+from .classification import zero_one_loss
+
+from .regression import explained_variance_score
+from .regression import mean_absolute_error
+from .regression import mean_squared_error
+from .regression import median_absolute_error
+from .regression import r2_score


### PR DESCRIPTION
Fixes #3452 

~~Based on #3614~~ (This is rewritten to conform to the referenced implementations). Thanks @Magellanea!
- [x] `binarized_multilabel_confusion_matrix` -> `multilabel_confusion_matrix`
- [x] Return MCM of shape `(n_labels, 4)` instead of numpy struct array.
- [x] Add `multilabel_confusion_matrix` entry to `test_common.py`
- [x] Add `multilabel_confusion_matrix` tests to `test_classification.py`
- [x] Add what's new entry
- [x] Add to metrics doc.

Rewrite TODO
- [ ] Rewrite `multilabel_confusion_matrix` to conform to more standard approaches.

Ref - http://www.clips.ua.ac.be/~vincent/scripts/confusionmatrix.py
Ref2 - http://www.clips.ua.ac.be/~vincent/pdf/microaverage.pdf
Ref3 - http://metaoptimize.com/qa/questions/8964/confusion-matrix-for-multiclass-multilabel-classification
