### PR TITLE
Fix for the SGDClassifier and SGDRegressor docstrings

### DIFF
--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -1121,7 +1121,7 @@ class SGDRegressor(BaseSGDRegressor, _LearntSelectorMixin):
 
     Parameters
     ----------
-    loss : str, 'squared_loss', 'huber', 'epsilon_insensitive', \
+    loss : str, 'squared_loss', 'huber', 'epsilon_insensitive',
                 or 'squared_epsilon_insensitive'
         The loss function to be used. Defaults to 'squared_loss' which refers
         to the ordinary least squares fit. 'huber' modifies 'squared_loss' to

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -586,8 +586,8 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     Parameters
     ----------
-    loss : str, 'hinge', 'log', 'modified_huber', 'squared_hinge',\
-                'perceptron', or a regression loss: 'squared_loss', 'huber',\
+    loss : str, 'hinge', 'log', 'modified_huber', 'squared_hinge',
+                'perceptron', or a regression loss: 'squared_loss', 'huber',
                 'epsilon_insensitive', or 'squared_epsilon_insensitive'
         The loss function to be used. Defaults to 'hinge', which gives a
         linear SVM.
@@ -683,7 +683,7 @@ class SGDClassifier(BaseSGDClassifier, _LearntSelectorMixin):
 
     Attributes
     ----------
-    coef_ : array, shape (1, n_features) if n_classes == 2 else (n_classes,\
+    coef_ : array, shape (1, n_features) if n_classes == 2 else (n_classes,
             n_features)
         Weights assigned to the features.
 


### PR DESCRIPTION
For issue #5078. 

Here are the new docstrings for SGDClassifier:

<img width="636" alt="screenshot 2015-08-02 16 43 53" src="https://cloud.githubusercontent.com/assets/1865885/9029054/ff63d73c-3940-11e5-8de8-51fa98c94184.png">
<img width="638" alt="screenshot 2015-08-02 16 44 35" src="https://cloud.githubusercontent.com/assets/1865885/9029055/010e55a8-3941-11e5-99c0-6e2891a61549.png">

The new docstrings for SGDRegressor:

<img width="630" alt="screenshot 2015-08-02 16 45 02" src="https://cloud.githubusercontent.com/assets/1865885/9029058/0fad74f4-3941-11e5-9fba-94a1fdd820b8.png">
