### PR TITLE
Tfidf mem fix

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -755,7 +755,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                     # Ignore out-of-vocabulary items for fixed_vocab=True
                     continue
 
-            for (vocabIdx, wordCount) in j_idx_to_count_dict.iteritems():
+            for (vocabIdx, wordCount) in j_idx_to_count_dict.items():
                 values.append(wordCount)
                 j_indices.append(vocabIdx)
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -770,7 +770,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         j_indices = frombuffer_empty(j_indices, dtype=np.int64)
         indptr = np.frombuffer(indptr, dtype=np.int64)
-        values = np.frombuffer(values, dtype=np.int64)
+        values = frombuffer_empty(values, dtype=np.int64)
 
         X = sp.csr_matrix((values, j_indices, indptr),
                           shape=(len(indptr) - 1, len(vocabulary)),

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -738,14 +738,27 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         analyze = self.build_analyzer()
         j_indices = _make_int_array()
         indptr = _make_int_array()
+        values = _make_int_array()
         indptr.append(0)
+
         for doc in raw_documents:
+
+            j_idx_to_count_dict = {}
+
             for feature in analyze(doc):
                 try:
-                    j_indices.append(vocabulary[feature])
+                    vocab_idx = vocabulary[feature]
+                    word_occurences = j_idx_to_count_dict.get(vocab_idx, 0)
+                    j_idx_to_count_dict[vocab_idx] = word_occurences + 1
+
                 except KeyError:
                     # Ignore out-of-vocabulary items for fixed_vocab=True
                     continue
+
+            for (vocabIdx, wordCount) in j_idx_to_count_dict.iteritems():
+                values.append(wordCount)
+                j_indices.append(vocabIdx)
+
             indptr.append(len(j_indices))
 
         if not fixed_vocab:
@@ -757,12 +770,13 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         j_indices = frombuffer_empty(j_indices, dtype=np.intc)
         indptr = np.frombuffer(indptr, dtype=np.intc)
-        values = np.ones(len(j_indices))
+        values = np.frombuffer(values, dtype=np.intc)
 
         X = sp.csr_matrix((values, j_indices, indptr),
                           shape=(len(indptr) - 1, len(vocabulary)),
                           dtype=self.dtype)
-        X.sum_duplicates()
+        X.sort_indices()
+
         return vocabulary, X
 
     def fit(self, raw_documents, y=None):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -768,9 +768,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 raise ValueError("empty vocabulary; perhaps the documents only"
                                  " contain stop words")
 
-        j_indices = frombuffer_empty(j_indices, dtype=np.intc)
-        indptr = np.frombuffer(indptr, dtype=np.intc)
-        values = np.frombuffer(values, dtype=np.intc)
+        j_indices = frombuffer_empty(j_indices, dtype=np.int64)
+        indptr = np.frombuffer(indptr, dtype=np.int64)
+        values = np.frombuffer(values, dtype=np.int64)
 
         X = sp.csr_matrix((values, j_indices, indptr),
                           shape=(len(indptr) - 1, len(vocabulary)),
@@ -913,7 +913,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
 def _make_int_array():
     """Construct an array.array of a type suitable for scipy.sparse indices."""
-    return array.array(str("i"))
+    return array.array(str("l"))
 
 
 class TfidfTransformer(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
previously, line 760 in `text.py`

```
values = np.ones(len(j_indices))
```

would cause memory issues as `len(j_indices)` is equal to the entire corpus' word count. I had issues with a dataset of 200,000 documents with ~4000 words each when many gigabytes would be allocated temporarily. I've eliminated the need for this line and the `X.sum_duplicates` calculation without a perceptible performance hit.

Additionally, for matrices with greater than 2 billion nnz, `np.intc` and `array.array(str("i"))` were insufficient for storing values of `indptr` that had to index into more than the (2^31 - 1)th position in the values or `j_indices` arrays. I've changed `np.intc` -> `np.int64` and  `array.array(str("i"))` -> `array.array(str("l"))` to accommodate this possibility.
