### PR TITLE
[WIP] Sample properties

### DIFF
--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -802,7 +802,7 @@ E.g., here's a custom classifier::
   ...     """Predicts the majority class of its training data."""
   ...     def __init__(self):
   ...         pass
-  ...     def fit(self, X, y):
+  ...     def fit(self, X, y, sample_props=None):
   ...         self.classes_, indices = np.unique(["foo", "bar", "foo"],
   ...                                            return_inverse=True)
   ...         self.majority_ = np.argmax(np.bincount(indices))

--- a/examples/hetero_feature_union.py
+++ b/examples/hetero_feature_union.py
@@ -75,7 +75,7 @@ class ItemSelector(BaseEstimator, TransformerMixin):
     def __init__(self, key):
         self.key = key
 
-    def fit(self, x, y=None):
+    def fit(self, x, y=None, sample_props=None):
         return self
 
     def transform(self, data_dict):
@@ -85,7 +85,7 @@ class ItemSelector(BaseEstimator, TransformerMixin):
 class TextStats(BaseEstimator, TransformerMixin):
     """Extract features from each document for DictVectorizer"""
 
-    def fit(self, x, y=None):
+    def fit(self, x, y=None, sample_props=None):
         return self
 
     def transform(self, posts):
@@ -100,7 +100,7 @@ class SubjectBodyExtractor(BaseEstimator, TransformerMixin):
     Takes a sequence of strings and produces a dict of sequences.  Keys are
     `subject` and `body`.
     """
-    def fit(self, x, y=None):
+    def fit(self, x, y=None, sample_props=None):
         return self
 
     def transform(self, posts):

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -24,7 +24,7 @@ from .isotonic import IsotonicRegression
 from .svm import LinearSVC
 from .cross_validation import _check_cv
 from .metrics.classification import _check_binary_probabilistic_predictions
-from ..utils.deprecations import _deprecate_sample_weight
+from .utils.deprecations import _deprecate_sample_weight
 
 
 class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -24,6 +24,7 @@ from .isotonic import IsotonicRegression
 from .svm import LinearSVC
 from .cross_validation import _check_cv
 from .metrics.classification import _check_binary_probabilistic_predictions
+from ..utils.deprecations import _deprecate_sample_weight
 
 
 class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
@@ -87,7 +88,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
         self.method = method
         self.cv = cv
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the calibrated model
 
         Parameters
@@ -106,6 +107,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
         self : object
             Returns an instance of self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         X, y = check_X_y(X, y, accept_sparse=['csc', 'csr', 'coo'],
                          force_all_finite=False)
         X, y = indexable(X, y)

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -269,7 +269,7 @@ class AffinityPropagation(BaseEstimator, ClusterMixin):
     def _pairwise(self):
         return self.affinity == "precomputed"
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """ Create affinity matrix from negative euclidean distances, then
         apply affinity propagation clustering.
 

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -109,7 +109,7 @@ class BaseSpectral(six.with_metaclass(ABCMeta, BaseEstimator,
                              " one of {1}.".format(self.svd_method,
                                                    legal_svd_methods))
 
-    def fit(self, X):
+    def fit(self, X, sample_props=None):
         """Creates a biclustering for X.
 
         Parameters

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -409,7 +409,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         self.compute_labels = compute_labels
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """
         Build a CF Tree for the input data.
 

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -19,6 +19,7 @@ from ..utils import check_array, check_consistent_length
 from ..neighbors import NearestNeighbors
 
 from ._dbscan_inner import dbscan_inner
+from ..utils.deprecations import _deprecate_sample_weight
 
 
 def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
@@ -214,7 +215,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         self.p = p
         self.random_state = random_state
 
-    def fit(self, X, y=None, sample_weight=None):
+    def fit(self, X, y=None, sample_weight=None, sample_props=None):
         """Perform DBSCAN clustering from features or distance matrix.
 
         Parameters
@@ -229,6 +230,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
             weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         X = check_array(X, accept_sparse='csr')
         clust = dbscan(X, sample_weight=sample_weight, **self.get_params())
         self.core_sample_indices_, self.labels_ = clust
@@ -240,7 +242,7 @@ class DBSCAN(BaseEstimator, ClusterMixin):
             self.components_ = np.empty((0, X.shape[1]))
         return self
 
-    def fit_predict(self, X, y=None, sample_weight=None):
+    def fit_predict(self, X, y=None, sample_weight=None, sample_props=None):
         """Performs clustering on X and returns cluster labels.
 
         Parameters
@@ -260,5 +262,6 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         y : ndarray, shape (n_samples,)
             cluster labels
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         self.fit(X, sample_weight=sample_weight)
         return self.labels_

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -695,7 +695,7 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         self.affinity = affinity
         self.pooling_func = pooling_func
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the hierarchical clustering on the data
 
         Parameters
@@ -849,7 +849,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         are merged to form node `n_features + i`
     """
 
-    def fit(self, X, y=None, **params):
+    def fit(self, X, y=None, sample_props=None, **params):
         """Fit the hierarchical clustering on the data
 
         Parameters

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -774,7 +774,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
         return X
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute k-means clustering.
 
         Parameters
@@ -1196,7 +1196,7 @@ class MiniBatchKMeans(KMeans):
         self.init_size = init_size
         self.reassignment_ratio = reassignment_ratio
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute the centroids on X by chunking it into mini-batches.
 
         Parameters
@@ -1358,7 +1358,7 @@ class MiniBatchKMeans(KMeans):
         labels, inertia = zip(*results)
         return np.hstack(labels), np.sum(inertia)
 
-    def partial_fit(self, X, y=None):
+    def partial_fit(self, X, y=None, sample_props=None):
         """Update k means estimate on a single mini-batch X.
 
         Parameters

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -334,7 +334,7 @@ class MeanShift(BaseEstimator, ClusterMixin):
         self.cluster_all = cluster_all
         self.min_bin_freq = min_bin_freq
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Perform clustering.
 
         Parameters

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -405,7 +405,7 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
         self.coef0 = coef0
         self.kernel_params = kernel_params
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Creates an affinity matrix for X using the selected affinity,
         then applies spectral clustering to this affinity matrix.
 

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -147,7 +147,7 @@ class EmpiricalCovariance(BaseEstimator):
             precision = pinvh(self.covariance_)
         return precision
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fits the Maximum Likelihood Estimator covariance model
         according to the given training data and parameters.
 

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -320,7 +320,7 @@ class GraphLasso(EmpiricalCovariance):
         # The base class needs this for the score method
         self.store_precision = True
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         X = check_array(X)
         if self.assume_centered:
             self.location_ = np.zeros(X.shape[1])
@@ -520,7 +520,7 @@ class GraphLassoCV(GraphLasso):
         # The base class needs this for the score method
         self.store_precision = True
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fits the GraphLasso covariance model to X.
 
         Parameters

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -181,7 +181,7 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
                            random_state=random_state)
         OutlierDetectionMixin.__init__(self, contamination=contamination)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         MinCovDet.fit(self, X)
         self.threshold_ = sp.stats.scoreatpercentile(
             self.dist_, 100. * (1. - self.contamination))

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -588,7 +588,7 @@ class MinCovDet(EmpiricalCovariance):
         self.support_fraction = support_fraction
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fits a Minimum Covariance Determinant with the FastMCD algorithm.
 
         Parameters

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -108,7 +108,7 @@ class ShrunkCovariance(EmpiricalCovariance):
                                      assume_centered=assume_centered)
         self.shrinkage = shrinkage
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """ Fits the shrunk covariance model
         according to the given training data and parameters.
 
@@ -356,7 +356,7 @@ class LedoitWolf(EmpiricalCovariance):
                                      assume_centered=assume_centered)
         self.block_size = block_size
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """ Fits the Ledoit-Wolf shrunk covariance model
         according to the given training data and parameters.
 
@@ -511,7 +511,7 @@ class OAS(EmpiricalCovariance):
 
     """
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """ Fits the Oracle Approximating Shrinkage covariance model
         according to the given training data and parameters.
 

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -219,7 +219,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         self.tol = tol
         self.copy = copy
 
-    def fit(self, X, Y):
+    def fit(self, X, Y, sample_props=None):
         """Fit model to data.
 
         Parameters
@@ -416,7 +416,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         Ypred = np.dot(X, self.coef_)
         return Ypred + self.y_mean_
 
-    def fit_transform(self, X, y=None, **fit_params):
+    def fit_transform(self, X, y=None, sample_props=None, **fit_params):
         """Learn and apply the dimension reduction on the train data.
 
         Parameters
@@ -721,7 +721,7 @@ class PLSSVD(BaseEstimator, TransformerMixin):
         self.scale = scale
         self.copy = copy
 
-    def fit(self, X, Y):
+    def fit(self, X, Y, sample_props=None):
         # copy since this will contains the centered data
         check_consistent_length(X, Y)
         X = check_array(X, dtype=np.float64, copy=self.copy)
@@ -769,7 +769,7 @@ class PLSSVD(BaseEstimator, TransformerMixin):
             return x_scores, y_scores
         return x_scores
 
-    def fit_transform(self, X, y=None, **fit_params):
+    def fit_transform(self, X, y=None, sample_props=None, **fit_params):
         """Learn and apply the dimension reduction on the train data.
 
         Parameters

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -945,6 +945,15 @@ class PredefinedSplit(_PartitionIterator):
 
 
 ##############################################################################
