### PR TITLE
[MRG+1] Fix gibbs sampling behavior in RBM with integral random_state.

### DIFF
--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -210,10 +210,10 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
             Values of the visible layer after one Gibbs step.
         """
         check_is_fitted(self, "components_")
-
-        rng = check_random_state(self.random_state)
-        h_ = self._sample_hiddens(v, rng)
-        v_ = self._sample_visibles(h_, rng)
+        if not hasattr(self, "random_state_"):
+            self.random_state_ = check_random_state(self.random_state)
+        h_ = self._sample_hiddens(v, self.random_state_)
+        v_ = self._sample_visibles(h_, self.random_state_)
 
         return v_
 

--- a/sklearn/neural_network/tests/test_rbm.py
+++ b/sklearn/neural_network/tests/test_rbm.py
@@ -131,14 +131,16 @@ def test_fit_gibbs_sparse():
 
 
 def test_gibbs_smoke():
-    """Check if we don't get NaNs sampling the full digits dataset."""
-    rng = np.random.RandomState(42)
+    """Check if we don't get NaNs sampling the full digits dataset.
+    Also check that sampling again will yield different results."""
     X = Xdigits
     rbm1 = BernoulliRBM(n_components=42, batch_size=40,
-                        n_iter=20, random_state=rng)
+                        n_iter=20, random_state=42)
     rbm1.fit(X)
     X_sampled = rbm1.gibbs(X)
     assert_all_finite(X_sampled)
+    X_sampled2 = rbm1.gibbs(X)
+    assert_true(np.all((X_sampled != X_sampled2).max(axis=1)))
 
 
 def test_score_samples():


### PR DESCRIPTION
Fixes #4227.
If `random_state` was an integer, all samplings were identical. That is not really the expected behavior, I think. Also, if `random_state` was `None` or a `RandomState` object, they were already different.

It seems to me that we might have more places where passing a `RandomState` object might have different behavior than passing a seed, and I am wondering what behavior we want in general.
