### PR TITLE
[MRG+1] CCA Stability

### DIFF
--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -58,10 +58,8 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         ## 2.2 Normalize y_weights
         if norm_y_weights:
             y_weights /= np.sqrt(np.dot(y_weights.T, y_weights)) + eps
-        else:
-            y_weights += eps
         # 2.3 Update y_score: the Y latent scores
-        y_score = np.dot(Y, y_weights) / np.dot(y_weights.T, y_weights)
+        y_score = np.dot(Y, y_weights) / (np.dot(y_weights.T, y_weights) + eps)
         ## y_score = np.dot(Y, y_weights) / np.dot(y_score.T, y_score) ## BUG
         x_weights_diff = x_weights - x_weights_old
         if np.dot(x_weights_diff.T, x_weights_diff) < tol or Y.shape[1] == 1:

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -32,6 +32,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
     x_weights_old = 0
     ite = 1
     X_pinv = Y_pinv = None
+    eps = np.finfo(X.dtype).eps
     # Inner loop of the Wold algo.
     while True:
         # 1.1 Update u: the X weights
@@ -43,7 +44,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
             # Mode A regress each X column on y_score
             x_weights = np.dot(X.T, y_score) / np.dot(y_score.T, y_score)
         # 1.2 Normalize u
-        x_weights /= np.sqrt(np.dot(x_weights.T, x_weights))
+        x_weights /= np.sqrt(np.dot(x_weights.T, x_weights)) + eps
         # 1.3 Update x_score: the X latent scores
         x_score = np.dot(X, x_weights)
         # 2.1 Update y_weights
@@ -56,7 +57,9 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
             y_weights = np.dot(Y.T, x_score) / np.dot(x_score.T, x_score)
         ## 2.2 Normalize y_weights
         if norm_y_weights:
-            y_weights /= np.sqrt(np.dot(y_weights.T, y_weights))
+            y_weights /= np.sqrt(np.dot(y_weights.T, y_weights)) + eps
+        else:
+            y_weights += eps
         # 2.3 Update y_score: the Y latent scores
         y_score = np.dot(Y, y_weights) / np.dot(y_weights.T, y_weights)
         ## y_score = np.dot(Y, y_weights) / np.dot(y_score.T, y_score) ## BUG


### PR DESCRIPTION
This pull request should address #4888.

On a Windows machine with 64bit python, the unit tests for CCA would fail because of the presence of NaN. This issue was traced to the function `_nipals_twoblocks_inner_loop`. 

Conceptually, the function takes in a data matrix X and a multivariate response Y, and tries to find a lower dimensional representation of both, one component at a time. However, if earlier components can reconstruct the data well, later components may have their weights shrunk to quantities below machine precision. In the case of the unit test, the values are ~5e-16, which can be represented on Ubuntu machines but not Windows machines, where they would be rounded to 0. 

Practically, this caused an issue because on line 47 and 60 of pls_.py the weights are normalized by dividing by some function of themselves. Instead of explicitly raising an error, numpy would fill in nan in those positions, which would cause math issues for the remainder of the function but return successfully.  It also wouldn't be caught in lines 300-302 because the numbers were not small, they were nan. It isn't until line 336-338 where the pseudoinverse is calculated that the array is checked to make sure no nan elements are present; and since they exist, the error above is raised.

This PR fixes the issue by adding an epsilon close to machine precision to the weights before they are divided, so that there is never a divide by zero issue. Unit tests run successfully on both Ubuntu and Windows 64bit machines. 
