### PR TITLE
[MRG+1] fix ompcv on old scipy versions

### DIFF
--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -10,7 +10,6 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import check_skip_travis
 
 
 from sklearn.linear_model import (orthogonal_mp, orthogonal_mp_gram,
@@ -172,17 +171,15 @@ def test_omp_path():
 
 
 def test_omp_return_path_prop_with_gram():
-    path = orthogonal_mp(X, y, n_nonzero_coefs=5, return_path=True, 
-            precompute=True)
+    path = orthogonal_mp(X, y, n_nonzero_coefs=5, return_path=True,
+                         precompute=True)
     last = orthogonal_mp(X, y, n_nonzero_coefs=5, return_path=False,
-            precompute=True)
+                         precompute=True)
     assert_equal(path.shape, (n_features, n_targets, 5))
     assert_array_almost_equal(path[:, :, -1], last)
 
 
 def test_omp_cv():
-    # FIXME: This test is unstable on Travis, see issue #3190 for more detail.
-    check_skip_travis()
     y_ = y[:, 0]
     gamma_ = gamma[:, 0]
     ompcv = OrthogonalMatchingPursuitCV(normalize=True, fit_intercept=False,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -23,7 +23,6 @@ from sklearn.utils.testing import META_ESTIMATORS
 from sklearn.utils.testing import set_random_state
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import SkipTest
-from sklearn.utils.testing import check_skip_travis
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.base import clone, ClassifierMixin
@@ -62,9 +61,6 @@ def _boston_subset(n_samples=200):
 def set_fast_parameters(estimator):
     # speed up some estimators
     params = estimator.get_params()
-    if estimator.__class__.__name__ == 'OrthogonalMatchingPursuitCV':
-        # FIXME: This test is unstable on Travis, see issue #3190.
-        check_skip_travis()
     if ("n_iter" in params
             and estimator.__class__.__name__ != "TSNE"):
         estimator.set_params(n_iter=5)


### PR DESCRIPTION
Fixes #4387.
We have an "if old scipy version ignore error" which made this error hard to track down ([here](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/linear_model/omp.py#L23) )
Solves #3190 [once and for all](http://i.imgur.com/gHcGr.jpg).
