### PR TITLE
Change name of variable to be consistent with dataset

### DIFF
--- a/examples/model_selection/randomized_search.py
+++ b/examples/model_selection/randomized_search.py
@@ -31,8 +31,8 @@ from sklearn.datasets import load_digits
 from sklearn.ensemble import RandomForestClassifier
 
 # get some data
-iris = load_digits()
-X, y = iris.data, iris.target
+digits = load_digits()
+X, y = digits.data, digits.target
 
 # build a classifier
 clf = RandomForestClassifier(n_estimators=20)


### PR DESCRIPTION
Example is loading digits dataset onto iris variable. Changed to digits variable for consistency.
