### PR TITLE
[MRG+1-1] consistent setting of train_size and test_size in ShuffleSplit [Fix Bug #4618 ]

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -773,7 +773,7 @@ def _validate_shuffle_split(n, test_size, train_size, param_tuple, param_dict):
         else:
             raise ValueError("Invalid value for train_size: %r" % train_size)
     else:  # test_size is not None and train_set is not None:
-        if np.array(test_size).dtype.kind == 'f' and
+        if np.array(test_size).dtype.kind == 'f' and \
         np.array(train_size).dtype.kind == 'f':
             if test_size >= 1.:
                 raise ValueError('test_size=%f should be smaller '
@@ -786,19 +786,19 @@ def _validate_shuffle_split(n, test_size, train_size, param_tuple, param_dict):
                                  'should be smaller than 1.0. Reduce '
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
-        elif np.array(test_size).dtype.kind == 'f' and
+        elif np.array(test_size).dtype.kind == 'f' and \
         np.array(train_size).dtype.kind == 'i':
             raise ValueError(
                 "Type of test_size and train_sizeis not the same, "
                 "test_size: %r, train_size: %r" %
                 (type(test_size), type(train_size)))
-        elif np.array(test_size).dtype.kind == 'i' and
+        elif np.array(test_size).dtype.kind == 'i' and \
         np.array(train_size).dtype.kind == 'f':
             raise ValueError(
                 "Type of test_size and train_sizeis not the same, "
                 "test_size: %r, train_size: %r" %
                 (type(test_size), type(train_size)))
-        elif np.array(test_size).dtype.kind == 'i' and
+        elif np.array(test_size).dtype.kind == 'i' and \
         np.array(train_size).dtype.kind == 'i':
             if test_size >= n:
                 raise ValueError('test_size=%d should be smaller '
@@ -814,11 +814,11 @@ def _validate_shuffle_split(n, test_size, train_size, param_tuple, param_dict):
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
         else:
-            if np.array(test_size).dtype.kind != 'f' and
+            if np.array(test_size).dtype.kind != 'f' and \
             np.array(test_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for test_size: %r" %
                                  test_size)
-            if np.array(train_size).dtype.kind != 'f' and
+            if np.array(train_size).dtype.kind != 'f' and \
             np.array(train_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for train_size: %r" %
                                  train_size)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -213,8 +213,8 @@ class LeavePOut(_PartitionIterator):
         )
 
     def __len__(self):
-        return int(factorial(self.n) / factorial(self.n - self.p)
-                   / factorial(self.p))
+        return int(factorial(self.n) / factorial(self.n - self.p) /
+                   factorial(self.p))
 
 
 class _BaseKFold(with_metaclass(ABCMeta, _PartitionIterator)):
@@ -775,14 +775,12 @@ def _validate_shuffle_split(n, test_size, train_size):
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
         else:
-            # test_size_kind != train_size_kin or
+            # test_size_kind != train_size_kind or
             # their kinds are nether 'f' nor 'i'
-            if np.array(test_size).dtype.kind != 'f' and \
-               np.array(test_size).dtype.kind != 'i':
+            if test_size_kind not in ['f', 'i']:
                 raise ValueError("Invalid value for test_size: %r" %
                                  test_size)
-            if np.array(train_size).dtype.kind != 'f' and \
-               np.array(train_size).dtype.kind != 'i':
+            if train_size_kind not in ['f', 'i']:
                 raise ValueError("Invalid value for train_size: %r" %
                                  train_size)
             raise ValueError(

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -775,6 +775,8 @@ def _validate_shuffle_split(n, test_size, train_size):
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
         else:
+            # test_size_kind != train_size_kin or
+            # their kinds are nether 'f' nor 'i'
             if np.array(test_size).dtype.kind != 'f' and \
                np.array(test_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for test_size: %r" %

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -837,7 +837,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float, int, or None (default None)
+    test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split.
         If int, represents the absolute number of test samples.

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -638,11 +638,11 @@ class ShuffleSplit(BaseShuffleSplit):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float (default 0.1), int, or None,
+    test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split.
         If int, represents the absolute number of test samples.
-        If None, the value is automatically set accroding  to train_size,
+        If None, the value is automatically set accroding to train_size,
         when test_size and train_size are both None, their values will be
         computed by default (.1/.9).
 
@@ -651,6 +651,9 @@ class ShuffleSplit(BaseShuffleSplit):
         proportion of the dataset to include in the train split. If
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test size.
+        If None, the value is automatically set accroding to test_size,
+        when test_size and train_size are both None, their values will be
+        computed by default (.1/.9).
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -834,7 +837,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float (default 0.1), int, or None
+    test_size : float, int, or None (default None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split.
         If int, represents the absolute number of test samples.
@@ -847,6 +850,9 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         proportion of the dataset to include in the train split. If
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test size.
+        If None, the value is automatically set accroding to test_size,
+        when test_size and train_size are both None, their values will be
+        computed by default (.1/.9).
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -870,7 +876,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     TRAIN: [0 2] TEST: [3 1]
     """
 
-    def __init__(self, y, n_iter=10, test_size=0.1, train_size=None,
+    def __init__(self, y, n_iter=10, test_size=None, train_size=None,
                  random_state=None):
 
         super(StratifiedShuffleSplit, self).__init__(

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -595,50 +595,21 @@ class LeavePLabelOut(_PartitionIterator):
 class BaseShuffleSplit(with_metaclass(ABCMeta)):
     """Base class for ShuffleSplit and StratifiedShuffleSplit"""
 
-    def __init__(self, *args, **kwargs):
-        if len(args) == 0:
-            raise ValueError("Parameter n must be specified.")
-        else:
-            self.n = args[0]
+    def __init__(self, n, n_iter=10, test_size=None, train_size=None,
+                 random_state=None):
+        self.n = n
+        self.n_iter = n_iter
+        self.random_state = random_state
 
-        if len(args) > 1:
-            self.n_iter = args[1]
-        elif "n_iter" in kwargs:
-            self.n_iter = kwargs["n_iter"]
-        else:
-            self.n_iter = 10
+        # we will compute the final value of
+        # test_size in _validate_shuffle_split()
+        self.test_size = test_size
+        # we will compute the final value of
+        # test_size in _validate_shuffle_split()
+        self.train_size = train_size
 
-        if len(args) > 2:
-            self.test_size = args[2]
-        elif "test_size" in kwargs:
-            self.test_size = kwargs["test_size"]
-        else:
-            # we will compute the final value of
-            # test_size in _validate_shuffle_split()
-            self.test_size = None
-
-        if len(args) > 3:
-            self.train_size = args[3]
-        elif "train_size" in kwargs:
-            self.train_size = kwargs["train_size"]
-        else:
-            # we will compute the final value of
-            # test_size in _validate_shuffle_split()
-            self.train_size = None
-
-        if len(args) > 4:
-            self.random_state = args[4]
-        elif "random_state" in kwargs:
-            self.random_state = kwargs["random_state"]
-        else:
-            self.random_state = None
-
-        if len(args) > 5:
-            raise ValueError("Too much parameter specified: %r" % args)
-
-        self.n_train, self.n_test = _validate_shuffle_split(
-            self.n, self.test_size, self.train_size,
-            args, kwargs)
+        self.n_train, self.n_test = _validate_shuffle_split(n, test_size,
+                                                            train_size)
 
     def __iter__(self):
         for train, test in self._iter_indices():
@@ -733,15 +704,12 @@ class ShuffleSplit(BaseShuffleSplit):
         return self.n_iter
 
 
-def _validate_shuffle_split(n, test_size, train_size, param_tuple, param_dict):
+def _validate_shuffle_split(n, test_size, train_size):
     if test_size is None and train_size is None:
-        if "test_size" not in param_dict and \
-           len(param_tuple) < 3:  # user didn't set test_size
-            test_size = 0.1       # we will use default value
-            train_size = 1. - test_size
-        else:
-            raise ValueError(
-                'test_size and train_size can not both be None.')
+        # user didn't set test_size
+        # we will use default value
+        test_size = 0.1
+        train_size = 1. - test_size
 
     if test_size is not None and train_size is None:
         if np.asarray(test_size).dtype.kind == 'f':

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -638,11 +638,13 @@ class ShuffleSplit(BaseShuffleSplit):
     n_iter : int (default 10)
         Number of re-shuffling & splitting iterations.
 
-    test_size : float (default 0.1), int, or None
+    test_size : float (default 0.1), int, or None,
         If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
+        proportion of the dataset to include in the test split.
+        If int, represents the absolute number of test samples.
+        If None, the value is automatically set accroding  to train_size,
+        when test_size and train_size are both None, their values will be
+        computed by default (.1/.9).
 
     train_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
@@ -712,13 +714,14 @@ def _validate_shuffle_split(n, test_size, train_size):
         train_size = 1. - test_size
 
     if test_size is not None and train_size is None:
-        if np.asarray(test_size).dtype.kind == 'f':
+        test_size_kind = np.asarray(test_size).dtype.kind
+        if test_size_kind == 'f':
             if test_size >= 1.:
                 raise ValueError(
                     'test_size=%f should be smaller '
                     'than 1.0 or be an integer' % test_size)
             train_size = 1. - test_size
-        elif np.asarray(test_size).dtype.kind == 'i':
+        elif test_size_kind == 'i':
             if test_size >= n:
                 raise ValueError(
                     'test_size=%d should be smaller '
@@ -727,12 +730,13 @@ def _validate_shuffle_split(n, test_size, train_size):
         else:
             raise ValueError("Invalid value for test_size: %r" % test_size)
     elif test_size is None and train_size is not None:
-        if np.asarray(train_size).dtype.kind == 'f':
+        train_size_kind = np.asarray(train_size).dtype.kind
+        if train_size_kind == 'f':
             if train_size >= 1.:
                 raise ValueError("train_size=%f should be smaller "
                                  "than 1.0 or be an integer" % train_size)
             test_size = 1. - train_size
-        elif np.asarray(train_size).dtype.kind == 'i':
+        elif train_size_kind == 'i':
             if train_size >= n:
                 raise ValueError("train_size=%d should be smaller "
                                  "than the number of samples %d" %
@@ -741,8 +745,10 @@ def _validate_shuffle_split(n, test_size, train_size):
         else:
             raise ValueError("Invalid value for train_size: %r" % train_size)
     else:  # test_size is not None and train_set is not None:
-        if np.array(test_size).dtype.kind == 'f' and \
-           np.array(train_size).dtype.kind == 'f':
+        test_size_kind = np.array(test_size).dtype.kind
+        train_size_kind = np.array(train_size).dtype.kind
+        if test_size_kind == 'f' and \
+           train_size_kind == 'f':
             if test_size >= 1.:
                 raise ValueError('test_size=%f should be smaller '
                                  'than 1.0 or be an integer' % test_size)
@@ -754,20 +760,7 @@ def _validate_shuffle_split(n, test_size, train_size):
                                  'should be smaller than 1.0. Reduce '
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
-        elif np.array(test_size).dtype.kind == 'f' and \
-                np.array(train_size).dtype.kind == 'i':
-            raise ValueError(
-                "Type of test_size and train_sizeis not the same, "
-                "test_size: %r, train_size: %r" %
-                (type(test_size), type(train_size)))
-        elif np.array(test_size).dtype.kind == 'i' and \
-                np.array(train_size).dtype.kind == 'f':
-            raise ValueError(
-                "Type of test_size and train_sizeis not the same, "
-                "test_size: %r, train_size: %r" %
-                (type(test_size), type(train_size)))
-        elif np.array(test_size).dtype.kind == 'i' and \
-                np.array(train_size).dtype.kind == 'i':
+        elif test_size_kind == 'i' and train_size_kind == 'i':
             if test_size >= n:
                 raise ValueError('test_size=%d should be smaller '
                                  'than the number of samples %d' %
@@ -790,6 +783,10 @@ def _validate_shuffle_split(n, test_size, train_size):
                np.array(train_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for train_size: %r" %
                                  train_size)
+            raise ValueError(
+                "Type of test_size and train_size is not the same, "
+                "test_size: %r, train_size: %r" %
+                (type(test_size), type(train_size)))
 
     if np.asarray(test_size).dtype.kind == 'f':
         n_test = ceil(test_size * n)
@@ -839,9 +836,11 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
     test_size : float (default 0.1), int, or None
         If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
+        proportion of the dataset to include in the test split.
+        If int, represents the absolute number of test samples.
+        If None, the value is automatically set accroding  to train_size,
+        when test_size and train_size are both None, their values will be
+        computed by default (.1/.9).
 
     train_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -742,7 +742,7 @@ def _validate_shuffle_split(n, test_size, train_size):
             raise ValueError("Invalid value for train_size: %r" % train_size)
     else:  # test_size is not None and train_set is not None:
         if np.array(test_size).dtype.kind == 'f' and \
-        np.array(train_size).dtype.kind == 'f':
+           np.array(train_size).dtype.kind == 'f':
             if test_size >= 1.:
                 raise ValueError('test_size=%f should be smaller '
                                  'than 1.0 or be an integer' % test_size)
@@ -755,19 +755,19 @@ def _validate_shuffle_split(n, test_size, train_size):
                                  'test_size and/or train_size.' %
                                  (train_size + test_size))
         elif np.array(test_size).dtype.kind == 'f' and \
-        np.array(train_size).dtype.kind == 'i':
+                np.array(train_size).dtype.kind == 'i':
             raise ValueError(
                 "Type of test_size and train_sizeis not the same, "
                 "test_size: %r, train_size: %r" %
                 (type(test_size), type(train_size)))
         elif np.array(test_size).dtype.kind == 'i' and \
-        np.array(train_size).dtype.kind == 'f':
+                np.array(train_size).dtype.kind == 'f':
             raise ValueError(
                 "Type of test_size and train_sizeis not the same, "
                 "test_size: %r, train_size: %r" %
                 (type(test_size), type(train_size)))
         elif np.array(test_size).dtype.kind == 'i' and \
-        np.array(train_size).dtype.kind == 'i':
+                np.array(train_size).dtype.kind == 'i':
             if test_size >= n:
                 raise ValueError('test_size=%d should be smaller '
                                  'than the number of samples %d' %
@@ -783,11 +783,11 @@ def _validate_shuffle_split(n, test_size, train_size):
                                  (train_size + test_size))
         else:
             if np.array(test_size).dtype.kind != 'f' and \
-            np.array(test_size).dtype.kind != 'i':
+               np.array(test_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for test_size: %r" %
                                  test_size)
             if np.array(train_size).dtype.kind != 'f' and \
-            np.array(train_size).dtype.kind != 'i':
+               np.array(train_size).dtype.kind != 'i':
                 raise ValueError("Invalid value for train_size: %r" %
                                  train_size)
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -796,22 +796,10 @@ def _validate_shuffle_split(n, test_size, train_size):
     elif np.asarray(test_size).dtype.kind == 'i':
         n_test = float(test_size)
 
-    if train_size is None:
-        n_train = n - n_test
-    else:
-        if np.asarray(train_size).dtype.kind == 'f':
-            n_train = floor(train_size * n)
-        else:
-            n_train = float(train_size)
-
-    if test_size is None:
-        n_test = n - n_train
-
-    if n_train + n_test > n:
-        raise ValueError('The sum of train_size and test_size = %d, '
-                         'should be smaller than the number of '
-                         'samples %d. Reduce test_size and/or '
-                         'train_size.' % (n_train + n_test, n))
+    if np.asarray(train_size).dtype.kind == 'f':
+        n_train = floor(train_size * n)
+    elif np.asarray(train_size).dtype.kind == 'i':
+        n_train = float(train_size)
 
     return int(n_train), int(n_test)
 

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -907,6 +907,26 @@ def test_shufflesplit_errors():
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=10)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=8, train_size=3)
     assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=1j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=".8")
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=".8",
+                  test_size=".2")
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=".8",
+                  test_size=.2)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=".8")
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=".8",
+                  train_size=".2")
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=".8",
+                  train_size=.2)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=.8j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=.8j,
+                  test_size=.2j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=.8j,
+                  test_size=.2)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=.8j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=.8j,
+                  train_size=.2j)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=.8j,
+                  train_size=.2)
 
 
 def test_shufflesplit_reproducible():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -362,13 +362,17 @@ def test_shuffle_split():
     ss3 = cval.ShuffleSplit(10, test_size=np.int32(2), random_state=0)
     for typ in six.integer_types:
         ss4 = cval.ShuffleSplit(10, test_size=typ(2), random_state=0)
-    for t1, t2, t3, t4 in zip(ss1, ss2, ss3, ss4):
+    ss5 = cval.ShuffleSplit(10, train_size=0.8, random_state=0)
+    for t1, t2, t3, t4, t5 in zip(ss1, ss2, ss3, ss4, ss5):
         assert_array_equal(t1[0], t2[0])
         assert_array_equal(t2[0], t3[0])
         assert_array_equal(t3[0], t4[0])
+        assert_array_equal(t4[0], t5[0])
         assert_array_equal(t1[1], t2[1])
         assert_array_equal(t2[1], t3[1])
         assert_array_equal(t3[1], t4[1])
+        assert_array_equal(t4[1], t5[1])
+
 
 
 def test_stratified_shuffle_split_init():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -374,10 +374,36 @@ def test_shuffle_split():
         assert_array_equal(t4[1], t5[1])
 
     ss6 = cval.ShuffleSplit(10, random_state=0)
-    ss7 = cval.ShuffleSplit(10, test_size=None, train_size=None, random_state=0)
-    for t6, t7 in zip(ss6, ss7):
+    ss7 = cval.ShuffleSplit(10, test_size=None, train_size=None,
+                            random_state=0)
+    ss8 = cval.ShuffleSplit(10, test_size=None, random_state=0)
+    ss9 = cval.ShuffleSplit(10, train_size=None, random_state=0)
+    ss10 = cval.ShuffleSplit(10, test_size=0.1, train_size=0.9,
+                             random_state=0)
+    ss11 = cval.ShuffleSplit(10, test_size=0.1, random_state=0)
+    ss12 = cval.ShuffleSplit(10, train_size=0.9, random_state=0)
+    ss13 = cval.ShuffleSplit(10, test_size=0.1, train_size=None,
+                             random_state=0)
+    ss14 = cval.ShuffleSplit(10, test_size=None, train_size=0.9,
+                             random_state=0)
+    for t6, t7, t8, t9, t10, t11, t12, t13, t14 in \
+            zip(ss6, ss7, ss8, ss9, ss10, ss11, ss12, ss13, ss14):
         assert_array_equal(t6[0], t7[0])
+        assert_array_equal(t7[0], t8[0])
+        assert_array_equal(t8[0], t9[0])
+        assert_array_equal(t9[0], t10[0])
+        assert_array_equal(t10[0], t11[0])
+        assert_array_equal(t11[0], t12[0])
+        assert_array_equal(t12[0], t13[0])
+        assert_array_equal(t13[0], t14[0])
         assert_array_equal(t6[1], t7[1])
+        assert_array_equal(t7[1], t8[1])
+        assert_array_equal(t8[1], t9[1])
+        assert_array_equal(t9[1], t10[1])
+        assert_array_equal(t10[1], t11[1])
+        assert_array_equal(t11[1], t12[1])
+        assert_array_equal(t12[1], t13[1])
+        assert_array_equal(t13[1], t14[1])
 
 
 def test_stratified_shuffle_split_init():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -373,6 +373,11 @@ def test_shuffle_split():
         assert_array_equal(t3[1], t4[1])
         assert_array_equal(t4[1], t5[1])
 
+    ss6 = cval.ShuffleSplit(10, random_state=0)
+    ss7 = cval.ShuffleSplit(10, test_size=None, train_size=None, random_state=0)
+    for t6, t7 in zip(ss6, ss7):
+        assert_array_equal(t6[0], t7[0])
+        assert_array_equal(t6[1], t7[1])
 
 
 def test_stratified_shuffle_split_init():
@@ -876,8 +881,6 @@ def test_shufflesplit_errors():
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=10)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=8, train_size=3)
     assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=1j)
-    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=None,
-                  train_size=None)
 
 
 def test_shufflesplit_reproducible():


### PR DESCRIPTION
cross_validation.ShuffleSplit setting train_size without setting test_size, the sum of train_size and test_size is not equal to 1. Now the sum of them is 0.1(default value of test_size) + train_size.

When setting test_size without setting train_size, the train_size is autocomputed by 1 - test_size, so we hope when setting train_size, the test_size is autocomputed by 1 - train_size as well, not defualt value 0.1.

https://github.com/scikit-learn/scikit-learn/issues/4618
