### PR TITLE
[MRG+2] rebasing pr/3474 (multioutput regression metrics)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1085,8 +1085,31 @@ Regression metrics
 
 The :mod:`sklearn.metrics` module implements several loss, score, and utility
 functions to measure regression performance. Some of those have been enhanced
-to handle the multioutput case: :func:`mean_absolute_error`,
-:func:`mean_squared_error`, :func:`median_absolute_error` and :func:`r2_score`.
+to handle the multioutput case: :func:`mean_squared_error`,
+:func:`mean_absolute_error`, :func:`explained_variance_score` and
+:func:`r2_score`.
+
+
+These functions have an ``multioutput`` keyword argument which specifies the
+way the scores or losses for each individual target should be averaged. The
+default is ``'uniform_average'``, which specifies a uniformly weighted mean
+over outputs. If an ``ndarray`` of shape ``(n_outputs,)`` is passed, then its
+entries are interpreted as weights and an according weighted average is
+returned. If ``multioutput`` is ``'raw_values'`` is specified, then all
+unaltered individual scores or losses will be returned in an array of shape
+``(n_outputs,)``.
+
+
+The :func:`r2_score` and :func:`explained_variance_score` accept an additional
+value ``'variance_weighted'`` for the ``multioutput`` parameter. This option
+leads to a weighting of each individual score by the variance of the
+corresponding target variable. This setting quantifies the globally captured
+unscaled variance. If the target variables are of different scale, then this
+score puts more importance on well explaining the higher variance variables.
+``multioutput='variance_weighted'`` is the default value for :func:`r2_score`
+for backward compatibility. This will be changed to ``uniform_average`` in the
+future.
+
 
 Explained variance score
 -------------------------
@@ -1113,6 +1136,14 @@ function::
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
     0.957...
+    >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+    >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
+    >>> explained_variance_score(y_true, y_pred, multioutput='raw_values')
+    ... # doctest: +ELLIPSIS
+    array([ 0.967...,  1.        ])
+    >>> explained_variance_score(y_true, y_pred, multioutput=[0.3, 0.7])
+    ... # doctest: +ELLIPSIS
+    0.990...
 
 Mean absolute error
 -------------------
@@ -1141,7 +1172,11 @@ Here is a small example of usage of the :func:`mean_absolute_error` function::
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
   >>> mean_absolute_error(y_true, y_pred)
   0.75
-
+  >>> mean_absolute_error(y_true, y_pred, multioutput='raw_values')
+  array([ 0.5,  1. ])
+  >>> mean_absolute_error(y_true, y_pred, multioutput=[0.3, 0.7])
+  ... # doctest: +ELLIPSIS
+  0.849...
 
 
 Mean squared error
@@ -1232,8 +1267,20 @@ Here is a small example of usage of the :func:`r2_score` function::
   0.948...
   >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
   >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
-  >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+  >>> r2_score(y_true, y_pred, multioutput='variance_weighted')
+  ... # doctest: +ELLIPSIS
   0.938...
+  >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+  >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
+  >>> r2_score(y_true, y_pred, multioutput='uniform_average')
+  ... # doctest: +ELLIPSIS
+  0.936...
+  >>> r2_score(y_true, y_pred, multioutput='raw_values')
+  ... # doctest: +ELLIPSIS
+  array([ 0.965...,  0.908...])
+  >>> r2_score(y_true, y_pred, multioutput=[0.3, 0.7])
+  ... # doctest: +ELLIPSIS
+  0.925...
 
 
 .. topic:: Example:

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -15,6 +15,9 @@ the lower the better
 #          Lars Buitinck <L.J.Buitinck@uva.nl>
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Noel Dawe <noel@dawe.me>
+#          Manoj Kumar <manojkumarsivaraj334@gmail.com>
+#          Michael Eickenberg <michael.eickenberg@gmail.com>
+#          Konstantin Shmelkov <konstantin.shmelkov@polytechnique.edu>
 # License: BSD 3 clause
 
 from __future__ import division
