### PR TITLE
[WIP] New assert helpers for model comparison and fit reset checks

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -77,6 +77,7 @@ DEPRECATED_TRANSFORM = [
 
 
 def _yield_non_meta_checks(name, Estimator):
+    """
     yield check_estimators_dtypes
     yield check_fit_score_takes_y
     yield check_dtype_object
@@ -108,6 +109,7 @@ def _yield_non_meta_checks(name, Estimator):
     # Test that estimators can be pickled, and once pickled
     # give the same answer as before.
     yield check_estimators_pickle
+    """
     if name not in ('SpectralEmbedding',):
         yield check_estimator_fit_reset
 
@@ -202,6 +204,7 @@ def _yield_clustering_checks(name, Clusterer):
 def _yield_all_checks(name, Estimator):
     for check in _yield_non_meta_checks(name, Estimator):
         yield check
+    """
     if issubclass(Estimator, ClassifierMixin):
         for check in _yield_classifier_checks(name, Estimator):
             yield check
@@ -220,6 +223,7 @@ def _yield_all_checks(name, Estimator):
     yield check_fit2d_1feature
     yield check_fit1d_1feature
     yield check_fit1d_1sample
+    """
 
 
 def check_estimator(Estimator):
@@ -1574,14 +1578,10 @@ def check_estimator_fit_reset(name, Estimator):
                         centers=3, random_state=2)
 
     # Some estimators work only on non-negative inputs
-    if name in ('AdditiveChi2Sampler', 'SkewedChi2Sampler',
-                'NMF', 'MultinomialNB', 'ProjectedGradientNMF'):
-        X1 -= X1.min()
-        X2 -= X2.min()
-        X3 -= X3.min()
-        X4 -= X4.min()
-        X5 -= X5.min()
-        X6 -= X6.min()
+    if name in ('AdditiveChi2Sampler', 'SkewedChi2Sampler', 'NMF',
+                'MultinomialNB', 'ProjectedGradientNMF',):
+        X1, X2, X3, X4, X5, X6 = map(lambda X: X - X.min(),
+                                     (X1, X2, X3, X4, X5, X6))
 
     y1, y2, y3, y4, y5, y6 = map(multioutput_estimator_convert_y_2d,
                                  (name,)*6, (y1, y2, y3, y4, y5, y6))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1576,7 +1576,12 @@ def check_estimator_fit_reset(name, Estimator):
     # Some estimators work only on non-negative inputs
     if name in ('AdditiveChi2Sampler', 'SkewedChi2Sampler',
                 'NMF', 'MultinomialNB', 'ProjectedGradientNMF'):
-        X1 -= X1.min(), X2, X3, X4, X5, X6 = map(np.fabs, (X1, X2, X3, X4, X5, X6))
+        X1 -= X1.min()
+        X2 -= X2.min()
+        X3 -= X3.min()
+        X4 -= X4.min()
+        X5 -= X5.min()
+        X6 -= X6.min()
 
     y1, y2, y3, y4, y5, y6 = map(multioutput_estimator_convert_y_2d,
                                  (name,)*6, (y1, y2, y3, y4, y5, y6))


### PR DESCRIPTION
Split from #3907 and #4162
- New helpers for model comparison - `assert_same_model`, `assert_not_same_model`, `assert_fitted_attributes_equal` and `assert_safe_sparse_allclose`.
- Check if all estimators reset upon fit

<hr>

**TODO**
- [ ] `assert_safe_sparse_allcose` - To support sparse/dense matrices. (naming inspired from `safe_sparse_dot`)
- [ ] `assert_same_model` / `assert_not_same_model` / `assert_fitted_attributes_equal`
- [ ] Unit tests for the assert helpers.
- [ ] Check to make sure estimator resets when `fit`.

<hr>

Partially fixes : #406 
