### PR TITLE
[MRG+1] NB partial_fit with class_prior - Fixes #3186

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -272,6 +272,10 @@ Bug fixes
       :class:`cluster.AgglomerativeClustering` when using connectivity
       constraints. By `Cathy Deng`_
 
+    - Correct ``partial_fit`` handling of ``class_prior`` for
+      :class:`sklearn.naive_bayes.MultinomialNB` and
+      :class:`sklearn.naive_bayes.BernoulliNB`. By `Trevor Stephens`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -437,6 +437,8 @@ class BaseDiscreteNB(BaseNB):
         if sample_weight is not None:
             Y *= check_array(sample_weight).T
 
+        class_prior = self.class_prior
+
         # Count raw events from data before updating the class log prior
         # and feature log probas
         self._count(X, Y)
@@ -446,7 +448,7 @@ class BaseDiscreteNB(BaseNB):
         # calls to partial_fit and prior any call to predict[_[log_]proba]
         # to avoid computing the smooth log probas at each call to partial fit
         self._update_feature_log_prob()
-        self._update_class_log_prior()
+        self._update_class_log_prior(class_prior=class_prior)
         return self
 
     def fit(self, X, y, sample_weight=None):


### PR DESCRIPTION
Fixes #3186 @amueller 

This actually affected both `BernoulliNB` and `MultinomialNB` as they share the `partial_fit` function. Added a test for this too.
