### PR TITLE
[MRG] Remove special-case in Pipeline.inverse_transform for 1D arrays.

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -303,8 +303,6 @@ class Pipeline(BaseEstimator):
             Data to inverse transform. Must fulfill output requirements of the
             last step of the pipeline.
         """
-        if X.ndim == 1:
-            X = X[None, :]
         Xt = X
         for name, step in self.steps[::-1]:
             Xt = step.inverse_transform(Xt)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -62,6 +62,9 @@ class TransfT(T):
     def transform(self, X, y=None):
         return X
 
+    def inverse_transform(self, X, y=None):
+        return X
+
 
 class FitParamT(object):
     """Mock classifier
@@ -325,6 +328,25 @@ def test_pipeline_transform():
     X_back = pipeline.inverse_transform(X_trans)
     X_back2 = pca.inverse_transform(X_trans)
     assert_array_almost_equal(X_back, X_back2)
+
+
+def test_pipeline_arbitrary_transform():
+    # Test that a pipeline can transform arbitrary data (not only
+    # arrays) and that the pipeline produces the same result as the
+    # plain transformer.
+
+    xfrm = TransfT()
+    pipeline = Pipeline([('xfrm', xfrm)])
+
+    for y in [None, 'test', 1, {'a': 'b'}]:
+        yt1 = xfrm.transform(y)
+        yt2 = pipeline.transform(y)
+        assert_equal(yt1, yt2)
+
+        y1 = xfrm.inverse_transform(yt1)
+        y2 = pipeline.inverse_transform(yt2)
+        assert_equal(y, y1)
+        assert_equal(y, y2)
 
 
 def test_pipeline_fit_transform():


### PR DESCRIPTION
This special-case resulted in pipelines that do not produce the same
results as calling their component transforms manually, and
prevented pipelines from containing transforms that processed
non-array inputs or outputs. (closes #5029)
