### PR TITLE
[MRG+1] Updated joblib to 0.9.0b2

### DIFF
--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -14,7 +14,7 @@ data and has specific optimizations for `numpy` arrays. It is
 
 
     ============================== ============================================
-    **User documentation**:        http://packages.python.org/joblib
+    **User documentation**:        http://pythonhosted.org/joblib
 
     **Download packages**:         http://pypi.python.org/pypi/joblib#downloads
 
@@ -100,7 +100,23 @@ Main features
 
 """
 
-__version__ = '0.8.4'
+# PEP0440 compatible formatted version, see:
+# https://www.python.org/dev/peps/pep-0440/
+#
+# Generic release markers:
+# X.Y
+# X.Y.Z # For bugfix releases
+#
+# Admissible pre-release markers:
+# X.YaN # Alpha release
+# X.YbN # Beta release
+# X.YrcN # Release Candidate
+# X.Y # Final release
+#
+# Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
+# 'X.Y.dev0' is the canonical version of 'X.Y.dev'
+#
+__version__ = '0.9.0b2'
 
 
 from .memory import Memory, MemorizedResult

--- a/sklearn/externals/joblib/_memory_helpers.py
+++ b/sklearn/externals/joblib/_memory_helpers.py
@@ -1,0 +1,105 @@
+try:
+    # Available in Python 3
+    from tokenize import open as open_py_source
+
+except ImportError:
+    # Copied from python3 tokenize
+    from codecs import lookup, BOM_UTF8
+    import re
+    from io import TextIOWrapper, open
+    cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+
+    def _get_normal_name(orig_enc):
+        """Imitates get_normal_name in tokenizer.c."""
+        # Only care about the first 12 characters.
+        enc = orig_enc[:12].lower().replace("_", "-")
+        if enc == "utf-8" or enc.startswith("utf-8-"):
+            return "utf-8"
+        if enc in ("latin-1", "iso-8859-1", "iso-latin-1") or \
+           enc.startswith(("latin-1-", "iso-8859-1-", "iso-latin-1-")):
+            return "iso-8859-1"
+        return orig_enc
+
+    def _detect_encoding(readline):
+        """
+        The detect_encoding() function is used to detect the encoding that
+        should be used to decode a Python source file.  It requires one
+        argment, readline, in the same way as the tokenize() generator.
+
+        It will call readline a maximum of twice, and return the encoding used
+        (as a string) and a list of any lines (left as bytes) it has read in.
+
+        It detects the encoding from the presence of a utf-8 bom or an encoding
+        cookie as specified in pep-0263.  If both a bom and a cookie are
+        present, but disagree, a SyntaxError will be raised.  If the encoding
+        cookie is an invalid charset, raise a SyntaxError.  Note that if a
+        utf-8 bom is found, 'utf-8-sig' is returned.
+
+        If no encoding is specified, then the default of 'utf-8' will be
+        returned.
+        """
+        bom_found = False
+        encoding = None
+        default = 'utf-8'
+
+        def read_or_stop():
+            try:
+                return readline()
+            except StopIteration:
+                return b''
+
+        def find_cookie(line):
+            try:
+                line_string = line.decode('ascii')
+            except UnicodeDecodeError:
+                return None
+
+            matches = cookie_re.findall(line_string)
+            if not matches:
+                return None
+            encoding = _get_normal_name(matches[0])
+            try:
+                codec = lookup(encoding)
+            except LookupError:
+                # This behaviour mimics the Python interpreter
+                raise SyntaxError("unknown encoding: " + encoding)
+
+            if bom_found:
+                if codec.name != 'utf-8':
+                    # This behaviour mimics the Python interpreter
+                    raise SyntaxError('encoding problem: utf-8')
+                encoding += '-sig'
+            return encoding
+
+        first = read_or_stop()
+        if first.startswith(BOM_UTF8):
+            bom_found = True
+            first = first[3:]
+            default = 'utf-8-sig'
+        if not first:
+            return default, []
+
+        encoding = find_cookie(first)
+        if encoding:
+            return encoding, [first]
+
+        second = read_or_stop()
+        if not second:
+            return default, [first]
+
+        encoding = find_cookie(second)
+        if encoding:
+            return encoding, [first, second]
+
+        return default, [first, second]
+
+    def open_py_source(filename):
+        """Open a file in read only mode using the encoding detected by
+        detect_encoding().
+        """
+        buffer = open(filename, 'rb')
+        encoding, lines = _detect_encoding(buffer.readline)
+        buffer.seek(0)
+        text = TextIOWrapper(buffer, encoding, line_buffering=True)
+        text.mode = 'r'
+        return text

--- a/sklearn/externals/joblib/format_stack.py
+++ b/sklearn/externals/joblib/format_stack.py
@@ -280,9 +280,9 @@ def format_records(records):   # , print_globals=False):
             # signals exit of tokenizer
             pass
         except tokenize.TokenError as msg:
-            _m = ("An unexpected error occurred while tokenizing input\n"
+            _m = ("An unexpected error occurred while tokenizing input file %s\n"
                   "The following traceback may be corrupted or invalid\n"
-                  "The error message is: %s\n" % msg)
+                  "The error message is: %s\n" % (file, msg))
             print(_m)
 
         # prune names list of duplicates, but keep the right order

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -14,7 +14,7 @@ import os
 
 from ._compat import _basestring
 from .logger import pformat
-
+from ._memory_helpers import open_py_source
 
 def get_func_code(func):
     """ Attempts to retrieve a reliable function code hash.
