### PR TITLE
[MRG+2] Fix memory access error in OneClassSVM

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -7,6 +7,7 @@ from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin, \
     LinearModel
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..utils import check_X_y
+from ..utils.validation import _num_samples
 
 
 class LinearSVC(BaseEstimator, LinearClassifierMixin,
@@ -1011,7 +1012,7 @@ class OneClassSVM(BaseLibSVM):
         If X is not a C-ordered contiguous array it is copied.
 
         """
-        super(OneClassSVM, self).fit(X, [], sample_weight=sample_weight,
+        super(OneClassSVM, self).fit(X, np.ones(_num_samples(X)), sample_weight=sample_weight,
                                      **params)
         return self
 


### PR DESCRIPTION
Fixes #4942.
This is a lazy fix in that I don't touch the C code but allocate a useless array `y`. This seems just soo much easier.
Valgrind is happy after this.
