### PR TITLE
[MRG] ROCCH calibration method

### DIFF
--- a/examples/calibration/plot_calibration.py
+++ b/examples/calibration/plot_calibration.py
@@ -14,8 +14,9 @@ returned probabilities using Brier's score
 (see http://en.wikipedia.org/wiki/Brier_score).
 
 Compared are the estimated probability using a Gaussian naive Bayes classifier
-without calibration, with a sigmoid calibration, and with a non-parametric
-isotonic calibration. One can observe that only the non-parametric model is able
+without calibration, with a sigmoid calibration, with a non-parametric
+isotonic calibration and with a non-parametric ROC convex hull calibration.
+One can observe that only the non-parametric models are able
 to provide a probability calibration that returns probabilities close to the
 expected 0.5 for most of the samples belonging to the middle cluster with
 heterogeneous labels. This results in a significantly improved Brier score.

--- a/examples/calibration/plot_calibration.py
+++ b/examples/calibration/plot_calibration.py
@@ -26,6 +26,7 @@ print(__doc__)
 #         Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #         Balazs Kegl <balazs.kegl@gmail.com>
 #         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+#         Alejandro Correa Bahnsen <al.bahnsen@gmail.com>
 # License: BSD Style.
 
 import numpy as np
@@ -72,16 +73,24 @@ clf_sigmoid = CalibratedClassifierCV(clf, cv=2, method='sigmoid')
 clf_sigmoid.fit(X_train, y_train, sw_train)
 prob_pos_sigmoid = clf_sigmoid.predict_proba(X_test)[:, 1]
 
+# Gaussian Naive-Bayes with rocch calibration
+clf_rocch = CalibratedClassifierCV(clf, cv=2, method='rocch')
+clf_rocch.fit(X_train, y_train, sw_train)
+prob_pos_rocch = clf_rocch.predict_proba(X_test)[:, 1]
+
 print("Brier scores: (the smaller the better)")
 
 clf_score = brier_score_loss(y_test, prob_pos_clf, sw_test)
-print("No calibration: %1.3f" % clf_score)
+print("No calibration: %1.4f" % clf_score)
 
 clf_isotonic_score = brier_score_loss(y_test, prob_pos_isotonic, sw_test)
-print("With isotonic calibration: %1.3f" % clf_isotonic_score)
+print("With isotonic calibration: %1.4f" % clf_isotonic_score)
 
 clf_sigmoid_score = brier_score_loss(y_test, prob_pos_sigmoid, sw_test)
-print("With sigmoid calibration: %1.3f" % clf_sigmoid_score)
+print("With sigmoid calibration: %1.4f" % clf_sigmoid_score)
+
+clf_rocch_score = brier_score_loss(y_test, prob_pos_rocch, sw_test)
+print("With rocch calibration: %1.4f" % clf_rocch_score)
 
 ###############################################################################
 # Plot the data and the predicted probabilities
@@ -103,6 +112,8 @@ plt.plot(prob_pos_isotonic[order], 'g', linewidth=3,
          label='Isotonic calibration (%1.3f)' % clf_isotonic_score)
 plt.plot(prob_pos_sigmoid[order], 'b', linewidth=3,
          label='Sigmoid calibration (%1.3f)' % clf_sigmoid_score)
+plt.plot(prob_pos_rocch[order], 'r', linewidth=3,
+         label='ROCConvexHull calibration (%1.3f)' % clf_rocch_score)
 plt.plot(np.linspace(0, y_test.size, 51)[1::2],
          y_test[order].reshape(25, -1).mean(1),
          'k', linewidth=3, label=r'Empirical')

--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -13,8 +13,9 @@ The experiment is performed on an artificial dataset for binary classification
 with 100.000 samples (1.000 of them are used for model fitting) with 20
 features. Of the 20 features, only 2 are informative and 10 are redundant. The
 first figure shows the estimated probabilities obtained with logistic
-regression, Gaussian naive Bayes, and Gaussian naive Bayes with both isotonic
-calibration and sigmoid calibration. The calibration performance is evaluated
+regression, Gaussian naive Bayes, and Gaussian naive Bayes with isotonic
+calibration, sigmoid calibration or ROC convex hull calibration.
+The calibration performance is evaluated
 with Brier score, reported in the legend (the smaller the better). One can
 observe here that logistic regression is well calibrated while raw Gaussian
 naive Bayes performs very badly. This is because of the redundant features
@@ -25,7 +26,8 @@ curve.
 Calibration of the probabilities of Gaussian naive Bayes with isotonic
 regression can fix this issue as can be seen from the nearly diagonal
 calibration curve. Sigmoid calibration also improves the brier score slightly,
-albeit not as strongly as the non-parametric isotonic regression. This can be
+albeit not as strongly as the non-parametric isotonic regression. Similarly,
+ROC convex hull have a similar impact as the Sigmoid calibration. This can be
 attributed to the fact that we have plenty of calibration data such that the
 greater flexibility of the non-parametric model can be exploited.
 
@@ -36,7 +38,7 @@ an under-confident classifier. In the case of LinearSVC, this is caused by the
 margin property of the hinge loss, which lets the model focus on hard samples
 that are close to the decision boundary (the support vectors).
 
-Both kinds of calibration can fix this issue and yield nearly identical
+The three kinds of calibration methods can fix this issue and yield nearly identical
 results. This shows that sigmoid calibration can deal with situations where
 the calibration curve of the base classifier is sigmoid (e.g., for LinearSVC)
 but not where it is transposed-sigmoid (e.g., Gaussian naive Bayes).
@@ -58,6 +60,7 @@ from sklearn.metrics import (brier_score_loss, precision_score, recall_score,
                              f1_score)
 from sklearn.calibration import CalibratedClassifierCV, calibration_curve
 from sklearn.cross_validation import train_test_split
+from sklearn.metrics import roc_auc_score
 
 
 # Create dataset of classification task with many redundant and few
@@ -108,7 +111,8 @@ def plot_calibration_curve(est, name, fig_index):
         print("\tBrier: %1.4f" % (clf_score))
         print("\tPrecision: %1.3f" % precision_score(y_test, y_pred))
         print("\tRecall: %1.3f" % recall_score(y_test, y_pred))
-        print("\tF1: %1.3f\n" % f1_score(y_test, y_pred))
+        print("\tF1: %1.3f" % f1_score(y_test, y_pred))
+        print("\tAuc: %1.4f\n" % roc_auc_score(y_test, prob_pos))
 
         fraction_of_positives, mean_predicted_value = \
             calibration_curve(y_test, prob_pos, n_bins=10)

--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -45,6 +45,7 @@ print(__doc__)
 
 # Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+#         Alejandro Correa Bahnsen <al.bahnsen@gmail.com>
 # License: BSD Style.
 
 import matplotlib.pyplot as plt
@@ -77,6 +78,9 @@ def plot_calibration_curve(est, name, fig_index):
     # Calibrated with sigmoid calibration
     sigmoid = CalibratedClassifierCV(est, cv=2, method='sigmoid')
 
+    # Calibrated with ROC convex hull calibration
+    rocch = CalibratedClassifierCV(est, cv=2, method='rocch')
+
     # Logistic regression with no calibration as baseline
     lr = LogisticRegression(C=1., solver='lbfgs')
 
@@ -88,7 +92,8 @@ def plot_calibration_curve(est, name, fig_index):
     for clf, name in [(lr, 'Logistic'),
                       (est, name),
                       (isotonic, name + ' + Isotonic'),
-                      (sigmoid, name + ' + Sigmoid')]:
+                      (sigmoid, name + ' + Sigmoid'),
+                      (rocch, name + ' + ROCConvexHull')]:
         clf.fit(X_train, y_train)
         y_pred = clf.predict(X_test)
         if hasattr(clf, "predict_proba"):