@@ -54,7 +54,7 @@ def get_func_code(func):
                 source_file = '<doctest %s>' % source_file
             return source_code, source_file, line_no
         # Try to retrieve the source code.
-        with open(source_file) as source_file_obj:
+        with open_py_source(source_file) as source_file_obj:
             first_line = code.co_firstlineno
             # All the lines after the function definition:
             source_lines = list(islice(source_file_obj, first_line - 1, None))
@@ -74,12 +74,13 @@ def get_func_code(func):
 
 
 def _clean_win_chars(string):
-    "Windows cannot encode some characters in filenames"
+    """Windows cannot encode some characters in filename."""
     import urllib
     if hasattr(urllib, 'quote'):
         quote = urllib.quote
     else:
         # In Python 3, quote is elsewhere
+        import urllib.parse
         quote = urllib.parse.quote
     for char in ('<', '>', '!', ':', '\\'):
         string = string.replace(char, quote(char))

--- a/sklearn/externals/joblib/memory.py
+++ b/sklearn/externals/joblib/memory.py
@@ -26,11 +26,13 @@ import warnings
 import inspect
 import json
 import weakref
+import io
 
 # Local imports
 from . import hashing
 from .func_inspect import get_func_code, get_func_name, filter_args
 from .func_inspect import format_signature, format_call
+from ._memory_helpers import open_py_source
 from .logger import Logger, format_time, pformat
 from . import numpy_pickle
 from .disk import mkdirp, rm_subdirs
@@ -540,8 +542,8 @@ class MemorizedFunc(Logger):
         # sometimes have several functions named the same way in a
         # file. This is bad practice, but joblib should be robust to bad
         # practice.
-        func_code = '%s %i\n%s' % (FIRST_LINE_TEXT, first_line, func_code)
-        with open(filename, 'w') as out:
+        func_code = u'%s %i\n%s' % (FIRST_LINE_TEXT, first_line, func_code)
+        with io.open(filename, 'w', encoding="UTF-8") as out:
             out.write(func_code)
         # Also store in the in-memory store of function hashes
         is_named_callable = False
@@ -590,7 +592,7 @@ class MemorizedFunc(Logger):
         func_code_file = os.path.join(func_dir, 'func_code.py')
 
         try:
-            with open(func_code_file) as infile:
+            with io.open(func_code_file, encoding="UTF-8") as infile:
                 old_func_code, old_first_line = \
                             extract_first_line(infile.read())
         except IOError:
@@ -624,7 +626,7 @@ class MemorizedFunc(Logger):
             if os.path.exists(source_file):
                 _, func_name = get_func_name(self.func, resolv_alias=False)
                 num_lines = len(func_code.split('\n'))
-                with open(source_file) as f:
+                with open_py_source(source_file) as f:
                     on_disk_func_code = f.readlines()[
                         old_first_line - 1:old_first_line - 1 + num_lines - 1]
                 on_disk_func_code = ''.join(on_disk_func_code)

--- a/sklearn/externals/joblib/pool.py
+++ b/sklearn/externals/joblib/pool.py
@@ -35,9 +35,6 @@ except ImportError:
 # Customizable pure Python pickler in Python 2
 # customizable C-optimized pickler under Python 3.3+
 from pickle import Pickler
-if sys.version_info[0] > 2 and not hasattr(Pickler, 'dispatch_table'):
-    # Special case for Python 3.2: use the pure Python pickler as fallback
-    from pickle import _Pickler as Pickler
 
 from pickle import HIGHEST_PROTOCOL
 from io import BytesIO
@@ -296,8 +293,8 @@ class CustomizablePickler(Pickler):
             # a reference to the class dictionary under Python 2
             self.dispatch = Pickler.dispatch.copy()
         else:
-            # Under Python 3 initialize the dispatch table with with a copy of
-            # the default registry
+            # Under Python 3 initialize the dispatch table with a copy of the
+            # default registry
             self.dispatch_table = copyreg.dispatch_table.copy()
         for type, reduce_func in reducers.items():
             self.register(type, reduce_func)


### PR DESCRIPTION
This is mostly to get early testing of jobs batching from https://github.com/joblib/joblib/pull/157 in order to stress-test the functionality.

Note that there has been other more minor changes in joblib too. From CHANGES.rst:
-   FIX compressed pickles interoperability between Python 2 and
  Python 3. Compressed pickles can be written with one and read with
  the other.
-   FIX make it possible to call `joblib.load(filename, mmap_mode='r')`
  on pickled objects that include a mix of arrays of both
  memmory memmapable dtypes and object dtype.
