### PR TITLE
[MRG + 1] Edit the docs to clarify inputs for Haversine Distance Metric

### DIFF
--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -138,10 +138,8 @@ cdef class DistanceMetric:
     ==============  ====================  ========  ===============================
 
     **Metrics intended for two-dimensional vector spaces:**  Note that the haversine
-    distance metric requires data in the form of [x (i.e.: latitude, in radians), 
-    y (i.e.: longitude, in radians)], and you must `convert from degrees
-    https://en.wikipedia.org/wiki/Radian#Conversions`_ first. The distances returned 
-    are also in radians.
+    distance metric requires data in the form of [latitude, longitude] and both
+    inputs and outputs are in units of radians.
 
     ============  ==================  ========================================
     identifier    class name          distance function

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -138,9 +138,9 @@ cdef class DistanceMetric:
     ==============  ====================  ========  ===============================
 
     **Metrics intended for two-dimensional vector spaces:**  Note that the haversine
-    distance metric requires data in the form of [latitude (radians), 
-    longitude (radians)].  Multiply degrees by ``pi / 180``.  The distances returned
-    are also in radians.
+    distance metric requires data in the form of [x (i.e.: latitude, in radians), 
+    y (i.e.: longitude, in radians)].  Multiply degrees by ``pi / 180``.  The 
+    distances returned are also in radians.
 
     ============  ==================  ========================================
     identifier    class name          distance function

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -139,8 +139,9 @@ cdef class DistanceMetric:
 
     **Metrics intended for two-dimensional vector spaces:**  Note that the haversine
     distance metric requires data in the form of [x (i.e.: latitude, in radians), 
-    y (i.e.: longitude, in radians)].  Multiply degrees by ``pi / 180``.  The 
-    distances returned are also in radians.
+    y (i.e.: longitude, in radians)], and you must `convert from degrees
+    https://en.wikipedia.org/wiki/Radian#Conversions`_ first. The distances returned 
+    are also in radians.
 
     ============  ==================  ========================================
     identifier    class name          distance function

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -137,7 +137,10 @@ cdef class DistanceMetric:
     "mahalanobis"   MahalanobisDistance   V or VI   ``sqrt((x - y)' V^-1 (x - y))``
     ==============  ====================  ========  ===============================
 
-    **Metrics intended for two-dimensional vector spaces:**
+    **Metrics intended for two-dimensional vector spaces:**  Note that the haversine
+    distance metric requires data in the form of [latitude (radians), 
+    longitude (radians)].  Multiply degrees by ``pi / 180``.  The distances returned
+    are also in radians.
 
     ============  ==================  ========================================
     identifier    class name          distance function


### PR DESCRIPTION
The haversine distance metric requires units of radians, and this simple PR edits the DistanceMetric documentation to make this more clear.

cc @jakevdp because he wrote it (thanks dude!)
