### PR TITLE
[MRG + 2] FIX avoid memory cost when sampling from large parameter grids

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -97,6 +97,9 @@ Bug fixes
     - Fixed bug in :class:`decomposition.DictLearning` when ``n_jobs < 0``. By
       `Andreas Müller`_.
 
+    - Fixed bug where :class:`grid_search.RandomizedSearchCV` could consume a
+      lot of memory for large discrete grids. By `Joel Nothman`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -92,6 +92,10 @@ X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
 y = np.array([1, 1, 2, 2])
 
 
+def assert_grid_iter_equals_getitem(grid):
+    assert_equal(list(grid), [grid[i] for i in range(len(grid))])
+
+
 def test_parameter_grid():
     # Test basic properties of ParameterGrid.
     params1 = {"foo": [1, 2, 3]}
@@ -99,6 +103,7 @@ def test_parameter_grid():
     assert_true(isinstance(grid1, Iterable))
     assert_true(isinstance(grid1, Sized))
     assert_equal(len(grid1), 3)
+    assert_grid_iter_equals_getitem(grid1)
 
     params2 = {"foo": [4, 2],
                "bar": ["ham", "spam", "eggs"]}
@@ -113,14 +118,19 @@ def test_parameter_grid():
                      set(("bar", x, "foo", y)
                          for x, y in product(params2["bar"], params2["foo"])))
 
+    assert_grid_iter_equals_getitem(grid2)
+
     # Special case: empty grid (useful to get default estimator settings)
     empty = ParameterGrid({})
     assert_equal(len(empty), 1)
     assert_equal(list(empty), [{}])
+    assert_grid_iter_equals_getitem(empty)
+    assert_raises(IndexError, lambda: empty[1])
 
-    has_empty = ParameterGrid([{'C': [1, 10]}, {}])
-    assert_equal(len(has_empty), 3)
-    assert_equal(list(has_empty), [{'C': 1}, {'C': 10}, {}])
+    has_empty = ParameterGrid([{'C': [1, 10]}, {}, {'C': [.5]}])
+    assert_equal(len(has_empty), 4)
+    assert_equal(list(has_empty), [{'C': 1}, {'C': 10}, {}, {'C': .5}])
+    assert_grid_iter_equals_getitem(has_empty)
 
 
 def test_grid_search():


### PR DESCRIPTION
Solve the issue reported at https://github.com/scikit-learn/scikit-learn/pull/3850#issuecomment-110238740 by making `ParameterGrid` able to dynamically look up a param setting by index; i.e. list of all possible settings is never realised.

Needs:
- [x] test
- [x] docstring
- [x] clearer code
