### PR TITLE
[MRG + 1] Fix signature not compatible with previous declaration

### DIFF
--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -981,10 +981,10 @@ cdef class HaversineDistance(DistanceMetric):
         return 2 * asin(sqrt(sin_0 * sin_0
                              + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1))
 
-    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist):
+    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return 2 * asin(sqrt(rdist))
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist):
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1:
         cdef DTYPE_t tmp = sin(0.5 * dist)
         return tmp * tmp
 


### PR DESCRIPTION
Fixes a compile error with Cython 0.22:

```
Error compiling Cython file:
------------------------------------------------------------
...
        cdef DTYPE_t sin_0 = sin(0.5 * (x1[0] - x2[0]))
        cdef DTYPE_t sin_1 = sin(0.5 * (x1[1] - x2[1]))
        return 2 * asin(sqrt(sin_0 * sin_0
                             + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1))

    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist):
        ^
------------------------------------------------------------

dist_metrics.pyx:984:9: Signature not compatible with previous declaration

Error compiling Cython file:
------------------------------------------------------------
...
    cdef int pdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] D) except -1

    cdef int cdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] Y,
                   DTYPE_t[:, ::1] D) except -1

    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1
                              ^
------------------------------------------------------------

dist_metrics.pxd:73:31: Previous declaration is here

Error compiling Cython file:
------------------------------------------------------------
...
                             + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1))

    cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist):
        return 2 * asin(sqrt(rdist))

    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist):
        ^
------------------------------------------------------------

dist_metrics.pyx:987:9: Signature not compatible with previous declaration

Error compiling Cython file:
------------------------------------------------------------
...
    cdef int cdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] Y,
                   DTYPE_t[:, ::1] D) except -1

    cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1

    cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1
                              ^
------------------------------------------------------------

dist_metrics.pxd:75:31: Previous declaration is here
```
