### PR TITLE
Added missing space to exception message

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -53,22 +53,20 @@ def test_no_nan():
 
 
 def test_correct_labelsize():
-    """ Assert 2 <= n_labels <= nsample -1 """
+    """Assert 1 < n_labels < n_samples"""
     dataset = datasets.load_iris()
     X = dataset.data
 
     # n_labels = n_samples
     y = np.arange(X.shape[0])
     assert_raises_regexp(ValueError,
-                         "Number of labels is %d "
-                         "but should be more than 2"
-                         "and less than n_samples - 1" % len(np.unique(y)),
+                         'Number of labels is %d\. Valid values are 2 '
+                         'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)
 
     # n_labels = 1
     y = np.zeros(X.shape[0])
     assert_raises_regexp(ValueError,
-                         "Number of labels is %d "
-                         "but should be more than 2"
-                         "and less than n_samples - 1" % len(np.unique(y)),
+                         'Number of labels is %d\. Valid values are 2 '
+                         'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -78,10 +78,9 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     """
     n_labels = len(np.unique(labels))
     n_samples = X.shape[0]
-    if not 2 <= n_labels <= n_samples-1:
-        raise ValueError("Number of labels is %d "
-                         "but should be more than 2"
-                         "and less than n_samples - 1" % n_labels)
+    if not 1 < n_labels < n_samples:
+        raise ValueError("Number of labels is %d. Valid values are 2 "
+                         "to n_samples - 1 (inclusive)" % n_labels)
 
     if sample_size is not None:
         random_state = check_random_state(random_state)


### PR DESCRIPTION
There was a `ValueError` being raised on line 82 of `sklearn/metrics/cluster/unsupervised.py` that had a missing space.

I went to fix it and realized the error message was actually incorrect (the test was that `2 <= n_labels` but the error message said the number of labels had to be more than 2).

So I improved the error message (IMO, at least) and I simplified the test, from `if not 2 <= n_labels <= n_samples-1` to `if not 1 < n_labels < n_samples` which feels cleaner to me.

I also updated the two tests of the error message. Note that the error text is a regex so regex metacharacters (`.` and `(` and `)`) are backslash quoted.
