### PR TITLE
TSNE in t_sne.py Replaced nan with 0 in distance matrix. Issue #4475

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -442,6 +442,9 @@ class TSNE(BaseEstimator):
             else:
                 distances = pairwise_distances(X, metric=self.metric)
 
+        # Replacing any nan entries with zero to avoid undefined distances
+        distances = np.nan_to_num(distances)
+
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # alpha = n_components - 1 comes from "Learning a Parametric Embedding
         # by Preserving Local Structure" Laurens van der Maaten, 2009.

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -271,3 +271,19 @@ def test_reduction_to_one_component():
     X = random_state.randn(5, 2)
     X_embedded = tsne.fit_transform(X)
     assert(np.all(np.isfinite(X_embedded)))
+
+def test_undefined_correlation():
+    # t-SNE throws an exception with undefined correlation (issue #4475)
+    from sklearn.manifold import TSNE
+    import numpy as np
+    np.random.seed(42)
+    
+    data = np.random.rand(10, 3)
+    data[-1, :] = 0
+    
+    try:
+        model = TSNE(metric="correlation")
+        model.fit_transform(data)
+        assert True
+    except ValueError as e:
+        assert False


### PR DESCRIPTION
Following the suggestion by @amueller, all nan in the distance matrix have been replaced by zeros. New tests have shown this to work.

Fixed together with @daveudaimon
