### PR TITLE
[MRG+2] Add option to get sparse output from cosine_similarity.

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -812,7 +812,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
         Input data. If ``None``, the output will be the pairwise
         similarities between all samples in ``X``.
 
-    dense_output : boolean (optional)
+    dense_output : boolean (optional), default True
         Whether to return dense output even when the input is sparse. If
         ``False``, the output is sparse if both input arrays are sparse.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -812,7 +812,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
         with shape (n_samples_Y, n_features).
 
     dense_output : boolean (optional)
-        Return sparse output.
+        Whether to return sparse output.
 
     Returns
     -------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -791,7 +791,7 @@ def rbf_kernel(X, Y=None, gamma=None):
     return K
 
 
-def cosine_similarity(X, Y=None):
+def cosine_similarity(X, Y=None, dense_output=True):
     """Compute cosine similarity between samples in X and Y.
 
     Cosine similarity, or the cosine kernel, computes similarity as the
@@ -811,6 +811,9 @@ def cosine_similarity(X, Y=None):
     Y : array_like, sparse matrix (optional)
         with shape (n_samples_Y, n_features).
 
+    dense_output : boolean (optional)
+        Return sparse output.
+
     Returns
     -------
     kernel matrix : array
@@ -826,7 +829,7 @@ def cosine_similarity(X, Y=None):
     else:
         Y_normalized = normalize(Y, copy=True)
 
-    K = safe_sparse_dot(X_normalized, Y_normalized.T, dense_output=True)
+    K = safe_sparse_dot(X_normalized, Y_normalized.T, dense_output=dense_output)
 
     return K
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -805,14 +805,16 @@ def cosine_similarity(X, Y=None, dense_output=True):
 
     Parameters
     ----------
-    X : array_like, sparse matrix
-        with shape (n_samples_X, n_features).
+    X : ndarray or sparse array, shape: (n_samples_X, n_features)
+        Input data.
 
-    Y : array_like, sparse matrix (optional)
-        with shape (n_samples_Y, n_features).
+    Y : ndarray or sparse array, shape: (n_samples_Y, n_features)
+        Input data. If ``None``, the output will be the pairwise
+        similarities between all samples in ``X``.
 
     dense_output : boolean (optional)
-        Whether to return sparse output.
+        Whether to return dense output even when the input is sparse. If
+        ``False``, the output is sparse if both input arrays are sparse.
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy import linalg
 
 from scipy.sparse import dok_matrix, csr_matrix, issparse
+from scipy.sparse.base import spmatrix
 from scipy.spatial.distance import cosine, cityblock, minkowski, wminkowski
 
 from sklearn.utils.testing import assert_greater
@@ -443,6 +444,22 @@ def test_rbf_kernel():
     K = rbf_kernel(X, X)
     # the diagonal elements of a rbf kernel are 1
     assert_array_almost_equal(K.flat[::6], np.ones(5))
+
+
+def test_cosine_similarity_spase_output():
+    # Test if cosine_similarity correctly produces sparse output.
+
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    Y = rng.random_sample((3, 4))
+    Xcsr = csr_matrix(X)
+    Ycsr = csr_matrix(Y)
+
+    K1 = cosine_similarity(X, Y, dense_output=False)
+    assert_true(isinstance(K1, spmatrix))
+
+    K2 = pairwise_kernels(Xcsr, Y=Ycsr, metric="cosine")
+    assert_array_almost_equal(K1.todense(), K2)
 
 
 def test_cosine_similarity():

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -2,7 +2,6 @@ import numpy as np
 from numpy import linalg
 
 from scipy.sparse import dok_matrix, csr_matrix, issparse
-from scipy.sparse.base import spmatrix
 from scipy.spatial.distance import cosine, cityblock, minkowski, wminkowski
 
 from sklearn.utils.testing import assert_greater
@@ -456,7 +455,7 @@ def test_cosine_similarity_sparse_output():
     Ycsr = csr_matrix(Y)
 
     K1 = cosine_similarity(Xcsr, Ycsr, dense_output=False)
-    assert_true(isinstance(K1, spmatrix))
+    assert_true(issparse(K1))
 
     K2 = pairwise_kernels(Xcsr, Y=Ycsr, metric="cosine")
     assert_array_almost_equal(K1.todense(), K2)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -446,7 +446,7 @@ def test_rbf_kernel():
     assert_array_almost_equal(K.flat[::6], np.ones(5))
 
 
-def test_cosine_similarity_spase_output():
+def test_cosine_similarity_sparse_output():
     # Test if cosine_similarity correctly produces sparse output.
 
     rng = np.random.RandomState(0)
@@ -455,7 +455,7 @@ def test_cosine_similarity_spase_output():
     Xcsr = csr_matrix(X)
     Ycsr = csr_matrix(Y)
 
-    K1 = cosine_similarity(X, Y, dense_output=False)
+    K1 = cosine_similarity(Xcsr, Ycsr, dense_output=False)
     assert_true(isinstance(K1, spmatrix))
 
     K2 = pairwise_kernels(Xcsr, Y=Ycsr, metric="cosine")


### PR DESCRIPTION
This PR adds a default argument to `sklearn.metrics.pairwise.cosine_similarity` that enables it to return  sparse output.
