### PR TITLE
[MRG+1] Implementing fix for fetching 20newsgroup dataset

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -25,12 +25,35 @@ from ..utils import check_random_state
 
 
 class Bunch(dict):
-    """Container object for datasets: dictionary-like object that
-       exposes its keys as attributes."""
+    """Container object for datasets
+
+    Dictionary-like object that exposes its keys as attributes.
+
+    >>> b = Bunch(a=1, b=2)
+    >>> b['b']
+    2
+    >>> b.b
+    2
+    >>> b.a = 3
+    >>> b['a']
+    3
+    >>> b.c = 6
+    >>> b['c']
+    6
+
+    """
 
     def __init__(self, **kwargs):
         dict.__init__(self, kwargs)
-        self.__dict__ = self
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __getattr__(self, key):
+        return self[key]
+
+    def __getstate__(self):
+        return self.__dict__
 
 
 def get_data_home(data_home=None):

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -39,6 +39,23 @@ def test_20news():
     assert_equal(entry1, entry2)
 
 
+def test_20news_length_consistency():
+    """Checks the length consistencies within the bunch
+
+    This is a non-regression test for a bug present in 0.16.1.
+    """
+    try:
+        data = datasets.fetch_20newsgroups(
+            subset='all', download_if_missing=False, shuffle=False)
+    except IOError:
+        raise SkipTest("Download 20 newsgroups to run this test")
+    # Extract the full dataset
+    data = datasets.fetch_20newsgroups(subset='all')
+    assert_equal(len(data['data']), len(data.data))
+    assert_equal(len(data['target']), len(data.target))
+    assert_equal(len(data['filenames']), len(data.filenames))
+
+
 def test_20news_vectorized():
     # This test is slow.
     raise SkipTest("Test too slow.")

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -161,7 +161,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         for the test set, 'all' for both, with shuffled ordering.
 
     data_home: optional, default: None
-        Specify an download and cache folder for the datasets. If None,
+        Specify a download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     categories: None or collection of string or unicode


### PR DESCRIPTION
Fixing issue #4435 :
the fetched bunch behaved differently for `.data` and `['data']`
(similary for target and filenames)
Fixed by updating both in the fetching (same as was suggested in the issue)
I copied the (three lines) changes from commit e3c9294dcdc1c55b3064e97032fb8f21ed54941e
instead of doing a rebase.

Also test has been added to check that both `.data` and `['data']` have the same length
(testing also target and filenames)
