### PR TITLE
[MRG] GBM & meta-ensembles - support for class_weight

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -166,8 +166,12 @@ Enhancements
      faster in general. By `Joel Nothman`_.
 
    - Add ``class_weight`` parameter to automatically weight samples by class
-     frequency for :class:`ensemble.RandomForestClassifier`,
-     :class:`tree.DecisionTreeClassifier`, :class:`ensemble.ExtraTreesClassifier`
+     frequency for :class:`ensemble.AdaBoostClassifier`,
+     :class:`ensemble.BaggingClassifier`,
+     :class:`ensemble.ExtraTreesClassifier`,
+     :class:`ensemble.GradientBoostingClassifier`,
+     :class:`ensemble.RandomForestClassifier`,
+     :class:`tree.DecisionTreeClassifier`,
      and :class:`tree.ExtraTreeClassifier`. By `Trevor Stephens`_.
 
    - :class:`grid_search.RandomizedSearchCV` now does sampling without

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -13,11 +13,12 @@ from abc import ABCMeta, abstractmethod
 
 from ..base import ClassifierMixin, RegressorMixin
 from ..externals.joblib import Parallel, delayed
-from ..externals.six import with_metaclass
+from ..externals.six import with_metaclass, string_types
 from ..externals.six.moves import zip
 from ..metrics import r2_score, accuracy_score
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import check_random_state, check_X_y, check_array, column_or_1d
+from ..utils import compute_sample_weight
 from ..utils.random import sample_without_replacement
 from ..utils.validation import has_fit_parameter, check_is_fitted
 from ..utils.fixes import bincount
@@ -32,7 +33,7 @@ MAX_INT = np.iinfo(np.int32).max
 
 
 def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
-                               seeds, verbose):
+                               class_weight, seeds, verbose):
     """Private function used to build a batch of estimators within a job."""
     # Retrieve settings
     n_samples, n_features = X.shape
@@ -51,7 +52,6 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
     bootstrap_features = ensemble.bootstrap_features
     support_sample_weight = has_fit_parameter(ensemble.base_estimator_,
                                               "sample_weight")
-
 
     # Build estimators
     estimators = []
@@ -98,6 +98,13 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
                     random_state=random_state)
 
                 curr_sample_weight[not_indices] = 0
+
+                if class_weight == 'subsample':
+                    indices = np.where(curr_sample_weight > 0)
+
+            if class_weight == 'subsample':
+                # Multiply all weights by subsample weights
+                curr_sample_weight *= compute_sample_weight('auto', y, indices)
 
             estimator.fit(X[:, features], y, sample_weight=curr_sample_weight)
             samples = curr_sample_weight > 0.
@@ -204,6 +211,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
                  bootstrap=True,
                  bootstrap_features=False,
                  oob_score=False,
+                 class_weight=None,
                  n_jobs=1,
                  random_state=None,
                  verbose=0):
@@ -216,6 +224,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         self.bootstrap = bootstrap
         self.bootstrap_features = bootstrap_features
         self.oob_score = oob_score
+        self.class_weight = class_weight
         self.n_jobs = n_jobs
         self.random_state = random_state
         self.verbose = verbose
@@ -251,7 +260,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Remap output
         n_samples, self.n_features_ = X.shape
-        y = self._validate_y(y)
+        y, expanded_class_weight = self._validate_y_class_weight(y)
 
         # Check parameters
         self._validate_estimator()
@@ -276,6 +285,13 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
             raise ValueError("Out of bag estimation only available"
                              " if bootstrap=True")
 
+        # Apply class_weights to sample weights
+        if expanded_class_weight is not None:
+            if sample_weight is not None:
+                sample_weight = sample_weight * expanded_class_weight
+            else:
+                sample_weight = expanded_class_weight
+
         # Free allocated memory, if any
         self.estimators_ = None
 
@@ -291,6 +307,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
                 X,
                 y,
                 sample_weight,
+                self.class_weight,
                 seeds[starts[i]:starts[i + 1]],
                 verbose=self.verbose)
             for i in range(n_jobs))
@@ -312,9 +329,9 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
     def _set_oob_score(self, X, y):
         """Calculate out of bag predictions and score."""
 
-    def _validate_y(self, y):
+    def _validate_y_class_weight(self, y):
         # Default implementation
-        return column_or_1d(y, warn=True)
+        return column_or_1d(y, warn=True), None
 
 
 class BaggingClassifier(BaseBagging, ClassifierMixin):
@@ -365,6 +382,23 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     oob_score : bool
         Whether to use out-of-bag samples to estimate
         the generalization error.