@@ -100,7 +105,7 @@ def plot_calibration_curve(est, name, fig_index):
 
         clf_score = brier_score_loss(y_test, prob_pos, pos_label=y.max())
         print("%s:" % name)
-        print("\tBrier: %1.3f" % (clf_score))
+        print("\tBrier: %1.4f" % (clf_score))
         print("\tPrecision: %1.3f" % precision_score(y_test, y_pred))
         print("\tRecall: %1.3f" % recall_score(y_test, y_pred))
         print("\tF1: %1.3f\n" % f1_score(y_test, y_pred))
@@ -109,7 +114,7 @@ def plot_calibration_curve(est, name, fig_index):
             calibration_curve(y_test, prob_pos, n_bins=10)
 
         ax1.plot(mean_predicted_value, fraction_of_positives, "s-",
-                 label="%s (%1.3f)" % (name, clf_score))
+                 label="%s (%1.4f)" % (name, clf_score))
 
         ax2.hist(prob_pos, range=(0, 1), bins=10, label=name,
                  histtype="step", lw=2)

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -26,7 +26,7 @@ from .svm import LinearSVC
 from .cross_validation import _check_cv
 from .metrics.classification import _check_binary_probabilistic_predictions
 from .metrics import roc_curve
-from scipy.spatial import ConvexHull
+from .utils.fixes import ConvexHull
 
 
 class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -595,8 +595,10 @@ class _ROCCHCalibration(BaseEstimator, RegressorMixin):
 
         # Calculate convex hull
         temp_ch = np.vstack((fpr,tpr)).T
