### PR TITLE
Test case that reproduces behaviour in issue #4949

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -258,7 +258,7 @@ class BaseEstimator(object):
                                      'Check the list of available parameters '
                                      'with `estimator.get_params().keys()`.' %
                                      (name, self))
-                sub_object = valid_params[name]
+                sub_object = getattr(self, name)
                 sub_object.set_params(**{sub_name: value})
             else:
                 # simple objects case

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -161,6 +161,20 @@ def test_gridsearch():
     clf.fit(boston.data, boston.target)
 
 
+def test_gridsearch_base_estimators():
+    # Check searching base estimators and their parameters
+    from sklearn.ensemble import RandomForestClassifier, BaggingClassifier
+    
+    boost = AdaBoostClassifier(base_estimator=BaggingClassifier(), random_state=2)
+    parameters = {'n_estimators': (1, 2),
+                  'base_estimator__n_estimators': (3, 5),
+                  'base_estimator': [BaggingClassifier(),
+                                     RandomForestClassifier()]}
+    clf = GridSearchCV(boost, parameters)
+    clf.fit(iris.data, iris.target)
+    assert_equal(clf.best_estimator_.base_estimator.n_estimators, 3)
+
+
 def test_pickle():
     # Check pickability.
     import pickle


### PR DESCRIPTION
Grid searching different `base_estimators` for `AdaBoostClassifier` and setting their parameters fails. You end up with the default parameters in `best_estimator_`. This adds a test that reproduces the example I posted in #4949 as well as a potential fix. Unsure if this is the correct fix.

I think there are two (potential) problems here:
1. setting a property to a new object so that `valid_params` now doesn't contain a reference to the correct object
2. there is no guarantee about the order in which the parameters from the parameter grid get looped over, so we could end up setting `base_estimator__max_depth` first and then setting `base_estimator`
