### PR TITLE
[MRG+1] Fix overflow warning in GradientBoosting

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -505,7 +505,7 @@ class BinomialDeviance(ClassificationLossFunction):
 
     def _score_to_proba(self, score):
         proba = np.ones((score.shape[0], 2), dtype=np.float64)
-        proba[:, 1] = 1.0 / (1.0 + np.exp(-score.ravel()))
+        proba[:, 1] = expit(score.ravel())
         proba[:, 0] -= proba[:, 1]
         return proba
 
@@ -628,7 +628,7 @@ class ExponentialLoss(ClassificationLossFunction):
 
     def _score_to_proba(self, score):
         proba = np.ones((score.shape[0], 2), dtype=np.float64)
-        proba[:, 1] = 1.0 / (1.0 + np.exp(-2.0 * score.ravel()))
+        proba[:, 1] = expit(2.0 * score.ravel())
         proba[:, 0] -= proba[:, 1]
         return proba
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -11,7 +11,6 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble.gradient_boosting import ZeroEstimator
 from sklearn.metrics import mean_squared_error
 from sklearn.utils import check_random_state, tosequence
-from sklearn.utils.fixes import expit
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -963,8 +962,8 @@ def test_probability_exponential():
     assert np.all(y_proba >= 0.0)
     assert np.all(y_proba <= 1.0)
     score = clf.decision_function(T).ravel()
-    assert_array_equal(y_proba[:, 1],
-                       expit(2.0 * score))
+    assert_array_almost_equal(y_proba[:, 1],
+                              1.0 / (1.0 + np.exp(-2 * score)))
 
     # derive predictions from probabilities
     y_pred = clf.classes_.take(y_proba.argmax(axis=1), axis=0)
@@ -991,14 +990,14 @@ def test_non_uniform_weights_toy_min_weight_leaf():
          [1, 0],
          [1, 0],
          [0, 1],
-        ]
+         ]
     y = [0, 0, 1, 0]
     # ignore the first 2 training samples by setting their weight to 0
     sample_weight = [0, 0, 1, 1]
     gb = GradientBoostingRegressor(n_estimators=5, min_weight_fraction_leaf=0.1)
     gb.fit(X, y, sample_weight=sample_weight)
     assert_true(gb.predict([[1, 0]])[0] > 0.5)
-    assert_almost_equal(gb.estimators_[0,0].splitter.min_weight_leaf, 0.2)
+    assert_almost_equal(gb.estimators_[0, 0].splitter.min_weight_leaf, 0.2)
 
 
 def test_non_uniform_weights_toy_edge_case_clf():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -11,6 +11,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble.gradient_boosting import ZeroEstimator
 from sklearn.metrics import mean_squared_error
 from sklearn.utils import check_random_state, tosequence
+from sklearn.utils.fixes import expit
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
@@ -963,7 +964,7 @@ def test_probability_exponential():
     assert np.all(y_proba <= 1.0)
     score = clf.decision_function(T).ravel()
     assert_array_equal(y_proba[:, 1],
-                       1.0 / (1.0 + np.exp(-2 * score)))
+                       expit(-2.0 * score))
 
     # derive predictions from probabilities
     y_pred = clf.classes_.take(y_proba.argmax(axis=1), axis=0)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -964,7 +964,7 @@ def test_probability_exponential():
     assert np.all(y_proba <= 1.0)
     score = clf.decision_function(T).ravel()
     assert_array_equal(y_proba[:, 1],
-                       expit(-2.0 * score))
+                       expit(2.0 * score))
 
     # derive predictions from probabilities
     y_pred = clf.classes_.take(y_proba.argmax(axis=1), axis=0)


### PR DESCRIPTION
Use expit function to compute the probability in ExponentialLoss class in GB. This PR may solve issues like #4152.
