### PR TITLE
Allow MinMaxScaler to scale specified columns

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -222,9 +222,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         Set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array).
 
-    continuous_features : list, optional, default None
-        Set to choose which columns should be normalized. If None,
-        defaults to each column.
+    selected : list, optional, default "all"
+        Set to choose which feature should be normalized. If "all"
+        defaults to each feature.
 
     Attributes
     ----------
@@ -233,13 +233,16 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     scale_ : ndarray, shape (n_features,)
         Per feature relative scaling of the data.
+
+
+
     """
 
-    def __init__(self, feature_range=(0, 1), copy=True,
-                 continuous_features=None):
+    def __init__(self, feature_range=(0, 1), copy=True, selected="all"):
         self.feature_range = feature_range
         self.copy = copy
-        self.continuous_features_ = continuous_features
+        self.selected = selected
+        self.scaled_features_ = None if selected == "all" else selected
         self.n_features_ = None
 
     def fit(self, X, y=None):
@@ -259,12 +262,12 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
                              " than maximum. Got %s." % str(feature_range))
 
         if len(X.shape) == 2:
-            if self.continuous_features_ is None:
+            if self.scaled_features_ is None:
                 # TODO: pandas dataframes as inputs
-                self.continuous_features_ = range(X.shape[1])
+                self.scaled_features_ = range(X.shape[1])
             self.n_features_ = X.shape[1]
 
-            selected = X[:, self.continuous_features_]
+            selected = X[:, self.scaled_features_]
 
         else:
             selected = X
@@ -295,8 +298,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             if X.shape[1] != self.n_features_:
                 raise ValueError("X has {0} features per sample; expecting {1}"\
                                  .format(X.shape[1], self.n_features_))
-            X[:, self.continuous_features_] *= self.scale_
-            X[:, self.continuous_features_] += self.min_
+            X[:, self.scaled_features_] *= self.scale_
+            X[:, self.scaled_features_] += self.min_
         else:
             X *= self.scale_
             X += self.min_
@@ -318,8 +321,8 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             if X.shape[1] != self.n_features_:
                 raise ValueError("X has {0} features per sample; expecting {1}"\
                                  .format(X.shape[1], self.n_features_))
-            X[:, self.continuous_features_] -= self.min_
-            X[:, self.continuous_features_] /= self.scale_
+            X[:, self.scaled_features_] -= self.min_
+            X[:, self.scaled_features_] /= self.scale_
         else:
             X -= self.min_
             X /= self.scale_

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -224,7 +224,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     selected : int list, optional, default "all"
         Indices of features which should be normalized. If "all",
-        defaults to each feature.
+        all features are scaled.
 
     Attributes
     ----------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -240,6 +240,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         self.feature_range = feature_range
         self.copy = copy
         self.continuous_features_ = continuous_features
+        self.num_features_ = None
 
     def fit(self, X, y=None):
         """Compute the minimum and maximum to be used for later scaling.
@@ -261,6 +262,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             if self.continuous_features_ is None:
                 # TODO: pandas dataframes as inputs
                 self.continuous_features_ = range(X.shape[1])
+            self.num_features_ = X.shape[1]
 
             selected = X[:, self.continuous_features_]
 
@@ -290,6 +292,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X = check_array(X, copy=self.copy, ensure_2d=False)
 
         if len(X.shape) == 2:
+            if X.shape[1] != self.num_features_:
+                raise ValueError("X has {0} features per sample; expecting {1}"\
+                                 .format(X.shape[1], self.num_features_))
             X[:, self.continuous_features_] *= self.scale_
             X[:, self.continuous_features_] += self.min_
         else:
@@ -310,6 +315,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X = check_array(X, copy=self.copy, ensure_2d=False)
 
         if len(X.shape) == 2:
+            if X.shape[1] != self.num_features_:
+                raise ValueError("X has {0} features per sample; expecting {1}"\
+                                 .format(X.shape[1], self.num_features_))
             X[:, self.continuous_features_] -= self.min_
             X[:, self.continuous_features_] /= self.scale_
         else:

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -240,7 +240,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         self.feature_range = feature_range
         self.copy = copy
         self.continuous_features_ = continuous_features
-        self.num_features_ = None
+        self.n_features_ = None
 
     def fit(self, X, y=None):
         """Compute the minimum and maximum to be used for later scaling.
@@ -262,7 +262,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             if self.continuous_features_ is None:
                 # TODO: pandas dataframes as inputs
                 self.continuous_features_ = range(X.shape[1])
-            self.num_features_ = X.shape[1]
+            self.n_features_ = X.shape[1]
 
             selected = X[:, self.continuous_features_]
 
@@ -292,9 +292,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X = check_array(X, copy=self.copy, ensure_2d=False)
 
         if len(X.shape) == 2:
-            if X.shape[1] != self.num_features_:
+            if X.shape[1] != self.n_features_:
                 raise ValueError("X has {0} features per sample; expecting {1}"\
-                                 .format(X.shape[1], self.num_features_))
+                                 .format(X.shape[1], self.n_features_))
             X[:, self.continuous_features_] *= self.scale_
             X[:, self.continuous_features_] += self.min_
         else:
@@ -315,9 +315,9 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
         X = check_array(X, copy=self.copy, ensure_2d=False)
 
         if len(X.shape) == 2:
-            if X.shape[1] != self.num_features_:
+            if X.shape[1] != self.n_features_:
                 raise ValueError("X has {0} features per sample; expecting {1}"\
-                                 .format(X.shape[1], self.num_features_))
+                                 .format(X.shape[1], self.n_features_))
             X[:, self.continuous_features_] -= self.min_
             X[:, self.continuous_features_] /= self.scale_
         else:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -226,6 +226,19 @@ def test_min_max_scaler_iris():
     scaler = MinMaxScaler(feature_range=(2, 1))
     assert_raises(ValueError, scaler.fit, X)
 
+def test_min_max_scaler_scale_selected_features():
+    # Check whether only specific features can be scaled
+    X = [[1., 3., 6.],
+         [2., 4., 7.],
+         [3., 5., 8.]]
+
+    X_expected = [[-1., 3., -1.],
+             [0., 4., 0.],
+             [1., 5., 1.]]
+
+    scaler = MinMaxScaler((-1, 1), selected=[0, 2])
+    X_trans = scaler.fit_transform(X)
+    assert_array_equal(X_trans, X_expected)
 
 def test_min_max_scaler_zero_variance_features():
     # Check min max scaler on toy data with zero variance features

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -226,6 +226,7 @@ def test_min_max_scaler_iris():
     scaler = MinMaxScaler(feature_range=(2, 1))
     assert_raises(ValueError, scaler.fit, X)
 
+
 def test_min_max_scaler_scale_selected_features():
     # Check whether only specific features can be scaled
     X = [[1., 3., 6.],
@@ -239,6 +240,15 @@ def test_min_max_scaler_scale_selected_features():
     scaler = MinMaxScaler((-1, 1), selected=[0, 2])
     X_trans = scaler.fit_transform(X)
     assert_array_equal(X_trans, X_expected)
+
+    X_expected = [[-1., -1., -1.],
+             [0., 0., 0.],
+             [1., 1., 1.]]
+
+    scaler = MinMaxScaler((-1, 1), selected=[0, 1, 2])
+    X_trans = scaler.fit_transform(X)
+    assert_array_equal(X_trans, X_expected)
+
 
 def test_min_max_scaler_zero_variance_features():
     # Check min max scaler on toy data with zero variance features


### PR DESCRIPTION
Addresses #5000. This should allow users to specify which columns to scale. This allows categorical data to exist in the dataset.
