### PR TITLE
[MRG + 1] Add class_weight to PA Classifier, remove from PA Regressor

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,10 @@ Enhancements
      option, which has a simpler forumlar and interpretation.
      By Hanna Wallach and `Andreas Müller`_.
 
+   - Add ``class_weight`` parameter to automatically weight samples by class
+     frequency for :class:`linear_model.PassiveAgressiveClassifier`. By
+     `Trevor Stephens`_.
+
    - Added backlinks from the API reference pages to the user guide. By
      `Andreas Müller`_.
 
@@ -572,7 +576,7 @@ API changes summary
 
     - The ``shuffle`` option of :class:`.linear_model.SGDClassifier`,
       :class:`linear_model.SGDRegressor`, :class:`linear_model.Perceptron`,
-      :class:`linear_model.PassiveAgressiveClassivier` and
+      :class:`linear_model.PassiveAgressiveClassifier` and
       :class:`linear_model.PassiveAgressiveRegressor` now defaults to ``True``.
 
     - :class:`cluster.DBSCAN` now uses a deterministic initialization. The

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -49,6 +49,16 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
 
+    class_weight : dict, {class_label: weight} or "balanced" or None, optional
+        Preset for the class_weight fit parameter.
+
+        Weights associated with classes. If not given, all classes
+        are supposed to have weight one.
+
+        The "balanced" mode uses the values of y to automatically adjust
+        weights inversely proportional to class frequencies in the input data
+        as ``n_samples / (n_classes * np.bincount(y))``
+
     Attributes
     ----------
     coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
@@ -71,9 +81,9 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     K. Crammer, O. Dekel, J. Keshat, S. Shalev-Shwartz, Y. Singer - JMLR (2006)
 
     """
-    def __init__(self, C=1.0, fit_intercept=True,
-                 n_iter=5, shuffle=True, verbose=0, loss="hinge",
-                 n_jobs=1, random_state=None, warm_start=False):
+    def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=True,
+                 verbose=0, loss="hinge", n_jobs=1, random_state=None,
+                 warm_start=False, class_weight=None):
         BaseSGDClassifier.__init__(self,
                                    penalty=None,
                                    fit_intercept=fit_intercept,
@@ -83,6 +93,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
                                    random_state=random_state,
                                    eta0=1.0,
                                    warm_start=warm_start,
+                                   class_weight=class_weight,
                                    n_jobs=n_jobs)
         self.C = C
         self.loss = loss
@@ -110,6 +121,16 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         -------
         self : returns an instance of self.
         """
+        if self.class_weight == 'balanced':
+            raise ValueError("class_weight 'balanced' is not supported for "
+                             "partial_fit. For 'balanced' weights, use "
+                             "`sklearn.utils.compute_class_weight` with "
+                             "`class_weight='balanced'`. In place of y you "
+                             "can use a large enough subset of the full "
+                             "training set target to properly estimate the "
+                             "class frequency distributions. Pass the "
+                             "resulting weights as the class_weight "
+                             "parameter.")
         lr = "pa1" if self.loss == "hinge" else "pa2"
         return self._partial_fit(X, y, alpha=1.0, C=self.C,
                                  loss="hinge", learning_rate=lr, n_iter=1,
@@ -209,8 +230,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     """
     def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, loss="epsilon_insensitive",
-                 epsilon=DEFAULT_EPSILON, random_state=None, class_weight=None,
-                 warm_start=False):
+                 epsilon=DEFAULT_EPSILON, random_state=None, warm_start=False):
         BaseSGDRegressor.__init__(self,
                                   penalty=None,
                                   l1_ratio=0,


### PR DESCRIPTION
Was browsing Landscape.io and noticed this strange one. `class_weight` is a zombie param for the `PassiveAggressiveRegressor`, not present for the `PassiveAggressiveClassifier` O_o

Removed from regressor, didn't think deprecation is necessary since it didn't go anywhere and makes no sense either, and implemented it for the classifier with some tests.
