### PR TITLE
[MRG + 1] Add SVR mathematical description to the tutorial and a test for decision_function

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -550,14 +550,13 @@ generalization error of the classifier.
 SVC
 ---
 
-Given training vectors :math:`x_i \in R^p`, i=1,..., n, in two classes, and a
-vector :math:`y \in R^n` such that :math:`y_i \in \{1, -1\}`, SVC solves the
-following primal problem:
+Given training vectors :math:`x_i \in \mathbb{R}^p`, i=1,..., n, in two classes, and a
+vector :math:`y \in \{1, -1\}^n`, SVC solves the following primal problem:
 
 
 .. math::
 
-    \min_ {w, b, \zeta} \frac{1}{2} w^T w + C \sum_{i=1, n} \zeta_i
+    \min_ {w, b, \zeta} \frac{1}{2} w^T w + C \sum_{i=1}^{n} \zeta_i
 
 
 
@@ -572,7 +571,7 @@ Its dual is
 
 
    \textrm {subject to } & y^T \alpha = 0\\
-   & 0 \leq \alpha_i \leq C, i=1, ..., l
+   & 0 \leq \alpha_i \leq C, i=1, ..., n
 
 where :math:`e` is the vector of all ones, :math:`C > 0` is the upper bound,
 :math:`Q` is an :math:`n` by :math:`n` positive semidefinite matrix,
@@ -593,7 +592,7 @@ The decision function is:
 
 .. TODO multiclass case ?/
 
-This parameters can be accessed through the members ``dual_coef_`
+This parameters can be accessed through the members ``dual_coef_``
 which holds the product :math:`y_i \alpha_i`, ``support_vectors_`` which
 holds the support vectors, and ``intercept_`` which holds the independent
 term :math:`\rho` :
@@ -622,6 +621,53 @@ bound of the fraction of support vectors.
 
 It can be shown that the :math:`\nu`-SVC formulation is a reparametrization
 of the :math:`C`-SVC and therefore mathematically equivalent.
+
+
+SVR
+---
+
+Given training vectors :math:`x_i \in \mathbb{R}^p`, i=1,..., n, and a
+vector :math:`y \in \mathbb{R}^n` :math:`\varepsilon`-SVR solves the following primal problem:
+
+
+.. math::
+
+    \min_ {w, b, \zeta, \zeta^*} \frac{1}{2} w^T w + C \sum_{i=1}^{n} (\zeta_i + \zeta_i^*)
+
+
+
+    \textrm {subject to } & y_i - w^T \phi (x_i) - b \leq \varepsilon + \zeta_i,\\
+                          & w^T \phi (x_i) + b - y_i \leq \varepsilon + \zeta_i^*,\\
+                          & \zeta_i, \zeta_i^* \geq 0, i=1, ..., n
+
+Its dual is
+
+.. math::
+
+   \min_{\alpha, \alpha^*} \frac{1}{2} (\alpha - \alpha^*)^T Q (\alpha - \alpha^*) + \varepsilon e^T (\alpha + \alpha^*) - y^T (\alpha - \alpha^*)
+
+
+   \textrm {subject to } & e^T (\alpha - \alpha^*) = 0\\
+   & 0 \leq \alpha_i, \alpha_i^* \leq C, i=1, ..., n
+
+where :math:`e`, :math:`C > 0` and :math:`Q` are the same as in the case of SVC.
+
+The decision function is:
+
+.. math:: \sum_{i=1}^n (\alpha_i - \alpha_i^*) K(x_i, x) + \rho
+
+These parameters can be accessed through the members ``dual_coef_``
+which holds the difference :math:`\alpha_i - \alpha_i^*`, ``support_vectors_`` which
+holds the support vectors, and ``intercept_`` which holds the independent
+term :math:`\rho`
+
+.. topic:: References:
+
+ * `"A Tutorial on Support Vector Regression"
+   <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.114.4288>`_
+   Alex J. Smola, Bernhard Schölkopf -Statistics and Computing archive
+   Volume 14 Issue 3, August 2004, p. 199-222  
+
 
 .. _svm_implementation_details:
 

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -575,9 +575,9 @@ Its dual is
 
 where :math:`e` is the vector of all ones, :math:`C > 0` is the upper bound,
 :math:`Q` is an :math:`n` by :math:`n` positive semidefinite matrix,
-:math:`Q_{ij} \equiv K(x_i, x_j)` and :math:`\phi (x_i)^T \phi (x)`
-is the kernel. Here training vectors are mapped into a higher (maybe infinite)
-dimensional space by the function :math:`\phi`.
+:math:`Q_{ij} \equiv K(x_i, x_j) = \phi (x_i)^T \phi (x_j)`
+is the kernel. Here training vectors are implicitly mapped into a higher
+(maybe infinite) dimensional space by the function :math:`\phi`.
 
 
 The decision function is:
@@ -650,7 +650,11 @@ Its dual is
    \textrm {subject to } & e^T (\alpha - \alpha^*) = 0\\
    & 0 \leq \alpha_i, \alpha_i^* \leq C, i=1, ..., n
 
-where :math:`e`, :math:`C > 0` and :math:`Q` are the same as in the case of SVC.
+where :math:`e` is the vector of all ones, :math:`C > 0` is the upper bound,
+:math:`Q` is an :math:`n` by :math:`n` positive semidefinite matrix,
+:math:`Q_{ij} \equiv K(x_i, x_j) = \phi (x_i)^T \phi (x_j)`
+is the kernel. Here training vectors are implicitly mapped into a higher
+(maybe infinite) dimensional space by the function :math:`\phi`.
 
 The decision function is:
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -303,9 +303,9 @@ def test_probability():
                             np.exp(clf.predict_log_proba(iris.data)), 8)
 
 
-def test_decision_function():
+def test_svc_decision_function():
     """
-    Test decision_function
+    Test SVC's decision_function
 
     Sanity check, test that decision_function implemented in python
     returns the same as the one in libsvm
@@ -336,6 +336,32 @@ def test_decision_function():
     rbfs = rbf_kernel(X, clf.support_vectors_, gamma=clf.gamma)
     dec = np.dot(rbfs, clf.dual_coef_.T) + clf.intercept_
     assert_array_almost_equal(dec.ravel(), clf.decision_function(X))
+
+
+def test_svr_decision_function():
+    """
+    Test SVR's decision_function
+
+    Sanity check, test that decision_function implemented in python
+    returns the same as the one in libsvm
+
+    """
+
+    X = iris.data
+    y = iris.target
+
+    # linear kernel
+    reg = svm.SVR(kernel='linear', C=0.1).fit(X, y)
+
+    dec = np.dot(X, reg.coef_.T) + reg.intercept_
+    assert_array_almost_equal(dec.ravel(), reg.decision_function(X).ravel())
+
+    # rbf kernel
+    reg = svm.SVR(kernel='rbf', gamma=1).fit(X, y)
+    
+    rbfs = rbf_kernel(X, reg.support_vectors_, gamma=reg.gamma)
+    dec = np.dot(rbfs, reg.dual_coef_.T) + reg.intercept_
+    assert_array_almost_equal(dec.ravel(), reg.decision_function(X).ravel())
 
 
 def test_weight():


### PR DESCRIPTION
This PR adds SVR's description to the [tutorial](http://scikit-learn.org/stable/modules/svm.html#mathematical-formulation) (Mathematical formulation section), adds a test to reproduce its `decision_function` (#4367), and makes sphinx use `six` that comes with `sklearn` being built, not the one already installed in a system.
