### PR TITLE
[MRG] Fix RFE / RFECV estimator tags

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -110,6 +110,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         self.estimator_params = estimator_params
         self.verbose = verbose
 
+    @property
+    def _estimator_type(self):
+        return self.estimator._estimator_type
+
     def fit(self, X, y):
         """Fit the RFE model and then the underlying estimator on the selected
            features.


### PR DESCRIPTION
Pretty bad regression from introducing `_estimator_tags`. I forgot to define them for RFE, which made accuracies on iris be 0 using default cross-validation. ouch.
