### PR TITLE
[MRG+1] fix logistic regression class weights

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -113,12 +113,6 @@ def test_class_weight_balanced_linear_classifiers():
                and issubclass(clazz, LinearClassifierMixin)]
 
     for name, Classifier in linear_classifiers:
-        if name == "LogisticRegressionCV":
-            # Contrary to RidgeClassifierCV, LogisticRegressionCV use actual
-            # CV folds and fit a model for each CV iteration before averaging
-            # the coef. Therefore it is expected to not behave exactly as the
-            # other linear model.
-            continue
         yield check_class_weight_balanced_linear_classifier, name, Classifier
 
 


### PR DESCRIPTION
-This PR tests that these two classifiers are equivalent:

``` python
class_weights = compute_class_weight("balanced", np.unique(y), y)
clf1 = LogisticRegression(multi_class="multinomial", class_weight="balanced")
clf2 = LogisticRegression(multi_class="multinomial", class_weight=class_weights)
```

-[EDIT]This PR also tests that these two classifiers are equivalent: (fix #5450)

``` python
class_weights = compute_class_weight("balanced", np.unique(y), y)
clf1 = LogisticRegressionCV(class_weight="balanced")
clf2 = LogisticRegressionCV(class_weight=class_weights)
```

That is why we can remove [this line](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tests/test_common.py#L116)

I also : 
- updated some remaining `"auto"` (deprecated) into `"balanced"`.
- added the test from #5420, which tests the bug detailed in #5415.
- changed the variable names to distinguish `y_bin` and `Y_bin`
