### PR TITLE
[MRG + 1] Directly compute polynomial features.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -157,7 +157,7 @@ Enhancements
 
    - Add ``n_iter_`` attribute to estimators that accept a ``max_iter`` attribute
      in their constructor. By `Manoj Kumar`_.
-  
+
    - Added decision function for :class:`multiclass.OneVsOneClassifier`
      By `Raghav R V`_ and `Kyle Beauchamp`_.
 
@@ -193,6 +193,9 @@ Enhancements
    - Make the :class:`GMM` stopping criterion less dependent on the number of
      samples by thresholding the average log-likelihood change instead of its
      sum over all samples. By `Hervé Bredin`_
+
+   - Significant performance and memory usage improvements in
+     :class:`preprocessing.PolynomialFeatures`. By `Eric Martin`_.
 
 Documentation improvements
 ..........................
@@ -3282,3 +3285,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Will Dawson: http://dawsonresearch.com
 
 .. _Balazs Kegl: https://github.com/kegl
+
+.. _Eric Martin: http://ericmart.in

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -2,6 +2,7 @@
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
+#          Eric Martin <eric@ericmart.in>
 # License: BSD 3 clause
 
 from itertools import chain, combinations

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -7,7 +7,6 @@
 
 from itertools import chain, combinations
 import numbers
-import warnings
 
 import numpy as np
 from scipy import sparse
@@ -474,8 +473,6 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
 
     @property
     def powers_(self):
-        warnings.warn('PolynomialFeatures.powers_ is deprecated and will be '
-                      'removed in version 0.18.', DeprecationWarning)
         check_is_fitted(self, 'n_input_features_')
 
         combinations = self._combinations(self.n_input_features_, self.degree,

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -459,7 +459,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         comb = (combinations if interaction_only else combinations_w_r)
         start = int(not include_bias)
         return chain.from_iterable(comb(range(n_features), i)
-                                   for i in xrange(start, degree + 1))
+                                   for i in range(start, degree + 1))
 
     def fit(self, X, y=None):
         """

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -68,8 +68,6 @@ def test_polynomial_features():
     X_poly = interact.fit_transform(X)
     assert_array_almost_equal(X_poly, P2[:, [0, 1, 2, 4]])
 
-    assert_raises(ValueError, interact.transform, X[:, 1:])
-
 
 def test_scaler_1d():
     """Test scaling of dataset along single axis"""


### PR DESCRIPTION
Polynomial features are computed by iterating over all combinations
of features. For each combination of features, the product of the
columns indexed by the combination is computed.

The fit method is now a no-op, and the transform method works with any
number of features (regardless of what fit was called with).

Both the memory usage and the runtime are favorable to #3512 and #3514.

I believe the total memory usage is twice the size of the output array
because the output array is stored both as the argument to hstack and
as the final output. This might be able to be reduced by pre-computing
the output size and writing directly to the output array (rather than
using the hstack call).
