### PR TITLE
[MRG] Visual tweak to appveyor badge on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 .. |Travis| image:: https://api.travis-ci.org/scikit-learn/scikit-learn.png?branch=master
 .. _Travis: https://travis-ci.org/scikit-learn/scikit-learn
 
-.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/sklearn-ci/scikit-learn/master.png
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/scikit-learn/scikit-learn?branch=master&svg=true
 .. _AppVeyor: https://ci.appveyor.com/project/sklearn-ci/scikit-learn/history
 
 scikit-learn


### PR DESCRIPTION
It now looks visually different from the Travis one. Result can be seen on my [branch](https://github.com/lesteve/scikit-learn/tree/better-appveyor-badge).

The link I used is from the AppVeyor [doc](http://www.appveyor.com/docs/status-badges#badges-for-projects-with-public-repositories-on-github-and-bitbucket).
