### PR TITLE
[MRG + 1] add Cohen's kappa score to metrics

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -353,6 +353,23 @@ In the multilabel case with binary label indicators: ::
     for an example of accuracy score usage using permutations of
     the dataset.
 
+.. _cohen_kappa:
+
+Cohen's kappa
+-------------
+
+The function :func:`cohen_kappa_score` computes Cohen's kappa statistic.
+This measure is intended to compare labelings by different human annotators,
+not a classifier versus a ground truth.
+
+The kappa score (see docstring) is a number between -1 and 1.
+Scores above .8 are generally considered good agreement;
+zero or lower means no agreement (practically random labels).
+
+Kappa scores can be computed for binary or multiclass problems,
+but not for multilabel problems (except by manually computing a per-label score)
+and not for more than two annotators.
+
 .. _confusion_matrix:
 
 Confusion matrix

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -15,6 +15,7 @@ from .ranking import roc_curve
 
 from .classification import accuracy_score
 from .classification import classification_report
+from .classification import cohen_kappa_score
 from .classification import confusion_matrix
 from .classification import f1_score
 from .classification import fbeta_score

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -266,6 +266,57 @@ def confusion_matrix(y_true, y_pred, labels=None):
     return CM
 
 
+def cohen_kappa_score(y1, y2, labels=None):
+    """Cohen's kappa: a statistic that measures inter-annotator agreement.
+
+    This function computes Cohen's kappa [1], a score that expresses the level
+    of agreement between two annotators on a classification problem. It is
+    defined as
+
+    .. math::
+        \kappa = (p_o - p_e) / (1 - p_e)
+
+    where :math:`p_o` is the empirical probability of agreement on the label
+    assigned to any sample (the observed agreement ratio), and :math:`p_e` is
+    the expected agreement when both annotators assign labels randomly.
+    :math:`p_e` is estimated using a per-annotator empirical prior over the
+    class labels [2].
+
+    Parameters
+    ----------
+    y1 : array, shape = [n_samples]
+        Labels assigned by the first annotator.
+
+    y2 : array, shape = [n_samples]
+        Labels assigned by the second annotator. The kappa statistic is
+        symmetric, so swapping ``y1`` and ``y2`` doesn't change the value.
+
+    labels : array, shape = [n_classes], optional
+        List of labels to index the matrix. This may be used to select a
+        subset of labels. If None, all labels that appear at least once in
+        ``y1`` or ``y2`` are used.
+
+    Returns
+    -------
+    kappa : float
+        The kappa statistic, which is a number between -1 and 1. The maximum
+        value means complete agreement; zero or lower means chance agreement.
+
+    References
+    ----------
+    .. [1] J. Cohen (1960). "A coefficient of agreement for nominal scales".
+           Educational and Psychological Measurement 20(1):37-46.
+           doi:10.1177/001316446002000104.
+    .. [2] R. Artstein and M. Poesio (2008). "Inter-coder agreement for
+           computational linguistics". Computational Linguistic 34(4):555-596.
+    """
+    confusion = confusion_matrix(y1, y2, labels=labels)
+    P = confusion / float(confusion.sum())
+    p_observed = np.trace(P)
+    p_expected = np.dot(P.sum(axis=0), P.sum(axis=1))
+    return (p_observed - p_expected) / (1 - p_expected)
+
+
 def jaccard_similarity_score(y_true, y_pred, normalize=True,
                              sample_weight=None):
     """Jaccard similarity coefficient score

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -30,6 +30,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import classification_report
+from sklearn.metrics import cohen_kappa_score
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import f1_score
 from sklearn.metrics import fbeta_score
@@ -314,6 +315,28 @@ def test_confusion_matrix_binary():
     test(y_true, y_pred)
     test([str(y) for y in y_true],
          [str(y) for y in y_pred])
+
+
+def test_cohen_kappa():
+    # These label vectors reproduce the contingency matrix from Artstein and
+    # Poesio (2008), Table 1: np.array([[20, 20], [10, 50]]).
+    y1 = np.array([0] * 40 + [1] * 60)
+    y2 = np.array([0] * 20 + [1] * 20 + [0] * 10 + [1] * 50)
+    kappa = cohen_kappa_score(y1, y2)
+    assert_almost_equal(kappa, .348, decimal=3)
+    assert_equal(kappa, cohen_kappa_score(y2, y1))
+
+    # Add spurious labels and ignore them.
+    y1 = np.append(y1, [2] * 4)
+    y2 = np.append(y2, [2] * 4)
+    assert_equal(cohen_kappa_score(y1, y2, labels=[0, 1]), kappa)
+
+    assert_almost_equal(cohen_kappa_score(y1, y1), 1.)
+
+    # Multiclass example: Artstein and Poesio, Table 4.
+    y1 = np.array([0] * 46 + [1] * 44 + [2] * 10)
+    y2 = np.array([0] * 52 + [1] * 32 + [2] * 16)
+    assert_almost_equal(cohen_kappa_score(y1, y2), .8013, decimal=4)
 
 
 @ignore_warnings


### PR DESCRIPTION
This was recently requested on the ML, and I happened to need an implementation myself.

I wasn't sure what the API should be:

``` py
cohen_kappa(y1, y2)
```

or

``` py
cohen_kappa(confusion_matrix(y1, y2))
```

but I chose the former to save users a call and an import. The code is simple enough to copy-paste if it needs to be applied to a confusion matrix.

Needs tests.
