### PR TITLE
[MRG] website: adding backlinks to docstrings

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -879,12 +879,10 @@ classes according to some similarity metric.
 
 .. currentmodule:: sklearn.metrics
 
+.. _adjusted_rand_score:
 
 Adjusted Rand index
 -------------------
-
-Presentation and usage
-~~~~~~~~~~~~~~~~~~~~~~
 
 Given the knowledge of the ground truth class assignments ``labels_true``
 and our clustering algorithm assignments of the same samples
@@ -1000,12 +998,10 @@ random labelings by defining the adjusted Rand index as follows:
  * `Wikipedia entry for the adjusted Rand index
    <http://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index>`_
 
+.. _mutual_info_score:
 
 Mutual Information based scores
 -------------------------------
-
-Presentation and usage
-~~~~~~~~~~~~~~~~~~~~~~
 
 Given the knowledge of the ground truth class assignments ``labels_true`` and
 our clustering algorithm assignments of the same samples ``labels_pred``, the
@@ -1168,11 +1164,10 @@ calculated using a similar form to that of the adjusted Rand index:
  * `Wikipedia entry for the Adjusted Mutual Information
    <http://en.wikipedia.org/wiki/Adjusted_Mutual_Information>`_
 
+.. _homogeneity_completeness:
+
 Homogeneity, completeness and V-measure
 ---------------------------------------
-
-Presentation and usage
-~~~~~~~~~~~~~~~~~~~~~~
 
 Given the knowledge of the ground truth class assignments of the samples,
 it is possible to define some intuitive metric using conditional entropy
@@ -1328,9 +1323,6 @@ mean of homogeneity and completeness**:
 
 Silhouette Coefficient
 ----------------------
-
-Presentation and usage
-~~~~~~~~~~~~~~~~~~~~~~
 
 If the ground truth labels are not known, evaluation must be performed using
 the model itself. The Silhouette Coefficient

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -248,6 +248,7 @@ paper. It is the same algorithm as in the R ``glasso`` package.
      graphical lasso" <http://biostatistics.oxfordjournals.org/content/9/3/432.short>`_,
      Biostatistics 9, pp 432, 2008
 
+.. _robust_covariance:
 
 Robust Covariance Estimation
 ============================

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -554,9 +554,9 @@ structure of the error covariance :math:`\Psi`:
 * :math:`\Psi = \sigma^2 \mathbf{I}`: This assumption leads to
   the probabilistic model of :class:`PCA`.
 
-* :math:`\Psi = diag(\psi_1, \psi_2, \dots, \psi_n)`: This model is called Factor
-  Analysis, a classical statistical model. The matrix W is sometimes called
-  the "factor loading matrix".
+* :math:`\Psi = diag(\psi_1, \psi_2, \dots, \psi_n)`: This model is called
+  :class:`FactorAnalysis`, a classical statistical model. The matrix W is
+  sometimes called the "factor loading matrix".
 
 Both model essentially estimate a Gaussian with a low-rank covariance matrix.
 Because both models are probabilistic they can be integrated in more complex

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -780,6 +780,8 @@ accessed via the ``feature_importances_`` property::
 
 .. currentmodule:: sklearn.ensemble.partial_dependence
 
+.. _partial_dependence:
+
 Partial dependence
 ..................
 
@@ -989,10 +991,10 @@ calculated as follows:
 ================  ==========    ==========      ==========
 classifier        class 1       class 2         class 3
 ================  ==========    ==========      ==========
-classifier 1	  w1 * 0.2     w1 * 0.5       w1 * 0.3
-classifier 2	  w2 * 0.6     w2 * 0.3       w2 * 0.1
+classifier 1	  w1 * 0.2      w1 * 0.5        w1 * 0.3
+classifier 2	  w2 * 0.6      w2 * 0.3        w2 * 0.1
 classifier 3      w3 * 0.3      w3 * 0.4        w3 * 0.3
-weighted average  0.37	        0.4            0.3
+weighted average  0.37	        0.4             0.3
 ================  ==========    ==========      ==========
 
 Here, the predicted class label is 2, since it has the
@@ -1031,7 +1033,7 @@ Vector Machine, a Decision Tree, and a K-nearest neighbor classifier::
     :scale: 75%
 
 Using the `VotingClassifier` with `GridSearch`
----------------------------------------------
+----------------------------------------------
 
 The `VotingClassifier` can also be used together with `GridSearch` in order
 to tune the hyperparameters of the individual estimators::

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -826,6 +826,7 @@ Some tips and tricks:
 Customizing the vectorizer can also be useful when handling Asian languages
 that do not use an explicit word separator such as whitespace.
 
+.. _image_feature_extraction:
 
 Image feature extraction
 ========================

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -13,6 +13,8 @@ improve estimators' accuracy scores or to boost their performance on very
 high-dimensional datasets.
 
 
+.. _variance_threshold:
+
 Removing features with low variance
 ===================================
 
@@ -44,6 +46,8 @@ so we can select using the threshold ``.8 * (1 - .8)``::
 
 As expected, ``VarianceThreshold`` has removed the first column,
 which has a probability :math:`p = 5/6 > .8` of containing a zero.
+
+.. _univariate_feature_selection:
 
 Univariate feature selection
 ============================
@@ -101,6 +105,7 @@ univariate p-values:
 
     :ref:`example_feature_selection_plot_feature_selection.py`
 
+.. _rfe:
 
 Recursive feature elimination
 =============================

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -72,6 +72,8 @@ evaluated and the best combination is retained.
       classifier (here a linear SVM trained with SGD with either elastic
       net or L2 penalty) using a :class:`pipeline.Pipeline` instance.
 
+.. _randomized_parameter_search:
+
 Randomized Parameter Optimization
 =================================
 While using a grid of parameter settings is currently the most widely used

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -43,6 +43,7 @@ kernel function or a precomputed kernel matrix.
 The number of samples used - which is also the dimensionality of the features computed -
 is given by the parameter ``n_components``.
 
+.. _rbf_kernel_approx:
 
 Radial Basis Function Kernel
 ----------------------------
@@ -98,6 +99,7 @@ use of larger feature spaces more efficient.
 
     * :ref:`example_plot_kernel_approximation.py`
 
+.. _additive_chi_kernel_approx:
 
 Additive Chi Squared Kernel
 ---------------------------
@@ -130,6 +132,7 @@ with the approximate feature map provided by :class:`RBFSampler` to yield an app
 feature map for the exponentiated chi squared kernel.
 See the [VZ2010]_ for details and [VVZ2010]_ for combination with the :class:`RBFSampler`.
 
+.. _skewed_chi_kernel_approx:
 
 Skewed Chi Squared Kernel
 -------------------------

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -266,6 +266,7 @@ They also tend to break when the problem is badly conditioned
 
   * :ref:`example_linear_model_plot_lasso_model_selection.py`
 
+.. _elastic_net:
 
 Elastic Net
 ===========
@@ -485,6 +486,9 @@ previously chosen dictionary elements.
  * `Matching pursuits with time-frequency dictionaries
    <http://blanche.polytechnique.fr/~mallat/papiers/MallatPursuit93.pdf>`_,
    S. G. Mallat, Z. Zhang,
+
+
+.. _bayesian_regression:
 
 Bayesian Regression
 ===================
@@ -751,6 +755,8 @@ while with ``loss="hinge"`` it fits a linear support vector machine (SVM).
 .. topic:: References
 
  * :ref:`sgd`
+
+.. _perceptron:
 
 Perceptron
 ==========

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -149,6 +149,7 @@ The overall complexity of Isomap is
      <http://www.sciencemag.org/content/290/5500/2319.full>`_
      Tenenbaum, J.B.; De Silva, V.; & Langford, J.C.  Science 290 (5500)
 
+.. _locally_linear_embedding:
 
 Locally Linear Embedding
 ========================

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -35,6 +35,8 @@ the kernel:
 
 .. currentmodule:: sklearn.metrics.pairwise
 
+.. _cosine_similarity:
+
 Cosine similarity
 -----------------
 :func:`cosine_similarity` computes the L2-normalized dot product of vectors.
@@ -63,6 +65,8 @@ is equivalent to :func:`linear_kernel`, only slower.)
       Information Retrieval. Cambridge University Press.
       http://nlp.stanford.edu/IR-book/html/htmledition/the-vector-space-model-for-scoring-1.html
 
+.. _linear_kernel:
+
 Linear kernel
 -------------
 The function :func:`linear_kernel` computes the linear kernel, that is, a
@@ -72,6 +76,8 @@ If ``x`` and ``y`` are column vectors, their linear kernel is:
 .. math::
 
     k(x, y) = x^\top y
+
+.. _polynomial_kernel:
 
 Polynomial kernel
 -----------------
@@ -94,6 +100,8 @@ where:
 
 If :math:`c_0 = 0` the kernel is said to be homogeneous.
 
+.. _sigmoid_kernel:
+
 Sigmoid kernel
 --------------
 The function :func:`sigmoid_kernel` computes the sigmoid kernel between two
@@ -111,6 +119,8 @@ where:
     * :math:`\gamma` is known as slope
     * :math:`c_0` is known as intercept
 
+.. _rbf_kernel:
+
 RBF kernel
 ----------
 The function :func:`rbf_kernel` computes the radial basis function (RBF) kernel
@@ -122,6 +132,8 @@ between two vectors. This kernel is defined as:
 
 where ``x`` and ``y`` are the input vectors. If :math:`\gamma = \sigma^{-2}`
 the kernel is known as the Gaussian kernel of variance :math:`\sigma^2`.
+
+.. _chi2_kernel:
 
 Chi-squared kernel
 ------------------

--- a/doc/modules/mixture.rst
+++ b/doc/modules/mixture.rst
@@ -133,6 +133,7 @@ parameters to maximize the likelihood of the data given those
 assignments. Repeating this process is guaranteed to always converge
 to a local optimum. 
 
+.. _vbgmm:
 
 VBGMM classifier: variational Gaussian mixtures
 ================================================

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -307,6 +307,7 @@ array of class labels, multilabel data is specified as an indicator matrix,
 in which cell ``[i, j]`` has value 1 if sample ``i`` has label ``j`` and value
 0 otherwise.
 
+.. _accuracy_score:
 
 Accuracy score
 --------------
@@ -352,6 +353,8 @@ In the multilabel case with binary label indicators: ::
     for an example of accuracy score usage using permutations of
     the dataset.
 
+.. _confusion_matrix:
+
 Confusion matrix
 ----------------
 
@@ -393,6 +396,7 @@ from the :ref:`example_model_selection_plot_confusion_matrix.py` example):
     for an example of using a confusion matrix to classify text
     documents.
 
+.. _classification_report:
 
 Classification report
 ----------------------
@@ -428,6 +432,8 @@ and inferred labels::
   * See :ref:`example_model_selection_grid_search_digits.py`
     for an example of classification report usage for
     grid search with nested cross-validation.
+
+.. _hamming_loss:
 
 Hamming loss
 -------------
@@ -469,6 +475,8 @@ In the multilabel case with binary label indicators: ::
     loss, is always between zero and one, inclusive; and predicting a proper subset
     or superset of the true labels will give a Hamming loss between
     zero and one, exclusive.
+
+.. _jaccard_similarity_score:
 
 Jaccard similarity coefficient score
 -------------------------------------
@@ -701,6 +709,7 @@ Then the metrics are defined as:
   ... # doctest: +ELLIPSIS
   (array([ 0.66...,  0.        ,  0.        ]), array([ 1.,  0.,  0.]), array([ 0.71...,  0.        ,  0.        ]), array([2, 2, 2]...))
 
+.. _hinge_loss:
 
 Hinge loss
 ----------
@@ -769,6 +778,7 @@ with a svm classifier in a multiclass problem::
   >>> hinge_loss(y_true, pred_decision, labels)  #doctest: +ELLIPSIS
   0.56...
 
+.. _log_loss:
 
 Log loss
 --------
@@ -821,6 +831,7 @@ method.
 The first ``[.9, .1]`` in ``y_pred`` denotes 90% probability that the first
 sample has label 0.  The log loss is non-negative.
 
+.. _matthews_corrcoef:
 
 Matthews correlation coefficient
 ---------------------------------
@@ -1002,6 +1013,8 @@ In multilabel learning, each sample can have any number of ground truth labels
 associated with it. The goal is to give high scores and better rank to
 the ground truth labels.
 
+.. _coverage_error:
+
 Coverage error
 --------------
 
@@ -1033,6 +1046,8 @@ Here is a small example of usage of this function::
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> coverage_error(y_true, y_score)
     2.5
+
+.. _label_ranking_average_precision:
 
 Label ranking average precision
 -------------------------------
@@ -1074,6 +1089,8 @@ Here is a small example of usage of this function::
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> label_ranking_average_precision_score(y_true, y_score) # doctest: +ELLIPSIS
     0.416...
+
+.. _label_ranking_loss:
 
 Ranking loss
 ------------
@@ -1144,6 +1161,7 @@ score puts more importance on well explaining the higher variance variables.
 for backward compatibility. This will be changed to ``uniform_average`` in the
 future.
 
+.. _explained_variance_score:
 
 Explained variance score
 -------------------------
@@ -1179,6 +1197,8 @@ function::
     ... # doctest: +ELLIPSIS
     0.990...
 
+.. _mean_absolute_error:
+
 Mean absolute error
 -------------------
 
@@ -1212,6 +1232,7 @@ Here is a small example of usage of the :func:`mean_absolute_error` function::
   ... # doctest: +ELLIPSIS
   0.849...
 
+.. _mean_squared_error:
 
 Mean squared error
 -------------------
@@ -1248,6 +1269,8 @@ function::
     for an example of mean squared error usage to
     evaluate gradient boosting regression.
 
+.. _median_absolute_error:
+
 Median absolute error
 ---------------------
 
@@ -1273,6 +1296,8 @@ function::
   >>> y_pred = [2.5, 0.0, 2, 8]
   >>> median_absolute_error(y_true, y_pred)
   0.5
+
+.. _r2_score:
 
 R² score, the coefficient of determination
 -------------------------------------------

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -105,6 +105,8 @@ format.
          [1, 1, 1, 1, 1],
          [1, 1, 1, 0, 0]])
 
+.. _ovr_classification:
+
 One-Vs-The-Rest
 ===============
 
@@ -155,6 +157,7 @@ To use this feature, feed the classifier an indicator matrix, in which cell
 
     * :ref:`example_plot_multilabel.py`
 
+.. _ovo_classification:
 
 One-Vs-One
 ==========
@@ -199,6 +202,7 @@ Below is an example of multiclass learning using OvO::
     .. [1] "Pattern Recognition and Machine Learning. Springer",
         Christopher M. Bishop, page 183, (First Edition)
 
+.. _ecoc:
 
 Error-Correcting Output-Codes
 =============================

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -74,6 +74,7 @@ it is known to be a bad estimator, so the probability outputs from
    <http://www.cs.unb.ca/profs/hzhang/publications/FLAIRS04ZhangH.pdf>`_
    Proc. FLAIRS.
 
+.. _gaussian_naive_bayes:
 
 Gaussian Naive Bayes
 --------------------

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -456,6 +456,7 @@ leaf nodes.  The level of this switch can be specified with the parameter
 
 ``leaf_size`` is not referenced for brute force queries.
 
+.. _nearest_centroid_classifier:
 
 Nearest Centroid Classifier
 ===========================
@@ -510,6 +511,8 @@ the model from 0.81 to 0.82.
 
   * :ref:`example_neighbors_plot_nearest_centroid.py`: an example of
     classification using nearest centroid with different shrink thresholds.
+
+.. _approximate_nearest_neighbors:
 
 Approximate Nearest Neighbors
 =============================

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -196,6 +196,7 @@ data.
     This is very useful for scaling the target / response variables used
     for regression.
 
