### PR TITLE
[MRG+1] Fix broken `L1` deprecations and svm scale C example.

### DIFF
--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -38,19 +38,19 @@ account for the different amount of training samples?`
 
 The figures below are used to illustrate the effect of scaling our
 `C` to compensate for the change in the number of samples, in the
-case of using an `L1` penalty, as well as the `L2` penalty.
+case of using an `l1` penalty, as well as the `l2` penalty.
 
-L1-penalty case
+l1-penalty case
 -----------------
-In the `L1` case, theory says that prediction consistency
+In the `l1` case, theory says that prediction consistency
 (i.e. that under given hypothesis, the estimator
 learned predicts as well as a model knowing the true distribution)
-is not possible because of the bias of the `L1`. It does say, however,
+is not possible because of the bias of the `l1`. It does say, however,
 that model consistency, in terms of finding the right set of non-zero
 parameters as well as their signs, can be achieved by scaling
 `C1`.
 
-L2-penalty case
+l2-penalty case
 -----------------
 The theory says that in order to achieve prediction consistency, the
 penalty parameter should be kept constant
@@ -63,17 +63,17 @@ The two figures below plot the values of `C` on the `x-axis` and the
 corresponding cross-validation scores on the `y-axis`, for several different
 fractions of a generated data-set.
 
-In the `L1` penalty case, the cross-validation-error correlates best with
+In the `l1` penalty case, the cross-validation-error correlates best with
 the test-error, when scaling our `C` with the number of samples, `n`,
 which can be seen in the first figure.
 
-For the `L2` penalty case, the best result comes from the case where `C`
+For the `l2` penalty case, the best result comes from the case where `C`
 is not scaled.
 
 .. topic:: Note:
 
     Two separate datasets are used for the two different plots. The reason
-    behind this is the `L1` case works better on sparse data, while `L2`
+    behind this is the `l1` case works better on sparse data, while `l2`
     is better suited to the non-sparse case.
 """
 print(__doc__)
@@ -100,20 +100,20 @@ rnd = check_random_state(1)
 n_samples = 100
 n_features = 300
 
-# L1 data (only 5 informative features)
+# l1 data (only 5 informative features)
 X_1, y_1 = datasets.make_classification(n_samples=n_samples,
                                         n_features=n_features, n_informative=5,
                                         random_state=1)
 
-# L2 data: non sparse, but less features
+# l2 data: non sparse, but less features
 y_2 = np.sign(.5 - rnd.rand(n_samples))
 X_2 = rnd.randn(n_samples, n_features / 5) + y_2[:, np.newaxis]
 X_2 += 5 * rnd.randn(n_samples, n_features / 5)
 
-clf_sets = [(LinearSVC(penalty='L1', loss='squared-hinge', dual=False,
+clf_sets = [(LinearSVC(penalty='l1', loss='squared_hinge', dual=False,
                        tol=1e-3),
              np.logspace(-2.3, -1.3, 10), X_1, y_1),
-            (LinearSVC(penalty='L2', loss='squared-hinge', dual=True,
+            (LinearSVC(penalty='l2', loss='squared_hinge', dual=True,
                        tol=1e-4),
              np.logspace(-4.5, -2, 10), X_2, y_2)]
 

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -110,10 +110,10 @@ y_2 = np.sign(.5 - rnd.rand(n_samples))
 X_2 = rnd.randn(n_samples, n_features / 5) + y_2[:, np.newaxis]
 X_2 += 5 * rnd.randn(n_samples, n_features / 5)
 
-clf_sets = [(LinearSVC(penalty='L1', loss='L2', dual=False,
+clf_sets = [(LinearSVC(penalty='L1', loss='squared-hinge', dual=False,
                        tol=1e-3),
              np.logspace(-2.3, -1.3, 10), X_1, y_1),
-            (LinearSVC(penalty='L2', loss='L2', dual=True,
+            (LinearSVC(penalty='L2', loss='squared-hinge', dual=True,
                        tol=1e-4),
              np.logspace(-4.5, -2, 10), X_2, y_2)]
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 
 from . import libsvm, liblinear
 from . import libsvm_sparse
-from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
+from ..base import BaseEstimator, ClassifierMixin
 from ..preprocessing import LabelEncoder
 from ..utils import check_array, check_random_state, column_or_1d
 from ..utils import ConvergenceWarning, compute_class_weight
@@ -70,7 +70,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                  tol, C, nu, epsilon, shrinking, probability, cache_size,
                  class_weight, verbose, max_iter, random_state):
 
-        if not impl in LIBSVM_IMPL:  # pragma: no cover
+        if impl not in LIBSVM_IMPL:  # pragma: no cover
             raise ValueError("impl should be one of %s, %s was given" % (
                 LIBSVM_IMPL, impl))
 
@@ -384,7 +384,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def _validate_for_predict(self, X):
         check_is_fitted(self, 'support_')
-        
+
         X = check_array(X, accept_sparse='csr', dtype=np.float64, order="C")
         if self._sparse and not sp.isspmatrix(X):
             X = sp.csr_matrix(X)
@@ -615,10 +615,10 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
         'logistic_regression': {
             'l1': {False: 6},
             'l2': {False: 0, True: 7}},
-        'hinge' : {
-            'l2' : {True: 3}},
+        'hinge': {
+            'l2': {True: 3}},
         'squared_hinge': {
-            'l1': {False : 5},
+            'l1': {False: 5},
             'l2': {False: 2, True: 1}},
         'epsilon_insensitive': {
             'l2': {True: 13}},
@@ -652,7 +652,7 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
                                 % (penalty, loss, dual))
             else:
                 return solver_num
-
+    
     raise ValueError(('Unsupported set of arguments: %s, '
                       'Parameters: penalty=%r, loss=%r, dual=%r')
                      % (error_string, penalty, loss, dual))
@@ -660,7 +660,7 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
 
 def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
                    penalty, dual, verbose, max_iter, tol,
-                   random_state=None, multi_class='ovr', 
+                   random_state=None, multi_class='ovr',
                    loss='logistic_regression', epsilon=0.1):
     """Used by Logistic Regression (and CV) and LinearSVC.
 
@@ -722,7 +722,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         If `crammer_singer` is chosen, the options loss, penalty and dual will
         be ignored.
 
-    loss : str, {'logistic_regression', 'hinge', 'squared_hinge', 
+    loss : str, {'logistic_regression', 'hinge', 'squared_hinge',
                  'epsilon_insensitive', 'squared_epsilon_insensitive}
         The loss function used to fit the model.
 
@@ -788,7 +788,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     # LibLinear wants targets as doubles, even for classification
     y_ind = np.asarray(y_ind, dtype=np.float64).ravel()
     solver_type = _get_liblinear_solver_type(multi_class, penalty, loss, dual)
-    raw_coef_, n_iter_  = liblinear.train_wrap(
+    raw_coef_, n_iter_ = liblinear.train_wrap(
         X, y_ind, sp.isspmatrix(X), solver_type, tol, bias, C,
         class_weight_, max_iter, rnd.randint(np.iinfo('i').max),
         epsilon

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -643,13 +643,13 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
         if _solver_dual is None:
             error_string = ("The combination of penalty='%s'"
                             "and loss='%s' is not supported"
-                            % (loss, penalty))
+                            % (penalty, loss))
         else:
             solver_num = _solver_dual.get(dual, None)
             if solver_num is None:
                 error_string = ("loss='%s' and penalty='%s'"
                                 "are not supported when dual=%s"
-                                % (loss, penalty, dual))
+                                % (penalty, loss, dual))
             else:
                 return solver_num
     raise ValueError('Unsupported set of arguments: %s, '

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -15,7 +15,6 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..externals import six
 
-
 LIBSVM_IMPL = ['c_svc', 'nu_svc', 'one_class', 'epsilon_svr', 'nu_svr']
 
 
@@ -604,8 +603,8 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
       - loss
       - dual
 
-    The same number is internally by LibLinear to determine which
-    solver to use.
+    The same number is also internally used by LibLinear to determine
+    which solver to use.
     """
     # nested dicts containing level 1: available loss functions,
     # level2: available penalties for the given loss functin,


### PR DESCRIPTION
fixes #4260 

@ogrisel Please take a look...
- [x] Fix #4260 
- [x] `loss, penalty` --> `penalty, loss` in error message
- [x] Add tests to check for error message when invalid `loss` and `penalty` are passed.
- [x] Deprecate and support `L1` ( upper case )
