### PR TITLE
[MRG] use the new container-based travis workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
-virtualenv:
-  system_site_packages: true
+# make it explicit that we favor the new container-based travis workers
+sudo: false
+addons:
+  apt:
+    packages:
+      # Only used by the DISTRIB="ubuntu" setting
+      - libatlas3gf-base
+      - libatlas-dev
+      - python-scipy
 env:
   matrix:
-    - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
-      COVERAGE="true"
+    # This environment tests that scikit-learn can be built against
+    # versions of numpy, scipy with ATLAS that comes with Ubuntu Precise 12.04
+    - DISTRIB="ubuntu" PYTHON_VERSION="2.7" COVERAGE="true"
     # This environment tests the oldest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.6" INSTALL_MKL="false"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
@@ -19,7 +27,6 @@ after_success:
     # because the coverage report failed to be published.
     - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
 cache: apt
-
 notifications:
   webhooks:
     urls:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,10 +13,6 @@ set -e
 export CC=gcc
 export CXX=g++
 
-sudo apt-get update -qq
-if [[ "$INSTALL_ATLAS" == "true" ]]; then
-    sudo apt-get install -qq libatlas3gf-base libatlas-dev
-fi
 
 if [[ "$DISTRIB" == "conda" ]]; then
     # Deactivate the travis-provided virtual environment and setup a
@@ -46,8 +42,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     fi
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
-    # Use standard ubuntu packages in their default version
-    sudo apt-get install -qq python-scipy
     # At the time of writing numpy 1.9.1 is included in the travis
     # virtualenv but we want to used numpy installed through apt-get
     # install.


### PR DESCRIPTION
This is an attempt to make it possible for the scikit-learn project to use the new container-based travis workers. Those workers run on EC2 and should be provisioned elastically meaning that queue time should be reduced.

More details here:

http://blog.travis-ci.com/2015-03-31-docker-default-on-the-way/
