### PR TITLE
[MRG + 2] Fixes #4385: Move newton_cg test out of optimize

### DIFF
--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -157,20 +157,3 @@ def newton_cg(func_grad_hess, func, grad, x0, args=(), eps=1e-4, tol=1e-4,
         warnings.warn("newton-cg failed to converge. Increase the "
                       "number of iterations.")
     return xk
-
-
-###############################################################################
-# Tests
-
-if __name__ == "__main__":
-    A = np.random.normal(size=(10, 10))
-
-    def func(x):
-        Ax = A.dot(x)
-        return .5*(Ax).dot(Ax)
-
-    def func_grad_hess(x):
-        return func(x), A.T.dot(A.dot(x)), lambda x: A.T.dot(A.dot(x))
-
-    x0 = np.ones(10)
-    out = newton_cg(func_grad_hess, func, x0)

--- a/sklearn/utils/tests/test_optimize.py
+++ b/sklearn/utils/tests/test_optimize.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from sklearn.utils.optimize import newton_cg
+from scipy.optimize import fmin_ncg
+
+from sklearn.utils.testing import assert_array_almost_equal
+
+
+def test_newton_cg():
+    # Test that newton_cg gives same result as scipy's fmin_ncg
+
+    rng = np.random.RandomState(0)
+    A = rng.normal(size=(10, 10))
+    x0 = np.ones(10)
+
+    def func(x):
+        Ax = A.dot(x)
+        return .5 * (Ax).dot(Ax)
+
+    def grad(x):
+        return A.T.dot(A.dot(x))
+
+    def hess(x, p):
+        return p.dot(A.T.dot(A.dot(x.all())))
+
+    def func_grad_hess(x):
+        return func(x), grad(x), lambda x: A.T.dot(A.dot(x))
+
+    assert_array_almost_equal(newton_cg(func_grad_hess, func, grad, x0, tol=1e-10),
+                              fmin_ncg(f=func, x0=x0, fprime=grad, fhess_p=hess))


### PR DESCRIPTION
#4385

I had to make new grad and hess functions from `func_grad_hess` to resolve errors. Still, I'm getting an error with `fmin_ncg`:

<pre>
Traceback (most recent call last):
  File "test.py", line 25, in <module>
    assert_almost_equal(newton_cg(func_grad_hess, func, grad, x0), fmin_ncg(f=func, x0=x0, fprime=grad, fhess=hess))
  File "/usr/lib/python3.4/site-packages/scipy/optimize/optimize.py", line 1313, in fmin_ncg
    callback=callback, **opts)
  File "/usr/lib/python3.4/site-packages/scipy/optimize/optimize.py", line 1405, in _minimize_newtoncg
    Ap = numpy.dot(A, psupi)
TypeError: unsupported operand type(s) for *: 'function' and 'float'
</pre>

Can anyone help me to resolve this?
ping @amueller

**UPD** The assertion is holding for some values now :| 
**UPD**  I think the test works fine now.
