### PR TITLE
[MRG + 1] fix agglomerative clustering w/ precomputed distances & connectivity matrix

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -167,6 +167,7 @@ Classes
    cross_validation.LeaveOneOut
    cross_validation.LeavePLabelOut
    cross_validation.LeavePOut
+   cross_validation.PredefinedSplit
    cross_validation.StratifiedKFold
    cross_validation.ShuffleSplit
    cross_validation.StratifiedShuffleSplit

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -168,7 +168,7 @@ Enhancements
      and :class:`tree.ExtraTreeClassifier`. By `Trevor Stephens`_.
 
    - :class:`grid_search.RandomizedSearchCV` now does sampling without
-     replacement if all parameters are given as lists. By `Andreas Mueller`_.
+     replacement if all parameters are given as lists. By `Andreas Müller`_.
 
    - Parallelized calculation of :func:`pairwise_distances` is now supported
      for scipy metrics and custom callables. By `Joel Nothman`_.
@@ -322,6 +322,10 @@ API changes summary
     - From now onwards, all estimators will uniformly raise ``NotFittedError``
       (:class:`utils.validation.NotFittedError`), when any of the ``predict``
       like methods are called before the model is fit. By `Raghav R V`_.
+
+    - Input data validation was refactored for more consistent input
+      validation. The ``check_arrays`` function was replaced by ``check_array``
+      and ``check_X_y``. By `Andreas Müller`_.
 
 .. _changes_0_15_2:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,10 @@ New features
      kernelized ridge regression.
      By `Mathieu Blondel`_ and `Jan Hendrik Metzen`_.
 