+
+    class_weight : dict, "auto", "subsample" or None, optional
+        Weights associated with classes in the form ``{class_label: weight}``.
+        If not given, all classes are supposed to have weight one.
+
+        The "auto" mode uses the values of y to automatically adjust
+        weights inversely proportional to class frequencies in the input data.
+
+        The "subsample" mode is the same as "auto" except that weights are
+        computed based on the bootstrap or sub-sample for every tree grown as
+        defined by the ``max_features`` and/or ``bootstrap`` options.
+
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
+
+        Note that this is supported only if the base estimator supports
+        sample weighting.
 
     n_jobs : int, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
@@ -433,6 +467,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
                  bootstrap=True,
                  bootstrap_features=False,
                  oob_score=False,
+                 class_weight=None,
                  n_jobs=1,
                  random_state=None,
                  verbose=0):
@@ -445,6 +480,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
             bootstrap=bootstrap,
             bootstrap_features=bootstrap_features,
             oob_score=oob_score,
+            class_weight=class_weight,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose)
@@ -493,12 +529,29 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
         self.oob_decision_function_ = oob_decision_function
         self.oob_score_ = oob_score
 
-    def _validate_y(self, y):
+    def _validate_y_class_weight(self, y):
         y = column_or_1d(y, warn=True)
+        expanded_class_weight = None
+
+        if self.class_weight is not None:
+            y_original = np.copy(y)
+
         self.classes_, y = np.unique(y, return_inverse=True)
         self.n_classes_ = len(self.classes_)
 
-        return y
+        if self.class_weight is not None:
+            valid_presets = ('auto', 'subsample')
+            if isinstance(self.class_weight, string_types):
+                if self.class_weight not in valid_presets:
+                    raise ValueError('Valid presets for class_weight include '
+                                     '"auto" and "subsample". Given "%s".'
+                                     % self.class_weight)
+
+            if self.class_weight != 'subsample':
+                expanded_class_weight = compute_sample_weight(
+                    self.class_weight, y_original)
+
+        return y, expanded_class_weight
 
     def predict(self, X):
         """Predict class for X.

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -23,6 +23,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.validation import DataConversionWarning
 from sklearn.utils.validation import NotFittedError
+from sklearn.cross_validation import StratifiedKFold
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -982,6 +983,66 @@ def test_non_uniform_weights_toy_edge_case_clf():
         gb = GradientBoostingClassifier(n_estimators=5)
         gb.fit(X, y, sample_weight=sample_weight)
         assert_array_equal(gb.predict([[1, 0]]), [1])
+
+
+def test_class_weights():
+    """Check class_weights resemble sample_weights behavior."""
+    for train_index, test_index in StratifiedKFold(iris.target, n_folds=2,
+                                                   random_state=0):
+
+        # Iris is balanced, so no effect expected for using 'auto' weights
+        clf1 = GradientBoostingClassifier(random_state=0)
+        clf1.fit(iris.data[train_index], iris.target[train_index])
+        clf2 = GradientBoostingClassifier(class_weight='auto', random_state=0)
+        clf2.fit(iris.data[train_index], iris.target[train_index])
+        assert_array_almost_equal(clf1.predict(iris.data[test_index]),
+                                  clf2.predict(iris.data[test_index]))
+
+        # Inflate importance of class 1, check against user-defined weights
+        sample_weight = np.ones(iris.target[train_index].shape)
+        sample_weight[iris.target[train_index] == 1] *= 100
+        class_weight = {0: 1., 1: 100., 2: 1.}
+        clf1 = GradientBoostingClassifier(random_state=0)
+        clf1.fit(iris.data[train_index], iris.target[train_index],
+                 sample_weight)
+        clf2 = GradientBoostingClassifier(class_weight=class_weight,
+                                          random_state=0)
+        clf2.fit(iris.data[train_index], iris.target[train_index])
+        assert_array_almost_equal(clf1.predict(iris.data[test_index]),
+                                  clf2.predict(iris.data[test_index]))
+
+        # Check that sample_weight and class_weight are multiplicative
+        clf1 = GradientBoostingClassifier(random_state=0)
+        clf1.fit(iris.data[train_index], iris.target[train_index],
+                 sample_weight**2)
+        clf2 = GradientBoostingClassifier(class_weight=class_weight,
+                                          random_state=0)
+        clf2.fit(iris.data[train_index], iris.target[train_index],
+                 sample_weight)
+        assert_array_almost_equal(clf1.predict(iris.data[test_index]),
+                                  clf2.predict(iris.data[test_index]))
+
+
+def check_class_weight_subsample():
+    """Test class_weight works for subsample option"""
+    clf = GradientBoostingClassifier(subsample=0.8, class_weight='subsample',
+                                     random_state=0)
+    clf.fit(iris.data, iris.target)
+    clf = GradientBoostingClassifier(subsample=1.0, class_weight='subsample',
+                                     random_state=0)
+    clf.fit(iris.data, iris.target)
+
+
+def check_class_weight_errors():
+    """Test if class_weight raises errors and warnings when expected."""
+
+    # Invalid preset string
+    clf = GradientBoostingClassifier(class_weight='the larch', random_state=0)
+    assert_raises(ValueError, clf.fit, iris.data, iris.target)
+    # Warning warm_start with preset
+    clf = GradientBoostingClassifier(class_weight='auto', warm_start=True,
+                                     random_state=0)
+    assert_warns(UserWarning, clf.fit, iris.data, iris.target)
 
 
 if __name__ == "__main__":

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -38,10 +38,9 @@ from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE
 from ..utils import check_array, check_X_y, check_random_state
+from ..utils import compute_sample_weight
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import (
-        has_fit_parameter,
-        check_is_fitted)
+from sklearn.utils.validation import has_fit_parameter, check_is_fitted
 
 __all__ = [
     'AdaBoostClassifier',
@@ -62,6 +61,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                  n_estimators=50,
                  estimator_params=tuple(),
                  learning_rate=1.,
+                 class_weight=None,
                  random_state=None):
 
         super(BaseWeightBoosting, self).__init__(
@@ -70,6 +70,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             estimator_params=estimator_params)
 
         self.learning_rate = learning_rate
+        self.class_weight = class_weight
         self.random_state = random_state
 
     def fit(self, X, y, sample_weight=None):
@@ -110,6 +111,20 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             accept_sparse = ['csr', 'csc']
 
         X, y = check_X_y(X, y, accept_sparse=accept_sparse, dtype=dtype)
+
+        if self.class_weight is not None:
+            if isinstance(self.class_weight, six.string_types):
+                if self.class_weight != 'auto':
+                    raise ValueError('The only supported preset for '
+                                     'class_weight is "auto". Given "%s".'
+                                     % self.class_weight)
+
+            expanded_class_weight = compute_sample_weight(self.class_weight,
+                                                          y)
+            if sample_weight is None:
+                sample_weight = expanded_class_weight
+            else:
+                sample_weight = expanded_class_weight * sample_weight
 
         if sample_weight is None:
             # Initialize weights to 1 / n_samples
@@ -271,6 +286,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         return X
 
+
 def _samme_proba(estimator, n_classes, X):
     """Calculate algorithm 4, step 2, equation c) of Zhu et al [1].
 
