### PR TITLE
[MRG + 1] Partially fixes #2274: Running tests should not print anything on stdout / stderr or warnings

### DIFF
--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -133,8 +133,8 @@ def _load_imgs(file_paths, slice_, color, resize):
         slice_ = tuple(s or ds for s, ds in zip(slice_, default_slice))
 
     h_slice, w_slice = slice_
-    h = (h_slice.stop - h_slice.start) / (h_slice.step or 1)
-    w = (w_slice.stop - w_slice.start) / (w_slice.step or 1)
+    h = (h_slice.stop - h_slice.start) // (h_slice.step or 1)
+    w = (w_slice.stop - w_slice.start) // (w_slice.step or 1)
 
     if resize is not None:
         resize = float(resize)

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -112,7 +112,7 @@ def f_oneway(*args):
     f = msb / msw
     # flatten matrix to vector in sparse case
     f = np.asarray(f).ravel()
-    prob = stats.fprob(dfbn, dfwn, f)
+    prob = special.fdtrc(dfbn, dfwn, f)
     return f, prob
 
 


### PR DESCRIPTION
#2274 I'm still going through all the warnings.
- Fixed `DeprecationWarning: fprob is deprecated!`
- Fixed some `DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future`

Tested with:

<pre>
nosetests -s sklearn doc/*.rst doc/modules/ doc/datasets/ \
        doc/developers doc/tutorial/basic doc/tutorial/statistical_inference \
        doc/tutorial/text_analytics
</pre>


and it's showing no errors.
