### PR TITLE
RandomForest Docstring Update

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -694,6 +694,9 @@ class RandomForestClassifier(ForestClassifier):
     A random forest is a meta estimator that fits a number of decision tree
     classifiers on various sub-samples of the dataset and use averaging to
     improve the predictive accuracy and control over-fitting.
+    The sub-sample size is always the same as the original
+    input sample size but the samples are drawn with replacement if
+    `bootstrap=True` (default).
 
     Read more in the :ref:`User Guide <forest>`.
 
@@ -715,7 +718,7 @@ class RandomForestClassifier(ForestClassifier):
           `int(max_features * n_features)` features are considered at each
           split.
         - If "auto", then `max_features=sqrt(n_features)`.
-        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "sqrt", then `max_features=sqrt(n_features)` (same as "auto").
         - If "log2", then `max_features=log2(n_features)`.
         - If None, then `max_features=n_features`.
 
@@ -883,6 +886,9 @@ class RandomForestRegressor(ForestRegressor):
     A random forest is a meta estimator that fits a number of classifying
     decision trees on various sub-samples of the dataset and use averaging
     to improve the predictive accuracy and control over-fitting.
+    The sub-sample size is always the same as the original
+    input sample size but the samples are drawn with replacement if
+    `bootstrap=True` (default).
 
     Read more in the :ref:`User Guide <forest>`.
 


### PR DESCRIPTION
Hi,
I added some lines to the RandomForest docstring. I think that using the original sample size for the bootstrap sub-sample size may be the typical implementation of random forests, but maybe it is useful to mention it explicitly for clarity. 

Also, "auto" and "sqrt" are the same for the `max_features` parameter in the rf classifier, and although this may be intended, someone might think that it's a typo.
