### PR TITLE
[MRG + 1] Added verbose flag to GMM

### DIFF
--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 #         Fabian Pedregosa <fabian.pedregosa@inria.fr>
 #
 
+import warnings
 import numpy as np
 from scipy.special import digamma as _digamma, gammaln as _gammaln
 from scipy import linalg
@@ -159,7 +160,9 @@ class DPGMM(GMM):
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
     verbose : boolean, default False
-        Controls output verbosity.
+        Controls output verbosity. This usage of a boolean flag is
+        deprecated as of version 0.17 and will changed to an int
+        in version 0.19.
 
     Attributes
     ----------
@@ -206,7 +209,7 @@ class DPGMM(GMM):
                                     random_state=random_state, thresh=thresh,
                                     tol=tol, min_covar=min_covar,
                                     n_iter=n_iter, params=params,
-                                    init_params=init_params)
+                                    init_params=init_params, verbose=verbose)
 
     def _get_precisions(self):
         """Return precisions as a full matrix."""
@@ -367,11 +370,29 @@ class DPGMM(GMM):
         expected.
 
         Note: this is very expensive and should not be used by default."""
-        if self.verbose:
-            print("Bound after updating %8s: %f" % (n, self.lower_bound(X, z)))
-            if end:
-                print("Cluster proportions:", self.gamma_.T[1])
-                print("covariance_type:", self.covariance_type)
+        if isinstance(self.verbose, bool):
+            warnings.warn("The parameter 'verbose' is deprecated as of "
+                          "version 0.17 and will be changed in 0.19. The "
+                          "parameter is a boolean but will be changed into "
+                          "an integer to be consistent and work with the GMM "
+                          "class. The changed parameter will use 0 for "
+                          "no output, 1 for only basic output from the GMM "
+                          "class and a value bigger than 1 for detailed "
+                          "output similar to the old output for verbose=True.",
+                          DeprecationWarning)
+            if self.verbose:
+                print("Bound after updating %8s: %f" %
+                      (n, self.lower_bound(X, z)))
+                if end:
+                    print("Cluster proportions:", self.gamma_.T[1])
+                    print("covariance_type:", self.covariance_type)
+        else:
+            if self.verbose > 1:
+                print("Bound after updating %8s: %f" %
+                      (n, self.lower_bound(X, z)))
+                if end:
+                    print("Cluster proportions:", self.gamma_.T[1])
+                    print("covariance_type:", self.covariance_type)
 
     def _do_mstep(self, X, z, params):
         """Maximize the variational lower bound
@@ -654,7 +675,9 @@ class VBGMM(DPGMM):
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
     verbose : boolean, default False
-        Controls output verbosity.
+        Controls output verbosity. This usage of a boolean flag is
+        deprecated as of version 0.17 and will changed to an int
+        in version 0.19.
 
     Attributes
     ----------
@@ -779,11 +802,29 @@ class VBGMM(DPGMM):
         expected.
 
         Note: this is very expensive and should not be used by default."""
-        if self.verbose:
-            print("Bound after updating %8s: %f" % (n, self.lower_bound(X, z)))
-            if end:
-                print("Cluster proportions:", self.gamma_)
-                print("covariance_type:", self.covariance_type)
+        if isinstance(self.verbose, bool):
+            warnings.warn("The parameter 'verbose' is deprecated as of "
+                          "version 0.17 and will be changed in 0.19. The "
+                          "parameter is a boolean but will be changed into "
+                          "an integer to be consistent and work with the GMM "
+                          "class. The changed parameter will use 0 for "
+                          "no output, 1 for only basic output from the GMM "
+                          "class and a value bigger than 1 for detailed "
+                          "output similar to the old output for verbose=True.",
+                          DeprecationWarning)
+            if self.verbose:
+                print("Bound after updating %8s: %f" %
+                      (n, self.lower_bound(X, z)))
+                if end:
+                    print("Cluster proportions:", self.gamma_)
+                    print("covariance_type:", self.covariance_type)
+        else:
+            if self.verbose > 1:
+                print("Bound after updating %8s: %f" %
+                      (n, self.lower_bound(X, z)))
+                if end:
+                    print("Cluster proportions:", self.gamma_)
+                    print("covariance_type:", self.covariance_type)
 
     def _set_weights(self):
         self.weights_[:] = self.gamma_

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 #         Fabian Pedregosa <fabian.pedregosa@inria.fr>
 #
 
-import warnings
 import numpy as np
 from scipy.special import digamma as _digamma, gammaln as _gammaln
 from scipy import linalg
@@ -159,10 +158,8 @@ class DPGMM(GMM):
         process.  Can contain any combination of 'w' for weights,
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
-    verbose : boolean, default False
-        Controls output verbosity. This usage of a boolean flag is
-        deprecated as of version 0.17 and will changed to an int
-        in version 0.19.
+    verbose : int, default 0
+        Controls output verbosity.
 
     Attributes
     ----------
@@ -201,10 +198,9 @@ class DPGMM(GMM):
     """
 
     def __init__(self, n_components=1, covariance_type='diag', alpha=1.0,
-                 random_state=None, thresh=None, tol=1e-3, verbose=False,
+                 random_state=None, thresh=None, tol=1e-3, verbose=0,
                  min_covar=None, n_iter=10, params='wmc', init_params='wmc'):
         self.alpha = alpha
