### PR TITLE
[Discussion] Sparse datastructure for MultinomialNB feature_count_

### DIFF
--- a/benchmarks/bench_sparse_mnnb.py
+++ b/benchmarks/bench_sparse_mnnb.py
@@ -41,7 +41,8 @@ def dataset():
     X = csr_matrix((n_samples, n_features))
     for i in xrange(n_samples):
         indexes = np.random.randint(0, n_features, n_informative)
-        X[i, indexes] = 1
+        for j in indexes:
+            X[i, j] = 1
     y = np.random.randint(0, n_classes, n_samples)
     return X, y
 

--- a/benchmarks/bench_sparse_mnnb.py
+++ b/benchmarks/bench_sparse_mnnb.py
@@ -1,0 +1,50 @@
+import numpy as np
+from scipy.sparse import csr_matrix
+
+from sklearn.naive_bayes import MultinomialNB
+from profile_support import profile
+
+__author__ = 'bas'
+
+
+# TODO: is there a better place/format for a test like this in the codebase?
+def run():
+    clf = MultinomialNB(fit_prior=False)
+    clf_sp = MultinomialNB(sparse=True, fit_prior=False)
+    X, y = dataset()
+
+    y_pred = fit_set(X, clf, y)
+    y_pred_sp = fit_set_sp(X, clf_sp, y)
+    #
+    print np.allclose(y_pred, y_pred_sp)
+
+
+@profile
+def fit_set(X, clf, y):
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+    return y_pred
+
+
+@profile
+def fit_set_sp(X, clf, y):
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+    return y_pred
+
+
+def dataset():
+    n_samples = 50
+    n_features = 2 ** 20
+    n_classes = 10
+    n_informative = 7
+    X = csr_matrix((n_samples, n_features))
+    for i in xrange(n_samples):
+        indexes = np.random.randint(0, n_features, n_informative)
+        X[i, indexes] = 1
+    y = np.random.randint(0, n_classes, n_samples)
+    return X, y
+
+
+if __name__ == '__main__':
+    run()

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -6,6 +6,7 @@ Naive Bayes
 
 .. currentmodule:: sklearn.naive_bayes
 
+.. TODO: add sparse parameter
 
 Naive Bayes methods are a set of supervised learning algorithms
 based on applying Bayes' theorem with the "naive" assumption of independence

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -58,7 +58,8 @@ filling in the names automatically::
     Pipeline(steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
                     ('multinomialnb', MultinomialNB(alpha=1.0,
                                                     class_prior=None,
-                                                    fit_prior=True))])
+                                                    fit_prior=True,
+                                                    sparse=False))])
 
 The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -146,6 +146,49 @@ def test_mnnb():
         assert_array_almost_equal(y_pred_proba3, y_pred_proba)
         assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
+def test_mnnb_sparse():
+    X = scipy.sparse.csr_matrix(X2)
+    clf = MultinomialNB()
+    clf_sp = MultinomialNB(sparse=True)
+    assert_raises(ValueError, clf.fit, -X, y2)
+    assert_raises(ValueError, clf_sp.fit, -X, y2)
+    y_pred = clf.fit(X, y2).predict(X)
+    y_pred_sp = clf_sp.fit(X, y2).predict(X)
+    # Verify that sparse fit/predict has same result as non-sparse
+    assert_array_equal(y_pred, y_pred_sp, "sparse mnNB does not have same output as non-sparse")
+
+    # Verify that np.log(clf.predict_proba(X)) gives the same results as
+    # clf.predict_log_proba(X)
+    y_pred_proba = clf_sp.predict_proba(X)
+    y_pred_log_proba = clf_sp.predict_log_proba(X)
+    assert_array_almost_equal(np.log(y_pred_proba), y_pred_log_proba, 8)
+
+    # Check that incremental fitting yields the same results
+    clf2 = MultinomialNB(sparse=True)
+    clf2.partial_fit(X[:2], y2[:2], classes=np.unique(y2))
+    clf2.partial_fit(X[2:5], y2[2:5])
+    clf2.partial_fit(X[5:], y2[5:])
+
+    y_pred2 = clf2.predict(X)
+    assert_array_equal(y_pred2, y2)
+
+    y_pred_proba2 = clf2.predict_proba(X)
+    y_pred_log_proba2 = clf2.predict_log_proba(X)
+    assert_array_almost_equal(np.log(y_pred_proba2), y_pred_log_proba2, 8)
+    assert_array_almost_equal(y_pred_proba2, y_pred_proba)
+    assert_array_almost_equal(y_pred_log_proba2, y_pred_log_proba)
+
+    # Partial fit on the whole data at once should be the same as fit too
+    clf3 = MultinomialNB(sparse=True)
+    clf3.partial_fit(X, y2, classes=np.unique(y2))
+
+    y_pred3 = clf3.predict(X)
+    assert_array_equal(y_pred3, y2)
+    y_pred_proba3 = clf3.predict_proba(X)
+    y_pred_log_proba3 = clf3.predict_log_proba(X)
+    assert_array_almost_equal(np.log(y_pred_proba3), y_pred_log_proba3, 8)
+    assert_array_almost_equal(y_pred_proba3, y_pred_proba)
+    assert_array_almost_equal(y_pred_log_proba3, y_pred_log_proba)
 
 def check_partial_fit(cls):
     clf1 = cls()


### PR DESCRIPTION
When `n_features` gets big, `feature_count_` has a large memory footprint. When using MultinomialNB with sparse features (e.g. a HashingVectorizer over short sentences), this is appears to be an unnecessary overhead. This commit adds a optional sparse argument to the constructor of MultinomialNB and the necessary adjustments to `(partial_)fit()`. A new nosetest is added, `make` runs succesfully.

`bench_sparse_mnnb.py` contains an experiment comparing the sparse v/s non-sparse implementation. Memory_profile result indicates that 300mb less memory is used, with `n_features = 2 ** 20`. Yappi indicates a 6x speed increase. 

This pull request is a work in progress, please note the #TODO's. Feedback is welcome :).

Relevant profiling logs:

memory_profile:

```
Line #    Mem usage    Increment   Line Contents
================================================
    29  349.762 MiB    0.000 MiB   @profile
    30                             def fit_set_sp(X, clf, y): #Sparse 
    31                                 clf.fit(X, y)
    32                                 y_pred = clf.predict(X)
    33  369.879 MiB   20.117 MiB       return y_pred

Line #    Mem usage    Increment   Line Contents
================================================
    22   29.664 MiB    0.000 MiB   @profile
    23                             def fit_set(X, clf, y): #Not sparse
    24                                 clf.fit(X, y)
    25                                 y_pred = clf.predict(X)
    26  349.762 MiB  320.098 MiB       return y_pred
```

Yappi pstat log:

```
Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.022    0.022    1.362    1.362 bench_sparse_mnnb.py:1(<module>)
...
        1    0.000    0.000    0.388    0.388 bench_sparse_mnnb.py:22(fit_set)
...
        1    0.000    0.000    0.064    0.064 bench_sparse_mnnb.py:29(fit_set_sp) # Sparse
...
```
