### PR TITLE
[MRG+1] add a prior strategy for the dummy classifier

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1270,6 +1270,8 @@ implements three such simple strategies for classification:
 - ``stratified`` generates random predictions by respecting the training
   set class distribution.
 - ``most_frequent`` always predicts the most frequent label in the training set.
+- ``prior`` always predicts the class that maximizes the class prior
+  (like ``most_frequent`) and ``predict_proba`` returns the class prior.
 - ``uniform`` generates predictions uniformly at random.
 - ``constant`` always predicts a constant label that is provided by the user.
    A major motivation of this method is F1-scoring, when the positive class

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -1,5 +1,5 @@
 from __future__ import division
-import warnings
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -11,17 +11,17 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.stats import _weighted_percentile
 
 from sklearn.dummy import DummyClassifier, DummyRegressor
 
 
+@ignore_warnings
 def _check_predict_proba(clf, X, y):
     proba = clf.predict_proba(X)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        # We know that we can have division by zero
-        log_proba = clf.predict_log_proba(X)
+    # We know that we can have division by zero
+    log_proba = clf.predict_log_proba(X)
 
     y = np.atleast_1d(y)
     if y.ndim == 1:
@@ -38,10 +38,8 @@ def _check_predict_proba(clf, X, y):
         assert_equal(proba[k].shape[0], n_samples)
         assert_equal(proba[k].shape[1], len(np.unique(y[:, k])))
         assert_array_equal(proba[k].sum(axis=1), np.ones(len(X)))
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            # We know that we can have division by zero
-            assert_array_equal(np.log(proba[k]), log_proba[k])
+        # We know that we can have division by zero
+        assert_array_equal(np.log(proba[k]), log_proba[k])
 
 
 def _check_behavior_2d(clf):
@@ -85,17 +83,25 @@ def _check_equality_regressor(statistic, y_learn, y_pred_learn,
                        y_pred_test)
 
 
-def test_most_frequent_strategy():
+def test_most_frequent_and_prior_strategy():
     X = [[0], [0], [0], [0]]  # ignored
     y = [1, 2, 1, 1]
 
-    clf = DummyClassifier(strategy="most_frequent", random_state=0)
-    clf.fit(X, y)
-    assert_array_equal(clf.predict(X), np.ones(len(X)))
-    _check_predict_proba(clf, X, y)
+    for strategy in ("most_frequent", "prior"):
+        clf = DummyClassifier(strategy=strategy, random_state=0)
+        clf.fit(X, y)
+        assert_array_equal(clf.predict(X), np.ones(len(X)))
+        _check_predict_proba(clf, X, y)
+
+        if strategy == "prior":
+            assert_array_equal(clf.predict_proba(X[0]),
+                               clf.class_prior_.reshape((1, -1)))
+        else:
+            assert_array_equal(clf.predict_proba(X[0]),
+                               clf.class_prior_.reshape((1, -1)) > 0.5)
 
 
-def test_most_frequent_strategy_multioutput():
+def test_most_frequent_and_prior_strategy_multioutput():
     X = [[0], [0], [0], [0]]  # ignored
     y = np.array([[1, 0],
                   [2, 0],
@@ -104,13 +110,14 @@ def test_most_frequent_strategy_multioutput():
 
     n_samples = len(X)
 
-    clf = DummyClassifier(strategy="most_frequent", random_state=0)
-    clf.fit(X, y)
-    assert_array_equal(clf.predict(X),
-                       np.hstack([np.ones((n_samples, 1)),
-                                  np.zeros((n_samples, 1))]))
-    _check_predict_proba(clf, X, y)
-    _check_behavior_2d(clf)
+    for strategy in ("prior", "most_frequent"):
+        clf = DummyClassifier(strategy=strategy, random_state=0)
+        clf.fit(X, y)
+        assert_array_equal(clf.predict(X),
+                           np.hstack([np.ones((n_samples, 1)),
+                                      np.zeros((n_samples, 1))]))
+        _check_predict_proba(clf, X, y)
+        _check_behavior_2d(clf)
 
 
 def test_stratified_strategy():
@@ -555,7 +562,7 @@ def test_stratified_strategy_sparse_target():
         assert_almost_equal(p[4], 1. / 5, decimal=1)
 
 
-def test_most_frequent_strategy_sparse_target():
+def test_most_frequent_and_prior_strategy_sparse_target():
     X = [[0]] * 5  # ignored
     y = sp.csc_matrix(np.array([[1, 0],
                                 [1, 3],
@@ -564,13 +571,14 @@ def test_most_frequent_strategy_sparse_target():
                                 [1, 0]]))
 
     n_samples = len(X)
-    clf = DummyClassifier(strategy="most_frequent", random_state=0)
-    clf.fit(X, y)
+    y_expected = np.hstack([np.ones((n_samples, 1)), np.zeros((n_samples, 1))])
+    for strategy in ("most_frequent", "prior"):
+        clf = DummyClassifier(strategy=strategy, random_state=0)
+        clf.fit(X, y)
 
-    y_pred = clf.predict(X)
-    assert_true(sp.issparse(y_pred))
-    assert_array_equal(y_pred.toarray(), np.hstack([np.ones((n_samples, 1)),
-                                                    np.zeros((n_samples, 1))]))
+        y_pred = clf.predict(X)
+        assert_true(sp.issparse(y_pred))
+        assert_array_equal(y_pred.toarray(), y_expected)
 
 
 def test_dummy_regressor_sample_weight(n_samples=10):


### PR DESCRIPTION
I wanted a strategy that is able to predict the prior with predict_proba, but failed to find one.
