### PR TITLE
[MRG + 1] [FIX] LarsCV and LassoLarsCV fails for numpy 1.8.0

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -983,7 +983,7 @@ class LarsCV(Lars):
             returns an instance of self.
         """
         self.fit_path = True
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, y_numeric=True)
 
         # init cross-validation generator
         cv = check_cv(self.cv, X, y, classifier=False)


### PR DESCRIPTION
fixes #4399

@amueller 

Also, should I also update `y_numeric` for https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/kernel_ridge.py#L144 and https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/linear_model/stochastic_gradient.py#L868 ? Both are explicitly regressors. There's a couple others that share `fit` between classifiers and regressors too: gbm, adaboost, bagging... with no `y_numeric=True` on `check_X_y`. 

Presumably all of the above get through tests because no call to the offending numpy function though...

Can confirm all tests pass locally on this branch, and 2 fails on an up to date master, with np 1.8.0 installed on python 2.7.9, ubuntu 14.04. :feelsgood: 
