### PR TITLE
[MRG + 2] FIX make sure we handle y.shape = (n_samples, 1) consistently in regressors.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -123,6 +123,9 @@ Bug fixes
     - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing 
       oob_score and X is a sparse.csc_matrix. By `Ankur Ankan`_.
 
+    - All regressors now consistently handle and warn when given ``y`` that is of
+      shape ``(n_samples, 1)``. By `Andreas Müller`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -17,7 +17,7 @@ from ..base import RegressorMixin
 from .base import center_data, sparse_center_data
 from ..utils import check_array, check_X_y, deprecated
 from ..utils.validation import check_random_state
-from ..cross_validation import check_cv
+from ..cross_validation import check_cv, column_or_1d
 from ..externals.joblib import Parallel, delayed
 from ..externals import six
 from ..externals.six.moves import xrange
@@ -1020,9 +1020,10 @@ class LinearModelCV(six.with_metaclass(ABCMeta, LinearModel)):
                 model = ElasticNet()
             else:
                 model = Lasso()
-            if y.ndim > 1:
+            if y.ndim > 1 and y.shape[1] > 1:
                 raise ValueError("For multi-task outputs, use "
                                  "MultiTask%sCV" % (model_str))
+            y = column_or_1d(y, warn=True)
         else:
             if sparse.isspmatrix(X):
                 raise TypeError("X should be dense but a sparse matrix was"

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1295,7 +1295,7 @@ class LassoLarsIC(LassoLars):
             returns an instance of self.
         """
         self.fit_path = True
-        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        X, y = check_X_y(X, y, y_numeric=True)
 
         X, y, Xmean, ymean, Xstd = LinearModel._center_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X)

--- a/sklearn/linear_model/theil_sen.py
+++ b/sklearn/linear_model/theil_sen.py
@@ -19,8 +19,8 @@ from scipy.linalg.lapack import get_lapack_funcs
 
 from .base import LinearModel
 from ..base import RegressorMixin
-from ..utils import check_array, check_random_state, ConvergenceWarning
-from ..utils import check_consistent_length, _get_n_jobs
+from ..utils import check_random_state, ConvergenceWarning
+from ..utils import check_X_y, _get_n_jobs
 from ..utils.random import choice
 from ..externals.joblib import Parallel, delayed
 from ..externals.six.moves import xrange as range
@@ -343,9 +343,7 @@ class TheilSenRegressor(LinearModel, RegressorMixin):
         self : returns an instance of self.
         """
         random_state = check_random_state(self.random_state)
-        X = check_array(X)
-        y = check_array(y, ensure_2d=False)
-        check_consistent_length(X, y)
+        X, y = check_X_y(X, y, y_numeric=True)
         n_samples, n_features = X.shape
         n_subsamples, self.n_subpopulation_ = self._check_subparams(n_samples,
                                                                     n_features)

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -80,8 +80,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                    "gamma='%s' as of 0.17. Backward compatibility"
                    " for gamma=%s will be removed in %s")
             invalid_gamma = 0.0
-            warnings.warn(msg % (invalid_gamma, "auto",
-                invalid_gamma, "0.18"), DeprecationWarning)
+            warnings.warn(msg % (invalid_gamma, "auto", invalid_gamma, "0.18"),
+                          DeprecationWarning)
 
         self._impl = impl
         self.kernel = kernel
@@ -171,8 +171,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                              % (sample_weight.shape, X.shape))
 
         # FIXME remove (self.gamma == 0) in 0.18
-        if (self.kernel in ['poly', 'rbf']) and ((self.gamma == 0)
-                or (self.gamma == 'auto')):
+        if (self.kernel in ['poly', 'rbf']) and ((self.gamma == 0) or
+                                                 (self.gamma == 'auto')):
             # if custom gamma is not provided ...
             self._gamma = 1.0 / X.shape[1]
         elif self.gamma == 'auto':
@@ -212,7 +212,7 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
         # XXX this is ugly.
         # Regression models should not have a class_weight_ attribute.
         self.class_weight_ = np.empty(0)
-        return np.asarray(y, dtype=np.float64, order='C')
+        return column_or_1d(y, warn=True).astype(np.float64)
 
     def _warn_from_fit_status(self):
         assert self.fit_status_ in (0, 1)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -48,6 +48,14 @@ from sklearn.datasets import load_iris, load_boston, make_blobs
 
 BOSTON = None
 CROSS_DECOMPOSITION = ['PLSCanonical', 'PLSRegression', 'CCA', 'PLSSVD']
