### PR TITLE
Multiprocessing fix for dictionary learning main loop

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -110,7 +110,8 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
         clf = Lasso(alpha=alpha, fit_intercept=False, precompute=gram,
                     max_iter=max_iter, warm_start=True)
         clf.coef_ = init
-        clf.fit(dictionary.T, X.T)
+        # Copying X to avoid buffer source-array read only error
+        clf.fit(dictionary.T, X.copy().T)
         new_code = clf.coef_
 
     elif algorithm == 'lars':
@@ -669,8 +670,9 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
                 print ("Iteration % 3i (elapsed time: % 3is, % 4.1fmn)"
                        % (ii, dt, dt / 60))
 
+        # Setting n_jobs = 1 to avoid creating workers at each iteration
         this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
-                                  alpha=alpha, n_jobs=n_jobs).T
+                                  alpha=alpha, n_jobs=1).T
 
         # Update the auxiliary variables
         if ii < batch_size - 1:

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -110,8 +110,7 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
         clf = Lasso(alpha=alpha, fit_intercept=False, precompute=gram,
                     max_iter=max_iter, warm_start=True)
         clf.coef_ = init
-        # Copying X to avoid buffer source-array read only error
-        clf.fit(dictionary.T, X.copy().T)
+        clf.fit(dictionary.T, X.T)
         new_code = clf.coef_
 
     elif algorithm == 'lars':


### PR DESCRIPTION
Setting n_jobs = 1 during online dictionary learning process

<del>Copying X before Lasso.fit call, for lasso_cd algorithm, to avoid buffer source-array read-only error</del> (see discussion)

Fixing issues : <del>#4772</del>, #4769
