### PR TITLE
[MRG + 2] Re-adding checks for prior in LDA

### DIFF
--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -420,7 +420,14 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
             _, y_t = np.unique(y, return_inverse=True)  # non-negative ints
             self.priors_ = bincount(y_t) / float(len(y))
         else:
-            self.priors_ = self.priors
+            self.priors_ = np.asarray(self.priors)
+
+        if (self.priors_ < 0).any():
+            raise ValueError("priors must be non-negative")
+        if self.priors_.sum() != 1:
+            warnings.warn("The priors do not sum to 1. Renormalizing",
+                          UserWarning)
+            self.priors_ = self.priors_ / self.priors_.sum()
 
         if self.solver == 'svd':
             if self.shrinkage is not None:

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -64,6 +64,25 @@ def test_lda_predict():
     assert_raises(ValueError, clf.fit, X, y)
 
 
+def test_lda_priors():
+    # Test priors (negative priors)
+    priors = np.array([0.5, -0.5])
+    clf = lda.LDA(priors=priors)
+    msg = "priors must be non-negative"
+    assert_raise_message(ValueError, msg, clf.fit, X, y)
+
+    # Test that priors passed as a list are correctly handled (run to see if failure)
+    clf = lda.LDA(priors=[0.5, 0.5])
+    clf.fit(X, y)
+
+    # Test that priors always sum to 1
+    priors = np.array([0.5, 0.6])
+    prior_norm = np.array([0.45, 0.55])
+    clf = lda.LDA(priors=priors)
+    clf.fit(X, y)
+    assert_array_almost_equal(clf.priors_, prior_norm, 2)
+
+
 def test_lda_coefs():
     # Test if the coefficients of the solvers are approximately the same.
     n_features = 2


### PR DESCRIPTION
After version 0.15.2 the checks to self.priors and the conversion of priors to a numpy array seem to have been removed. 

I'm not sure if this is intentional but it causes issues if priors is passed as a list to init instead of as a numpy array. 

e.g. if  'priors' is passed as a list then the following error results when multiplying n_samples\* self.priors_ in _solve_svd (line 379 of lda.py):

```
X = np.dot(((np.sqrt((n_samples * self.priors_) * fac)) *
TypeError: can't multiply sequence by non-int of type 'float'
```

This is my first pull request to scikit-learn so hopefully I'm following protocol :)
