### PR TITLE
[MRG] Use absolute imports in tests

### DIFF
--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -5,7 +5,7 @@ Tests for the birch clustering algorithm.
 from scipy import sparse
 import numpy as np
 
-from .common import generate_clustered_data
+from sklearn.cluster.tests.common import generate_clustered_data
 from sklearn.cluster.birch import Birch
 from sklearn.cluster.hierarchical import AgglomerativeClustering
 from sklearn.datasets import make_blobs

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -14,7 +14,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.cluster.dbscan_ import DBSCAN
 from sklearn.cluster.dbscan_ import dbscan
-from .common import generate_clustered_data
+from sklearn.cluster.tests.common import generate_clustered_data
 from sklearn.metrics.pairwise import pairwise_distances
 
 

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -9,10 +9,10 @@ from scipy import ndimage
 from nose.tools import assert_equal, assert_true
 from numpy.testing import assert_raises
 
-from ..image import img_to_graph, grid_to_graph
-from ..image import (extract_patches_2d, reconstruct_from_patches_2d,
-                     PatchExtractor, extract_patches)
-from ...utils.graph import connected_components
+from sklearn.feature_extraction.image import (
+    img_to_graph, grid_to_graph, extract_patches_2d,
+    reconstruct_from_patches_2d, PatchExtractor, extract_patches)
+from sklearn.utils.graph import connected_components
 
 
 def test_img_to_graph():

--- a/sklearn/feature_selection/tests/test_chi2.py
+++ b/sklearn/feature_selection/tests/test_chi2.py
@@ -7,8 +7,8 @@ import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 import scipy.stats
 
-from .. import SelectKBest, chi2
-from ..univariate_selection import _chisquare
+from sklearn.feature_selection import SelectKBest, chi2
+from sklearn.feature_selection.univariate_selection import _chisquare
 
 from nose.tools import assert_raises
 from numpy.testing import assert_equal, assert_array_almost_equal

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from .... import datasets
-from ..unsupervised import silhouette_score
-from ... import pairwise_distances
+from sklearn import datasets
+from sklearn.metrics.cluster.unsupervised import silhouette_score
+from sklearn.metrics import pairwise_distances
 from sklearn.utils.testing import assert_false, assert_almost_equal
 from sklearn.utils.testing import assert_raises_regexp
 

--- a/sklearn/mixture/tests/test_dpgmm.py
+++ b/sklearn/mixture/tests/test_dpgmm.py
@@ -8,7 +8,7 @@ from sklearn.mixture import DPGMM, VBGMM
 from sklearn.mixture.dpgmm import log_normalize
 from sklearn.datasets import make_blobs
 from sklearn.utils.testing import assert_array_less
-from .test_gmm import GMMTester
+from sklearn.mixture.tests.test_gmm import GMMTester
 
 np.seterr(all='warn')
 

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -9,7 +9,7 @@ from nose.tools import assert_equal
 from numpy.testing import (assert_almost_equal,
                            assert_array_almost_equal)
 
-from ..fixes import divide, expit
+from sklearn.utils.fixes import divide, expit
 
 
 def test_expit():

--- a/sklearn/utils/tests/test_graph.py
+++ b/sklearn/utils/tests/test_graph.py
@@ -4,7 +4,7 @@
 import numpy as np
 from scipy import sparse
 
-from ..graph import graph_laplacian
+from sklearn.utils.graph import graph_laplacian
 
 
 def test_graph_laplacian():


### PR DESCRIPTION
Excerpt from the scikit-learn developers guideline [here](http://scikit-learn.org/stable/developers/#coding-guidelines):

> Unit tests are an exception to the previous rule; they should use absolute imports, exactly as client code would.
