### PR TITLE
Change `clf` to `regr` in decision tree regression examples

### DIFF
--- a/examples/ensemble/plot_adaboost_regression.py
+++ b/examples/ensemble/plot_adaboost_regression.py
@@ -30,17 +30,17 @@ X = np.linspace(0, 6, 100)[:, np.newaxis]
 y = np.sin(X).ravel() + np.sin(6 * X).ravel() + rng.normal(0, 0.1, X.shape[0])
 
 # Fit regression model
-clf_1 = DecisionTreeRegressor(max_depth=4)
+regr_1 = DecisionTreeRegressor(max_depth=4)
 
-clf_2 = AdaBoostRegressor(DecisionTreeRegressor(max_depth=4),
+regr_2 = AdaBoostRegressor(DecisionTreeRegressor(max_depth=4),
                           n_estimators=300, random_state=rng)
 
-clf_1.fit(X, y)
-clf_2.fit(X, y)
+regr_1.fit(X, y)
+regr_2.fit(X, y)
 
 # Predict
-y_1 = clf_1.predict(X)
-y_2 = clf_2.predict(X)
+y_1 = regr_1.predict(X)
+y_2 = regr_2.predict(X)
 
 # Plot the results
 plt.figure()

--- a/examples/tree/plot_tree_regression.py
+++ b/examples/tree/plot_tree_regression.py
@@ -27,15 +27,15 @@ y = np.sin(X).ravel()
 y[::5] += 3 * (0.5 - rng.rand(16))
 
 # Fit regression model
-clf_1 = DecisionTreeRegressor(max_depth=2)
-clf_2 = DecisionTreeRegressor(max_depth=5)
-clf_1.fit(X, y)
-clf_2.fit(X, y)
+regr_1 = DecisionTreeRegressor(max_depth=2)
+regr_2 = DecisionTreeRegressor(max_depth=5)
+regr_1.fit(X, y)
+regr_2.fit(X, y)
 
 # Predict
 X_test = np.arange(0.0, 5.0, 0.01)[:, np.newaxis]
-y_1 = clf_1.predict(X_test)
-y_2 = clf_2.predict(X_test)
+y_1 = regr_1.predict(X_test)
+y_2 = regr_2.predict(X_test)
 
 # Plot the results
 plt.figure()

--- a/examples/tree/plot_tree_regression_multioutput.py
+++ b/examples/tree/plot_tree_regression_multioutput.py
@@ -27,18 +27,18 @@ y = np.array([np.pi * np.sin(X).ravel(), np.pi * np.cos(X).ravel()]).T
 y[::5, :] += (0.5 - rng.rand(20, 2))
 
 # Fit regression model
-clf_1 = DecisionTreeRegressor(max_depth=2)
-clf_2 = DecisionTreeRegressor(max_depth=5)
-clf_3 = DecisionTreeRegressor(max_depth=8)
-clf_1.fit(X, y)
-clf_2.fit(X, y)
-clf_3.fit(X, y)
+regr_1 = DecisionTreeRegressor(max_depth=2)
+regr_2 = DecisionTreeRegressor(max_depth=5)
+regr_3 = DecisionTreeRegressor(max_depth=8)
+regr_1.fit(X, y)
+regr_2.fit(X, y)
+regr_3.fit(X, y)
 
 # Predict
 X_test = np.arange(-100.0, 100.0, 0.01)[:, np.newaxis]
-y_1 = clf_1.predict(X_test)
-y_2 = clf_2.predict(X_test)
-y_3 = clf_3.predict(X_test)
+y_1 = regr_1.predict(X_test)
+y_2 = regr_2.predict(X_test)
+y_3 = regr_3.predict(X_test)
 
 # Plot the results
 plt.figure()


### PR DESCRIPTION
I just replaced the variables that used "clf" with "regr" in the Decision tree regression examples. It's not really important, but the wording "classifier" in the regression examples bugged me ;)