+.. _kernel_centering:
 
 Centering kernel matrices
 -------------------------
@@ -206,6 +207,7 @@ a :class:`KernelCenterer` can transform the kernel matrix
 so that it contains inner products in the feature space
 defined by :math:`phi` followed by removal of the mean in that space.
 
+.. _preprocessing_normalization:
 
 Normalization
 =============
@@ -267,6 +269,7 @@ The normalizer instance can then be used on sample vectors as any transformer::
   efficient Cython routines. To avoid unnecessary memory copies, it is
   recommended to choose the CSR representation upstream.
 
+.. _preprocessing_binarization:
 
 Binarization
 ============

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,9 @@ Enhancements
      option, which has a simpler forumlar and interpretation.
      By Hanna Wallach and `Andreas Müller`_.
 
+   - Added backlinks from the API reference pages to the user guide. By
+     `Andreas Müller`_.
+
 Bug fixes
 .........
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -37,6 +37,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
     fitted already and all data is used for calibration. Note that
     data for fitting the classifier and for calibrating it must be disjpint.
 
+    Read more in the :ref:`User Guide <calibration>`.
+
     Parameters
     ----------
     base_estimator : instance BaseEstimator
@@ -477,6 +479,8 @@ class _SigmoidCalibration(BaseEstimator, RegressorMixin):
 
 def calibration_curve(y_true, y_prob, normalize=False, n_bins=5):
     """Compute true and predicted probabilities for a calibration curve.
+
+    Read more in the :ref:`User Guide <calibration>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/affinity_propagation_.py
+++ b/sklearn/cluster/affinity_propagation_.py
@@ -21,6 +21,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
                          return_n_iter=False):
     """Perform Affinity Propagation Clustering of data
 
+    Read more in the :ref:`User Guide <affinity_propagation>`.
+
     Parameters
     ----------
 
@@ -190,6 +192,8 @@ def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
 
 class AffinityPropagation(BaseEstimator, ClusterMixin):
     """Perform Affinity Propagation Clustering of data.
+
+    Read more in the :ref:`User Guide <affinity_propagation>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -182,6 +182,8 @@ class SpectralCoclustering(BaseSpectral):
 
     Supports sparse matrices, as long as they are nonnegative.
 
+    Read more in the :ref:`User Guide <spectral_coclustering>`.
+
     Parameters
     ----------
     n_clusters : integer, optional, default: 3
@@ -293,6 +295,8 @@ class SpectralBiclustering(BaseSpectral):
     belong to three biclusters, and each column will belong to two
     biclusters. The outer product of the corresponding row and column
     label vectors gives this checkerboard structure.
+
+    Read more in the :ref:`User Guide <spectral_biclustering>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -328,6 +328,8 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
     centroid closest to the new sample. This is done recursively till it
     ends up at the subcluster of the leaf of the tree has the closest centroid.
 
+    Read more in the :ref:`User Guide <birch>`.
+
     Parameters
     ----------
     threshold : float, default 0.5

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -26,6 +26,8 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
            random_state=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
+    Read more in the :ref:`User Guide <dbscan>`.
+
     Parameters
     ----------
     X : array or sparse (CSR) matrix of shape (n_samples, n_features), or \
@@ -147,6 +149,8 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
     Finds core samples of high density and expands clusters from them.
     Good for data which contains clusters of similar density.
+
+    Read more in the :ref:`User Guide <dbscan>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -98,6 +98,8 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
     This is the structured version, that takes into account some topological
     structure between samples.
 
+    Read more in the :ref:`User Guide <hierarchical_clustering>`.
+
     Parameters
     ----------
     X : array, shape (n_samples, n_features)
@@ -310,6 +312,8 @@ def linkage_tree(X, connectivity=None, n_components=None,
 
     This is the structured version, that takes into account some topological
     structure between samples.
+
+    Read more in the :ref:`User Guide <hierarchical_clustering>`.
 
     Parameters
     ----------
@@ -607,6 +611,8 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
     Recursively merges the pair of clusters that minimally increases
     a given linkage distance.
 
+    Read more in the :ref:`User Guide <hierarchical_clustering>`.
+
     Parameters
     ----------
     n_clusters : int, default=2
@@ -775,6 +781,8 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
 
     Similar to AgglomerativeClustering, but recursively merges features
     instead of samples.
+
+    Read more in the :ref:`User Guide <hierarchical_clustering>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -155,6 +155,8 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
             return_n_iter=False):
     """K-means clustering algorithm.
 
+    Read more in the :ref:`User Guide <k_means>`.
+
     Parameters
     ----------
     X : array-like or sparse matrix, shape (n_samples, n_features)
@@ -627,6 +629,8 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
 
 class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
     """K-Means clustering
+
+    Read more in the :ref:`User Guide <k_means>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -71,6 +71,8 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                max_iterations=None):
     """Perform mean shift clustering of data using a flat kernel.
 
+    Read more in the :ref:`User Guide <mean_shift>`.
+
     Parameters
     ----------
 
@@ -259,6 +261,8 @@ class MeanShift(BaseEstimator, ClusterMixin):
     eliminate near-duplicates to form the final set of centroids.
 
     Seeding is performed using a binning technique for scalability.
+
+    Read more in the :ref:`User Guide <mean_shift>`.
 
     Parameters
     ----------

--- a/sklearn/cluster/spectral.py
+++ b/sklearn/cluster/spectral.py
@@ -170,6 +170,8 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
     If affinity is the adjacency matrix of a graph, this method can be
     used to find normalized graph cuts.
 
+    Read more in the :ref:`User Guide <spectral_clustering>`.
+
     Parameters
     -----------
     affinity : array-like or sparse matrix, shape: (n_samples, n_samples)
@@ -286,6 +288,8 @@ class SpectralClustering(BaseEstimator, ClusterMixin):
 
     Alternatively, using ``precomputed``, a user-provided affinity
     matrix can be used.
+
+    Read more in the :ref:`User Guide <spectral_clustering>`.
 
     Parameters
     -----------

--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -85,6 +85,8 @@ def empirical_covariance(X, assume_centered=False):
 class EmpiricalCovariance(BaseEstimator):
     """Maximum likelihood covariance estimator
 
+    Read more in the :ref:`User Guide <covariance>`.
+
     Parameters
     ----------
     store_precision : bool

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -84,6 +84,8 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
                 return_n_iter=False):
     """l1-penalized covariance estimator
 
+    Read more in the :ref:`User Guide <sparse_inverse_covariance>`.
+
     Parameters
     ----------
     emp_cov : 2D ndarray, shape (n_features, n_features)
@@ -267,6 +269,8 @@ def graph_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
 class GraphLasso(EmpiricalCovariance):
     """Sparse inverse covariance estimation with an l1-penalized estimator.
 
+    Read more in the :ref:`User Guide <sparse_inverse_covariance>`.
+
     Parameters
     ----------
     alpha : positive float, default 0.01
@@ -348,6 +352,8 @@ class GraphLasso(EmpiricalCovariance):
 def graph_lasso_path(X, alphas, cov_init=None, X_test=None, mode='cd',
                      tol=1e-4, enet_tol=1e-4, max_iter=100, verbose=False):
     """l1-penalized covariance estimator along a path of decreasing alphas
+
+    Read more in the :ref:`User Guide <sparse_inverse_covariance>`.
 
     Parameters
     ----------
