### PR TITLE
[MRG+1] Fix Float Resolution Bug on Gaussian Process Test

### DIFF
--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -66,8 +66,9 @@ def test_2d(regr=regression.constant, corr=correlation.squared_exponential,
 
     assert_true(np.allclose(y_pred, y) and np.allclose(MSE, 0.))
 
-    assert_true(np.all(gp.theta_ >= thetaL))  # Lower bounds of hyperparameters
-    assert_true(np.all(gp.theta_ <= thetaU))  # Upper bounds of hyperparameters
+    eps = np.finfo(gp.theta_.dtype).eps
+    assert_true(np.all(gp.theta_ >= thetaL - eps))  # Lower bounds of hyperparameters
+    assert_true(np.all(gp.theta_ <= thetaU + eps))  # Upper bounds of hyperparameters
 
 
 def test_2d_2d(regr=regression.constant, corr=correlation.squared_exponential,


### PR DESCRIPTION
Observed with:
Ubuntu 14.04.1 LTS (vagrant/VirtualBox)
scikit-learn==0.17.dev0
scipy==0.13.3
numpy==1.8.2

Was causing:

```
FAIL: sklearn.gaussian_process.tests.test_gaussian_process.test_2d

Traceback (most recent call last):
  File "/vagrant/plangrid-workers/.venv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/vagrant/scikit-learn/sklearn/gaussian_process/tests/test_gaussian_process.py", line 69, in test_2d
    assert_true(np.all(gp.theta_ >= thetaL))  # Lower bounds of hyperparameters
AssertionError: False is not true
    'False is not true' = self._formatMessage('False is not true', "%s is not true" % safe_repr(False))
 raise self.failureException('False is not true')
```

because 0.0001 != 1e-4
