### PR TITLE
[MRG] python 3 fix in plot_kmeans_silhouette_analysis.py

### DIFF
--- a/examples/cluster/plot_kmeans_silhouette_analysis.py
+++ b/examples/cluster/plot_kmeans_silhouette_analysis.py
@@ -117,8 +117,9 @@ for n_clusters in range_n_clusters:
     ax1.set_xticks([-0.1, 0, 0.2, 0.4, 0.6, 0.8, 1])
 
     # 2nd Plot showing the actual clusters formed
+    colors = cm.spectral(cluster_labels.astype(float) / n_clusters)
     ax2.scatter(X[:, 0], X[:, 1], marker='.', s=30, lw=0, alpha=0.7,
-                c=map(cm.spectral, cluster_labels.astype(float) / n_clusters))
+                c=colors)
 
     # Labeling the clusters
     centers = clusterer.cluster_centers_


### PR DESCRIPTION
To reproduce:

```
$ ipython --matplotlib -i examples/cluster/plot_kmeans_silhouette_analysis.py

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/home/lesteve/dev/scikit-learn/examples/cluster/plot_kmeans_silhouette_analysis.py in <module>()
    119     # 2nd Plot showing the actual clusters formed
    120     ax2.scatter(X[:, 0], X[:, 1], marker='.', s=30, lw=0, alpha=0.7,
--> 121                 c=map(cm.spectral, cluster_labels.astype(float) / n_clusters))
    122 
    123     # Labeling the clusters

/home/lesteve/anaconda/envs/sklearn-dev/lib/python3.4/site-packages/matplotlib/axes/_axes.py in scatter(self, x, y, s, c, marker, cmap, norm, vmin, vmax, alpha, linewidths, verts, **kwargs)
   3612                 colors = None  # use cmap, norm after collection is created
   3613             else:
-> 3614                 colors = mcolors.colorConverter.to_rgba_array(c, alpha)
   3615 
   3616         faceted = kwargs.pop('faceted', None)

/home/lesteve/anaconda/envs/sklearn-dev/lib/python3.4/site-packages/matplotlib/colors.py in to_rgba_array(self, c, alpha)
    389         except TypeError:
    390             raise ValueError(
--> 391                 "Cannot convert argument type %s to rgba array" % type(c))
    392         try:
    393             if nc == 0 or c.lower() == 'none':

ValueError: Cannot convert argument type <class 'numpy.ndarray'> to rgba array
```
