### PR TITLE
[MRG+1] ForestClassifier.predict docstring correction

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -444,8 +444,10 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
     def predict(self, X):
         """Predict class for X.
 
-        The predicted class of an input sample is computed as the majority
-        prediction of the trees in the forest.
+        The predicted class of an input sample is a vote by the trees in
+        the forest, weighted by their probability estimates. That is,
+        the predicted class is the one with highest mean probability
+        estimate across the trees.
 
         Parameters
         ----------


### PR DESCRIPTION
RandomForestClassifier predicts based on the mean probability estimate, rather than a majority vote as in the original Breiman paper. This is mentioned in the narrative docs. But the `predict` docstring currently says

> The predicted class of an input sample is computed as the majority prediction of the trees in the forest.

which is incorrect, or at best quite misleading.

It would also be good to explain somewhere the rationale for this difference from the original method. I assume it's just so `predict` and `predict_proba` are consistent....

(There's some discussion [in this crossvalidated question](http://stats.stackexchange.com/q/127077/9964), which is what brought me here.)
