### PR TITLE
[MRG] remove referrence to HMM in common tests

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -61,7 +61,7 @@ def test_non_meta_estimators():
     for name, Estimator in estimators:
         if issubclass(Estimator, BiclusterMixin):
             continue
-        if name.endswith("HMM") or name.startswith("_"):
+        if name.startswith("_"):
             continue
         for check in _yield_all_checks(name, Estimator):
             yield check, name, Estimator


### PR DESCRIPTION
This remaining condition in `test_common` should now be useless. Will merge if travis agrees.
