### PR TITLE
[MRG+1] Script for example ensemble OOB error plot. Fixes #4273

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -732,6 +732,7 @@ is too time consuming.
 
  * :ref:`example_ensemble_plot_gradient_boosting_regularization.py`
  * :ref:`example_ensemble_plot_gradient_boosting_oob.py`
+ * :ref:`example_ensemble_plot_ensemble_oob.py`
 
 Interpretation
 --------------

--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -1,0 +1,90 @@
+"""
+
+==============================================================
+OOB Error Trace for Random Forests and Extra Trees Classifiers
+==============================================================
+
+The `RandomForestClassifier` and `ExtraTreesClasifier` are trained using
+*bootstrap aggregation*. During training, each new tree is fit from a
+bootstrap sample of the training observations :math:`z_i = (x_i, y_i)`. The
+*out-of-bag* (OOB) error is the average prediction error for each :math:`z_i`
+from trees that do not contain :math:`z_i` in their respective bootstrap
+sample. This allows models to be simultaneously fit and cross-validated.
+
+The example below demonstrates how the OOB error can be measured at the
+inclusion of each new tree whilst the fitting `RandomForestClassifier` and
+`ExtraTreesClassifier` models. The subsequent plot enables the practitioner to
+approximate the error stabilization point of each model at which training can
+be halted.
+
+.. [1] T. Hastie, R. Tibshirani and J. Friedman, "Elements of Statistical
+       Learning Ed. 2", Springer, 2009.
+
+"""
+print(__doc__)
+
+# Author: Kian Ho <hui.kian.ho@gmail.com>
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#         
+# License: BSD 3 Clause
+
+import pylab
+
+from collections import OrderedDict
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
+
+RANDOM_STATE = 12345
+
+# Generate a binary classification dataset. 
+N_SAMPLES = 300
+N_FEATURES = 50
+
+X, y = make_classification(n_samples=N_SAMPLES, n_features=N_FEATURES, 
+                           random_state=RANDOM_STATE)
+
+# NOTE: Setting the `warm_start` construction parameter to `True` disables
+# support for paralellised ensembles but is necessary for tracking the OOB
+# error trajectory during training.
+clfs = [
+    ("RandomForestClassifier (max_features='auto')",
+        RandomForestClassifier(warm_start=True, oob_score=True,
+                               max_features="auto",
+                               random_state=RANDOM_STATE)),
+    ("RandomForestClassifier (max_features=2)",
+        RandomForestClassifier(warm_start=True, max_features=2, 
+                               oob_score=True, random_state=RANDOM_STATE)),
+    ("ExtraTreesClassifier (max_features='auto')",
+        ExtraTreesClassifier(warm_start=True, max_features="auto",
+                             oob_score=True, bootstrap=True,
+                             random_state=RANDOM_STATE)),
+    ("ExtraTreesClassifier (max_features=2)",
+        ExtraTreesClassifier(warm_start=True, max_features=2,
+                             oob_score=True, bootstrap=True,
+                             random_state=RANDOM_STATE))
+]
+
+# Map a classifier name to a list of (<n_estimators>, <error rate>) pairs.
+error_rate = OrderedDict((label, []) for label, _ in clfs)
+
+# Max no. of estimators to use in each ensemble.
+n_estimators = 400
+
+for label, clf in clfs:
+    for i in range(1, n_estimators + 1):
+        clf.set_params(n_estimators=i)
+        clf.fit(X, y)
+        
+        # Record the <error rate> for each <n_estimators> setting. 
+        error_rate[label].append((i, 1 - clf.oob_score_))
+    
+# Generate the "OOB error rate" vs. "no. of estimators" plot
+for label, clf_err in error_rate.items():
+    xs, ys = zip(*clf_err)
+    pylab.plot(xs, ys, label=label)
+    
+pylab.xlabel("n_estimators")
+pylab.ylabel("OOB error rate")
+pylab.legend(loc="upper right")
+pylab.gcf().set_size_inches(8, 6)
+pylab.show()

--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -1,23 +1,22 @@
 """
-=========================================================
-OOB Errors for Random Forests and Extra Trees Classifiers
-=========================================================
+=============================
+OOB Errors for Random Forests
+=============================
 
-The ``RandomForestClassifier`` and ``ExtraTreesClasifier`` are trained using
-*bootstrap aggregation*. During training, each new tree is fit from a
-bootstrap sample of the training observations :math:`z_i = (x_i, y_i)`. The
-*out-of-bag* (OOB) error is the average prediction error for each :math:`z_i`
-from trees that do not contain :math:`z_i` in their respective bootstrap
-sample. This allows models to be simultaneously fit and cross-validated [1].
+The ``RandomForestClassifier`` is trained using *bootstrap aggregation*. During
+training, each new tree is fit from a bootstrap sample of the training
+observations :math:`z_i = (x_i, y_i)`. The *out-of-bag* (OOB) error is the
+average prediction error for each :math:`z_i` from trees that do not contain
+:math:`z_i` in their respective bootstrap sample. This allows models to be
+simultaneously fit and validated [1].
 
 The example below demonstrates how the OOB error can be measured at the
-inclusion of each new tree whilst fitting ``RandomForestClassifier`` and
-``ExtraTreesClassifier`` models. The subsequent plot enables the practitioner
-to approximate the error stabilization point of each model at which training
-can be halted.
+inclusion of each new tree whilst fitting ``RandomForestClassifier`` models.
+The subsequent plot enables the practitioner to approximate the error
+stabilization point of each model at which training can be halted.
 
 .. [1] T. Hastie, R. Tibshirani and J. Friedman, "Elements of Statistical
-       Learning Ed. 2", Springer, 2009.
+       Learning Ed. 2", p592-593, Springer, 2009.
 
 """
 import matplotlib.pyplot as plt
