### PR TITLE
DOC Fix doc for NMF `init` default

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -267,7 +267,7 @@ class ProjectedGradientNMF(BaseEstimator, TransformerMixin):
 
     init :  'nndsvd' |  'nndsvda' | 'nndsvdar' | 'random'
         Method used to initialize the procedure.
-        Default: 'nndsvdar' if n_components < n_features, otherwise random.
+        Default: 'nndsvd' if n_components < n_features, otherwise random.
         Valid options::
 
             'nndsvd': Nonnegative Double Singular Value Decomposition (NNDSVD)


### PR DESCRIPTION
Docs had claimed that the `init` argument defaulted to "nndsvdar" when `n_components < n_features`, but it actually defaults to "nndsvd".

Resolves issue #4929 .
