### PR TITLE
Unused params in GridSearchCV

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -705,10 +705,9 @@ class GridSearchCV(BaseSearchCV):
 
     """
 
-    def __init__(self, estimator, param_grid, scoring=None, loss_func=None,
-                 score_func=None, fit_params=None, n_jobs=1, iid=True,
-                 refit=True, cv=None, verbose=0, pre_dispatch='2*n_jobs',
-                 error_score='raise'):
+    def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
+                 n_jobs=1, iid=True, refit=True, cv=None, verbose=0,
+                 pre_dispatch='2*n_jobs', error_score='raise'):
 
         super(GridSearchCV, self).__init__(
             estimator, scoring, fit_params, n_jobs, iid,


### PR DESCRIPTION
Looks like the zombie parameters `loss_func` & `score_func` should have been removed in #3411 ... Deprecated for 0.15 it seems.