@@ -37,30 +36,26 @@ print(__doc__)
 RANDOM_STATE = 123
 
 # Generate a binary classification dataset.
-X, y = make_classification(n_samples=500, n_features=30,
-                           n_clusters_per_class=1,
+X, y = make_classification(n_samples=500, n_features=25,
+                           n_clusters_per_class=1, n_informative=15,
                            random_state=RANDOM_STATE)
 
 # NOTE: Setting the `warm_start` construction parameter to `True` disables
 # support for paralellised ensembles but is necessary for tracking the OOB
 # error trajectory during training.
 ensemble_clfs = [
-    ("RandomForestClassifier, max_features='auto'",
+    ("RandomForestClassifier, max_features='sqrt'",
         RandomForestClassifier(warm_start=True, oob_score=True,
-                               max_features="auto",
+                               max_features="sqrt",
                                random_state=RANDOM_STATE)),
-    ("RandomForestClassifier, max_features=2",
-        RandomForestClassifier(warm_start=True, max_features=2,
+    ("RandomForestClassifier, max_features='log2'",
+        RandomForestClassifier(warm_start=True, max_features='log2',
                                oob_score=True,
                                random_state=RANDOM_STATE)),
-    ("ExtraTreesClassifier, max_features='auto'",
-        ExtraTreesClassifier(warm_start=True, max_features="auto",
-                             oob_score=True, bootstrap=True,
-                             random_state=RANDOM_STATE)),
-    ("ExtraTreesClassifier, max_features=2",
-        ExtraTreesClassifier(warm_start=True, max_features=2,
-                             oob_score=True, bootstrap=True,
-                             random_state=RANDOM_STATE))
+    ("RandomForestClassifier, max_features=None",
+        RandomForestClassifier(warm_start=True, max_features=None,
+                               oob_score=True,
+                               random_state=RANDOM_STATE))
 ]
 
 # Map a classifier name to a list of (<n_estimators>, <error rate>) pairs.
@@ -68,7 +63,7 @@ error_rate = OrderedDict((label, []) for label, _ in ensemble_clfs)
 
 # Range of `n_estimators` values to explore.
 min_estimators = 15
-max_estimators = 150
+max_estimators = 175
 
 for label, clf in ensemble_clfs:
     for i in range(min_estimators, max_estimators + 1):

--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -1,21 +1,21 @@
 """
 
-==============================================================
-OOB Error Trace for Random Forests and Extra Trees Classifiers
-==============================================================
+=========================================================
+OOB Errors for Random Forests and Extra Trees Classifiers
+=========================================================
 
-The `RandomForestClassifier` and `ExtraTreesClasifier` are trained using
+The ``RandomForestClassifier`` and ``ExtraTreesClasifier`` are trained using
 *bootstrap aggregation*. During training, each new tree is fit from a
 bootstrap sample of the training observations :math:`z_i = (x_i, y_i)`. The
 *out-of-bag* (OOB) error is the average prediction error for each :math:`z_i`
 from trees that do not contain :math:`z_i` in their respective bootstrap
-sample. This allows models to be simultaneously fit and cross-validated.
+sample. This allows models to be simultaneously fit and cross-validated [1].
 
 The example below demonstrates how the OOB error can be measured at the
-inclusion of each new tree whilst the fitting `RandomForestClassifier` and
-`ExtraTreesClassifier` models. The subsequent plot enables the practitioner to
-approximate the error stabilization point of each model at which training can
-be halted.
+inclusion of each new tree whilst fitting ``RandomForestClassifier`` and
+``ExtraTreesClassifier`` models. The subsequent plot enables the practitioner
+to approximate the error stabilization point of each model at which training
+can be halted.
 
 .. [1] T. Hastie, R. Tibshirani and J. Friedman, "Elements of Statistical
        Learning Ed. 2", Springer, 2009.
@@ -24,7 +24,7 @@ be halted.
 print(__doc__)
 
 # Author: Kian Ho <hui.kian.ho@gmail.com>
-#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#         Gilles Louppe <g.louppe@gmail.com>
 #         
 # License: BSD 3 Clause
 
@@ -86,5 +86,4 @@ for label, clf_err in error_rate.items():
 pylab.xlabel("n_estimators")
 pylab.ylabel("OOB error rate")
 pylab.legend(loc="upper right")
-pylab.gcf().set_size_inches(8, 6)
 pylab.show()

--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -1,5 +1,4 @@
 """
-
 =========================================================
 OOB Errors for Random Forests and Extra Trees Classifiers
 =========================================================
@@ -21,69 +20,72 @@ can be halted.
        Learning Ed. 2", Springer, 2009.
 
 """
-print(__doc__)
-
-# Author: Kian Ho <hui.kian.ho@gmail.com>
-#         Gilles Louppe <g.louppe@gmail.com>
-#         
-# License: BSD 3 Clause
-
-import pylab
+import matplotlib.pyplot as plt
 
 from collections import OrderedDict
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 
-RANDOM_STATE = 12345
+# Author: Kian Ho <hui.kian.ho@gmail.com>
+#         Gilles Louppe <g.louppe@gmail.com>
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#
+# License: BSD 3 Clause
 
-# Generate a binary classification dataset. 
-N_SAMPLES = 300
-N_FEATURES = 50
+print(__doc__)
 
-X, y = make_classification(n_samples=N_SAMPLES, n_features=N_FEATURES, 
+RANDOM_STATE = 123
+
+# Generate a binary classification dataset.
+X, y = make_classification(n_samples=500, n_features=30,
+                           n_clusters_per_class=1,
                            random_state=RANDOM_STATE)
 
 # NOTE: Setting the `warm_start` construction parameter to `True` disables
 # support for paralellised ensembles but is necessary for tracking the OOB
 # error trajectory during training.
-clfs = [
-    ("RandomForestClassifier (max_features='auto')",
+ensemble_clfs = [
+    ("RandomForestClassifier, max_features='auto'",
         RandomForestClassifier(warm_start=True, oob_score=True,
                                max_features="auto",
                                random_state=RANDOM_STATE)),
-    ("RandomForestClassifier (max_features=2)",
-        RandomForestClassifier(warm_start=True, max_features=2, 
-                               oob_score=True, random_state=RANDOM_STATE)),
-    ("ExtraTreesClassifier (max_features='auto')",
+    ("RandomForestClassifier, max_features=2",
+        RandomForestClassifier(warm_start=True, max_features=2,
+                               oob_score=True,
+                               random_state=RANDOM_STATE)),
+    ("ExtraTreesClassifier, max_features='auto'",
         ExtraTreesClassifier(warm_start=True, max_features="auto",
                              oob_score=True, bootstrap=True,
                              random_state=RANDOM_STATE)),
-    ("ExtraTreesClassifier (max_features=2)",
+    ("ExtraTreesClassifier, max_features=2",
         ExtraTreesClassifier(warm_start=True, max_features=2,
                              oob_score=True, bootstrap=True,
                              random_state=RANDOM_STATE))
 ]
 
 # Map a classifier name to a list of (<n_estimators>, <error rate>) pairs.
-error_rate = OrderedDict((label, []) for label, _ in clfs)
+error_rate = OrderedDict((label, []) for label, _ in ensemble_clfs)
 
-# Max no. of estimators to use in each ensemble.
-n_estimators = 400
+# Range of `n_estimators` values to explore.
+min_estimators = 15
+max_estimators = 150
 
-for label, clf in clfs:
-    for i in range(1, n_estimators + 1):
+for label, clf in ensemble_clfs:
+    for i in range(min_estimators, max_estimators + 1):
         clf.set_params(n_estimators=i)
         clf.fit(X, y)
-        
-        # Record the <error rate> for each <n_estimators> setting. 
-        error_rate[label].append((i, 1 - clf.oob_score_))
-    
-# Generate the "OOB error rate" vs. "no. of estimators" plot
+
+        # Record the OOB error for each `n_estimators=i` setting.
+        oob_error = 1 - clf.oob_score_
+        error_rate[label].append((i, oob_error))
+
+# Generate the "OOB error rate" vs. "n_estimators" plot.
 for label, clf_err in error_rate.items():
     xs, ys = zip(*clf_err)
-    pylab.plot(xs, ys, label=label)
-    
-pylab.xlabel("n_estimators")
-pylab.ylabel("OOB error rate")
-pylab.legend(loc="upper right")
-pylab.show()
+    plt.plot(xs, ys, label=label)
+
+plt.xlim(min_estimators, max_estimators)
+plt.xlabel("n_estimators")
+plt.ylabel("OOB error rate")
+plt.legend(loc="upper right")
+plt.show()


### PR DESCRIPTION
This script generates an example plot of the OOB error vs. n_estimators using the `RandomForestClassifier(warm_start=True)` approach, for inclusion in the website docs/examples section, as suggested by @glouppe and @amueller in #4273.

Please advise if further amendments are required.
