### PR TITLE
[MRG + 1] don't warn about multi-output deprecation if not using multi-output

### DIFF
--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -444,7 +444,7 @@ def r2_score(y_true, y_pred,
     # arbitrary set to zero to avoid -inf scores, having a constant
     # y_true is not interesting for scoring a regression anyway
     output_scores[nonzero_numerator & ~nonzero_denominator] = 0.
-    if multioutput is None:
+    if multioutput is None and y_true.shape[1] != 1:
         # @FIXME change in 0.18
         warnings.warn("Default 'multioutput' behavior now corresponds to "
                       "'variance_weighted' value, it will be changed "


### PR DESCRIPTION
Fixes part of #4728.
I feel that we don't need to warn about multi-output stuff if it doesn't have any consequence for the computation.
