### PR TITLE
DOC add official install guide in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,9 @@ To install for all users on Unix/Linux::
   python setup.py build
   sudo python setup.py install
 
+You can refer to details from the following link.
+http://scikit-learn.org/dev/install.html
+
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ To install for all users on Unix/Linux::
   python setup.py build
   sudo python setup.py install
 
-You can refer to details from the following link.
-http://scikit-learn.org/dev/install.html
+You can refer to details from the document.
+https://github.com/shopetan/scikit-learn/blob/master/doc/install.rst
 
 
 Development


### PR DESCRIPTION
I Installed `scikit-learn` using `README.rst` in Github.
But I can't Install this.
I have found that the official page explains a more detailed installation instructions.
So, I think it is good that official link is added to `README.rst`.
