### PR TITLE
[MRG] DOC make contributor's guide etc. more prominent on front page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -279,10 +279,9 @@
                 <ul>
                 <li><em>About us</em> See <a href="about.html#people">authors</a></li>
                 <li><em>More Machine Learning</em> Find <a href="related_projects.html">related projects</a></li>
-                <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a> #scikit-learn</li>
+                <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
                 <li><em>Mailing list:</em> <a href="https://lists.sourceforge.net/lists/listinfo/scikit-learn-general">scikit-learn-general@lists.sourceforge.net</a></li>
                 <li><em>IRC:</em> #scikit-learn @ <a href="http://webchat.freenode.net/">freenode</a></li>
-                <li><em>Want to contribute?</em> See <a href="developers/">developers' guide</li>
                 </ul>
 
                 <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -277,11 +277,12 @@
             <div class="span4">
                 <h4>Community</h4>
                 <ul>
-                <li><em>About us</em> See <a href="about.html">authors</a> # scikit-learn</li>
+                <li><em>About us</em> See <a href="about.html#people">authors</a></li>
                 <li><em>More Machine Learning</em> Find <a href="related_projects.html">related projects</a></li>
-                <li><em>Questions?</em> See <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a> # scikit-learn</li>
+                <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a> #scikit-learn</li>
                 <li><em>Mailing list:</em> <a href="https://lists.sourceforge.net/lists/listinfo/scikit-learn-general">scikit-learn-general@lists.sourceforge.net</a></li>
                 <li><em>IRC:</em> #scikit-learn @ <a href="http://webchat.freenode.net/">freenode</a></li>
+                <li><em>Want to contribute?</em> See <a href="developers/">developers' guide</li>
                 </ul>
 
                 <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -76,6 +76,7 @@
             <li><a href="{{ pathto('user_guide') }}">User guide</a></li>
             <li><a href="{{ pathto('modules/classes') }}">API</a></li>
             <li><a href="{{ pathto('faq') }}">FAQ</a></li>
+            <li><a href="{{ pathto('developers') }}">Contributing</a></li>
             <li class="divider"></li>
                 <li><a href="http://scikit-learn.org/stable/documentation.html">Scikit-learn 0.16.1 (stable)</a></li>
                 <li><a href="http://scikit-learn.org/0.15/documentation.html">Scikit-learn 0.15</a></li>


### PR DESCRIPTION
I find it strange that some parts of the documentation need you to click the "Documentation" menu item despite it having a drop-down. This is most noticeable for contributors' guide, but I've played with some other front page links as well.
