### PR TITLE
Add MSMBuilder to related_projects.rst?

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -75,6 +75,9 @@ Domain Specific Packages
 - `Natural language toolkit (nltk) <http://www.nltk.org/>`_ Natual language processing and some machine learning.
 - `NiLearn <https://nilearn.github.io/>`_ Machine learning for neuro-imaging.
 - `AstroML <http://www.astroml.org/>`_  Machine learning for astronomy.
+- `MSMBuilder <http://www.msmbuilder.org/>`_  Machine learning for protein conformational dynamics time series.
+
+
 
 Snippets and tidbits
 ---------------------


### PR DESCRIPTION
Proposed adding our MSMBuilder project to the list of related domain specific packages.  We have some stuff that could be generally useful for time series models, such as temporal independent component analysis.
