### PR TITLE
fixed reverse sorting issue in label_binarize()

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -559,7 +559,7 @@ def label_binarize(y, classes, neg_label=0, pos_label=1,
 
     # preserve label ordering
     if np.any(classes != sorted_class):
-        indices = np.argsort(classes)
+        indices = np.searchsorted(sorted_class, classes)
         Y = Y[:, indices]
 
     if y_type == "binary":

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -410,6 +410,13 @@ def test_label_binarize_with_class_order():
     expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0]])
     assert_array_equal(out, expected)
 
+    out = label_binarize([0, 1, 2, 3], classes=[3, 2, 0, 1])
+    expected = np.array([[0, 0, 1, 0],
+                         [0, 0, 0, 1],
+                         [0, 1, 0, 0],
+                         [1, 0, 0, 0]])
+    assert_array_equal(out, expected)
+
 
 def check_binarized_results(y, classes, pos_label, neg_label, expected):
     for sparse_output in [True, False]:


### PR DESCRIPTION
`label_binarize` was not properly setting indices when the `classes` keyword argument was set.

E.g., previous output:

```
In [75]: label_binarize([0,1,2,3], classes=[3,2,0,1])
Out[75]: 
array([[0, 0, 0, 1],
       [0, 0, 1, 0],
       [1, 0, 0, 0],
       [0, 1, 0, 0]])
```

Output after this PR:

```
In [2]: label_binarize([0,1,2,3], classes=[3,2,0,1])
Out[2]: 
array([[0, 0, 1, 0],
       [0, 0, 0, 1],
       [0, 1, 0, 0],
       [1, 0, 0, 0]])
```
