### PR TITLE
[MRG + 1] DOC links should not always point to dev

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -63,8 +63,8 @@
         {%- block navbar -%}
         <div class="navbar">
             <ul>
-                <li><a href="{{pathto('../dev/index')}}">Home</a></li>
-                <li><a href="{{pathto('../dev/install')}}">Installation</a></li>
+                <li><a href="{{pathto('index')}}">Home</a></li>
+                <li><a href="{{pathto('install')}}">Installation</a></li>
                 <li class="btn-li"><div class="btn-group">
               <a href="{{pathto('documentation')}}">Documentation</a>
               <a class="btn dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
I assume this was introduced in error in ca7b6df4 [here](https://github.com/scikit-learn/scikit-learn/commit/ca7b6df4bb02114a77d81e6b32194689fbe86fd3#commitcomment-11674044)
