### PR TITLE
[MRG + 1] optimize rfecv by eliminating the ```for``` loop

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -398,18 +398,16 @@ class RFECV(RFE, MetaEstimatorMixin):
             X_train, y_train = _safe_split(self.estimator, X, y, train)
             X_test, y_test = _safe_split(self.estimator, X, y, test, train)
 
-            rfe = RFE(estimator=self.estimator, n_features_to_select=1,
+            rfe = RFE(estimator=self.estimator,
+                      n_features_to_select=n_features_to_select,
                       step=self.step, estimator_params=self.estimator_params,
                       verbose=self.verbose - 1)
 
-            # Compute a full ranking of the features
-            # ranking_ contains the same set of values for all CV folds,
-            # but perhaps reordered
             rfe._fit(X_train, y_train, lambda estimator, features:
                      _score(estimator, X_test[:, features], y_test, scorer))
             scores.append(np.array(rfe.scores_[::-1]).reshape(1, -1))
         scores = np.sum(np.concatenate(scores, 0), 0)
-        # The index in scores when 'n_features' features is selected
+        # The index in 'scores' when 'n_features' features are selected
         n_feature_index = np.ceil((n_features - n_features_to_select) /
                                   float(self.step))
         n_features_to_select = max(n_features_to_select,

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -122,6 +122,9 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         y : array-like, shape = [n_samples]
             The target values.
         """
+        return self._fit(X, y)
+
+    def _fit(self, X, y, step_score=None):
         X, y = check_X_y(X, y, "csc")
         # Initialization
         n_features = X.shape[1]
@@ -146,6 +149,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
+
+        if step_score:
+            self.scores_ = []
+
         # Elimination
         while np.sum(support_) > n_features_to_select:
             # Remaining features
@@ -181,14 +188,25 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
             # Eliminate the worse features
             threshold = min(step, np.sum(support_) - n_features_to_select)
+
+            # Compute step score on the previous selection iteration
+            # because 'estimator' must use features
+            # that have not been eliminated yet
+            if step_score:
+                self.scores_.append(step_score(estimator, features))
             support_[features[ranks][:threshold]] = False
             ranking_[np.logical_not(support_)] += 1
 
         # Set final attributes
+        features = np.arange(n_features)[support_]
         self.estimator_ = clone(self.estimator)
         if self.estimator_params:
             self.estimator_.set_params(**self.estimator_params)
-        self.estimator_.fit(X[:, support_], y)
+        self.estimator_.fit(X[:, features], y)
+
+        # Compute step score when only n_features_to_select features left
+        if step_score:
+            self.scores_.append(step_score(self.estimator_, features))
         self.n_features_ = support_.sum()
         self.support_ = support_
         self.ranking_ = ranking_
@@ -308,7 +326,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
     Notes
     -----
-    The size of ``grid_scores_`` is equal to (n_features + step - 2) // step + 1,
+    The size of ``grid_scores_`` is equal to ceil((n_features - 1) / step) + 1,
     where step is the number of features removed at each iteration.
 
     Examples
@@ -367,47 +385,40 @@ class RFECV(RFE, MetaEstimatorMixin):
                           "value is set via the estimator initialisation or "
                           "set_params method.", DeprecationWarning)
         # Initialization
-        rfe = RFE(estimator=self.estimator, n_features_to_select=1,
-                  step=self.step, estimator_params=self.estimator_params,
-                  verbose=self.verbose - 1)
-
         cv = check_cv(self.cv, X, y, is_classifier(self.estimator))
         scorer = check_scoring(self.estimator, scoring=self.scoring)
-        scores = np.zeros(X.shape[1])
-        n_features_to_select_by_rank = np.zeros(X.shape[1])
+        n_features = X.shape[1]
+        n_features_to_select = 1
+
+        # Determine the number of subsets of features
+        scores = []
 
         # Cross-validation
         for n, (train, test) in enumerate(cv):
             X_train, y_train = _safe_split(self.estimator, X, y, train)
             X_test, y_test = _safe_split(self.estimator, X, y, test, train)
 
+            rfe = RFE(estimator=self.estimator, n_features_to_select=1,
+                      step=self.step, estimator_params=self.estimator_params,
+                      verbose=self.verbose - 1)
+
             # Compute a full ranking of the features
             # ranking_ contains the same set of values for all CV folds,
             # but perhaps reordered
-            ranking_ = rfe.fit(X_train, y_train).ranking_
-            # Score each subset of features
-            for k in range(0, np.max(ranking_)):
-                indices = np.where(ranking_ <= k + 1)[0]
-                estimator = clone(self.estimator)
-                estimator.fit(X_train[:, indices], y_train)
-                score = _score(estimator, X_test[:, indices], y_test, scorer)
-
-                if self.verbose > 0:
-                    print("Finished fold with %d / %d feature ranks, score=%f"
-                          % (k + 1, np.max(ranking_), score))
-                scores[k] += score
-                # n_features_to_select_by_rank[k] is being overwritten
-                # multiple times, but by the same value
-                n_features_to_select_by_rank[k] = indices.size
-
-        # Select the best upper bound for feature rank. It's OK to use the
-        # last ranking_, as np.max(ranking_) is the same over all CV folds.
-        scores = scores[:np.max(ranking_)]
-        k = np.argmax(scores)
-
+            rfe._fit(X_train, y_train, lambda estimator, features:
+                     _score(estimator, X_test[:, features], y_test, scorer))
+            scores.append(np.array(rfe.scores_[::-1]).reshape(1, -1))
+        scores = np.sum(np.concatenate(scores, 0), 0)
+        # The index in scores when 'n_features' features is selected
+        n_feature_index = np.ceil((n_features - n_features_to_select) /
+                                  float(self.step))
+        n_features_to_select = max(n_features_to_select,
+                                   n_features - ((n_feature_index -
+                                                 np.argmax(scores)) *
+                                                 self.step))
         # Re-execute an elimination with best_k over the whole set
         rfe = RFE(estimator=self.estimator,
-                  n_features_to_select=n_features_to_select_by_rank[k],
+                  n_features_to_select=n_features_to_select,
                   step=self.step, estimator_params=self.estimator_params)
 
         rfe.fit(X, y)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -8,9 +8,10 @@ from nose.tools import assert_equal, assert_true
 from scipy import sparse
 
 from sklearn.feature_selection.rfe import RFE, RFECV
-from sklearn.datasets import load_iris, make_friedman1
+from sklearn.datasets import load_iris, make_friedman1, make_regression
 from sklearn.metrics import zero_one_loss
 from sklearn.svm import SVC, SVR
+from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import RandomForestClassifier
 
 from sklearn.utils import check_random_state
@@ -19,6 +20,7 @@ from sklearn.utils.testing import assert_warns_message
 
 from sklearn.metrics import make_scorer
 from sklearn.metrics import get_scorer
+
 
 class MockClassifier(object):
     """
@@ -236,7 +238,6 @@ def test_rfecv_mockclassifier():
 
 
 def test_rfe_min_step():
-
     n_features = 10
     X, y = make_friedman1(n_samples=50, n_features=n_features, random_state=0)
     n_samples, n_features = X.shape
@@ -244,15 +245,75 @@ def test_rfe_min_step():
 
     # Test when floor(step * n_features) <= 0
     selector = RFE(estimator, step=0.01)
-    sel = selector.fit(X,y)
+    sel = selector.fit(X, y)
     assert_equal(sel.support_.sum(), n_features // 2)
 
     # Test when step is between (0,1) and floor(step * n_features) > 0
     selector = RFE(estimator, step=0.20)
-    sel = selector.fit(X,y)
+    sel = selector.fit(X, y)
     assert_equal(sel.support_.sum(), n_features // 2)
 
     # Test when step is an integer
     selector = RFE(estimator, step=5)
-    sel = selector.fit(X,y)
+    sel = selector.fit(X, y)
     assert_equal(sel.support_.sum(), n_features // 2)
+
+
+def test_number_of_subsets_of_features():
+    # In RFE, 'number_of_subsets_of_features'
+    # = the number of iterations in '_fit'
+    # = max(ranking_)
+    # = 1 + (n_features + step - n_features_to_select - 1) // step
+    # After optimization #4534, this number
+    # = 1 + np.ceil((n_features - n_features_to_select) / float(step))
+    # This test case is to test their equivalence, refer to #4534 and #3824
+
+    def formula1(n_features, n_features_to_select, step):
+        return 1 + ((n_features + step - n_features_to_select - 1) // step)
+
+    def formula2(n_features, n_features_to_select, step):
+        return 1 + np.ceil((n_features - n_features_to_select) / float(step))
+
+    # RFE
+    # Case 1, n_features - n_features_to_select is divisible by step
+    # Case 2, n_features - n_features_to_select is not divisible by step
+    n_features_list = [11, 11]
+    n_features_to_select_list = [3, 3]
+    step_list = [2, 3]
+    for n_features, n_features_to_select, step in zip(
+            n_features_list, n_features_to_select_list, step_list):
+        generator = check_random_state(43)
+        X = generator.normal(size=(100, n_features))
+        y = generator.rand(100).round()
+        rfe = RFE(estimator=SVC(kernel="linear"),
+              n_features_to_select=n_features_to_select, step=step)
+        rfe.fit(X, y)
+        # this number also equals to the maximum of ranking_
+        assert_equal(np.max(rfe.ranking_),
+                     formula1(n_features, n_features_to_select, step))
+        assert_equal(np.max(rfe.ranking_),
+                     formula2(n_features, n_features_to_select, step))
+
+    # In RFECV, 'fit' calls 'RFE._fit'
+    # 'number_of_subsets_of_features' of RFE
+    # = the size of 'grid_scores' of RFECV
+    # = the number of iterations of the for loop before optimization #4534
+
+    # RFECV, n_features_to_select = 1
+    # Case 1, n_features - 1 is divisible by step
+    # Case 2, n_features - 1 is not divisible by step
+
+    n_features_to_select = 1
+    n_features_list = [11, 10]
+    step_list = [2, 2]
+    for n_features, step in zip(n_features_list, step_list):
+        generator = check_random_state(43)
+        X = generator.normal(size=(100, n_features))
+        y = generator.rand(100).round()
+        rfecv = RFECV(estimator=SVC(kernel="linear"), step=step, cv=5)
+        rfecv.fit(X, y)
+
+        assert_equal(rfecv.grid_scores_.shape[0],
+                 formula1(n_features, n_features_to_select, step))
+        assert_equal(rfecv.grid_scores_.shape[0],
+                 formula2(n_features, n_features_to_select, step))

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -89,6 +89,7 @@ def test_rfe_features_importance():
     diff_support = rfe.get_support() == rfe_svc.get_support()
     assert_true(sum(diff_support) == len(diff_support))
 
+
 def test_rfe_deprecation_estimator_params():
     deprecation_message = ("The parameter 'estimator_params' is deprecated as "
                            "of version 0.16 and will be removed in 0.18. The "


### PR DESCRIPTION
Fixes #4382 , I am not sure this is good enough. Any comment is warmly welcome. 

Basically, in this PR, `RFE` has  `_fit` which is almost identical to previous `fit`. `_fit` has a third parameter `step_score` which is a function evaluating the score of a parameter. `step_score` takes `estimator` and `support`, then gives a score. In `RFECV` there is no `for` loop right now. For each fold, one `rfe._fit` is called with the return value of `_step_score_on_test`. `_step_score_on_test` acts like a factory method. It accepts `X_test`, `y_test`, and builds a `step_score` function, which use `_score` just like the implementation in the `for` loop before this PR. By doing so, `RFE` is not aware of the test data. Because I think it is weird that implementing a new `fit` function in RFE which explicitly accepts test data to get the score.

The number of subsets of features needs to be evaluated is `ceil((n_features - n_features_to_select)/step) + 1`. For example `n_features = 10`, `n_features_to_select=1`, `step=2`. The sizes of each subsets of features are `[10, 8, 6, 4, 2, 1]`. In `RFE.fit`'s `for` loop, the subsets which has size of `[10, 8, 6, 4, 2]` is evaluated. The last one is evaluated in the final estimator's `fit` after `for` loop. This explains the size of `scores_` in `RFE`.
