### PR TITLE
[MRG+1] extend R^2 description

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1318,7 +1318,10 @@ R² score, the coefficient of determination
 The :func:`r2_score` function computes R², the `coefficient of
 determination <http://en.wikipedia.org/wiki/Coefficient_of_determination>`_.
 It provides a measure of how well future samples are likely to
-be predicted by the model.
+be predicted by the model. Best possible score is 1.0 and it can be negative
+(because the model can be arbitrarily worse). A constant model that always
+predicts the expected value of y, disregarding the input features, would get a
+R^2 score of 0.0.
 
 If :math:`\hat{y}_i` is the predicted value of the :math:`i`-th sample
 and :math:`y_i` is the corresponding true value, then the score R² estimated

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -320,7 +320,10 @@ class RegressorMixin(object):
         The coefficient R^2 is defined as (1 - u/v), where u is the regression
         sum of squares ((y_true - y_pred) ** 2).sum() and v is the residual
         sum of squares ((y_true - y_true.mean()) ** 2).sum().
-        Best possible score is 1.0, lower values are worse.
+        Best possible score is 1.0 and it can be negative (because the
+        model can be arbitrarily worse). A constant model that always
+        predicts the expected value of y, disregarding the input features,
+        would get a R^2 score of 0.0.
 
         Parameters
         ----------

--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -368,7 +368,10 @@ def r2_score(y_true, y_pred,
              multioutput=None):
     """R^2 (coefficient of determination) regression score function.
 
-    Best possible score is 1.0, lower values are worse.
+    Best possible score is 1.0 and it can be negative (because the
+    model can be arbitrarily worse). A constant model that always
+    predicts the expected value of y, disregarding the input features,
+    would get a R^2 score of 0.0.
 
     Read more in the :ref:`User Guide <r2_score>`.
 


### PR DESCRIPTION
To make the docs more explicit for R^2 score in regression.
