### PR TITLE
[MRG+1] Updated _std docstring in StandardScaler to make internal handling of zero values explicit.

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -319,7 +319,8 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         The mean value for each feature in the training set.
 
     std_ : array of floats with shape [n_features]
-        The standard deviation for each feature in the training set.
+        The standard deviation for each feature in the training set. 
+        Set to one if the standard deviation is zero for a given feature.
 
     See also
     --------


### PR DESCRIPTION
Fix for Issue #4609 
