### PR TITLE
[MRG + 1] Don't allow unseen values for inverse transform

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -166,6 +166,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         """
         self._check_fitted()
 
+        diff = np.setdiff1d(y, np.arange(len(self.classes_)))
+        if diff:
+            raise ValueError("y contains new labels: %s" % str(diff))
         y = np.asarray(y)
         return self.classes_[y]
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -219,6 +219,11 @@ def test_label_encoder_errors():
     assert_raises(ValueError, le.transform, [])
     assert_raises(ValueError, le.inverse_transform, [])
 
+    # Fail on unseen labels
+    le = LabelEncoder()
+    le.fit([1, 2, 3, 1, -1])
+    assert_raises(ValueError, le.inverse_transform, [-1])
+
 
 def test_sparse_output_multilabel_binarizer():
     # test input as iterable of iterables


### PR DESCRIPTION
Currently negative labels are allowed for LabelEncoder inverse_transform, instead raise error similar to transform.
