### PR TITLE
[MRG+2] add validation for non-empty input data

### DIFF
--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -435,7 +435,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin):
 
             self.constant = check_array(self.constant,
                                         accept_sparse=['csr', 'csc', 'coo'],
-                                        ensure_2d=False)
+                                        ensure_2d=False, ensure_min_samples=0)
 
             if self.output_2d_ and self.constant.shape[0] != y.shape[1]:
                 raise ValueError(

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -8,6 +8,7 @@ from nose.tools import assert_raises, assert_true, assert_false, assert_equal
 from itertools import product
 
 from sklearn.utils import as_float_array, check_array, check_symmetric
+from sklearn.utils import check_X_y
 
 from sklearn.utils.estimator_checks import NotAnArray
 
@@ -19,12 +20,12 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.svm import SVR
 
 from sklearn.datasets import make_blobs
-from sklearn.utils import as_float_array, check_array
-from sklearn.utils.estimator_checks import NotAnArray
 from sklearn.utils.validation import (
-        NotFittedError,
-        has_fit_parameter,
-        check_is_fitted)
+    NotFittedError,
+    has_fit_parameter,
+    check_is_fitted)
+
+from sklearn.utils.testing import assert_raise_message
 
 
 def test_as_float_array():
@@ -177,7 +178,7 @@ def test_check_array():
     Xs = [X_csc, X_coo, X_dok, X_int, X_float]
     accept_sparses = [['csr', 'coo'], ['coo', 'dok']]
     for X, dtype, accept_sparse, copy in product(Xs, dtypes, accept_sparses,
-                                                  copys):
+                                                 copys):
         X_checked = check_array(X, dtype=dtype, accept_sparse=accept_sparse,
                                 copy=copy)
         if dtype is not None:
@@ -208,6 +209,55 @@ def test_check_array():
     X_no_array = NotAnArray(X_dense)
     result = check_array(X_no_array)
     assert_true(isinstance(result, np.ndarray))
+
+
+def test_check_array_min_samples_and_features_messages():
+    # empty list is considered 2D by default:
+    msg = "0 feature(s) (shape=(1, 0)) while a minimum of 1 is required."
+    assert_raise_message(ValueError, msg, check_array, [])
+
+    # If considered a 1D collection when ensure_2d=False, then the minimum
+    # number of samples will break:
+    msg = "0 sample(s) (shape=(0,)) while a minimum of 1 is required."
+    assert_raise_message(ValueError, msg, check_array, [], ensure_2d=False)
+
+    # Invalid edge case when checking the default minimum sample of a scalar
+    msg = "Singleton array array(42) cannot be considered a valid collection."
+    assert_raise_message(TypeError, msg, check_array, 42, ensure_2d=False)
+
+    # But this works if the input data is forced to look like a 2 array with
+    # one sample and one feature:
+    X_checked = check_array(42, ensure_2d=True)
+    assert_array_equal(np.array([[42]]), X_checked)
+
+    # Simulate a model that would need at least 2 samples to be well defined
+    X = np.ones((1, 10))
+    y = np.ones(1)
+    msg = "1 sample(s) (shape=(1, 10)) while a minimum of 2 is required."
+    assert_raise_message(ValueError, msg, check_X_y, X, y,
+                         ensure_min_samples=2)
+
+    # Simulate a model that would require at least 3 features (e.g. SelectKBest
+    # with k=3)
+    X = np.ones((10, 2))
+    y = np.ones(2)
+    msg = "2 feature(s) (shape=(10, 2)) while a minimum of 3 is required."
+    assert_raise_message(ValueError, msg, check_X_y, X, y,
+                         ensure_min_features=3)
+
+    # Simulate a case where a pipeline stage as trimmed all the features of a
+    # 2D dataset.
+    X = np.empty(0).reshape(10, 0)
+    y = np.ones(10)
+    msg = "0 feature(s) (shape=(10, 0)) while a minimum of 1 is required."
+    assert_raise_message(ValueError, msg, check_X_y, X, y)
+
+    # nd-data is not checked for any minimum number of features by default:
+    X = np.ones((10, 0, 28, 28))
+    y = np.ones(10)
+    X_checked, y_checked = check_X_y(X, y, allow_nd=True)
+    assert_array_equal(X, X_checked)
+    assert_array_equal(y, y_checked)
 
 
 def test_has_fit_parameter():
@@ -274,6 +324,6 @@ def test_check_is_fitted():
 
     ard.fit(*make_blobs())
     svr.fit(*make_blobs())
- 
+
     assert_equal(None, check_is_fitted(ard, "coef_"))
     assert_equal(None, check_is_fitted(svr, "support_"))


### PR DESCRIPTION
This follows the discussion in #4206. This makes `check_array` and `check_X_y` reject input arrays with less than 1 samples and less than 1 feature for 2D inputs while providing informative error message to the caller. 

FYI I also have implemented some common checks based on this PR in edcd0793ec8adad7aef1d2de5bdad1c403ced1c6 but this reveals some missing input validation in several estimators. Those missing validation checks should better be added once @amueller's own #4136 is merged in master to avoid conflict resolution pain and redundant work.
