### PR TITLE
[MRG + 2] Stratified `train_test_split`

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1547,6 +1547,10 @@ def train_test_split(*arrays, **options):
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
+    stratify: array-like or None (default is None)
+        If not None, data is split in a stratified fashion, using this as
+        the labels array.
+
     Returns
     -------
     splitting : list of arrays, length=2 * len(arrays)
@@ -1596,6 +1600,7 @@ def train_test_split(*arrays, **options):
 
     allow_nd = options.pop('allow_nd', None)
     allow_lists = options.pop('allow_lists', None)
+    stratify = options.pop('stratify', None)
 
     if allow_lists is not None:
         warnings.warn("The allow_lists option is deprecated and will be "
@@ -1615,10 +1620,22 @@ def train_test_split(*arrays, **options):
     if test_size is None and train_size is None:
         test_size = 0.25
     arrays = indexable(*arrays)
-    n_samples = _num_samples(arrays[0])
-    cv = ShuffleSplit(n_samples, test_size=test_size,
-                      train_size=train_size,
-                      random_state=random_state)
+    if stratify is not None:
+        # StratifiedKFold expects n_folds, not train_size/test_size
+        # compute the former from the latter
+        # todo this won't work correctly when test_size > train_size
+        n_train, n_test = _validate_shuffle_split(len(stratify),
+                                                  test_size,
+                                                  train_size)
+        n_folds = ceil((n_test + n_train) / n_test)
+        # todo shuffle parameter of StratifiedKFold not exposed
+        cv = StratifiedKFold(stratify, n_folds=n_folds,
+                             random_state=random_state)
+    else:
+        n_samples = _num_samples(arrays[0])
+        cv = ShuffleSplit(n_samples, test_size=test_size,
+                          train_size=train_size,
+                          random_state=random_state)
 
     train, test = next(iter(cv))
     return list(chain.from_iterable((safe_indexing(a, train),

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1547,7 +1547,7 @@ def train_test_split(*arrays, **options):
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
-    stratify: array-like or None (default is None)
+    stratify : array-like or None (default is None)
         If not None, data is split in a stratified fashion, using this as
         the labels array.
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -702,10 +702,13 @@ def test_train_test_split():
                                         [2, 4, 2, 4, 6]):
         train, test = cval.train_test_split(y,
                                             test_size=test_size,
-                                            stratify=y)
+                                            stratify=y,
+                                            random_state=0)
         assert_equal(len(test), exp_test_size)
         assert_equal(len(test) + len(train), len(y))
-        assert_almost_equal(np.sum(y[train] == 1), np.sum(y[train] == 1))
+        # check the 1:1 ratio of ones and twos in the data is preserved
+        assert_equal(np.sum(train == 1), np.sum(train == 2))
+
 
 def train_test_split_pandas():
     # check cross_val_score doesn't destroy pandas dataframe

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -696,6 +696,16 @@ def test_train_test_split():
     assert_equal(split[2].shape, (7, 7, 11))
     assert_equal(split[3].shape, (3, 7, 11))
 
+    # test stratification option
+    y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
+    for test_size, exp_test_size in zip([2, 4, 0.25, 0.5],
+                                        [2, 4, 2, 4]):
+        train, test = cval.train_test_split(y,
+                                            test_size=test_size,
+                                            stratify=y)
+        assert_equal(len(test), exp_test_size)
+        assert_equal(len(test) + len(train), len(y))
+        assert_almost_equal(np.sum(y[train] == 1), np.sum(y[train] == 1))
 
 def train_test_split_pandas():
     # check cross_val_score doesn't destroy pandas dataframe

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -698,8 +698,8 @@ def test_train_test_split():
 
     # test stratification option
     y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
-    for test_size, exp_test_size in zip([2, 4, 0.25, 0.5],
-                                        [2, 4, 2, 4]):
+    for test_size, exp_test_size in zip([2, 4, 0.25, 0.5, 0.75],
+                                        [2, 4, 2, 4, 6]):
         train, test = cval.train_test_split(y,
                                             test_size=test_size,
                                             stratify=y)


### PR DESCRIPTION
This is a first stab at #4437. 

It features a hack I am not particularly happy with, but can't think of a better option at the moment. Your input is greatly appreciated.

 The issue is that internally `train_test_split` uses a `ShuffleSplit` iterator, and both take a `train_size`/ `test_size` parameter. To implement stratification, I used a `StatifiedKFold` iterator, which takes `n_folds`. To maintain the semantics of `train_size`/ `test_size`, `n_folds` has to be computed out of these. However, as far as I can tell there isn't a value of `n_folds` which can generate train/test sets such that `train_size < test_size`, which is possible with the current implementation. When the user requests that `train_size < test_size`, I generate a train/test where `train_size` and  `test_size` are swapped (easy to do with current implementation of `StatifiedKFold`), and then swap them again.

Maybe a better solution would have been to extract the stratification logic out of `StatifiedKFold` and generate appropriately sized train/test sets to begin with. 
