### PR TITLE
DOC fix fastica source matrix output shape

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -224,7 +224,7 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
             w = np.dot(W, K.T)
             A = w.T * (w * w.T).I
 
-    S : array, shape (n_components, n_samples) | None
+    S : array, shape (n_samples, n_components) | None
         Estimated source matrix
 
     X_mean : array, shape (n_features, )


### PR DESCRIPTION
Not only does it not make much sense the way it's documented, I've confirmed via testing that the output S matrix really does have shape (n_samples, n_components).
