### PR TITLE
Rename n_iter variable to weight_update_counter.(Issue 5107)

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -306,6 +306,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
 
         self.random_state_ = check_random_state(self.random_state)
         self.weight_update_counter_ = 1
+        self.n_iter_ = 0
 
         if self.doc_topic_prior is None:
             self.doc_topic_prior_ = 1. / self.n_topics
@@ -525,7 +526,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                 if last_bound and abs(last_bound - bound) < self.perp_tol:
                     break
                 last_bound = bound
-
+            self.n_iter_ += 1
         return self
 
     def transform(self, X):

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -243,8 +243,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         Topic word distribution. ``components_[i, j]`` represents word j in
         topic `i`. In the literature, this is called lambda.
 
-    n_iter_ : int
-        Number of iterations.
+    weight_update_counter_ : int
+        Number of iterations of the EM step.
 
     References
     ----------
@@ -305,7 +305,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         """Initialize latent variables."""
 
         self.random_state_ = check_random_state(self.random_state)
-        self.n_iter_ = 1
+        self.weight_update_counter_ = 1
 
         if self.doc_topic_prior is None:
             self.doc_topic_prior_ = 1. / self.n_topics
@@ -416,7 +416,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         else:
             # online update
             # In the literature, the weight is `rho`
-            weight = np.power(self.learning_offset + self.n_iter_,
+            weight = np.power(self.learning_offset + self.weight_update_counter_,
                               -self.learning_decay)
             doc_ratio = float(total_samples) / X.shape[0]
             self.components_ *= (1 - weight)
@@ -426,7 +426,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         # update `component_` related variables
         self.dirichlet_component_ = _log_dirichlet_expectation(self.components_)
         self.exp_dirichlet_component_ = np.exp(self.dirichlet_component_)
-        self.n_iter_ += 1
+        self.weight_update_counter_ += 1
         return
 
     def _check_non_neg_array(self, X, whom):

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -243,8 +243,12 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         Topic word distribution. ``components_[i, j]`` represents word j in
         topic `i`. In the literature, this is called lambda.
 
-    weight_update_counter_ : int
+    n_batch_iter_ : int
         Number of iterations of the EM step.
+
+    n_iter_ : int
+        Number of passes over the dataset.
+    
 
     References
     ----------
@@ -305,7 +309,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         """Initialize latent variables."""
 
         self.random_state_ = check_random_state(self.random_state)
-        self.weight_update_counter_ = 1
+        self.n_batch_iter_ = 1
         self.n_iter_ = 0
 
         if self.doc_topic_prior is None:
@@ -417,7 +421,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         else:
             # online update
             # In the literature, the weight is `rho`
-            weight = np.power(self.learning_offset + self.weight_update_counter_,
+            weight = np.power(self.learning_offset + self.n_batch_iter_,
                               -self.learning_decay)
             doc_ratio = float(total_samples) / X.shape[0]
             self.components_ *= (1 - weight)
@@ -427,7 +431,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         # update `component_` related variables
         self.dirichlet_component_ = _log_dirichlet_expectation(self.components_)
         self.exp_dirichlet_component_ = np.exp(self.dirichlet_component_)
-        self.weight_update_counter_ += 1
+        self.n_batch_iter_ += 1
         return
 
     def _check_non_neg_array(self, X, whom):


### PR DESCRIPTION
This resolves #5107  . We need to rename n_iter_ variable as it is the number of iterations of the EM step. This will help avoid unnecessary confusion.
