### PR TITLE
[MRG] MAINT fix numpy / scipy install on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Install the build and runtime dependencies of the project.
-  - "%CMD_IN_ENV% pip install --timeout=60 -r continuous_integration/appveyor/requirements.txt"
+  - "%CMD_IN_ENV% pip install --timeout=60 --trusted-host 28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com -r continuous_integration/appveyor/requirements.txt"
   - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst -b doc/logos/scikit-learn-logo.bmp"
   - ps: "ls dist"
 


### PR DESCRIPTION
Make it possible to use plain HTTP to download pre-built numpy & scipy from rackspace container.

New versions of pip refuse to download packages over non-secure HTTP by default.
