### PR TITLE
precision_recall_curve threshold fix

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -658,7 +658,7 @@ Here are some small examples in binary classification::
   >>> recall
   array([ 1. ,  0.5,  0.5,  0. ])
   >>> threshold
-  array([ 0.35,  0.4 ,  0.8 ])
+  array([ 0.1 ,  0.35,  0.4 ,  0.8 ])
   >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
   0.79...
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -396,7 +396,7 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     >>> recall
     array([ 1. ,  0.5,  0.5,  0. ])
     >>> thresholds
-    array([ 0.35,  0.4 ,  0.8 ])
+    array([ 0.1 ,  0.35,  0.4 ,  0.8 ])
 
     """
     fps, tps, thresholds = _binary_clf_curve(y_true, probas_pred,
@@ -410,7 +410,8 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     # and reverse the outputs so recall is decreasing
     last_ind = tps.searchsorted(tps[-1])
     sl = slice(last_ind, None, -1)
-    return np.r_[precision[sl], 1], np.r_[recall[sl], 0], thresholds[sl]
+    thresholds = thresholds[last_ind + 1::-1]
+    return np.r_[precision[sl], 1], np.r_[recall[sl], 0], thresholds
 
 
 def roc_curve(y_true, y_score, pos_label=None, sample_weight=None):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -467,7 +467,7 @@ def test_precision_recall_curve_pos_label():
     assert_array_almost_equal(r, r2)
     assert_array_almost_equal(thresholds, thresholds2)
     assert_equal(p.size, r.size)
-    assert_equal(p.size, thresholds.size + 1)
+    assert_equal(p.size, thresholds.size)
 
 
 def _test_precision_recall_curve(y_true, probas_pred):
@@ -480,7 +480,7 @@ def _test_precision_recall_curve(y_true, probas_pred):
     assert_almost_equal(_average_precision(y_true, probas_pred),
                         precision_recall_auc, 1)
     assert_equal(p.size, r.size)
-    assert_equal(p.size, thresholds.size + 1)
+    assert_equal(p.size, thresholds.size)
     # Smoke test in the case of proba having only one value
     p, r, thresholds = precision_recall_curve(y_true,
                                               np.zeros_like(probas_pred))


### PR DESCRIPTION
(potential) Fix for #4996

Included smallest threshold value when full recall is attained in `sklearn.metrics.precision_recall_curve`.  Modified associated tests to agree.
