### PR TITLE
[MRG + 2] Deprecates load_lfw_pairs and load_lfw_people

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -210,9 +210,7 @@ Loaders
    datasets.load_digits
    datasets.load_files
    datasets.load_iris
-   datasets.load_lfw_pairs
    datasets.fetch_lfw_pairs
-   datasets.load_lfw_people
    datasets.fetch_lfw_people
    datasets.load_linnerud
    datasets.mldata_filename

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -26,6 +26,8 @@ detector from various online websites.
 from os import listdir, makedirs, remove
 from os.path import join, exists, isdir
 
+from sklearn.utils import deprecated
+
 import logging
 import numpy as np
 
@@ -362,6 +364,9 @@ def _fetch_lfw_pairs(index_file_path, data_folder_path, slice_=None,
     return pairs, target, np.array(['Different persons', 'Same person'])
 
 
+@deprecated("Function 'load_lfw_people' has been deprecated in 0.17 and will be "
+            "removed in 0.19."
+            "Use fetch_lfw_people(download_if_missing=False) instead.")
 def load_lfw_people(download_if_missing=False, **kwargs):
     """Alias for fetch_lfw_people(download_if_missing=False)
 
@@ -484,6 +489,9 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
                  DESCR="'%s' segment of the LFW pairs dataset" % subset)
 
 
+@deprecated("Function 'load_lfw_pairs' has been deprecated in 0.17 and will be "
+            "removed in 0.19."
+            "Use fetch_lfw_pairs(download_if_missing=False) instead.")
 def load_lfw_pairs(download_if_missing=False, **kwargs):
     """Alias for fetch_lfw_pairs(download_if_missing=False)
 

--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -24,9 +24,12 @@ except ImportError:
 
 from sklearn.datasets import load_lfw_pairs
 from sklearn.datasets import load_lfw_people
+from sklearn.datasets import fetch_lfw_pairs
+from sklearn.datasets import fetch_lfw_people
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import raises
 
@@ -112,12 +115,20 @@ def teardown_module():
 
 @raises(IOError)
 def test_load_empty_lfw_people():
-    load_lfw_people(data_home=SCIKIT_LEARN_EMPTY_DATA)
+    fetch_lfw_people(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
+
+
+def test_load_lfw_people_deprecation():
+    msg = ("Function 'load_lfw_people' has been deprecated in 0.17 and will be "
+           "removed in 0.19."
+           "Use fetch_lfw_people(download_if_missing=False) instead.")
+    assert_warns_message(DeprecationWarning, msg, load_lfw_people,
+                         data_home=SCIKIT_LEARN_DATA)
 
 
 def test_load_fake_lfw_people():
-    lfw_people = load_lfw_people(data_home=SCIKIT_LEARN_DATA,
-                                 min_faces_per_person=3)
+    lfw_people = fetch_lfw_people(data_home=SCIKIT_LEARN_DATA,
+                                  min_faces_per_person=3, download_if_missing=False)
 
     # The data is croped around the center as a rectangular bounding box
     # arounthe the face. Colors are converted to gray levels:
@@ -133,8 +144,8 @@ def test_load_fake_lfw_people():
 
     # It is possible to ask for the original data without any croping or color
     # conversion and not limit on the number of picture per person
-    lfw_people = load_lfw_people(data_home=SCIKIT_LEARN_DATA,
-                                 resize=None, slice_=None, color=True)
+    lfw_people = fetch_lfw_people(data_home=SCIKIT_LEARN_DATA,
+                                  resize=None, slice_=None, color=True, download_if_missing=False)
     assert_equal(lfw_people.images.shape, (17, 250, 250, 3))
 
     # the ids and class names are the same as previously
@@ -147,16 +158,24 @@ def test_load_fake_lfw_people():
 
 @raises(ValueError)
 def test_load_fake_lfw_people_too_restrictive():
-    load_lfw_people(data_home=SCIKIT_LEARN_DATA, min_faces_per_person=100)
+    fetch_lfw_people(data_home=SCIKIT_LEARN_DATA, min_faces_per_person=100, download_if_missing=False)
 
 
 @raises(IOError)
 def test_load_empty_lfw_pairs():
-    load_lfw_pairs(data_home=SCIKIT_LEARN_EMPTY_DATA)
+    fetch_lfw_pairs(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
+
+
+def test_load_lfw_pairs_deprecation():
+    msg = ("Function 'load_lfw_pairs' has been deprecated in 0.17 and will be "
+           "removed in 0.19."
+           "Use fetch_lfw_pairs(download_if_missing=False) instead.")
+    assert_warns_message(DeprecationWarning, msg, load_lfw_pairs,
+                         data_home=SCIKIT_LEARN_DATA)
 
 
 def test_load_fake_lfw_pairs():
-    lfw_pairs_train = load_lfw_pairs(data_home=SCIKIT_LEARN_DATA)
+    lfw_pairs_train = fetch_lfw_pairs(data_home=SCIKIT_LEARN_DATA, download_if_missing=False)
 
     # The data is croped around the center as a rectangular bounding box
     # arounthe the face. Colors are converted to gray levels:
@@ -171,8 +190,8 @@ def test_load_fake_lfw_pairs():
 
     # It is possible to ask for the original data without any croping or color
     # conversion
-    lfw_pairs_train = load_lfw_pairs(data_home=SCIKIT_LEARN_DATA,
-                                     resize=None, slice_=None, color=True)
+    lfw_pairs_train = fetch_lfw_pairs(data_home=SCIKIT_LEARN_DATA,
+                                      resize=None, slice_=None, color=True, download_if_missing=False)
     assert_equal(lfw_pairs_train.pairs.shape, (10, 2, 250, 250, 3))
 
     # the ids and class names are the same as previously


### PR DESCRIPTION
#4425 I was wondering if this needs a `DeprecationWarning` or some change in the doc?

ping @amueller @ogrisel 
