### PR TITLE
[MRG] Add KNN strategy for imputation

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -388,10 +388,10 @@ values. However, this comes at the price of losing data which may be valuable
 i.e., to infer them from the known part of the data.
 
 The :class:`Imputer` class provides basic strategies for imputing missing
-values, either using the mean, the median, the most frequent value of
-the row or column in which the missing values are located or the mean of the
-k-nearest neighbors computed using samples without missing values. This class also
-allows for different missing values encodings.
+values. It can use the mean, the median, the most frequent value of
+the row or column in which the missing values are located. Alternatively it can fill
+with the mean of only the k-nearest neighbors computed using samples without missing
+values. The placeholder for missing values is configurable.
 
 The following snippet demonstrates how to replace missing values,
 encoded as ``np.nan``, using the mean value of the columns (axis 0)
@@ -425,7 +425,8 @@ Note that, here, missing values are encoded by 0 and are thus implicitly stored
 in the matrix. This format is thus suitable when there are many more missing
 values than observed values.
 
-Also, knn imputation strategy will use samples with full features, and if all samples
+When using ``strategy=knn``, only samples without any missing features will be used for imputation.
+If all samples
 have missing features, this strategy will fail.
 
 :class:`Imputer` can be used in a Pipeline as a way to build a composite

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -399,8 +399,8 @@ that contain the missing values::
     >>> import numpy as np
     >>> from sklearn.preprocessing import Imputer
     >>> imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
