### PR TITLE
Filled in missing negation

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -160,7 +160,7 @@ and ``value`` is an estimator object::
         transformer_weights=None)
 
 Like pipelines, feature unions have a shorthand constructor called
-:func:`make_union` that does require manual naming of the components.
+:func:`make_union` that does not require explicit naming of the components.
 
                                                                        
 .. topic:: Examples:


### PR DESCRIPTION
Since `make_union` is a convenience factory method that returns a `FeatureUnion` class with names automatically filled in and obviously does _not_ require manual naming of the components.
