### PR TITLE
[MRG+1] RandomForest decrease allocated memory when using bootstrap option. (Fix issue#4774)

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -378,7 +378,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
             predictions.append(np.zeros((n_samples, n_classes_[k])))
 
         for estimator in self.estimators_:
-            unsampled_indices = _generate_unsampled_indices(estimator.random_state, n_samples)
+            unsampled_indices = _generate_unsampled_indices(
+                estimator.random_state, n_samples)
             p_estimator = estimator.predict_proba(X[unsampled_indices, :],
                                                   check_input=False)
 
@@ -645,8 +646,10 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
         n_predictions = np.zeros((n_samples, self.n_outputs_))
 
         for estimator in self.estimators_:
-            unsampled_indices = _generate_unsampled_indices(estimator.random_state, n_samples)
-            p_estimator = estimator.predict(X[unsampled_indices, :], check_input=False)
+            unsampled_indices = _generate_unsampled_indices(
+                estimator.random_state, n_samples)
+            p_estimator = estimator.predict(
+                X[unsampled_indices, :], check_input=False)
 
             if self.n_outputs_ == 1:
                 p_estimator = p_estimator[:, np.newaxis]

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -368,10 +368,8 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
             random_state = check_random_state(estimator.random_state)
             indices = random_state.randint(0, n_samples, n_samples)
             sample_counts = bincount(indices, minlength=n_samples)
-            indices_map = sample_counts > 0.
+            mask = sample_counts == 0
 
-            mask = np.ones(n_samples, dtype=np.bool)
-            mask[indices_map] = False
             mask_indices = sample_indices[mask]
             p_estimator = estimator.predict_proba(X[mask_indices, :],
                                                   check_input=False)
@@ -644,10 +642,8 @@ class ForestRegressor(six.with_metaclass(ABCMeta, BaseForest, RegressorMixin)):
             random_state = check_random_state(estimator.random_state)
             indices = random_state.randint(0, n_samples, n_samples)
             sample_counts = bincount(indices, minlength=n_samples)
-            indices_map = sample_counts > 0.
+            mask = sample_counts == 0
 
-            mask = np.ones(n_samples, dtype=np.bool)
-            mask[indices_map] = False
             mask_indices = sample_indices[mask]
             p_estimator = estimator.predict(X[mask_indices, :], check_input=False)
 


### PR DESCRIPTION
Fix issue https://github.com/scikit-learn/scikit-learn/issues/4774

RandomForest was allocating a lot of memory for calculate oob_score. 
Remove member-valuable `tree.indices_` what sample is using for bootstrap, and generate it when it referenced.
