### PR TITLE
WIP : allow to normalize y but not X in GP

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -285,11 +285,9 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             X_std[X_std == 0.] = 1.
             y_std[y_std == 0.] = 1.
             # center and scale X if necessary
-            X = (X - X_mean) / X_std
+            # X = (X - X_mean) / X_std # Rémi: cancel normalization
             y = (y - y_mean) / y_std
         else:
-            X_mean = np.zeros(1)
-            X_std = np.ones(1)
             y_mean = np.zeros(1)
             y_std = np.ones(1)
 
@@ -430,7 +428,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             # (evaluates all given points in a single batch run)
 
             # Normalize input
-            X = (X - self.X_mean) / self.X_std
+            #X = (X - self.X_mean) / self.X_std
 
             # Initialize output
             y = np.zeros(n_eval)


### PR DESCRIPTION
@rbardenet spotted that one cannot scale y and not X is GP. Using a periodic kernel with known period scaling X is catastrophic but you still want to scale y ...

maybe @cangermueller you can have a look

I am thinking of a new parameter normalize_y but we should not break backward compat
