### PR TITLE
[MRG] Fix for a bug in shrinkage LDA covariance

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -133,6 +133,9 @@ Bug fixes
     - Fix in :class:`cluster.KMeans` cluster reassignment for sparse input by
       `Lars Buitinck`_.
 
+    - Fixed a bug in :class:`lda.LDA` that could cause asymmetric covariance 
+      matrices when using shrinkage. By `Martin Billinger`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -53,7 +53,8 @@ def _cov(X, shrinkage=None):
         if shrinkage == 'auto':
             sc = StandardScaler()  # standardize features
             X = sc.fit_transform(X)
-            s = sc.std_ * ledoit_wolf(X)[0] * sc.std_[np.newaxis].T  # rescale
+            s = ledoit_wolf(X)[0]
+            s = sc.std_[:, np.newaxis] * s * sc.std_[np.newaxis, :]  # rescale
         elif shrinkage == 'empirical':
             s = empirical_covariance(X)
         else:

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -53,7 +53,7 @@ def _cov(X, shrinkage=None):
         if shrinkage == 'auto':
             sc = StandardScaler()  # standardize features
             X = sc.fit_transform(X)
-            s = sc.std_ * ledoit_wolf(X)[0] * sc.std_  # scale back
+            s = sc.std_ * ledoit_wolf(X)[0] * sc.std_[np.newaxis].T  # rescale
         elif shrinkage == 'empirical':
             s = empirical_covariance(X)
         else:

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -149,3 +149,17 @@ def test_lda_scaling():
         # should be able to separate the data perfectly
         assert_equal(clf.fit(x, y).score(x, y), 1.0,
                      'using covariance: %s' % solver)
+
+
+def test_covariance():
+    x, y = make_blobs(n_samples=100, n_features=5,
+                      centers=1, random_state=42)
+
+    # make features correlated
+    x = np.dot(x, np.arange(x.shape[1] ** 2).reshape(x.shape[1], x.shape[1]))
+
+    c_e = lda._cov(x, 'empirical')
+    assert_almost_equal(c_e, c_e.T)
+
+    c_s = lda._cov(x, 'auto')
+    assert_almost_equal(c_s, c_s.T)


### PR DESCRIPTION
cc @cle1109 

I found a bug in our LDA code where the shrunk covariance matrix could become unsymmetric. This is caused by incorrectly broadcasting a vector to the columns of the matrix instead of the rows.

This PR contains a test case that reveals the bug and a fix.
