### PR TITLE
Fix string literal concatenation whitespace

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -196,7 +196,7 @@ class LinearClassifierMixin(ClassifierMixin):
             class would be predicted.
         """
         if not hasattr(self, 'coef_') or self.coef_ is None:
-            raise NotFittedError("This %(name)s instance is not fitted"
+            raise NotFittedError("This %(name)s instance is not fitted "
                                  "yet" % {'name': type(self).__name__})
 
         X = check_array(X, accept_sparse='csr')


### PR DESCRIPTION
Changes "This LogisticRegression instance is not fittedyet" to "This LogisticRegression instance is not fitted yet"