@@ -440,6 +446,8 @@ def graph_lasso_path(X, alphas, cov_init=None, X_test=None, mode='cd',
 class GraphLassoCV(GraphLasso):
     """Sparse inverse covariance w/ cross-validated choice of the l1 penalty
 
+    Read more in the :ref:`User Guide <sparse_inverse_covariance>`.
+
     Parameters
     ----------
     alphas : integer, or list positive float, optional
@@ -487,7 +495,6 @@ class GraphLassoCV(GraphLasso):
         Useful when working with data whose mean is almost, but not exactly
         zero.
         If False, data are centered before computation.
-
 
     Attributes
     ----------

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -112,6 +112,8 @@ class OutlierDetectionMixin(object):
 class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
     """An object for detecting outliers in a Gaussian distributed dataset.
 
+    Read more in the :ref:`User Guide <outlier_detection>`.
+
     Attributes
     ----------
     `contamination` : float, 0. < contamination < 0.5

--- a/sklearn/covariance/robust_covariance.py
+++ b/sklearn/covariance/robust_covariance.py
@@ -298,6 +298,8 @@ def fast_mcd(X, support_fraction=None,
              random_state=None):
     """Estimates the Minimum Covariance Determinant matrix.
 
+    Read more in the :ref:`User Guide <robust_covariance>`.
+
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)
@@ -510,6 +512,8 @@ class MinCovDet(EmpiricalCovariance):
     likely to fail in such a case).
     One should consider projection pursuit methods to deal with multi-modal
     datasets.
+
+    Read more in the :ref:`User Guide <robust_covariance>`.
 
     Parameters
     ----------

--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -27,6 +27,8 @@ from ..utils import check_array
 def shrunk_covariance(emp_cov, shrinkage=0.1):
     """Calculates a covariance matrix shrunk on the diagonal
 
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
+
     Parameters
     ----------
     emp_cov : array-like, shape (n_features, n_features)
@@ -63,6 +65,8 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
 
 class ShrunkCovariance(EmpiricalCovariance):
     """Covariance estimator with shrinkage
+
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
 
     Parameters
     ----------
@@ -145,6 +149,8 @@ class ShrunkCovariance(EmpiricalCovariance):
 
 def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     """Estimates the shrunk Ledoit-Wolf covariance matrix.
+
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
 
     Parameters
     ----------
@@ -235,6 +241,8 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
 def ledoit_wolf(X, assume_centered=False, block_size=1000):
     """Estimates the shrunk Ledoit-Wolf covariance matrix.
 
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
+
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)
@@ -303,6 +311,8 @@ class LedoitWolf(EmpiricalCovariance):
     described in "A Well-Conditioned Estimator for Large-Dimensional
     Covariance Matrices", Ledoit and Wolf, Journal of Multivariate
     Analysis, Volume 88, Issue 2, February 2004, pages 365-411.
+
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
 
     Parameters
     ----------
@@ -461,6 +471,8 @@ def oas(X, assume_centered=False):
 
 class OAS(EmpiricalCovariance):
     """Oracle Approximating Shrinkage Estimator
+
+    Read more in the :ref:`User Guide <shrunk_covariance>`.
 
     OAS is a particular form of shrinkage described in
     "Shrinkage Algorithms for MMSE Covariance Estimation"

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -8,6 +8,8 @@ class CCA(_PLS):
 
     CCA inherits from PLS with mode="B" and deflation_mode="canonical".
 
+    Read more in the :ref:`User Guide <cross_decomposition>`.
+
     Parameters
     ----------
     n_components : int, (default 2).

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -448,6 +448,8 @@ class PLSRegression(_PLS):
     This class inherits from _PLS with mode="A", deflation_mode="regression",
     norm_y_weights=False and algorithm="nipals".
 
+    Read more in the :ref:`User Guide <cross_decomposition>`.
+
     Parameters
     ----------
     n_components : int, (default 2)
@@ -569,6 +571,8 @@ class PLSCanonical(_PLS):
     norm_y_weights=True and algorithm="nipals", but svd should provide similar
     results up to numerical errors.
 
+    Read more in the :ref:`User Guide <cross_decomposition>`.
+
     Parameters
     ----------
     scale : boolean, scale data? (default True)
@@ -684,6 +688,8 @@ class PLSSVD(BaseEstimator, TransformerMixin):
 
     Simply perform a svd on the crosscovariance matrix: X'Y
     There are no iterative deflation here.
+
+    Read more in the :ref:`User Guide <cross_decomposition>`.
 
     Parameters
     ----------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -107,6 +107,8 @@ class LeaveOneOut(_PartitionIterator):
     For large datasets one should favor KFold, StratifiedKFold or
     ShuffleSplit.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     n : int
@@ -165,6 +167,8 @@ class LeavePOut(_PartitionIterator):
     Due to the high number of iterations which grows combinatorically with the
     number of samples this cross validation method can be very costly. For
     large datasets one should favor KFold, StratifiedKFold or ShuffleSplit.
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -254,6 +258,8 @@ class KFold(_BaseKFold):
     Each fold is then used a validation set once while the k - 1 remaining
     fold form the training set.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     n : int
@@ -340,6 +346,8 @@ class StratifiedKFold(_BaseKFold):
     This cross-validation object is a variation of KFold that
     returns stratified folds. The folds are made by preserving
     the percentage of samples for each class.
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -455,6 +463,8 @@ class LeaveOneLabelOut(_PartitionIterator):
     For instance the labels could be the year of collection of the samples
     and thus allow for cross-validation against time-based splits.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     labels : array-like of int with shape (n_samples,)
@@ -524,6 +534,8 @@ class LeavePLabelOut(_PartitionIterator):
     the former builds the test sets with all the samples assigned to
     ``p`` different values of the labels while the latter uses samples
     all assigned the same labels.
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -623,6 +635,8 @@ class ShuffleSplit(BaseShuffleSplit):
     Note: contrary to other cross-validation strategies, random splits
     do not guarantee that all folds will be different, although this is
     still very likely for sizeable datasets.
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -774,6 +788,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     do not guarantee that all folds will be different, although this is
     still very likely for sizeable datasets.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     y : array, [n_samples]
@@ -898,6 +914,8 @@ class PredefinedSplit(_PartitionIterator):
     scheme. Each sample can be assigned to at most one test set fold, as
     specified by the user through the ``test_fold`` parameter.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     test_fold : "array-like, shape (n_samples,)
@@ -958,6 +976,8 @@ def _index_param_value(X, v, indices):
 def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -1034,6 +1054,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
 def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
     """Fit estimator and predict values for a given dataset split.
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     estimator : estimator object implementing 'fit' and 'predict'
@@ -1109,6 +1131,8 @@ def _check_is_partition(locs, n):
 def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
                     verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Evaluate a score by cross-validation
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------
@@ -1432,6 +1456,8 @@ def permutation_test_score(estimator, X, y, cv=None,
                            random_state=0, verbose=0, scoring=None):
     """Evaluate the significance of a cross-validated score with permutations
 
+    Read more in the :ref:`User Guide <cross_validation>`.
+
     Parameters
     ----------
     estimator : estimator object implementing 'fit'
@@ -1524,6 +1550,8 @@ def train_test_split(*arrays, **options):
     ``next(iter(ShuffleSplit(n_samples)))`` and application to input
     data into a single call for splitting (and optionally subsampling)
     data in a oneliner.
+
+    Read more in the :ref:`User Guide <cross_validation>`.
 
     Parameters
     ----------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -129,6 +129,8 @@ def load_files(container_path, description=None, categories=None,
     Similar feature extractors should be built for other kind of unstructured
     data input such as images, audio, video, ...
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Parameters
     ----------
     container_path : string or unicode
@@ -241,6 +243,8 @@ def load_iris():
     Features            real, positive
     =================   ==============
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Returns
     -------
     data : Bunch
@@ -299,6 +303,7 @@ def load_digits(n_class=10):
     Features             integers 0-16
     =================   ==============
 
+    Read more in the :ref:`User Guide <datasets>`.
 
     Parameters
     ----------
@@ -358,6 +363,8 @@ def load_diabetes():
     Features            real, -.2 < x < .2
     Targets             integer 25 - 346
     ==============      ==================
+
+    Read more in the :ref:`User Guide <datasets>`.
 
     Returns
     -------

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -50,6 +50,8 @@ MODULE_DOCS = __doc__
 def fetch_california_housing(data_home=None, download_if_missing=True):
     """Loader for the California housing dataset from StatLib.
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Parameters
     ----------
     data_home : optional, default: None

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -45,6 +45,8 @@ def fetch_covtype(data_home=None, download_if_missing=True,
                   random_state=None, shuffle=False):
     """Load the covertype dataset, downloading it if necessary.
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Parameters
     ----------
     data_home : string, optional

--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -402,6 +402,8 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
     The original images are 250 x 250 pixels, but the default slice and resize
     arguments reduce them to 62 x 74.
 
+    Read more in the :ref:`User Guide <labeled_faces_in_the_wild>`.
+
     Parameters
     ----------
     subset : optional, default: 'train'

--- a/sklearn/datasets/mlcomp.py
+++ b/sklearn/datasets/mlcomp.py
@@ -36,6 +36,8 @@ def load_mlcomp(name_or_id, set_="raw", mlcomp_root=None, **kwargs):
 
     **kwargs : domain specific kwargs to be passed to the dataset loader.
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Returns
     -------
 

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -54,6 +54,8 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
                          download_if_missing=True):
     """Loader for the Olivetti faces data-set from AT&T.
 
+    Read more in the :ref:`User Guide <olivetti_faces>`.
+
     Parameters
     ----------
     data_home : optional, default: None
@@ -83,7 +85,8 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
         Each row is a face image corresponding to one of the 40 subjects of the dataset.
 
     target : numpy array of shape (400, )
-        Labels associated to each face image. Those labels are ranging from 0-39 and correspond to the Subject IDs.
+        Labels associated to each face image. Those labels are ranging from
+        0-39 and correspond to the Subject IDs.
 
     DESCR : string
         Description of the modified Olivetti Faces Dataset.

--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -52,6 +52,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     features, "redundant" linear combinations of these, "repeated" duplicates
     of sampled features, and arbitrary noise for and remaining features.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -263,6 +265,8 @@ def make_multilabel_classification(n_samples=100, n_features=20, n_classes=5,
     n is never zero or more than `n_classes`, and that the document length
     is never zero. Likewise, we reject classes which have already been chosen.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -404,6 +408,8 @@ def make_hastie_10_2(n_samples=12000, random_state=None):
 
       y[i] = 1 if np.sum(X[i] ** 2) > 9.34 else -1
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=12000)
@@ -456,6 +462,8 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
     regression model with `n_informative` nonzero regressors to the previously
     generated input and some gaussian centered noise with some adjustable
     scale.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -570,6 +578,8 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
     A simple toy dataset to visualize clustering and classification
     algorithms.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -635,6 +645,8 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
     noise : double or None (default=None)
         Standard deviation of Gaussian noise added to the data.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Returns
     -------
     X : array of shape [n_samples, 2]
@@ -671,6 +683,8 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 def make_blobs(n_samples=100, n_features=2, centers=3, cluster_std=1.0,
                center_box=(-10.0, 10.0), shuffle=True, random_state=None):
     """Generate isotropic Gaussian blobs for clustering.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -773,6 +787,8 @@ def make_friedman1(n_samples=100, n_features=10, noise=0.0, random_state=None):
 
     The number of features has to be >= 5.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -835,6 +851,8 @@ def make_friedman2(n_samples=100, noise=0.0, random_state=None):
 
         y(X) = (X[:, 0] ** 2 + (X[:, 1] * X[:, 2] \
  - 1 / (X[:, 1] * X[:, 3])) ** 2) ** 0.5 + noise * N(0, 1).
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -899,6 +917,8 @@ def make_friedman3(n_samples=100, noise=0.0, random_state=None):
 
         y(X) = arctan((X[:, 1] * X[:, 2] - 1 / (X[:, 1] * X[:, 3])) \
 / X[:, 0]) + noise * N(0, 1).
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -967,6 +987,8 @@ def make_low_rank_matrix(n_samples=100, n_features=100, effective_rank=10,
      - gray level pictures of faces
      - TF-IDF vectors of text documents crawled from the web
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -1020,6 +1042,8 @@ def make_sparse_coded_signal(n_samples, n_components, n_features,
     Returns a matrix Y = DX, such as D is (n_features, n_components),
     X is (n_components, n_samples) and each column of X has exactly
     n_nonzero_coefs non-zero elements.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -1082,6 +1106,8 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
     Only the first 4 features are informative. The remaining features are
     useless.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -1124,6 +1150,8 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, random_state=None):
 def make_spd_matrix(n_dim, random_state=None):
     """Generate a random symmetric, positive-definite matrix.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_dim : int
@@ -1157,6 +1185,8 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
                            smallest_coef=.1, largest_coef=.9,
                            random_state=None):
     """Generate a sparse symmetric definite positive matrix.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -1228,6 +1258,8 @@ def make_sparse_spd_matrix(dim=1, alpha=0.95, norm_diag=False,
 def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
     """Generate a swiss roll dataset.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -1279,6 +1311,8 @@ def make_swiss_roll(n_samples=100, noise=0.0, random_state=None):
 def make_s_curve(n_samples=100, noise=0.0, random_state=None):
     """Generate an S curve dataset.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     n_samples : int, optional (default=100)
@@ -1326,6 +1360,8 @@ def make_gaussian_quantiles(mean=None, cov=1., n_samples=100,
     standard normal distribution and defining classes separated by nested
     concentric multi-dimensional spheres such that roughly equal numbers of
     samples are in each class (quantiles of the :math:`\chi^2` distribution).
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------
@@ -1416,6 +1452,8 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
     """Generate an array with constant block diagonal structure for
     biclustering.
 
+    Read more in the :ref:`User Guide <sample_generators>`.
+
     Parameters
     ----------
     shape : iterable (n_rows, n_cols)
@@ -1503,8 +1541,11 @@ def make_biclusters(shape, n_clusters, noise=0.0, minval=10,
 
 def make_checkerboard(shape, n_clusters, noise=0.0, minval=10,
                       maxval=100, shuffle=True, random_state=None):
+
     """Generate an array with block checkerboard structure for
     biclustering.
+
+    Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
     ----------

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -134,6 +134,8 @@ def fetch_species_distributions(data_home=None,
                                 download_if_missing=True):
     """Loader for species distribution dataset from Phillips et. al. (2006)
 
+    Read more in the :ref:`User Guide <datasets>`.
+
     Parameters
     ----------
     data_home : optional, default: None

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -156,6 +156,8 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
                        download_if_missing=True):
     """Load the filenames and data from the 20 newsgroups dataset.
 
+    Read more in the :ref:`User Guide <20newsgroups>`.
+
     Parameters
     ----------
     subset: 'train' or 'test', 'all', optional
@@ -286,6 +288,8 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None):
     default settings for `sklearn.feature_extraction.text.Vectorizer`. For more
     advanced usage (stopword filtering, n-gram extraction, etc.), combine
     fetch_20newsgroups with a custom `Vectorizer` or `CountVectorizer`.
+
+    Read more in the :ref:`User Guide <20newsgroups>`.
 
     Parameters
     ----------

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -150,6 +150,8 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
 
         X ~= code * dictionary
 
+    Read more in the :ref:`User Guide <SparseCoder>`.
+
     Parameters
     ----------
     X: array of shape (n_samples, n_features)
@@ -345,6 +347,8 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
 
     where V is the dictionary and U is the sparse code.
 
+    Read more in the :ref:`User Guide <DictionaryLearning>`.
+
     Parameters
     ----------
     X: array of shape (n_samples, n_features)
@@ -517,6 +521,8 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     where V is the dictionary and U is the sparse code. This is
     accomplished by repeatedly iterating over mini-batches by slicing
     the input data.
+
+    Read more in the :ref:`User Guide <DictionaryLearning>`.
 
     Parameters
     ----------
@@ -787,6 +793,8 @@ class SparseCoder(BaseEstimator, SparseCodingMixin):
 
         X ~= code * dictionary
 
+    Read more in the :ref:`User Guide <SparseCoder>`.
+
     Parameters
     ----------
     dictionary : array, [n_components, n_features]
@@ -870,6 +878,8 @@ class DictionaryLearning(BaseEstimator, SparseCodingMixin):
         (U^*,V^*) = argmin 0.5 || Y - U V ||_2^2 + alpha * || U ||_1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
+
+    Read more in the :ref:`User Guide <DictionaryLearning>`.
 
     Parameters
     ----------
@@ -1028,6 +1038,8 @@ class MiniBatchDictionaryLearning(BaseEstimator, SparseCodingMixin):
        (U^*,V^*) = argmin 0.5 || Y - U V ||_2^2 + alpha * || U ||_1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
+
+    Read more in the :ref:`User Guide <DictionaryLearning>`.
 
     Parameters
     ----------

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -52,6 +52,8 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
     `loading` matrix, the transformation of the latent variables to the
     observed ones, using expectation-maximization (EM).
 
+    Read more in the :ref:`User Guide <FA>`.
+
     Parameters
     ----------
     n_components : int | None
@@ -316,7 +318,7 @@ class FactorAnalysis(BaseEstimator, TransformerMixin):
             Log-likelihood of each sample under the current model
         """
         check_is_fitted(self, 'components_')
-        
+
         Xr = X - self.mean_
         precision = self.get_precision()
         n_features = X.shape[1]

--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -149,6 +149,8 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
             return_n_iter=False):
     """Perform Fast Independent Component Analysis.
 
+    Read more in the :ref:`User Guide <ICA>`.
+
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)
@@ -372,6 +374,8 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
 
 class FastICA(BaseEstimator, TransformerMixin):
     """FastICA: a fast algorithm for Independent Component Analysis.
+
+    Read more in the :ref:`User Guide <ICA>`.
 
     Parameters
     ----------

--- a/sklearn/decomposition/incremental_pca.py
+++ b/sklearn/decomposition/incremental_pca.py
@@ -31,6 +31,8 @@ class IncrementalPCA(_BasePCA):
     computations to get the principal components, versus 1 large SVD of
     complexity ``O(n_samples * n_features ** 2)`` for PCA.
 
+    Read more in the :ref:`User Guide <IncrementalPCA>`.
+
     Parameters
     ----------
     n_components : int or None, (default=None)

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -19,6 +19,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
     Non-linear dimensionality reduction through the use of kernels (see
     :ref:`metrics`).
 
+    Read more in the :ref:`User Guide <kernel_PCA>`.
+
     Parameters
     ----------
     n_components: int or None

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -95,7 +95,7 @@ def _initialize_nmf(X, n_components, variant=None, eps=1e-6,
 
     References
     ----------
-    C. Boutsidis, E. Gallopoulos: SVD based initialization: A head start for 
+    C. Boutsidis, E. Gallopoulos: SVD based initialization: A head start for
     nonnegative matrix factorization - Pattern Recognition, 2008
 
     http://tinyurl.com/nndsvd
@@ -256,6 +256,8 @@ def _nls_subproblem(V, W, H, tol, max_iter, sigma=0.01, beta=0.1):
 
 class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
     """Non-Negative matrix factorization by Projected Gradient (NMF)
+
+    Read more in the :ref:`User Guide <NMF>`.
 
     Parameters
     ----------

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -110,6 +110,8 @@ class PCA(BaseEstimator, TransformerMixin):
     The time complexity of this implementation is ``O(n ** 3)`` assuming
     n ~ n_samples ~ n_features.
 
+    Read more in the :ref:`User Guide <PCA>`.
+
     Parameters
     ----------
     n_components : int, None or string
@@ -415,7 +417,6 @@ class PCA(BaseEstimator, TransformerMixin):
         else:
             return fast_dot(X, self.components_) + self.mean_
 
-
     def score_samples(self, X):
         """Return the log-likelihood of each sample
 
@@ -471,6 +472,8 @@ class RandomizedPCA(BaseEstimator, TransformerMixin):
     Linear dimensionality reduction using approximated Singular Value
     Decomposition of the data and keeping only the most significant
     singular vectors to project the data to a lower dimensional space.
+
+    Read more in the :ref:`User Guide <RandomizedPCA>`.
 
     Parameters
     ----------

--- a/sklearn/decomposition/sparse_pca.py
+++ b/sklearn/decomposition/sparse_pca.py
@@ -18,6 +18,8 @@ class SparsePCA(BaseEstimator, TransformerMixin):
     the data.  The amount of sparseness is controllable by the coefficient
     of the L1 penalty, given by the parameter alpha.
 
+    Read more in the :ref:`User Guide <SparsePCA>`.
+
     Parameters
     ----------
     n_components : int,
@@ -172,6 +174,8 @@ class MiniBatchSparsePCA(SparsePCA):
     the data.  The amount of sparseness is controllable by the coefficient
     of the L1 penalty, given by the parameter alpha.
 
+    Read more in the :ref:`User Guide <SparsePCA>`.
+
     Parameters
     ----------
     n_components : int,
@@ -275,7 +279,6 @@ class MiniBatchSparsePCA(SparsePCA):
             shuffle=self.shuffle,
             n_jobs=self.n_jobs, method=self.method,
             random_state=random_state,
-            return_n_iter=True
-            )
+            return_n_iter=True)
         self.components_ = Vt.T
         return self

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -38,6 +38,8 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     a "naive" algorithm that uses ARPACK as an eigensolver on (X * X.T) or
     (X.T * X), whichever is more efficient.
 
+    Read more in the :ref:`User Guide <LSA>`.
+
     Parameters
     ----------
     n_components : int, default = 2

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -24,6 +24,8 @@ class DummyClassifier(BaseEstimator, ClassifierMixin):
     This classifier is useful as a simple baseline to compare with other
     (real) classifiers. Do not use it for real problems.
 
+    Read more in the :ref:`User Guide <dummy_estimators>`.
+
     Parameters
     ----------
     strategy : str
@@ -322,6 +324,8 @@ class DummyRegressor(BaseEstimator, RegressorMixin):
 
     This regressor is useful as a simple baseline to compare with other
     (real) regressors. Do not use it for real problems.
+
+    Read more in the :ref:`User Guide <dummy_estimators>`.
 
     Parameters
     ----------

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -369,6 +369,8 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
     on subsets of both samples and features, then the method is known as
     Random Patches [4]_.
 
+    Read more in the :ref:`User Guide <bagging>`.
+
     Parameters
     ----------
     base_estimator : object or None, optional (default=None)
@@ -731,6 +733,8 @@ class BaggingRegressor(BaseBagging, RegressorMixin):
     is known as Random Subspaces [3]_. Finally, when base estimators are built
     on subsets of both samples and features, then the method is known as
     Random Patches [4]_.
+
+    Read more in the :ref:`User Guide <bagging>`.
 
     Parameters
     ----------

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -693,6 +693,8 @@ class RandomForestClassifier(ForestClassifier):
     classifiers on various sub-samples of the dataset and use averaging to
     improve the predictive accuracy and control over-fitting.
 
+    Read more in the :ref:`User Guide <forest>`.
+
     Parameters
     ----------
     n_estimators : integer, optional (default=10)
@@ -880,6 +882,8 @@ class RandomForestRegressor(ForestRegressor):
     decision trees on various sub-samples of the dataset and use averaging
     to improve the predictive accuracy and control over-fitting.
 
+    Read more in the :ref:`User Guide <forest>`.
+
     Parameters
     ----------
     n_estimators : integer, optional (default=10)
@@ -1035,6 +1039,8 @@ class ExtraTreesClassifier(ForestClassifier):
     randomized decision trees (a.k.a. extra-trees) on various sub-samples
     of the dataset and use averaging to improve the predictive accuracy
     and control over-fitting.
+
+    Read more in the :ref:`User Guide <forest>`.
 
     Parameters
     ----------
@@ -1226,6 +1232,8 @@ class ExtraTreesRegressor(ForestRegressor):
     of the dataset and use averaging to improve the predictive accuracy
     and control over-fitting.
 
+    Read more in the :ref:`User Guide <forest>`.
+
     Parameters
     ----------
     n_estimators : integer, optional (default=10)
@@ -1389,6 +1397,8 @@ class RandomTreesEmbedding(BaseForest):
     The dimensionality of the resulting representation is
     ``n_out <= n_estimators * max_leaf_nodes``. If ``max_leaf_nodes == None``,
     the number of leaf nodes is at most ``n_estimators * 2 ** max_depth``.
+
+    Read more in the :ref:`User Guide <random_trees_embedding>`.
 
     Parameters
     ----------

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1195,6 +1195,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
     binomial or multinomial deviance loss function. Binary classification
     is a special case where only a single regression tree is induced.
 
+    Read more in the :ref:`User Guide <gradient_boosting>`.
+
     Parameters
     ----------
     loss : {'deviance', 'exponential'}, optional (default='deviance')
@@ -1514,6 +1516,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
     it allows for the optimization of arbitrary differentiable loss functions.
     In each stage a regression tree is fit on the negative gradient of the
     given loss function.
+
+    Read more in the :ref:`User Guide <gradient_boosting>`.
 
     Parameters
     ----------

--- a/sklearn/ensemble/partial_dependence.py
+++ b/sklearn/ensemble/partial_dependence.py
@@ -76,6 +76,8 @@ def partial_dependence(gbrt, target_variables, grid=None, X=None,
     of the ``target_variables`` and the function represented
     by the ``gbrt``.
 
+    Read more in the :ref:`User Guide <partial_dependence>`.
+
     Parameters
     ----------
     gbrt : BaseGradientBoosting
@@ -172,6 +174,8 @@ def plot_partial_dependence(gbrt, X, features, feature_names=None,
     The ``len(features)`` plots are arranged in a grid with ``n_cols``
     columns. Two-way partial dependence plots are plotted as contour
     plots.
+
+    Read more in the :ref:`User Guide <partial_dependence>`.
 
     Parameters
     ----------

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -24,6 +24,8 @@ from ..externals import six
 class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
     """Soft Voting/Majority Rule classifier for unfitted estimators.
 
+    Read more in the :ref:`User Guide <voting_classifier>`.
+
     Parameters
     ----------
     estimators : list of (string, estimator) tuples
@@ -143,8 +145,7 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         else:  # 'hard' voting
             predictions = self._predict(X)
-            maj = np.apply_along_axis(
-                                      lambda x:
+            maj = np.apply_along_axis(lambda x:
                                       np.argmax(np.bincount(x,
                                                 weights=self.weights)),
                                       axis=1,

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -39,9 +39,7 @@ from ..tree.tree import BaseDecisionTree
 from ..tree._tree import DTYPE
 from ..utils import check_array, check_X_y, check_random_state
 from ..metrics import accuracy_score, r2_score
-from sklearn.utils.validation import (
-        has_fit_parameter,
-        check_is_fitted)
+from sklearn.utils.validation import has_fit_parameter, check_is_fitted
 
 __all__ = [
     'AdaBoostClassifier',
@@ -271,6 +269,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
 
         return X
 
+
 def _samme_proba(estimator, n_classes, X):
     """Calculate algorithm 4, step 2, equation c) of Zhu et al [1].
 
@@ -301,6 +300,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
     more on difficult cases.
 
     This class implements the algorithm known as AdaBoost-SAMME [2].
+
+    Read more in the :ref:`User Guide <adaboost>`.
 
     Parameters
     ----------
@@ -750,7 +751,7 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
             outputs is the same of that of the `classes_` attribute.
         """
         check_is_fitted(self, "n_classes_")
-        
+
         n_classes = self.n_classes_
         X = self._validate_X_predict(X)
 
@@ -855,6 +856,8 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
     subsequent regressors focus more on difficult cases.
 
     This class implements the algorithm known as AdaBoost.R2 [2].
+
+    Read more in the :ref:`User Guide <adaboost>`.
 
     Parameters
     ----------

--- a/sklearn/feature_extraction/dict_vectorizer.py
+++ b/sklearn/feature_extraction/dict_vectorizer.py
@@ -40,6 +40,8 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
     Features that do not occur in a sample (mapping) will have a zero value
     in the resulting array/matrix.
 
+    Read more in the :ref:`User Guide <dict_feature_extraction>`.
+
     Parameters
     ----------
     dtype : callable, optional
@@ -322,7 +324,7 @@ class DictVectorizer(BaseEstimator, TransformerMixin):
             Boolean mask or list of indices (as returned by the get_support
             member of feature selectors).
         indices : boolean, optional
-            Whether support is a list of indices. 
+            Whether support is a list of indices.
 
         Returns
         -------

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -31,6 +31,8 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
     where memory is tight, e.g. when running prediction code on embedded
     devices.
 
+    Read more in the :ref:`User Guide <feature_hashing>`.
+
     Parameters
     ----------
     n_features : integer, optional

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -135,21 +135,23 @@ def img_to_graph(img, mask=None, return_as=sparse.coo_matrix, dtype=None):
 
     Edges are weighted with the gradient values.
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
-    ===========
-    img: ndarray, 2D or 3D
+    ----------
+    img : ndarray, 2D or 3D
         2D or 3D image
     mask : ndarray of booleans, optional
         An optional mask of the image, to consider only part of the
         pixels.
-    return_as: np.ndarray or a sparse matrix class, optional
+    return_as : np.ndarray or a sparse matrix class, optional
         The class to use to build the returned adjacency matrix.
-    dtype: None or dtype, optional
+    dtype : None or dtype, optional
         The data of the returned sparse matrix. By default it is the
         dtype of img
 
     Notes
-    =====
+    -----
     For sklearn versions 0.14.1 and prior, return_as=np.ndarray was handled
     by returning a dense np.matrix instance.  Going forward, np.ndarray
     returns an np.ndarray, as expected.
@@ -169,23 +171,23 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
     Edges exist if 2 voxels are connected.
 
     Parameters
-    ===========
-    n_x: int
+    ----------
+    n_x : int
         Dimension in x axis
-    n_y: int
+    n_y : int
         Dimension in y axis
-    n_z: int, optional, default 1
+    n_z : int, optional, default 1
         Dimension in z axis
     mask : ndarray of booleans, optional
         An optional mask of the image, to consider only part of the
         pixels.
-    return_as: np.ndarray or a sparse matrix class, optional
+    return_as : np.ndarray or a sparse matrix class, optional
         The class to use to build the returned adjacency matrix.
-    dtype: dtype, optional, default int
+    dtype : dtype, optional, default int
         The data of the returned sparse matrix. By default it is int
 
     Notes
-    =====
+    -----
     For sklearn versions 0.14.1 and prior, return_as=np.ndarray was handled
     by returning a dense np.matrix instance.  Going forward, np.ndarray
     returns an np.ndarray, as expected.
@@ -203,17 +205,19 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
 def _compute_n_patches(i_h, i_w, p_h, p_w, max_patches=None):
     """Compute the number of patches that will be extracted in an image.
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
-    ===========
-    i_h: int
+    ----------
+    i_h : int
         The image height
-    i_w: int
+    i_w : int
         The image with
-    p_h: int
+    p_h : int
         The height of a patch
-    p_w: int
+    p_w : int
         The width of a patch
-    max_patches: integer or float, optional default is None
+    max_patches : integer or float, optional default is None
         The maximum number of patches to extract. If max_patches is a float
         between 0 and 1, it is taken to be a proportion of the total number
         of patches.
@@ -244,24 +248,26 @@ def extract_patches(arr, patch_shape=8, extraction_step=1):
     performed on the first n dimensions will cause numpy to copy data, leading
     to a list of extracted patches.
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
     ----------
-    arr: ndarray
+    arr : ndarray
         n-dimensional array of which patches are to be extracted
 
-    patch_shape: integer or tuple of length arr.ndim
+    patch_shape : integer or tuple of length arr.ndim
         Indicates the shape of the patches to be extracted. If an
         integer is given, the shape will be a hypercube of
         sidelength given by its value.
 
-    extraction_step: integer or tuple of length arr.ndim
+    extraction_step : integer or tuple of length arr.ndim
         Indicates step size at which extraction shall be performed.
         If integer is given, then the step is uniform in all dimensions.
 
 
     Returns
     -------
-    patches: strided ndarray
+    patches : strided ndarray
         2n-dimensional array indexing patches on first n dimensions and
         containing patches on the last n dimensions. These dimensions
         are fake, but this way no data is copied. A simple reshape invokes
@@ -296,28 +302,30 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
 
     The resulting patches are allocated in a dedicated array.
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
     ----------
-    image: array, shape = (image_height, image_width) or
+    image : array, shape = (image_height, image_width) or
         (image_height, image_width, n_channels)
         The original image data. For color images, the last dimension specifies
         the channel: a RGB image would have `n_channels=3`.
 
-    patch_size: tuple of ints (patch_height, patch_width)
+    patch_size : tuple of ints (patch_height, patch_width)
         the dimensions of one patch
 
-    max_patches: integer or float, optional default is None
+    max_patches : integer or float, optional default is None
         The maximum number of patches to extract. If max_patches is a float
         between 0 and 1, it is taken to be a proportion of the total number
         of patches.
 
-    random_state: int or RandomState
+    random_state : int or RandomState
         Pseudo number generator state used for random sampling to use if
         `max_patches` is not None.
 
     Returns
     -------
-    patches: array, shape = (n_patches, patch_height, patch_width) or
+    patches : array, shape = (n_patches, patch_height, patch_width) or
          (n_patches, patch_height, patch_width, n_channels)
          The collection of patches extracted from the image, where `n_patches`
          is either `max_patches` or the total number of patches that can be
@@ -389,21 +397,23 @@ def reconstruct_from_patches_2d(patches, image_size):
     the patches from left to right, top to bottom, averaging the overlapping
     regions.
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
     ----------
-    patches: array, shape = (n_patches, patch_height, patch_width) or
+    patches : array, shape = (n_patches, patch_height, patch_width) or
         (n_patches, patch_height, patch_width, n_channels)
         The complete set of patches. If the patches contain colour information,
         channels are indexed along the last dimension: RGB patches would
         have `n_channels=3`.
 
-    image_size: tuple of ints (image_height, image_width) or
+    image_size : tuple of ints (image_height, image_width) or
         (image_height, image_width, n_channels)
         the size of the image that will be reconstructed
 
     Returns
     -------
-    image: array, shape = image_size
+    image : array, shape = image_size
         the reconstructed image
 
     """
@@ -428,17 +438,19 @@ def reconstruct_from_patches_2d(patches, image_size):
 class PatchExtractor(BaseEstimator):
     """Extracts patches from a collection of images
 
+    Read more in the :ref:`User Guide <image_feature_extraction>`.
+
     Parameters
     ----------
-    patch_size: tuple of ints (patch_height, patch_width)
+    patch_size : tuple of ints (patch_height, patch_width)
         the dimensions of one patch
 
-    max_patches: integer or float, optional default is None
+    max_patches : integer or float, optional default is None
         The maximum number of patches per image to extract. If max_patches is a
         float in (0, 1), it is taken to mean a proportion of the total number
         of patches.
 
-    random_state: int or RandomState
+    random_state : int or RandomState
         Pseudo number generator state used for random sampling.
 
     """

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -317,6 +317,8 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
 
     The hash function employed is the signed 32-bit version of Murmurhash3.
 
+    Read more in the :ref:`User Guide <text_feature_extraction>`.
+
     Parameters
     ----------
 
@@ -502,6 +504,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
     If you do not provide an a-priori dictionary and you do not use an analyzer
     that does some kind of feature selection then the number of features will
     be equal to the vocabulary size found by analyzing the data.
+
+    Read more in the :ref:`User Guide <text_feature_extraction>`.
 
     Parameters
     ----------
@@ -921,6 +925,8 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
     Idf is "t" when use_idf is given, "n" (none) otherwise.
     Normalization is "c" (cosine) when norm='l2', "n" (none) when norm=None.
 
+    Read more in the :ref:`User Guide <text_feature_extraction>`.
+
     Parameters
     ----------
     norm : 'l1', 'l2' or None, optional
@@ -1038,6 +1044,8 @@ class TfidfVectorizer(CountVectorizer):
     """Convert a collection of raw documents to a matrix of TF-IDF features.
 
     Equivalent to CountVectorizer followed by TfidfTransformer.
+
+    Read more in the :ref:`User Guide <text_feature_extraction>`.
 
     Parameters
     ----------

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -32,6 +32,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     That procedure is recursively repeated on the pruned set until the desired
     number of features to select is eventually reached.
 
+    Read more in the :ref:`User Guide <rfe>`.
+
     Parameters
     ----------
     estimator : object
@@ -268,6 +270,8 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 class RFECV(RFE, MetaEstimatorMixin):
     """Feature ranking with recursive feature elimination and cross-validated
     selection of the best number of features.
+
+    Read more in the :ref:`User Guide <rfe>`.
 
     Parameters
     ----------

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -46,6 +46,8 @@ def f_oneway(*args):
     the same population mean. The test is applied to samples from two or
     more groups, possibly with differing sizes.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     sample1, sample2, ... : array_like, sparse matrices
@@ -119,6 +121,8 @@ def f_oneway(*args):
 def f_classif(X, y):
     """Compute the ANOVA F-value for the provided sample.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix} shape = [n_samples, n_features]
@@ -176,6 +180,8 @@ def chi2(X, y):
     most likely to be independent of class and therefore irrelevant for
     classification.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape = (n_samples, n_features_in)
@@ -232,6 +238,8 @@ def f_regression(X, y, center=True):
        wrt constant regressors.
     2. The cross correlation between data and regressors is computed.
     3. It is converted to an F score then to a p-value.
+
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
 
     Parameters
     ----------
@@ -335,6 +343,8 @@ class _BaseFilter(BaseEstimator, SelectorMixin):
 class SelectPercentile(_BaseFilter):
     """Select features according to a percentile of the highest scores.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     score_func : callable
@@ -401,6 +411,8 @@ class SelectPercentile(_BaseFilter):
 
 class SelectKBest(_BaseFilter):
     """Select features according to the k highest scores.
+
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
 
     Parameters
     ----------
@@ -470,6 +482,8 @@ class SelectFpr(_BaseFilter):
     FPR test stands for False Positive Rate test. It controls the total
     amount of false detections.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     score_func : callable
@@ -514,6 +528,8 @@ class SelectFdr(_BaseFilter):
 
     This uses the Benjamini-Hochberg procedure. ``alpha`` is an upper bound
     on the expected false discovery rate.
+
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
 
     Parameters
     ----------
@@ -568,6 +584,8 @@ class SelectFdr(_BaseFilter):
 class SelectFwe(_BaseFilter):
     """Filter: Select the p-values corresponding to Family-wise error rate
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     score_func : callable
@@ -616,6 +634,8 @@ class SelectFwe(_BaseFilter):
 class GenericUnivariateSelect(_BaseFilter):
     """Univariate feature selector with configurable strategy.
 
+    Read more in the :ref:`User Guide <univariate_feature_selection>`.
+
     Parameters
     ----------
     score_func : callable
@@ -648,11 +668,11 @@ class GenericUnivariateSelect(_BaseFilter):
     SelectFwe: Select features based on family-wise error rate.
     """
 
-    _selection_modes = {'percentile':   SelectPercentile,
-                        'k_best':       SelectKBest,
-                        'fpr':          SelectFpr,
-                        'fdr':          SelectFdr,
-                        'fwe':          SelectFwe}
+    _selection_modes = {'percentile': SelectPercentile,
+                        'k_best': SelectKBest,
+                        'fpr': SelectFpr,
+                        'fdr': SelectFdr,
+                        'fwe': SelectFwe}
 
     def __init__(self, score_func=f_classif, mode='percentile', param=1e-5):
         super(GenericUnivariateSelect, self).__init__(score_func)

--- a/sklearn/feature_selection/variance_threshold.py
+++ b/sklearn/feature_selection/variance_threshold.py
@@ -15,6 +15,8 @@ class VarianceThreshold(BaseEstimator, SelectorMixin):
     This feature selection algorithm looks only at the features (X), not the
     desired outputs (y), and can thus be used for unsupervised learning.
 
+    Read more in the :ref:`User Guide <variance_threshold>`.
+
     Parameters
     ----------
     threshold : float, optional

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -59,6 +59,8 @@ def l1_cross_distances(X):
 class GaussianProcess(BaseEstimator, RegressorMixin):
     """The Gaussian Process model class.
 
+    Read more in the :ref:`User Guide <gaussian_process>`.
+
     Parameters
     ----------
     regr : string or callable, optional

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -42,6 +42,8 @@ class ParameterGrid(object):
     Can be used to iterate over parameter value combinations with the
     Python built-in function iter.
 
+    Read more in the :ref:`User Guide <grid_search>`.
+
     Parameters
     ----------
     param_grid : dict of string to sequence, or sequence of such
@@ -125,6 +127,8 @@ class ParameterSampler(object):
     ``numpy.random``. Hence setting ``random_state`` will not guarantee a
     deterministic iteration whenever ``scipy.stats`` distributions are used to
     define the parameter search space.
+
+    Read more in the :ref:`User Guide <grid_search>`.
 
     Parameters
     ----------
@@ -566,6 +570,8 @@ class GridSearchCV(BaseSearchCV):
     any classifier except that the parameters of the classifier
     used to predict is optimized by cross-validation.
 
+    Read more in the :ref:`User Guide <grid_search>`.
+
     Parameters
     ----------
     estimator : object type that implements the "fit" and "predict" methods
@@ -750,6 +756,8 @@ class RandomizedSearchCV(BaseSearchCV):
     is given as a distribution, sampling with replacement is used.
     It is highly recommended to use continuous distributions for continuous
     parameters.
+
+    Read more in the :ref:`User Guide <randomized_parameter_search>`.
 
     Parameters
     ----------

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -88,6 +88,8 @@ def isotonic_regression(y, sample_weight=None, y_min=None, y_max=None,
         - y_[i] are fitted
         - w[i] are optional strictly positive weights (default to 1.0)
 
+    Read more in the :ref:`User Guide <isotonic>`.
+
     Parameters
     ----------
     y : iterable of floating-point values
@@ -162,6 +164,8 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         - ``X`` specifies the order.
           If ``X`` is non-decreasing then ``y_`` is non-decreasing.
         - ``w[i]`` are optional strictly positive weights (default to 1.0)
+
+    Read more in the :ref:`User Guide <isotonic>`.
 
     Parameters
     ----------

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -24,8 +24,10 @@ from .metrics.pairwise import pairwise_kernels
 class RBFSampler(BaseEstimator, TransformerMixin):
     """Approximates feature map of an RBF kernel by Monte Carlo approximation
     of its Fourier transform.
-    
+
     It implements a variant of Random Kitchen Sinks.[1]
+
+    Read more in the :ref:`User Guide <rbf_kernel_approx>`.
 
     Parameters
     ----------
@@ -110,6 +112,8 @@ class RBFSampler(BaseEstimator, TransformerMixin):
 class SkewedChi2Sampler(BaseEstimator, TransformerMixin):
     """Approximates feature map of the "skewed chi-squared" kernel by Monte
     Carlo approximation of its Fourier transform.
+
+    Read more in the :ref:`User Guide <skewed_chi_kernel_approx>`.
 
     Parameters
     ----------
@@ -213,6 +217,8 @@ class AdditiveChi2Sampler(BaseEstimator, TransformerMixin):
 
     Optimal choices for the sampling interval for certain data ranges can be
     computed (see the reference). The default values should be reasonable.
+
+    Read more in the :ref:`User Guide <additive_chi_kernel_approx>`.
 
     Parameters
     ----------
@@ -357,6 +363,8 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     Constructs an approximate feature map for an arbitrary kernel
     using a subset of the data as basis.
+
+    Read more in the :ref:`User Guide <nystroem_kernel_approx>`.
 
     Parameters
     ----------

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -34,6 +34,8 @@ class KernelRidge(BaseEstimator, RegressorMixin):
     This estimator has built-in support for multi-variate regression
     (i.e., when y is a 2d-array of shape [n_samples, n_targets]).
 
+    Read more in the :ref:`User Guide <kernel_ridge>`.
+
     Parameters
     ----------
     alpha : {float, array-like}, shape = [n_targets]
@@ -143,7 +145,6 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True)
 
-        n_samples = X.shape[0]
         K = self._get_kernel(X)
         alpha = np.atleast_1d(self.alpha)
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -136,6 +136,8 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
     The fitted model can also be used to reduce the dimensionality of the input
     by projecting it to the most discriminative directions.
 
+    Read more in the :ref:`User Guide <lda_qda>`.
+
     Parameters
     ----------
     solver : string, optional

--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -34,6 +34,8 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
     test set will be computed. Afterwards, the scores will be averaged over
     all k runs for each training subset size.
 
+    Read more in the :ref:`User Guide <learning_curves>`.
+
     Parameters
     ----------
     estimator : object type that implements the "fit" and "predict" methods
@@ -237,6 +239,8 @@ def validation_curve(estimator, X, y, param_name, param_range, cv=None,
     parameter. This is similar to grid search with one parameter. However, this
     will also compute training scores and is merely a utility for plotting the
     results.
+
+    Read more in the :ref:`User Guide <validation_curve>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -25,6 +25,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
     Fit a Bayesian ridge model and optimize the regularization parameters
     lambda (precision of the weights) and alpha (precision of the noise).
 
+    Read more in the :ref:`User Guide <bayesian_regression>`.
+
     Parameters
     ----------
     n_iter : int, optional
@@ -224,6 +226,8 @@ class ARDRegression(LinearModel, RegressorMixin):
     Also estimate the parameters lambda (precisions of the distributions of the
     weights) and alpha (precision of the distribution of the noise).
     The estimation is done by an iterative procedures (Evidence Maximization)
+
+    Read more in the :ref:`User Guide <bayesian_regression>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -132,6 +132,8 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     i.e. the sum of norm of each row.
 
+    Read more in the :ref:`User Guide <lasso>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
@@ -273,6 +275,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
 
     i.e. the sum of norm of each row.
+
+    Read more in the :ref:`User Guide <elastic_net>`.
 
     Parameters
     ----------
@@ -482,6 +486,8 @@ class ElasticNet(LinearModel, RegressorMixin):
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio
     = 1 is the lasso penalty. Currently, l1_ratio <= 0.01 is not reliable,
     unless you supply your own sequence of alpha.
+
+    Read more in the :ref:`User Guide <elastic_net>`.
 
     Parameters
     ----------
@@ -736,6 +742,8 @@ class Lasso(ElasticNet):
 
     Technically the Lasso model is optimizing the same objective function as
     the Elastic Net with ``l1_ratio=1.0`` (no L2 penalty).
+
+    Read more in the :ref:`User Guide <lasso>`.
 
     Parameters
     ----------
@@ -1161,6 +1169,8 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
         (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
+    Read more in the :ref:`User Guide <lasso>`.
+
     Parameters
     ----------
     eps : float, optional
@@ -1285,6 +1295,8 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
     """Elastic Net model with iterative fitting along a regularization path
 
     The best model is selected by cross-validation.
+
+    Read more in the :ref:`User Guide <elastic_net>`.
 
     Parameters
     ----------
@@ -1463,6 +1475,8 @@ class MultiTaskElasticNet(Lasso):
         ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
 
     i.e. the sum of norm of each row.
+
+    Read more in the :ref:`User Guide <multi_task_lasso>`.
 
     Parameters
     ----------
@@ -1647,6 +1661,8 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     i.e. the sum of norm of earch row.
 
+    Read more in the :ref:`User Guide <multi_task_lasso>`.
+
     Parameters
     ----------
     alpha : float, optional
@@ -1754,6 +1770,8 @@ class MultiTaskElasticNetCV(LinearModelCV, RegressorMixin):
         ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
 
     i.e. the sum of norm of each row.
+
+    Read more in the :ref:`User Guide <multi_task_lasso>`.
 
     Parameters
     ----------
@@ -1908,6 +1926,8 @@ class MultiTaskLassoCV(LinearModelCV, RegressorMixin):
         ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
 
     i.e. the sum of norm of each row.
+
+    Read more in the :ref:`User Guide <multi_task_lasso>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -47,6 +47,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
     in the case of method='lars', the objective function is only known in
     the form of an implicit equation (see discussion in [1])
 
+    Read more in the :ref:`User Guide <least_angle_regression>`.
+
     Parameters
     -----------
     X : array, shape: (n_samples, n_features)
@@ -465,6 +467,8 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500,
 class Lars(LinearModel, RegressorMixin):
     """Least Angle Regression model a.k.a. LAR
 
+    Read more in the :ref:`User Guide <least_angle_regression>`.
+
     Parameters
     ----------
     n_nonzero_coefs : int, optional
@@ -671,6 +675,8 @@ class LassoLars(Lars):
 
     (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
+    Read more in the :ref:`User Guide <least_angle_regression>`.
+
     Parameters
     ----------
     alpha : float
@@ -798,32 +804,43 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     -----------
     X_train : array, shape (n_samples, n_features)
         The data to fit the LARS on
+
     y_train : array, shape (n_samples)
         The target variable to fit LARS on
+
     X_test : array, shape (n_samples, n_features)
         The data to compute the residues on
+
     y_test : array, shape (n_samples)
         The target variable to compute the residues on
+
     Gram : None, 'auto', array, shape: (n_features, n_features), optional
         Precomputed Gram matrix (X' * X), if ``'auto'``, the Gram
         matrix is precomputed from the given X, if there are more samples
         than features
+
     copy : boolean, optional
         Whether X_train, X_test, y_train and y_test should be copied;
         if False, they may be overwritten.
+
     method : 'lar' | 'lasso'
         Specifies the returned model. Select ``'lar'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
+
     verbose : integer, optional
         Sets the amount of verbosity
+
     fit_intercept : boolean
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (e.g. data is expected to be already centered).
+
     normalize : boolean, optional, default False
         If True, the regressors X will be normalized before regression.
+
     max_iter : integer, optional
         Maximum number of iterations to perform.
+
     eps : float, optional
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
@@ -879,6 +896,8 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
 
 class LarsCV(Lars):
     """Cross-validated Least Angle Regression model
+
+    Read more in the :ref:`User Guide <least_angle_regression>`.
 
     Parameters
     ----------
@@ -1056,6 +1075,8 @@ class LassoLarsCV(LarsCV):
 
     (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
+    Read more in the :ref:`User Guide <least_angle_regression>`.
+
     Parameters
     ----------
     fit_intercept : boolean
@@ -1156,6 +1177,8 @@ class LassoLarsIC(LassoLars):
     of the regularization parameter by making a trade-off between the
     goodness of fit and the complexity of the model. A good model should
     explain well the data while being simple.
+
+    Read more in the :ref:`User Guide <least_angle_regression>`.
 
     Parameters
     ----------
@@ -1262,7 +1285,7 @@ class LassoLarsIC(LassoLars):
 
         y : array-like, shape (n_samples,)
             target values.
-    
+
         copy_X : boolean, optional, default True
             If ``True``, X will be copied; else, it may be overwritten.
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -427,6 +427,8 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     to speed up computations along the set of solutions, making it faster
     than sequentially calling LogisticRegression for the different parameters.
 
+    Read more in the :ref:`User Guide <logistic_regression>`.
+
     Parameters
     ----------
     X : array-like or sparse matrix, shape (n_samples, n_features)
@@ -601,8 +603,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             if coef.size not in (n_features, w0.size):
                 raise ValueError(
                     'Initialization coef is of shape %d, expected shape '
-                    '%d or %d' % (coef.size, n_features, w0.size)
-                    )
+                    '%d or %d' % (coef.size, n_features, w0.size))
             w0[:coef.size] = coef
         else:
             # For binary problems coef.shape[0] should be 1, otherwise it
@@ -617,9 +618,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                     'Initialization coef is of shape (%d, %d), expected '
                     'shape (%d, %d) or (%d, %d)' % (
                         coef.shape[0], coef.shape[1], classes.size,
-                        n_features, classes.size, n_features + 1
-                        )
-                    )
+                        n_features, classes.size, n_features + 1))
             w0[:, :coef.shape[1]] = coef
 
     if multi_class == 'multinomial':
@@ -649,15 +648,13 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                 w0, loss, info = optimize.fmin_l_bfgs_b(
                     func, w0, fprime=None,
                     args=(X, target, 1. / C, sample_weight),
-                    iprint=(verbose > 0) - 1, pgtol=tol, maxiter=max_iter
-                    )
+                    iprint=(verbose > 0) - 1, pgtol=tol, maxiter=max_iter)
             except TypeError:
                 # old scipy doesn't have maxiter
                 w0, loss, info = optimize.fmin_l_bfgs_b(
                     func, w0, fprime=None,
                     args=(X, target, 1. / C, sample_weight),
-                    iprint=(verbose > 0) - 1, pgtol=tol
-                    )
+                    iprint=(verbose > 0) - 1, pgtol=tol)
             if info["warnflag"] == 1 and verbose > 0:
                 warnings.warn("lbfgs failed to converge. Increase the number "
                               "of iterations.")
@@ -668,8 +665,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         elif solver == 'liblinear':
             coef_, intercept_, _, = _fit_liblinear(
                 X, y, C, fit_intercept, intercept_scaling, class_weight,
-                penalty, dual, verbose, max_iter, tol, random_state
-                )
+                penalty, dual, verbose, max_iter, tol, random_state)
             if fit_intercept:
                 w0 = np.concatenate([coef_.ravel(), intercept_])
             else:
@@ -875,6 +871,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     formulation. The liblinear solver supports both L1 and L2 regularization,
     with a dual formulation only for the L2 penalty.
 
+    Read more in the :ref:`User Guide <logistic_regression>`.
+
     Parameters
     ----------
     penalty : str, 'l1' or 'l2'
@@ -1042,8 +1040,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             self.coef_, self.intercept_, self.n_iter_ = _fit_liblinear(
                 X, y, self.C, self.fit_intercept, self.intercept_scaling,
                 self.class_weight, self.penalty, self.dual, self.verbose,
-                self.max_iter, self.tol, self.random_state
-                )
+                self.max_iter, self.tol, self.random_state)
             return self
 
         n_classes = len(self.classes_)
@@ -1142,6 +1139,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
     For a multiclass problem, the hyperparameters for each class are computed
     using the best scores got by doing a one-vs-rest in parallel across all
     folds and classes. Hence this is not the true multinomial loss.
+
+    Read more in the :ref:`User Guide <logistic_regression>`.
 
     Parameters
     ----------
@@ -1340,8 +1339,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                 "A column-vector y was passed when a 1d array was"
                 " expected. Please change the shape of y to "
                 "(n_samples, ), for example using ravel().",
-                DataConversionWarning
-                )
+                DataConversionWarning)
             y = np.ravel(y)
 
         check_consistent_length(X, y)
@@ -1456,10 +1454,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                 # Take the best scores across every fold and the average of all
                 # coefficients corresponding to the best scores.
                 best_indices = np.argmax(scores, axis=1)
-                w = np.mean([
-                    coefs_paths[i][best_indices[i]]
-                    for i in range(len(folds))
-                    ], axis=0)
+                w = np.mean([coefs_paths[i][best_indices[i]]
+                             for i in range(len(folds))], axis=0)
                 self.C_.append(np.mean(self.Cs_[best_indices]))
 
             if self.multi_class == 'multinomial':

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -281,6 +281,8 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
     When parametrized by error using the parameter `tol`:
     argmin ||\gamma||_0 subject to ||y - X\gamma||^2 <= tol
 
+    Read more in the :ref:`User Guide <omp>`.
+
     Parameters
     ----------
     X : array, shape (n_samples, n_features)
@@ -414,6 +416,8 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
 
     Solves n_targets Orthogonal Matching Pursuit problems using only
     the Gram matrix X.T * X and the product X.T * y.
+
+    Read more in the :ref:`User Guide <omp>`.
 
     Parameters
     ----------
@@ -561,6 +565,8 @@ class OrthogonalMatchingPursuit(LinearModel, RegressorMixin):
         calculations. Improves performance when `n_targets` or `n_samples` is
         very large. Note that if you already have such matrices, you can pass
         them directly to the fit method.
+
+    Read more in the :ref:`User Guide <omp>`.
 
     Attributes
     ----------
@@ -759,6 +765,8 @@ class OrthogonalMatchingPursuitCV(LinearModel, RegressorMixin):
 
     verbose : boolean or integer, optional
         Sets the verbosity amount
+
+    Read more in the :ref:`User Guide <omp>`.
 
     Attributes
     ----------

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -9,6 +9,8 @@ from .stochastic_gradient import DEFAULT_EPSILON
 class PassiveAggressiveClassifier(BaseSGDClassifier):
     """Passive Aggressive Classifier
 
+    Read more in the :ref:`User Guide <passive_aggressive>`.
+
     Parameters
     ----------
 
@@ -143,6 +145,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
 class PassiveAggressiveRegressor(BaseSGDRegressor):
     """Passive Aggressive Regressor
+
+    Read more in the :ref:`User Guide <passive_aggressive>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/perceptron.py
+++ b/sklearn/linear_model/perceptron.py
@@ -8,6 +8,8 @@ from ..feature_selection.from_model import _LearntSelectorMixin
 class Perceptron(BaseSGDClassifier, _LearntSelectorMixin):
     """Perceptron
 
+    Read more in the :ref:`User Guide <perceptron>`.
+
     Parameters
     ----------
 

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -190,6 +190,8 @@ class RandomizedLasso(BaseRandomizedLinearModel):
     a Lasso on each resampling. In short, the features selected more
     often are good features. It is also known as stability selection.
 
+    Read more in the :ref:`User Guide <randomized_l1>`.
+
     Parameters
     ----------
     alpha : float, 'aic', or 'bic', optional
@@ -372,6 +374,8 @@ class RandomizedLogisticRegression(BaseRandomizedLinearModel):
     a LogisticRegression on each resampling. In short, the features selected
     more often are good features. It is also known as stability selection.
 
+    Read more in the :ref:`User Guide <randomized_l1>`.
+
     Parameters
     ----------
     C : float, optional, default=1
@@ -536,6 +540,8 @@ def lasso_stability_path(X, y, scaling=0.5, random_state=None,
                          eps=4 * np.finfo(np.float).eps, n_jobs=1,
                          verbose=False):
     """Stabiliy path based on randomized Lasso estimates
+
+    Read more in the :ref:`User Guide <randomized_l1>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -60,6 +60,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
     A detailed description of the algorithm can be found in the documentation
     of the ``linear_model`` sub-package.
 
+    Read more in the :ref:`User Guide <RansacRegression>`.
+
     Parameters
     ----------
     base_estimator : object, optional

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -201,6 +201,8 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                      max_iter=None, tol=1e-3, verbose=0):
     """Solve the ridge equation by the method of normal equations.
 
+    Read more in the :ref:`User Guide <ridge_regression>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix, LinearOperator},
@@ -396,6 +398,8 @@ class Ridge(_BaseRidge, RegressorMixin):
     This estimator has built-in support for multi-variate regression
     (i.e., when y is a 2d-array of shape [n_samples, n_targets]).
 
+    Read more in the :ref:`User Guide <ridge_regression>`.
+
     Parameters
     ----------
     alpha : {float, array-like}
@@ -498,6 +502,8 @@ class Ridge(_BaseRidge, RegressorMixin):
 
 class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
     """Classifier using Ridge regression.
+
+    Read more in the :ref:`User Guide <ridge_regression>`.
 
     Parameters
     ----------
@@ -887,6 +893,8 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
     By default, it performs Generalized Cross-Validation, which is a form of
     efficient Leave-One-Out cross-validation.
 
+    Read more in the :ref:`User Guide <ridge_regression>`.
+
     Parameters
     ----------
     alphas : numpy array of shape [n_alphas]
@@ -970,6 +978,8 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     By default, it performs Generalized Cross-Validation, which is a form of
     efficient Leave-One-Out cross-validation. Currently, only the n_features >
     n_samples case is handled efficiently.
+
+    Read more in the :ref:`User Guide <ridge_regression>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -582,6 +582,8 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
     update is truncated to 0.0 to allow for learning sparse models and achieve
     online feature selection.
 
+    Read more in the :ref:`User Guide <sgd>`.
+
     Parameters
     ----------
     loss : str, 'hinge', 'log', 'modified_huber', 'squared_hinge',\
@@ -1100,6 +1102,8 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
 
     This implementation works with data represented as dense numpy arrays of
     floating point values for the features.
+
+    Read more in the :ref:`User Guide <sgd>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -207,6 +207,8 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
     reached, the subsets are chosen randomly. In a final step, the spatial
     median (or L1 median) is calculated of all least square solutions.
 
+    Read more in the :ref:`User Guide <theil_sen_regression>`.
+
     Parameters
     ----------
     fit_intercept : boolean, optional, default True

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -17,6 +17,8 @@ class Isomap(BaseEstimator, TransformerMixin):
 
     Non-linear dimensionality reduction through Isometric Mapping
 
+    Read more in the :ref:`User Guide <isomap>`.
+
     Parameters
     ----------
     n_neighbors : integer

--- a/sklearn/manifold/locally_linear.py
+++ b/sklearn/manifold/locally_linear.py
@@ -180,6 +180,8 @@ def locally_linear_embedding(
         random_state=None):
     """Perform a Locally Linear Embedding analysis on the data.
 
+    Read more in the :ref:`User Guide <locally_linear_embedding>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix, BallTree, KDTree, NearestNeighbors}
@@ -496,6 +498,8 @@ def locally_linear_embedding(
 
 class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
     """Locally Linear Embedding
+
+    Read more in the :ref:`User Guide <locally_linear_embedding>`.
 
     Parameters
     ----------

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -274,6 +274,8 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
 class MDS(BaseEstimator):
     """Multidimensional scaling
 
+    Read more in the :ref:`User Guide <multidimensional_scaling>`.
+
     Parameters
     ----------
     metric : boolean, optional, default: True

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -137,6 +137,8 @@ def spectral_embedding(adjacency, n_components=8, eigen_solver=None,
     However care must taken to always make the affinity matrix symmetric
     so that the eigenvector decomposition works as expected.
 
+    Read more in the :ref:`User Guide <spectral_embedding>`.
+
     Parameters
     ----------
     adjacency : array-like or sparse matrix, shape: (n_samples, n_samples)
@@ -315,6 +317,8 @@ class SpectralEmbedding(BaseEstimator):
     applies spectral decomposition to the corresponding graph laplacian.
     The resulting transformation is given by the value of the
     eigenvectors for each data point.
+
+    Read more in the :ref:`User Guide <spectral_embedding>`.
 
     Parameters
     -----------

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -304,6 +304,8 @@ class TSNE(BaseEstimator):
     noise and speed up the computation of pairwise distances between
     samples. For more tips see Laurens van der Maaten's FAQ [2].
 
+    Read more in the :ref:`User Guide <t_sne>`.
+
     Parameters
     ----------
     n_components : int, optional (default: 2)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -125,6 +125,8 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     the set of labels predicted for a sample must *exactly* match the
     corresponding set of labels in y_true.
 
+    Read more in the :ref:`User Guide <accuracy_score>`.
+
     Parameters
     ----------
     y_true : 1d array-like, or label indicator array / sparse matrix
@@ -192,6 +194,8 @@ def confusion_matrix(y_true, y_pred, labels=None):
     By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
     is equal to the number of observations known to be in group :math:`i` but
     predicted to be in group :math:`j`.
+
+    Read more in the :ref:`User Guide <confusion_matrix>`.
 
     Parameters
     ----------
@@ -270,6 +274,8 @@ def jaccard_similarity_score(y_true, y_pred, normalize=True,
     the size of the intersection divided by the size of the union of two label
     sets, is used to compare set of predicted labels for a sample to the
     corresponding set of labels in ``y_true``.
+
+    Read more in the :ref:`User Guide <jaccard_similarity_score>`.
 
     Parameters
     ----------
@@ -365,6 +371,8 @@ def matthews_corrcoef(y_true, y_pred):
     Only in the binary case does this relate to information about true and
     false positives and negatives. See references below.
 
+    Read more in the :ref:`User Guide <matthews_corrcoef>`.
+
     Parameters
     ----------
     y_true : array, shape = [n_samples]
@@ -422,6 +430,8 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
     If normalize is ``True``, return the fraction of misclassifications
     (float), else it returns the number of misclassifications (int). The best
     performance is 0.
+
+    Read more in the :ref:`User Guide <zero_one_loss>`.
 
     Parameters
     ----------
@@ -496,6 +506,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
     In the multi-class and multi-label case, this is the weighted average of
     the F1 score of each class.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
     ----------
@@ -588,6 +600,8 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
     score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
     favors recall (``beta -> 0`` considers only precision, ``beta -> inf``
     only recall).
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
     ----------
@@ -756,6 +770,8 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     If ``pos_label is None`` and in binary classification, this function
     returns the average precision, recall and F-measure if ``average``
     is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
     ----------
@@ -1009,6 +1025,8 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
 
     The best value is 1 and the worst value is 0.
 
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
     Parameters
     ----------
     y_true : 1d array-like, or label indicator array / sparse matrix
@@ -1100,6 +1118,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
     The best value is 1 and the worst value is 0.
 
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
     Parameters
     ----------
     y_true : 1d array-like, or label indicator array / sparse matrix
@@ -1183,6 +1203,8 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 def classification_report(y_true, y_pred, labels=None, target_names=None,
                           sample_weight=None, digits=2):
     """Build a text report showing the main classification metrics
+
+    Read more in the :ref:`User Guide <classification_report>`.
 
     Parameters
     ----------
@@ -1281,6 +1303,8 @@ def hamming_loss(y_true, y_pred, classes=None):
 
     The Hamming loss is the fraction of labels that are incorrectly predicted.
 
+    Read more in the :ref:`User Guide <hamming_loss>`.
+
     Parameters
     ----------
     y_true : 1d array-like, or label indicator array / sparse matrix
@@ -1366,6 +1390,8 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     estimated probability yp that yt = 1, the log loss is
 
         -log P(yt|yp) = -(yt log(yp) + (1 - yt) log(1 - yp))
+
+    Read more in the :ref:`User Guide <log_loss>`.
 
     Parameters
     ----------
@@ -1454,6 +1480,8 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     contains all the labels. The multilabel margin is calculated according
     to Crammer-Singer's method. As in the binary case, the cumulated hinge loss
     is an upper bound of the number of mistakes made by the classifier.
+
+    Read more in the :ref:`User Guide <hinge_loss>`.
 
     Parameters
     ----------
@@ -1605,6 +1633,7 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     "distant" from one another). Which label is considered to be the positive
     label is controlled via the parameter pos_label, which defaults to 1.
 
+    Read more in the :ref:`User Guide <calibration>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/cluster/bicluster.py
+++ b/sklearn/metrics/cluster/bicluster.py
@@ -54,6 +54,8 @@ def consensus_score(a, b, similarity="jaccard"):
     The final score is the sum of similarities divided by the size of
     the larger set.
 
+    Read more in the :ref:`User Guide <biclustering>`.
+
     Parameters
     ----------
     a : (rows, columns)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -109,6 +109,8 @@ def adjusted_rand_score(labels_true, labels_pred):
 
         adjusted_rand_score(a, b) == adjusted_rand_score(b, a)
 
+    Read more in the :ref:`User Guide <adjusted_rand_score>`.
+
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
@@ -119,7 +121,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     Returns
     -------
-    ari: float
+    ari : float
        Similarity score between -1.0 and 1.0. Random labelings have an ARI
        close to 0.0. 1.0 stands for perfect match.
 
@@ -214,6 +216,8 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred):
     ``label_pred`` will give the same score. This does not hold for
     homogeneity and completeness.
 
+    Read more in the :ref:`User Guide <homogeneity_completeness>`.
+
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
@@ -274,6 +278,8 @@ def homogeneity_score(labels_true, labels_pred):
     This metric is not symmetric: switching ``label_true`` with ``label_pred``
     will return the :func:`completeness_score` which will be different in
     general.
+
+    Read more in the :ref:`User Guide <homogeneity_completeness>`.
 
     Parameters
     ----------
@@ -347,6 +353,8 @@ def completeness_score(labels_true, labels_pred):
     will return the :func:`homogeneity_score` which will be different in
     general.
 
+    Read more in the :ref:`User Guide <homogeneity_completeness>`.
+
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
@@ -418,6 +426,8 @@ def v_measure_score(labels_true, labels_pred):
     ``label_pred`` will return the same score value. This can be useful to
     measure the agreement of two independent label assignments strategies
     on the same dataset when the real ground truth is not known.
+
+    Read more in the :ref:`User Guide <homogeneity_completeness>`.
 
     Parameters
     ----------
@@ -519,6 +529,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
     measure the agreement of two independent label assignments strategies
     on the same dataset when the real ground truth is not known.
 
+    Read more in the :ref:`User Guide <mutual_info_score>`.
+
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
@@ -585,6 +597,8 @@ def adjusted_mutual_info_score(labels_true, labels_pred):
 
     Be mindful that this function is an order of magnitude slower than other
     metrics, such as the Adjusted Rand Index.
+
+    Read more in the :ref:`User Guide <mutual_info_score>`.
 
     Parameters
     ----------
@@ -676,6 +690,8 @@ def normalized_mutual_info_score(labels_true, labels_pred):
     ``label_pred`` will return the same score value. This can be useful to
     measure the agreement of two independent label assignments strategies
     on the same dataset when the real ground truth is not known.
+
+    Read more in the :ref:`User Guide <mutual_info_score>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -29,6 +29,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
     overlapping clusters. Negative values generally indicate that a sample has
     been assigned to the wrong cluster, as a different cluster is more similar.
 
+    Read more in the :ref:`User Guide <silhouette_coefficient>`.
+
     Parameters
     ----------
     X : array [n_samples_a, n_samples_a] if metric == "precomputed", or, \
@@ -112,6 +114,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     The best value is 1 and the worst value is -1. Values near 0 indicate
     overlapping clusters.
+
+    Read more in the :ref:`User Guide <silhouette_coefficient>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -152,6 +152,8 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False):
     the distance matrix returned by this function may not be exactly
     symmetric as required by, e.g., ``scipy.spatial.distance`` functions.
 
+    Read more in the :ref:`User Guide <metrics>`.
+
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples_1, n_features)
@@ -361,7 +363,7 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
     This function works with dense 2D arrays only.
 
     Parameters
-    ==========
+    ----------
     X : array-like
         Arrays containing points. Respective shapes (n_samples1, n_features)
         and (n_samples2, n_features)
@@ -410,12 +412,12 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
         Axis along which the argmin and distances are to be computed.
 
     Returns
-    =======
+    -------
     argmin : numpy.ndarray
         Y[argmin[i], :] is the row in Y that is closest to X[i, :].
 
     See also
-    ========
+    --------
     sklearn.metrics.pairwise_distances
     sklearn.metrics.pairwise_distances_argmin_min
     """
@@ -432,6 +434,8 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
 
     With sum_over_features equal to False it returns the componentwise
     distances.
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
@@ -507,6 +511,8 @@ def cosine_distances(X, Y=None):
 
     Cosine distance is defined as 1.0 minus the cosine similarity.
 
+    Read more in the :ref:`User Guide <metrics>`.
+
     Parameters
     ----------
     X : array_like, sparse matrix
@@ -537,6 +543,8 @@ def paired_euclidean_distances(X, Y):
     """
     Computes the paired euclidean distances between X and Y
 
+    Read more in the :ref:`User Guide <metrics>`.
+
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)
@@ -553,6 +561,8 @@ def paired_euclidean_distances(X, Y):
 
 def paired_manhattan_distances(X, Y):
     """Compute the L1 distances between the vectors in X and Y.
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
@@ -576,6 +586,8 @@ def paired_manhattan_distances(X, Y):
 def paired_cosine_distances(X, Y):
     """
     Computes the paired cosine distances between X and Y
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
@@ -610,6 +622,8 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
     Computes the paired distances between X and Y.
 
     Computes the distances between (X[0], Y[0]), (X[1], Y[1]), etc...
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
@@ -665,6 +679,8 @@ def linear_kernel(X, Y=None):
     """
     Compute the linear kernel between X and Y.
 
+    Read more in the :ref:`User Guide <linear_kernel>`.
+
     Parameters
     ----------
     X : array of shape (n_samples_1, n_features)
@@ -684,6 +700,8 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
     Compute the polynomial kernel between X and Y::
 
         K(X, Y) = (gamma <X, Y> + coef0)^degree
+
+    Read more in the :ref:`User Guide <polynomial_kernel>`.
 
     Parameters
     ----------
@@ -716,6 +734,8 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
         K(X, Y) = tanh(gamma <X, Y> + coef0)
 
+    Read more in the :ref:`User Guide <sigmoid_kernel>`.
+
     Parameters
     ----------
     X : ndarray of shape (n_samples_1, n_features)
@@ -746,6 +766,8 @@ def rbf_kernel(X, Y=None, gamma=None):
         K(x, y) = exp(-gamma ||x-y||^2)
 
     for each pair of rows x in X and y in Y.
+
+    Read more in the :ref:`User Guide <rbf_kernel>`.
 
     Parameters
     ----------
@@ -778,6 +800,8 @@ def cosine_similarity(X, Y=None):
         K(X, Y) = <X, Y> / (||X||*||Y||)
 
     On L2-normalized data, this function is equivalent to linear_kernel.
+
+    Read more in the :ref:`User Guide <cosine_similarity>`.
 
     Parameters
     ----------
@@ -819,6 +843,8 @@ def additive_chi2_kernel(X, Y=None):
         k(x, y) = -Sum [(x - y)^2 / (x + y)]
 
     It can be interpreted as a weighted difference per entry.
+
+    Read more in the :ref:`User Guide <chi2_kernel>`.
 
     Notes
     -----
@@ -878,6 +904,8 @@ def chi2_kernel(X, Y=None, gamma=1.):
         k(x, y) = exp(-gamma Sum [(x - y)^2 / (x + y)])
 
     It can be interpreted as a weighted difference per entry.
+
+    Read more in the :ref:`User Guide <chi2_kernel>`.
 
     Parameters
     ----------
@@ -943,6 +971,8 @@ def distance_metrics():
     'l2'             metrics.pairwise.euclidean_distances
     'manhattan'      metrics.pairwise.manhattan_distances
     ============     ====================================
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     """
     return PAIRWISE_DISTANCE_FUNCTIONS
