### PR TITLE
[MRG + 1]  don't check that warning was raised when slicing pd dataframe

### DIFF
--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -6,7 +6,7 @@ from scipy.linalg import pinv2
 
 from sklearn.utils.testing import (assert_equal, assert_raises, assert_true,
                                    assert_almost_equal, assert_array_equal,
-                                   SkipTest, assert_warns)
+                                   SkipTest)
 
 from sklearn.utils import check_random_state
 from sklearn.utils import deprecated
@@ -17,7 +17,6 @@ from sklearn.utils import safe_indexing
 from sklearn.utils import shuffle
 from sklearn.utils.extmath import pinvh
 from sklearn.utils.mocking import MockDataFrame
-from sklearn.utils.validation import DataConversionWarning
 
 
 def test_make_rng():
@@ -172,8 +171,8 @@ def test_safe_indexing_pandas():
     # this happens in joblib memmapping
     X.setflags(write=False)
     X_df_readonly = pd.DataFrame(X)
-    X_df_ro_indexed = assert_warns(DataConversionWarning, safe_indexing,
-                                   X_df_readonly, inds)
+    with warnings.catch_warnings(record=True):
+        X_df_ro_indexed = safe_indexing(X_df_readonly, inds)
 
     assert_array_equal(np.array(X_df_ro_indexed), X_indexed)
 


### PR DESCRIPTION
Removes a silly test I added in #4678.
Whether a copy needs to be made or not depends on the pandas version. Version 0.12 and 0.13 apparently don't use cython here, and >=0.17 will have a fix by @ogrisel.
