### PR TITLE
[MRG + 2] DOC add warning for partial pip upgrades

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -165,6 +165,17 @@ python modules. The install command is::
 
     python setup.py install
 
+or alternatively (also from within the scikit-learn source folder)::
+
+    pip install .
+
+.. warning::
+
+   Packages installed with the ``python setup.py install`` command cannot
+   be uninstalled nor upgraded by ``pip`` later. To properly uninstall
+   scikit-learn in that case it is necessary to delete the ``sklearn`` folder
+   from your Python ``site-packages`` directory.
+
 
 .. _install_by_distribution:
 
@@ -213,8 +224,32 @@ Canopy and Anaconda for all supported platforms
 
 `Canopy
 <http://www.enthought.com/products/canopy>`_ and `Anaconda
-<https://store.continuum.io/cshop/anaconda/>`_ ships a recent
-version, in addition to a large set of scientific python library.
+<https://store.continuum.io/cshop/anaconda/>`_ both ship a recent
+version of scikit-learn, in addition to a large set of scientific python
+library for Windows, Mac OSX and Linux.
+
+Anaconda offers scikit-learn as part of its free distribution.
+
+
+.. warning::
+
+    To upgrade or uninstall scikit-learn installed with Anaconda
+    or ``conda`` you **should not use the pip command**. Instead:
+
+    To upgrade ``scikit-learn``::
+
+        conda update scikit-learn
+
+    To uninstall ``scikit-learn``::
+
+        conda remove scikit-learn
+
+    Upgrading with ``pip install -U scikit-learn`` or uninstalling
+    ``pip uninstall scikit-learn`` is likely fail to properly remove files
+    installed by the ``conda`` command.
+
+    pip upgrade and uninstall operations only work on packages installed
+    via ``pip install``.
 
 
 MacPorts for Mac OSX


### PR DESCRIPTION
Add warnings to the install doc to make it explicit that as of now, pip cannot properly upgrade scikit-learn if it was installed with `python setup.py install` or by `conda` / `Anaconda`.

This issue caused problems such as #4472.

Note: future versions of pip will refuse to uninstall (and therefore upgrade) packages that lacks the missing metadata, in particular the list of installed files that is usually stored in the old-style `site-packages/package_name-version.egg-info/installed-files.txt` or in the new-style `site-packages/package_name-version.dist-info/RECORD`.
