### PR TITLE
[MRG] Add distance threshold on Hierarchical Clustering, see #3796

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -123,10 +123,12 @@ def ward_tree(X, connectivity=None, n_components=None,
         complete tree is not computed, thus the 'children' output is of
         limited use, and the 'parents' output should rather be used.
         This option is valid only when specifying a connectivity matrix.
+        You should set distance_threshold OR n_clusters.
 
     distance_threshold : int (optional)
         Stop early the construction of the tree when a given value
         of distance if obtained.
+        You should set distance_threshold OR n_clusters.
 
     return_distance: bool (optional)
         If True, return the distance between the clusters.
@@ -345,10 +347,12 @@ def linkage_tree(X, connectivity=None, n_components=None,
         complete tree is not computed, thus the 'children' output is of
         limited use, and the 'parents' output should rather be used.
         This option is valid only when specifying a connectivity matrix.
+        You should set distance_threshold OR n_clusters.
 
     distance_threshold : int (optional)
         Stop early the construction of the tree when a given value
         of distance if obtained.
+        You should set distance_threshold OR n_clusters.
 
     linkage : {"average", "complete"}, optional, default: "complete"
         Which linkage critera to use. The linkage criterion determines which
@@ -784,7 +788,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             memory.cache(tree_builder)(X, connectivity,
                                        n_components=self.n_components,
                                        n_clusters=n_clusters,
-                                       distance_threshold = \
+                                       distance_threshold=\
                                            self.distance_threshold,
                                        **kwargs)
         # Cut the tree

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -123,10 +123,10 @@ def test_distance_threshold():
     connectivity = grid_to_graph(*mask.shape)
     for name, linkage_func in _TREE_BUILDERS.items():
         # n_cluster case
-        res =  linkage_func(X.T, connectivity, return_distance=True)
+        res = linkage_func(X.T, connectivity, return_distance=True)
         children, n_nodes, n_leaves, parent, distances = res
         # distance_threshold case
-        distance_idx  = 42
+        distance_idx = 42
         distance_threshold = distances[distance_idx]
         if name == 'ward':
             # Revert the final scaling on distance


### PR DESCRIPTION
It is now possible to define a distance_threshold that will be used as an early break criterion in Hierarchical Clustering. It is used in both ward_tree() and linkage_tree().
An error is now raised if n_cluster and distance_threshold are not set OR are both set
(I don't know yet what should be the behavior if the number of clusters AND the distance threshold
are set together).
