### PR TITLE
[MRG+2] use astype to avoid unnecessary copy

### DIFF
--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -356,7 +356,8 @@ class Imputer(BaseEstimator, TransformerMixin):
             indexes = np.repeat(np.arange(len(X.indptr) - 1, dtype=np.int),
                                 np.diff(X.indptr))[mask]
 
-            X.data[mask] = valid_statistics[indexes].astype(X.dtype)
+            X.data[mask] = astype(valid_statistics[indexes], X.dtype,
+                                  copy=False)
         else:
             if sparse.issparse(X):
                 X = X.toarray()


### PR DESCRIPTION
use astype to avoid unnecessary copy

Additional to PR #4645 for issue #4573