@@ -312,6 +328,17 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
     n_estimators : integer, optional (default=50)
         The maximum number of estimators at which boosting is terminated.
         In case of perfect fit, the learning procedure is stopped early.
+
+    class_weight : dict, "auto", or None, optional (default=None)
+
+        Weights associated with classes in the form ``{class_label: weight}``.
+        If not given, all classes are supposed to have weight one.
+
+        The "auto" mode uses the values of y to automatically adjust
+        weights inversely proportional to class frequencies in the input data.
+
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
 
     learning_rate : float, optional (default=1.)
         Learning rate shrinks the contribution of each classifier by
@@ -368,6 +395,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
                  base_estimator=None,
                  n_estimators=50,
                  learning_rate=1.,
+                 class_weight=None,
                  algorithm='SAMME.R',
                  random_state=None):
 
@@ -375,6 +403,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             base_estimator=base_estimator,
             n_estimators=n_estimators,
             learning_rate=learning_rate,
+            class_weight=class_weight,
             random_state=random_state)
 
         self.algorithm = algorithm

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -32,6 +32,8 @@ from sklearn.random_projection import BaseRandomProjection
 from sklearn.feature_selection import SelectKBest
 from sklearn.svm.base import BaseLibSVM
 from sklearn.pipeline import make_pipeline
+from sklearn.ensemble import AdaBoostClassifier, BaggingClassifier
+from sklearn.tree import DecisionTreeClassifier
 
 from sklearn.utils.validation import DataConversionWarning, NotFittedError
 from sklearn.cross_validation import train_test_split
@@ -788,8 +790,15 @@ def check_class_weight_classifiers(name, Classifier):
             classifier = Classifier(class_weight=class_weight)
         if hasattr(classifier, "n_iter"):
             classifier.set_params(n_iter=100)
+        # The below attributes are set because the dataset is noisy and
+        # tree-based classifiers are not regularized
         if hasattr(classifier, "min_weight_fraction_leaf"):
             classifier.set_params(min_weight_fraction_leaf=0.01)
+        if isinstance(classifier, (BaggingClassifier, AdaBoostClassifier)):
+            classifier.set_params(base_estimator=DecisionTreeClassifier(
+                max_depth=1, min_weight_fraction_leaf=0.01))
+            if hasattr(classifier, "learning_rate"):
+                classifier.set_params(learning_rate=0.1)
 
         set_random_state(classifier)
         classifier.fit(X_train, y_train)


### PR DESCRIPTION
Refactoring #4114 on top of #4190 and removing the GBM coding style changes from the scope of this PR for ease of review. Basically I'm adding `class_weights` to the remaining ensemble classes as was done in #3961 for forests and trees.

@amueller @pprett @glouppe you have all at least glanced at #4114 so perhaps you'll have a chance to review the new refactored version here.
