### PR TITLE
[MRG + 2] FIX ransac output shape, add test for regressor output shapes

### DIFF
--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -196,8 +196,6 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         """
         X = check_array(X, accept_sparse='csr')
         y = check_array(y, ensure_2d=False)
-        if y.ndim == 1:
-            y = y.reshape(-1, 1)
         check_consistent_length(X, y)
 
         if self.base_estimator is not None:
@@ -278,10 +276,10 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
             # residuals of all data for current random sample model
             y_pred = base_estimator.predict(X)
-            if y_pred.ndim == 1:
-                y_pred = y_pred[:, None]
-
-            residuals_subset = residual_metric(y_pred - y)
+            diff = y_pred - y
+            if diff.ndim == 1:
+                diff = diff.reshape(-1, 1)
+            residuals_subset = residual_metric(diff)
 
             # classify data into inliers and outliers
             inlier_mask_subset = residuals_subset < residual_threshold

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -135,7 +135,7 @@ def test_ransac_predict():
                                        residual_threshold=0.5, random_state=0)
     ransac_estimator.fit(X, y)
 
-    assert_equal(ransac_estimator.predict(X), np.zeros((100, 1)))
+    assert_equal(ransac_estimator.predict(X), np.zeros(100))
 
 
 def test_ransac_sparse_coo():
@@ -201,7 +201,7 @@ def test_ransac_none_estimator():
 def test_ransac_min_n_samples():
     base_estimator = LinearRegression()
     ransac_estimator1 = RANSACRegressor(base_estimator, min_samples=2,
-                                        residual_threshold=5,  random_state=0)
+                                        residual_threshold=5, random_state=0)
     ransac_estimator2 = RANSACRegressor(base_estimator,
                                         min_samples=2. / X.shape[0],
                                         residual_threshold=5, random_state=0)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -961,7 +961,8 @@ def check_regressors_train(name, Regressor):
     set_random_state(regressor)
     regressor.fit(X, y_)
     regressor.fit(X.tolist(), y_.tolist())
-    regressor.predict(X)
+    y_pred = regressor.predict(X)
+    assert_equal(y_pred.shape, y_.shape)
 
     # TODO: find out why PLS and CCA fail. RANSAC is random
     # and furthermore assumes the presence of outliers, hence


### PR DESCRIPTION
Adds a tests for regressor output shapes.
I'm not sure if it is strict enough. I'm not sure what happens with `y.shape = (n_samples, 1)` currently.
This is to make sure that we don't return `(n_samples, 1)` if the training data was `(n_samples,)`.

Inspired by @naught101's comment [here](https://github.com/scikit-learn/scikit-learn/pull/3204#issuecomment-98048384)
