### PR TITLE
MCD Exact Fit: Fixes Issue #3367

### DIFF
--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -118,7 +118,7 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
     # Iterative procedure for Minimum Covariance Determinant computation
     det = fast_logdet(covariance)
     previous_det = np.inf
-    while (det < previous_det) and (remaining_iterations > 0) and (det != -np.inf):
+    while (det < previous_det) and (remaining_iterations > 0) and not (np.isinf(det)):
         # save old estimates values
         previous_location = location
         previous_covariance = covariance
@@ -140,15 +140,9 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
 
     previous_dist = dist
     dist = (np.dot(X - location, precision) * (X - location)).sum(axis=1)
-    # Catch computation errors
+    # Check if best fit already found (det => 0, logdet => -inf)
     if np.isinf(det):
         results = location, covariance, det, support, dist
-        # raise ValueError(
-        #     "Singular covariance matrix. "
-        #     "Please check that the covariance matrix corresponding "
-        #     "to the dataset is full rank and that MinCovDet is used with "
-        #     "Gaussian-distributed data (or at least data drawn from a "
-        #     "unimodal, symmetric distribution.")
     # Check convergence
     if np.allclose(det, previous_det):
         # c_step procedure converged

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -140,11 +140,8 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
 
     previous_dist = dist
     dist = (np.dot(X - location, precision) * (X - location)).sum(axis=1)
-    # Check if best fit already found (det => 0, logdet => -inf)
-    if np.isinf(det):
-        results = location, covariance, det, support, dist
     # Check convergence
-    if np.allclose(det, previous_det):
+    if np.isinf(det) or np.allclose(det, previous_det):
         # c_step procedure converged
         if verbose:
             print("Optimal couple (location, covariance) found before"

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -142,12 +142,13 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
     dist = (np.dot(X - location, precision) * (X - location)).sum(axis=1)
     # Catch computation errors
     if np.isinf(det):
-        raise ValueError(
-            "Singular covariance matrix. "
-            "Please check that the covariance matrix corresponding "
-            "to the dataset is full rank and that MinCovDet is used with "
-            "Gaussian-distributed data (or at least data drawn from a "
-            "unimodal, symmetric distribution.")
+        return location, covariance, det, support, dist
+        # raise ValueError(
+        #     "Singular covariance matrix. "
+        #     "Please check that the covariance matrix corresponding "
+        #     "to the dataset is full rank and that MinCovDet is used with "
+        #     "Gaussian-distributed data (or at least data drawn from a "
+        #     "unimodal, symmetric distribution.")
     # Check convergence
     if np.allclose(det, previous_det):
         # c_step procedure converged

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -118,7 +118,7 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
     # Iterative procedure for Minimum Covariance Determinant computation
     det = fast_logdet(covariance)
     previous_det = np.inf
-    while (det < previous_det) and (remaining_iterations > 0):
+    while (det < previous_det) and (remaining_iterations > 0) and (det != -np.inf):
         # save old estimates values
         previous_location = location
         previous_covariance = covariance
@@ -142,7 +142,7 @@ def _c_step(X, n_support, random_state, remaining_iterations=30,
     dist = (np.dot(X - location, precision) * (X - location)).sum(axis=1)
     # Catch computation errors
     if np.isinf(det):
-        return location, covariance, det, support, dist
+        results = location, covariance, det, support, dist
         # raise ValueError(
         #     "Singular covariance matrix. "
         #     "Please check that the covariance matrix corresponding "

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -362,8 +362,9 @@ def fast_mcd(X, support_fraction=None,
     X = np.asarray(X)
     if X.ndim == 1:
         X = np.reshape(X, (-1, 1))
-        warnings.warn("Only one sample available. "
-                      "You may want to reshape your data array")
+        warnings.warn("1D array passed in. "
+                      "Assuming the array contains samples, not features. "
+                      "You may wish to reshape your data.")
     n_samples, n_features = X.shape
 
     # minimum breakdown value

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -361,7 +361,7 @@ def fast_mcd(X, support_fraction=None,
 
     X = np.asarray(X)
     if X.ndim == 1:
-        X = np.reshape(X, (1, -1))
+        X = np.reshape(X, (-1, 1))
         warnings.warn("Only one sample available. "
                       "You may want to reshape your data array")
     n_samples, n_features = X.shape


### PR DESCRIPTION
The following patch fixes issue #3367, to the best of my knowledge. However, while testing with various "exact fit" scenarios, I encountered an issue which I believe may be somewhere else in the code. The data I used to test this is a simple plane (all Z = 0) with a few outliers present. The exact fit scenario works and no issues arise.

However, taking the same data as above, converting it to the affine subspace spanned by the data, which is basically a rotation about the principal axes and a translation by the mean, the data occasionally raises an error where the determinant is larger than that of the previous determinant. Both datasets can be found at https://gist.github.com/ThatGeoGuy/713bd1355b87ea2d5d07, where `good_data.txt` is the original data, and `bad_data.txt` is the same data transformed into its affine subspace. 

The final result is still correct in the end despite a couple of the trials triggering the above issue, and it only happens with the `bad_data.txt` dataset. I am unsure what is causing this, but it appears to be something different than what caused #3367.
