### PR TITLE
[MRG+1] Multioutput bagging

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -101,6 +101,8 @@ Enhancements
      with ``n_jobs > 1`` used with a large grid of parameters on a small
      dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and `Loic Esteve`_.
 
+   - Add multi-output support to :class:`bagging.BaggingClassifier`
+     and :class:`bagging.BaggingRegressor`. By `Arnaud Joly`_.
 
 Bug fixes
 .........
@@ -120,7 +122,7 @@ Bug fixes
     - Fixed bug in :class:`linear_model.LogisticRegressionCV` where `penalty` was ignored
       in the final fit. By `Manoj Kumar`_.
 
-    - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing 
+    - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing
       oob_score and X is a sparse.csc_matrix. By `Ankur Ankan`_.
 
 API changes summary

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -139,11 +139,11 @@ def _parallel_predict_proba(estimators, estimators_features, X, n_outputs,
     proba = [np.zeros((n_samples, n_classes_k)) for n_classes_k in n_classes]
 
     for estimator, features in zip(estimators, estimators_features):
-        try:
+        if hasattr(estimator, "predict_proba"):
             proba_est = estimator.predict_proba(X[:, features])
             if n_outputs == 1:
                 proba_est = [proba_est]
-        except AttributeError:
+        else:
             # We resort to voting
             y_pred = estimator.predict(X[:, features])
             if n_outputs == 1:


### PR DESCRIPTION
This pull request brings multi-output support (#3449) to the bagging meta estimators.

It's different of https://github.com/scikit-learn/scikit-learn/issues/3449 since the implementation to make the averaging is shared for single-output and multi-output data.

I haven't implemented multi-output decision function as no base estimator currently support this.
