### PR TITLE
[MRG+1] Common test refactoring

### DIFF
--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -777,7 +777,9 @@ Rolling your own estimator
 If you want to implement a new estimator that is scikit-learn-compatible,
 whether it is just for you or for contributing it to sklearn, there are several
 internals of scikit-learn that you should be aware of in addition to the
-sklearn API outlined above.
+sklearn API outlined above. You can check whether your estimator
+adheres to the scikit-learn interface and standards by running
+:func:`utils.estimator_checks.check_estimator` on the class.
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model assessment and

--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -779,7 +779,11 @@ whether it is just for you or for contributing it to sklearn, there are several
 internals of scikit-learn that you should be aware of in addition to the
 sklearn API outlined above. You can check whether your estimator
 adheres to the scikit-learn interface and standards by running
-:func:`utils.estimator_checks.check_estimator` on the class.
+:func:`utils.estimator_checks.check_estimator` on the class::
+
+  >>> from sklearn.utils.estimator_checks import check_estimator
+  >>> from sklearn.svm import LinearSVC
+  >>> check_estimator(LinearSVC)  # passes
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model assessment and

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1286,5 +1286,6 @@ Low-level methods
    :template: function.rst
 
    utils.check_random_state
+   utils.estimator_checks.check_estimator
    utils.resample
    utils.shuffle

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -39,7 +39,7 @@ def clone(estimator, safe=True):
         else:
             raise TypeError("Cannot clone object '%s' (type %s): "
                             "it does not seem to be a scikit-learn estimator "
-                            "it does not implement a 'get_params' methods."
+                            "as it does not implement a 'get_params' methods."
                             % (repr(estimator), type(estimator)))
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -14,6 +14,7 @@ import struct
 from sklearn.externals.six.moves import zip
 from sklearn.externals.joblib import hash
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_true
@@ -313,7 +314,7 @@ def check_dtype_object(name, Estimator):
 
     X[0, 0] = {'foo': 'bar'}
     msg = "argument must be a string or a number"
-    assert_raise_message(TypeError, msg, estimator.fit, X, y)
+    assert_raises_regex(TypeError, msg, estimator.fit, X, y)
 
 
 def check_transformer_general(name, Transformer):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -26,7 +26,8 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import ignore_warnings
 
-from sklearn.base import clone, ClassifierMixin, BaseEstimator
+from sklearn.base import (clone, ClassifierMixin, RegressorMixin,
+                          TransformerMixin, ClusterMixin, BaseEstimator)
 from sklearn.metrics import accuracy_score, adjusted_rand_score, f1_score
 
 from sklearn.lda import LDA
@@ -44,6 +45,140 @@ from sklearn.datasets import load_iris, load_boston, make_blobs
 
 BOSTON = None
 CROSS_DECOMPOSITION = ['PLSCanonical', 'PLSRegression', 'CCA', 'PLSSVD']
