### PR TITLE
[MRG+3] move NotFittedError to sklearn.base

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -443,6 +443,15 @@ class MetaEstimatorMixin(object):
 
 
 ###############################################################################
+class NotFittedError(ValueError, AttributeError):
+    """Exception class to raise if estimator is used before fitting.
+
+    This class inherits from both ValueError and AttributeError to help with
+    exception handling and backward compatibility.
+    """
+
+
+###############################################################################
 # XXX: Temporary solution to figure out if an estimator is a classifier
 
 def _get_sub_estimator(estimator):

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -10,11 +10,12 @@ from scipy import sparse
 from math import sqrt
 
 from ..metrics.pairwise import euclidean_distances
-from ..base import TransformerMixin, ClusterMixin, BaseEstimator
+from ..base import (TransformerMixin, ClusterMixin, BaseEstimator,
+                    NotFittedError)
 from ..externals.six.moves import xrange
 from ..utils import check_array
 from ..utils.extmath import row_norms, safe_sparse_dot
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import check_is_fitted
 from .hierarchical import AgglomerativeClustering
 
 

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -9,9 +9,9 @@ import numpy as np
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
-from sklearn.utils.validation import NotFittedError
 
 from sklearn import datasets
+from sklearn.base import NotFittedError
 from sklearn.covariance import empirical_covariance, MinCovDet, \
     EllipticEnvelope
 

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -7,8 +7,8 @@ import numpy as np
 from scipy import linalg
 
 from ..utils.arpack import eigsh
-from ..utils.validation import check_is_fitted, NotFittedError
-from ..base import BaseEstimator, TransformerMixin
+from ..utils.validation import check_is_fitted
+from ..base import BaseEstimator, TransformerMixin, NotFittedError
 from ..preprocessing import KernelCenterer
 from ..metrics.pairwise import pairwise_kernels
 

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -31,7 +31,7 @@ import numpy as np
 from scipy import stats
 
 from .base import BaseEnsemble
-from ..base import BaseEstimator
+from ..base import BaseEstimator, NotFittedError
 from ..base import ClassifierMixin
 from ..base import RegressorMixin
 from ..utils import check_random_state, check_array, check_X_y, column_or_1d
@@ -39,7 +39,7 @@ from ..utils import check_consistent_length
 from ..utils.extmath import logsumexp
 from ..utils.fixes import expit, bincount
 from ..utils.stats import _weighted_percentile
-from ..utils.validation import check_is_fitted, NotFittedError
+from ..utils.validation import check_is_fitted
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -5,11 +5,12 @@ Testing for the gradient boosting module (sklearn.ensemble.gradient_boosting).
 import numpy as np
 
 from sklearn import datasets
-from sklearn.base import clone
+from sklearn.base import clone, NotFittedError
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble.gradient_boosting import ZeroEstimator
 from sklearn.metrics import mean_squared_error
+
 from sklearn.utils import check_random_state, tosequence
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -21,7 +22,6 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.validation import DataConversionWarning
-from sklearn.utils.validation import NotFittedError
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]

--- a/sklearn/feature_selection/from_model.py
+++ b/sklearn/feature_selection/from_model.py
@@ -3,10 +3,10 @@
 
 import numpy as np
 
-from ..base import TransformerMixin
+from ..base import TransformerMixin, NotFittedError
 from ..externals import six
 from ..utils import safe_mask, check_array
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import check_is_fitted
 
 
 class _LearntSelectorMixin(TransformerMixin):

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -24,12 +24,13 @@ from scipy import sparse
 
 from ..externals import six
 from ..externals.joblib import Parallel, delayed
-from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
+from ..base import (BaseEstimator, ClassifierMixin, RegressorMixin,
+                    NotFittedError)
 from ..utils import as_float_array, check_array, check_X_y
 from ..utils.extmath import safe_sparse_dot
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import check_is_fitted
 
 
 ###

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -14,13 +14,12 @@ from scipy.sparse import csr_matrix, issparse
 
 from .ball_tree import BallTree
 from .kd_tree import KDTree
-from ..base import BaseEstimator
+from ..base import BaseEstimator, NotFittedError
 from ..metrics import pairwise_distances
 from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from ..utils import check_X_y, check_array
 from ..utils.fixes import argpartition
 from ..utils.validation import DataConversionWarning
-from ..utils.validation import NotFittedError
 from ..externals import six
 
 

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -35,13 +35,13 @@ import numpy as np
 from numpy.testing import assert_equal
 import scipy.sparse as sp
 
-from .base import BaseEstimator, TransformerMixin
+from .base import BaseEstimator, TransformerMixin, NotFittedError
 from .externals import six
 from .externals.six.moves import xrange
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
 from .utils.random import sample_without_replacement
-from .utils.validation import check_array, NotFittedError
+from .utils.validation import check_array
 from .utils import DataDimensionalityWarning
 
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -22,11 +22,12 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 from scipy.sparse import issparse
 
-from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
+from ..base import (BaseEstimator, ClassifierMixin, RegressorMixin,
+                    NotFittedError)
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_array, check_random_state, compute_sample_weight
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import check_is_fitted
 
 
 from ._tree import Criterion

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -27,7 +27,7 @@ from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import check_skip_travis
 from sklearn.utils.testing import ignore_warnings
 
-from sklearn.base import clone, ClassifierMixin
+from sklearn.base import clone, ClassifierMixin, NotFittedError
 from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
 
 from sklearn.lda import LDA
@@ -36,7 +36,7 @@ from sklearn.feature_selection import SelectKBest
 from sklearn.svm.base import BaseLibSVM
 from sklearn.pipeline import make_pipeline
 
-from sklearn.utils.validation import DataConversionWarning, NotFittedError
+from sklearn.utils.validation import DataConversionWarning
 from sklearn.cross_validation import train_test_split
 
 from sklearn.utils import shuffle

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -12,6 +12,7 @@ import numbers
 import numpy as np
 import scipy.sparse as sp
 
+from ..base import NotFittedError
 from ..externals import six
 from inspect import getargspec
 
@@ -25,14 +26,6 @@ warnings.simplefilter("always", DataConversionWarning)
 
 class NonBLASDotWarning(UserWarning):
     """A warning on implicit dispatch to numpy.dot"""
-
-
-class NotFittedError(ValueError, AttributeError):
-    """Exception class to raise if estimator is used before fitting
-
-    This class inherits from both ValueError and AttributeError to help with
-    exception handling and backward compatibility.
-    """
 
 
 # Silenced by default to reduce verbosity. Turn on at runtime for


### PR DESCRIPTION
This moves the recently added `NotFittedError` to `sklearn.base` so user code that wants to catch it does not have to import it from `sklearn.utils.validation`. I'm not sure if we've made a decision regarding the public status of (parts of) `sklearn.utils` yet, but in any case, an exception that is thrown at the user is a public thing, and it is not a utility.

Ping @ogrisel.