@@ -1042,6 +1072,8 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
     for 'cityblock'). For a verbose description of the metrics from
     scikit-learn, see the __doc__ of the sklearn.pairwise.distance_metrics
     function.
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
@@ -1146,6 +1178,8 @@ def kernel_metrics():
       'sigmoid'         sklearn.pairwise.sigmoid_kernel
       'cosine'          sklearn.pairwise.cosine_similarity
       ===============   ========================================
+
+    Read more in the :ref:`User Guide <metrics>`.
     """
     return PAIRWISE_KERNEL_FUNCTIONS
 
@@ -1180,6 +1214,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
 
     Valid values for metric are::
         ['rbf', 'sigmoid', 'polynomial', 'poly', 'linear', 'cosine']
+
+    Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -112,6 +112,8 @@ def average_precision_score(y_true, y_score, average="macro",
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
 
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
     Parameters
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
@@ -180,6 +182,8 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task in label indicator format.
+
+    Read more in the :ref:`User Guide <roc_metrics>`.
 
     Parameters
     ----------
@@ -349,6 +353,8 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     have a corresponding threshold.  This ensures that the graph starts on the
     x axis.
 
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
     Parameters
     ----------
     y_true : array, shape = [n_samples]
@@ -411,6 +417,8 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None):
     """Compute Receiver operating characteristic (ROC)
 
     Note: this implementation is restricted to the binary classification task.
