### PR TITLE
[MRG+1] ENH add minmax_scale

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1108,6 +1108,7 @@ See the :ref:`metrics` section of the user guide for further details.
    preprocessing.LabelBinarizer
    preprocessing.LabelEncoder
    preprocessing.MultiLabelBinarizer
+   preprocessing.MaxAbsScaler
    preprocessing.MinMaxScaler
    preprocessing.Normalizer
    preprocessing.OneHotEncoder
@@ -1122,8 +1123,12 @@ See the :ref:`metrics` section of the user guide for further details.
    preprocessing.add_dummy_feature
    preprocessing.binarize
    preprocessing.label_binarize
+   preprocessing.maxabs_scale
+   preprocessing.minmax_scale
    preprocessing.normalize
+   preprocessing.robust_scale
    preprocessing.scale
+
 
 
 :mod:`sklearn.qda`: Quadratic Discriminant Analysis

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -173,9 +173,9 @@ Here is how to use the toy data from the previous example with this scaler::
   array([ 2.,  1.,  2.])
 
 
-As with :func:`scale`, the module further provides a
-convenience function :func:`maxabs_scale` if you don't want to
-create an object.
+As with :func:`scale`, the module further provides
+convenience functions :func:`minmax_scale` and :func:`maxabs_scale` if you
+don't want to create an object.
 
 
 Scaling sparse data
@@ -507,4 +507,4 @@ The features of X have been transformed from :math:`(X_1, X_2, X_3)` to :math:`(
 
 Note that polynomial features are used implicitily in `kernel methods <http://en.wikipedia.org/wiki/Kernel_method>`_ (e.g., :class:`sklearn.svm.SVC`, :class:`sklearn.decomposition.KernelPCA`) when using polynomial :ref:`svm_kernels`.
 
-See :ref:`example_linear_model_plot_polynomial_interpolation.py` for Ridge regression using created polynomial features.  
+See :ref:`example_linear_model_plot_polynomial_interpolation.py` for Ridge regression using created polynomial features.

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -173,9 +173,9 @@ Here is how to use the toy data from the previous example with this scaler::
   array([ 2.,  1.,  2.])
 
 
-As with :func:`scale`, the module further provides
-convenience functions :func:`minmax_scale` and :func:`maxabs_scale` if you
-don't want to create an object.
+As with :func:`scale`, the module further provides convenience functions
+:func:`minmax_scale` and :func:`maxabs_scale` if you don't want to create
+an object.
 
 
 Scaling sparse data

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,7 +64,7 @@ Enhancements
      :class:`linear_model.LogisticRegression`, by avoiding loss computation.
      By `Mathieu Blondel`_ and `Tom Dupre la Tour`_.
 
-   - The ``class_weight="auto"`` heuristic in classifiers supporting 
+   - The ``class_weight="auto"`` heuristic in classifiers supporting
      ``class_weight`` was deprecated and replaced by the ``class_weight="balanced"``
      option, which has a simpler forumlar and interpretation.
      By Hanna Wallach and `Andreas Müller`_.
@@ -84,6 +84,9 @@ Enhancements
 
    - Provide an option for sparse output from
      :func:`sklearn.metrics.pairwise.cosine_similarity`. By `Jaidev Deshpande`_.
+
+   - Add :func:`minmax_scale` to provide a function interface for
+     :class:`MinMaxScaler`. By `Thomas Unterthiner`_.
 
 Bug fixes
 .........

--- a/sklearn/preprocessing/__init__.py
+++ b/sklearn/preprocessing/__init__.py
@@ -16,6 +16,7 @@ from .data import normalize
 from .data import scale
 from .data import robust_scale
 from .data import maxabs_scale
+from .data import minmax_scale
 from .data import OneHotEncoder
 
 from .data import PolynomialFeatures
@@ -47,5 +48,6 @@ __all__ = [
     'scale',
     'robust_scale',
     'maxabs_scale',
+    'minmax_scale',
     'label_binarize',
 ]

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -195,20 +195,20 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
 
 class MinMaxScaler(BaseEstimator, TransformerMixin):
-    """Standardizes features by scaling each feature to a given range.
+    """Transforms features by scaling each feature to a given range.
 
     This estimator scales and translates each feature individually such
     that it is in the given range on the training set, i.e. between
     zero and one.
 