@@ -23,6 +26,8 @@ import numpy as np
 
 from ..utils.validation import check_array, check_consistent_length
 from ..utils.validation import column_or_1d
+
+import warnings
 
 __ALL__ = [
     "mean_absolute_error",
@@ -33,7 +38,7 @@ __ALL__ = [
 ]
 
 
-def _check_reg_targets(y_true, y_pred):
+def _check_reg_targets(y_true, y_pred, multioutput):
     """Check that y_true and y_pred belong to the same regression task
 
     Parameters
@@ -42,17 +47,28 @@ def _check_reg_targets(y_true, y_pred):
 
     y_pred : array-like,
 
+    multioutput : array-like or string in ['raw_values', uniform_average',
+        'variance_weighted'] or None
+        None is accepted due to backward compatibility of r2_score().
+
     Returns
     -------
     type_true : one of {'continuous', continuous-multioutput'}
         The type of the true target data, as output by
-        ``utils.multiclass.type_of_target``
+        'utils.multiclass.type_of_target'
 
-    y_true : array-like of shape = [n_samples, n_outputs]
+    y_true : array-like of shape = (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape = [n_samples, n_outputs]
+    y_pred : array-like of shape = (n_samples, n_outputs)
         Estimated target values.
+
+    multioutput : array-like of shape = (n_outputs) or string in ['raw_values',
+        uniform_average', 'variance_weighted'] or None
+        Custom output weights if ``multioutput`` is array-like or
+        just the corresponding argument if ``multioutput`` is a
+        correct keyword.
+
     """
     check_consistent_length(y_true, y_pred)
     y_true = check_array(y_true, ensure_2d=False)
@@ -68,60 +84,60 @@ def _check_reg_targets(y_true, y_pred):
         raise ValueError("y_true and y_pred have different number of output "
                          "({0}!={1})".format(y_true.shape[1], y_pred.shape[1]))
 
-    y_type = 'continuous' if y_true.shape[1] == 1 else 'continuous-multioutput'
+    n_outputs = y_true.shape[1]
+    multioutput_options = (None, 'raw_values', 'uniform_average',
+                           'variance_weighted')
+    if multioutput not in multioutput_options:
+        multioutput = check_array(multioutput, ensure_2d=False)
+        if n_outputs == 1:
+            raise ValueError("Custom weights are useful only in "
+                             "multi-output cases.")
+        elif n_outputs != len(multioutput):
+            raise ValueError(("There must be equally many custom weights "
+                              "(%d) as outputs (%d).") %
+                             (len(multioutput), n_outputs))
+    y_type = 'continuous' if n_outputs == 1 else 'continuous-multioutput'
 
-    return y_type, y_true, y_pred
-
-
-def _average_and_variance(values, sample_weight=None):
-    """
-    Compute the (weighted) average and variance.
-
-    Parameters
-    ----------
-    values : array-like of shape = [n_samples] or [n_samples, n_outputs]
-
-    sample_weight : array-like of shape = [n_samples], optional
-        Sample weights.
-
-    Returns
-    -------
-    average : float
-        The weighted average
-
-    variance : float
-        The weighted variance
-    """
-    values = np.asarray(values)
-    if values.ndim == 1:
-        values = values.reshape((-1, 1))
-    if sample_weight is not None:
-        sample_weight = np.asarray(sample_weight)
-        if sample_weight.ndim == 1:
-            sample_weight = sample_weight.reshape((-1, 1))
-    average = np.average(values, weights=sample_weight)
-    variance = np.average((values - average)**2, weights=sample_weight)
-    return average, variance
+    return y_type, y_true, y_pred, multioutput
 
 
-def mean_absolute_error(y_true, y_pred, sample_weight=None):
+def mean_absolute_error(y_true, y_pred,
+                        sample_weight=None,
+                        multioutput='uniform_average'):
     """Mean absolute error regression loss
 
     Parameters
     ----------
-    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_pred : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Estimated target values.
 
-    sample_weight : array-like of shape = [n_samples], optional
+    sample_weight : array-like of shape = (n_samples), optional
         Sample weights.
+
+    multioutput : string in ['raw_values', 'uniform_average']
+        or array-like of shape (n_outputs)
+        Defines aggregating of multiple output values.
+        Array-like value defines weights used to average errors.
+
+        'raw_values' :
+            Returns a full set of errors in case of multioutput input.
+
+        'uniform_average' :
+            Errors of all outputs are averaged with uniform weight.
+
 
     Returns
     -------
-    loss : float
-        A positive floating point value (the best value is 0.0).
+    loss : float or ndarray of floats
+        If multioutput is 'raw_values', then mean absolute error is returned
+        for each output separately.
+        If multioutput is 'uniform_average' or an ndarray of weights, then the
+        weighted average of all output errors is returned.
+
+        MAE output is non-negative floating point. The best value is 0.0.
 
     Examples
     --------
@@ -134,31 +150,57 @@ def mean_absolute_error(y_true, y_pred, sample_weight=None):
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> mean_absolute_error(y_true, y_pred)
     0.75
-
+    >>> mean_absolute_error(y_true, y_pred, multioutput='raw_values')
+    array([ 0.5,  1. ])
+    >>> mean_absolute_error(y_true, y_pred, multioutput=[0.3, 0.7])
+    ... # doctest: +ELLIPSIS
+    0.849...
     """
-    y_type, y_true, y_pred = _check_reg_targets(y_true, y_pred)
-    return np.average(np.abs(y_pred - y_true).mean(axis=1),
-                      weights=sample_weight)
+    y_type, y_true, y_pred, multioutput = _check_reg_targets(
+        y_true, y_pred, multioutput)
+    output_errors = np.average(np.abs(y_pred - y_true),
+                               weights=sample_weight, axis=0)
+    if multioutput == 'raw_values':
+        return output_errors
+    elif multioutput == 'uniform_average':
+        # pass None as weights to np.average: uniform mean
+        multioutput = None
+
+    return np.average(output_errors, weights=multioutput)
 
 
-def mean_squared_error(y_true, y_pred, sample_weight=None):
+def mean_squared_error(y_true, y_pred,
+                       sample_weight=None,
+                       multioutput='uniform_average'):
     """Mean squared error regression loss
 
     Parameters
     ----------
-    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_pred : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Estimated target values.
 
-    sample_weight : array-like of shape = [n_samples], optional
+    sample_weight : array-like of shape = (n_samples), optional
         Sample weights.
+
+    multioutput : string in ['raw_values', 'uniform_average']
+        or array-like of shape (n_outputs)
+        Defines aggregating of multiple output values.
+        Array-like value defines weights used to average errors.
+
+        'raw_values' :
+            Returns a full set of errors in case of multioutput input.
+
+        'uniform_average' :
+            Errors of all outputs are averaged with uniform weight.
 
     Returns
     -------
-    loss : float
-        A positive floating point value (the best value is 0.0).
+    loss : float or ndarray of floats
+        A non-negative floating point value (the best value is 0.0), or an
+        array of floating point values, one for each individual target.
 
     Examples
     --------
@@ -171,11 +213,25 @@ def mean_squared_error(y_true, y_pred, sample_weight=None):
     >>> y_pred = [[0, 2],[-1, 2],[8, -5]]
     >>> mean_squared_error(y_true, y_pred)  # doctest: +ELLIPSIS
     0.708...
+    >>> mean_squared_error(y_true, y_pred, multioutput='raw_values')
+    ... # doctest: +ELLIPSIS
+    array([ 0.416...,  1.        ])
+    >>> mean_squared_error(y_true, y_pred, multioutput=[0.3, 0.7])
+    ... # doctest: +ELLIPSIS
+    0.824...
 
     """
-    y_type, y_true, y_pred = _check_reg_targets(y_true, y_pred)
-    return np.average(((y_pred - y_true) ** 2).mean(axis=1),
-                      weights=sample_weight)
+    y_type, y_true, y_pred, multioutput = _check_reg_targets(
+        y_true, y_pred, multioutput)
+    output_errors = np.average((y_true - y_pred) ** 2, axis=0,
+                               weights=sample_weight)
+    if multioutput == 'raw_values':
+        return output_errors
+    elif multioutput == 'uniform_average':
+        # pass None as weights to np.average: uniform mean
+        multioutput = None
+
+    return np.average(output_errors, weights=multioutput)
 
 
 def median_absolute_error(y_true, y_pred):
@@ -183,10 +239,10 @@ def median_absolute_error(y_true, y_pred):
 
     Parameters
     ----------
-    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_true : array-like of shape = (n_samples)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_pred : array-like of shape = (n_samples)
         Estimated target values.
 
     Returns
@@ -203,32 +259,50 @@ def median_absolute_error(y_true, y_pred):
     0.5
 
     """
-    y_type, y_true, y_pred = _check_reg_targets(y_true, y_pred)
+    y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred,
+                                                   'uniform_average')
     if y_type == 'continuous-multioutput':
         raise ValueError("Multioutput not supported in median_absolute_error")
     return np.median(np.abs(y_pred - y_true))
 
 
-def explained_variance_score(y_true, y_pred, sample_weight=None):
+def explained_variance_score(y_true, y_pred,
+                             sample_weight=None,
+                             multioutput='uniform_average'):
     """Explained variance regression score function
 
     Best possible score is 1.0, lower values are worse.
 
     Parameters
     ----------
-    y_true : array-like
+    y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : array-like
+    y_pred : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Estimated target values.
 
-    sample_weight : array-like of shape = [n_samples], optional
+    sample_weight : array-like of shape = (n_samples), optional
         Sample weights.
+
+    multioutput : string in ['raw_values', 'uniform_average',
+                'variance_weighted'] or array-like of shape (n_outputs)
+        Defines aggregating of multiple output scores.
+        Array-like value defines weights used to average scores.
+
+        'raw_values' :
+            Returns a full set of scores in case of multioutput input.
+
+        'uniform_average' :
+            Scores of all outputs are averaged with uniform weight.
+
+        'variance_weighted' :
+            Scores of all outputs are averaged, weighted by the variances
+            of each individual output.
 
     Returns
     -------
-    score : float
-        The explained variance.
+    score : float or ndarray of floats
+        The explained variance or ndarray if 'multioutput' is 'raw_values'.
 
     Notes
     -----
@@ -241,45 +315,85 @@ def explained_variance_score(y_true, y_pred, sample_weight=None):
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> explained_variance_score(y_true, y_pred)  # doctest: +ELLIPSIS
     0.957...
+    >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
+    >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
+    >>> explained_variance_score(y_true, y_pred, multioutput='uniform_average')  # doctest: +ELLIPSIS
+    0.983...
 
     """
-    y_type, y_true, y_pred = _check_reg_targets(y_true, y_pred)
+    y_type, y_true, y_pred, multioutput = _check_reg_targets(
+        y_true, y_pred, multioutput)
 
-    if y_type != "continuous":
-        raise ValueError("{0} is not supported".format(y_type))
+    y_diff_avg = np.average(y_true - y_pred, weights=sample_weight, axis=0)
+    numerator = np.average((y_true - y_pred - y_diff_avg) ** 2,
+                           weights=sample_weight, axis=0)
 
-    _, numerator = _average_and_variance(y_true - y_pred, sample_weight)
-    _, denominator = _average_and_variance(y_true, sample_weight)
-    if denominator == 0.0:
-        if numerator == 0.0:
-            return 1.0
-        else:
-            # arbitrary set to zero to avoid -inf scores, having a constant
-            # y_true is not interesting for scoring a regression anyway
-            return 0.0
-    return 1 - numerator / denominator
+    y_true_avg = np.average(y_true, weights=sample_weight, axis=0)
+    denominator = np.average((y_true - y_true_avg) ** 2,
+                             weights=sample_weight, axis=0)
+
+    nonzero_numerator = numerator != 0
+    nonzero_denominator = denominator != 0
+    valid_score = nonzero_numerator & nonzero_denominator
+    output_scores = np.ones(y_true.shape[1])
+
+    output_scores[valid_score] = 1 - (numerator[valid_score] /
+                                      denominator[valid_score])
+    output_scores[nonzero_numerator & ~nonzero_denominator] = 0.
+    if multioutput == 'raw_values':
+        # return scores individually
+        return output_scores
+    elif multioutput == 'uniform_average':
+        # passing to np.average() None as weights results is uniform mean
+        avg_weights = None
+    elif multioutput == 'variance_weighted':
+        avg_weights = denominator
+    else:
+        avg_weights = multioutput
+
+    return np.average(output_scores, weights=avg_weights)
 
 
-def r2_score(y_true, y_pred, sample_weight=None):
+def r2_score(y_true, y_pred,
+             sample_weight=None,
+             multioutput=None):
     """R^2 (coefficient of determination) regression score function.
 
     Best possible score is 1.0, lower values are worse.
 
     Parameters
     ----------
-    y_true : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Ground truth (correct) target values.
 
-    y_pred : array-like of shape = [n_samples] or [n_samples, n_outputs]
+    y_pred : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Estimated target values.
 
-    sample_weight : array-like of shape = [n_samples], optional
+    sample_weight : array-like of shape = (n_samples), optional
         Sample weights.
+
+    multioutput : string in ['raw_values', 'uniform_average',
+                'variance_weighted'] or None or array-like of shape (n_outputs)
+        Defines aggregating of multiple output scores.
+        Array-like value defines weights used to average scores.
+        Default value correponds to 'variance_weighted', but
+        will be changed to 'uniform_average' in next versions.
+
+        'raw_values' :
+            Returns a full set of scores in case of multioutput input.
+
+        'uniform_average' :
+            Scores of all outputs are averaged with uniform weight.
+
+        'variance_weighted' :
+            Scores of all outputs are averaged, weighted by the variances
+            of each individual output.
 
     Returns
     -------
-    z : float
-        The R^2 score.
+    z : float or ndarray of floats
+        The R^2 score or ndarray of scores if 'multioutput' is
+        'raw_values'.
 
     Notes
     -----
@@ -302,11 +416,12 @@ def r2_score(y_true, y_pred, sample_weight=None):
     0.948...
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
-    >>> r2_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    >>> r2_score(y_true, y_pred, multioutput='variance_weighted')  # doctest: +ELLIPSIS
     0.938...
 
     """
-    y_type, y_true, y_pred = _check_reg_targets(y_true, y_pred)
+    y_type, y_true, y_pred, multioutput = _check_reg_targets(
+        y_true, y_pred, multioutput)
 
     if sample_weight is not None:
         sample_weight = column_or_1d(sample_weight)
@@ -314,16 +429,42 @@ def r2_score(y_true, y_pred, sample_weight=None):
     else:
         weight = 1.
 
-    numerator = (weight * (y_true - y_pred) ** 2).sum(dtype=np.float64)
+    numerator = (weight * (y_true - y_pred) ** 2).sum(axis=0,
+                                                      dtype=np.float64)
     denominator = (weight * (y_true - np.average(
-        y_true, axis=0, weights=sample_weight)) ** 2).sum(dtype=np.float64)
+        y_true, axis=0, weights=sample_weight)) ** 2).sum(axis=0,
+                                                          dtype=np.float64)
+    nonzero_denominator = denominator != 0
+    nonzero_numerator = numerator != 0
+    valid_score = nonzero_denominator & nonzero_numerator
+    output_scores = np.ones([y_true.shape[1]])
+    output_scores[valid_score] = 1 - (numerator[valid_score] /
+                                      denominator[valid_score])
+    # arbitrary set to zero to avoid -inf scores, having a constant
+    # y_true is not interesting for scoring a regression anyway
+    output_scores[nonzero_numerator & ~nonzero_denominator] = 0.
+    if multioutput is None:
+        # @FIXME change in 0.18
+        warnings.warn("Default 'multioutput' behavior now corresponds to "
+                      "'variance_weighted' value, it will be changed "
+                      "to 'uniform_average' in 0.18.",
+                      DeprecationWarning)
+        multioutput = 'variance_weighted'
+    if multioutput == 'raw_values':
+        # return scores individually
+        return output_scores
+    elif multioutput == 'uniform_average':
+        # passing None as weights results is uniform mean
+        avg_weights = None
+    elif multioutput == 'variance_weighted':
+        avg_weights = denominator
+        # avoid fail on constant y or one-element arrays
+        if not np.any(nonzero_denominator):
+            if not np.any(nonzero_numerator):
+                return 1.0
+            else:
+                return 0.0
+    else:
+        avg_weights = multioutput
 
-    if denominator == 0.0:
-        if numerator == 0.0:
-            return 1.0
-        else:
-            # arbitrary set to zero to avoid -inf scores, having a constant
-            # y_true is not interesting for scoring a regression anyway
-            return 0.0
-
-    return 1 - numerator / denominator
+    return np.average(output_scores, weights=avg_weights)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -298,6 +298,7 @@ MULTILABELS_METRICS = [
 # Regression metrics with "multioutput-continuous" format support
 MULTIOUTPUT_METRICS = [
     "mean_absolute_error", "mean_squared_error", "r2_score",
+    "explained_variance_score"
 ]
 
 # Symmetric with respect to their input arguments y_true and y_pred

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 
 from sklearn.metrics import explained_variance_score
 from sklearn.metrics import mean_absolute_error
@@ -40,8 +41,11 @@ def test_multioutput_regression():
     error = mean_absolute_error(y_true, y_pred)
     assert_almost_equal(error, (1. / 3 + 2. / 3 + 2. / 3) / 4.)
 
-    error = r2_score(y_true, y_pred)
-    assert_almost_equal(error, 1 - 5. / 2)
+    error = r2_score(y_true, y_pred, multioutput='variance_weighted')
+    assert_almost_equal(error, 1. - 5. / 2)
+    error = r2_score(y_true, y_pred, multioutput='uniform_average')
+    assert_almost_equal(error, -.875)
+
 
 
 def test_regression_metrics_at_limits():
@@ -66,7 +70,8 @@ def test__check_reg_targets():
                                                             repeat=2):
 
         if type1 == type2 and n_out1 == n_out2:
-            y_type, y_check1, y_check2 = _check_reg_targets(y1, y2)
+            y_type, y_check1, y_check2, multioutput = _check_reg_targets(
+                y1, y2, None)
             assert_equal(type1, y_type)
             if type1 == 'continuous':
                 assert_array_equal(y_check1, np.reshape(y1, (-1, 1)))
@@ -75,4 +80,65 @@ def test__check_reg_targets():
                 assert_array_equal(y_check1, y1)
                 assert_array_equal(y_check2, y2)
         else:
-            assert_raises(ValueError, _check_reg_targets, y1, y2)
+            assert_raises(ValueError, _check_reg_targets, y1, y2, None)
+
+
+def test_regression_multioutput_array():
+    y_true = [[1, 2], [2.5, -1], [4.5, 3], [5, 7]]
+    y_pred = [[1, 1], [2, -1], [5, 4], [5, 6.5]]
+
+    mse = mean_squared_error(y_true, y_pred, multioutput='raw_values')
+    mae = mean_absolute_error(y_true, y_pred, multioutput='raw_values')
+    r = r2_score(y_true, y_pred, multioutput='raw_values')
+    evs = explained_variance_score(y_true, y_pred, multioutput='raw_values')
+
+    assert_array_almost_equal(mse, [0.125, 0.5625], decimal=2)
+    assert_array_almost_equal(mae, [0.25, 0.625], decimal=2)
+    assert_array_almost_equal(r, [0.95, 0.93], decimal=2)
+    assert_array_almost_equal(evs, [0.95, 0.93], decimal=2)
+
+    # mean_absolute_error and mean_squared_error are equal because
+    # it is a binary problem.
+    y_true = [[0, 0]]*4
+    y_pred = [[1, 1]]*4
+    mse = mean_squared_error(y_true, y_pred, multioutput='raw_values')
+    mae = mean_absolute_error(y_true, y_pred, multioutput='raw_values')
+    r = r2_score(y_true, y_pred, multioutput='raw_values')
+    assert_array_almost_equal(mse, [1., 1.], decimal=2)
+    assert_array_almost_equal(mae, [1., 1.], decimal=2)
+    assert_array_almost_equal(r, [0., 0.], decimal=2)
+
+    r = r2_score([[0, -1], [0, 1]], [[2, 2], [1, 1]], multioutput='raw_values')
+    assert_array_almost_equal(r, [0, -3.5], decimal=2)
+    assert_equal(np.mean(r), r2_score([[0, -1], [0, 1]], [[2, 2], [1, 1]],
+                 multioutput='uniform_average'))
+    evs = explained_variance_score([[0, -1], [0, 1]], [[2, 2], [1, 1]],
+                                   multioutput='raw_values')
+    assert_array_almost_equal(evs, [0, -1.25], decimal=2)
+
+    # Checking for the condition in which both numerator and denominator is
+    # zero.
+    y_true = [[1, 3], [-1, 2]]
+    y_pred = [[1, 4], [-1, 1]]
+    r2 = r2_score(y_true, y_pred, multioutput='raw_values')
+    assert_array_almost_equal(r2, [1., -3.], decimal=2)
+    assert_equal(np.mean(r2), r2_score(y_true, y_pred,
+                 multioutput='uniform_average'))
+    evs = explained_variance_score(y_true, y_pred, multioutput='raw_values')
+    assert_array_almost_equal(evs, [1., -3.], decimal=2)
+    assert_equal(np.mean(evs), explained_variance_score(y_true, y_pred))
+
+
+def test_regression_custom_weights():
+    y_true = [[1, 2], [2.5, -1], [4.5, 3], [5, 7]]
+    y_pred = [[1, 1], [2, -1], [5, 4], [5, 6.5]]
+
+    msew = mean_squared_error(y_true, y_pred, multioutput=[0.4, 0.6])
+    maew = mean_absolute_error(y_true, y_pred, multioutput=[0.4, 0.6])
+    rw = r2_score(y_true, y_pred, multioutput=[0.4, 0.6])
+    evsw = explained_variance_score(y_true, y_pred, multioutput=[0.4, 0.6])
+
+    assert_almost_equal(msew, 0.39, decimal=2)
+    assert_almost_equal(maew, 0.475, decimal=3)
+    assert_almost_equal(rw, 0.94, decimal=2)
+    assert_almost_equal(evsw, 0.94, decimal=2)


### PR DESCRIPTION
I have tried to rebase PR #3474. If it passes Travis, I guess mentionned PR can be replaced.

Basically, it is a support of multioutput support for regression metrics (MAE, MSE, R2, explained variance) in a way that we can get a whole array of scores instead of some kind of averaging. BTW, I corrected a small mistake in docs: it states that median absolute error supports multioutput while it doesn't.
