### PR TITLE
[MRG] DOC/MAINT remove _ref tags

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -8,8 +8,6 @@ function raw specifications may not be enough to give full guidelines on their
 uses.
 
 
-.. _base_ref:
-
 :mod:`sklearn.base`: Base classes and utility functions
 =======================================================
 
@@ -41,8 +39,6 @@ Functions
 
    base.clone
 
-
-.. _cluster_ref:
 
 :mod:`sklearn.cluster`: Clustering
 ==================================
@@ -85,8 +81,6 @@ Functions
    cluster.mean_shift
    cluster.spectral_clustering
 
-.. _bicluster_ref:
-
 :mod:`sklearn.cluster.bicluster`: Biclustering
 ==============================================
 
@@ -106,8 +100,6 @@ Classes
 
    SpectralBiclustering
    SpectralCoclustering
-
-.. _covariance_ref:
 
 :mod:`sklearn.covariance`: Covariance Estimators
 ================================================
@@ -144,8 +136,6 @@ Classes
    covariance.graph_lasso
 
 
-.. _cross_validation_ref:
-
 :mod:`sklearn.cross_validation`: Cross Validation
 =================================================
 
@@ -180,8 +170,6 @@ Classes
    cross_validation.cross_val_predict
    cross_validation.permutation_test_score
    cross_validation.check_cv
-
-.. _datasets_ref:
 
 :mod:`sklearn.datasets`: Datasets
 =================================
@@ -257,8 +245,6 @@ Samples generator
    datasets.make_checkerboard
 
 
-.. _decomposition_ref:
-
 :mod:`sklearn.decomposition`: Matrix Decomposition
 ==================================================
 
@@ -299,8 +285,6 @@ Samples generator
    decomposition.dict_learning_online
    decomposition.sparse_encode
 
-.. _dummy_ref:
-
 :mod:`sklearn.dummy`: Dummy estimators
 ======================================
 
@@ -322,8 +306,6 @@ Samples generator
 .. autosummary::
    :toctree: generated/
    :template: function.rst
-
-.. _ensemble_ref:
 
 :mod:`sklearn.ensemble`: Ensemble Methods
 =========================================
@@ -375,8 +357,6 @@ partial dependence
    ensemble.partial_dependence.plot_partial_dependence
 
 
-.. _feature_extraction_ref:
-
 :mod:`sklearn.feature_extraction`: Feature Extraction
 =====================================================
 
@@ -417,8 +397,6 @@ From images
 
    feature_extraction.image.PatchExtractor
 
-.. _text_feature_extraction_ref:
-
 From text
 ---------
 
@@ -437,8 +415,6 @@ From text
    feature_extraction.text.TfidfTransformer
    feature_extraction.text.TfidfVectorizer
 
-
-.. _feature_selection_ref:
 
 :mod:`sklearn.feature_selection`: Feature Selection
 ===================================================
@@ -474,8 +450,6 @@ From text
    feature_selection.f_regression
 
 
-.. _gaussian_process_ref:
-
 :mod:`sklearn.gaussian_process`: Gaussian Processes
 ===================================================
 
@@ -508,8 +482,6 @@ From text
    gaussian_process.regression_models.quadratic
 
 
-.. _grid_search_ref:
-
 :mod:`sklearn.grid_search`: Grid Search
 =======================================
 
@@ -530,8 +502,6 @@ From text
    grid_search.ParameterSampler
    grid_search.RandomizedSearchCV
 
-
-.. _isotonic_ref:
 
 :mod:`sklearn.isotonic`: Isotonic regression
 ============================================
@@ -557,8 +527,6 @@ From text
    isotonic.isotonic_regression
    isotonic.check_increasing
 
-.. _kernel_approximation_ref:
-
 :mod:`sklearn.kernel_approximation` Kernel Approximation
 ========================================================
 
@@ -579,8 +547,6 @@ From text
    kernel_approximation.RBFSampler
    kernel_approximation.SkewedChi2Sampler
 
-.. _kernel_ridge_ref:
-
 :mod:`sklearn.kernel_ridge` Kernel Ridge Regression
 ========================================================
 
@@ -597,8 +563,6 @@ From text
    :template: class.rst
 
    kernel_ridge.KernelRidge
-
-.. _lda_ref:
 
 :mod:`sklearn.lda`: Linear Discriminant Analysis
 ================================================
@@ -618,8 +582,6 @@ From text
    lda.LDA
 
 
-.. _learning_curve_ref:
-
 :mod:`sklearn.learning_curve` Learning curve evaluation
 =======================================================
 
@@ -635,8 +597,6 @@ From text
 
    learning_curve.learning_curve
    learning_curve.validation_curve
-
-.. _linear_model_ref:
 
 :mod:`sklearn.linear_model`: Generalized Linear Models
 ======================================================
@@ -698,8 +658,6 @@ From text
    linear_model.orthogonal_mp_gram
 
 
-.. _manifold_ref:
-
 :mod:`sklearn.manifold`: Manifold Learning
 ==========================================
 
@@ -728,8 +686,6 @@ From text
     manifold.locally_linear_embedding
     manifold.spectral_embedding
 
-
-.. _metrics_ref:
 
 :mod:`sklearn.metrics`: Metrics
 ===============================
@@ -890,8 +846,6 @@ See the :ref:`metrics` section of the user guide for further details.
    metrics.pairwise_distances_argmin_min
 
 
