### PR TITLE
[MRG+1] FIX: ensure that get_params returns VotingClassifier own params

### DIFF
--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -173,12 +173,8 @@ def test_gridsearch():
                 voting='soft')
 
     params = {'lr__C': [1.0, 100.0],
-              'rf__n_estimators': [20, 200]}
+              'voting': ['soft', 'hard'],
+              'weights': [[0.5, 0.5, 0.5], [1.0, 0.5, 0.5]]}
 
     grid = GridSearchCV(estimator=eclf, param_grid=params, cv=5)
     grid.fit(iris.data, iris.target)
-
-    expect = [0.953, 0.960, 0.960, 0.953]
-    scores = [mean_score for params, mean_score, scores in grid.grid_scores_]
-    for e, s in zip(expect, scores):
-        assert_almost_equal(e, s, decimal=3)

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -212,7 +212,8 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         if not deep:
             return super(VotingClassifier, self).get_params(deep=False)
         else:
-            out = self.named_estimators.copy()
+            out = super(VotingClassifier, self).get_params(deep=False)
+            out.update(self.named_estimators.copy())
             for name, step in six.iteritems(self.named_estimators):
                 for key, value in six.iteritems(step.get_params(deep=True)):
                     out['%s__%s' % (name, key)] = value


### PR DESCRIPTION
This is a fix to ensure that `VotingClassifier.get_params` returns `VotingClassifier` own params, and not only the params from the sub-estimators. 

CC: @rasbt 
