### PR TITLE
Better error message for ransac fit when number of inliers equals 0

### DIFF
--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -292,7 +292,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
                 continue
             if n_inliers_subset == 0:
                 raise ValueError("No inliers found, possible cause is "
-                    "setting residual_threshold ({}) too low.".format(
+                    "setting residual_threshold ({0}) too low.".format(
                     self.residual_threshold))
 
             # extract inlier data set

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -291,10 +291,9 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
             if n_inliers_subset < n_inliers_best:
                 continue
             if n_inliers_subset == 0:
-                raise ValueError("no inliers found, possible cause is "
+                raise ValueError("No inliers found, possible cause is "
                     "setting residual_threshold ({}) too low.".format(
-		    self.residual_threshold))
-                    
+                    self.residual_threshold))
 
             # extract inlier data set
             inlier_idxs_subset = sample_idxs[inlier_mask_subset]
@@ -304,8 +303,6 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
             # score of inlier data set
             score_subset = base_estimator.score(X_inlier_subset,
                                                 y_inlier_subset)
-
-
 
             # same number of inliers but worse score -> skip current random
             # sample

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -165,8 +165,6 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
                  stop_probability=0.99, residual_metric=None,
                  random_state=None):
 
-	if residual_threshold == 0.0:
-	    raise ValueError('residual threshold must be > 0.0')
         self.base_estimator = base_estimator
         self.min_samples = min_samples
         self.residual_threshold = residual_threshold
@@ -292,6 +290,11 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
             # less inliers -> skip current random sample
             if n_inliers_subset < n_inliers_best:
                 continue
+            if n_inliers_subset == 0:
+                raise ValueError("no inliers found, possible cause is "
+                    "setting residual_threshold ({}) too low.".format(
+		    self.residual_threshold))
+                    
 
             # extract inlier data set
             inlier_idxs_subset = sample_idxs[inlier_mask_subset]
@@ -301,6 +304,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
             # score of inlier data set
             score_subset = base_estimator.score(X_inlier_subset,
                                                 y_inlier_subset)
+
+
 
             # same number of inliers but worse score -> skip current random
             # sample

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -165,6 +165,8 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
                  stop_probability=0.99, residual_metric=None,
                  random_state=None):
 
+	if residual_threshold == 0.0:
+	    raise ValueError('residual threshold must be > 0.0')
         self.base_estimator = base_estimator
         self.min_samples = min_samples
         self.residual_threshold = residual_threshold

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -140,16 +140,16 @@ def test_ransac_predict():
 
 
 def test_ransac_resid_thresh_no_inliers():
-    """when residual_threshold=0.0 there are no inliers and a
-    ValueError with a message should be raised"""
+    # When residual_threshold=0.0 there are no inliers and a
+    # ValueError with a message should be raised
     base_estimator = LinearRegression()
     ransac_estimator = RANSACRegressor(base_estimator, min_samples=2,
                                        residual_threshold=0.0, random_state=0)
-    
-    assert_raises_regexp(ValueError, 
+
+    assert_raises_regexp(ValueError,
                     "no inliers.*residual_threshold.*0\.0",
                     ransac_estimator.fit, X, y)
-    
+
 
 def test_ransac_sparse_coo():
     X_sparse = sparse.coo_matrix(X)

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -147,7 +147,7 @@ def test_ransac_resid_thresh_no_inliers():
                                        residual_threshold=0.0, random_state=0)
 
     assert_raises_regexp(ValueError,
-                    "no inliers.*residual_threshold.*0\.0",
+                    "No inliers.*residual_threshold.*0\.0",
                     ransac_estimator.fit, X, y)
 
 

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal, assert_raises
 from numpy.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_raises_regexp
 from scipy import sparse
 
 from sklearn.utils.testing import assert_less
@@ -137,6 +138,18 @@ def test_ransac_predict():
 
     assert_equal(ransac_estimator.predict(X), np.zeros(100))
 
+
+def test_ransac_resid_thresh_no_inliers():
+    """when residual_threshold=0.0 there are no inliers and a
+    ValueError with a message should be raised"""
+    base_estimator = LinearRegression()
+    ransac_estimator = RANSACRegressor(base_estimator, min_samples=2,
+                                       residual_threshold=0.0, random_state=0)
+    
+    assert_raises_regexp(ValueError, 
+                    "no inliers.*residual_threshold.*0\.0",
+                    ransac_estimator.fit, X, y)
+    
 
 def test_ransac_sparse_coo():
     X_sparse = sparse.coo_matrix(X)


### PR DESCRIPTION
Fix for issue #4907 
