### PR TITLE
[MRG+1] Change xrange function to range in bicluster newsgroups example

### DIFF
--- a/examples/bicluster/bicluster_newsgroups.py
+++ b/examples/bicluster/bicluster_newsgroups.py
@@ -66,6 +66,7 @@ import numpy as np
 from sklearn.cluster.bicluster import SpectralCoclustering
 from sklearn.cluster import MiniBatchKMeans
 from sklearn.externals import six
+from sklearn.externals.six.moves import xrange
 from sklearn.datasets.twenty_newsgroups import fetch_20newsgroups
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.cluster import v_measure_score

--- a/examples/bicluster/bicluster_newsgroups.py
+++ b/examples/bicluster/bicluster_newsgroups.py
@@ -66,7 +66,6 @@ import numpy as np
 from sklearn.cluster.bicluster import SpectralCoclustering
 from sklearn.cluster import MiniBatchKMeans
 from sklearn.externals.six import iteritems
-from sklearn.externals.six.moves import xrange
 from sklearn.datasets.twenty_newsgroups import fetch_20newsgroups
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.cluster import v_measure_score
@@ -148,7 +147,7 @@ def most_common(d):
 
 
 bicluster_ncuts = list(bicluster_ncut(i)
-                       for i in xrange(len(newsgroups.target_names)))
+                       for i in range(len(newsgroups.target_names)))
 best_idx = np.argsort(bicluster_ncuts)[:5]
 
 print()

--- a/examples/bicluster/bicluster_newsgroups.py
+++ b/examples/bicluster/bicluster_newsgroups.py
@@ -65,7 +65,7 @@ import numpy as np
 
 from sklearn.cluster.bicluster import SpectralCoclustering
 from sklearn.cluster import MiniBatchKMeans
-from sklearn.externals import six
+from sklearn.externals.six import iteritems
 from sklearn.externals.six.moves import xrange
 from sklearn.datasets.twenty_newsgroups import fetch_20newsgroups
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -144,7 +144,7 @@ def most_common(d):
 
     Like Counter.most_common in Python >=2.7.
     """
-    return sorted(six.iteritems(d), key=operator.itemgetter(1), reverse=True)
+    return sorted(iteritems(d), key=operator.itemgetter(1), reverse=True)
 
 
 bicluster_ncuts = list(bicluster_ncut(i)


### PR DESCRIPTION
The `bicluster_newsgroups.py` example did not have the `xrange` function defined in Python3. This raised a NameError from the function call at line 150. 

Added the function import from sklearn.externals.six.moves to resolve.
