### PR TITLE
[MRG] astype sparse matrix

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -14,7 +14,6 @@ import inspect
 import warnings
 import sys
 import functools
-import inspect
 
 import numpy as np
 import scipy.sparse as sp

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -112,11 +112,11 @@ def astype(array, dtype, copy=True):
     if not copy and array.dtype == dtype:
         return array
     elif sp.issparse(array):
-        return array.astype(t=dtype)
+        return array.astype(dtype)
     elif np_astype_copy_supported:
-        return array.astype(dtype=dtype, copy=copy)
+        return array.astype(dtype, copy=copy)
     else:
-        return array.astype(dtype=dtype)
+        return array.astype(dtype)
 
 try:
     with warnings.catch_warnings(record=True):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -14,6 +14,7 @@ import inspect
 import warnings
 import sys
 import functools
+import inspect
 
 import numpy as np
 import scipy.sparse as sp
@@ -100,15 +101,23 @@ except TypeError:
 
 try:
     np.array(5).astype(float, copy=False)
-except TypeError:
-    # Compat where astype accepted no copy argument
-    def astype(array, dtype, copy=True):
-        if not copy and array.dtype == dtype:
-            return array
-        return array.astype(dtype)
-else:
-    astype = np.ndarray.astype
 
+except TypeError:
+    np_astype_copy_supported = False
+
+else:
+    np_astype_copy_supported = True
+
+
+def astype(array, dtype, copy=True):
+    if not copy and array.dtype == dtype:
+        return array
+    elif sp.issparse(array):
+        return array.astype(t=dtype)
+    elif np_astype_copy_supported:
+        return array.astype(dtype=dtype, copy=copy)
+    else:
+        return array.astype(dtype=dtype)
 
 try:
     with warnings.catch_warnings(record=True):

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -57,6 +57,23 @@ def test_astype_copy_memory():
 
 
 def test_astype_sparse_matrix():
-    # Check that the copy boolean is ignored for SciPy sparse matrices
-    sparse_matrix = bsr_matrix(np.ones((3, 4), dtype=np.float32))
-    astype(sparse_matrix, dtype=np.int32, copy=False)
+    # Checking that the copy boolean is ignored for SciPy sparse matrices
+    a_spmatrix = bsr_matrix(np.ones((3, 4), dtype=np.int32))
+
+    # Check that dtype conversion works
+    b_spmatrix = astype(a_spmatrix, dtype=np.float32, copy=False)
+    assert_equal(b_spmatrix.dtype, np.float32)
+
+    # Changing dtype forces a copy even if copy=False
+    assert_false(np.may_share_memory(b_spmatrix, a_spmatrix))
+
+    # Check that copy can be skipped if requested dtype match
+    c_spmatrix = astype(a_spmatrix, dtype=np.int32, copy=False)
+    assert_true(c_spmatrix is a_spmatrix)
+
+    # Check that copy can be forced, and is the case by default:
+    d_spmatrix = astype(a_spmatrix, dtype=np.int32, copy=True)
+    assert_false(np.may_share_memory(d_spmatrix, a_spmatrix))
+
+    e_spmatrix = astype(a_spmatrix, dtype=np.int32)
+    assert_false(np.may_share_memory(e_spmatrix, a_spmatrix))

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -14,12 +14,13 @@ from numpy.testing import (assert_almost_equal,
 from sklearn.utils.fixes import divide, expit
 from sklearn.utils.fixes import astype
 
+from scipy.sparse import bsr_matrix
 
 def test_expit():
     # Check numerical stability of expit (logistic function).
 
     # Simulate our previous Cython implementation, based on
-    #http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression
+    # http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression
     assert_almost_equal(expit(1000.), 1. / (1. + np.exp(-1000.)), decimal=16)
     assert_almost_equal(expit(-1000.), np.exp(-1000.) / (1. + np.exp(-1000.)),
                         decimal=16)
@@ -53,3 +54,9 @@ def test_astype_copy_memory():
 
     e_int32 = astype(a_int32, dtype=np.int32)
     assert_false(np.may_share_memory(e_int32, a_int32))
+
+
+def test_astype_sparse_matrix():
+    # Check that the copy boolean is ignored for SciPy sparse matrices
+    sparse_matrix = bsr_matrix(np.ones((3, 4), dtype=np.float32))
+    astype(sparse_matrix, dtype=np.int32, copy=False)


### PR DESCRIPTION
Changes astype() in utils/fixes.py which failed on SciPy sparse matrices
