### PR TITLE
[MRG + 1] DOC remove linewidth in pca/ica example

### DIFF
--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -61,7 +61,7 @@ S_ica_ /= S_ica_.std(axis=0)
 # Plot results
 
 def plot_samples(S, axis_list=None):
-    plt.scatter(S[:, 0], S[:, 1], s=2, marker='o', linewidths=0, zorder=10,
+    plt.scatter(S[:, 0], S[:, 1], s=2, marker='o', zorder=10,
                 color='steelblue', alpha=0.5)
     if axis_list is not None:
         colors = ['orange', 'red']


### PR DESCRIPTION
http://scikit-learn.org/0.16/auto_examples/decomposition/plot_ica_vs_pca.html
vs
http://scikit-learn.org/dev/auto_examples/decomposition/plot_ica_vs_pca.html

Maybe it was a change in matplotlib? I'm not sure.