+        # Close the plane to avoid issues when points are on the right of the diag
+        temp_ch = np.r_[temp_ch, np.array([[1, 0]])]
         hull = ConvexHull(temp_ch)
-        hull_idx = np.sort(hull.vertices)
+        hull_idx = np.sort(hull.vertices)[:-1]
 
         # Get new thresholds and invert order
         ch_thresholds = thresholds[hull_idx]

--- a/sklearn/utils/_scipy_convexhull_backport.py
+++ b/sklearn/utils/_scipy_convexhull_backport.py
@@ -1,0 +1,95 @@
+"""Convex Hull of a set of points
+
+"""
+
+import numpy as np
+
+__all__ = ['ConvexHull']
+
+
+class ConvexHull():
+    """ Private function that calculate the convex hull of a set of 2-D points
+    The algorithm was taken from [1].
+    http://code.activestate.com/recipes/66527-finding-the-convex-hull-of-a-set-of-2d-points/
+
+    Convex hulls in 2 dimensions.
+
+    Parameters
+    ----------
+    points : ndarray of floats, shape (npoints, 2)
+        Coordinates of points to construct a convex hull from
+
+    Attributes
+    ----------
+    vertices : ndarray of ints, shape (nvertices,)
+        Indices of points forming the vertices of the convex hull.
+        For 2-D convex hulls, the vertices are in counterclockwise order.
+        For other dimensions, they are in input order.
+
+    References
+    ----------
+    .. [1] Alex Martelli, Ann
+        for point in c_points:
+            print np.nonzero(points[:, 0] == point[0])a Ravenscroft, David Ascher, 'Python Cookbook', O'Reilly Media, Inc., 2005.
+
+    """
+
+    def mydet(self, p, q, r):
+        """Calc. determinant of a special matrix with three 2D points.
+
+        The sign, "-" or "+", determines the side, right or left,
+        respectivly, on which the point r lies, when measured against
+        a directed vector from p to q.
+        """
+
+        # We use Sarrus' Rule to calculate the determinant.
+        # (could also use the Numeric package...)
+        sum1 = q[0] * r[1] + p[0] * q[1] + r[0] * p[1]
+        sum2 = q[0] * p[1] + r[0] * q[1] + p[0] * r[1]
+
+        return sum1 - sum2
+
+    def isrightturn(self, p, q, r):
+        "Do the vectors pq:qr form a right turn, or not?"
+
+        assert p != q and q != r and p != r
+
+        if self.mydet(p, q, r) < 0:
+            return 1
+        else:
+            return 0
+
+    def __init__(self, points):
+
+        # Get a local list copy of the points and sort them lexically.
+        points_ = points.tolist()
+        points_.sort()
+
+        # Build upper half of the hull.
+        upper = [points_[0], points_[1]]
+        for p in points_[2:]:
+            upper.append(p)
+            while len(upper) > 2 and not self.isrightturn(*upper[-3:]):
+                del upper[-2]
+
+        # Build lower half of the hull.
+        points_.reverse()
+        lower = [points_[0], points_[1]]
+        for p in points_[2:]:
+            lower.append(p)
+            while len(lower) > 2 and not self.isrightturn(*lower[-3:]):
+                del lower[-2]
+
+        # Remove duplicates.
+        del lower[0]
+        del lower[-1]
+
+        # Concatenate both halfs and construct vertices.
+        c_points = np.array(tuple(upper + lower))
+        vertices = []
+        for point in c_points:
+            vertices.append(np.intersect1d(
+                            np.nonzero(point[0] == points[:, 0])[0],
+                            np.nonzero(point[1] == points[:, 1])[0])[0])
+
+        self.vertices = np.array(vertices)

--- a/sklearn/utils/_scipy_convexhull_backport.py
+++ b/sklearn/utils/_scipy_convexhull_backport.py
@@ -28,9 +28,7 @@ class ConvexHull():
 
     References
     ----------
