### PR TITLE
[MRG + 1] BUG: get_param in FeatureUnion disjoint for shallow/deep params

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -102,6 +102,8 @@ class Pipeline(BaseEstimator):
             for name, step in six.iteritems(self.named_steps):
                 for key, value in six.iteritems(step.get_params(deep=True)):
                     out['%s__%s' % (name, key)] = value
+
+            out.update(super(Pipeline, self).get_params(deep=False))
             return out
 
     @property
@@ -487,6 +489,7 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
             for name, trans in self.transformer_list:
                 for key, value in iteritems(trans.get_params(deep=True)):
                     out['%s__%s' % (name, key)] = value
+            out.update(super(FeatureUnion, self).get_params(deep=False))
             return out
 
     def _update_transformer_list(self, transformers):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -62,6 +62,7 @@ from sklearn.utils.estimator_checks import (
     check_fit_score_takes_y,
     check_non_transformer_estimators_n_iter,
     check_pipeline_consistency,
+    check_get_params_invariance,
     CROSS_DECOMPOSITION)
 
 
@@ -377,3 +378,15 @@ def test_transformer_n_iter():
 
         if hasattr(estimator, "max_iter") and name not in external_solver:
             yield check_transformer_n_iter, name, estimator
+
+def test_get_params_invariance():
+    # Test for estimators that support get_params, that
+    # get_params(deep=False) is a subset of get_params(deep=True)
+    # Related to issue #4465
+    
+    estimators = all_estimators(include_meta_estimators=False, 
+            include_other=True)
+    for name, Estimator in estimators:
+        if hasattr(Estimator, 'get_params'):
+            yield check_get_params_invariance, name, Estimator
+

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -87,7 +87,9 @@ def test_pipeline_init():
     clf = T()
     pipe = Pipeline([('svc', clf)])
     assert_equal(pipe.get_params(deep=True),
-                 dict(svc__a=None, svc__b=None, svc=clf))
+                 dict(svc__a=None, svc__b=None, svc=clf,
+                     **pipe.get_params(deep=False)
+                     ))
 
     # Check that params are set
     pipe.set_params(svc__a=0.1)
@@ -118,8 +120,15 @@ def test_pipeline_init():
     assert_false(pipe.named_steps['svc'] is pipe2.named_steps['svc'])
 
     # Check that apart from estimators, the parameters are the same
-    params = pipe.get_params()
-    params2 = pipe2.get_params()
+    params = pipe.get_params(deep=True)
+    params2 = pipe2.get_params(deep=True)
+    
+    for x in pipe.get_params(deep=False):
+        params.pop(x)
+    
+    for x in pipe2.get_params(deep=False):
+        params2.pop(x)
+    
     # Remove estimators that where copied
     params.pop('svc')
     params.pop('anova')

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -25,7 +25,7 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import ignore_warnings
 
-from sklearn.base import clone, ClassifierMixin
+from sklearn.base import clone, ClassifierMixin, BaseEstimator
 from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
 
 from sklearn.lda import LDA
@@ -33,7 +33,6 @@ from sklearn.random_projection import BaseRandomProjection
 from sklearn.feature_selection import SelectKBest
 from sklearn.svm.base import BaseLibSVM
 from sklearn.pipeline import make_pipeline
-
 from sklearn.utils.validation import DataConversionWarning, NotFittedError
 from sklearn.cross_validation import train_test_split
 
@@ -1117,3 +1116,31 @@ def check_transformer_n_iter(name, estimator):
             assert_greater(iter_, 1)
     else:
         assert_greater(estimator.n_iter_, 1)
+
+
+def check_get_params_invariance(name, estimator):
+    class T(BaseEstimator):
+        """Mock classifier
+        """
+
+        def __init__(self):
+            pass
+
+        def fit(self, X, y):
+            return self
+
+    if name in ('FeatureUnion', 'Pipeline'):
+        e = estimator([('clf', T())])
+
+    elif name in ('GridSearchCV' 'RandomizedSearchCV'):
+        return
+
+    else:
+        e = estimator()
+
+
+    shallow_params = e.get_params(deep=False)
+    deep_params = e.get_params(deep=True)
+
+    assert_true(all(item in deep_params.items() for item in 
+        shallow_params.items()))


### PR DESCRIPTION
- Previously params in a FeatureUnion or Pipeline were different
  when deep=False and deep=True, making it impossible to set shallow
  params during GridSearch (issue #4461)
- Added test to enforce deep=True results to be superset of deep=False.
- Updated deep get_param output in pipeline estimators with shallow params.

TST: Test estimators for get_params invariance (issue #4465)
- Estimators that support get_params should always be consistent
  in that get_params(deep=False) should be a subset of get_params(deep=True) 
- Implemented test over all "normal" and "other" estimators provided by
  all_estimators
- Ignoring grid_search estimators for now