-        self.verbose = verbose
         super(DPGMM, self).__init__(n_components, covariance_type,
                                     random_state=random_state, thresh=thresh,
                                     tol=tol, min_covar=min_covar,
@@ -370,29 +366,12 @@ class DPGMM(GMM):
         expected.
 
         Note: this is very expensive and should not be used by default."""
-        if isinstance(self.verbose, bool):
-            warnings.warn("The parameter 'verbose' is deprecated as of "
-                          "version 0.17 and will be changed in 0.19. The "
-                          "parameter is a boolean but will be changed into "
-                          "an integer to be consistent and work with the GMM "
-                          "class. The changed parameter will use 0 for "
-                          "no output, 1 for only basic output from the GMM "
-                          "class and a value bigger than 1 for detailed "
-                          "output similar to the old output for verbose=True.",
-                          DeprecationWarning)
-            if self.verbose:
-                print("Bound after updating %8s: %f" %
-                      (n, self.lower_bound(X, z)))
-                if end:
-                    print("Cluster proportions:", self.gamma_.T[1])
-                    print("covariance_type:", self.covariance_type)
-        else:
-            if self.verbose > 1:
-                print("Bound after updating %8s: %f" %
-                      (n, self.lower_bound(X, z)))
-                if end:
-                    print("Cluster proportions:", self.gamma_.T[1])
-                    print("covariance_type:", self.covariance_type)
+        if self.verbose > 0:
+            print("Bound after updating %8s: %f" % (n, self.lower_bound(X, z)))
+            if end:
+                print("Cluster proportions:", self.gamma_.T[1])
+                print("covariance_type:", self.covariance_type)
+
 
     def _do_mstep(self, X, z, params):
         """Maximize the variational lower bound
@@ -674,10 +653,8 @@ class VBGMM(DPGMM):
         process.  Can contain any combination of 'w' for weights,
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
-    verbose : boolean, default False
-        Controls output verbosity. This usage of a boolean flag is
-        deprecated as of version 0.17 and will changed to an int
-        in version 0.19.
+    verbose : int, default 0
+        Controls output verbosity.
 
     Attributes
     ----------
@@ -718,7 +695,7 @@ class VBGMM(DPGMM):
     """
 
     def __init__(self, n_components=1, covariance_type='diag', alpha=1.0,
-                 random_state=None, thresh=None, tol=1e-3, verbose=False,
+                 random_state=None, thresh=None, tol=1e-3, verbose=0,
                  min_covar=None, n_iter=10, params='wmc', init_params='wmc'):
         super(VBGMM, self).__init__(
             n_components, covariance_type, random_state=random_state,
@@ -802,29 +779,12 @@ class VBGMM(DPGMM):
         expected.
 
         Note: this is very expensive and should not be used by default."""
-        if isinstance(self.verbose, bool):
-            warnings.warn("The parameter 'verbose' is deprecated as of "
-                          "version 0.17 and will be changed in 0.19. The "
-                          "parameter is a boolean but will be changed into "
-                          "an integer to be consistent and work with the GMM "
-                          "class. The changed parameter will use 0 for "
-                          "no output, 1 for only basic output from the GMM "
-                          "class and a value bigger than 1 for detailed "
-                          "output similar to the old output for verbose=True.",
-                          DeprecationWarning)
-            if self.verbose:
-                print("Bound after updating %8s: %f" %
-                      (n, self.lower_bound(X, z)))
-                if end:
-                    print("Cluster proportions:", self.gamma_)
-                    print("covariance_type:", self.covariance_type)
-        else:
-            if self.verbose > 1:
-                print("Bound after updating %8s: %f" %
-                      (n, self.lower_bound(X, z)))
-                if end:
-                    print("Cluster proportions:", self.gamma_)
-                    print("covariance_type:", self.covariance_type)
+        if self.verbose > 0:
+            print("Bound after updating %8s: %f" % (n, self.lower_bound(X, z)))
+            if end:
+                print("Cluster proportions:", self.gamma_)
+                print("covariance_type:", self.covariance_type)
+
 
     def _set_weights(self):
         self.weights_[:] = self.gamma_

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -372,7 +372,6 @@ class DPGMM(GMM):
                 print("Cluster proportions:", self.gamma_.T[1])
                 print("covariance_type:", self.covariance_type)
 
-
     def _do_mstep(self, X, z, params):
         """Maximize the variational lower bound
 
@@ -784,7 +783,6 @@ class VBGMM(DPGMM):
             if end:
                 print("Cluster proportions:", self.gamma_)
                 print("covariance_type:", self.covariance_type)
-
 
     def _set_weights(self):
         self.weights_[:] = self.gamma_

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -209,7 +209,7 @@ class GMM(BaseEstimator):
     >>> g.fit(obs) # doctest: +NORMALIZE_WHITESPACE
     GMM(covariance_type='diag', init_params='wmc', min_covar=0.001,
             n_components=2, n_init=1, n_iter=100, params='wmc',
-            random_state=None, thresh=None, tol=0.001)
+            random_state=None, thresh=None, tol=0.001, verbose=0)
     >>> np.round(g.weights_, 2)
     array([ 0.75,  0.25])
     >>> np.round(g.means_, 2)
@@ -227,7 +227,7 @@ class GMM(BaseEstimator):
     >>> g.fit(20 * [[0]] +  20 * [[10]]) # doctest: +NORMALIZE_WHITESPACE
     GMM(covariance_type='diag', init_params='wmc', min_covar=0.001,
             n_components=2, n_init=1, n_iter=100, params='wmc',
-            random_state=None, thresh=None, tol=0.001)
+            random_state=None, thresh=None, tol=0.001, verbose=0)
     >>> np.round(g.weights_, 2)
     array([ 0.5,  0.5])
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -12,6 +12,7 @@ of Gaussian Mixture Models.
 import warnings
 import numpy as np
 from scipy import linalg
+from time import time
 
 from ..base import BaseEstimator
 from ..utils import check_random_state, check_array
@@ -156,6 +157,11 @@ class GMM(BaseEstimator):
         process.  Can contain any combination of 'w' for weights,
         'm' for means, and 'c' for covars.  Defaults to 'wmc'.
 
+    verbose : int, default: 0
+        Enable verbose output. If 1 then it always prints the current
+        initialization and iteration step. If greater than 1 then
+        it prints additionally the change and time needed for each step.
+
     Attributes
     ----------
     weights_ : array, shape (`n_components`,)
@@ -229,7 +235,8 @@ class GMM(BaseEstimator):
 
     def __init__(self, n_components=1, covariance_type='diag',
                  random_state=None, thresh=None, tol=1e-3, min_covar=1e-3,
-                 n_iter=100, n_init=1, params='wmc', init_params='wmc'):
+                 n_iter=100, n_init=1, params='wmc', init_params='wmc',
+                 verbose=0):
         if thresh is not None:
             warnings.warn("'thresh' has been replaced by 'tol' in 0.16 "
                           " and will be removed in 0.18.",
@@ -244,6 +251,7 @@ class GMM(BaseEstimator):
         self.n_init = n_init
         self.params = params
         self.init_params = init_params
+        self.verbose = verbose
 
         if covariance_type not in ['spherical', 'tied', 'diag', 'full']:
             raise ValueError('Invalid value for covariance_type: %s' %
@@ -458,15 +466,26 @@ class GMM(BaseEstimator):
 
         max_log_prob = -np.infty
 
-        for _ in range(self.n_init):
+        if self.verbose > 0:
+            print('Expectation-maximization algorithm started.')
+
+        for init in range(self.n_init):
+            if self.verbose > 0:
+                print('Initialization '+str(init+1))
+                start_init_time = time()
+
             if 'm' in self.init_params or not hasattr(self, 'means_'):
                 self.means_ = cluster.KMeans(
                     n_clusters=self.n_components,
                     random_state=self.random_state).fit(X).cluster_centers_
+                if self.verbose > 1:
+                    print('\tMeans have been initialized.')
 
             if 'w' in self.init_params or not hasattr(self, 'weights_'):
                 self.weights_ = np.tile(1.0 / self.n_components,
                                         self.n_components)
+                if self.verbose > 1:
+                    print('\tWeights have been initialized.')
 
             if 'c' in self.init_params or not hasattr(self, 'covars_'):
                 cv = np.cov(X.T) + self.min_covar * np.eye(X.shape[1])
@@ -475,6 +494,8 @@ class GMM(BaseEstimator):
                 self.covars_ = \
                     distribute_covar_matrix_to_match_covariance_type(
                         cv, self.covariance_type, self.n_components)
+                if self.verbose > 1:
+                    print('\tCovariance matrices have been initialized.')
 
             # EM algorithms
             current_log_likelihood = None
@@ -486,6 +507,9 @@ class GMM(BaseEstimator):
                    else self.thresh / float(X.shape[0]))
 
             for i in range(self.n_iter):
+                if self.verbose > 0:
+                    print('\tEM iteration '+str(i+1))
+                    start_iter_time = time()
                 prev_log_likelihood = current_log_likelihood
                 # Expectation step
                 log_likelihoods, responsibilities = self.score_samples(X)
@@ -496,13 +520,19 @@ class GMM(BaseEstimator):
                 # removed in v0.18)
                 if prev_log_likelihood is not None:
                     change = abs(current_log_likelihood - prev_log_likelihood)
+                    if self.verbose > 1:
+                        print('\t\tChange: '+str(change))
                     if change < tol:
                         self.converged_ = True
+                        if self.verbose > 0:
+                            print('\t\tEM algorithm converged.')
                         break
 
                 # Maximization step
                 self._do_mstep(X, responsibilities, self.params,
                                self.min_covar)
+                if self.verbose > 1:
+                    print('\t\tEM iteration '+str(i+1)+' took {0:.5f}s'.format(time()-start_iter_time))
 
             # if the results are better, keep it
             if self.n_iter:
@@ -511,6 +541,12 @@ class GMM(BaseEstimator):
                     best_params = {'weights': self.weights_,
                                    'means': self.means_,
                                    'covars': self.covars_}
+                    if self.verbose > 1:
+                        print('\tBetter parameters were found.')
+
+            if self.verbose > 1:
+                print('\tInitialization '+str(init+1)+' took {0:.5f}s'.format(time()-start_init_time))
+
         # check the existence of an init param that was not subject to
         # likelihood computation issue.
         if np.isneginf(max_log_prob) and self.n_iter:

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -699,7 +699,8 @@ def _log_multivariate_normal_density_full(X, means, covars, min_covar=1.e-7):
                 cv_chol = linalg.cholesky(cv + min_covar * np.eye(n_dim),
                                           lower=True)
             except linalg.LinAlgError:
-                raise ValueError("'covars' must be symmetric, positive-definite")
+                raise ValueError("'covars' must be symmetric, "
+                                 "positive-definite")
 
         cv_log_det = 2 * np.sum(np.log(np.diagonal(cv_chol)))
         cv_sol = linalg.solve_triangular(cv_chol, (X - mu).T, lower=True).T

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -516,7 +516,7 @@ class GMM(BaseEstimator):
                 current_log_likelihood = log_likelihoods.mean()
 
                 # Check for convergence.
-                # (should compare to self.tol when dreprecated 'thresh' is
+                # (should compare to self.tol when deprecated 'thresh' is
                 # removed in v0.18)
                 if prev_log_likelihood is not None:
                     change = abs(current_log_likelihood - prev_log_likelihood)

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -532,7 +532,8 @@ class GMM(BaseEstimator):
                 self._do_mstep(X, responsibilities, self.params,
                                self.min_covar)
                 if self.verbose > 1:
-                    print('\t\tEM iteration '+str(i+1)+' took {0:.5f}s'.format(time()-start_iter_time))
+                    print('\t\tEM iteration '+str(i+1)+' took {0:.5f}s'.format(
+                        time()-start_iter_time))
 
             # if the results are better, keep it
             if self.n_iter:
@@ -545,7 +546,8 @@ class GMM(BaseEstimator):
                         print('\tBetter parameters were found.')
 
             if self.verbose > 1:
-                print('\tInitialization '+str(init+1)+' took {0:.5f}s'.format(time()-start_init_time))
+                print('\tInitialization '+str(init+1)+' took {0:.5f}s'.format(
+                    time()-start_init_time))
 
         # check the existence of an init param that was not subject to
         # likelihood computation issue.

--- a/sklearn/mixture/tests/test_dpgmm.py
+++ b/sklearn/mixture/tests/test_dpgmm.py
@@ -8,7 +8,7 @@ import numpy as np
 from sklearn.mixture import DPGMM, VBGMM
 from sklearn.mixture.dpgmm import log_normalize
 from sklearn.datasets import make_blobs
-from sklearn.utils.testing import assert_array_less
+from sklearn.utils.testing import assert_array_less, assert_equal
 from sklearn.mixture.tests.test_gmm import GMMTester
 from sklearn.externals.six.moves import cStringIO as StringIO
 
@@ -30,6 +30,33 @@ def test_class_weights():
         assert_array_less(.1, dpgmm.weights_[active])
         # others are not
         assert_array_less(dpgmm.weights_[~active], .05)
+
+
+def test_verbose_boolean():
+    # checks that the output for the verbose output is the same
+    # for the flag values '1' and 'True'
+    # simple 3 cluster dataset
+    X, y = make_blobs(random_state=1)
+    for Model in [DPGMM, VBGMM]:
+        dpgmm_bool = Model(n_components=10, random_state=1, alpha=20,
+                              n_iter=50, verbose=True)
+        dpgmm_int = Model(n_components=10, random_state=1, alpha=20,
+                          n_iter=50, verbose=1)
+
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            dpgmm_bool.fit(X)
+            verbose_output = sys.stdout
+            verbose_output.seek(0)
+            bool_output = verbose_output.readline()
+            dpgmm_int.fit(X)
+            verbose_output = sys.stdout
+            verbose_output.seek(0)
+            int_output = verbose_output.readline()
+            assert_equal(bool_output, int_output)
+        finally:
+            sys.stdout = old_stdout
 
 
 def test_verbose_first_level():

--- a/sklearn/mixture/tests/test_dpgmm.py
+++ b/sklearn/mixture/tests/test_dpgmm.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 import nose
 
@@ -9,6 +10,7 @@ from sklearn.mixture.dpgmm import log_normalize
 from sklearn.datasets import make_blobs
 from sklearn.utils.testing import assert_array_less
 from sklearn.mixture.tests.test_gmm import GMMTester
+from sklearn.externals.six.moves import cStringIO as StringIO
 
 np.seterr(all='warn')
 
@@ -28,6 +30,36 @@ def test_class_weights():
         assert_array_less(.1, dpgmm.weights_[active])
         # others are not
         assert_array_less(dpgmm.weights_[~active], .05)
+
+
+def test_verbose_first_level():
+    # simple 3 cluster dataset
+    X, y = make_blobs(random_state=1)
+    for Model in [DPGMM, VBGMM]:
+        dpgmm = Model(n_components=10, random_state=1, alpha=20, n_iter=50,
+                      verbose=1)
+
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            dpgmm.fit(X)
+        finally:
+            sys.stdout = old_stdout
+
+
+def test_verbose_second_level():
+    # simple 3 cluster dataset
+    X, y = make_blobs(random_state=1)
+    for Model in [DPGMM, VBGMM]:
+        dpgmm = Model(n_components=10, random_state=1, alpha=20, n_iter=50,
+                      verbose=2)
+
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            dpgmm.fit(X)
+        finally:
+            sys.stdout = old_stdout
 
 
 def test_log_normalize():

--- a/sklearn/mixture/tests/test_dpgmm.py
+++ b/sklearn/mixture/tests/test_dpgmm.py
@@ -39,17 +39,19 @@ def test_verbose_boolean():
     X, y = make_blobs(random_state=1)
     for Model in [DPGMM, VBGMM]:
         dpgmm_bool = Model(n_components=10, random_state=1, alpha=20,
-                              n_iter=50, verbose=True)
+                           n_iter=50, verbose=True)
         dpgmm_int = Model(n_components=10, random_state=1, alpha=20,
                           n_iter=50, verbose=1)
 
         old_stdout = sys.stdout
         sys.stdout = StringIO()
         try:
+            # generate output with the boolean flag
             dpgmm_bool.fit(X)
             verbose_output = sys.stdout
             verbose_output.seek(0)
             bool_output = verbose_output.readline()
+            # generate output with the int flag
             dpgmm_int.fit(X)
             verbose_output = sys.stdout
             verbose_output.seek(0)

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -373,7 +373,7 @@ def test_fit_predict():
 
     model = mixture.GMM(n_components=n_comps, n_iter=0)
     z = model.fit_predict(X)
-    assert np.all(z==0), "Quick Initialization Failed!"
+    assert np.all(z == 0), "Quick Initialization Failed!"
 
 
 def test_aic():

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -1,5 +1,6 @@
 import unittest
 import copy
+import sys
 
 from nose.tools import assert_true
 import numpy as np
@@ -11,6 +12,7 @@ from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raise_message
 from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.externals.six.moves import cStringIO as StringIO
 
 rng = np.random.RandomState(0)
 
@@ -441,6 +443,34 @@ def test_positive_definite_covars():
     # Check positive definiteness for all covariance types
     for covariance_type in ["full", "tied", "diag", "spherical"]:
         yield check_positive_definite_covars, covariance_type
+
+
+def test_verbose_first_level():
+    # Create sample data
+    X = rng.randn(30, 5)
+    X[:10] += 2
+    g = mixture.GMM(n_components=2, n_init=2, verbose=1)
+
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        g.fit(X)
+    finally:
+        sys.stdout = old_stdout
+
+
+def test_verbose_second_level():
+    # Create sample data
+    X = rng.randn(30, 5)
+    X[:10] += 2
+    g = mixture.GMM(n_components=2, n_init=2, verbose=2)
+
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        g.fit(X)
+    finally:
+        sys.stdout = old_stdout
 
 
 if __name__ == '__main__':

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -110,7 +110,7 @@ def test_lmvnpdf_full():
 
 
 def test_lvmpdf_full_cv_non_positive_definite():
-    n_features, n_components, n_samples = 2, 1, 10
+    n_features, n_samples = 2, 10
     rng = np.random.RandomState(0)
     X = rng.randint(10) * rng.rand(n_samples, n_features)
     mu = np.mean(X, 0)
@@ -265,7 +265,7 @@ class GMMTester():
         # Train on 1-D data
         # Create a training set by sampling from the predefined distribution.
         X = rng.randn(100, 1)
-        #X.T[1:] = 0
+        # X.T[1:] = 0
         g = self.model(n_components=2, covariance_type=self.covariance_type,
                        random_state=rng, min_covar=1e-7, n_iter=5,
                        init_params=params)


### PR DESCRIPTION
This PR addresses issue #4633.
Example outputs for a GMM with `n_init=2`:
`verbose = 1`

```
Expectation-maximization algorithm started.
Initialization 1
    EM iteration 1
    EM iteration 2
    EM iteration 3
    EM iteration 4
    EM iteration 5
    EM iteration 6
        EM algorithm converged.
Initialization 2
    EM iteration 1
    EM iteration 2
    EM iteration 3
    EM iteration 4
    EM iteration 5
    EM iteration 6
        EM algorithm converged.
```

`verbose > 1`

```
Expectation-maximization algorithm started.
Initialization 1
    Means have been initialized.
    Weights have been initialized.
    Covariance matrices have been initialized.
    EM iteration 1
        EM iteration 1 took 0.00023s
    EM iteration 2
        Change: 0.254791525352
        EM iteration 2 took 0.00023s
    EM iteration 3
        Change: 0.668347041104
        EM iteration 3 took 0.00023s
    EM iteration 4
        Change: 4.01160843517
        EM iteration 4 took 0.00024s
    EM iteration 5
        Change: 0.00821640659597
        EM iteration 5 took 0.00024s
    EM iteration 6
        Change: 0.0
        EM algorithm converged.
    Better parameters were found.
    Initialization 1 took 0.00660s
Initialization 2
    Means have been initialized.
    Weights have been initialized.
    Covariance matrices have been initialized.
    EM iteration 1
        EM iteration 1 took 0.00025s
    EM iteration 2
        Change: 0.254791525352
        EM iteration 2 took 0.00026s
    EM iteration 3
        Change: 0.668347041104
        EM iteration 3 took 0.00023s
    EM iteration 4
        Change: 4.01160843517
        EM iteration 4 took 0.00023s
    EM iteration 5
        Change: 0.00821640659597
        EM iteration 5 took 0.00023s
    EM iteration 6
        Change: 0.0
        EM algorithm converged.
    Initialization 2 took 0.00661s
```