-.. _mixture_ref:
-
 :mod:`sklearn.mixture`: Gaussian Mixture Models
 ===============================================
 
@@ -912,8 +866,6 @@ See the :ref:`metrics` section of the user guide for further details.
    mixture.VBGMM
 
 
-.. _multiclass_ref:
-
 :mod:`sklearn.multiclass`: Multiclass and multilabel classification
 ===================================================================
 
@@ -932,8 +884,6 @@ See the :ref:`metrics` section of the user guide for further details.
     multiclass.OneVsRestClassifier
     multiclass.OneVsOneClassifier
     multiclass.OutputCodeClassifier
-
-.. _naive_bayes_ref:
 
 :mod:`sklearn.naive_bayes`: Naive Bayes
 =======================================
@@ -954,8 +904,6 @@ See the :ref:`metrics` section of the user guide for further details.
    naive_bayes.MultinomialNB
    naive_bayes.BernoulliNB
 
-
-.. _neighbors_ref:
 
 :mod:`sklearn.neighbors`: Nearest Neighbors
 ===========================================
@@ -991,8 +939,6 @@ See the :ref:`metrics` section of the user guide for further details.
    neighbors.kneighbors_graph
    neighbors.radius_neighbors_graph
 
-.. _neural_network_ref:
-
 :mod:`sklearn.neural_network`: Neural network models
 =====================================================
 
@@ -1010,8 +956,6 @@ See the :ref:`metrics` section of the user guide for further details.
 
    neural_network.BernoulliRBM
 
-
-.. _calibration_ref:
 
 :mod:`sklearn.calibration`: Probability Calibration
 ===================================================
@@ -1038,8 +982,6 @@ See the :ref:`metrics` section of the user guide for further details.
    calibration.calibration_curve
 
 
-.. _cross_decomposition_ref:
-
 :mod:`sklearn.cross_decomposition`: Cross decomposition
 =======================================================
 
@@ -1060,8 +1002,6 @@ See the :ref:`metrics` section of the user guide for further details.
    cross_decomposition.CCA
    cross_decomposition.PLSSVD
 
-
-.. _pipeline_ref:
 
 :mod:`sklearn.pipeline`: Pipeline
 =================================
@@ -1086,8 +1026,6 @@ See the :ref:`metrics` section of the user guide for further details.
    pipeline.make_pipeline
    pipeline.make_union
 
-
-.. _preprocessing_ref:
 
 :mod:`sklearn.preprocessing`: Preprocessing and Normalization
 =============================================================
@@ -1151,8 +1089,6 @@ See the :ref:`metrics` section of the user guide for further details.
 
    qda.QDA
 
-.. _random_projection_ref:
-
 :mod:`sklearn.random_projection`: Random projection
 ===================================================
 
@@ -1178,8 +1114,6 @@ See the :ref:`metrics` section of the user guide for further details.
    random_projection.johnson_lindenstrauss_min_dim
 
 
-.. _semi_supervised_ref:
-
 :mod:`sklearn.semi_supervised` Semi-Supervised Learning
 ========================================================
 
@@ -1198,8 +1132,6 @@ See the :ref:`metrics` section of the user guide for further details.
    semi_supervised.LabelPropagation
    semi_supervised.LabelSpreading
 
-
-.. _svm_ref:
 
 :mod:`sklearn.svm`: Support Vector Machines
 ===========================================
@@ -1247,8 +1179,6 @@ Low-level methods
    svm.libsvm.cross_validation
 
 
-.. _tree_ref:
-
 :mod:`sklearn.tree`: Decision Trees
 ===================================
 
@@ -1275,8 +1205,6 @@ Low-level methods
 
    tree.export_graphviz
 
-
-.. _utils_ref:
 
 :mod:`sklearn.utils`: Utilities
 ===============================

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -286,8 +286,8 @@ counting in a single class::
   >>> from sklearn.feature_extraction.text import CountVectorizer
 
 This model has many parameters, however the default values are quite
-reasonable (please see  the :ref:`reference documentation
-<text_feature_extraction_ref>` for the details)::
+reasonable (please see  the :ref:`feature_extraction` documentation
+for the details)::
 
   >>> vectorizer = CountVectorizer(min_df=1)
   >>> vectorizer                     # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -412,8 +412,8 @@ class::
   TfidfTransformer(norm=...'l2', smooth_idf=True, sublinear_tf=False,
                    use_idf=True)
 
-Again please see the :ref:`reference documentation
-<text_feature_extraction_ref>` for the details on all the parameters.
+Again please see the :ref:`feature_extraction` documentation for the details
+on all the parameters.
 
 Let's take an example with the following counts. The first term is present
 100% of the time hence not very interesting. The two other features only

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3239,8 +3239,7 @@ New classes
       :class:`hmm.GaussianHMM`, :class:`hmm.MultinomialHMM`,
       :class:`hmm.GMMHMM`)
 
-    - New module feature_extraction (see :ref:`class reference
-      <feature_extraction_ref>`)
+    - New module feature_extraction (see :ref:`feature_extraction` documentation)
 
     - New FastICA algorithm in module sklearn.fastica
 


### PR DESCRIPTION
`_ref` tags were added in 6709ed5fd99e59e0b0d26d05b116d1789b957a66 and later removed...

Refer Andy's [comment](https://github.com/rvraghav93/scikit-learn/pull/4#discussion_r37102100) which pointed this out.

@glouppe @GaelVaroquaux @vene @amueller ping!