+
+
+def _yield_non_meta_checks(name, Estimator):
+    yield check_estimators_dtypes
+    yield check_fit_score_takes_y
+    yield check_dtype_object
+
+    # Check that all estimator yield informative messages when
+    # trained on empty datasets
+    yield check_estimators_empty_data_messages
+
+    if name not in CROSS_DECOMPOSITION + ['SpectralEmbedding']:
+        # SpectralEmbedding is non-deterministic,
+        # see issue #4236
+        # cross-decomposition's "transform" returns X and Y
+        yield check_pipeline_consistency
+
+    if name not in ['Imputer']:
+        # Test that all estimators check their input for NaN's and infs
+        yield check_estimators_nan_inf
+
+    if name not in ['GaussianProcess']:
+        # FIXME!
+        # in particular GaussianProcess!
+        yield check_estimators_overwrite_params
+    if hasattr(Estimator, 'sparsify'):
+        yield check_sparsify_coefficients
+
+    yield check_estimator_sparse_data
+
+
+def _yield_classifier_checks(name, Classifier):
+    # test classfiers can handle non-array data
+    yield check_classifier_data_not_an_array
+    # test classifiers trained on a single label always return this label
+    yield check_classifiers_one_label
+    yield check_classifiers_classes
+    yield check_classifiers_pickle
+    yield check_estimators_partial_fit_n_features
+    # basic consistency testing
+    yield check_classifiers_train
+    if (name not in ["MultinomialNB", "LabelPropagation", "LabelSpreading"]
+        # TODO some complication with -1 label
+            and name not in ["DecisionTreeClassifier",
+                             "ExtraTreeClassifier"]):
+            # We don't raise a warning in these classifiers, as
+            # the column y interface is used by the forests.
+
+        # test if classifiers can cope with y.shape = (n_samples, 1)
+        yield check_classifiers_input_shapes
+    # test if NotFittedError is raised
+    yield check_estimators_unfitted
+    if 'class_weight' in Classifier().get_params().keys():
+        yield check_class_weight_classifiers
+
+
+def _yield_regressor_checks(name, Regressor):
+    # TODO: test with intercept
+    # TODO: test with multiple responses
+    # basic testing
+    yield check_regressors_train
+    yield check_regressor_data_not_an_array
+    yield check_estimators_partial_fit_n_features
+    yield check_regressors_no_decision_function
+    # Test that estimators can be pickled, and once pickled
+    # give the same answer as before.
+    yield check_regressors_pickle
+    if name != 'CCA':
+        # check that the regressor handles int input
+        yield check_regressors_int
+    # Test if NotFittedError is raised
+    yield check_estimators_unfitted
+
+
+def _yield_transformer_checks(name, Transformer):
+    # All transformers should either deal with sparse data or raise an
+    # exception with type TypeError and an intelligible error message
+    yield check_transformer_pickle
+    if name not in ['AdditiveChi2Sampler', 'Binarizer', 'Normalizer',
+                    'PLSCanonical', 'PLSRegression', 'CCA', 'PLSSVD']:
+        yield check_transformer_data_not_an_array
+    # these don't actually fit the data, so don't raise errors
+    if name not in ['AdditiveChi2Sampler', 'Binarizer', 'Normalizer']:
+        # basic tests
+        yield check_transformer_general
+        yield check_transformers_unfitted
+
+
+def _yield_clustering_checks(name, Clusterer):
+    yield check_clusterer_compute_labels_predict
+    if name not in ('WardAgglomeration', "FeatureAgglomeration"):
+        # this is clustering on the features
+        # let's not test that here.
+        yield check_clustering
+        yield check_estimators_partial_fit_n_features
+
+
+def _yield_all_checks(name, Estimator):
+    #yield check_parameters_default_constructible, name, Estimator
+    for check in _yield_non_meta_checks(name, Estimator):
+        yield check
+    if issubclass(Estimator, ClassifierMixin):
+        for check in _yield_classifier_checks(name, Estimator):
+            yield check
+    if issubclass(Estimator, RegressorMixin):
+        for check in _yield_regressor_checks(name, Estimator):
+            yield check
+    if issubclass(Estimator, TransformerMixin):
+        for check in _yield_transformer_checks(name, Estimator):
+            yield check
+    if issubclass(Estimator, ClusterMixin):
+        for check in _yield_clustering_checks(name, Estimator):
+            yield check
+
+
+def check_estimator(Estimator):
+    """Check if estimator adheres to sklearn conventions.
+
+    This estimator will run an extensive test-suite for input validation,
+    shapes, etc.
+    Additional tests for classifiers, regressors, clustering or transformers
+    will be run if the Estimator class inherits from the corresponding mixin
+    from sklearn.base.
+
+    Parameters
+    ----------
+    Estimator : class
+        Class to check.
+
+    """
+    name = Estimator.__class__.__name__
+    check_parameters_default_constructible(name, Estimator)
+    for check in _yield_all_checks(name, Estimator):
+        check(name, Estimator)
 
 
 def _boston_subset(n_samples=200):
@@ -177,10 +312,11 @@ def check_dtype_object(name, Estimator):
             raise
 
     X[0, 0] = {'foo': 'bar'}
-    assert_raise_message(TypeError, "string or a number", estimator.fit, X, y)
+    msg = "argument must be a string or a number"
+    assert_raise_message(TypeError, msg, estimator.fit, X, y)
 
 
-def check_transformer(name, Transformer):
+def check_transformer_general(name, Transformer):
     X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
                       random_state=0, n_features=2, cluster_std=0.1)
     X = StandardScaler().fit_transform(X)
@@ -869,6 +1005,14 @@ def check_regressors_no_decision_function(name, Regressor):
 
 
 def check_class_weight_classifiers(name, Classifier):
+    if name == "NuSVC":
+        # the sparse version has a parameter that doesn't do anything
+        raise SkipTest
+    if name.endswith("NB"):
+        # NaiveBayes classifiers have a somewhat different interface.
+        # FIXME SOON!
+        raise SkipTest
+
     for n_centers in [2, 3]:
         # create a very noisy dataset
         X, y = make_blobs(centers=n_centers, random_state=0, cluster_std=20)