+def _slice_attributes(attributes, indices):
+    """Private helper to slice dictionaries or dataframes"""
+    try:
+        attributes_train = dict([(k, safe_indexing(v, train)) for k, v in
+                                 attributes.items()])
+    except AttributeError:
+        # doesn't have items, hopefully is a dataframe
+
+
 def _index_param_value(X, v, indices):
     """Private helper function for parameter value indexing."""
     if not _is_arraylike(v) or _num_samples(v) != _num_samples(X):

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -955,7 +955,7 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_predict(estimator, X, y=None, attributes=None, cv=None, n_jobs=1,
+def cross_val_predict(estimator, X, y=None, sample_props=None, cv=None, n_jobs=1,
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
@@ -971,8 +971,8 @@ def cross_val_predict(estimator, X, y=None, attributes=None, cv=None, n_jobs=1,
         The target variable to try to predict in the case of
         supervised learning.
 
-    attributes : dict, recarray or dataframe
-        Per-sample attributes like sample groups, sample weights, etc.
+    sample_props : dict, recarray or dataframe
+        Per-sample properties like sample groups, sample weights, etc.
         Each value / key must have length n_samples.
 
     cv : cross-validation generator or int, optional, default: None
@@ -1015,7 +1015,7 @@ def cross_val_predict(estimator, X, y=None, attributes=None, cv=None, n_jobs=1,
     preds : ndarray
         This is the result of calling 'predict'
     """
-    X, y, attributes = indexable(X, y, attributes)
+    X, y, sample_props = indexable(X, y, sample_props)
 
     cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
     # We clone the estimator to make sure that all the folds are
@@ -1023,7 +1023,7 @@ def cross_val_predict(estimator, X, y=None, attributes=None, cv=None, n_jobs=1,
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
-                                                      attributes, train, test,
+                                                      sample_props, train, test,
                                                       verbose, fit_params)
                             for train, test in cv)
     p = np.concatenate([p for p, _ in preds_blocks])
@@ -1035,7 +1035,7 @@ def cross_val_predict(estimator, X, y=None, attributes=None, cv=None, n_jobs=1,
     return preds
 
 
-def _fit_and_predict(estimator, X, y, attributes, train, test, verbose, fit_params):
+def _fit_and_predict(estimator, X, y, sample_props, train, test, verbose, fit_params):
     """Fit estimator and predict values for a given dataset split.
 
     Parameters
@@ -1050,8 +1050,8 @@ def _fit_and_predict(estimator, X, y, attributes, train, test, verbose, fit_para
         The target variable to try to predict in the case of
         supervised learning.
 
-    attributes : dict, recarray or dataframe
-        Per-sample attributes like sample groups, sample weights, etc.
+    sample_props : dict, recarray or dataframe
+        Per-sample properties like sample groups, sample weights, etc.
         Each value / key must have length n_samples.
 
     train : array-like, shape (n_train_samples,)
@@ -1079,13 +1079,15 @@ def _fit_and_predict(estimator, X, y, attributes, train, test, verbose, fit_para
     fit_params = dict([(k, _index_param_value(X, v, train))
                       for k, v in fit_params.items()])
 
-    attributes_train = dict([(k, safe_indexing(v, train)) for k, v in
-                             attributes.items()])
+    sample_props_train = dict([(k, safe_indexing(v, train)) for k, v in
+                               sample_props.items()])
 
-    X_train, y_train, attributes = _safe_split(estimator, X, y, attributes, train)
-    X_test, _, _ = _safe_split(estimator, X, y, attributes, test, train)
+    X_train, y_train, sample_props_train = _safe_split(estimator, X, y,
+                                                       sample_props, train)
+    X_test, _, _ = _safe_split(estimator, X, y, sample_props, test, train)
 
-    estimator.fit(X_train, y_train, attributes=attributes_train, **fit_params)
+    estimator.fit(X_train, y_train, sample_props=sample_props_train,
+                  **fit_params)
     preds = estimator.predict(X_test)
     return preds, test
 
@@ -1114,7 +1116,7 @@ def _check_is_partition(locs, n):
     return True
 
 
-def cross_val_score(estimator, X, y=None, attributes=None, scoring=None,
+def cross_val_score(estimator, X, y=None, sample_props=None, scoring=None,
                     cv=None, n_jobs=1, verbose=0, fit_params=None,
                     pre_dispatch='2*n_jobs'):
     """Evaluate a score by cross-validation
@@ -1131,8 +1133,8 @@ def cross_val_score(estimator, X, y=None, attributes=None, scoring=None,
         The target variable to try to predict in the case of
         supervised learning.
 
-    attributes : dict, recarray or dataframe
-        Per-sample attributes like sample groups, sample weights, etc.
+    sample_props : dict, recarray or dataframe
+        Per-sample properties like sample groups, sample weights, etc.
         Each value / key must have length n_samples.
 
     scoring : string, callable or None, optional, default: None
@@ -1178,7 +1180,7 @@ def cross_val_score(estimator, X, y=None, attributes=None, scoring=None,
     scores : array of float, shape=(len(list(cv)),)
         Array of scores of the estimator for each run of the cross validation.
     """
-    X, y, attributes = indexable(X, y, attributes)
+    X, y, sample_props = indexable(X, y, sample_props)
 
     cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
     scorer = check_scoring(estimator, scoring=scoring)
@@ -1187,7 +1189,7 @@ def cross_val_score(estimator, X, y=None, attributes=None, scoring=None,
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
                         pre_dispatch=pre_dispatch)
     scores = parallel(delayed(_fit_and_score)(clone(estimator), X, y,
-                                              attributes, scorer, train, test,
+                                              sample_props, scorer, train, test,
                                               verbose, None, fit_params)
                       for train, test in cv)
     return np.array(scores)[:, 0]
@@ -1197,7 +1199,7 @@ class FitFailedWarning(RuntimeWarning):
     pass
 
 
-def _fit_and_score(estimator, X, y, attributes, scorer, train, test, verbose,
+def _fit_and_score(estimator, X, y, sample_props, scorer, train, test, verbose,
                    parameters, fit_params, return_train_score=False,
                    return_parameters=False, error_score='raise'):
     """Fit estimator and compute scores for a given dataset split.
@@ -1214,8 +1216,8 @@ def _fit_and_score(estimator, X, y, attributes, scorer, train, test, verbose,
         The target variable to try to predict in the case of
         supervised learning.
 
-    attributes : dict, recarray or dataframe
-        Per-sample attributes like sample groups, sample weights, etc.
+    sample_props : dict, recarray or dataframe
+        Per-sample properties like sample groups, sample weights, etc.
         Each value / key must have length n_samples.
 
     scorer : callable
@@ -1284,11 +1286,11 @@ def _fit_and_score(estimator, X, y, attributes, scorer, train, test, verbose,
 
     start_time = time.time()
 
-    X_train, y_train, attributes_train = _safe_split(estimator, X, y, attributes, train)
-    X_test, y_test, attributes_test = _safe_split(estimator, X, y, attributes, test, train)
+    X_train, y_train, sample_props_train = _safe_split(estimator, X, y, sample_props, train)
+    X_test, y_test, sample_props_test = _safe_split(estimator, X, y, sample_props, test, train)
 
     try:
-        estimator.fit(X_train, y_train, attributes=attributes_train,
+        estimator.fit(X_train, y_train, sample_props=sample_props_train,
                       **fit_params)
 
     except Exception as e:
@@ -1327,7 +1329,7 @@ def _fit_and_score(estimator, X, y, attributes, scorer, train, test, verbose,
     return ret
 
 
-def _safe_split(estimator, X, y, attributes, indices, train_indices=None):
+def _safe_split(estimator, X, y, sample_props, indices, train_indices=None):
     """Create subset of dataset and properly handle kernels."""
     if hasattr(estimator, 'kernel') and callable(estimator.kernel):
         # cannot compute the kernel values with custom function
@@ -1352,9 +1354,9 @@ def _safe_split(estimator, X, y, attributes, indices, train_indices=None):
             X_subset = safe_indexing(X, indices)
 
     y_subset = safe_indexing(y, indices)
-    attributes_subset = safe_indexing(attributes, indices)
+    sample_props_subset = safe_indexing(sample_props, indices)
 
-    return X_subset, y_subset, attributes_subset
+    return X_subset, y_subset, sample_props_subset
 
 
 def _score(estimator, X_test, y_test, scorer):

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -847,7 +847,7 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
                                        transform_alpha, split_sign, n_jobs)
         self.components_ = dictionary
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Do nothing and return the estimator unchanged
 
         This method is just there to implement the usual API and hence
@@ -978,7 +978,7 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
         self.verbose = verbose
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters
@@ -1144,7 +1144,7 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
         self.split_sign = split_sign
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -137,7 +137,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
         self.iterated_power = iterated_power
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the FactorAnalysis model to X using EM
 
         Parameters

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -502,7 +502,7 @@ class FastICA(BaseEstimator, TransformerMixin):
         """
         return self._fit(X, compute_sources=True)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model to X.
 
         Parameters

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -138,7 +138,7 @@ class IncrementalPCA(_BasePCA):
         self.copy = copy
         self.batch_size = batch_size
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model with X, using minibatches of size batch_size.
 
         Parameters
@@ -174,7 +174,7 @@ class IncrementalPCA(_BasePCA):
             self.partial_fit(X[batch])
         return self
 
-    def partial_fit(self, X, y=None):
+    def partial_fit(self, X, y=None, sample_props=None):
         """Incremental fit with X. All of X is processed as a single batch.
 
         Parameters

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -183,7 +183,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self.dual_coef_ = linalg.solve(K, X, sym_pos=True, overwrite_a=True)
         self.X_transformed_fit_ = X_transformed
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -456,7 +456,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
         return H, gradH, iterH
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y=None, sample_props=None):
         """Learn a NMF model for the data X and returns the transformed data.
 
         This is more efficient than calling fit followed by transform.
@@ -535,7 +535,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
         self.n_iter_ = n_iter
         return W
 
-    def fit(self, X, y=None, **params):
+    def fit(self, X, y=None, sample_props=None, **params):
         """Learn a NMF model for the data X.
 
         Parameters

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -204,7 +204,7 @@ class PCA(BaseEstimator, TransformerMixin):
         self.copy = copy
         self.whiten = whiten
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model with X.
 
         Parameters
@@ -550,7 +550,7 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
         self.whiten = whiten
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model with X by extracting the first principal components.
 
         Parameters

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -91,7 +91,7 @@ class SparsePCA(BaseEstimator, TransformerMixin):
         self.verbose = verbose
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters
@@ -246,7 +246,7 @@ class MiniBatchSparsePCA(SparsePCA):
         self.method = method
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -114,7 +114,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         self.random_state = random_state
         self.tol = tol
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit LSI model on training data X.
 
         Parameters

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -15,6 +15,7 @@ from .utils.validation import check_consistent_length
 from .utils.random import random_choice_csc
 from .utils.stats import _weighted_percentile
 from .utils.multiclass import class_distribution
+from ..utils.deprecations import _deprecate_sample_weight
 
 
 class DummyClassifier(BaseEstimator, ClassifierMixin):
@@ -76,7 +77,7 @@ class DummyClassifier(BaseEstimator, ClassifierMixin):
         self.random_state = random_state
         self.constant = constant
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the random classifier.
 
         Parameters
@@ -96,6 +97,7 @@ class DummyClassifier(BaseEstimator, ClassifierMixin):
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if self.strategy not in ("most_frequent", "stratified", "uniform",
                                  "constant", "prior"):
             raise ValueError("Unknown strategy type.")
@@ -362,7 +364,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin):
         self.constant = constant
         self.quantile = quantile
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the random regressor.
 
         Parameters
@@ -382,7 +384,7 @@ class DummyRegressor(BaseEstimator, RegressorMixin):
         self : object
             Returns self.
         """
-
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if self.strategy not in ("mean", "median", "quantile", "constant"):
             raise ValueError("Unknown strategy type: %s, expected "
                              "'mean', 'median', 'quantile' or 'constant'"

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -15,7 +15,7 @@ from .utils.validation import check_consistent_length
 from .utils.random import random_choice_csc
 from .utils.stats import _weighted_percentile
 from .utils.multiclass import class_distribution
-from ..utils.deprecations import _deprecate_sample_weight
+from .utils.deprecations import _deprecate_sample_weight
 
 
 class DummyClassifier(BaseEstimator, ClassifierMixin):

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -22,6 +22,7 @@ from ..utils.random import sample_without_replacement
 from ..utils.validation import has_fit_parameter, check_is_fitted
 from ..utils.fixes import bincount
 from ..utils.metaestimators import if_delegate_has_method
+from ..utils.deprecations import _deprecate_sample_weight
 
 from .base import BaseEnsemble, _partition_estimators
 
@@ -224,7 +225,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         self.random_state = random_state
         self.verbose = verbose
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Build a Bagging ensemble of estimators from the training
            set (X, y).
 
@@ -249,6 +250,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
             Returns self.
         """
         random_state = check_random_state(self.random_state)
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
 
         # Convert data
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'])

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -58,6 +58,7 @@ from ..tree import (DecisionTreeClassifier, DecisionTreeRegressor,
 from ..tree._tree import DTYPE, DOUBLE
 from ..utils import check_random_state, check_array, compute_sample_weight
 from ..utils.validation import DataConversionWarning, NotFittedError
+from ..utils.deprecations import _deprecate_sample_weight
 from .base import BaseEnsemble, _partition_estimators
 from ..utils.fixes import bincount
 
@@ -163,7 +164,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
 
         return np.array(results).T
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Build a forest of trees from the training set (X, y).
 
         Parameters
@@ -189,6 +190,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # Validate or convert input data
         X = check_array(X, dtype=DTYPE, accept_sparse="csc")
         if issparse(X):
@@ -1452,7 +1454,7 @@ class RandomTreesEmbedding(BaseForest):
     def _set_oob_score(self, X, y):
         raise NotImplementedError("OOB score not supported by tree embedding")
 
-    def fit(self, X, y=None, sample_weight=None):
+    def fit(self, X, y=None, sample_weight=None, sample_props=None):
         """Fit estimator.
 
         Parameters
@@ -1468,10 +1470,11 @@ class RandomTreesEmbedding(BaseForest):
             Returns self.
 
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         self.fit_transform(X, y, sample_weight=sample_weight)
         return self
 
-    def fit_transform(self, X, y=None, sample_weight=None):
+    def fit_transform(self, X, y=None, sample_weight=None, sample_props=None):
         """Fit estimator and transform dataset.
 
         Parameters
@@ -1485,6 +1488,7 @@ class RandomTreesEmbedding(BaseForest):
         X_transformed : sparse matrix, shape=(n_samples, n_out)
             Transformed dataset.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # ensure_2d=False because there are actually unit test checking we fail
         # for 1d.
         X = check_array(X, accept_sparse=['csc'], ensure_2d=False)

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -40,6 +40,8 @@ from ..utils.extmath import logsumexp
 from ..utils.fixes import expit, bincount
 from ..utils.stats import _weighted_percentile
 from ..utils.validation import check_is_fitted, NotFittedError
+from ..utils.deprecations import _deprecate_sample_weight
+
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 
@@ -60,7 +62,8 @@ class QuantileEstimator(BaseEstimator):
             raise ValueError("`alpha` must be in (0, 1.0) but was %r" % alpha)
         self.alpha = alpha
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if sample_weight is None:
             self.quantile = stats.scoreatpercentile(y, self.alpha * 100.0)
         else:
@@ -76,7 +79,8 @@ class QuantileEstimator(BaseEstimator):
 
 class MeanEstimator(BaseEstimator):
     """An estimator predicting the mean of the training targets."""
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if sample_weight is None:
             self.mean = np.mean(y)
         else:
@@ -94,7 +98,8 @@ class LogOddsEstimator(BaseEstimator):
     """An estimator predicting the log odds ratio."""
     scale = 1.0
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # pre-cond: pos, neg are encoded as 1, 0
         if sample_weight is None:
             pos = np.sum(y)
@@ -124,7 +129,8 @@ class PriorProbabilityEstimator(BaseEstimator):
     """An estimator predicting the probability of each
     class in the training data.
     """
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if sample_weight is None:
             sample_weight = np.ones_like(y, dtype=np.float64)
         class_counts = bincount(y, weights=sample_weight)
@@ -141,7 +147,8 @@ class PriorProbabilityEstimator(BaseEstimator):
 class ZeroEstimator(BaseEstimator):
     """An estimator that simply predicts zero. """
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if np.issubdtype(y.dtype, int):
             # classification
             self.n_classes = np.unique(y).shape[0]
@@ -898,7 +905,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
     def _is_initialized(self):
         return len(getattr(self, 'estimators_', [])) > 0
 
-    def fit(self, X, y, sample_weight=None, monitor=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None, monitor=None):
         """Fit the gradient boosting model.
 
         Parameters
@@ -933,6 +940,7 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # if not warmstart - clear the estimator state
         if not self.warm_start:
             self._clear_state()

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -81,7 +81,7 @@ def test_sparse_classification():
     class CustomSVC(SVC):
         """SVC variant that records the nature of the training set"""
 
-        def fit(self, X, y):
+        def fit(self, X, y, sample_props=None):
             super(CustomSVC, self).fit(X, y)
             self.data_type_ = type(X)
             return self
@@ -166,7 +166,7 @@ def test_sparse_regression():
     class CustomSVR(SVR):
         """SVC variant that records the nature of the training set"""
 
-        def fit(self, X, y):
+        def fit(self, X, y, sample_props=None):
             super(CustomSVR, self).fit(X, y)
             self.data_type_ = type(X)
             return self
@@ -556,7 +556,7 @@ def test_bagging_with_pipeline():
 
 class DummyZeroEstimator(BaseEstimator):
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         self.classes_ = np.unique(y)
         return self
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -228,7 +228,6 @@ def test_error():
 def test_base_estimator():
     # Test different base estimators.
     from sklearn.ensemble import RandomForestClassifier
-    from sklearn.svm import SVC
 
     # XXX doesn't work with y_class because RF doesn't support classes_
     # Shouldn't AdaBoost run a LabelBinarizer?
@@ -239,7 +238,6 @@ def test_base_estimator():
     clf.fit(X, y_class)
 
     from sklearn.ensemble import RandomForestRegressor
-    from sklearn.svm import SVR
 
     clf = AdaBoostRegressor(RandomForestRegressor(), random_state=0)
     clf.fit(X, y_regr)
@@ -278,9 +276,10 @@ def test_sparse_classification():
     class CustomSVC(SVC):
         """SVC variant that records the nature of the training set."""
 
-        def fit(self, X, y, sample_weight=None):
+        def fit(self, X, y, sample_weight=None, sample_props=None):
             """Modification on fit caries data type for later verification."""
-            super(CustomSVC, self).fit(X, y, sample_weight=sample_weight)
+            super(CustomSVC, self).fit(X, y, sample_weight=sample_weight,
+                                       sample_props=sample_props)
             self.data_type_ = type(X)
             return self
 
@@ -376,9 +375,10 @@ def test_sparse_regression():
     class CustomSVR(SVR):
         """SVR variant that records the nature of the training set."""
 
-        def fit(self, X, y, sample_weight=None):
+        def fit(self, X, y, sample_weight=None, sample_props=None):
             """Modification on fit caries data type for later verification."""
-            super(CustomSVR, self).fit(X, y, sample_weight=sample_weight)
+            super(CustomSVR, self).fit(X, y, sample_weight=sample_weight,
+                                       sample_props=sample_props)
             self.data_type_ = type(X)
             return self
 

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -84,7 +84,7 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         self.voting = voting
         self.weights = weights
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """ Fit the estimators.
 
         Parameters

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -39,9 +39,8 @@ from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE
 from ..utils import check_array, check_X_y, check_random_state
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import (
-        has_fit_parameter,
-        check_is_fitted)
+from ..utils.validation import has_fit_parameter, check_is_fitted
+from ..utils.deprecations import _deprecate_sample_weight
 
 __all__ = [
     'AdaBoostClassifier',
@@ -72,7 +71,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         self.learning_rate = learning_rate
         self.random_state = random_state
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Build a boosted classifier/regressor from the training set (X, y).
 
         Parameters
@@ -96,6 +95,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # Check parameters
         if self.learning_rate <= 0:
             raise ValueError("learning_rate must be greater than zero")
@@ -271,6 +271,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         return X
 
+
 def _samme_proba(estimator, n_classes, X):
     """Calculate algorithm 4, step 2, equation c) of Zhu et al [1].
 
@@ -379,7 +380,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
 
         self.algorithm = algorithm
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Build a boosted classifier from the training set (X, y).
 
         Parameters
@@ -400,6 +401,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # Check that algorithm is supported
         if self.algorithm not in ('SAMME', 'SAMME.R'):
             raise ValueError("algorithm %s is not supported" % self.algorithm)
@@ -750,7 +752,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             outputs is the same of that of the `classes_` attribute.
         """
         check_is_fitted(self, "n_classes_")
-        
+
         n_classes = self.n_classes_
         X = self._validate_X_predict(X)
 
@@ -923,7 +925,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         self.loss = loss
         self.random_state = random_state
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Build a boosted regressor from the training set (X, y).
 
         Parameters
@@ -950,7 +952,7 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
                 "loss must be 'linear', 'square', or 'exponential'")
 
         # Fit
-        return super(AdaBoostRegressor, self).fit(X, y, sample_weight)
+        return super(AdaBoostRegressor, self).fit(X, y, sample_weight, sample_props)
 
     def _validate_estimator(self):
         """Check the estimator and set the base_estimator_ attribute."""

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -93,7 +93,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
         self.sparse = sparse
         self.sort = sort
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Learn a list of feature name -> indices mappings.
 
         Parameters

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -86,7 +86,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
             raise ValueError("input_type must be 'dict', 'pair' or 'string',"
                              " got %r." % input_type)
 
-    def fit(self, X=None, y=None):
+    def fit(self, X=None, y=None, sample_props=None):
         """No-op.
 
         This method doesn't do anything. It exists purely for compatibility

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -447,7 +447,7 @@ class PatchExtractor(BaseEstimator):
         self.max_patches = max_patches
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Do nothing and return the estimator unchanged
 
         This method is just there to implement the usual API and hence

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -435,7 +435,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         self.non_negative = non_negative
         self.dtype = dtype
 
-    def partial_fit(self, X, y=None):
+    def partial_fit(self, X, y=None, sample_props=None):
         """Does nothing: this transformer is stateless.
 
         This method is just there to mark the fact that this transformer
@@ -444,7 +444,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         """
         return self
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Does nothing: this transformer is stateless."""
         # triggers a parameter validation
         self._get_hasher().fit(X, y=y)
@@ -955,7 +955,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
         self.smooth_idf = smooth_idf
         self.sublinear_tf = sublinear_tf
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Learn the idf vector (global term weights)
 
         Parameters

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -363,7 +363,7 @@ class RFECV(RFE, MetaEstimatorMixin):
         self.estimator_params = estimator_params
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, attributes=None):
         """Fit the RFE model and automatically tune the number of selected
            features.
 
@@ -395,15 +395,15 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         # Cross-validation
         for n, (train, test) in enumerate(cv):
-            X_train, y_train = _safe_split(self.estimator, X, y, train)
-            X_test, y_test = _safe_split(self.estimator, X, y, test, train)
+            X_train, y_train, attributes = _safe_split(self.estimator, X, y, attributes, train)
+            X_test, y_test, attributes = _safe_split(self.estimator, X, y, attributes, test, train)
 
             rfe = RFE(estimator=self.estimator,
                       n_features_to_select=n_features_to_select,
                       step=self.step, estimator_params=self.estimator_params,
                       verbose=self.verbose - 1)
 
-            rfe._fit(X_train, y_train, lambda estimator, features:
+            rfe._fit(X_train, y_train, attributes, lambda estimator, features:
                      _score(estimator, X_test[:, features], y_test, scorer))
             scores.append(np.array(rfe.scores_[::-1]).reshape(1, -1))
         scores = np.sum(np.concatenate(scores, 0), 0)
@@ -419,7 +419,7 @@ class RFECV(RFE, MetaEstimatorMixin):
                   n_features_to_select=n_features_to_select,
                   step=self.step, estimator_params=self.estimator_params)
 
-        rfe.fit(X, y)
+        rfe.fit(X, y, attributes=attributes)
 
         # Set final attributes
         self.support_ = rfe.support_

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -110,7 +110,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.estimator_params = estimator_params
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the RFE model and then the underlying estimator on the selected
            features.
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -363,7 +363,7 @@ class RFECV(RFE, MetaEstimatorMixin):
         self.estimator_params = estimator_params
         self.verbose = verbose
 
-    def fit(self, X, y, attributes=None):
+    def fit(self, X, y, sample_props=None):
         """Fit the RFE model and automatically tune the number of selected
            features.
 
@@ -395,15 +395,18 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         # Cross-validation
         for n, (train, test) in enumerate(cv):
-            X_train, y_train, attributes = _safe_split(self.estimator, X, y, attributes, train)
-            X_test, y_test, attributes = _safe_split(self.estimator, X, y, attributes, test, train)
+            X_train, y_train, sample_props = _safe_split(self.estimator, X, y,
+                                                         sample_props, train)
+            X_test, y_test, sample_props = _safe_split(self.estimator, X, y,
+                                                       sample_props, test,
+                                                       train)
 
             rfe = RFE(estimator=self.estimator,
                       n_features_to_select=n_features_to_select,
                       step=self.step, estimator_params=self.estimator_params,
                       verbose=self.verbose - 1)
 
-            rfe._fit(X_train, y_train, attributes, lambda estimator, features:
+            rfe._fit(X_train, y_train, sample_props, lambda estimator, features:
                      _score(estimator, X_test[:, features], y_test, scorer))
             scores.append(np.array(rfe.scores_[::-1]).reshape(1, -1))
         scores = np.sum(np.concatenate(scores, 0), 0)
@@ -419,7 +422,7 @@ class RFECV(RFE, MetaEstimatorMixin):
                   n_features_to_select=n_features_to_select,
                   step=self.step, estimator_params=self.estimator_params)
 
-        rfe.fit(X, y, attributes=attributes)
+        rfe.fit(X, y, sample_props=sample_props)
 
         # Set final attributes
         self.support_ = rfe.support_

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -14,7 +14,7 @@ class StepSelector(SelectorMixin, BaseEstimator):
     def __init__(self, step=2):
         self.step = step
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         X = check_array(X, 'csc')
         self.n_input_feats = X.shape[1]
         return self

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -8,10 +8,9 @@ from nose.tools import assert_equal, assert_true
 from scipy import sparse
 
 from sklearn.feature_selection.rfe import RFE, RFECV
-from sklearn.datasets import load_iris, make_friedman1, make_regression
+from sklearn.datasets import load_iris, make_friedman1
 from sklearn.metrics import zero_one_loss
 from sklearn.svm import SVC, SVR
-from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import RandomForestClassifier
 
 from sklearn.utils import check_random_state
@@ -30,7 +29,7 @@ class MockClassifier(object):
     def __init__(self, foo_param=0):
         self.foo_param = foo_param
 
-    def fit(self, X, Y):
+    def fit(self, X, Y, sample_props=None):
         assert_true(len(X) == len(Y))
         self.coef_ = np.ones(X.shape[1], dtype=np.float64)
         return self
@@ -92,7 +91,6 @@ def test_rfe_features_importance():
 
     # Check if the supports are equal
     assert_array_equal(rfe.get_support(), rfe_svc.get_support())
-
 
 
 def test_rfe_deprecation_estimator_params():
@@ -289,7 +287,7 @@ def test_number_of_subsets_of_features():
         X = generator.normal(size=(100, n_features))
         y = generator.rand(100).round()
         rfe = RFE(estimator=SVC(kernel="linear"),
-              n_features_to_select=n_features_to_select, step=step)
+                  n_features_to_select=n_features_to_select, step=step)
         rfe.fit(X, y)
         # this number also equals to the maximum of ranking_
         assert_equal(np.max(rfe.ranking_),
@@ -317,6 +315,6 @@ def test_number_of_subsets_of_features():
         rfecv.fit(X, y)
 
         assert_equal(rfecv.grid_scores_.shape[0],
-                 formula1(n_features, n_features_to_select, step))
+                     formula1(n_features, n_features_to_select, step))
         assert_equal(rfecv.grid_scores_.shape[0],
-                 formula2(n_features, n_features_to_select, step))
+                     formula2(n_features, n_features_to_select, step))

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -294,7 +294,7 @@ class _BaseFilter(BaseEstimator, SelectorMixin):
     def __init__(self, score_func):
         self.score_func = score_func
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Run score function on (X, y) and get the appropriate features.
 
         Parameters

--- a/sklearn/feature_selection/variance_threshold.py
+++ b/sklearn/feature_selection/variance_threshold.py
@@ -43,7 +43,7 @@ class VarianceThreshold(BaseEstimator, SelectorMixin):
     def __init__(self, threshold=0.):
         self.threshold = threshold
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Learn empirical variances from X.
 
         Parameters

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -238,7 +238,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
         self.random_start = random_start
         self.random_state = random_state
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """
         The Gaussian Process model fitting method.
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -207,7 +207,7 @@ class ParameterSampler(object):
         return self.n_iter
 
 
-def fit_grid_point(X, y, attributes, estimator, parameters, train, test,
+def fit_grid_point(X, y, sample_props, estimator, parameters, train, test,
                    scorer, verbose, error_score='raise', **fit_params):
     """Run fit on one set of parameters.
 
@@ -258,7 +258,7 @@ def fit_grid_point(X, y, attributes, estimator, parameters, train, test,
     n_samples_test : int
         Number of test samples in this split.
     """
-    score, n_samples_test, _ = _fit_and_score(estimator, X, y, attributes,
+    score, n_samples_test, _ = _fit_and_score(estimator, X, y, sample_props,
                                               scorer, train, test, verbose,
                                               parameters, fit_params,
                                               error_score)
@@ -469,7 +469,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.transform(Xt)
 
-    def _fit(self, X, y, attributes, parameter_iterable):
+    def _fit(self, X, y, sample_props, parameter_iterable):
         """Actual fitting,  performing the search over parameters."""
 
         estimator = self.estimator
@@ -501,7 +501,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             n_jobs=self.n_jobs, verbose=self.verbose,
             pre_dispatch=pre_dispatch
         )(
-            delayed(_fit_and_score)(clone(base_estimator), X, y, attributes,
+            delayed(_fit_and_score)(clone(base_estimator), X, y, sample_props,
                                     self.scorer_, train, test, self.verbose,
                                     parameters, self.fit_params,
                                     return_parameters=True,
@@ -718,7 +718,7 @@ class GridSearchCV(BaseSearchCV):
         self.param_grid = param_grid
         _check_param_grid(param_grid)
 
-    def fit(self, X, y=None, attributes=None):
+    def fit(self, X, y=None, sample_props=None):
         """Run fit with all sets of parameters.
 
         Parameters
@@ -733,7 +733,7 @@ class GridSearchCV(BaseSearchCV):
             None for unsupervised learning.
 
         """
-        return self._fit(X, y, attributes, ParameterGrid(self.param_grid))
+        return self._fit(X, y, sample_props, ParameterGrid(self.param_grid))
 
 
 class RandomizedSearchCV(BaseSearchCV):
@@ -882,7 +882,7 @@ class RandomizedSearchCV(BaseSearchCV):
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score)
 
-    def fit(self, X, y=None, attributes=None):
+    def fit(self, X, y=None, sample_props=None):
         """Run fit on the estimator with randomly drawn parameters.
 
         Parameters
@@ -899,4 +899,4 @@ class RandomizedSearchCV(BaseSearchCV):
         sampled_params = ParameterSampler(self.param_distributions,
                                           self.n_iter,
                                           random_state=self.random_state)
-        return self._fit(X, y, attributes, sampled_params)
+        return self._fit(X, y, sample_props, sampled_params)

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -552,9 +552,11 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             best_estimator = clone(base_estimator).set_params(
                 **best.parameters)
             if y is not None:
-                best_estimator.fit(X, y, **self.fit_params)
+                best_estimator.fit(X, y, sample_props=sample_props,
+                                   **self.fit_params)
             else:
-                best_estimator.fit(X, **self.fit_params)
+                best_estimator.fit(X, sample_props=sample_props,
+                                   **self.fit_params)
             self.best_estimator_ = best_estimator
         return self
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -9,6 +9,7 @@ from scipy.stats import spearmanr
 from .base import BaseEstimator, TransformerMixin, RegressorMixin
 from .utils import as_float_array, check_array, check_consistent_length
 from .utils.fixes import astype
+from .utils.deprecations import _deprecate_sample_weight
 from ._isotonic import _isotonic_regression, _make_unique
 import warnings
 import math
@@ -284,7 +285,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
 
         return order_inv
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -309,6 +310,7 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         X is stored for future use, as `transform` needs X to interpolate
         new input data.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # Build y_
         self._build_y(X, y, sample_weight)
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -56,7 +56,7 @@ class RBFSampler(BaseEstimator, TransformerMixin):
         self.n_components = n_components
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model with X.
 
         Samples random projection according to n_features.
@@ -142,7 +142,7 @@ class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
         self.n_components = n_components
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model with X.
 
         Samples random projection according to n_features.
@@ -248,7 +248,7 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
         self.sample_steps = sample_steps
         self.sample_interval = sample_interval
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Set parameters."""
         X = check_array(X, accept_sparse='csr')
         if self.sample_interval is None:
@@ -433,7 +433,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         self.n_components = n_components
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit estimator to data.
 
         Samples a subset of training points, computes kernel

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -11,6 +11,7 @@ from .metrics.pairwise import pairwise_kernels
 from .linear_model.ridge import _solve_cholesky_kernel
 from .utils import check_X_y
 from .utils.validation import check_is_fitted
+from .utils.deprecations import _deprecate_sample_weight
 
 
 class KernelRidge(BaseEstimator, RegressorMixin):
@@ -122,7 +123,7 @@ class KernelRidge(BaseEstimator, RegressorMixin):
     def _pairwise(self):
         return self.kernel == "precomputed"
 
-    def fit(self, X, y=None, sample_weight=None):
+    def fit(self, X, y=None, sample_weight=None, sample_props=None):
         """Fit Kernel Ridge regression model
 
         Parameters
@@ -140,10 +141,10 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         -------
         self : returns an instance of self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True)
 
-        n_samples = X.shape[0]
         K = self._get_kernel(X)
         alpha = np.atleast_1d(self.alpha)
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -389,7 +389,7 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
         self.coef_ = np.dot(coef, self.scalings_.T)
         self.intercept_ -= np.dot(self.xbar_, self.coef_.T)
 
-    def fit(self, X, y, store_covariance=False, tol=1.0e-4):
+    def fit(self, X, y, sample_props=None, store_covariance=False, tol=1.0e-4):
         """Fit LDA model according to the given training data and parameters.
 
         Parameters

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -116,7 +116,7 @@ class LinearModel(six.with_metaclass(ABCMeta, BaseEstimator)):
     """Base class for Linear Models"""
 
     @abstractmethod
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit model."""
 
     @deprecated(" and will be removed in 0.19.")
@@ -351,7 +351,7 @@ class LinearRegression(LinearModel, RegressorMixin):
         self.copy_X = copy_X
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """
         Fit linear model.
 

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -118,7 +118,7 @@ class BayesianRidge(LinearModel, RegressorMixin):
         self.copy_X = copy_X
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model
 
         Parameters
@@ -324,7 +324,7 @@ class ARDRegression(LinearModel, RegressorMixin):
         self.copy_X = copy_X
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the ARDRegression model according to the given training data
         and parameters.
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -593,7 +593,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         self.random_state = random_state
         self.selection = selection
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit model with coordinate descent.
 
         Parameters
@@ -983,7 +983,7 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
         self.random_state = random_state
         self.selection = selection
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit linear model with coordinate descent
 
         Fit is on grid of alphas and best alpha estimated by cross-validation.
@@ -1564,7 +1564,7 @@ class MultiTaskElasticNet(Lasso):
         self.random_state = random_state
         self.selection = selection
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit MultiTaskLasso model with coordinate descent
 
         Parameters

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -568,7 +568,7 @@ class Lars(LinearModel, RegressorMixin):
             Gram = None
         return Gram
 
-    def fit(self, X, y, Xy=None):
+    def fit(self, X, y, Xy=None, sample_props=None):
         """Fit the model using X, y as training data.
 
         parameters
@@ -1257,7 +1257,7 @@ class LassoLarsIC(LassoLars):
 
         y : array-like, shape (n_samples,)
             target values.
-    
+
         copy_X : boolean, optional, default True
             If ``True``, X will be copied; else, it may be overwritten.
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -966,7 +966,7 @@ class LarsCV(Lars):
         self.n_jobs = n_jobs
         self.eps = eps
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -1035,7 +1035,7 @@ class LarsCV(Lars):
         # Now compute the full model
         # it will call a lasso internally when self if LassoLarsCV
         # as self.method == 'lasso'
-        Lars.fit(self, X, y)
+        Lars.fit(self, X, y, sample_props=None)
         return self
 
     @property

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -993,7 +993,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         self.multi_class = multi_class
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model according to the given training data.
 
         Parameters
@@ -1292,7 +1292,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         self.intercept_scaling = intercept_scaling
         self.multi_class = multi_class
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model according to the given training data.
 
         Parameters

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -597,7 +597,7 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         self.normalize = normalize
         self.precompute = precompute
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -793,7 +793,7 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
         self.n_jobs = n_jobs
         self.verbose = verbose
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X, y as training data.
 
         Parameters

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -221,7 +221,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         self.C = C
         self.loss = loss
 
-    def partial_fit(self, X, y):
+    def partial_fit(self, X, y, sample_props=None):
         """Fit linear model with Passive Aggressive algorithm.
 
         Parameters

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -114,7 +114,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
                                  classes=classes, sample_weight=None,
                                  coef_init=None, intercept_init=None)
 
-    def fit(self, X, y, coef_init=None, intercept_init=None):
+    def fit(self, X, y, sample_props=None, coef_init=None,
+            intercept_init=None):
         """Fit linear model with Passive Aggressive algorithm.
 
         Parameters
@@ -243,7 +244,8 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
                                  sample_weight=None,
                                  coef_init=None, intercept_init=None)
 
-    def fit(self, X, y, coef_init=None, intercept_init=None):
+    def fit(self, X, y, sample_props=None, coef_init=None,
+            intercept_init=None):
         """Fit linear model with Passive Aggressive algorithm.
 
         Parameters

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -72,7 +72,7 @@ class BaseRandomizedLinearModel(six.with_metaclass(ABCMeta, BaseEstimator,
 
     _center_data = staticmethod(center_data)
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X, y as training data.
 
         Parameters

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -175,7 +175,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         self.residual_metric = residual_metric
         self.random_state = random_state
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit estimator using RANSAC algorithm.
 
         Parameters

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -563,7 +563,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
             copy_X=copy_X, max_iter=max_iter, tol=tol, solver=solver)
         self.class_weight = class_weight
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit Ridge regression model.
 
         Parameters

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -23,6 +23,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils import check_X_y
 from ..utils import compute_sample_weight
 from ..utils import column_or_1d
+from ..utils.deprecations import _deprecate_sample_weight
 from ..preprocessing import LabelBinarizer
 from ..grid_search import GridSearchCV
 from ..externals import six
@@ -365,7 +366,8 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
         self.tol = tol
         self.solver = solver
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float,
                          multi_output=True, y_numeric=True)
 
@@ -475,7 +477,7 @@ class Ridge(_BaseRidge, RegressorMixin):
                                     normalize=normalize, copy_X=copy_X,
                                     max_iter=max_iter, tol=tol, solver=solver)
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit Ridge regression model
 
         Parameters
@@ -493,7 +495,8 @@ class Ridge(_BaseRidge, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        return super(Ridge, self).fit(X, y, sample_weight=sample_weight)
+        return super(Ridge, self).fit(X, y, sample_weight=sample_weight,
+                                      sample_props=sample_props)
 
 
 class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
@@ -712,7 +715,7 @@ class _RidgeGCV(LinearModel):
             G_diag = G_diag[:, np.newaxis]
         return y - (c / G_diag), c
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit Ridge regression model
 
         Parameters
@@ -730,6 +733,7 @@ class _RidgeGCV(LinearModel):
         -------
         self : Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float,
                          multi_output=True, y_numeric=True)
 
@@ -828,7 +832,7 @@ class _BaseRidgeCV(LinearModel):
         self.gcv_mode = gcv_mode
         self.store_cv_values = store_cv_values
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit Ridge regression model
 
         Parameters
@@ -846,6 +850,7 @@ class _BaseRidgeCV(LinearModel):
         -------
         self : Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if self.cv is None:
             estimator = _RidgeGCV(self.alphas,
                                   fit_intercept=self.fit_intercept,
@@ -853,7 +858,8 @@ class _BaseRidgeCV(LinearModel):
                                   scoring=self.scoring,
                                   gcv_mode=self.gcv_mode,
                                   store_cv_values=self.store_cv_values)
-            estimator.fit(X, y, sample_weight=sample_weight)
+            estimator.fit(X, y, sample_weight=sample_weight,
+                          sample_props=sample_props)
             self.alpha_ = estimator.alpha_
             if self.store_cv_values:
                 self.cv_values_ = estimator.cv_values_
@@ -868,7 +874,7 @@ class _BaseRidgeCV(LinearModel):
             fit_params = {}
             gs = GridSearchCV(Ridge(fit_intercept=self.fit_intercept),
                               parameters, fit_params=fit_params, cv=self.cv)
-            gs.fit(X, y)
+            gs.fit(X, y, sample_props=sample_props)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
 
@@ -1033,7 +1039,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
             scoring=scoring, cv=cv)
         self.class_weight = class_weight
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the ridge classifier.
 
         Parameters
@@ -1053,6 +1059,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if sample_weight is None:
             sample_weight = 1.
 

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -19,6 +19,7 @@ from ..utils import (check_array, check_random_state, check_X_y,
 from ..utils.extmath import safe_sparse_dot
 from ..utils.multiclass import _check_partial_fit_first_call
 from ..utils.validation import check_is_fitted
+from ..utils.deprecations import _deprecate_sample_weight
 from ..externals import six
 
 from .sgd_fast import plain_sgd, average_sgd
@@ -396,7 +397,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         return self
 
     def _fit(self, X, y, alpha, C, loss, learning_rate, coef_init=None,
-             intercept_init=None, sample_weight=None):
+             intercept_init=None, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if hasattr(self, "classes_"):
             self.classes_ = None
 
@@ -525,7 +527,8 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                                  classes=classes, sample_weight=sample_weight,
                                  coef_init=None, intercept_init=None)
 
-    def fit(self, X, y, coef_init=None, intercept_init=None, sample_weight=None):
+    def fit(self, X, y, coef_init=None, intercept_init=None,
+            sample_weight=None, sample_props=None):
         """Fit linear model with Stochastic Gradient Descent.
 
         Parameters
@@ -555,7 +558,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
         return self._fit(X, y, alpha=self.alpha, C=1.0,
                          loss=self.loss, learning_rate=self.learning_rate,
                          coef_init=coef_init, intercept_init=intercept_init,
-                         sample_weight=sample_weight)
+                         sample_weight=sample_weight, sample_props=sample_props)
 
 
 class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
@@ -945,7 +948,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
                                  coef_init, intercept_init)
 
     def fit(self, X, y, coef_init=None, intercept_init=None,
-            sample_weight=None):
+            sample_weight=None, sample_props=None):
         """Fit linear model with Stochastic Gradient Descent.
 
         Parameters
@@ -973,7 +976,7 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
                          loss=self.loss, learning_rate=self.learning_rate,
                          coef_init=coef_init,
                          intercept_init=intercept_init,
-                         sample_weight=sample_weight)
+                         sample_weight=sample_weight, sample_props=sample_props)
 
     @deprecated(" and will be removed in 0.19.")
     def decision_function(self, X):

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -924,7 +924,8 @@ class BaseSGDRegressor(BaseSGD, RegressorMixin):
                                  coef_init=None, intercept_init=None)
 
     def _fit(self, X, y, alpha, C, loss, learning_rate, coef_init=None,
-             intercept_init=None, sample_weight=None):
+             intercept_init=None, sample_weight=None, sample_props=None):
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         if self.warm_start and self.coef_ is not None:
             if coef_init is None:
                 coef_init = self.coef_

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -89,7 +89,7 @@ class BaseSGD(six.with_metaclass(ABCMeta, BaseEstimator, SparseCoefMixin)):
         return self
 
     @abstractmethod
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit model."""
 
     def _validate_params(self):

--- a/sklearn/linear_model/tests/test_passive_aggressive.py
+++ b/sklearn/linear_model/tests/test_passive_aggressive.py
@@ -31,7 +31,7 @@ class MyPassiveAggressive(ClassifierMixin):
         self.fit_intercept = fit_intercept
         self.n_iter = n_iter
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         n_samples, n_features = X.shape
         self.w = np.zeros(n_features, dtype=np.float64)
         self.b = 0.0

--- a/sklearn/linear_model/tests/test_perceptron.py
+++ b/sklearn/linear_model/tests/test_perceptron.py
@@ -24,7 +24,7 @@ class MyPerceptron(object):
     def __init__(self, n_iter=1):
         self.n_iter = n_iter
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         n_samples, n_features = X.shape
         self.w = np.zeros(n_features, dtype=np.float64)
         self.b = 0.0

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -326,7 +326,7 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
 
         return n_subsamples, n_subpopulation
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit linear model.
 
         Parameters

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -139,7 +139,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         evals = self.kernel_pca_.lambdas_
         return np.sqrt(np.sum(G_center ** 2) - np.sum(evals ** 2)) / G.shape[0]
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute the embedding vectors for data X
 
         Parameters

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -621,7 +621,7 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
                 hessian_tol=self.hessian_tol, modified_tol=self.modified_tol,
                 random_state=random_state)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute the embedding vectors for data X
 
         Parameters

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -357,7 +357,7 @@ class MDS(BaseEstimator):
     def _pairwise(self):
         return self.kernel == "precomputed"
 
-    def fit(self, X, y=None, init=None):
+    def fit(self, X, y=None, init=None, sample_props=None):
         """
         Computes the position of the points in the embedding space
 
@@ -374,7 +374,7 @@ class MDS(BaseEstimator):
         self.fit_transform(X, init=init)
         return self
 
-    def fit_transform(self, X, y=None, init=None):
+    def fit_transform(self, X, y=None, init=None, sample_props=None):
         """
         Fit the data from X, and returns the embedded coordinates
 

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -426,7 +426,7 @@ class SpectralEmbedding(BaseEstimator):
         self.affinity_matrix_ = self.affinity(X)
         return self.affinity_matrix_
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model from data in X.
 
         Parameters

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -407,7 +407,7 @@ class TSNE(BaseEstimator):
         self.verbose = verbose
         self.random_state = random_state
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model using X as training data.
 
         Parameters

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -53,13 +53,13 @@ class EstimatorWithoutFit(object):
 
 class EstimatorWithFit(BaseEstimator):
     """Dummy estimator to test check_scoring"""
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         return self
 
 
 class EstimatorWithFitAndScore(object):
     """Dummy estimator to test check_scoring"""
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         return self
 
     def score(self, X, y):
@@ -68,7 +68,7 @@ class EstimatorWithFitAndScore(object):
 
 class EstimatorWithFitAndPredict(object):
     """Dummy estimator to test check_scoring"""
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         self.y = y
         return self
 

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -479,7 +479,7 @@ class DPGMM(GMM):
                                                     + self.gamma_[i, 2])
         self.weights_ /= np.sum(self.weights_)
 
-    def _fit(self, X, y=None):
+    def _fit(self, X, y=None, sample_props=None):
         """Estimate model parameters with the variational
         algorithm.
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -568,7 +568,7 @@ class GMM(BaseEstimator):
 
         return responsibilities
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Estimate model parameters with the EM algorithm.
 
         A initialization step is performed before entering the

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -181,7 +181,7 @@ def predict_proba_ovr(estimators, X, is_multilabel):
 
 class _ConstantPredictor(BaseEstimator):
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         self.y_ = y
         return self
 
@@ -251,7 +251,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         self.estimator = estimator
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit underlying estimators.
 
         Parameters
@@ -484,7 +484,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         self.estimator = estimator
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit underlying estimators.
 
         Parameters
@@ -698,7 +698,7 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         self.random_state = random_state
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit underlying estimators.
 
         Parameters

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -30,6 +30,7 @@ from .utils.extmath import safe_sparse_dot, logsumexp
 from .utils.multiclass import _check_partial_fit_first_call
 from .utils.fixes import in1d
 from .utils.validation import check_is_fitted
+from .utils.deprecations import _deprecate_sample_weight
 from .externals import six
 
 __all__ = ['BernoulliNB', 'GaussianNB', 'MultinomialNB']
@@ -145,7 +146,7 @@ class GaussianNB(BaseNB):
     [1]
     """
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit Gaussian Naive Bayes according to X, y
 
         Parameters
@@ -165,6 +166,7 @@ class GaussianNB(BaseNB):
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         X, y = check_X_y(X, y)
         return self._partial_fit(X, y, np.unique(y), _refit=True,
                                  sample_weight=sample_weight)
@@ -491,7 +493,7 @@ class BaseDiscreteNB(BaseNB):
         self._update_class_log_prior(class_prior=class_prior)
         return self
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit Naive Bayes classifier according to X, y
 
         Parameters
@@ -513,6 +515,7 @@ class BaseDiscreteNB(BaseNB):
         """
         X, y = check_X_y(X, y, 'csr')
         _, n_features = X.shape
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
 
         labelbin = LabelBinarizer()
         Y = labelbin.fit_transform(y)

--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -332,7 +332,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
             max_depth = max_depth - 1
         return total_neighbors, total_distances
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the LSH forest on the data.
 
         This creates binary hashes of input data points by getting the
@@ -502,7 +502,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
         else:
             return _array_of_arrays(neighbors)
 
-    def partial_fit(self, X, y=None):
+    def partial_fit(self, X, y=None, sample_props=None):
         """
         Inserts new data into the already fitted LSH Forest.
         Cost is proportional to new total size, so additions

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -711,7 +711,7 @@ class RadiusNeighborsMixin(object):
 
 
 class SupervisedFloatMixin(object):
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X as training data and y as target values
 
         Parameters
@@ -730,7 +730,7 @@ class SupervisedFloatMixin(object):
 
 
 class SupervisedIntegerMixin(object):
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model using X as training data and y as target values
 
         Parameters
@@ -771,7 +771,7 @@ class SupervisedIntegerMixin(object):
 
 
 class UnsupervisedMixin(object):
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model using X as training data
 
         Parameters

--- a/sklearn/neighbors/kde.py
+++ b/sklearn/neighbors/kde.py
@@ -110,7 +110,7 @@ class KernelDensity(BaseEstimator):
         else:
             raise ValueError("invalid algorithm: '{0}'".format(algorithm))
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the Kernel Density model on the data.
 
         Parameters

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -81,7 +81,7 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
         self.metric = metric
         self.shrink_threshold = shrink_threshold
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """
         Fit the NearestCentroid model according to the given training data.
 

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -217,7 +217,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
 
         return v_
 
-    def partial_fit(self, X, y=None):
+    def partial_fit(self, X, y=None, sample_props=None):
         """Fit the model to the data X which should contain a partial
         segment of the data.
 
@@ -319,7 +319,7 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
         fe_ = self._free_energy(v_)
         return v.shape[1] * log_logistic(fe_ - fe)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the model to the data X.
 
         Parameters

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -17,9 +17,7 @@ from ..externals import six
 from ..utils import check_array
 from ..utils import warn_if_not_float
 from ..utils.extmath import row_norms
-from ..utils.fixes import (combinations_with_replacement as combinations_w_r,
-                           bincount)
-from ..utils.fixes import isclose
+from ..utils.fixes import combinations_with_replacement as combinations_w_r
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale, mean_variance_axis)
@@ -214,7 +212,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         self.feature_range = feature_range
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute the minimum and maximum to be used for later scaling.
 
         Parameters
@@ -335,7 +333,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         self.with_std = with_std
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Compute the mean and std to be used for later scaling.
 
         Parameters
@@ -514,7 +512,7 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         return np.vstack(np.bincount(c, minlength=self.n_input_features_)
                          for c in combinations)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """
         Compute number of output features.
         """
@@ -666,7 +664,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
         self.norm = norm
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Do nothing and return the estimator unchanged
 
         This method is just there to implement the usual API and hence
@@ -770,7 +768,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
         self.threshold = threshold
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Do nothing and return the estimator unchanged
 
         This method is just there to implement the usual API and hence
@@ -803,7 +801,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
     sklearn.preprocessing.StandardScaler(with_std=False).
     """
 
-    def fit(self, K, y=None):
+    def fit(self, K, y=None, sample_props=None):
         """Fit KernelCenterer
 
         Parameters
@@ -1052,7 +1050,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         self.sparse = sparse
         self.handle_unknown = handle_unknown
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit OneHotEncoder to X.
 
         Parameters

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -121,7 +121,7 @@ class Imputer(BaseEstimator, TransformerMixin):
         self.verbose = verbose
         self.copy = copy
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Fit the imputer on X.
 
         Parameters

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -95,7 +95,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         if not hasattr(self, "classes_"):
             raise ValueError("LabelEncoder was not fitted yet.")
 
-    def fit(self, y):
+    def fit(self, y, sample_props=None):
         """Fit label encoder
 
         Parameters
@@ -112,7 +112,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         self.classes_ = np.unique(y)
         return self
 
-    def fit_transform(self, y):
+    def fit_transform(self, y, sample_props=None):
         """Fit label encoder and return encoded labels
 
         Parameters
@@ -299,7 +299,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         if not hasattr(self, "classes_"):
             raise ValueError("LabelBinarizer was not fitted yet.")
 
-    def fit(self, y):
+    def fit(self, y, sample_props=None):
         """Fit label binarizer
 
         Parameters
@@ -712,7 +712,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         self.classes = classes
         self.sparse_output = sparse_output
 
-    def fit(self, y):
+    def fit(self, y, sample_props=None):
         """Fit the label sets binarizer, storing `classes_`
 
         Parameters
@@ -735,7 +735,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         self.classes_[:] = classes
         return self
 
-    def fit_transform(self, y):
+    def fit_transform(self, y, sample_props=None):
         """Fit the label sets binarizer and transform the given label sets
 
         Parameters

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -81,7 +81,7 @@ class QDA(BaseEstimator, ClassifierMixin):
         self.priors = np.asarray(priors) if priors is not None else None
         self.reg_param = reg_param
 
-    def fit(self, X, y, store_covariances=False, tol=1.0e-4):
+    def fit(self, X, y, sample_props=None, store_covariances=False, tol=1.0e-4):
         """
         Fit the QDA model according to the given training data and parameters.
 
@@ -97,7 +97,7 @@ class QDA(BaseEstimator, ClassifierMixin):
         store_covariances : boolean
             If True the covariance matrices are computed and stored in the
             `self.covariances_` attribute.
-        
+
         tol : float, optional, default 1.0e-4
             Threshold used for rank estimation.
         """

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -318,7 +318,7 @@ class BaseRandomProjection(six.with_metaclass(ABCMeta, BaseEstimator,
 
         """
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         """Generate a sparse random projection matrix
 
         Parameters

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -191,7 +191,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         probabilities /= normalizer
         return probabilities
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit a semi-supervised label propagation model based
 
         All the input data is provided matrix X (labeled and unlabeled)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -13,6 +13,8 @@ from ..utils import check_array, check_random_state, column_or_1d
 from ..utils import ConvergenceWarning, compute_class_weight, deprecated
 from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
+from ..utils.deprecations import _deprecate_sample_weight
+
 from ..externals import six
 
 LIBSVM_IMPL = ['c_svc', 'nu_svc', 'one_class', 'epsilon_svr', 'nu_svr']
@@ -96,7 +98,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         kernel = self.kernel
         return kernel == "precomputed" or callable(kernel)
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, sample_props=None):
         """Fit the SVM model according to the given training data.
 
         Parameters
@@ -129,6 +131,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         matrices as input.
         """
 
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         rnd = check_random_state(self.random_state)
 
         sparse = sp.isspmatrix(X)

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -160,7 +160,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         self.penalty = penalty
         self.loss = loss
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model according to the given training data.
 
         Parameters
@@ -323,7 +323,7 @@ class LinearSVR(LinearModel, RegressorMixin):
         self.dual = dual
         self.loss = loss
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         """Fit the model according to the given training data.
 
         Parameters

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -937,7 +937,7 @@ class OneClassSVM(BaseLibSVM):
             shrinking, False, cache_size, None, verbose, max_iter,
             random_state)
 
-    def fit(self, X, y=None, sample_weight=None, **params):
+    def fit(self, X, y=None, sample_weight=None, sample_props=None, **params):
         """
         Detects the soft boundary of the set of samples X.
 
@@ -962,5 +962,5 @@ class OneClassSVM(BaseLibSVM):
 
         """
         super(OneClassSVM, self).fit(X, [], sample_weight=sample_weight,
-                                     **params)
+                                     sample_props=sample_props, **params)
         return self

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -29,6 +29,7 @@ from sklearn.utils.estimator_checks import (
     check_parameters_default_constructible,
     check_class_weight_auto_linear_classifier,
     check_transformer_n_iter,
+    check_sample_properties,
     check_non_transformer_estimators_n_iter,
     check_get_params_invariance)
 
@@ -193,7 +194,8 @@ def test_get_params_invariance():
     # get_params(deep=False) is a subset of get_params(deep=True)
     # Related to issue #4465
 
-    estimators = all_estimators(include_meta_estimators=False, include_other=True)
+    estimators = all_estimators(include_meta_estimators=False,
+                                include_other=True)
     for name, Estimator in estimators:
         if hasattr(Estimator, 'get_params'):
             yield check_get_params_invariance, name, Estimator

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -555,22 +555,22 @@ def test_cross_val_score_pandas():
         cval.cross_val_score(clf, X_df, y_ser)
 
 
-def test_cross_val_score_attributes():
-    # check that cross_val_score slices sample attributes
+def test_cross_val_score_sample_props():
+    # check that cross_val_score slices sample sample_props
     # given as dictionaries properly
     n_samples_train = len(X) * 1 // 2
     check_length = lambda x: len(x) == n_samples_train
 
-    def check_attributes(x):
+    def check_sample_props(x):
         type_check = isinstance(x, dict)
         length_check = all(len(value) == n_samples_train for value in x.values())
         key_check = sorted(x.keys()) == ["other_attribute", "sample_weights"]
         return key_check and length_check and type_check
 
     clf = CheckingClassifier(check_X=check_length, check_y=check_length,
-                             check_attributes=check_attributes)
-    attributes = {'sample_weights': np.ones(len(X)), 'other_attribute': np.zeros(len(X))}
-    cval.cross_val_score(clf, X, y, attributes=attributes, cv=2)
+                             check_sample_props=check_sample_props)
+    sample_props = {'sample_weights': np.ones(len(X)), 'other_attribute': np.zeros(len(X))}
+    cval.cross_val_score(clf, X, y, sample_props=sample_props, cv=2)
 
     # test with pandas dataframe if we have pandas
     #try:
@@ -578,15 +578,15 @@ def test_cross_val_score_attributes():
     #except ImportError:
     #    return
 
-    #attributes = pd.DataFame(attributes)
+    #sample_props = pd.DataFame(sample_props)
 
-    #def check_attributes_df(x):
+    #def check_sample_props(x):
     #    type_check = isinstance(x, pd.DataFrame)
     #    length_check = len(x) == n_samples_train
     #    key_check = x.columns == ["sample_weights", "other_attribute"]
     #    return key_check and length_check and type_check
 
-    #cval.cross_val_score(clf, X, y, attributes=attributes)
+    #cval.cross_val_score(clf, X, y, sample_props=sample_props)
 
 
 def test_cross_val_score_mask():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -555,6 +555,40 @@ def test_cross_val_score_pandas():
         cval.cross_val_score(clf, X_df, y_ser)
 
 
+def test_cross_val_score_attributes():
+    # check that cross_val_score slices sample attributes
+    # given as dictionaries properly
+    n_samples_train = len(X) * 1 // 2
+    check_length = lambda x: len(x) == n_samples_train
+
+    def check_attributes(x):
+        type_check = isinstance(x, dict)
+        length_check = all(len(value) == n_samples_train for value in x.values())
+        key_check = sorted(x.keys()) == ["other_attribute", "sample_weights"]
+        return key_check and length_check and type_check
+
+    clf = CheckingClassifier(check_X=check_length, check_y=check_length,
+                             check_attributes=check_attributes)
+    attributes = {'sample_weights': np.ones(len(X)), 'other_attribute': np.zeros(len(X))}
+    cval.cross_val_score(clf, X, y, attributes=attributes, cv=2)
+
+    # test with pandas dataframe if we have pandas
+    #try:
+    #    import pandas as pd
+    #except ImportError:
+    #    return
+
+    #attributes = pd.DataFame(attributes)
+
+    #def check_attributes_df(x):
+    #    type_check = isinstance(x, pd.DataFrame)
+    #    length_check = len(x) == n_samples_train
+    #    key_check = x.columns == ["sample_weights", "other_attribute"]
+    #    return key_check and length_check and type_check
+
+    #cval.cross_val_score(clf, X, y, attributes=attributes)
+
+
 def test_cross_val_score_mask():
     # test that cross_val_score works with boolean masks
     svm = SVC(kernel="linear")

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -50,7 +50,7 @@ class MockClassifier(object):
 
     def fit(self, X, Y=None, sample_weight=None, class_prior=None,
             sparse_sample_weight=None, sparse_param=None, dummy_int=None,
-            dummy_str=None, dummy_obj=None, callback=None):
+            dummy_str=None, dummy_obj=None, callback=None, sample_props=None):
         """The dummy arguments are to test that this fit function can
         accept non-array arguments through cross-validation, such as:
             - int

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -59,8 +59,8 @@ class MockClassifier(object):
     def __init__(self, foo_param=0):
         self.foo_param = foo_param
 
-    def fit(self, X, Y):
-        assert_true(len(X) == len(Y))
+    def fit(self, X, Y, sample_props=None):
+        assert_true(len(X) == len(y))
         return self
 
     def predict(self, T):
@@ -414,7 +414,7 @@ class BrokenClassifier(BaseEstimator):
     def __init__(self, parameter=None):
         self.parameter = parameter
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         assert_true(not hasattr(self, 'has_been_fit_'))
         self.has_been_fit_ = True
 
@@ -688,7 +688,7 @@ class FailingClassifier(BaseEstimator):
     def __init__(self, parameter=None):
         self.parameter = parameter
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_props=None):
         if self.parameter == FailingClassifier.FAILING_PARAMETER:
             raise ValueError("Failing classifier failed as required")
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -788,3 +788,21 @@ def test_sample_props_slicing():
                              sample_props={'sample_weight': sample_weights})
     # make sure we are not better than predicting always class 0
     assert_less(scores.max(), 0.4)
+
+    # test with checking classifier
+    # make properties dependent on X and y and see that they are passed
+    # correctly for all calls to fit
+    sample_weights = 2 * y
+    other_property = ["foo_%f" % x for x in X[:, 0]]
+    params = {'foo_param': [0, 1]}
+
+    def check_all(X_, y_, sample_props_):
+        assert_array_equal(sample_props_['sample_weight'], 2 * y_)
+        assert_array_equal(sample_props_['other_property'], ["foo_%f" % x for x in X_[:, 0]])
+        return True
+
+    grid = GridSearchCV(CheckingClassifier(check_all=check_all), params)
+
+    cross_val_score(grid, X, y, sample_props={'sample_weight': sample_weights,
+                                              'other_property':
+                                              other_property})

--- a/sklearn/tests/test_learning_curve.py
+++ b/sklearn/tests/test_learning_curve.py
@@ -25,7 +25,7 @@ class MockImprovingEstimator(BaseEstimator):
         self.train_sizes = 0
         self.X_subset = None
 
-    def fit(self, X_subset, y_subset=None):
+    def fit(self, X_subset, y_subset=None, sample_props=None):
         self.X_subset = X_subset
         self.train_sizes = X_subset.shape[0]
         return self
@@ -65,7 +65,7 @@ class MockEstimatorWithParameter(BaseEstimator):
         self.X_subset = None
         self.param = param
 
-    def fit(self, X_subset, y_subset):
+    def fit(self, X_subset, y_subset, sample_props=None):
         self.X_subset = X_subset
         self.train_sizes = X_subset.shape[0]
         return self

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -46,7 +46,7 @@ class IncorrectT(object):
 
 class T(IncorrectT):
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         return self
 
     def get_params(self, deep=False):
@@ -71,7 +71,7 @@ class FitParamT(object):
         self.successful = False
         pass
 
-    def fit(self, X, y, should_succeed=False):
+    def fit(self, X, y, should_succeed=False, sample_props=None):
         self.successful = should_succeed
 
     def predict(self, X):
@@ -89,8 +89,7 @@ def test_pipeline_init():
     pipe = Pipeline([('svc', clf)])
     assert_equal(pipe.get_params(deep=True),
                  dict(svc__a=None, svc__b=None, svc=clf,
-                     **pipe.get_params(deep=False)
-                     ))
+                      **pipe.get_params(deep=False)))
 
     # Check that params are set
     pipe.set_params(svc__a=0.1)
@@ -123,13 +122,13 @@ def test_pipeline_init():
     # Check that apart from estimators, the parameters are the same
     params = pipe.get_params(deep=True)
     params2 = pipe2.get_params(deep=True)
-    
+
     for x in pipe.get_params(deep=False):
         params.pop(x)
-    
+
     for x in pipe2.get_params(deep=False):
         params2.pop(x)
-    
+
     # Remove estimators that where copied
     params.pop('svc')
     params.pop('anova')

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -26,7 +26,8 @@ from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_array, check_random_state, compute_sample_weight
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import NotFittedError
+from ..utils.deprecations import _deprecate_sample_weight
 
 
 from ._tree import Criterion
@@ -102,7 +103,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         self.tree_ = None
         self.max_features_ = None
 
-    def fit(self, X, y, sample_weight=None, check_input=True):
+    def fit(self, X, y, sample_weight=None, sample_props=None, check_input=True):
         """Build a decision tree from the training set (X, y).
 
         Parameters
@@ -133,6 +134,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         self : object
             Returns self.
         """
+        sample_weight = _deprecate_sample_weight(sample_weight, sample_props)
         random_state = check_random_state(self.random_state)
         if check_input:
             X = check_array(X, dtype=DTYPE, accept_sparse="csc")

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -147,7 +147,15 @@ def safe_indexing(X, indices):
     indices : array-like, list
         Indices according to which X will be subsampled.
     """
-    if hasattr(X, "iloc"):
+    if X is None:
+        # fall-through
+        return None
+    elif isinstance(X, dict):
+        # slice per value
+        return dict([(k, safe_indexing(v, indices)) for k, v in
+                     X.items()])
+
+    elif hasattr(X, "iloc"):
         # Pandas Dataframes and Series
         try:
             return X.iloc[indices]

--- a/sklearn/utils/deprecations.py
+++ b/sklearn/utils/deprecations.py
@@ -1,0 +1,16 @@
+import warnings
+
+
+def _deprecate_sample_weight(sample_weight, sample_props):
+    if sample_props is None:
+        sample_props = {}
+    if "sample_weight" in sample_props.keys() and sample_weight is not None:
+        raise ValueError("sample_weight and sample_props['sample_weight'] passed to fit. "
+                         "Please specify only one of the two.")
+    if sample_weight is not None:
+        warnings.warn("The sample_weight parameter was removed by the "
+                      "sample_props parameter and will be removed in 0.19.",
+                      DeprecationWarning)
+        return sample_weight
+    else:
+        return sample_props.get('sample_weight', None)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -289,6 +289,29 @@ def check_estimator_sparse_data(name, Estimator):
         raise
 
 
+@ignore_warnings
+def check_sample_properties(name, Estimator):
+    # check that estimator takes sample_properties
+    # XXX check that warning is raised once we add the global
+    # warning level flags
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 3))
+    y = np.arange(10) % 3
+    y = multioutput_estimator_convert_y_2d(name, y)
+    estimator = Estimator()
+    set_fast_parameters(estimator)
+    set_random_state(estimator)
+    funcs = ["fit", "fit_predict", "fit_transform"]
+    attributes = {'sample_weights': np.ones(10)}
+
+    for func_name in funcs:
+        func = getattr(estimator, func_name, None)
+        if func is not None:
+            func(X, y, attributes=None)
+            func(X, y, attributes=attributes)
+            # XXX check for size of attributes?
+
+
 def check_dtype_object(name, Estimator):
     # check that estimators treat dtype object as numeric if possible
     rng = np.random.RandomState(0)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -302,14 +302,14 @@ def check_sample_properties(name, Estimator):
     set_fast_parameters(estimator)
     set_random_state(estimator)
     funcs = ["fit", "fit_predict", "fit_transform"]
-    attributes = {'sample_weights': np.ones(10)}
+    sample_props = {'sample_weights': np.ones(10)}
 
     for func_name in funcs:
         func = getattr(estimator, func_name, None)
         if func is not None:
-            func(X, y, attributes=None)
-            func(X, y, attributes=attributes)
-            # XXX check for size of attributes?
+            func(X, y, sample_props=None)
+            func(X, y, sample_props=sample_props)
+            # XXX check for size of sample_props?
 
 
 def check_dtype_object(name, Estimator):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1320,7 +1320,7 @@ def check_get_params_invariance(name, estimator):
         def __init__(self):
             pass
 
-        def fit(self, X, y):
+        def fit(self, X, y, sample_props=None):
             return self
 
     if name in ('FeatureUnion', 'Pipeline'):

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -37,18 +37,21 @@ class CheckingClassifier(BaseEstimator):
     This allows testing whether pipelines / cross-validation or metaestimators
     changed the input.
     """
-    def __init__(self, check_y=None,
-                 check_X=None, foo_param=0):
+    def __init__(self, check_y=None, check_X=None, check_attributes=None,
+                 foo_param=0):
         self.check_y = check_y
         self.check_X = check_X
+        self.check_attributes = check_attributes
         self.foo_param = foo_param
 
-    def fit(self, X, y):
+    def fit(self, X, y, attributes=None):
         assert_true(len(X) == len(y))
         if self.check_X is not None:
             assert_true(self.check_X(X))
         if self.check_y is not None:
             assert_true(self.check_y(y))
+        if self.check_attributes is not None:
+            assert_true(self.check_attributes(attributes))
 
         return self
 

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -38,10 +38,11 @@ class CheckingClassifier(BaseEstimator):
     changed the input.
     """
     def __init__(self, check_y=None, check_X=None, check_sample_props=None,
-                 foo_param=0):
+                 foo_param=0, check_all=None):
         self.check_y = check_y
         self.check_X = check_X
         self.check_sample_props = check_sample_props
+        self.check_all = check_all
         self.foo_param = foo_param
 
     def fit(self, X, y, sample_props=None):
@@ -52,6 +53,8 @@ class CheckingClassifier(BaseEstimator):
             assert_true(self.check_y(y))
         if self.check_sample_props is not None:
             assert_true(self.check_sample_props(sample_props))
+        if self.check_all is not None:
+            assert_true(self.check_all(X, y, sample_props))
 
         return self
 

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -37,21 +37,21 @@ class CheckingClassifier(BaseEstimator):
     This allows testing whether pipelines / cross-validation or metaestimators
     changed the input.
     """
-    def __init__(self, check_y=None, check_X=None, check_attributes=None,
+    def __init__(self, check_y=None, check_X=None, check_sample_props=None,
                  foo_param=0):
         self.check_y = check_y
         self.check_X = check_X
-        self.check_attributes = check_attributes
+        self.check_sample_props = check_sample_props
         self.foo_param = foo_param
 
-    def fit(self, X, y, attributes=None):
+    def fit(self, X, y, sample_props=None):
         assert_true(len(X) == len(y))
         if self.check_X is not None:
             assert_true(self.check_X(X))
         if self.check_y is not None:
             assert_true(self.check_y(y))
-        if self.check_attributes is not None:
-            assert_true(self.check_attributes(attributes))
+        if self.check_sample_props is not None:
+            assert_true(self.check_sample_props(sample_props))
 
         return self
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -11,7 +11,7 @@ from sklearn.utils.validation import check_X_y, check_array
 
 
 class BaseBadClassifier(BaseEstimator, ClassifierMixin):
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         return self
 
     def predict(self, X):
@@ -19,13 +19,13 @@ class BaseBadClassifier(BaseEstimator, ClassifierMixin):
 
 
 class NoCheckinPredict(BaseBadClassifier):
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         X, y = check_X_y(X, y)
         return self
 
 
 class NoSparseClassifier(BaseBadClassifier):
-    def fit(self, X, y):
+    def fit(self, X, y, sample_props=None):
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         if sp.issparse(X):
             raise ValueError("Nonsensical Error")

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -108,6 +108,13 @@ def _num_samples(x):
         # Don't get num_samples from an ensembles length!
         raise TypeError('Expected sequence or array-like, got '
                         'estimator %s' % x)
+    if isinstance(x, dict):
+        n_samples = [_num_samples(xx) for xx in x.values()]
+        unique_samples = np.unique(n_samples)
+        if len(unique_samples) > 1:
+            raise ValueError("Inconsistent number of samples in dictionary: %s"
+                             % (unique_samples))
+        return n_samples[0]
     if not hasattr(x, '__len__') and not hasattr(x, 'shape'):
         if hasattr(x, '__array__'):
             x = np.asarray(x)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -191,6 +191,7 @@ def indexable(*iterables):
         if sp.issparse(X):
             result.append(X.tocsr())
         elif hasattr(X, "__getitem__") or hasattr(X, "iloc"):
+            # np.array, tuple, list, dict or pandas data frame
             result.append(X)
         elif X is None:
             result.append(X)


### PR DESCRIPTION
Shot at #4497.

Todo:
- [ ] handling in pipeline
- [x] add to all estimators fit
- [ ] add to all estimators fit_transform
- [ ] add to all estimators fit_predict
- [x] deprecate sample weights
- [ ] don't use sample_weights in the code / examples
- [ ] deprecate slicing of fit_params?
- [x] testing that all estimators support it in fit
- [ ] testing that all estimators support it in fit_transform
- [ ] testing that all estimators support it in fit_predict
- [ ] test that sample_weights is deprecated everywhere
- [ ] test that sample_weights works the same way as sample_props['sample_weights']
- [ ] testing that estimators that don't support sample_props don't break
- [x] test that cross-validation and grid-search handle it appropriately.
- [ ] examples 
- [ ] docs
- [ ] change all docstrings

Issues
- the `len` of `dict`s behaves different from recarray and dataframes. Not supporting dicts might lead to a cleaner interface, but not sure.
- Just using the new interface in GridSearchCV and cross_val_score will break all 3rd party estimators. Should we inspect / try-except and raise a deprecation warning? Or just try/except and not raise a warning?
- It's unclear to me how to prevent typos in specifying sample_props column names / dictionary keys.
- should it be passed to the score function, too?
- should it be passed to partial_fit, too?
