### PR TITLE
[MRG+1] FIX #4902: SV*.predict_proba visible before fit

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -13,7 +13,7 @@ from ..multiclass import _ovr_decision_function
 from ..utils import check_array, check_random_state, column_or_1d
 from ..utils import ConvergenceWarning, compute_class_weight, deprecated
 from ..utils.extmath import safe_sparse_dot
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, NotFittedError
 from ..externals import six
 
 LIBSVM_IMPL = ['c_svc', 'nu_svc', 'one_class', 'epsilon_svr', 'nu_svr']
@@ -571,8 +571,8 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
     # probabilities are not available depending on a setting, introduce two
     # estimators.
     def _check_proba(self):
-        if not self.probability or self.probA_.size == 0 or self.probB_.size == 0:
-            raise AttributeError("predict_proba is not available when fitted with"
+        if not self.probability:
+            raise AttributeError("predict_proba is not available when "
                                  " probability=False")
         if self._impl not in ('c_svc', 'nu_svc'):
             raise AttributeError("predict_proba only implemented for SVC"
@@ -610,6 +610,9 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
 
     def _predict_proba(self, X):
         X = self._validate_for_predict(X)
+        if self.probA_.size == 0 or self.probB_.size == 0:
+            raise NotFittedError("predict_proba is not available when fitted "
+                                 "with probability=False")
         pred_proba = (self._sparse_predict_proba
                       if self._sparse else self._dense_predict_proba)
         return pred_proba(X)


### PR DESCRIPTION
Fixes #4902, and provides an alternative fix to #4791.