-    >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]])
-    Imputer(axis=0, copy=True, missing_values='NaN', strategy='mean', verbose=0)
+    >>> imp.fit([[1, 2], [np.nan, 3], [7, 6]]) # doctest: +NORMALIZE_WHITESPACE
+    Imputer(axis=0, copy=True, missing_values='NaN', n_neighbors=1, strategy='mean', verbose=0)
     >>> X = [[np.nan, 2], [6, np.nan], [7, 6]]
     >>> print(imp.transform(X))                           # doctest: +ELLIPSIS
     [[ 4.          2.        ]
@@ -412,8 +412,8 @@ The :class:`Imputer` class also supports sparse matrices::
     >>> import scipy.sparse as sp
     >>> X = sp.csc_matrix([[1, 2], [0, 3], [7, 6]])
     >>> imp = Imputer(missing_values=0, strategy='mean', axis=0)
-    >>> imp.fit(X)
-    Imputer(axis=0, copy=True, missing_values=0, strategy='mean', verbose=0)
+    >>> imp.fit(X) # doctest: +NORMALIZE_WHITESPACE
+    Imputer(axis=0, copy=True, missing_values=0, n_neighbors=1, strategy='mean', verbose=0)
     >>> X_test = sp.csc_matrix([[0, 2], [6, 0], [7, 6]])
     >>> print(imp.transform(X_test))                      # doctest: +ELLIPSIS
     [[ 4.          2.        ]

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -388,9 +388,10 @@ values. However, this comes at the price of losing data which may be valuable
 i.e., to infer them from the known part of the data.
 
 The :class:`Imputer` class provides basic strategies for imputing missing
-values, either using the mean, the median or the most frequent value of
-the row or column in which the missing values are located. This class
-also allows for different missing values encodings.
+values, either using the mean, the median, the most frequent value of
+the row or column in which the missing values are located or the mean of the
+k-nearest neighbors computed using samples without missing values. This class also
+allows for different missing values encodings.
 
 The following snippet demonstrates how to replace missing values,
 encoded as ``np.nan``, using the mean value of the columns (axis 0)

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -425,5 +425,8 @@ Note that, here, missing values are encoded by 0 and are thus implicitly stored
 in the matrix. This format is thus suitable when there are many more missing
 values than observed values.
 
+Also, knn imputation strategy will use samples with full features, and if all samples
+have missing features, this strategy will fail.
+
 :class:`Imputer` can be used in a Pipeline as a way to build a composite
 estimator that supports imputation. See :ref:`example_missing_values.py`

--- a/examples/missing_values.py
+++ b/examples/missing_values.py
@@ -16,7 +16,7 @@ which could dominate results (otherwise known as a 'long tail').
 Script output::
 
   Score with the entire dataset = 0.43
-  Score without the samples containing missing values = 0.36
+  Score without the samples containing missing values = 0.35
   Score after mean imputation of the missing values = 0.42
   Score after knn imputation with 7 neighbors of the missing values = 0.43
 
@@ -39,20 +39,24 @@ n_samples = X_full.shape[0]
 n_features = X_full.shape[1]
 
 #Create a random matrix to randomly make missing values
-missing_matrix = np.random.rand(n_samples, n_features)
-th = 0.15  # each sample has (1-th)^n_features of probability to have full features
+missing_matrix = rng.rand(n_samples, n_features)
+
+# each sample has (1-th)^n_features of probability to have full features
+th = 0.14
 mask = missing_matrix < th
-missing_samples = mask.any(1)
+missing_samples = mask.any(axis=1)
 full_percentage = (n_samples - missing_samples.sum())/float(n_samples)
 print("Percentage of samples with full features: %f" %full_percentage )
 
 # Estimate the score on the entire dataset, with no missing values
+
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_full, y_full).mean()
 print("Score with the entire dataset = %.2f" % score)
 
 
 # Estimate the score without the lines containing missing values
+
 X_filtered = X_full[~missing_samples, :]
 y_filtered = y_full[~missing_samples]
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
@@ -73,10 +77,12 @@ score = cross_val_score(estimator, X_missing, y_missing).mean()
 print("Score after mean imputation of the missing values = %.2f" % score)
 
 # Estimate the score after knn imputation of the missing values
-neigh = 7
+
+neigh = 7  # Number of neighbors to be used
 estimator2 = Pipeline([("imputer", Imputer(strategy="knn",
                                            axis=0, n_neighbors=neigh)),
                       ("forest", RandomForestRegressor(random_state=0,
                                                        n_estimators=100))])
 score = cross_val_score(estimator2, X_missing, y_missing).mean()
-print("Score after knn imputation with %d neighbors of the missing values = %.2f" % (neigh, score))
+print("Score after knn imputation with %d neighbors of the missing values ="
+      " %.2f" % (neigh, score))

--- a/examples/missing_values.py
+++ b/examples/missing_values.py
@@ -8,23 +8,24 @@ than discarding the samples containing any missing value.
 Imputing does not always improve the predictions, so please check via cross-validation.
 Sometimes dropping rows or using marker values is more effective.
 
-Missing values can be replaced by the mean, the median or the most frequent
-value using the ``strategy`` hyper-parameter.
+Missing values can be replaced by the mean, the median, the most frequent
+value or the mean of values of k-nearest neighbors using the ``strategy`` hyper-parameter.
 The median is a more robust estimator for data with high magnitude variables
 which could dominate results (otherwise known as a 'long tail').
 
 Script output::
 
-  Score with the entire dataset = 0.56
-  Score without the samples containing missing values = 0.48
-  Score after imputation of the missing values = 0.55
+  Score with the entire dataset = 0.43
+  Score without the samples containing missing values = 0.36
+  Score after mean imputation of the missing values = 0.42
+  Score after knn imputation with 10 neighbors of the missing values = 0.43
 
 In this case, imputing helps the classifier get close to the original score.
-  
+
 """
 import numpy as np
 
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_diabetes
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import Imputer
@@ -32,7 +33,7 @@ from sklearn.cross_validation import cross_val_score
 
 rng = np.random.RandomState(0)
 
-dataset = load_boston()
+dataset = load_diabetes()
 X_full, y_full = dataset.data, dataset.target
 n_samples = X_full.shape[0]
 n_features = X_full.shape[1]
@@ -42,15 +43,18 @@ estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_full, y_full).mean()
 print("Score with the entire dataset = %.2f" % score)
 
-# Add missing values in 75% of the lines
-missing_rate = 0.75
+# Add missing values in 60% of the lines
+missing_rate = 0.60 # 60% of samples have missing value
+missing2_rate = 0.80 # 80% of samples with missing value have 2 missing features
 n_missing_samples = np.floor(n_samples * missing_rate)
+n_missing2_samples = np.floor(n_samples * missing_rate * missing2_rate)
 missing_samples = np.hstack((np.zeros(n_samples - n_missing_samples,
                                       dtype=np.bool),
                              np.ones(n_missing_samples,
                                      dtype=np.bool)))
 rng.shuffle(missing_samples)
 missing_features = rng.randint(0, n_features, n_missing_samples)
+missing2_features = rng.randint(0, n_features, n_missing2_samples)
 
 # Estimate the score without the lines containing missing values
 X_filtered = X_full[~missing_samples, :]
@@ -59,14 +63,25 @@ estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_filtered, y_filtered).mean()
 print("Score without the samples containing missing values = %.2f" % score)
 
-# Estimate the score after imputation of the missing values
+# Estimate the score after mean imputation of the missing values
+missing_index = np.where(missing_samples)[0]
+missing2_index = np.random.choice(missing_index, n_missing2_samples)
 X_missing = X_full.copy()
-X_missing[np.where(missing_samples)[0], missing_features] = 0
+X_missing[np.where(missing_samples)[0], missing_features] = np.nan
+X_missing[missing2_index, missing2_features] = np.nan
 y_missing = y_full.copy()
-estimator = Pipeline([("imputer", Imputer(missing_values=0,
-                                          strategy="mean",
+estimator = Pipeline([("imputer", Imputer(strategy="mean",
                                           axis=0)),
                       ("forest", RandomForestRegressor(random_state=0,
                                                        n_estimators=100))])
 score = cross_val_score(estimator, X_missing, y_missing).mean()
-print("Score after imputation of the missing values = %.2f" % score)
+print("Score after mean imputation of the missing values = %.2f" % score)
+
+# Estimate the score after knn imputation of the missing values
+neigh = 7
+estimator2 = Pipeline([("imputer", Imputer(strategy="knn",
+                                           axis=0, n_neighbors=neigh)),
+                      ("forest", RandomForestRegressor(random_state=0,
+                                                       n_estimators=100))])
+score = cross_val_score(estimator2, X_missing, y_missing).mean()
+print("Score after knn imputation with %d neighbors of the missing values = %.2f" % (neigh, score))

--- a/examples/missing_values.py
+++ b/examples/missing_values.py
@@ -18,7 +18,7 @@ Script output::
   Score with the entire dataset = 0.43
   Score without the samples containing missing values = 0.36
   Score after mean imputation of the missing values = 0.42
-  Score after knn imputation with 10 neighbors of the missing values = 0.43
+  Score after knn imputation with 7 neighbors of the missing values = 0.43
 
 In this case, imputing helps the classifier get close to the original score.
 
@@ -38,23 +38,19 @@ X_full, y_full = dataset.data, dataset.target
 n_samples = X_full.shape[0]
 n_features = X_full.shape[1]
 
+#Create a random matrix to randomly make missing values
+missing_matrix = np.random.rand(n_samples, n_features)
+th = 0.15  # each sample has (1-th)^n_features of probability to have full features
+mask = missing_matrix < th
+missing_samples = mask.any(1)
+full_percentage = (n_samples - missing_samples.sum())/float(n_samples)
+print("Percentage of samples with full features: %f" %full_percentage )
+
 # Estimate the score on the entire dataset, with no missing values
 estimator = RandomForestRegressor(random_state=0, n_estimators=100)
 score = cross_val_score(estimator, X_full, y_full).mean()
 print("Score with the entire dataset = %.2f" % score)
 
-# Add missing values in 60% of the lines
-missing_rate = 0.60 # 60% of samples have missing value
-missing2_rate = 0.80 # 80% of samples with missing value have 2 missing features
-n_missing_samples = np.floor(n_samples * missing_rate)
-n_missing2_samples = np.floor(n_samples * missing_rate * missing2_rate)
-missing_samples = np.hstack((np.zeros(n_samples - n_missing_samples,
-                                      dtype=np.bool),
-                             np.ones(n_missing_samples,
-                                     dtype=np.bool)))
-rng.shuffle(missing_samples)
-missing_features = rng.randint(0, n_features, n_missing_samples)
-missing2_features = rng.randint(0, n_features, n_missing2_samples)
 
 # Estimate the score without the lines containing missing values
 X_filtered = X_full[~missing_samples, :]
@@ -64,12 +60,11 @@ score = cross_val_score(estimator, X_filtered, y_filtered).mean()
 print("Score without the samples containing missing values = %.2f" % score)
 
 # Estimate the score after mean imputation of the missing values
-missing_index = np.where(missing_samples)[0]
-missing2_index = np.random.choice(missing_index, n_missing2_samples)
+
 X_missing = X_full.copy()
-X_missing[np.where(missing_samples)[0], missing_features] = np.nan
-X_missing[missing2_index, missing2_features] = np.nan
+X_missing[mask] = np.nan
 y_missing = y_full.copy()
+
 estimator = Pipeline([("imputer", Imputer(strategy="mean",
                                           axis=0)),
                       ("forest", RandomForestRegressor(random_state=0,

--- a/examples/missing_values.py
+++ b/examples/missing_values.py
@@ -45,8 +45,8 @@ missing_matrix = rng.rand(n_samples, n_features)
 th = 0.14
 mask = missing_matrix < th
 missing_samples = mask.any(axis=1)
-full_percentage = (n_samples - missing_samples.sum())/float(n_samples)
-print("Percentage of samples with full features: %f" %full_percentage )
+full_percentage = (n_samples - missing_samples.sum()) / float(n_samples)
+print("Percentage of samples with full features: %f" % full_percentage)
 
 # Estimate the score on the entire dataset, with no missing values
 

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -420,6 +420,8 @@ class Imputer(BaseEstimator, TransformerMixin):
                     # Preallocate output array for np.multiply(test1, test1, out=D2)
                     for sl in list(gen_batches(len(missing_index), batch_size)):
                         X_sl = X[missing_index[sl]]
+                        mask_sl = mask[missing_index[sl]]
+                        X_sl[mask_sl] = np.nan
                         test1 = X_sl[:][:, np.newaxis, :] - statistics
                         #D2 = np.empty_like(test1)
 
@@ -452,6 +454,8 @@ class Imputer(BaseEstimator, TransformerMixin):
                             for sl in batch_slice:
                                 index_sl = missing_index[sl]
                                 X_sl = X[index_sl]
+                                mask_sl = mask[missing_index[sl]]
+                                X_sl[mask_sl] = np.nan
                                 test1 = X_sl[:][:, np.newaxis, :] - statistics
                                 D2 = np.empty_like(test1)
                                 np.multiply(test1, test1, out=D2)

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -425,7 +425,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                         X_sl = X[index_start: index_stop]
                         mask_sl = _get_mask(X_sl, self.missing_values)
                         missing_index_sl = np.where(mask_sl.any(1))[0]
-                        D2 = (X_sl[missing_index_sl, np.newaxis, :] - statistics) ** 2
+                        D2 = (X_sl[missing_index_sl][:, np.newaxis, :] - statistics) ** 2
                         D2[np.isnan(D2)] = 0
                         missing_row, missing_col = np.where(np.isnan(X_sl))
                         sqdist = D2.sum(axis=2)

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -405,14 +405,19 @@ class Imputer(BaseEstimator, TransformerMixin):
                     mask = mask.transpose()
                     statistics = statistics.transpose()
 
-                batch_size = 10  # set batch size for block query
-                if False:
+                batch_size = 20  # set batch size for block query
+                if True:
                     missing_index = np.where(mask.any(axis=1))[0]
                     #@jnothman 's method
+                    D2 = np.empty_like(np.zeros([batch_size, statistics.shape[0], statistics.shape[1]]))
                     for sl in list(gen_batches(len(missing_index), batch_size)):
                         X_sl = X[missing_index[sl]]
                         test1 = X_sl[:][:, np.newaxis, :] - statistics
-                        D2 = test1 ** 2
+                        #D2 = np.empty_like(test1)
+                        if test1.shape != D2.shape:
+                            D2 = np.empty_like(test1)
+                        np.multiply(test1, test1, out=D2)
+                        #D2 = test1 ** 2
                         #D2 = (X_sl[missing_index_sl][:, np.newaxis, :] - statistics) ** 2
                         D2[np.isnan(D2)] = 0
                         missing_row, missing_col = np.where(np.isnan(X_sl))
@@ -434,7 +439,10 @@ class Imputer(BaseEstimator, TransformerMixin):
                             for sl in batch_slice:
                                 index_sl = missing_index[sl]
                                 X_sl = X[index_sl]
-                                D2 = (X_sl[:][:, np.newaxis, :] - statistics) ** 2
+                                test1 = X_sl[:][:, np.newaxis, :] - statistics
+                                D2 = np.empty_like(test1)
+                                np.multiply(test1, test1, out=D2)
+                                #D2 = test1 ** 2
                                 D2[np.isnan(D2)] = 0
                                 missing_row, missing_col = np.where(np.isnan(X_sl))
                                 sqdist = D2.sum(axis=2)

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -422,22 +422,21 @@ class Imputer(BaseEstimator, TransformerMixin):
                         X_sl = X[missing_index[sl]]
                         mask_sl = mask[missing_index[sl]]
                         X_sl[mask_sl] = np.nan
-                        test1 = X_sl[:][:, np.newaxis, :] - statistics
-                        #D2 = np.empty_like(test1)
+                        impute_dist = X_sl[:][:, np.newaxis, :] - statistics
 
                         # For the last slice, the length may not be the same
                         # as batch_size
-                        if test1.shape != D2.shape:
-                            D2 = np.empty_like(test1)
-                        np.multiply(test1, test1, out=D2)
+                        if impute_dist.shape != D2.shape:
+                            D2 = np.empty_like(impute_dist)
+                        np.multiply(impute_dist, impute_dist, out=D2)
                         #D2 = test1 ** 2
                         #D2 = (X_sl[missing_index_sl][:, np.newaxis, :] - statistics)
                         #  ** 2
                         D2[np.isnan(D2)] = 0
                         missing_row, missing_col = np.where(np.isnan(X_sl))
                         sqdist = D2.sum(axis=2)
-                        ind = np.argsort(sqdist, axis=1)[:, :self.n_neighbors]
-                        means = np.mean(statistics[ind], axis=1)
+                        target_index = np.argsort(sqdist, axis=1)[:, :self.n_neighbors]
+                        means = np.mean(statistics[target_index], axis=1)
                         X_sl[missing_row, missing_col] = means[np.where(np.isnan(X_sl))[0],
                                                                missing_col]
                         X[missing_index[sl]] = X_sl
@@ -456,15 +455,15 @@ class Imputer(BaseEstimator, TransformerMixin):
                                 X_sl = X[index_sl]
                                 mask_sl = mask[missing_index[sl]]
                                 X_sl[mask_sl] = np.nan
-                                test1 = X_sl[:][:, np.newaxis, :] - statistics
-                                D2 = np.empty_like(test1)
-                                np.multiply(test1, test1, out=D2)
+                                impute_dist = X_sl[:][:, np.newaxis, :] - statistics
+                                D2 = np.empty_like(impute_dist)
+                                np.multiply(impute_dist, impute_dist, out=D2)
                                 #D2 = test1 ** 2
                                 D2[np.isnan(D2)] = 0
                                 missing_row, missing_col = np.where(np.isnan(X_sl))
                                 sqdist = D2.sum(axis=2)
-                                ind = np.argsort(sqdist, axis=1)[:, :self.n_neighbors]
-                                means = np.mean(statistics[ind], axis=1)
+                                target_index = np.argsort(sqdist, axis=1)[:, :self.n_neighbors]
+                                means = np.mean(statistics[target_index], axis=1)
                                 X_sl[missing_row, missing_col] = means[np.where(np.isnan(X_sl))[0],
                                                                        missing_col]
                                 X[index_sl] = X_sl

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -83,13 +83,14 @@ class Imputer(BaseEstimator, TransformerMixin):
         - If "most_frequent", then replace missing using the most frequent
           value along the axis.
         - If "knn", then replace missing using the mean of the k-nearest
-          neighbors along the axis.
+          neighbors along the axis. Only samples with no missing values are
+          considered as neighbors.
 
     axis : integer, optional (default=0)
         The axis along which to impute.
 
-        - If `axis=0`, then impute along columns.
-        - If `axis=1`, then impute along rows.
+        - If ``axis=0``, then impute along columns.
+        - If ``axis=1``, then impute along rows.
 
     verbose : integer, optional (default=0)
         Controls the verbosity of the imputer.
@@ -101,18 +102,18 @@ class Imputer(BaseEstimator, TransformerMixin):
 
         - If X is not an array of floating values;
         - If X is sparse and `missing_values=0`;
-        - If `axis=0` and X is encoded as a CSR matrix;
-        - If `axis=1` and X is encoded as a CSC matrix.
+        - If ``axis=0`` and X is encoded as a CSR matrix;
+        - If ``axis=1`` and X is encoded as a CSC matrix.
 
     n_neighbors : int, optional (default=1)
-        It only has effect if the `strategy=knn`. It controls the number of
-        nearest neighbors used to compute the mean along the axis.
+        Controls the number of nearest neighbors used to compute the mean
+        along the axis. Only used when ``strategy=knn``
 
     Attributes
     ----------
     statistics_ : array of shape (n_features,)
         The imputation fill value for each feature if axis == 0.
-        If `strategy=knn`, then it contains those samples having no missing value.
+        If ``strategy=knn``, then it contains those samples having no missing value.
 
     Notes
     -----
@@ -412,6 +413,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                     statistics = statistics.transpose()
 
                 batch_size = 1  # set batch size for block query
+
                 missing_index = np.where(mask.any(axis=1))[0]
                 D2 = np.empty_like(np.zeros([batch_size, statistics.shape[0],
                                              statistics.shape[1]]))

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -412,12 +412,7 @@ class Imputer(BaseEstimator, TransformerMixin):
                         X_sl = X[index_start: index_stop]
                         mask_sl = _get_mask(X_sl, self.missing_values)
                         missing_index_sl = np.where(mask_sl.any(1))[0]
-                        t1 = time()
-                        fancy_index = X_sl[missing_index_sl][:, np.newaxis, :]
-                        D2 = np.square(fancy_index - statistics)
-                        #D2 = (X_sl[missing_index_sl][:, np.newaxis, :] - statistics) ** 2
-                        t2 = time()
-                        time_1 = time_1 + (t2-t1)
+                        D2 = (X_sl[missing_index_sl][:, np.newaxis, :] - statistics) ** 2
                         D2[np.isnan(D2)] = 0
                         missing_row, missing_col = np.where(np.isnan(X_sl))
                         sqdist = D2.sum(axis=2)

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -356,8 +356,22 @@ def test_imputation_knn():
         [-1,  2,  3,  7],
     ])
 
+    X_true_1 = np.array([
+        [-1, -1,  0,  5],
+        [0,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [-1,  2,  3,  7],
+    ])
+
     X2 = np.array([
         [np.nan, -1,  0,  np.nan],
+        [0,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [-1,  2,  3,  7],
+    ])
+
+    X_true_2 = np.array([
+        [-0.5, -1,  0,  5],
         [0,  2, -1,  3],
         [-1,  -1,  0, 5],
         [-1,  2,  3,  7],
@@ -377,32 +391,18 @@ def test_imputation_knn():
         [0,  2,  -1,  6],
     ])
 
-    X5 = np.array([
-        [999, -1,  0,  5],
-        [0,  2, -1,  3],
-        [-1,  -1,  0, 5],
-        [-1,  2,  3,  7],
-    ])
-
-    X_true_1 = np.array([
-        [-1, -1,  0,  5],
-        [0,  2, -1,  3],
-        [-1,  -1,  0, 5],
-        [-1,  2,  3,  7],
-    ])
-
-    X_true_2 = np.array([
-        [-0.5, -1,  0,  5],
-        [0,  2, -1,  3],
-        [-1,  -1,  0, 5],
-        [-1,  2,  3,  7],
-    ])
-
     X_true_4 = np.array([
         [-1, -1,  0,  5],
         [0,  2, -1,  3],
         [-1,  -1,  0, 5],
         [0,  2, -1,  6],
+    ])
+
+    X5 = np.array([
+        [999, -1,  0,  5],
+        [0,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [-1,  2,  3,  7],
     ])
 
     imputer = Imputer(missing_values='NaN', strategy="knn",
@@ -435,6 +435,7 @@ def test_imputation_knn():
     X5 = X5.astype(float)
     X_impute = imputer.fit(X5).transform(X5)
     assert_array_equal(X_true_1, X5)
+    assert_array_equal(X_impute, X5)
 
     imputer = Imputer(missing_values='NaN', strategy="knn", axis=0)
     msg = "There is no sample with complete data."

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -377,6 +377,13 @@ def test_imputation_knn():
         [0,  2,  -1,  6],
     ])
 
+    X5 = np.array([
+        [999, -1,  0,  5],
+        [0,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [-1,  2,  3,  7],
+    ])
+
     X_true_1 = np.array([
         [-1, -1,  0,  5],
         [0,  2, -1,  3],
@@ -398,25 +405,36 @@ def test_imputation_knn():
         [0,  2, -1,  6],
     ])
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn",
+                      axis=0, n_neighbors=1)
     X_impute = imputer.fit(X).transform(X)
     assert_array_equal(X_true_1, X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=1, n_neighbors=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn",
+                      axis=1, n_neighbors=1)
     X_impute = imputer.fit(X.transpose()).transform(X.transpose())
     assert_array_equal(X_true_1.transpose(), X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=2)
+    imputer = Imputer(missing_values='NaN', strategy="knn",
+                      axis=0, n_neighbors=2)
     X_impute = imputer.fit(X).transform(X)
     assert_array_equal(X_true_2, X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn",
+                      axis=0, n_neighbors=1)
     X_impute = imputer.fit(X2).transform(X2)
     assert_array_equal(X_true_1, X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn",
+                      axis=0, n_neighbors=1)
     X_impute = imputer.fit(X4).transform(X4)
     assert_array_equal(X_true_4, X_impute)
+
+    imputer = Imputer(missing_values=999, strategy="knn",
+                      axis=0, n_neighbors=1, copy=False)
+    X5 = X5.astype(float)
+    X_impute = imputer.fit(X5).transform(X5)
+    assert_array_equal(X_true_1, X5)
 
     imputer = Imputer(missing_values='NaN', strategy="knn", axis=0)
     msg = "There is no sample with complete data."

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -425,5 +425,3 @@ def test_imputation_knn():
     imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=4)
     msg = "There are only 3 complete samples, but n_neighbors=4."
     assert_raise_message(ValueError, msg, imputer.fit, X)
-
-

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -16,7 +16,7 @@ from sklearn.random_projection import sparse_random_matrix
 
 
 def _check_statistics(X, X_true,
-                      strategy, statistics, missing_values, kneighbor=1):
+                      strategy, statistics, missing_values):
     """Utility function for testing imputation for a given strategy.
 
     Test:
@@ -370,6 +370,13 @@ def test_imputation_knn():
         [-1,  2,  3,  np.nan],
     ])
 
