### PR TITLE
Fixes Buffer has wrong number of dimensions

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -137,6 +137,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         X = check_array(X, accept_sparse='csr', dtype=np.float64, order='C')
         y = self._validate_targets(y)
+        y = np.asarray(y).ravel()
 
         sample_weight = np.asarray([]
                                    if sample_weight is None


### PR DESCRIPTION
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-1a154f38b9fb> in <module>()
----> 1 clf.fit(X, y)

/usr/local/lib/python2.7/dist-packages/sklearn/svm/base.pyc in fit(self, X, y, sample_weight)
    176 
    177         seed = rnd.randint(np.iinfo('i').max)
--> 178         fit(X, y, sample_weight, solver_type, kernel, random_seed=seed)
    179         # see comment on the other call to np.iinfo in this file
    180 

/usr/local/lib/python2.7/dist-packages/sklearn/svm/base.pyc in _dense_fit(self, X, y, sample_weight, solver_type, kernel, random_seed)
    234                 cache_size=self.cache_size, coef0=self.coef0,
    235                 gamma=self._gamma, epsilon=self.epsilon,
--> 236                 max_iter=self.max_iter, random_seed=random_seed)
    237 
    238         self._warn_from_fit_status()

sklearn/svm/libsvm.pyx in sklearn.svm.libsvm.fit (sklearn/svm/libsvm.c:1756)()

ValueError: Buffer has wrong number of dimensions (expected 1, got 2)
```
