### PR TITLE
[MRG+1] make defensive copies in GradientBoosting*.staged_decision function.

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1120,7 +1120,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         score = self._init_decision_function(X)
         for i in range(self.estimators_.shape[0]):
             predict_stage(self.estimators_, i, X, self.learning_rate, score)
-            yield score
+            yield score.copy()
 
     @property
     def feature_importances_(self):


### PR DESCRIPTION
Fixes #3741.
@pprett do you see any problem with this?
I feel like a function that is solely for debugging should not worry that much about memory consumption. Also, the memory consumption is really not that large, as GRBT is usually used for binary classification.
