### PR TITLE
[MRG + 1] Ensure dict_learning_online has at least one batch

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1096,11 +1096,6 @@ def check_estimators_overwrite_params(name, Estimator):
         # catch deprecation warnings
         estimator = Estimator()
 
-    if name == 'MiniBatchDictLearning' or name == 'MiniBatchSparsePCA':
-        # FIXME
-        # for MiniBatchDictLearning and MiniBatchSparsePCA
-        estimator.batch_size = 1
-
     set_fast_parameters(estimator)
     set_random_state(estimator)
 


### PR DESCRIPTION
If there are less samples than the batch_size set the number of batches to one. This came up during #4694. Is this a good fix? Are there more tests which special case this?
