### PR TITLE
[WIP] Correct ducktyping of predict proba in GridSearchCV

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -415,7 +415,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                           ChangedBehaviorWarning)
         return self.scorer_(self.best_estimator_, X, y)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def predict(self, X):
         """Call predict on the estimator with the best found parameters.
 
@@ -431,7 +431,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.predict(X)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def predict_proba(self, X):
         """Call predict_proba on the estimator with the best found parameters.
 
@@ -447,7 +447,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.predict_proba(X)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def predict_log_proba(self, X):
         """Call predict_log_proba on the estimator with the best found parameters.
 
@@ -463,7 +463,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.predict_log_proba(X)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def decision_function(self, X):
         """Call decision_function on the estimator with the best found parameters.
 
@@ -479,7 +479,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.decision_function(X)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def transform(self, X):
         """Call transform on the estimator with the best found parameters.
 
@@ -495,7 +495,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.transform(X)
 
-    @if_delegate_has_method(delegate='estimator')
+    @if_delegate_has_method(delegate='best_estimator_')
     def inverse_transform(self, Xt):
         """Call inverse_transform on the estimator with the best found parameters.
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -571,6 +571,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
     # probabilities are not available depending on a setting, introduce two
     # estimators.
     def _check_proba(self):
+        check_is_fitted(self, 'support_')
         if not self.probability or self.probA_.size == 0 or self.probB_.size == 0:
             raise AttributeError("predict_proba is not available when fitted with"
                                  " probability=False")


### PR DESCRIPTION
Fixes #4902 

The decorator (used for ducktyping) was set to `'estimator'` (the unfitted est.) rather than the final `'best_estimator_'` at #3982

And so `predict_proba_` checked for the attr `probA_` in the `estimator` instead of `best_estimator_`...

Also we need to make sure `NotFittedError` gets raised first since `estimator` is not fitted...

@agramfort @adammenges Please take a look!
