### PR TITLE
[docs] [trivial] Fix small error in cross-validation docs.

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -247,7 +247,7 @@ Stratified k-fold
 folds: each set contains approximately the same percentage of samples of each
 target class as the complete set.
 
-Example of stratified 2-fold cross-validation on a dataset with 10 samples from
+Example of stratified 3-fold cross-validation on a dataset with 10 samples from
 two slightly unbalanced classes::
 
   >>> from sklearn.cross_validation import StratifiedKFold


### PR DESCRIPTION
In the cross-validation docs in the user guide, the StratifiedKFold example mentions 2-fold CV but actually uses 3. This fixes the text.
