### PR TITLE
[MRG + 1] Change urlopen and iteritems functions for Python3 compat

### DIFF
--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -46,6 +46,8 @@ from scipy import sparse
 
 from sklearn.decomposition import randomized_svd
 from sklearn.externals.joblib import Memory
+from sklearn.externals.six.moves.urllib.request import urlopen
+from sklearn.externals.six import iteritems
 
 
 print(__doc__)
@@ -65,9 +67,8 @@ resources = [
 
 for url, filename in resources:
     if not os.path.exists(filename):
-        import urllib
         print("Downloading data from '%s', please wait..." % url)
-        opener = urllib.urlopen(url)
+        opener = urlopen(url)
         open(filename, 'wb').write(opener.read())
         print()
 
@@ -171,7 +172,7 @@ def get_adjacency_matrix(redirects_filename, page_links_filename, limit=None):
 # stop after 5M links to make it possible to work in RAM
 X, redirects, index_map = get_adjacency_matrix(
     redirects_filename, page_links_filename, limit=5000000)
-names = dict((i, name) for name, i in index_map.iteritems())
+names = dict((i, name) for name, i in iteritems(index_map))
 
 print("Computing the principal singular vectors using randomized_svd")
 t0 = time()


### PR DESCRIPTION
The Wikipedia example had used Python2-only modules and methods. These have been changed to their equivalents in `six`. 