+   - Added :class:`cross_validation.PredefinedSplit` cross-validation
+     for fixed user-provided cross-validation folds.
+     By `untom <https://github.com/untom>`_.
+
 
 Enhancements
 ............

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -436,11 +436,11 @@ def linkage_tree(X, connectivity=None, n_components=None,
     connectivity.data = connectivity.data[diag_mask]
     del diag_mask
 
-    # FIXME We compute all the distances, while we could have only computed
-    # the "interesting" distances
     if affinity == 'precomputed':
-        distances = np.array([X[i][j] for i,j in zip(connectivity.row, connectivity.col)])
+        distances = X[connectivity.row, connectivity.col]
     else:
+        # FIXME We compute all the distances, while we could have only computed
+        # the "interesting" distances
         distances = paired_distances(X[connectivity.row],
                                      X[connectivity.col],
                                      metric=affinity)

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -438,9 +438,12 @@ def linkage_tree(X, connectivity=None, n_components=None,
 
     # FIXME We compute all the distances, while we could have only computed
     # the "interesting" distances
-    distances = paired_distances(X[connectivity.row],
-                                 X[connectivity.col],
-                                 metric=affinity)
+    if affinity == 'precomputed':
+        distances = np.array([X[i][j] for i,j in zip(connectivity.row, connectivity.col)])
+    else:
+        distances = paired_distances(X[connectivity.row],
+                                     X[connectivity.col],
+                                     metric=affinity)
     connectivity.data = distances
 
     if n_clusters is None:

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -11,6 +11,7 @@ from functools import partial
 import numpy as np
 from scipy import sparse
 from scipy.cluster import hierarchy
+from scipy.spatial.distance import pdist, squareform
 
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_raises
@@ -50,6 +51,7 @@ def test_linkage_misc():
 
     # test hiearchical clustering on a precomputed distances matrix
     dis = cosine_distances(X)
+
     res = linkage_tree(dis, affinity="precomputed")
     assert_array_equal(res[0], linkage_tree(X, affinity="cosine")[0])
 
@@ -191,6 +193,22 @@ def test_agglomerative_clustering():
         assert_almost_equal(normalized_mutual_info_score(clustering2.labels_,
                                                          clustering.labels_),
                             1)
+
+    # Test that using a distance matrix (affinity = 'precomputed') has same results
+    # (with connectivity constraints)
+    clustering = AgglomerativeClustering(
+            n_clusters=10,
+            connectivity=connectivity,
+            linkage="complete")
+    clustering.fit(X)
+    X_dist = squareform(pdist(X))
+    clustering2 = AgglomerativeClustering(
+            n_clusters=10,
+            connectivity=connectivity,
+            affinity='precomputed',
+            linkage="complete")
+    clustering2.fit(X_dist)
+    assert_array_equal(clustering.labels_, clustering2.labels_)
 
 
 def test_ward_agglomeration():

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -23,7 +23,6 @@ The module structure is the following:
 from __future__ import print_function
 from __future__ import division
 from abc import ABCMeta, abstractmethod
-from warnings import warn
 from time import time
 
 import numbers
@@ -219,8 +218,8 @@ class LossFunction(six.with_metaclass(ABCMeta, object)):
         sample_mask : ndarray, shape=(n,)
             The sample mask to be used.
         learning_rate : float, default=0.1
-            learning rate shrinks the contribution of each tree by 
-            ``learning_rate``.
+            learning rate shrinks the contribution of each tree by
+             ``learning_rate``.
         k : int, default 0
             The index of the estimator being updated.
 
@@ -268,8 +267,8 @@ class LeastSquaresError(RegressionLossFunction):
         if sample_weight is None:
             return np.mean((y - pred.ravel()) ** 2.0)
         else:
-            return (1.0 / sample_weight.sum()) * \
-              np.sum(sample_weight * ((y - pred.ravel()) ** 2.0))
+            return (1.0 / sample_weight.sum() *
+                    np.sum(sample_weight * ((y - pred.ravel()) ** 2.0)))
 
     def negative_gradient(self, y, pred, **kargs):
         return y - pred.ravel()
@@ -298,8 +297,8 @@ class LeastAbsoluteError(RegressionLossFunction):
         if sample_weight is None:
             return np.abs(y - pred.ravel()).mean()
         else:
-            return (1.0 / sample_weight.sum()) * \
-              np.sum(sample_weight * np.abs(y - pred.ravel()))
+            return (1.0 / sample_weight.sum() *
+                    np.sum(sample_weight * np.abs(y - pred.ravel())))
 
     def negative_gradient(self, y, pred, **kargs):
         """1.0 if y - pred > 0.0 else -1.0"""
@@ -602,8 +601,8 @@ class ExponentialLoss(ClassificationLossFunction):
         if sample_weight is None:
             return np.mean(np.exp(-(2. * y - 1.) * pred))
         else:
-            return (1.0 / sample_weight.sum()) * \
-              np.sum(sample_weight * np.exp(-(2 * y - 1) * pred))
+            return (1.0 / sample_weight.sum() *
+                    np.sum(sample_weight * np.exp(-(2 * y - 1) * pred)))
 
     def negative_gradient(self, y, pred, **kargs):
         y_ = -(2. * y - 1.)
@@ -1147,6 +1146,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         # Default implementation
         return y
 
+
 class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     """Gradient Boosting for classification.
 
@@ -1333,13 +1333,12 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
         Returns
         -------
-        y : array of shape = [n_samples]
+        y : generator of array of shape = [n_samples]
             The predicted value of the input samples.
         """
         for score in self.staged_decision_function(X):
             decisions = self.loss_._score_to_decision(score)
             yield self.classes_.take(decisions, axis=0)
-
 
     def predict_proba(self, X):
         """Predict class probabilities for X.
@@ -1363,7 +1362,7 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         score = self.decision_function(X)
         try:
             return self.loss_._score_to_proba(score)
-        except NotFittedError as e:
+        except NotFittedError:
             raise
         except AttributeError:
             raise AttributeError('loss=%r does not support predict_proba' %
@@ -1382,13 +1381,13 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
         Returns
         -------
-        y : array of shape = [n_samples]
+        y : generator of array of shape = [n_samples]
             The predicted value of the input samples.
         """
         try:
             for score in self.staged_decision_function(X):
                 yield self.loss_._score_to_proba(score)
-        except NotFittedError as e:
+        except NotFittedError:
             raise
         except AttributeError:
             raise AttributeError('loss=%r does not support predict_proba' %
@@ -1576,7 +1575,7 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
         Returns
         -------
-        y : array of shape = [n_samples]
+        y : generator of array of shape = [n_samples]
             The predicted value of the input samples.
         """
         for y in self.staged_decision_function(X):


### PR DESCRIPTION
linkage_tree doesn't calculate distances when affinity = 'precomputed' and connectivity is not None. PR includes fix & test case. let me know if there's anything I should change!
