### PR TITLE
#4475 : Add a safe_pairwise_distances function, dealing with zero varian...

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -17,7 +17,7 @@ from ..utils import check_array
 from ..utils import check_random_state
 from ..utils.extmath import _ravel
 from ..decomposition import RandomizedPCA
-from ..metrics.pairwise import pairwise_distances
+from ..metrics.pairwise import safe_pairwise_distances
 from . import _utils
 
 
@@ -269,8 +269,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     if precomputed:
         dist_X = X
     else:
-        dist_X = pairwise_distances(X, squared=True)
-    dist_X_embedded = pairwise_distances(X_embedded, squared=True)
+        dist_X = safe_pairwise_distances(X, squared=True)
+    dist_X_embedded = safe_pairwise_distances(X_embedded, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
     ind_X_embedded = np.argsort(dist_X_embedded, axis=1)[:, 1:n_neighbors + 1]
 
@@ -438,9 +438,9 @@ class TSNE(BaseEstimator):
                 print("[t-SNE] Computing pairwise distances...")
 
             if self.metric == "euclidean":
-                distances = pairwise_distances(X, metric=self.metric, squared=True)
+                distances = safe_pairwise_distances(X, metric=self.metric, squared=True)
             else:
-                distances = pairwise_distances(X, metric=self.metric)
+                distances = safe_pairwise_distances(X, metric=self.metric)
 
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # alpha = n_components - 1 comes from "Learning a Parametric Embedding

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -17,7 +17,7 @@ from ..utils import check_array
 from ..utils import check_random_state
 from ..utils.extmath import _ravel
 from ..decomposition import RandomizedPCA
-from ..metrics.pairwise import safe_pairwise_distances
+from ..metrics.pairwise import pairwise_distances
 from . import _utils
 
 
@@ -269,8 +269,8 @@ def trustworthiness(X, X_embedded, n_neighbors=5, precomputed=False):
     if precomputed:
         dist_X = X
     else:
-        dist_X = safe_pairwise_distances(X, squared=True)
-    dist_X_embedded = safe_pairwise_distances(X_embedded, squared=True)
+        dist_X = pairwise_distances(X, squared=True)
+    dist_X_embedded = pairwise_distances(X_embedded, squared=True)
     ind_X = np.argsort(dist_X, axis=1)
     ind_X_embedded = np.argsort(dist_X_embedded, axis=1)[:, 1:n_neighbors + 1]
 
@@ -438,9 +438,9 @@ class TSNE(BaseEstimator):
                 print("[t-SNE] Computing pairwise distances...")
 
             if self.metric == "euclidean":
-                distances = safe_pairwise_distances(X, metric=self.metric, squared=True)
+                distances = pairwise_distances(X, metric=self.metric, squared=True)
             else:
-                distances = safe_pairwise_distances(X, metric=self.metric)
+                distances = pairwise_distances(X, metric=self.metric)
 
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # alpha = n_components - 1 comes from "Learning a Parametric Embedding

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -271,3 +271,21 @@ def test_reduction_to_one_component():
     X = random_state.randn(5, 2)
     X_embedded = tsne.fit_transform(X)
     assert(np.all(np.isfinite(X_embedded)))
+
+
+def test_undefined_correlation():
+    #t_SNE throws an exception with undefined correlation (issue #4475)
+    from sklearn.manifold import TSNE
+    import numpy as np
+    np.random.seed(42)
+
+    data = np.random.rand(10, 3)
+    data[-1, :] = 0
+
+    try:
+        model = TSNE(metric="correlation")
+        model.fit_transform(data)
+        assert True
+    except ValueError as e:
+        assert False
+


### PR DESCRIPTION
#4475 : Add a safe_pairwise_distances function, dealing with zero variance samples when using correlation metric.

The best fix would be to have the metric not returning NaN values, but as the correlation metric is actually computed by scipy, we can't modify it directly.
So, when metric=='correlation', we replace rows and cols corresponding to zero variance samples by the maximum distance (here 1.0).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/4495)

<!-- Reviewable:end -->
