### PR TITLE
[MRG + 2] Friendly error when lvmpdf has non positive definite covariance

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -608,8 +608,12 @@ def _log_multivariate_normal_density_full(X, means, covars, min_covar=1.e-7):
         except linalg.LinAlgError:
             # The model is most probably stuck in a component with too
             # few observations, we need to reinitialize this components
-            cv_chol = linalg.cholesky(cv + min_covar * np.eye(n_dim),
-                                      lower=True)
+            try:
+                cv_chol = linalg.cholesky(cv + min_covar * np.eye(n_dim),
+                                          lower=True)
+            except linalg.LinAlgError:
+                raise ValueError("'covars' must be symmetric, positive-definite")
+
         cv_log_det = 2 * np.sum(np.log(np.diagonal(cv_chol)))
         cv_sol = linalg.solve_triangular(cv_chol, (X - mu).T, lower=True).T
         log_prob[:, c] = - .5 * (np.sum(cv_sol ** 2, axis=1) +

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -8,6 +8,8 @@ from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_raise_message
+
 
 rng = np.random.RandomState(0)
 
@@ -102,6 +104,18 @@ def test_lmvnpdf_full():
     reference = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, fullcv, 'full')
     assert_array_almost_equal(lpr, reference)
+
+
+def test_lvmpdf_full_cv_non_positive_definite():
+    n_features, n_components, n_samples = 2, 1, 10
+    rng = np.random.RandomState(0)
+    X = rng.randint(10) * rng.rand(n_samples, n_features)
+    mu = np.mean(X, 0)
+    cv = np.array([[[-1, 0], [0, 1]]])
+    expected_message = "'covars' must be symmetric, positive-definite"
+    assert_raise_message(ValueError, expected_message,
+                         mixture.log_multivariate_normal_density,
+                         X, mu, cv, 'full')
 
 
 def test_GMM_attributes():


### PR DESCRIPTION
Catch `linalg.LinAlgError`, and raise `ValueError` when `log_multivariate_normal_density` has full type but non positive definite covariance. #4429 
