### PR TITLE
[MRG+1] Reorder target_names in rcv1

### DIFF
--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -178,12 +178,17 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
         # Samples in X are ordered with sample_id,
         # whereas in y, they are ordered with sample_id_bis.
         permutation = _find_permutation(sample_id_bis, sample_id)
-        y = sp.csr_matrix(y[permutation, :])
+        y = y[permutation, :]
 
         # save category names in a list, with same order than y
         categories = np.empty(N_CATEGORIES, dtype=object)
         for k in category_names.keys():
             categories[category_names[k]] = k
+
+        # reorder categories in lexicographic order
+        order = np.argsort(categories)
+        categories = categories[order]
+        y = sp.csr_matrix(y[:, order])
 
         joblib.dump(y, sample_topics_path, compress=9)
         joblib.dump(categories, topics_path, compress=9)

--- a/sklearn/datasets/tests/test_rcv1.py
+++ b/sklearn/datasets/tests/test_rcv1.py
@@ -36,6 +36,10 @@ def test_fetch_rcv1():
     assert_equal((804414,), s1.shape)
     assert_equal(103, len(cat_list))
 
+    # test ordering of categories
+    first_categories = [u'C11', u'C12', u'C13', u'C14', u'C15', u'C151']
+    assert_array_equal(first_categories, cat_list[:6])
+
     # test number of sample for some categories
     some_categories = ('GMIL', 'E143', 'CCAT')
     number_non_zero_in_cat = (5, 1206, 381327)


### PR DESCRIPTION
I re-ordered the categories to be in lexicographic order.
Now, the ordering is equivalent to the one obtained loading "rcv1v2 (topics; full sets)" [from LIBSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel.html).