@@ -1164,9 +1308,8 @@ def check_get_params_invariance(name, estimator):
     else:
         e = estimator()
 
-
     shallow_params = e.get_params(deep=False)
     deep_params = e.get_params(deep=True)
 
-    assert_true(all(item in deep_params.items() for item in 
-        shallow_params.items()))
+    assert_true(all(item in deep_params.items() for item in
+                    shallow_params.items()))

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -88,8 +88,8 @@ except ImportError:
                                      "%r. %r does not." %
                                      (expected_regexp, error_message))
         if not_raised:
-            raise AssertionError("Should have raised %r" %
-                                 expected_exception(expected_regexp))
+            raise AssertionError("%s not raised by %s" %
+                                 (expected_exception.__name__, callable_obj.__name__))
 
 # assert_raises_regexp is deprecated in Python 3.4 in favor of
 # assert_raises_regex but lets keep the bacward compat in scikit-learn with

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -43,12 +43,16 @@ def test_check_estimator():
     # check that we have a set_params and can clone
     msg = "it does not implement a 'get_params' methods"
     assert_raises_regex(TypeError, msg, check_estimator, object)
+    # check that we have a fit method
     msg = "object has no attribute 'fit'"
     assert_raises_regex(AttributeError, msg, check_estimator, BaseEstimator)
+    # check that fit does input validation
     msg = "argument must be a string or a number"
     assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
+    # check that predict does input validation
     msg = "Estimator doesn't check for NaN and inf in predict"
     assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)
+    # check for sparse matrix input handling
     msg = "Estimator type doesn't seem to fail gracefully on sparse data"
     # the check for sparse input handling prints to the stdout,
     # instead of raising an error, so as not to remove the original traceback.

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -1,0 +1,51 @@
+import scipy.sparse as sp
+import numpy as np
+
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils.testing import assert_raises_regex
+from sklearn.utils.estimator_checks import check_estimator
+from sklearn.linear_model import LogisticRegression
+from sklearn.utils.validation import check_X_y, check_array
+
+
+class BaseBadClassifier(BaseEstimator, ClassifierMixin):
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        return np.ones(X.shape[0])
+
+
+class NoCheckinPredict(BaseBadClassifier):
+    def fit(self, X, y):
+        X, y = check_X_y(X, y)
+        return self
+
+
+class NoSparseClassifier(BaseBadClassifier):
+    def fit(self, X, y):
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
+        if sp.issparse(X):
+            raise ValueError("Nonsensical Error")
+        return self
+
+    def predict(self, X):
+        X = check_array(X)
+        return np.ones(X.shape[0])
+
+
+def test_check_estimator():
+    # check that we have a set_params and can clone
+    msg = "it does not implement a 'get_params' methods"
+    assert_raises_regex(TypeError, msg, check_estimator, object)
+    msg = "object has no attribute 'fit'"
+    assert_raises_regex(AttributeError, msg, check_estimator, BaseEstimator)
+    msg = "argument must be a string or a number"
+    assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
+    msg = "Estimator doesn't check for NaN and inf in predict"
+    assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)
+    msg = "Estimator type doesn't seem to fail gracefully on sparse data"
+    assert_raises_regex(TypeError, msg, check_estimator, NoSparseClassifier)
+
+    # doesn't error on actual estimator
+    check_estimator(LogisticRegression)

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -47,9 +47,9 @@ def test_check_estimator():
     msg = "object has no attribute 'fit'"
     assert_raises_regex(AttributeError, msg, check_estimator, BaseEstimator)
     # check that fit does input validation
-    msg = "argument must be a string or a number"
+    msg = "TypeError not raised by fit"
     assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
-    # check that predict does input validation
+    # check that predict does input validation (doesn't accept dicts in input)
     msg = "Estimator doesn't check for NaN and inf in predict"
     assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)
     # check for sparse matrix input handling


### PR DESCRIPTION
Fixes #3810.

Introduces a public `check_estimator` that runs all checks.
Currently it relies on inheritance to see which tests to run (in addition to the general tests).
It could also rely on the recently introduced tags #4418 **but** there is currently only a single tag, while something might be a classifier **and** a transformer....

Todo:
- [x] tests for high-level interface function.
- [x] make sure all tests are run as they were before
- [x] add to docs
