### PR TITLE
[MRG+1] Improve doc and test for radius queries

### DIFF
--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -117,6 +117,11 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
     Random projection is used as the hash family which approximates
     cosine distance.
 
+    The cosine distance is defined as ``1 - cosine_similarity``: the lowest
+    value is 0 (identical point) but it is bounded above by 2 for the farthest
+    points. Its value does not depend on the norm of the vector points but
+    only on their relative angles.
+
     Parameters
     ----------
 
@@ -387,8 +392,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
         return bin_queries, np.max(depths, axis=0)
 
     def kneighbors(self, X, n_neighbors=None, return_distance=True):
-        """
-        Returns the n_number of approximated nearest neighbors
+        """Returns n_neighbors of approximate nearest neighbors.
 
         Parameters
         ----------
@@ -436,13 +440,22 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
             return np.array(neighbors)
 
     def radius_neighbors(self, X, radius=None, return_distance=True):
-        """
-        Returns the approximated nearest neighbors within the radius
+        """Finds the neighbors within a given radius of a point or points.
+
+        Return the indices and distances of some points from the dataset
+        lying in a ball with size ``radius`` around the points of the query
+        array. Points lying on the boundary are included in the results.
+
+        The result points are *not* necessarily sorted by distance to their
+        query point.
+
+        LSH Forest being an approximate method, some true neighbors from the
+        indexed dataset might be missing from the results.
 
         Parameters
         ----------
         X : array_like or sparse (CSR) matrix, shape (n_samples, n_features)
-            List of n_features-dimensional data points.  Each row
+            List of n_features-dimensional data points. Each row
             corresponds to a single query.
 
         radius : float
@@ -455,12 +468,13 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
         Returns
         -------
         dist : array, shape (n_samples,) of arrays
-            Array representing the cosine distances to each point,
-            only present if return_distance=True.
+            Each element is an array representing the cosine distances
+            to some points found within ``radius`` of the respective query.
+            Only present if ``return_distance=True``.
 
         ind : array, shape (n_samples,) of arrays
-            An array of arrays of indices of the approximated nearest points
-            with in the `radius` to the query in the population matrix.
+            Each element is an array of indices for neighbors within ``radius``
+            of the respective query.
         """
         if not hasattr(self, 'hash_functions_'):
             raise ValueError("estimator should be fitted.")

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -86,8 +86,8 @@ def _get_weights(dist, weights):
         if dist.dtype is np.dtype(object):
             for point_dist_i, point_dist in enumerate(dist):
                 # check if point_dist is iterable
-                # (ex: RadiusNeighborClassifier.predict may set an element of dist
-                # to 1e-6 to represent an 'outlier')
+                # (ex: RadiusNeighborClassifier.predict may set an element of
+                # dist to 1e-6 to represent an 'outlier')
                 if hasattr(point_dist, '__contains__') and 0. in point_dist:
                     dist[point_dist_i] = point_dist == 0.
                 else:
@@ -489,7 +489,12 @@ class RadiusNeighborsMixin(object):
     def radius_neighbors(self, X=None, radius=None, return_distance=True):
         """Finds the neighbors within a given radius of a point or points.
 
-        Returns indices of and distances to the neighbors of each point.
+        Return the indices and distances of each point from the dataset
+        lying in a ball with size ``radius`` around the points of the query
+        array. Points lying on the boundary are included in the results.
+
+        The result points are *not* necessarily sorted by distance to their
+        query point.
 
         Parameters
         ----------
@@ -507,18 +512,21 @@ class RadiusNeighborsMixin(object):
 
         Returns
         -------
-        dist : array
-            Array representing the euclidean distances to each point,
-            only present if return_distance=True.
+        dist : array, shape (n_samples,) of arrays
+            Array representing the distances to each point, only present if
+            return_distance=True. The distance values are computed according
+            to the ``metric`` constructor parameter.
 
-        ind : array
-            Indices of the nearest points in the population matrix.
+        ind : array, shape (n_samples,) of arrays
+            An array of arrays of indices of the approximate nearest points
+            from the population matrix that lie within a ball of size
+            ``radius`` around the query points.
 
         Examples
         --------
         In the following example, we construct a NeighborsClassifier
         class from an array representing our data set and ask who's
-        the closest point to [1,1,1]
+        the closest point to [1, 1, 1]:
 
         >>> import numpy as np
         >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]


### PR DESCRIPTION
This is a follow-up on the discussions in #4303 and #4072 to improve the docstrings of the `radius_neighbors` method of both exact and approximate neighbors methods.
