### PR TITLE
[MRG+2] BUG Use epsilon threshold in `_samme_proba`

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -283,7 +283,7 @@ def _samme_proba(estimator, n_classes, X):
     # Displace zero probabilities so the log is defined.
     # Also fix negative elements which may occur with
     # negative sample weights.
-    proba[proba <= 0] = 1e-5
+    proba[proba < np.finfo(proba.dtype).eps] = np.finfo(proba.dtype).eps
     log_proba = np.log(proba)
 
     return (n_classes - 1) * (log_proba - (1. / n_classes)
@@ -512,7 +512,8 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
         # Displace zero probabilities so the log is defined.
         # Also fix negative elements which may occur with
         # negative sample weights.
-        y_predict_proba[y_predict_proba <= 0] = 1e-5
+        proba = y_predict_proba  # alias for readability
+        proba[proba < np.finfo(proba.dtype).eps] = np.finfo(proba.dtype).eps
 
         # Boost weight using multi-class AdaBoost SAMME.R alg
         estimator_weight = (-1. * self.learning_rate

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -710,7 +710,7 @@ def check_classifiers_one_label(name, Classifier):
 
 
 def check_classifiers_train(name, Classifier):
-    X_m, y_m = make_blobs(random_state=0)
+    X_m, y_m = make_blobs(n_samples=300, random_state=0)
     X_m, y_m = shuffle(X_m, y_m, random_state=7)
     X_m = StandardScaler().fit_transform(X_m)
     # generate binary problem from multi-class one


### PR DESCRIPTION
The `ensemble.weight_boosting._samme_proba` function should preserve ordering of class probabilities within an example, but thresholding logic (to avoid taking the log of values <= 0) was disrupting this. Instead of thresholding `proba < 0` probabilities to 1e-5, threshold `proba < epsilon` to epsilon. This avoids the issue of, e.g., probability values of 0 becoming larger than values of 1e-7.

Add a unit test for `_samme_proba` which checks that probability ordering is unchanged. This test fails on the un-modified version of `_samme_proba`. 

Resolves issue #4944 .
