### PR TITLE
[MRG + 1] Added a note about variance reduction in DecisionTreeRegressor

### DIFF
--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -675,7 +675,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
     ----------
     criterion : string, optional (default="mse")
         The function to measure the quality of a split. The only supported
-        criterion is "mse" for the mean squared error.
+        criterion is "mse" for the mean squared error, which is equal to
+        variance reduction as feature selection criterion.
 
     splitter : string, optional (default="best")
         The strategy used to choose the split at each node. Supported


### PR DESCRIPTION
Hi,
I just added a short note to clarify that using mse as criterion is the same as the "variance reduction," which was introduced in CART.
