### PR TITLE
[MRG] DOC train_test_split, use standart (X, y) notation

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1556,29 +1556,29 @@ def train_test_split(*arrays, **options):
     --------
     >>> import numpy as np
     >>> from sklearn.cross_validation import train_test_split
-    >>> a, b = np.arange(10).reshape((5, 2)), range(5)
-    >>> a
+    >>> X, y = np.arange(10).reshape((5, 2)), range(5)
+    >>> X
     array([[0, 1],
            [2, 3],
            [4, 5],
            [6, 7],
            [8, 9]])
-    >>> list(b)
+    >>> list(y)
     [0, 1, 2, 3, 4]
 
-    >>> a_train, a_test, b_train, b_test = train_test_split(
-    ...     a, b, test_size=0.33, random_state=42)
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X, y, test_size=0.33, random_state=42)
     ...
-    >>> a_train
+    >>> X_train
     array([[4, 5],
            [0, 1],
            [6, 7]])
-    >>> b_train
+    >>> y_train
     [2, 0, 3]
-    >>> a_test
+    >>> X_test
     array([[2, 3],
            [8, 9]])
-    >>> b_test
+    >>> y_test
     [1, 4]
 
     """


### PR DESCRIPTION
Hi, this docstring confused me once to often :) .
I would suggest to change (a, b) to our standart( X, y) notation