+    X4 = np.array([
+        [np.nan, -1,  0,  5],
+        [np.nan,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [0,  2,  -1,  6],
+    ])
+
     X_true_1 = np.array([
         [-1, -1,  0,  5],
         [0,  2, -1,  3],
@@ -384,28 +391,39 @@ def test_imputation_knn():
         [-1,  2,  3,  7],
     ])
 
+    X_true_4 = np.array([
+        [-1, -1,  0,  5],
+        [0,  2, -1,  3],
+        [-1,  -1,  0, 5],
+        [0,  2, -1,  6],
+    ])
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, kneighbor=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
     X_impute = imputer.fit(X).transform(X)
     assert_array_equal(X_true_1, X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=1, kneighbor=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=1, n_neighbors=1)
     X_impute = imputer.fit(X.transpose()).transform(X.transpose())
     assert_array_equal(X_true_1.transpose(), X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, kneighbor=2)
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=2)
     X_impute = imputer.fit(X).transform(X)
     assert_array_equal(X_true_2, X_impute)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, kneighbor=1)
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
     X_impute = imputer.fit(X2).transform(X2)
     assert_array_equal(X_true_1, X_impute)
 
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=1)
+    X_impute = imputer.fit(X4).transform(X4)
+    assert_array_equal(X_true_4, X_impute)
+
     imputer = Imputer(missing_values='NaN', strategy="knn", axis=0)
-    msg = "There is no row with complete data!"
+    msg = "There is no sample with complete data."
     assert_raise_message(ValueError, msg, imputer.fit, X3)
 
-    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, kneighbor=4)
-    msg = "There are at most 3 neighbors!"
+    imputer = Imputer(missing_values='NaN', strategy="knn", axis=0, n_neighbors=4)
+    msg = "There are only 3 complete samples, but n_neighbors=4."
     assert_raise_message(ValueError, msg, imputer.fit, X)
+
 


### PR DESCRIPTION
Trying to solve #2989.

Imputation strategy is following:

Find all rows with full features as complete set, and impute the missing features in a row by taking the mean of those features among its K-nearest neighbors in complete set. Use scikit-learn.neighbors.NearestNeighbors to find neighbors. Now it can only handle dense matrix. 

Based on this paper: http://web.stanford.edu/~hastie/Papers/missing.pdf

Similar package for R: Impute(http://www.bioconductor.org/packages/release/bioc/manuals/impute/man/impute.pdf)
Similar function for Matlab:
Knnimpute(http://www.mathworks.com/help/bioinfo/ref/knnimpute.html)

Still working on documentation and examples.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/4844)

<!-- Reviewable:end -->