+
+    Read more in the :ref:`User Guide <roc_metrics>`.
 
     Parameters
     ----------
@@ -516,6 +524,8 @@ def label_ranking_average_precision_score(y_true, y_score):
     The obtained score is always strictly greater than 0 and
     the best value is 1.
 
+    Read more in the :ref:`User Guide <label_ranking_average_precision>`.
+
     Parameters
     ----------
     y_true : array or sparse matrix, shape = [n_samples, n_labels]
@@ -586,6 +596,8 @@ def coverage_error(y_true, y_score, sample_weight=None):
     Ties in ``y_scores`` are broken by giving maximal rank that would have
     been assigned to all tied values.
 
+    Read more in the :ref:`User Guide <coverage_error>`.
+
     Parameters
     ----------
     y_true : array, shape = [n_samples, n_labels]
@@ -638,6 +650,8 @@ def label_ranking_loss(y_true, y_score, sample_weight=None):
     This is similar to the error set size, but weighted by the number of
     relevant and irrelevant labels. The best performance is achieved with
     a ranking loss of zero.
+
+    Read more in the :ref:`User Guide <label_ranking_loss>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -106,6 +106,8 @@ def mean_absolute_error(y_true, y_pred,
                         multioutput='uniform_average'):
     """Mean absolute error regression loss
 
+    Read more in the :ref:`User Guide <mean_absolute_error>`.
+
     Parameters
     ----------
     y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
@@ -174,6 +176,8 @@ def mean_squared_error(y_true, y_pred,
                        multioutput='uniform_average'):
     """Mean squared error regression loss
 
+    Read more in the :ref:`User Guide <mean_squared_error>`.
+
     Parameters
     ----------
     y_true : array-like of shape = (n_samples) or (n_samples, n_outputs)
@@ -237,6 +241,8 @@ def mean_squared_error(y_true, y_pred,
 def median_absolute_error(y_true, y_pred):
     """Median absolute error regression loss
 
+    Read more in the :ref:`User Guide <median_absolute_error>`.
+
     Parameters
     ----------
     y_true : array-like of shape = (n_samples)
@@ -272,6 +278,8 @@ def explained_variance_score(y_true, y_pred,
     """Explained variance regression score function
 
     Best possible score is 1.0, lower values are worse.
+
+    Read more in the :ref:`User Guide <explained_variance_score>`.
 
     Parameters
     ----------
@@ -361,6 +369,8 @@ def r2_score(y_true, y_pred,
     """R^2 (coefficient of determination) regression score function.
 
     Best possible score is 1.0, lower values are worse.
+
+    Read more in the :ref:`User Guide <r2_score>`.
 
     Parameters
     ----------

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -255,6 +255,8 @@ def make_scorer(score_func, greater_is_better=True, needs_proba=False,
     ``mean_squared_error``, ``adjusted_rand_index`` or ``average_precision``
     and returns a callable that scores an estimator's output.
 
+    Read more in the :ref:`User Guide <scoring>`.
+
     Parameters
     ----------
     score_func : callable,

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -125,6 +125,8 @@ class DPGMM(GMM):
     Initialization is with normally-distributed means and identity
     covariance, for proper convergence.
 
+    Read more in the :ref:`User Guide <dpgmm>`.
+
     Parameters
     ----------
     n_components: int, default 1
@@ -620,6 +622,8 @@ class VBGMM(DPGMM):
 
     Initialization is with normally-distributed means and identity
     covariance, for proper convergence.
+
+    Read more in the :ref:`User Guide <vbgmm>`.
 
     Parameters
     ----------

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -122,6 +122,8 @@ class GMM(BaseEstimator):
     Initializes parameters such that every mixture component has zero
     mean and identity covariance.
 
+    Read more in the :ref:`User Guide <gmm>`.
+
     Parameters
     ----------
     n_components : int, optional
@@ -473,7 +475,7 @@ class GMM(BaseEstimator):
 
         for init in range(self.n_init):
             if self.verbose > 0:
-                print('Initialization '+str(init+1))
+                print('Initialization ' + str(init + 1))
                 start_init_time = time()
 
             if 'm' in self.init_params or not hasattr(self, 'means_'):
@@ -510,7 +512,7 @@ class GMM(BaseEstimator):
 
             for i in range(self.n_iter):
                 if self.verbose > 0:
-                    print('\tEM iteration '+str(i+1))
+                    print('\tEM iteration ' + str(i + 1))
                     start_iter_time = time()
                 prev_log_likelihood = current_log_likelihood
                 # Expectation step
@@ -523,7 +525,7 @@ class GMM(BaseEstimator):
                 if prev_log_likelihood is not None:
                     change = abs(current_log_likelihood - prev_log_likelihood)
                     if self.verbose > 1:
-                        print('\t\tChange: '+str(change))
+                        print('\t\tChange: ' + str(change))
                     if change < tol:
                         self.converged_ = True
                         if self.verbose > 0:
@@ -534,8 +536,8 @@ class GMM(BaseEstimator):
                 self._do_mstep(X, responsibilities, self.params,
                                self.min_covar)
                 if self.verbose > 1:
-                    print('\t\tEM iteration '+str(i+1)+' took {0:.5f}s'.format(
-                        time()-start_iter_time))
+                    print('\t\tEM iteration ' + str(i + 1) + ' took {0:.5f}s'.format(
+                        time() - start_iter_time))
 
             # if the results are better, keep it
             if self.n_iter:
@@ -548,8 +550,8 @@ class GMM(BaseEstimator):
                         print('\tBetter parameters were found.')
 
             if self.verbose > 1:
-                print('\tInitialization '+str(init+1)+' took {0:.5f}s'.format(
-                    time()-start_init_time))
+                print('\tInitialization ' + str(init + 1) + ' took {0:.5f}s'.format(
+                    time() - start_init_time))
 
         # check the existence of an init param that was not subject to
         # likelihood computation issue.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -221,6 +221,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     In the multilabel learning literature, OvR is also known as the binary
     relevance method.
 
+    Read more in the :ref:`User Guide <ovr_classification>`.
+
     Parameters
     ----------
     estimator : estimator object
@@ -462,6 +464,8 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     a small subset of the data whereas, with one-vs-the-rest, the complete
     dataset is used `n_classes` times.
 
+    Read more in the :ref:`User Guide <ovo_classification>`.
+
     Parameters
     ----------
     estimator : estimator object
@@ -642,6 +646,8 @@ class OutputCodeClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     that the number of classifiers used can be controlled by the user, either
     for compressing the model (0 < code_size < 1) or for making the model more
     robust to errors (code_size > 1). See the documentation for more details.
+
+    Read more in the :ref:`User Guide <ecoc>`.
 
     Parameters
     ----------

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -113,6 +113,8 @@ class GaussianNB(BaseNB):
 
         http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf
 
+    Read more in the :ref:`User Guide <gaussian_naive_bayes>`.
+
     Attributes
     ----------
     class_prior_ : array, shape (n_classes,)
@@ -564,6 +566,8 @@ class MultinomialNB(BaseDiscreteNB):
     multinomial distribution normally requires integer feature counts. However,
     in practice, fractional counts such as tf-idf may also work.
 
+    Read more in the :ref:`User Guide <multinomial_naive_bayes>`.
+
     Parameters
     ----------
     alpha : float, optional (default=1.0)
@@ -664,6 +668,8 @@ class BernoulliNB(BaseDiscreteNB):
     Like MultinomialNB, this classifier is suitable for discrete data. The
     difference is that while MultinomialNB works with occurrence counts,
     BernoulliNB is designed for binary/boolean features.
+
+    Read more in the :ref:`User Guide <bernoulli_naive_bayes>`.
 
     Parameters
     ----------

--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -122,6 +122,8 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
     points. Its value does not depend on the norm of the vector points but
     only on their relative angles.
 
+    Read more in the :ref:`User Guide <approximate_nearest_neighbors>`.
+
     Parameters
     ----------
 

--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -24,6 +24,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
                            SupervisedIntegerMixin, ClassifierMixin):
     """Classifier implementing the k-nearest neighbors vote.
 
+    Read more in the :ref:`User Guide <classification>`.
+
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)
@@ -219,6 +221,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
 class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                                 SupervisedIntegerMixin, ClassifierMixin):
     """Classifier implementing a vote among neighbors within a given radius
+
+    Read more in the :ref:`User Guide <classification>`.
 
     Parameters
     ----------

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -9,6 +9,7 @@ import warnings
 from .base import KNeighborsMixin, RadiusNeighborsMixin
 from .unsupervised import NearestNeighbors
 
+
 def _check_params(X, metric, p, metric_params):
     """Check the validity of the input parameters"""
     params = zip(['metric', 'p', 'metric_params'],
@@ -49,6 +50,8 @@ def _query_include_self(X, include_self, mode):
 def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
                      p=2, metric_params=None, include_self=None):
     """Computes the (weighted) graph of k-Neighbors for points in X
+
+    Read more in the :ref:`User Guide <unsupervised_neighbors>`.
 
     Parameters
     ----------
@@ -105,9 +108,8 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
     radius_neighbors_graph
     """
     if not isinstance(X, KNeighborsMixin):
-        X = NearestNeighbors(
-            n_neighbors, metric=metric, p=p, metric_params=metric_params
-            ).fit(X)
+        X = NearestNeighbors(n_neighbors, metric=metric, p=p,
+                             metric_params=metric_params).fit(X)
     else:
         _check_params(X, metric, p, metric_params)
 
@@ -121,6 +123,8 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
 
     Neighborhoods are restricted the points at a distance lower than
     radius.
+
+    Read more in the :ref:`User Guide <unsupervised_neighbors>`.
 
     Parameters
     ----------
@@ -177,10 +181,8 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
     kneighbors_graph
     """
     if not isinstance(X, RadiusNeighborsMixin):
-        X = NearestNeighbors(
-            radius=radius, metric=metric, p=p,
-            metric_params=metric_params
-            ).fit(X)
+        X = NearestNeighbors(radius=radius, metric=metric, p=p,
+                             metric_params=metric_params).fit(X)
     else:
         _check_params(X, metric, p, metric_params)
 

--- a/sklearn/neighbors/kde.py
+++ b/sklearn/neighbors/kde.py
@@ -24,6 +24,8 @@ TREE_DICT = {'ball_tree': BallTree, 'kd_tree': KDTree}
 class KernelDensity(BaseEstimator):
     """Kernel Density Estimation
 
+    Read more in the :ref:`User Guide <kernel_density>`.
+
     Parameters
     ----------
     bandwidth : float

--- a/sklearn/neighbors/nearest_centroid.py
+++ b/sklearn/neighbors/nearest_centroid.py
@@ -13,7 +13,6 @@ import numpy as np
 from scipy import sparse as sp
 
 from ..base import BaseEstimator, ClassifierMixin
-from ..externals.six.moves import xrange
 from ..metrics.pairwise import pairwise_distances
 from ..preprocessing import LabelEncoder
 from ..utils.validation import check_array, check_X_y, check_is_fitted
@@ -25,6 +24,8 @@ class NearestCentroid(BaseEstimator, ClassifierMixin):
 
     Each class is represented by its centroid, with test samples classified to
     the class with the nearest centroid.
+
+    Read more in the :ref:`User Guide <nearest_centroid_classifier>`.
 
     Parameters
     ----------

--- a/sklearn/neighbors/regression.py
+++ b/sklearn/neighbors/regression.py
@@ -24,6 +24,8 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
     The target is predicted by local interpolation of the targets
     associated of the nearest neighbors in the training set.
 
+    Read more in the :ref:`User Guide <regression>`.
+
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)
@@ -163,6 +165,8 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
     The target is predicted by local interpolation of the targets
     associated of the nearest neighbors in the training set.
+
+    Read more in the :ref:`User Guide <regression>`.
 
     Parameters
     ----------

--- a/sklearn/neighbors/unsupervised.py
+++ b/sklearn/neighbors/unsupervised.py
@@ -10,6 +10,8 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
                        RadiusNeighborsMixin, UnsupervisedMixin):
     """Unsupervised learner for implementing neighbor searches.
 
+    Read more in the :ref:`User Guide <unsupervised_neighbors>`.
+
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)
@@ -42,7 +44,7 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         sklearn.metrics.pairwise.pairwise_distances. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
- 
+
     metric : string or callable, default 'minkowski'
         metric to use for distance computation. Any metric from scikit-learn
         or scipy.spatial.distance can be used.

--- a/sklearn/neural_network/rbm.py
+++ b/sklearn/neural_network/rbm.py
@@ -36,6 +36,8 @@ class BernoulliRBM(BaseEstimator, TransformerMixin):
     The time complexity of this implementation is ``O(d ** 2)`` assuming
     d ~ n_features ~ n_components.
 
+    Read more in the :ref:`User Guide <rbm>`.
+
     Parameters
     ----------
     n_components : int, optional

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -37,6 +37,8 @@ class Pipeline(BaseEstimator):
     For this, it enables setting parameters of the various steps using their
     names and the parameter name separated by a '__', as in the example below.
 
+    Read more in the :ref:`User Guide <pipeline>`.
+
     Parameters
     ----------
     steps : list
@@ -418,6 +420,8 @@ class FeatureUnion(BaseEstimator, TransformerMixin):
     This estimator applies a list of transformer objects in parallel to the
     input data, then concatenates the results. This is useful to combine
     several feature extraction mechanisms into a single transformer.
+
+    Read more in the :ref:`User Guide <feature_union>`.
 
     Parameters
     ----------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -20,7 +20,7 @@ from ..utils.fixes import combinations_with_replacement as combinations_w_r
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale, mean_variance_axis,
-                                 min_max_axis)
+                                 min_max_axis, inplace_row_scale)
 from ..utils.validation import check_is_fitted, FLOAT_DTYPES
 
 
@@ -73,6 +73,8 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     """Standardize a dataset along any axis
 
     Center to the mean and component wise scale to unit variance.
+
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
     Parameters
     ----------
@@ -194,6 +196,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
     This standardization is often used as an alternative to zero mean,
     unit variance scaling.
 
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
+
     Parameters
     ----------
     feature_range: tuple (min, max), default=(0, 1)
@@ -295,6 +299,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
     order. If a feature has a variance that is orders of magnitude larger
     that others, it might dominate the objective function and make the
     estimator unable to learn from other features correctly as expected.
+
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
     Parameters
     ----------
@@ -448,6 +454,8 @@ class RobustScaler(BaseEstimator, TransformerMixin):
     and scaling to unit variance. However, outliers can often influence the
     sample mean / variance in a negative way. In such cases, the median and
     the interquartile range often give better results.
+
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
     Parameters
     ----------
@@ -605,6 +613,8 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True, copy=True):
 
     Center to the median and component wise scale
     according to the interquartile range.
+
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
     Parameters
     ----------
@@ -789,6 +799,8 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
 def normalize(X, norm='l2', axis=1, copy=True):
     """Scale input vectors individually to unit norm (vector length).
 
+    Read more in the :ref:`User Guide <preprocessing_normalization>`.
+
     Parameters
     ----------
     X : array or scipy.sparse matrix with shape [n_samples, n_features]
@@ -873,6 +885,8 @@ class Normalizer(BaseEstimator, TransformerMixin):
     of the vectors and is the base similarity metric for the Vector
     Space Model commonly used by the Information Retrieval community.
 
+    Read more in the :ref:`User Guide <preprocessing_normalization>`.
+
     Parameters
     ----------
     norm : 'l1', 'l2', or 'max', optional ('l2' by default)
@@ -923,6 +937,8 @@ class Normalizer(BaseEstimator, TransformerMixin):
 
 def binarize(X, threshold=0.0, copy=True):
     """Boolean thresholding of array-like or scipy.sparse matrix
+
+    Read more in the :ref:`User Guide <preprocessing_binarization>`.
 
     Parameters
     ----------
@@ -979,6 +995,8 @@ class Binarizer(BaseEstimator, TransformerMixin):
     consider boolean random variables (e.g. modelled using the Bernoulli
     distribution in a Bayesian setting).
 
+    Read more in the :ref:`User Guide <preprocessing_binarization>`.
+
     Parameters
     ----------
     threshold : float, optional (0.0 by default)
@@ -1033,6 +1051,8 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
     normalize to have zero mean) the data without explicitly computing phi(x).
     It is equivalent to centering phi(x) with
     sklearn.preprocessing.StandardScaler(with_std=False).
+
+    Read more in the :ref:`User Guide <kernel_centering>`.
     """
 
     def fit(self, K, y=None):
@@ -1206,6 +1226,8 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
     This encoding is needed for feeding categorical data to many scikit-learn
     estimators, notably linear models and SVMs with the standard kernels.
+
+    Read more in the :ref:`User Guide <preprocessing_categorical_features>`.
 
     Parameters
     ----------

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -64,6 +64,8 @@ def _most_frequent(array, extra_value, n_repeat):
 class Imputer(BaseEstimator, TransformerMixin):
     """Imputation transformer for completing missing values.
 
+    Read more in the :ref:`User Guide <imputation>`.
+
     Parameters
     ----------
     missing_values : integer or "NaN", optional (default="NaN")

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -56,6 +56,8 @@ def _check_numpy_unicode_bug(labels):
 class LabelEncoder(BaseEstimator, TransformerMixin):
     """Encode labels with value between 0 and n_classes-1.
 
+    Read more in the :ref:`User Guide <preprocessing_targets>`.
+
     Attributes
     ----------
     classes_ : array of shape (n_class,)
@@ -185,6 +187,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     At prediction time, one assigns the class for which the corresponding
     model gave the greatest confidence. LabelBinarizer makes this easy
     with the inverse_transform method.
+
+    Read more in the :ref:`User Guide <preprocessing_targets>`.
 
     Parameters
     ----------

--- a/sklearn/qda.py
+++ b/sklearn/qda.py
@@ -29,6 +29,8 @@ class QDA(BaseEstimator, ClassifierMixin):
 
     The model fits a Gaussian density to each class.
 
+    Read more in the :ref:`User Guide <lda_qda>`.
+
     Parameters
     ----------
     priors : array, optional, shape = [n_classes]
@@ -97,7 +99,7 @@ class QDA(BaseEstimator, ClassifierMixin):
         store_covariances : boolean
             If True the covariance matrices are computed and stored in the
             `self.covariances_` attribute.
-        
+
         tol : float, optional, default 1.0e-4
             Threshold used for rank estimation.
         """

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -75,6 +75,8 @@ def johnson_lindenstrauss_min_dim(n_samples, eps=0.1):
     the larger the dataset, the higher is the minimal dimensionality of
     an eps-embedding.
 
+    Read more in the :ref:`User Guide <johnson_lindenstrauss>`.
+
     Parameters
     ----------
     n_samples : int or numpy array of int greater than 0,
@@ -158,6 +160,8 @@ def gaussian_random_matrix(n_components, n_features, random_state=None):
 
         N(0, 1.0 / n_components).
 
+    Read more in the :ref:`User Guide <gaussian_random_matrix>`.
+
     Parameters
     ----------
     n_components : int,
@@ -202,6 +206,8 @@ def sparse_random_matrix(n_components, n_features, density='auto',
       - -sqrt(s) / sqrt(n_components)   with probability 1 / 2s
       -  0                              with probability 1 - 1 / s
       - +sqrt(s) / sqrt(n_components)   with probability 1 / 2s
+
+    Read more in the :ref:`User Guide <sparse_random_matrix>`.
 
     Parameters
     ----------
@@ -420,6 +426,8 @@ class GaussianRandomProjection(BaseRandomProjection):
 
     The components of the random matrix are drawn from N(0, 1 / n_components).
 
+    Read more in the :ref:`User Guide <gaussian_random_matrix>`.
+
     Parameters
     ----------
     n_components : int or 'auto', optional (default = 'auto')
@@ -503,6 +511,8 @@ class SparseRandomProjection(BaseRandomProjection):
       - -sqrt(s) / sqrt(n_components)   with probability 1 / 2s
       -  0                              with probability 1 - 1 / s
       - +sqrt(s) / sqrt(n_components)   with probability 1 / 2s
+
+    Read more in the :ref:`User Guide <sparse_random_matrix>`.
 
     Parameters
     ----------

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -98,7 +98,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
     n_neighbors : integer > 0
         Parameter for knn kernel
- 
+
     """
 
     def __init__(self, kernel='rbf', gamma=20, n_neighbors=7,
@@ -268,19 +268,26 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 class LabelPropagation(BaseLabelPropagation):
     """Label Propagation classifier
 
+    Read more in the :ref:`User Guide <label_propagation>`.
+
     Parameters
     ----------
     kernel : {'knn', 'rbf'}
         String identifier for kernel function to use.
         Only 'rbf' and 'knn' kernels are currently supported..
+
     gamma : float
         Parameter for rbf kernel
+
     n_neighbors : integer > 0
         Parameter for knn kernel
+
     alpha : float
         Clamping factor
+
     max_iter : float
         Change maximum number of iterations allowed
+
     tol : float
         Convergence tolerance: threshold to consider the system at steady
         state
@@ -350,19 +357,26 @@ class LabelSpreading(BaseLabelPropagation):
     but uses affinity matrix based on the normalized graph Laplacian
     and soft clamping across the labels.
 
+    Read more in the :ref:`User Guide <label_propagation>`.
+
     Parameters
     ----------
     kernel : {'knn', 'rbf'}
         String identifier for kernel function to use.
         Only 'rbf' and 'knn' kernels are currently supported.
+
     gamma : float
       parameter for rbf kernel
+
     n_neighbors : integer > 0
       parameter for knn kernel
+
     alpha : float
       clamping factor
+
     max_iter : float
       maximum number of iterations allowed
+
     tol : float
       Convergence tolerance: threshold to consider the system at steady
       state

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -21,6 +21,8 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
     This class supports both dense and sparse input and the multiclass support
     is handled according to a one-vs-the-rest scheme.
 
+    Read more in the :ref:`User Guide <svm_classification>`.
+
     Parameters
     ----------
     C : float, optional (default=1.0)
@@ -226,6 +228,8 @@ class LinearSVR(LinearModel, RegressorMixin):
 
     This class supports both dense and sparse input.
 
+    Read more in the :ref:`User Guide <svm_regression>`.
+
     Parameters
     ----------
     C : float, optional (default=1.0)
@@ -389,7 +393,7 @@ class SVC(BaseSVC):
     other, see the corresponding section in the narrative documentation:
     :ref:`svm_kernels`.
 
-    .. The narrative documentation is available at http://scikit-learn.org/
+    Read more in the :ref:`User Guide <svm_classification>`.
 
     Parameters
     ----------
@@ -521,6 +525,8 @@ class NuSVC(BaseSVC):
 
     The implementation is based on libsvm.
 
+    Read more in the :ref:`User Guide <svm_classification>`.
+
     Parameters
     ----------
     nu : float, optional (default=0.5)
@@ -641,6 +647,8 @@ class SVR(BaseLibSVM, RegressorMixin):
 
     The implementation is based on libsvm.
 
+    Read more in the :ref:`User Guide <svm_regression>`.
+
     Parameters
     ----------
     C : float, optional (default=1.0)
@@ -752,6 +760,8 @@ class NuSVR(BaseLibSVM, RegressorMixin):
 
     The implementation is based on libsvm.
 
+    Read more in the :ref:`User Guide <svm_regression>`.
+
     Parameters
     ----------
     C : float, optional (default=1.0)
@@ -859,6 +869,8 @@ class OneClassSVM(BaseLibSVM):
     Estimate the support of a high-dimensional distribution.
 
     The implementation is based on libsvm.
+
+    Read more in the :ref:`User Guide <svm_outlier_detection>`.
 
     Parameters
     ----------

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -37,7 +37,7 @@ def _color_brew(n):
     c = s * v
     m = v - c
 
-    for h in np.arange(25, 385, 360./n).astype(int):
+    for h in np.arange(25, 385, 360. / n).astype(int):
         # Calculate some intermediate values
         h_bar = h / 60.
         x = c * (1 - abs((h_bar % 2) - 1))
@@ -75,6 +75,8 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
 
     The sample counts that are shown are weighted with any sample_weights that
     might be present.
+
+    Read more in the :ref:`User Guide <tree>`.
 
     Parameters
     ----------
@@ -304,11 +306,11 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
                     if tree.n_outputs != 1:
                         # Find max and min impurities for multi-output
                         colors['bounds'] = (np.min(-tree.impurity),
-                                             np.max(-tree.impurity))
+                                            np.max(-tree.impurity))
                     elif tree.n_classes[0] == 1:
                         # Find max and min values in leaf nodes for regression
                         colors['bounds'] = (np.min(tree.value),
-                                             np.max(tree.value))
+                                            np.max(tree.value))
                 if tree.n_outputs == 1:
                     node_val = (tree.value[node_id][0, :] /
                                 tree.weighted_n_node_samples[node_id])

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -26,7 +26,7 @@ from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_array, check_random_state, compute_sample_weight
-from ..utils.validation import NotFittedError, check_is_fitted
+from ..utils.validation import NotFittedError
 
 
 from ._tree import Criterion
@@ -433,6 +433,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
     """A decision tree classifier.
 
+    Read more in the :ref:`User Guide <tree>`.
+
     Parameters
     ----------
     criterion : string, optional (default="gini")
@@ -665,6 +667,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     """A decision tree regressor.
 
+    Read more in the :ref:`User Guide <tree>`.
+
     Parameters
     ----------
     criterion : string, optional (default="mse")
@@ -805,6 +809,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     Warning: Extra-trees should only be used within ensemble methods.
 
+    Read more in the :ref:`User Guide <tree>`.
+
     See also
     --------
     ExtraTreeRegressor, ExtraTreesClassifier, ExtraTreesRegressor
@@ -850,6 +856,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     decision tree.
 
     Warning: Extra-trees should only be used within ensemble methods.
+
+    Read more in the :ref:`User Guide <tree>`.
 
     See also
     --------


### PR DESCRIPTION
We discussed previously that doclinks from the API back to the user-guide would be helpful, and I have heard many people wishing for these.

I don't think there is another PR for that, though. 

The main questions are:
- manual or automatics
- just on the website or also in the docstring

I'm happy to do this manually if we can agree on how to do it. Doing it directly in the docstring is substantially easier than using sphinx and/or JS to insert them into the page later. The downside is that the the printed docstring looks a bit "ugly".
I would argue that people mostly look at the docs on the website, and that it isn't _that bad_.

looking good:
![backlinks4](https://cloud.githubusercontent.com/assets/449558/7639350/2e1c8d58-fa49-11e4-8226-2a91ad106bcf.png)

not that bad:
![backlinks1](https://cloud.githubusercontent.com/assets/449558/7639306/e0b7da68-fa48-11e4-801d-62a5d2e86686.png)
![backlinks2](https://cloud.githubusercontent.com/assets/449558/7639307/e0bada38-fa48-11e4-9655-1eefd6d9e39e.png)

The placement directly after the one-line summary is slightly violating [pep 0257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings) but makes for a nice rendering on the website.
Wdyt?
