### PR TITLE
[RFC] Allow transformers on y

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -410,6 +410,36 @@ class BiclusterMixin(object):
 class TransformerMixin(object):
     """Mixin class for all transformers in scikit-learn."""
 
+    def pipe(self, X=None, y=None):
+        """Transform X and y.
+
+        Default implemenation based on transform that
+        will just pass through y.
+
+        Parameters
+        ----------
+        X : array-like of shape [n_samples, n_features]
+            Data to be transformed
+
+        y : array-like of shape [n_samples]
+            Labels to be handed through.
+
+        Returns
+        -------
+        X_new : numpy-array of shape [n_samples, n_feature_new]
+            Transformed data.
+
+        y : numpy-array of shape [n_samples]
+            Passed-through labels.
+
+        """
+        Xt = self.transform(X)
+        return Xt, y
+
+    def fit_pipe(self, X=None, y=None):
+        self.fit(X, y)
+        return self.pipe(X, y)
+
     def fit_transform(self, X, y=None, **fit_params):
         """Fit to data, then transform it.
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -125,7 +125,7 @@ class Pipeline(BaseEstimator):
             if hasattr(transform, "fit_pipe"):
                 Xt, yt = transform.fit_pipe(Xt, yt, **fit_params_steps[name])
             elif hasattr(transform, "pipe"):
-                Xt = transform.fit(Xt, y, **fit_params_steps[name]).pipe(Xt, yt)
+                Xt, yt = transform.fit(Xt, y, **fit_params_steps[name]).pipe(Xt, yt)
             elif hasattr(transform, "fit_transform"):
                 Xt = transform.fit_transform(Xt, yt, **fit_params_steps[name])
             else:
@@ -138,7 +138,7 @@ class Pipeline(BaseEstimator):
         yt = y
         for name, transform in self.steps[:-1]:
             if hasattr(transform, "pipe"):
-                Xt = transform.pipe(Xt, yt)
+                Xt, yt = transform.pipe(Xt, yt)
             else:
                 Xt = transform.transform(Xt)
         return Xt, yt

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -64,10 +64,14 @@ class _LabelTransformer(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMi
         pass
 
     def pipe(self, X=None, y=None):
-        return X, self.transform(y)
+        if y is not None:
+            y = self.transform(y)
+        return X, y
 
     def fit_pipe(self, X=None, y=None):
-        return X, self.fit_transform(y)
+        if y is not None:
+            y = self.fit_transform(y)
+        return X, y
 
 
 class LabelEncoder(_LabelTransformer):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 import itertools
 import array
 import warnings
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 import scipy.sparse as sp
@@ -53,7 +54,23 @@ def _check_numpy_unicode_bug(labels):
                            " NumPy to use LabelEncoder with unicode inputs.")
 
 
-class LabelEncoder(BaseEstimator, TransformerMixin):
+class _LabelTransformer(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
+    """Transformer for labels.
+
+    The pipe-method passes through X and transforms y.
+    """
+    @abstractmethod
+    def fit(self, X=None, y=None):
+        pass
+
+    def pipe(self, X=None, y=None):
+        return X, self.transform(y)
+
+    def fit_pipe(self, X=None, y=None):
+        return X, self.fit_transform(y)
+
+
+class LabelEncoder(_LabelTransformer):
     """Encode labels with value between 0 and n_classes-1.
 
     Attributes
@@ -168,7 +185,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         return self.classes_[y]
 
 
-class LabelBinarizer(BaseEstimator, TransformerMixin):
+class LabelBinarizer(_LabelTransformer):
     """Binarize labels in a one-vs-all fashion
 
     Several regression and binary classification algorithms are
@@ -670,7 +687,7 @@ def _inverse_binarize_thresholding(y, output_type, classes, threshold):
         raise ValueError("{0} format is not supported".format(output_type))
 
 
-class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
+class MultiLabelBinarizer(_LabelTransformer):
     """Transform between iterable of iterables and a multilabel format
 
     Although a list of sets or tuples is a very intuitive format for multilabel

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -40,6 +40,7 @@ from sklearn.utils.estimator_checks import (
     check_regressors_train,
     check_regressors_pickle,
     check_transformer_pickle,
+    check_transformer_pipe,
     check_transformers_unfitted,
     check_estimators_empty_data_messages,
     check_estimators_nan_inf,
@@ -132,6 +133,7 @@ def test_transformers():
         # All transformers should either deal with sparse data or raise an
         # exception with type TypeError and an intelligible error message
         yield check_transformer_pickle, name, Transformer
+        yield check_transformer_pipe, name, Transformer
         if name not in ['AdditiveChi2Sampler', 'Binarizer', 'Normalizer',
                         'PLSCanonical', 'PLSRegression', 'CCA', 'PLSSVD']:
             yield check_transformer_data_not_an_array, name, Transformer

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -190,6 +190,23 @@ def check_transformer(name, Transformer):
     _check_transformer(name, Transformer, X.tolist(), y.tolist())
 
 
+def check_transformer_pipe(name, Transformer):
+    # check that transformers implement pipe and that it does the right thing.
+    # todo: pipe does input validation
+    X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
+                      random_state=0, n_features=2, cluster_std=0.1)
+    X = StandardScaler().fit_transform(X)
+    X -= X.min()
+    transformer = Transformer()
+    set_fast_parameters(transformer)
+    set_random_state(transformer)
+    transformer.fit(X, y)
+    Xt, yt = transformer.pipe(X, y)
+    Xt2, yt2 = transformer.fit_pipe(X, y)
+    assert_array_almost_equal(Xt, Xt2)
+    assert_array_almost_equal(yt, yt2)
+
+
 def check_transformer_data_not_an_array(name, Transformer):
     X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
                       random_state=0, n_features=2, cluster_std=0.1)


### PR DESCRIPTION
Shot at #4143.

Adds a new function to the interface, with the uninspired name `pipe`,
with signature

``` python
def pipe(self, X=None, y=None):
     ...
    return Xt, yt
```

example:

``` python
from sklearn.preprocessing.label import _LabelTransformer
from sklearn.preprocessing import StandardScaler
from sklearn.datasets import make_regression


class TargetScaler(StandardScaler, _LabelTransformer):
    pass

X, y = make_regression()
Xt, yt = TargetScaler().fit_pipe(X, y)
print(y.mean())
print(yt.mean())
```

> 15.5246170559
> -1.11022302463e-18

Another (unnecessary) example:

``` python
from sklearn.pipeline import make_pipeline
from sklearn.datasets import load_iris
iris = load_iris()
X, y = iris.data, iris.target_names[iris.target]
pipe = make_pipeline(LabelEncoder(), DecisionTreeClassifier()).fit(X, y)
print(pipe.score(X, y))
print(pipe.predict(X))
```

> 1.0
> [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
>  0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
>  1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 2
>  2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
>  2 2]

(the labels got mapped to numbers again)
