### PR TITLE
[MRG + 1] Friendly error on KNeighbors(n_neighbors=0 or not convertible to int)

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -258,6 +258,14 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         else:
             raise ValueError("algorithm = '%s' not recognized"
                              % self.algorithm)
+
+        if self.n_neighbors is not None:
+            if self.n_neighbors <= 0:
+                raise ValueError(
+                    "Expected n_neighbors > 0. Got %d" %
+                    self.n_neighbors
+                )
+
         return self
 
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -830,6 +830,10 @@ def test_neighbors_badargs():
         assert_raises(ValueError,
                       nbrs.predict,
                       [])
+        if (isinstance(cls, neighbors.KNeighborsClassifier) or
+                isinstance(cls, neighbors.KNeighborsRegressor)):
+            nbrs = cls(n_neighbors=-1)
+            assert_raises(ValueError, nbrs.fit, X, y)
 
     nbrs = neighbors.NearestNeighbors().fit(X)
 


### PR DESCRIPTION
This PR added some lines to `NeighborsBase._fit` for checking `n_neighbors`. If it is 0 or not convertible to int, it raise ValueError. Fix #4296 
