### PR TITLE
[MRG+1] Printing top terms when using LSI in examples/text/document_clustering.py

### DIFF
--- a/examples/text/document_clustering.py
+++ b/examples/text/document_clustering.py
@@ -27,6 +27,9 @@ Two feature extraction methods can be used in this example:
 Two algorithms are demoed: ordinary k-means and its more scalable cousin
 minibatch k-means.
 
+Additionally, latent sematic analysis can also be used to reduce dimensionality
+and discover latent patterns in the data. 
+
 It can be noted that k-means (and minibatch k-means) are very sensitive to
 feature scaling and that in this case the IDF weighting helps improve the
 quality of the clustering by quite a lot as measured against the "ground truth"
@@ -160,7 +163,8 @@ if opts.n_components:
     # spherical k-means for better results. Since LSA/SVD results are
     # not normalized, we have to redo the normalization.
     svd = TruncatedSVD(opts.n_components)
-    lsa = make_pipeline(svd, Normalizer(copy=False))
+    normalizer = Normalizer(copy=False)
+    lsa = make_pipeline(svd, normalizer)
 
     X = lsa.fit_transform(X)
 
@@ -199,9 +203,16 @@ print("Silhouette Coefficient: %0.3f"
 
 print()
 
-if not (opts.n_components or opts.use_hashing):
+
+if not opts.use_hashing:
     print("Top terms per cluster:")
-    order_centroids = km.cluster_centers_.argsort()[:, ::-1]
+
+    if opts.n_components:
+        original_space_centroids = svd.inverse_transform(km.cluster_centers_)
+        order_centroids = original_space_centroids.argsort()[:, ::-1]
+    else:
+        order_centroids = km.cluster_centers_.argsort()[:, ::-1]
+
     terms = vectorizer.get_feature_names()
     for i in range(true_k):
         print("Cluster %d:" % i, end='')


### PR DESCRIPTION
Now when LSI is used it doesn't print the top 10 terms per cluster. However, we can bring the centroids from the semantic space back to the original space via `svd.inverse_transform`, and then find the top terms there. 

For example, here are the top terms for 20 clusters (for all categories in 20 newsgroups)

```
Cluster 0:  space  shuttle  alaska  edu  nasa  moon  launch  orbit  henry  sci
Cluster 1:  edu  game  team  games  year  ca  university  players  hockey  baseball
Cluster 2:  sale  00  edu  10  offer  new  distribution  subject  lines  shipping
Cluster 3:  israel  israeli  jews  arab  jewish  arabs  edu  jake  peace  israelis
Cluster 4:  cmu  andrew  org  com  stratus  edu  mellon  carnegie  pittsburgh  pa
Cluster 5:  god  jesus  christian  bible  church  christ  christians  people  edu  believe
Cluster 6:  drive  scsi  card  edu  mac  disk  ide  bus  pc  apple
Cluster 7:  com  ca  hp  subject  edu  lines  organization  writes  article  like
Cluster 8:  car  cars  com  edu  engine  ford  new  dealer  just  oil
Cluster 9:  sun  monitor  com  video  edu  vga  east  card  monitors  microsystems
Cluster 10:  nasa  gov  jpl  larc  gsfc  jsc  center  fnal  article  writes
Cluster 11:  windows  dos  file  edu  ms  files  program  os  com  use
Cluster 12:  netcom  com  edu  cramer  fbi  sandvik  408  writes  article  people
Cluster 13:  armenian  turkish  armenians  armenia  serdar  argic  turks  turkey  genocide  soviet
Cluster 14:  uiuc  cso  edu  illinois  urbana  uxa  university  writes  news  cobb
Cluster 15:  edu  cs  university  posting  host  nntp  state  subject  organization  lines
Cluster 16:  uk  ac  window  mit  server  lines  subject  university  com  edu
Cluster 17:  caltech  edu  keith  gatech  technology  institute  prism  morality  sgi  livesey
Cluster 18:  key  clipper  chip  encryption  com  keys  escrow  government  algorithm  des
Cluster 19:  people  edu  gun  com  government  don  like  think  just  access
```
