### PR TITLE
Added error messages in case user provides one dimensional data

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -461,6 +461,12 @@ class GMM(BaseEstimator):
             observation.
         """
 
+        if len(self.means_.shape)<2:
+           raise ValueError(
+               'GMM means_ is one dimensional.  use reshape(means_,(-1,1))')
+        if len(X.shape)<2:
+           raise ValueError(
+               'X is one dimensional.  use reshape(X,(-1,1))')
         # initialization step
         X = check_array(X, dtype=np.float64)
         if X.shape[0] < self.n_components:


### PR DESCRIPTION
When trying to learn a GMM on one dimensional data, both weights and the data can be represented as 1-d vectors.  However, this breaks GMM.fit() and it used to die with cryptic error messages.  This addition specifically checks for one dimensional input and issues an error message accordingly.
