### PR TITLE
[MRG] Bootstrap with test_size=1 fix

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -685,11 +685,11 @@ class Bootstrap(object):
                       "will be removed in 0.17", DeprecationWarning)
         self.n = n
         self.n_iter = n_iter
-        if (isinstance(train_size, numbers.Real) and train_size >= 0.0
+        if isinstance(train_size, numbers.Integral):
+            self.train_size = train_size
+        elif (isinstance(train_size, numbers.Real) and train_size >= 0.0
                 and train_size <= 1.0):
             self.train_size = int(ceil(train_size * n))
-        elif isinstance(train_size, numbers.Integral):
-            self.train_size = train_size
         else:
             raise ValueError("Invalid value for train_size: %r" %
                              train_size)
@@ -697,10 +697,10 @@ class Bootstrap(object):
             raise ValueError("train_size=%d should not be larger than n=%d" %
                              (self.train_size, n))
 
-        if isinstance(test_size, numbers.Real) and 0.0 <= test_size <= 1.0:
-            self.test_size = int(ceil(test_size * n))
-        elif isinstance(test_size, numbers.Integral):
+        if isinstance(test_size, numbers.Integral):
             self.test_size = test_size
+        elif isinstance(test_size, numbers.Real) and 0.0 <= test_size <= 1.0:
+            self.test_size = int(ceil(test_size * n))
         elif test_size is None:
             self.test_size = self.n - self.train_size
         else:

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -926,6 +926,8 @@ def test_bootstrap_errors():
 @ignore_warnings
 def test_bootstrap_test_sizes():
     assert_equal(cval.Bootstrap(10, test_size=0.2).test_size, 2)
+    assert_equal(cval.Bootstrap(10, test_size=1).test_size, 1)
+    assert_equal(cval.Bootstrap(10, train_size=1.).train_size, 10)
     assert_equal(cval.Bootstrap(10, test_size=2).test_size, 2)
     assert_equal(cval.Bootstrap(10, test_size=None).test_size, 5)
 


### PR DESCRIPTION
Before `test_size=1` gave you the whole data.

``` python
isinstance(1, numbers.real) == True
```

so we need to change the order of evaluation.

Fixes #4070
