### PR TITLE
DOC Grammar fix in preprocessing

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -16,8 +16,8 @@ Standardization, or mean removal and variance scaling
 =====================================================
 
 **Standardization** of datasets is a **common requirement for many
-machine learning estimators** implemented in the scikit: they might behave
-badly if the individual feature do not more or less look like standard
+machine learning estimators** implemented in the scikit; they might behave
+badly if the individual features do not more or less look like standard
 normally distributed data: Gaussian with **zero mean and unit variance**.
 
 In practice we often ignore the shape of the distribution and just


### PR DESCRIPTION
Just a minor grammar fix:

![image](https://cloud.githubusercontent.com/assets/7017045/6995696/096025c0-db0d-11e4-982c-88f60e4ce8b0.png)

![image](https://cloud.githubusercontent.com/assets/7017045/6995695/fee0ed78-db0c-11e4-8bb6-f5c00ed3a889.png)