-    .. [1] Alex Martelli, Ann
-        for point in c_points:
-            print np.nonzero(points[:, 0] == point[0])a Ravenscroft, David Ascher, 'Python Cookbook', O'Reilly Media, Inc., 2005.
+    .. [1] Alex Martelli, Anna Ravenscroft, David Ascher, 'Python Cookbook', O'Reilly Media, Inc., 2005.
 
     """
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -7,6 +7,7 @@ at which the fixe is no longer needed.
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
 #          Fabian Pedregosa <fpedregosa@acm.org>
 #          Lars Buitinck
+#          Alejandro Correa Bahnsen <al.bahnsen@gmail.com>
 #
 # License: BSD 3 clause
 
@@ -351,3 +352,10 @@ if np_version < (1, 6, 2):
 
 else:
     from numpy import bincount
+
+
+if sp_version < (0, 12):
+    # Backport ConvexHull function from scipy < 0.12
+    from ._scipy_convexhull_backport import ConvexHull
+else:
+    from scipy.spatial import ConvexHull


### PR DESCRIPTION
Implementation of the ROCCH calibration method, as described in http://www.jmlr.org/papers/volume13/hernandez-orallo12a/hernandez-orallo12a.pdf and http://link.springer.com/article/10.1007/s10994-007-5011-0

It is implemented as an other method within the CalibratedClassifierCV class. Moreover, the documentation is expanded to include the results.

The method performs similarly to Isotonic calibration when measured by Brier loss, F1 Score or AUC. But  with an speedup of up to 1.3X

Here an example

```python
In[2]: %paste

import pandas as pd
from sklearn import datasets
from sklearn.naive_bayes import GaussianNB
from sklearn.svm import LinearSVC
from sklearn.calibration import CalibratedClassifierCV
from sklearn.cross_validation import train_test_split
from sklearn.metrics import brier_score_loss, f1_score, roc_auc_score

X, y = datasets.make_classification(n_samples=100000, n_features=20,
                                    n_informative=2, n_redundant=10,
                                    random_state=42)

X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.99,
                                                    random_state=42)

def test_times(method, est):
    clf =  CalibratedClassifierCV(est, cv=5, method=method)
    clf.fit(X_train, y_train)
    y_pred = clf.predict(X_test)
    y_prob = clf.predict_proba(X_test)[:,1]
    brier = brier_score_loss(y_test, y_prob, pos_label=y.max())
    f1 = f1_score(y_test, y_pred)
    auc = roc_auc_score(y_test, y_prob)
    return brier, f1, auc

res = pd.DataFrame(columns=['brier_loss','f1_score','auc_score'])
## -- End pasted text --
Backend TkAgg is interactive backend. Turning interactive mode on.
In[3]: %timeit res.loc['GNB+isotonic'] = test_times(method='isotonic', est=GaussianNB())
1 loops, best of 3: 823 ms per loop
In[4]: %timeit res.loc['GNB+sigmoid'] = test_times(method='sigmoid', est=GaussianNB())
1 loops, best of 3: 776 ms per loop
In[5]: %timeit res.loc['GNB+rocch'] = test_times(method='rocch', est=GaussianNB())
1 loops, best of 3: 752 ms per loop
In[6]: %timeit res.loc['LSVC+isotonic'] = test_times(method='isotonic', est=LinearSVC())
1 loops, best of 3: 416 ms per loop
In[7]: %timeit res.loc['LSVC+sigmoid'] = test_times(method='sigmoid', est=LinearSVC())
1 loops, best of 3: 367 ms per loop
In[8]: %timeit res.loc['LSVC+rocch'] = test_times(method='rocch', est=LinearSVC())
1 loops, best of 3: 324 ms per loop
In[9]: res['time'] = [823, 776, 752, 416, 367, 324]
In[10]: print res
```

| brier_loss | f1_score | auc_score | time |
| --- | --- | --- | --- |
| GNB+isotonic | 0.098487 | 0.854058 | 0.939305 |
| GNB+sigmoid | 0.108937 | 0.866259 | 0.937025 |
| GNB+rocch | 0.098752 | 0.851963 | 0.939027 |
| LSVC+isotonic | 0.099401 | 0.864936 | 0.936852 |
| LSVC+sigmoid | 0.098603 | 0.862041 | 0.937657 |
| LSVC+rocch | 0.099584 | 0.864046 | 0.936733 |
