### PR TITLE
[MRG+1] Fix README.rst coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/scikit-learn/scikit-learn?branch=master&svg=true
 .. _AppVeyor: https://ci.appveyor.com/project/sklearn-ci/scikit-learn/history
 
-.. |Coveralls| image:: https://img.shields.io/coveralls/scikit-learn/scikit-learn.svg
+.. |Coveralls| image:: https://coveralls.io/repos/scikit-learn/scikit-learn/badge.svg?branch=master
 .. _Coveralls: https://coveralls.io/r/scikit-learn/scikit-learn
 
 scikit-learn


### PR DESCRIPTION
It looks like the shields.io link to the image doesn't work right now. I switched it to the badge provided by coveralls. 

I have to admit I don't really know whether shields.io badges are supposed to have any advantages, ping @amueller who added the coveralls badge in 0d3fa51.