+MULTI_OUTPUT = ['CCA', 'DecisionTreeRegressor', 'ElasticNet',
+                'ExtraTreeRegressor', 'ExtraTreesRegressor', 'GaussianProcess',
+                'KNeighborsRegressor', 'KernelRidge', 'Lars', 'Lasso',
+                'LassoLars', 'LinearRegression', 'MultiTaskElasticNet',
+                'MultiTaskElasticNetCV', 'MultiTaskLasso', 'MultiTaskLassoCV',
+                'OrthogonalMatchingPursuit', 'PLSCanonical', 'PLSRegression',
+                'RANSACRegressor', 'RadiusNeighborsRegressor',
+                'RandomForestRegressor', 'Ridge', 'RidgeCV']
 
 
 def _yield_non_meta_checks(name, Estimator):
@@ -100,8 +108,7 @@ def _yield_classifier_checks(name, Classifier):
             # We don't raise a warning in these classifiers, as
             # the column y interface is used by the forests.
 
-        # test if classifiers can cope with y.shape = (n_samples, 1)
-        yield check_classifiers_input_shapes
+        yield check_supervised_y_2d
     # test if NotFittedError is raised
     yield check_estimators_unfitted
     if 'class_weight' in Classifier().get_params().keys():
@@ -116,6 +123,7 @@ def _yield_regressor_checks(name, Regressor):
     yield check_regressor_data_not_an_array
     yield check_estimators_partial_fit_n_features
     yield check_regressors_no_decision_function
+    yield check_supervised_y_2d
     if name != 'CCA':
         # check that the regressor handles int input
         yield check_regressors_int
@@ -831,31 +839,36 @@ def check_estimators_unfitted(name, Estimator):
                              est.predict_log_proba, X)
 
 
-def check_classifiers_input_shapes(name, Classifier):
-    iris = load_iris()
-    X, y = iris.data, iris.target
-    X, y = shuffle(X, y, random_state=1)
-    X = StandardScaler().fit_transform(X)
+def check_supervised_y_2d(name, Estimator):
+    if "MultiTask" in name:
+        # These only work on 2d, this test makes not sense
+        return
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 3))
+    y = np.arange(10) % 3
     # catch deprecation warnings
     with warnings.catch_warnings(record=True):
-        classifier = Classifier()
-    set_fast_parameters(classifier)
-    set_random_state(classifier)
+        estimator = Estimator()
+    set_fast_parameters(estimator)
+    set_random_state(estimator)
     # fit
-    classifier.fit(X, y)
-    y_pred = classifier.predict(X)
+    estimator.fit(X, y)
+    y_pred = estimator.predict(X)
 
-    set_random_state(classifier)
+    set_random_state(estimator)
     # Check that when a 2D y is given, a DataConversionWarning is
     # raised
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", DataConversionWarning)
         warnings.simplefilter("ignore", RuntimeWarning)
-        classifier.fit(X, y[:, np.newaxis])
+        estimator.fit(X, y[:, np.newaxis])
+    y_pred_2d = estimator.predict(X)
     msg = "expected 1 DataConversionWarning, got: %s" % (
         ", ".join([str(w_x) for w_x in w]))
-    assert_equal(len(w), 1, msg)
-    assert_array_equal(y_pred, classifier.predict(X))
+    if name not in MULTI_OUTPUT:
+        # warned if we don't support multi-output
+        assert_equal(len(w), 1, msg)
+    assert_array_equal(y_pred.ravel(), y_pred_2d.ravel())
 
 
 def check_classifiers_classes(name, Classifier):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -841,7 +841,7 @@ def check_estimators_unfitted(name, Estimator):
 
 def check_supervised_y_2d(name, Estimator):
     if "MultiTask" in name:
-        # These only work on 2d, this test makes not sense
+        # These only work on 2d, so this test makes no sense
         return
     rnd = np.random.RandomState(0)
     X = rnd.uniform(size=(10, 3))
@@ -866,9 +866,9 @@ def check_supervised_y_2d(name, Estimator):
     msg = "expected 1 DataConversionWarning, got: %s" % (
         ", ".join([str(w_x) for w_x in w]))
     if name not in MULTI_OUTPUT:
-        # warned if we don't support multi-output
+        # check that we warned if we don't support multi-output
         assert_equal(len(w), 1, msg)
-    assert_array_equal(y_pred.ravel(), y_pred_2d.ravel())
+    assert_array_almost_equal(y_pred.ravel(), y_pred_2d.ravel())
 
 
 def check_classifiers_classes(name, Classifier):


### PR DESCRIPTION
Fixes #5056.

This is the same behavior as in classifiers: if we don't support multi-output / multi-task, we flatten and warn.
