### PR TITLE
Added new kernels for Mean Shift clustering

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -401,6 +401,9 @@ given sample.
  * :ref:`example_cluster_plot_mean_shift.py`: Mean Shift clustering
    on a synthetic 2D datasets with 3 classes.
 
+ * :ref:`example_cluster_plot_mean_shift_kernels.py`: An example of a situation
+   where the rbf and flat kernel give a different clustering result.
+
 .. topic:: References:
 
  * `"Mean shift: A robust approach toward feature space analysis."

--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -3,6 +3,12 @@
 A demo of the mean-shift clustering algorithm
 =============================================
 
+MeanShift clustering aims to discover *blobs* in a smooth density of
+samples. It is a centroid based algorithm, which works by updating
+candidates for centroids to be the mean of the points within a given
+region. These candidates are then filtered in a post-processing stage
+to eliminate near-duplicates to form the final set of centroids.
+
 Reference:
 
 Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward

--- a/examples/cluster/plot_mean_shift_kernels.py
+++ b/examples/cluster/plot_mean_shift_kernels.py
@@ -1,0 +1,84 @@
+"""
+=============================================
+A demo of the mean-shift clustering algorithm
+=============================================
+
+Reference:
+
+Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward
+feature space analysis". IEEE Transactions on Pattern Analysis and
+Machine Intelligence. 2002. pp. 603-619.
+
+"""
+#print(__doc__)
+
+import numpy as np
+from sklearn.cluster import MeanShift, estimate_bandwidth
+from sklearn.datasets.samples_generator import make_blobs
+import sklearn
+
+###############################################################################
+# Generate sample data
+centers = [[2, 0], [-2, 0]]
+X, _ = make_blobs(n_samples=10000, centers=centers, cluster_std=(1.0,1.0))
+
+###############################################################################
+# Compute clustering with MeanShift
+
+# The difference between the kernels is best noticable when the bandwidth
+# parameter is chosen somewhat too large. The bandwidth estimation function
+# returns a value around 1.44
+bandwidth = 3
+
+ms_rbf = MeanShift(bandwidth=bandwidth, bin_seeding=True, kernel='rbf',
+                   gamma=2)
+ms_rbf.fit(X)
+labels_rbf = ms_rbf.labels_
+cluster_centers_rbf = ms_rbf.cluster_centers_
+
+labels_unique_rbf = np.unique(labels_rbf)
+n_clusters_rbf = len(labels_unique_rbf)
+
+print("number of estimated clusters using the rbf kernel: %d" % n_clusters_rbf)
+
+
+ms_flat = MeanShift(bandwidth=bandwidth, bin_seeding=True, kernel='flat')
+ms_flat.fit(X)
+labels_flat = ms_flat.labels_
+cluster_centers_flat = ms_flat.cluster_centers_
+
+labels_unique_flat = np.unique(labels_flat)
+n_clusters_flat = len(labels_unique_flat)
+
+print("number of estimated clusters using the flat kernel: %d" % 
+      n_clusters_flat)
+
+###############################################################################
+# Plot result
+import pylab as pl
+from itertools import cycle
+
+pl.figure(1)
+pl.clf()
+colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
+
+pl.subplot(2,1,1)
+for k, col in zip(range(n_clusters_rbf), colors):
+    my_members = labels_rbf == k
+    cluster_center = cluster_centers_rbf[k]
+    pl.plot(X[my_members, 0], X[my_members, 1], col + '.')
+    pl.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,
+            markeredgecolor='k', markersize=14)
+pl.title('Clustering using the rbf kernel')
+
+pl.subplot(2,1,2)
+for k, col in zip(range(n_clusters_flat), colors):
+    my_members = labels_flat == k
+    cluster_center = cluster_centers_flat[k]
+    pl.plot(X[my_members, 0], X[my_members, 1], col + '.')
+    pl.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,
+            markeredgecolor='k', markersize=14)
+pl.title('Clustering using the flat kernel')
+
+pl.show()
+pl.close()

--- a/examples/cluster/plot_mean_shift_kernels.py
+++ b/examples/cluster/plot_mean_shift_kernels.py
@@ -1,7 +1,22 @@
 """
-=============================================
-A demo of the mean-shift clustering algorithm
-=============================================
+============================================
+Mean-Shift clustering with different kernels
+============================================
+
+This example shows the different outcomes with different kernels.
+The flat kernel simply wants to have as many points as possible located
+in it, while the rbf kernel wants as many points possible near its center.
+This means that the flat kernel will be more likely to try to cover up two
+or more distinct clusters because it doesn't care if the dense cluster
+centers are located at its periphery.
+
+With real world data the rbf kernel is probably preferred. The cluster center
+is more likely to end up directly above an area with high density. It should
+also be more robust on datasets with few points and noise.
+
+The code borrows heavily from the other Mean-Shift example, and a
+blog post by the original author:
+http://sociograph.blogspot.nl/2011/11/accessible-introduction-to-mean-shift.html
 
 Reference:
 
@@ -9,18 +24,20 @@ Dorin Comaniciu and Peter Meer, "Mean Shift: A robust approach toward
 feature space analysis". IEEE Transactions on Pattern Analysis and
 Machine Intelligence. 2002. pp. 603-619.
 
+Yizong Cheng, "Mean Shift, Mode Seeking, and Clustering". IEEE
+Transactions on Pattern Analysis and Machine Intelligence. 1995. pp. 790-799.
+
 """
-#print(__doc__)
+print(__doc__)
 
 import numpy as np
-from sklearn.cluster import MeanShift, estimate_bandwidth
+from sklearn.cluster import MeanShift
 from sklearn.datasets.samples_generator import make_blobs
-import sklearn
 
 ###############################################################################
 # Generate sample data
 centers = [[2, 0], [-2, 0]]
-X, _ = make_blobs(n_samples=10000, centers=centers, cluster_std=(1.0,1.0))
+X, _ = make_blobs(n_samples=10000, centers=centers, cluster_std=(1.0, 1.0))
 
 ###############################################################################
 # Compute clustering with MeanShift
@@ -50,7 +67,7 @@ cluster_centers_flat = ms_flat.cluster_centers_
 labels_unique_flat = np.unique(labels_flat)
 n_clusters_flat = len(labels_unique_flat)
 
-print("number of estimated clusters using the flat kernel: %d" % 
+print("number of estimated clusters using the flat kernel: %d" %
       n_clusters_flat)
 
 ###############################################################################
@@ -62,7 +79,7 @@ pl.figure(1)
 pl.clf()
 colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
 
-pl.subplot(2,1,1)
+pl.subplot(2, 1, 1)
 for k, col in zip(range(n_clusters_rbf), colors):
     my_members = labels_rbf == k
     cluster_center = cluster_centers_rbf[k]
@@ -71,7 +88,7 @@ for k, col in zip(range(n_clusters_rbf), colors):
             markeredgecolor='k', markersize=14)
 pl.title('Clustering using the rbf kernel')
 
-pl.subplot(2,1,2)
+pl.subplot(2, 1, 2)
 for k, col in zip(range(n_clusters_flat), colors):
     my_members = labels_flat == k
     cluster_center = cluster_centers_flat[k]

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -305,30 +305,32 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
     variable.
     """
 
-    implemented_kernels = ['flat', 'rbf', 'epanechnikov', 'biweight']
-    if kernel not in implemented_kernels:
-        raise ValueError("Unknown kernel, please use one of: %s" %
-                         ", ".join(implemented_kernels))
-
     # The flat kernel gives all points within range equal weight
     # No extra calculations needed
     if kernel == 'flat':
-        return np.mean(points, axis=0)
+        weighted_mean = np.mean(points, axis=0)
 
-    # Define the weights function for each kernel
-    if kernel == 'rbf':
-        compute_weights = lambda p, b: np.exp(-1 * gamma * (p ** 2))
+    else:
+        # Define the weights function for each kernel
+        if kernel == 'rbf':
+            compute_weights = lambda p, b: np.exp(-1 * gamma * (p ** 2))
 
-    if kernel == 'epanechnikov':
-        compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2)
+        elif kernel == 'epanechnikov':
+            compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2)
 
-    if kernel == 'biweight':
-        compute_weights = lambda p, b: (1.0 - (p ** 2 / b ** 2)) ** 2
+        elif kernel == 'biweight':
+            compute_weights = lambda p, b: (1.0 - (p ** 2 / b ** 2)) ** 2
 
-    # Compute new mean
-    distances = euclidean_distances(points, old_cluster_center)
-    weights = compute_weights(distances, bandwidth)
-    weighted_mean = np.sum(points * weights, axis=0) / np.sum(weights)
+        else:
+            implemented_kernels = ['flat', 'rbf', 'epanechnikov', 'biweight']
+            raise ValueError("Unknown kernel, please use one of: %s" %
+                             ", ".join(implemented_kernels))
+
+        # Compute new mean
+        distances = euclidean_distances(points, old_cluster_center)
+        weights = compute_weights(distances, bandwidth)
+        weighted_mean = np.sum(points * weights, axis=0) / np.sum(weights)
+
     return weighted_mean
 
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -317,8 +317,6 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
 
     # Define the weights function for each kernel
     if kernel == 'rbf':
-        print "rbf used!"
-        exit()
         compute_weights = lambda p, b: np.exp(-1 * gamma *
                                               (p ** 2 / b ** 2))
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -72,10 +72,10 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     """Perform MeanShift Clustering of data using a flat kernel
 
     MeanShift clustering aims to discover *blobs* in a smooth density of
-    samples. It is a centroid based algorithm, which works by updating candidates
-    for centroids to be the mean of the points within a given region. These
-    candidates are then filtered in a post-processing stage to eliminate
-    near-duplicates to form the final set of centroids.
+    samples. It is a centroid based algorithm, which works by updating
+    candidates for centroids to be the mean of the points within a given
+    region. These candidates are then filtered in a post-processing stage
+    to eliminate near-duplicates to form the final set of centroids.
 
     Seeding is performed using a binning technique for scalability.
 
@@ -119,11 +119,11 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         Maximum number of iterations, per seed point before the clustering
         operation terminates (for that seed point), if has not converged yet.
     
-    kernel : string, optional (default='flat')
+    kernel : string, optional, default 'flat'
         The kernel used to update the centroid candidates. Implemented kernels
         are 'flat', 'rbf', 'Epanechnikov' and 'biweight'.
-    
-    beta : float, optional (default='1.0')
+
+    beta : float, optional, default 1.0
         Kernel coefficient for 'rbf'. Higher values make it prefer more
         datapoints in the center of the cluster, lower values make the kernel
         more like the flat kernel.
@@ -175,8 +175,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
             if len(points_within) == 0:
                 break  # Depending on seeding strategy this condition may occur
             my_old_mean = my_mean  # save the old mean
-
-            my_mean = _kernel_update(my_old_mean, points_within, bandwidth, 
+            my_mean = _kernel_update(my_old_mean, points_within, bandwidth,
                                      kernel, beta)
             # If converged or at max_iterations, addS the cluster
             if (extmath.norm(my_mean - my_old_mean) < stop_thresh or
@@ -267,69 +266,71 @@ def get_bin_seeds(X, bin_size, min_bin_freq=1):
     bin_seeds = bin_seeds * bin_size
     return bin_seeds
 
+
 def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
     """ Update cluster center according to kernel used
-    
+
     Parameters
     ----------
     old_window_center : array_like
         The location of the old centroid candidate.
-    
+
     points : array_like
         All data points that fall within the window of which the new mean
         is to be computed.
-    
+
     bandwidth : float
         Size of the kernel. All points within this range are used to
         compute the new mean. There should be no points outside this range
         in the points variable.
-    
+
     kernel : string
         The kernel used for updating the window center. Available are:
         'flat', 'rbf', 'Epanechnikov' and 'biweight'
-    
+
     beta : float
         Controls the width of the rbf kernel. Only used with rbf kernel
         Lower values make it more like the flat kernel, higher values give
         points closer to the old center more weights.
-    
+
     Notes
     -----
     Kernels as mentioned in the paper "Mean Shift, Mode Seeking, and
     Clustering" by Yizong Cheng, published in IEEE Transaction On Pattern
     Analysis and Machine Intelligence, vol. 17, no. 8, august 1995.
-    
+
     The rbf or Gaussian kernel is a truncated version, since in this
     implementation of Mean Shift clustering only the points within the
     range of bandwidth around old_cluster_center are fed into the points
     variable.
-    
     """
+    
     if kernel not in ['flat', 'rbf', 'Epanechnikov', 'biweight']:
         # Raise error here
         pass
-    
+
     # The flat kernel gives all points within range equal weight
     # No extra calculations needed
     if kernel == 'flat':
         return np.mean(points, axis=0)
-    
+
     # Define the weights function for each kernel
     if kernel == 'rbf':
-        compute_weights = lambda p, band, beta: np.exp(-1 * beta * \
+        compute_weights = lambda p, band, beta: np.exp(-1 * beta *
                                                 (p ** 2 / band ** 2))
-    
+
     if kernel == 'Epanechnikov':
-        compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2))
-    
+        compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2)
+
     if kernel == 'biweight':
         compute_weights = lambda p, b: (1.0 - (p ** 2 / b ** 2)) ** 2
-    
+
     # Compute new mean
-    distances = euclidian_distances(points, old_cluster_center)
+    distances = euclidean_distances(points, old_cluster_center)
     weights = compute_weights(distances, bandwidth)
     weighted_mean = np.sum(points * weights, axis=0) / np.sum(weights)
     return weighted_mean
+
 
 class MeanShift(BaseEstimator, ClusterMixin):
     """Mean shift clustering using a flat kernel.
@@ -345,7 +346,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
     Parameters
     ----------
     bandwidth : float, optional
-        Bandwidth used in the RBF kernel.
+        Window size around centroid candidates used to compute new centroids.
 
         If not given, the bandwidth is estimated using
         sklearn.cluster.estimate_bandwidth; see the documentation for that
@@ -374,6 +375,15 @@ class MeanShift(BaseEstimator, ClusterMixin):
         If true, then all points are clustered, even those orphans that are
         not within any kernel. Orphans are assigned to the nearest kernel.
         If false, then orphans are given cluster label -1.
+
+    kernel : string, optional, default 'flat'
+        The kernel used to update the centroid candidates. Implemented kernels
+        are 'flat', 'rbf', 'Epanechnikov' and 'biweight'.
+
+    beta : float, optional, default 1.0
+        Kernel coefficient for 'rbf'. Higher values make it prefer more
+        datapoints in the center of the cluster, lower values make the kernel
+        more like the flat kernel.
 
     Attributes
     ----------
@@ -409,12 +419,15 @@ class MeanShift(BaseEstimator, ClusterMixin):
 
     """
     def __init__(self, bandwidth=None, seeds=None, bin_seeding=False,
-                 min_bin_freq=1, cluster_all=True):
+                 min_bin_freq=1, cluster_all=True, kernel='flat',
+                 beta=1.0):
         self.bandwidth = bandwidth
         self.seeds = seeds
         self.bin_seeding = bin_seeding
         self.cluster_all = cluster_all
         self.min_bin_freq = min_bin_freq
+        self.kernel = kernel
+        self.beta = beta
 
     def fit(self, X, y=None):
         """Perform clustering.

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -126,7 +126,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     gamma : float, optional, default 1.0
         Kernel coefficient for 'rbf'. Higher values make it prefer more
         datapoints in the center of the cluster, lower values make the kernel
-        more like the flat kernel.
+        behave more like the flat kernel.
 
     Returns
     -------
@@ -317,6 +317,8 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
 
     # Define the weights function for each kernel
     if kernel == 'rbf':
+        print "rbf used!"
+        exit()
         compute_weights = lambda p, b: np.exp(-1 * gamma *
                                               (p ** 2 / b ** 2))
 
@@ -384,7 +386,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
     gamma : float, optional, default 1.0
         Kernel coefficient for 'rbf'. Higher values make it prefer more
         datapoints in the center of the cluster, lower values make the kernel
-        more like the flat kernel.
+        behave more like the flat kernel.
 
     Attributes
     ----------
@@ -443,7 +445,9 @@ class MeanShift(BaseEstimator, ClusterMixin):
             mean_shift(X, bandwidth=self.bandwidth, seeds=self.seeds,
                        min_bin_freq=self.min_bin_freq,
                        bin_seeding=self.bin_seeding,
-                       cluster_all=self.cluster_all)
+                       cluster_all=self.cluster_all,
+                       kernel=self.kernel,
+                       gamma=self.gamma)
         return self
 
     def predict(self, X):

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -68,7 +68,7 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                min_bin_freq=1, cluster_all=True, max_iterations=300,
-               kernel='flat', beta=1.0):
+               kernel='flat', gamma=1.0):
     """Perform MeanShift Clustering of data using a flat kernel
 
     MeanShift clustering aims to discover *blobs* in a smooth density of
@@ -121,9 +121,9 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     
     kernel : string, optional, default 'flat'
         The kernel used to update the centroid candidates. Implemented kernels
-        are 'flat', 'rbf', 'Epanechnikov' and 'biweight'.
+        are 'flat', 'rbf', 'epanechnikov' and 'biweight'.
 
-    beta : float, optional, default 1.0
+    gamma : float, optional, default 1.0
         Kernel coefficient for 'rbf'. Higher values make it prefer more
         datapoints in the center of the cluster, lower values make the kernel
         more like the flat kernel.
@@ -176,7 +176,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                 break  # Depending on seeding strategy this condition may occur
             my_old_mean = my_mean  # save the old mean
             my_mean = _kernel_update(my_old_mean, points_within, bandwidth,
-                                     kernel, beta)
+                                     kernel, gamma)
             # If converged or at max_iterations, addS the cluster
             if (extmath.norm(my_mean - my_old_mean) < stop_thresh or
                     completed_iterations == max_iter):
@@ -267,7 +267,7 @@ def get_bin_seeds(X, bin_size, min_bin_freq=1):
     return bin_seeds
 
 
-def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
+def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
     """ Update cluster center according to kernel used
 
     Parameters
@@ -286,9 +286,9 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
 
     kernel : string
         The kernel used for updating the window center. Available are:
-        'flat', 'rbf', 'Epanechnikov' and 'biweight'
+        'flat', 'rbf', 'epanechnikov' and 'biweight'
 
-    beta : float
+    gamma : float
         Controls the width of the rbf kernel. Only used with rbf kernel
         Lower values make it more like the flat kernel, higher values give
         points closer to the old center more weights.
@@ -304,10 +304,11 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
     range of bandwidth around old_cluster_center are fed into the points
     variable.
     """
-    
-    if kernel not in ['flat', 'rbf', 'Epanechnikov', 'biweight']:
-        # Raise error here
-        pass
+
+    implemented_kernels = ['flat', 'rbf', 'epanechnikov', 'biweight']
+    if kernel not in implemented_kernels:
+        raise ValueError("Unknown kernel, please use one of: %s" %
+                         ", ".join(implemented_kernels))
 
     # The flat kernel gives all points within range equal weight
     # No extra calculations needed
@@ -316,10 +317,10 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
 
     # Define the weights function for each kernel
     if kernel == 'rbf':
-        compute_weights = lambda p, band, beta: np.exp(-1 * beta *
-                                                (p ** 2 / band ** 2))
+        compute_weights = lambda p, b: np.exp(-1 * gamma *
+                                              (p ** 2 / b ** 2))
 
-    if kernel == 'Epanechnikov':
+    if kernel == 'epanechnikov':
         compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2)
 
     if kernel == 'biweight':
@@ -378,9 +379,9 @@ class MeanShift(BaseEstimator, ClusterMixin):
 
     kernel : string, optional, default 'flat'
         The kernel used to update the centroid candidates. Implemented kernels
-        are 'flat', 'rbf', 'Epanechnikov' and 'biweight'.
+        are 'flat', 'rbf', 'epanechnikov' and 'biweight'.
 
-    beta : float, optional, default 1.0
+    gamma : float, optional, default 1.0
         Kernel coefficient for 'rbf'. Higher values make it prefer more
         datapoints in the center of the cluster, lower values make the kernel
         more like the flat kernel.
@@ -420,14 +421,14 @@ class MeanShift(BaseEstimator, ClusterMixin):
     """
     def __init__(self, bandwidth=None, seeds=None, bin_seeding=False,
                  min_bin_freq=1, cluster_all=True, kernel='flat',
-                 beta=1.0):
+                 gamma=1.0):
         self.bandwidth = bandwidth
         self.seeds = seeds
         self.bin_seeding = bin_seeding
         self.cluster_all = cluster_all
         self.min_bin_freq = min_bin_freq
         self.kernel = kernel
-        self.beta = beta
+        self.gamma = gamma
 
     def fit(self, X, y=None):
         """Perform clustering.

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -317,8 +317,7 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
 
     # Define the weights function for each kernel
     if kernel == 'rbf':
-        compute_weights = lambda p, b: np.exp(-1 * gamma *
-                                              (p ** 2 / b ** 2))
+        compute_weights = lambda p, b: np.exp(-1 * gamma * (p ** 2))
 
     if kernel == 'epanechnikov':
         compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2)

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -272,10 +272,10 @@ def _kernel_update(old_cluster_center, points, bandwidth, kernel, gamma):
 
     Parameters
     ----------
-    old_window_center : array_like
+    old_window_center : array_like, shape=[n_features]
         The location of the old centroid candidate.
 
-    points : array_like
+    points : array_like, shape=[n_samples, n_features]
         All data points that fall within the window of which the new mean
         is to be computed.
 

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -22,7 +22,7 @@ from ..utils.validation import check_is_fitted
 from ..utils import extmath, check_random_state, gen_batches, check_array
 from ..base import BaseEstimator, ClusterMixin
 from ..neighbors import NearestNeighbors
-from ..metrics.pairwise import pairwise_distances_argmin
+from ..metrics.pairwise import pairwise_distances_argmin, euclidean_distances
 
 
 def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
@@ -67,9 +67,17 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
 
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
-               min_bin_freq=1, cluster_all=True, max_iter=300,
-               max_iterations=None):
-    """Perform mean shift clustering of data using a flat kernel.
+               min_bin_freq=1, cluster_all=True, max_iterations=300,
+               kernel='flat', beta=1.0):
+    """Perform MeanShift Clustering of data using a flat kernel
+
+    MeanShift clustering aims to discover *blobs* in a smooth density of
+    samples. It is a centroid based algorithm, which works by updating candidates
+    for centroids to be the mean of the points within a given region. These
+    candidates are then filtered in a post-processing stage to eliminate
+    near-duplicates to form the final set of centroids.
+
+    Seeding is performed using a binning technique for scalability.
 
     Parameters
     ----------
@@ -110,6 +118,15 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     max_iter : int, default 300
         Maximum number of iterations, per seed point before the clustering
         operation terminates (for that seed point), if has not converged yet.
+    
+    kernel : string, optional (default='flat')
+        The kernel used to update the centroid candidates. Implemented kernels
+        are 'flat', 'rbf', 'Epanechnikov' and 'biweight'.
+    
+    beta : float, optional (default='1.0')
+        Kernel coefficient for 'rbf'. Higher values make it prefer more
+        datapoints in the center of the cluster, lower values make the kernel
+        more like the flat kernel.
 
     Returns
     -------
@@ -158,8 +175,10 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
             if len(points_within) == 0:
                 break  # Depending on seeding strategy this condition may occur
             my_old_mean = my_mean  # save the old mean
-            my_mean = np.mean(points_within, axis=0)
-            # If converged or at max_iter, adds the cluster
+
+            my_mean = _kernel_update(my_old_mean, points_within, bandwidth, 
+                                     kernel, beta)
+            # If converged or at max_iterations, addS the cluster
             if (extmath.norm(my_mean - my_old_mean) < stop_thresh or
                     completed_iterations == max_iter):
                 center_intensity_dict[tuple(my_mean)] = len(points_within)
@@ -248,6 +267,69 @@ def get_bin_seeds(X, bin_size, min_bin_freq=1):
     bin_seeds = bin_seeds * bin_size
     return bin_seeds
 
+def _kernel_update(old_cluster_center, points, bandwidth, kernel, beta):
+    """ Update cluster center according to kernel used
+    
+    Parameters
+    ----------
+    old_window_center : array_like
+        The location of the old centroid candidate.
+    
+    points : array_like
+        All data points that fall within the window of which the new mean
+        is to be computed.
+    
+    bandwidth : float
+        Size of the kernel. All points within this range are used to
+        compute the new mean. There should be no points outside this range
+        in the points variable.
+    
+    kernel : string
+        The kernel used for updating the window center. Available are:
+        'flat', 'rbf', 'Epanechnikov' and 'biweight'
+    
+    beta : float
+        Controls the width of the rbf kernel. Only used with rbf kernel
+        Lower values make it more like the flat kernel, higher values give
+        points closer to the old center more weights.
+    
+    Notes
+    -----
+    Kernels as mentioned in the paper "Mean Shift, Mode Seeking, and
+    Clustering" by Yizong Cheng, published in IEEE Transaction On Pattern
+    Analysis and Machine Intelligence, vol. 17, no. 8, august 1995.
+    
+    The rbf or Gaussian kernel is a truncated version, since in this
+    implementation of Mean Shift clustering only the points within the
+    range of bandwidth around old_cluster_center are fed into the points
+    variable.
+    
+    """
+    if kernel not in ['flat', 'rbf', 'Epanechnikov', 'biweight']:
+        # Raise error here
+        pass
+    
+    # The flat kernel gives all points within range equal weight
+    # No extra calculations needed
+    if kernel == 'flat':
+        return np.mean(points, axis=0)
+    
+    # Define the weights function for each kernel
+    if kernel == 'rbf':
+        compute_weights = lambda p, band, beta: np.exp(-1 * beta * \
+                                                (p ** 2 / band ** 2))
+    
+    if kernel == 'Epanechnikov':
+        compute_weights = lambda p, b: 1.0 - (p ** 2 / b ** 2))
+    
+    if kernel == 'biweight':
+        compute_weights = lambda p, b: (1.0 - (p ** 2 / b ** 2)) ** 2
+    
+    # Compute new mean
+    distances = euclidian_distances(points, old_cluster_center)
+    weights = compute_weights(distances, bandwidth)
+    weighted_mean = np.sum(points * weights, axis=0) / np.sum(weights)
+    return weighted_mean
 
 class MeanShift(BaseEstimator, ClusterMixin):
     """Mean shift clustering using a flat kernel.

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -67,8 +67,8 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0):
 
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
-               min_bin_freq=1, cluster_all=True, max_iterations=300,
-               kernel='flat', gamma=1.0):
+               min_bin_freq=1, cluster_all=True, max_iter=300,
+               max_iterations=None, kernel='flat', gamma=1.0):
     """Perform MeanShift Clustering of data using a flat kernel
 
     MeanShift clustering aims to discover *blobs* in a smooth density of
@@ -92,6 +92,8 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         the median of all pairwise distances. This will take quadratic time in
         the number of samples. The sklearn.cluster.estimate_bandwidth function
         can be used to do this more efficiently.
+        The only exception is when an rbf kernel is used. In this case
+        the default value of bandwidth is 3 / sqrt(gamma).
 
     seeds : array-like, shape=[n_seeds, n_features] or None
         Point used as initial kernel locations. If None and bin_seeding=False,
@@ -150,7 +152,10 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
         max_iter = max_iterations
 
     if bandwidth is None:
-        bandwidth = estimate_bandwidth(X)
+        if kernel == 'rbf':
+            bandwidth = 3 / np.sqrt(gamma)
+        else:
+            bandwidth = estimate_bandwidth(X)
     elif bandwidth <= 0:
         raise ValueError("bandwidth needs to be greater than zero or None, got %f" %
                          bandwidth)

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -33,17 +33,19 @@ def test_estimate_bandwidth():
 def test_mean_shift():
     # Test MeanShift algorithm
     bandwidth = 1.2
+    implemented_kernels = ['flat', 'rbf', 'epanechnikov', 'biweight']
+    for kernel in implemented_kernels:
+        ms = MeanShift(bandwidth=bandwidth, kernel=kernel)
+        labels = ms.fit(X).labels_
+        labels_unique = np.unique(labels)
+        n_clusters_ = len(labels_unique)
+        assert_equal(n_clusters_, n_clusters)
 
-    ms = MeanShift(bandwidth=bandwidth)
-    labels = ms.fit(X).labels_
-    labels_unique = np.unique(labels)
-    n_clusters_ = len(labels_unique)
-    assert_equal(n_clusters_, n_clusters)
-
-    cluster_centers, labels = mean_shift(X, bandwidth=bandwidth)
-    labels_unique = np.unique(labels)
-    n_clusters_ = len(labels_unique)
-    assert_equal(n_clusters_, n_clusters)
+        cluster_centers, labels = mean_shift(X, bandwidth=bandwidth,
+                                             kernel=kernel)
+        labels_unique = np.unique(labels)
+        n_clusters_ = len(labels_unique)
+        assert_equal(n_clusters_, n_clusters)
 
 
 def test_meanshift_predict():


### PR DESCRIPTION
There is a [PR](https://github.com/scikit-learn/scikit-learn/pull/3026) that adds new kernels for mean shift clustering. However, the owner (@PeterJacob) of the PR seems to be inactive for a while. This PR includes the changes from the previous [PR](https://github.com/scikit-learn/scikit-learn/pull/3026).

In addition,

According to [the discussion here](https://github.com/scikit-learn/scikit-learn/pull/3026#issuecomment-73734480), I updated the RBF kernel.

I also refactored the control flow of _kernel_update function. There is now one return statement and therefore it is a bit cleaner.
