### PR TITLE
added a return_indices option in cross_validation::train_test_split()

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1570,6 +1570,10 @@ def train_test_split(*arrays, **options):
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
+    return_indices: boolean (default is False)
+        If True, the indices of the train and test split will additionally be
+        returned.
+
     stratify : array-like or None (default is None)
         If not None, data is split in a stratified fashion, using this as
         the labels array.
@@ -1577,7 +1581,9 @@ def train_test_split(*arrays, **options):
     Returns
     -------
     splitting : list of arrays, length=2 * len(arrays)
-        List containing train-test split of input array.
+        List containing train-test split of input array. If return_indices
+        is True, the indices of the train and test split will additionally be
+        returned.
 
     Examples
     --------
@@ -1616,6 +1622,7 @@ def train_test_split(*arrays, **options):
     test_size = options.pop('test_size', None)
     train_size = options.pop('train_size', None)
     random_state = options.pop('random_state', None)
+    return_indices = options.pop('return_indices', False)
     dtype = options.pop('dtype', None)
     if dtype is not None:
         warnings.warn("dtype option is ignored and will be removed in 0.18.",
@@ -1654,8 +1661,12 @@ def train_test_split(*arrays, **options):
                           random_state=random_state)
 
     train, test = next(iter(cv))
-    return list(chain.from_iterable((safe_indexing(a, train),
-                                     safe_indexing(a, test)) for a in arrays))
+    splitted = list(chain.from_iterable((safe_indexing(a, train),
+                                         safe_indexing(a, test))
+                                        for a in arrays))
+    if return_indices:
+        splitted += list((train, test))
+    return splitted
 
 
 train_test_split.__test__ = False  # to avoid a pb with nosetests

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -710,6 +710,27 @@ def test_train_test_split():
         assert_equal(np.sum(train == 1), np.sum(train == 2))
 
 
+def test_train_test_split_with_indices():
+    X = np.arange(100).reshape((10, 10))
+    y = np.arange(10)
+
+    split = cval.train_test_split(X, y, test_size=None, train_size=.2)
+    split_with_indices = cval.train_test_split(X, y, test_size=None, train_size=.2, return_indices=True)
+
+    # verify that specifying 'return_indices=True' return 2 additional objects
+    assert_equal(len(split)+2, len(split_with_indices))
+
+    X_train, X_test, y_train, y_test, train_indices, test_indices = split_with_indices
+    # verify the indices arrays are disjoint
+    assert_equal(len(np.intersect1d(test_indices, train_indices)), 0)
+
+    # verify the returned indices are indeed the indices used to divide the train/test sets
+    assert_array_equal(X_train, X[train_indices])
+    assert_array_equal(X_test, X[test_indices])
+    assert_array_equal(y_train, y[train_indices])
+    assert_array_equal(y_test, y[test_indices])
+
+
 def train_test_split_pandas():
     # check cross_val_score doesn't destroy pandas dataframe
     types = [MockDataFrame]


### PR DESCRIPTION
  Added a boolean return_indices option to cross_validation.py's train_test_split() method
  If True, the indices of the train and test split will additionally be returned.

Motivation: I needed the indices of the cross validation split, and I saw online that I wasn't the only one having this use case:
https://twitter.com/treycausey/status/423193367745286144

Please note - This is my first push to this repository. I did not run any tests to validate this code because I didn't know where the tests are located. 