-    The standardization is given by::
+    The transformation is given by::
 
         X_std = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
         X_scaled = X_std * (max - min) + min
 
     where min, max = feature_range.
 
-    This standardization is often used as an alternative to zero mean,
+    This transformation is often used as an alternative to zero mean,
     unit variance scaling.
 
     Read more in the :ref:`User Guide <preprocessing_scaler>`.
@@ -291,20 +291,20 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
 
 def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
-    """Standardizes features by scaling each feature to a given range.
+    """Transforms features by scaling each feature to a given range.
 
     This estimator scales and translates each feature individually such
     that it is in the given range on the training set, i.e. between
     zero and one.
 
-    The standardization is given by::
+    The transformation is given by::
 
         X_std = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
         X_scaled = X_std * (max - min) + min
 
     where min, max = feature_range.
 
-    This standardization is often used as an alternative to zero mean,
+    This transformation is often used as an alternative to zero mean,
     unit variance scaling.
 
     Read more in the :ref:`User Guide <preprocessing_scaler>`.

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -43,6 +43,7 @@ __all__ = [
     'scale',
     'robust_scale',
     'maxabs_scale',
+    'minmax_scale',
 ]
 
 
@@ -289,6 +290,45 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         return X
 
 
+def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
+    """Standardizes features by scaling each feature to a given range.
+
+    This estimator scales and translates each feature individually such
+    that it is in the given range on the training set, i.e. between
+    zero and one.
+
+    The standardization is given by::
+
+        X_std = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
+        X_scaled = X_std * (max - min) + min
+
+    where min, max = feature_range.
+
+    This standardization is often used as an alternative to zero mean,
+    unit variance scaling.
+
+    Read more in the :ref:`User Guide <preprocessing_scaler>`.
+
+    Parameters
+    ----------
+    feature_range: tuple (min, max), default=(0, 1)
+        Desired range of transformed data.
+
+    axis : int (0 by default)
+        axis used to scale along. If 0, independently scale each feature,
+        otherwise (if 1) scale each sample.
+
+    copy : boolean, optional, default is True
+        Set to False to perform inplace scaling and avoid a copy (if the input
+        is already a numpy array).
+    """
+    s = MinMaxScaler(feature_range=feature_range, copy=copy)
+    if axis == 0:
+        return s.fit_transform(X)
+    else:
+        return s.fit_transform(X.T).T
+
+
 class StandardScaler(BaseEstimator, TransformerMixin):
     """Standardize features by removing the mean and scaling to unit variance
 
@@ -337,7 +377,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         The mean value for each feature in the training set.
 
     std_ : array of floats with shape [n_features]
-        The standard deviation for each feature in the training set. 
+        The standard deviation for each feature in the training set.
         Set to one if the standard deviation is zero for a given feature.
 
     See also

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -27,6 +27,7 @@ from sklearn.preprocessing.data import OneHotEncoder
 from sklearn.preprocessing.data import StandardScaler
 from sklearn.preprocessing.data import scale
 from sklearn.preprocessing.data import MinMaxScaler
+from sklearn.preprocessing.data import minmax_scale
 from sklearn.preprocessing.data import MaxAbsScaler
 from sklearn.preprocessing.data import maxabs_scale
 from sklearn.preprocessing.data import RobustScaler
@@ -259,6 +260,19 @@ def test_min_max_scaler_zero_variance_features():
                       [1., 1., 1.0],
                       [1., 1., 2.0]]
     assert_array_almost_equal(X_trans, X_expected_1_2)
+
+    # function interface
+    X_trans = minmax_scale(X)
+    assert_array_almost_equal(X_trans, X_expected_0_1)
+    X_trans = minmax_scale(X, feature_range=(1, 2))
+    assert_array_almost_equal(X_trans, X_expected_1_2)
+
+
+def test_minmax_scale_axis1():
+    X = iris.data
+    X_trans = minmax_scale(X, axis=1)
+    assert_array_almost_equal(np.min(X_trans, axis=1), 0)
+    assert_array_almost_equal(np.max(X_trans, axis=1), 1)
 
 
 def test_min_max_scaler_1d():


### PR DESCRIPTION
This PR adds `minmax_scale`, which is a function that provides the same functionality as `MinMaxScaler`, but as a function. Exactly like how `scale`/`robust_scale`/`maxabs_scale` provide function-interfaces for `StandardScaler`/`RobustScaler`/`MaxAbsScaler`.
