### PR TITLE
[MRG+2] MAINT merge _check_cv into check_cv as indices argument is removed in 0.17

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -22,7 +22,7 @@ from .utils import check_X_y, check_array, indexable, column_or_1d
 from .utils.validation import check_is_fitted
 from .isotonic import IsotonicRegression
 from .svm import LinearSVC
-from .cross_validation import _check_cv
+from .cross_validation import check_cv
 from .metrics.classification import _check_binary_probabilistic_predictions
 
 
@@ -141,7 +141,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
                 calibrated_classifier.fit(X, y)
             self.calibrated_classifiers_.append(calibrated_classifier)
         else:
-            cv = _check_cv(self.cv, X, y, classifier=True)
+            cv = check_cv(self.cv, X, y, classifier=True)
             arg_names = inspect.getargspec(base_estimator.fit)[0]
             estimator_name = type(base_estimator).__name__
             if (sample_weight is not None

--- a/sklearn/covariance/graph_lasso_.py
+++ b/sklearn/covariance/graph_lasso_.py
@@ -21,7 +21,7 @@ from ..utils.extmath import pinvh
 from ..utils.validation import check_random_state, check_array
 from ..linear_model import lars_path
 from ..linear_model import cd_fast
-from ..cross_validation import _check_cv as check_cv, cross_val_score
+from ..cross_validation import check_cv, cross_val_score
 from ..externals.joblib import Parallel, delayed
 import collections
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1033,7 +1033,7 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     """
     X, y = indexable(X, y)
 
-    cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
+    cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
@@ -1191,7 +1191,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
     """
     X, y = indexable(X, y)
 
-    cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
+    cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
     scorer = check_scoring(estimator, scoring=scoring)
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
@@ -1428,11 +1428,6 @@ def check_cv(cv, X=None, y=None, classifier=False):
         The return value is guaranteed to be a cv generator instance, whatever
         the input type.
     """
-    return _check_cv(cv, X=X, y=y, classifier=classifier)
-
-
-def _check_cv(cv, X=None, y=None, classifier=False):
-    # This exists for internal use while indices is being deprecated.
     is_sparse = sp.issparse(X)
     if cv is None:
         cv = 3
@@ -1523,7 +1518,7 @@ def permutation_test_score(estimator, X, y, cv=None,
 
     """
     X, y = indexable(X, y)
-    cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
+    cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
     scorer = check_scoring(estimator, scoring=scoring)
     random_state = check_random_state(random_state)
 

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -14,7 +14,7 @@ from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..base import clone
 from ..base import is_classifier
-from ..cross_validation import _check_cv as check_cv
+from ..cross_validation import check_cv
 from ..cross_validation import _safe_split, _score
 from ..metrics.scorer import check_scoring
 from .base import SelectorMixin

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from .base import BaseEstimator, is_classifier, clone
 from .base import MetaEstimatorMixin, ChangedBehaviorWarning
-from .cross_validation import _check_cv as check_cv
+from .cross_validation import check_cv
 from .cross_validation import _fit_and_score
 from .externals.joblib import Parallel, delayed
 from .externals import six

--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 
 from .base import is_classifier, clone
-from .cross_validation import _check_cv
+from .cross_validation import check_cv
 from .externals.joblib import Parallel, delayed
 from .cross_validation import _safe_split, _score, _fit_and_score
 from .metrics.scorer import check_scoring
@@ -108,7 +108,7 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
 
     X, y = indexable(X, y)
     # Make a list since we will be iterating multiple times over the folds
-    cv = list(_check_cv(cv, X, y, classifier=is_classifier(estimator)))
+    cv = list(check_cv(cv, X, y, classifier=is_classifier(estimator)))
     scorer = check_scoring(estimator, scoring=scoring)
 
     # HACK as long as boolean indices are allowed in cv generators
@@ -297,7 +297,7 @@ def validation_curve(estimator, X, y, param_name, param_range, cv=None,
     <example_model_selection_plot_validation_curve.py>`
     """
     X, y = indexable(X, y)
-    cv = _check_cv(cv, X, y, classifier=is_classifier(estimator))
+    cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
     scorer = check_scoring(estimator, scoring=scoring)
 
     parallel = Parallel(n_jobs=n_jobs, pre_dispatch=pre_dispatch,

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -17,7 +17,7 @@ from ..base import RegressorMixin
 from .base import center_data, sparse_center_data
 from ..utils import check_array, check_X_y, deprecated
 from ..utils.validation import check_random_state
-from ..cross_validation import _check_cv as check_cv
+from ..cross_validation import check_cv
 from ..externals.joblib import Parallel, delayed
 from ..externals import six
 from ..externals.six.moves import xrange

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -22,7 +22,7 @@ from scipy.linalg.lapack import get_lapack_funcs
 from .base import LinearModel
 from ..base import RegressorMixin
 from ..utils import arrayfuncs, as_float_array, check_X_y
-from ..cross_validation import _check_cv as check_cv
+from ..cross_validation import check_cv
 from ..utils import ConvergenceWarning
 from ..externals.joblib import Parallel, delayed
 from ..externals.six.moves import xrange

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -28,7 +28,7 @@ from ..utils.validation import (as_float_array, DataConversionWarning,
                                 check_X_y)
 from ..utils.fixes import expit
 from ..externals.joblib import Parallel, delayed
-from ..cross_validation import _check_cv
+from ..cross_validation import check_cv
 from ..externals import six
 from ..metrics import SCORERS
 
@@ -1345,7 +1345,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         check_consistent_length(X, y)
 
         # init cross-validation generator
-        cv = _check_cv(self.cv, X, y, classifier=True)
+        cv = check_cv(self.cv, X, y, classifier=True)
         folds = list(cv)
 
         self._enc = LabelEncoder()

--- a/sklearn/linear_model/omp.py
+++ b/sklearn/linear_model/omp.py
@@ -15,7 +15,7 @@ from scipy.linalg.lapack import get_lapack_funcs
 from .base import LinearModel, _pre_fit
 from ..base import RegressorMixin
 from ..utils import as_float_array, check_array, check_X_y
-from ..cross_validation import _check_cv as check_cv
+from ..cross_validation import check_cv
 from ..externals.joblib import Parallel, delayed
 
 import scipy

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -950,15 +950,15 @@ def test_permutation_test_score_allow_nans():
 
 def test_check_cv_return_types():
     X = np.ones((9, 2))
-    cv = cval._check_cv(3, X, classifier=False)
+    cv = cval.check_cv(3, X, classifier=False)
     assert_true(isinstance(cv, cval.KFold))
 
     y_binary = np.array([0, 1, 0, 1, 0, 0, 1, 1, 1])
-    cv = cval._check_cv(3, X, y_binary, classifier=True)
+    cv = cval.check_cv(3, X, y_binary, classifier=True)
     assert_true(isinstance(cv, cval.StratifiedKFold))
 
     y_multiclass = np.array([0, 1, 0, 1, 2, 1, 2, 0, 2])
-    cv = cval._check_cv(3, X, y_multiclass, classifier=True)
+    cv = cval.check_cv(3, X, y_multiclass, classifier=True)
     assert_true(isinstance(cv, cval.StratifiedKFold))
 
     X = np.ones((5, 2))
@@ -966,15 +966,15 @@ def test_check_cv_return_types():
 
     with warnings.catch_warnings(record=True):
         # deprecated sequence of sequence format
-        cv = cval._check_cv(3, X, y_seq_of_seqs, classifier=True)
+        cv = cval.check_cv(3, X, y_seq_of_seqs, classifier=True)
     assert_true(isinstance(cv, cval.KFold))
 
     y_indicator_matrix = LabelBinarizer().fit_transform(y_seq_of_seqs)
-    cv = cval._check_cv(3, X, y_indicator_matrix, classifier=True)
+    cv = cval.check_cv(3, X, y_indicator_matrix, classifier=True)
     assert_true(isinstance(cv, cval.KFold))
 
     y_multioutput = np.array([[1, 2], [0, 3], [0, 0], [3, 1], [2, 0]])
-    cv = cval._check_cv(3, X, y_multioutput, classifier=True)
+    cv = cval.check_cv(3, X, y_multioutput, classifier=True)
     assert_true(isinstance(cv, cval.KFold))
 
 


### PR DESCRIPTION
As a follow up to #4370 

Ref: https://github.com/scikit-learn/scikit-learn/pull/4370/files#diff-d1a79b4a1b5f91f6b6c1829b212fca53L1592
