### PR TITLE
[WIP] Add warm_start to Ridge. 

### DIFF
--- a/benchmarks/bench_ridge_warm_start.py
+++ b/benchmarks/bench_ridge_warm_start.py
@@ -1,0 +1,26 @@
+import numpy as np
+import time
+
+from sklearn.datasets import fetch_20newsgroups_vectorized
+from sklearn.linear_model import Ridge
+from sklearn.random_projection import SparseRandomProjection
+
+# Load News20 dataset from scikit-learn.
+bunch = fetch_20newsgroups_vectorized(subset="train")
+X = bunch.data
+y = bunch.target
+y[y >= 1] = 1
+X = SparseRandomProjection(n_components=1000).fit_transform(X)
+
+alphas = np.logspace(-2, -1, 10)[::-1]
+
+for warm_start in (False, True):
+    start = time.clock()
+    ridge = Ridge(warm_start=warm_start, fit_intercept=False, solver="sparse_cg")
+    for alpha in alphas:
+        ridge.set_params(alpha=alpha)
+        ridge.fit(X, y)
+
+    print "Warm start", warm_start
+    print time.clock() - start
+    print

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -413,7 +413,8 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
                                       sample_weight=sample_weight,
                                       max_iter=self.max_iter,
                                       tol=self.tol,
-                                      solver=solver)
+                                      solver=solver,
+                                      coef_init=coef_init)
         self._set_intercept(X_mean, y_mean, X_std)
         return self
 


### PR DESCRIPTION
I started working on a warm_start option for Ridge (only used for solver="sparse_cg"). However, there is an issue in the n_samples < n_features case. We need to warm-start with the dual coefficients but they are currently not returned by ridge_regression and thus not stored in the estimator. One way would be to transform the primal coefficients to dual coefficients but I couldn't find an efficient way.

See issue #769
