### PR TITLE
[MRG + 1] added predict_proba functionality to cross_val_predict method

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,10 +62,10 @@ New features
      shuffling step in the ``cd`` solver.
      By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
 
-   - The new function :func:`cross_validation.cross_val_apply` provides a
-     generalized alternative to :func:`cross_validation.cross_val_predict` where 
-     one can pass functions such as `predict_proba` into the cross validation framework. 
-     By `Sears Merritt`_.
+   - Generalization of :func:`cross_validation.cross_val_predict` where
+     one can pass method names such as `predict_proba` to be used in the cross
+     validation framework instead of the default `predict`.
+     By `Sears Merritt`_ and `Ori Ziv`_.
 
 
 Enhancements

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,11 @@ New features
      function into a ``Pipeline``-compatible transformer object.
      By Joe Jevnik.
 
+   - The new function :func:`cross_validation.cross_val_apply` provides a
+     generalized alternative to :func:`cross_validation.cross_val_predict` where 
+     one can pass functions such as `predict_proba` into the cross validation framework. 
+     By `Sears Merritt`_.
+
 Enhancements
 ............
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,6 @@ New features
      function into a ``Pipeline``-compatible transformer object.
      By Joe Jevnik.
 
-<<<<<<< HEAD
    - The new classes :class:`cross_validation.LabelKFold` and
      :class:`cross_validation.LabelShuffleSplit` generate train-test folds,
      respectively similar to :class:`cross_validation.KFold` and
@@ -63,17 +62,12 @@ New features
      shuffling step in the ``cd`` solver.
      By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
 
-=======
->>>>>>> bbb72af814f529deb10e8c3825cbc8fd2d0cfbdc
    - The new function :func:`cross_validation.cross_val_apply` provides a
      generalized alternative to :func:`cross_validation.cross_val_predict` where 
      one can pass functions such as `predict_proba` into the cross validation framework. 
      By `Sears Merritt`_.
 
-<<<<<<< HEAD
 
-=======
->>>>>>> bbb72af814f529deb10e8c3825cbc8fd2d0cfbdc
 Enhancements
 ............
    - :class:`manifold.TSNE` now supports approximate optimization via the

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -62,6 +62,12 @@ New features
      shuffling step in the ``cd`` solver.
      By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
 
+   - The new function :func:`cross_validation.cross_val_apply` provides a
+     generalized alternative to :func:`cross_validation.cross_val_predict` where 
+     one can pass functions such as `predict_proba` into the cross validation framework. 
+     By `Sears Merritt`_.
+
+
 Enhancements
 ............
    - :class:`manifold.TSNE` now supports approximate optimization via the

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1190,8 +1190,9 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict',
-                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, 
+                    apply_func='predict', verbose=0, fit_params=None, 
+                    pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1227,8 +1228,8 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    apply_func : string, optional, default: predict
-        Invokes the passed function on the passed estimator. Default calls predict.
+    apply_func : string, optional, default: 'predict'
+        Invokes the passed function on the passed estimator.
 
     verbose : integer, optional
         The verbosity level.
@@ -1256,7 +1257,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'apply_func'
+        This is the result of calling ``apply_func``
     """
     X, y = indexable(X, y)
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1190,8 +1190,8 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, 
-                    apply_func='predict', verbose=0, fit_params=None, 
+def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
+                    apply_func='predict', verbose=0, fit_params=None,
                     pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
@@ -1262,18 +1262,19 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
     X, y = indexable(X, y)
 
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
-    
+
     # Ensure the estimator has implemented the passed decision function
     if not hasattr(estimator, apply_func):
-        raise AttributeError(' '.join((apply_func,'not implemented in estimator')))
+        raise AttributeError(' '.join((apply_func,
+                                       'not implemented in estimator')))
 
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_apply)(clone(estimator), X, y,
-                                                      train, test, verbose,
-                                                      fit_params, apply_func)
+                                                    train, test, verbose,
+                                                    fit_params, apply_func)
                             for train, test in cv)
 
     preds = [p for p, _ in preds_blocks]
@@ -1291,7 +1292,8 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
     return preds[inv_locs]
 
 
-def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, apply_func):
+def _fit_and_apply(estimator, X, y, train, test, verbose,
+                   fit_params, apply_func):
     """Fit estimator and predict values for a given dataset split.
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1319,10 +1321,10 @@ def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, apply_func
 
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
-    
+
     apply_func : string
         Invokes the apply_func on the passed estimator.
-    
+
     Returns
     -------
     preds : sequence
@@ -1343,7 +1345,7 @@ def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, apply_func
         estimator.fit(X_train, **fit_params)
     else:
         estimator.fit(X_train, y_train, **fit_params)
-    
+
     func = getattr(estimator, apply_func)
     preds = func(X_test)
     return preds, test
@@ -1405,11 +1407,12 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'predict'
+        Result of calling 'predict'. Also see `cross_val_apply` section
     """
-    # Preserve the existing API and delegate to cross_val_apply with 'predict' function.
-    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs, apply_func='predict',
-                      verbose=verbose, fit_params=fit_params, pre_dispatch=pre_dispatch)
+    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs,
+                            apply_func='predict', verbose=verbose,
+                            fit_params=fit_params,
+                            pre_dispatch=pre_dispatch)
     return preds
 
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1227,9 +1227,9 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    proba : True or False
-        True invokes the predict_proba on the estimator, false 
-        invokes predict.
+    proba : boolean, optional, default: False
+        Invokes the predict_proba on the estimator 
+        otherwise uses predict.
     
     verbose : integer, optional
         The verbosity level.
@@ -1317,8 +1317,8 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
     
-    proba: True or False
-        Use predict_proba or predict method on estimator.
+    proba: boolean
+        If True, use predict_proba otherwise use predict method on estimator.
     
     Returns
     -------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -973,7 +973,7 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='predict',
+def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict',
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
@@ -1003,8 +1003,8 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='pred
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    decision_func : string, optional, default: predict
-        Invokes the decision function on the passed estimator. Default calls predict.
+    apply_func : string, optional, default: predict
+        Invokes the passed function on the passed estimator. Default calls predict.
 
     verbose : integer, optional
         The verbosity level.
@@ -1032,15 +1032,15 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='pred
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'decision_function'
+        This is the result of calling 'apply_func'
     """
     X, y = indexable(X, y)
 
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
     
     # Ensure the estimator has implemented the passed decision function
-    if not hasattr(estimator, decision_func):
-        raise AttributeError(' '.join((decision_func,'not implemented in estimator')))
+    if not hasattr(estimator, apply_func):
+        raise AttributeError(' '.join((apply_func,'not implemented in estimator')))
 
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
@@ -1048,7 +1048,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='pred
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_apply)(clone(estimator), X, y,
                                                       train, test, verbose,
-                                                      fit_params, decision_func)
+                                                      fit_params, apply_func)
                             for train, test in cv)
     p = np.concatenate([p for p, _ in preds_blocks])
     locs = np.concatenate([loc for _, loc in preds_blocks])
@@ -1059,7 +1059,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='pred
     return preds
 
 
-def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, decision_func):
+def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, apply_func):
     """Fit estimator and predict values for a given dataset split.
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1088,13 +1088,13 @@ def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, decision_f
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
     
-    decision_function : string
-        Invokes the decision function on the passed estimator.
+    apply_func : string
+        Invokes the apply_func on the passed estimator.
     
     Returns
     -------
     preds : sequence
-        Result of calling 'estimator.decision_function'
+        Result of calling 'estimator.apply_func'
 
     test : array-like
         This is the value of the test parameter
@@ -1112,7 +1112,7 @@ def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, decision_f
     else:
         estimator.fit(X_train, y_train, **fit_params)
     
-    func = getattr(estimator, decision_func)
+    func = getattr(estimator, apply_func)
     preds = func(X_test)
     return preds, test
 
@@ -1175,8 +1175,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     preds : ndarray
         This is the result of calling 'predict'
     """
-    # Preserve the existing API and delegate to cross_val_apply with 'predict' decision function.
-    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs, decision_func='predict',
+    # Preserve the existing API and delegate to cross_val_apply with 'predict' function.
+    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs, apply_func='predict',
                       verbose=verbose, fit_params=fit_params, pre_dispatch=pre_dispatch)
     return preds
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1003,9 +1003,9 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    proba : True or False
-        True invokes the predict_proba on the estimator, false 
-        invokes predict.
+    proba : boolean, optional, default: False
+        Invokes the predict_proba on the estimator 
+        otherwise uses predict.
     
     verbose : integer, optional
         The verbosity level.
@@ -1086,8 +1086,8 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
     
-    proba: True or False
-        Use predict_proba or predict method on estimator.
+    proba: boolean
+        If True, use predict_proba otherwise use predict method on estimator.
     
     Returns
     -------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1229,7 +1229,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
         'all CPUs'.
 
     apply_func : string, optional, default: 'predict'
-        Invokes the passed function on the passed estimator.
+        Invokes the passed method name of the passed estimator.
 
     verbose : integer, optional
         The verbosity level.

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -973,7 +973,7 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
+def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
@@ -1003,6 +1003,10 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
+    proba : True or False
+        True invokes the predict_proba on the estimator, false 
+        invokes predict.
+    
     verbose : integer, optional
         The verbosity level.
 
@@ -1040,7 +1044,7 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
                                                       train, test, verbose,
-                                                      fit_params)
+                                                      fit_params, proba)
                             for train, test in cv)
     p = np.concatenate([p for p, _ in preds_blocks])
     locs = np.concatenate([loc for _, loc in preds_blocks])
@@ -1050,8 +1054,10 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     preds[locs] = p
     return preds
 
+    
 
-def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
+
+def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
     """Fit estimator and predict values for a given dataset split.
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1079,11 +1085,14 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
 
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
-
+    
+    proba: True or False
+        Use predict_proba or predict method on estimator.
+    
     Returns
     -------
     preds : sequence
-        Result of calling 'estimator.predict'
+        Result of calling 'estimator.predict' or 'estimator.predict_proba'
 
     test : array-like
         This is the value of the test parameter
@@ -1100,7 +1109,10 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
         estimator.fit(X_train, **fit_params)
     else:
         estimator.fit(X_train, y_train, **fit_params)
-    preds = estimator.predict(X_test)
+    if proba:
+        preds = estimator.predict_proba(X_test)
+    else:
+        preds = estimator.predict(X_test)
     return preds, test
 
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1190,7 +1190,7 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
+def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                     apply_func='predict', verbose=0, fit_params=None,
                     pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
@@ -1209,7 +1209,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
         The target variable to try to predict in the case of
         supervised learning.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, optional, default: None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
           - None, to use the default 3-fold cross-validation,
@@ -1223,6 +1223,9 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
+
+        This generator must include all elements in the test set exactly once.
+        Otherwise, a ValueError is raised.
 
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
@@ -1257,8 +1260,9 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1,
     Returns
     -------
     preds : ndarray
-        This is the result of calling ``apply_func``
+        Result of calling ``apply_func``
     """
+
     X, y = indexable(X, y)
 
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
@@ -1349,71 +1353,6 @@ def _fit_and_apply(estimator, X, y, train, test, verbose,
     func = getattr(estimator, apply_func)
     preds = func(X_test)
     return preds, test
-
-
-def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
-                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
-    """Generate cross-validated estimates for each input data point
-
-    Read more in the :ref:`User Guide <cross_validation>`.
-
-    Parameters
-    ----------
-    estimator : estimator object implementing 'fit' and 'predict'
-        The object to use to fit the data.
-
-    X : array-like
-        The data to fit. Can be, for example a list, or an array at least 2d.
-
-    y : array-like, optional, default: None
-        The target variable to try to predict in the case of
-        supervised learning.
-
-    cv : cross-validation generator or int, optional, default: None
-        A cross-validation generator to use. If int, determines
-        the number of folds in StratifiedKFold if y is binary
-        or multiclass and estimator is a classifier, or the number
-        of folds in KFold otherwise. If None, it is equivalent to cv=3.
-        This generator must include all elements in the test set exactly once.
-        Otherwise, a ValueError is raised.
-
-    n_jobs : integer, optional
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose : integer, optional
-        The verbosity level.
-
-    fit_params : dict, optional
-        Parameters to pass to the fit method of the estimator.
-
-    pre_dispatch : int, or string, optional
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-            - None, in which case all the jobs are immediately
-              created and spawned. Use this for lightweight and
-              fast-running jobs, to avoid delays due to on-demand
-              spawning of the jobs
-
-            - An int, giving the exact number of total jobs that are
-              spawned
-
-            - A string, giving an expression as a function of n_jobs,
-              as in '2*n_jobs'
-
-    Returns
-    -------
-    preds : ndarray
-        Result of calling 'predict'. Also see `cross_val_apply` section
-    """
-    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs,
-                            apply_func='predict', verbose=verbose,
-                            fit_params=fit_params,
-                            pre_dispatch=pre_dispatch)
-    return preds
 
 
 def _check_is_partition(locs, n):

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -973,8 +973,9 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict',
-                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, 
+                    apply_func='predict', verbose=0, fit_params=None, 
+                    pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1003,8 +1004,8 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    apply_func : string, optional, default: predict
-        Invokes the passed function on the passed estimator. Default calls predict.
+    apply_func : string, optional, default: 'predict'
+        Invokes the passed function on the passed estimator.
 
     verbose : integer, optional
         The verbosity level.
@@ -1032,7 +1033,7 @@ def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, apply_func='predict
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'apply_func'
+        This is the result of calling ``apply_func``
     """
     X, y = indexable(X, y)
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -973,7 +973,7 @@ def _index_param_value(X, v, indices):
     return safe_indexing(v, indices)
 
 
-def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
+def cross_val_apply(estimator, X, y=None, cv=None, n_jobs=1, decision_func='predict',
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
     """Generate cross-validated estimates for each input data point
 
@@ -1003,10 +1003,9 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
 
-    proba : boolean, optional, default: False
-        Invokes the predict_proba on the estimator 
-        otherwise uses predict.
-    
+    decision_func : string, optional, default: predict
+        Invokes the decision function on the passed estimator. Default calls predict.
+
     verbose : integer, optional
         The verbosity level.
 
@@ -1033,31 +1032,34 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'predict'
+        This is the result of calling 'decision_function'
     """
     X, y = indexable(X, y)
 
     cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
+    
+    # Ensure the estimator has implemented the passed decision function
+    if not hasattr(estimator, decision_func):
+        raise AttributeError(' '.join((decision_func,'not implemented in estimator')))
+
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose,
                         pre_dispatch=pre_dispatch)
-    preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
+    preds_blocks = parallel(delayed(_fit_and_apply)(clone(estimator), X, y,
                                                       train, test, verbose,
-                                                      fit_params, proba)
+                                                      fit_params, decision_func)
                             for train, test in cv)
     p = np.concatenate([p for p, _ in preds_blocks])
     locs = np.concatenate([loc for _, loc in preds_blocks])
     if not _check_is_partition(locs, _num_samples(X)):
-        raise ValueError('cross_val_predict only works for partitions')
+        raise ValueError('cross_val_apply only works for partitions')
     preds = p.copy()
     preds[locs] = p
     return preds
 
-    
 
-
-def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
+def _fit_and_apply(estimator, X, y, train, test, verbose, fit_params, decision_func):
     """Fit estimator and predict values for a given dataset split.
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1086,13 +1088,13 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
     
-    proba: boolean
-        If True, use predict_proba otherwise use predict method on estimator.
+    decision_function : string
+        Invokes the decision function on the passed estimator.
     
     Returns
     -------
     preds : sequence
-        Result of calling 'estimator.predict' or 'estimator.predict_proba'
+        Result of calling 'estimator.decision_function'
 
     test : array-like
         This is the value of the test parameter
@@ -1109,11 +1111,74 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba):
         estimator.fit(X_train, **fit_params)
     else:
         estimator.fit(X_train, y_train, **fit_params)
-    if proba:
-        preds = estimator.predict_proba(X_test)
-    else:
-        preds = estimator.predict(X_test)
+    
+    func = getattr(estimator, decision_func)
+    preds = func(X_test)
     return preds, test
+
+
+def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
+                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+    """Generate cross-validated estimates for each input data point
+
+    Read more in the :ref:`User Guide <cross_validation>`.
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit' and 'predict'
+        The object to use to fit the data.
+
+    X : array-like
+        The data to fit. Can be, for example a list, or an array at least 2d.
+
+    y : array-like, optional, default: None
+        The target variable to try to predict in the case of
+        supervised learning.
+
+    cv : cross-validation generator or int, optional, default: None
+        A cross-validation generator to use. If int, determines
+        the number of folds in StratifiedKFold if y is binary
+        or multiclass and estimator is a classifier, or the number
+        of folds in KFold otherwise. If None, it is equivalent to cv=3.
+        This generator must include all elements in the test set exactly once.
+        Otherwise, a ValueError is raised.
+
+    n_jobs : integer, optional
+        The number of CPUs to use to do the computation. -1 means
+        'all CPUs'.
+
+    verbose : integer, optional
+        The verbosity level.
+
+    fit_params : dict, optional
+        Parameters to pass to the fit method of the estimator.
+
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+
+            - An int, giving the exact number of total jobs that are
+              spawned
+
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    Returns
+    -------
+    preds : ndarray
+        This is the result of calling 'predict'
+    """
+    # Preserve the existing API and delegate to cross_val_apply with 'predict' decision function.
+    preds = cross_val_apply(estimator, X, y, cv=cv, n_jobs=n_jobs, decision_func='predict',
+                      verbose=verbose, fit_params=fit_params, pre_dispatch=pre_dispatch)
+    return preds
 
 
 def _check_is_partition(locs, n):

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1155,7 +1155,7 @@ def test_cross_val_predict():
     assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
 
 
-def test_cross_val_apply():
+def test_cross_val_predict_apply():
     iris = load_iris()
     X, y = iris.data, iris.target
     classes = len(set(y))
@@ -1175,25 +1175,25 @@ def test_cross_val_apply():
 
         func = getattr(est, func_name)
 
-        # Naive loop (should be same as cross_val_apply):
+        # Naive loop (should be same as cross_val_predict):
         for train, test in cv:
             est.fit(X[train], y[train])
             preds2[test] = func(X[test])
 
-        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
+        preds = cval.cross_val_predict(est, X, y, apply_func=func_name, cv=cv)
         assert_array_almost_equal(preds, preds2)
 
-        preds = cval.cross_val_apply(est, X, y, apply_func=func_name)
+        preds = cval.cross_val_predict(est, X, y, apply_func=func_name)
         assert_equal(len(preds), len(y))
 
         cv = cval.LeaveOneOut(len(y))
-        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
+        preds = cval.cross_val_predict(est, X, y, apply_func=func_name, cv=cv)
         assert_equal(len(preds), len(y))
 
         Xsp = X.copy()
         Xsp *= (Xsp > np.median(Xsp))
         Xsp = coo_matrix(Xsp)
-        preds = cval.cross_val_apply(est, Xsp, y)
+        preds = cval.cross_val_predict(est, Xsp, y)
         assert_array_almost_equal(len(preds), len(y))
 
         def bad_cv():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -34,10 +34,7 @@ from sklearn.metrics import precision_score
 from sklearn.externals import six
 from sklearn.externals.six.moves import zip
 
-<<<<<<< HEAD
 from sklearn.multiclass import OneVsRestClassifier
-=======
->>>>>>> bbb72af814f529deb10e8c3825cbc8fd2d0cfbdc
 from sklearn.linear_model import Ridge, LogisticRegression
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.svm import SVC

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -34,8 +34,8 @@ from sklearn.metrics import precision_score
 from sklearn.externals import six
 from sklearn.externals.six.moves import zip
 
-from sklearn.linear_model import Ridge
 from sklearn.multiclass import OneVsRestClassifier
+from sklearn.linear_model import Ridge, LogisticRegression
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.svm import SVC
 from sklearn.cluster import KMeans

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1028,48 +1028,54 @@ def test_cross_val_predict():
     assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
 
 
-def test_cross_val_predict_proba():
+def test_cross_val_apply():
     iris = load_iris()
     X, y = iris.data, iris.target
-    cv = cval.KFold(len(iris.target))
+    classes = len(set(y))
 
-    for proba in [True, False]:
-        est = LogisticRegression()
+    # Shuffle the data before doing cross validation
+    shf = np.random.permutation(np.arange(len(X)))
+    X = X[shf]
+    y = y[shf]
     
-        if proba:
-            preds2 = np.zeros([len(y),2])
-        else:
+    cv = cval.KFold(len(iris.target))
+    est = LogisticRegression()
+
+    # Not testing 'predict' because it is tested in 'test_cross_val_predict' above
+    for func_name in ['decision_function', 'predict_proba','predict_log_proba']:
+        if func_name == 'predict':
             preds2 = np.zeros_like(y)
+        else:
+            preds2 = np.zeros([len(y),classes])
+
+        func = getattr(est, func_name)
     
-        # Naive loop (should be same as cross_val_predict):
+        # Naive loop (should be same as cross_val_apply):
         for train, test in cv:
             est.fit(X[train], y[train])
-            if proba:
-                preds2[test] = est.predict_proba(X[test])
-            else:
-                preds2[test] = est.predict(X[test])
+            preds2[test] = func(X[test])
         
-        preds = cval.cross_val_predict(est, X, y, proba=proba, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
         assert_array_almost_equal(preds, preds2)
 
-        preds = cval.cross_val_predict(est, X, y, proba=proba)
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name)
         assert_equal(len(preds), len(y))
 
         cv = cval.LeaveOneOut(len(y))
-        preds = cval.cross_val_predict(est, X, y, proba=proba, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
         assert_equal(len(preds), len(y))
 
         Xsp = X.copy()
         Xsp *= (Xsp > np.median(Xsp))
         Xsp = coo_matrix(Xsp)
-        preds = cval.cross_val_predict(est, Xsp, y, proba=proba)
+        preds = cval.cross_val_apply(est, Xsp, y)
         assert_array_almost_equal(len(preds), len(y))
         
         def bad_cv():
             for i in range(4):
                 yield np.array([0, 1, 2, 3]), np.array([4, 5, 6, 7, 8])
 
-        assert_raises(ValueError, cval.cross_val_predict, est, X, y, proba=proba, cv=bad_cv())
+        assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
 
 
 def test_cross_val_predict_input_types():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1042,11 +1042,8 @@ def test_cross_val_apply():
     est = LogisticRegression()
 
     # Not testing 'predict' because it is tested in 'test_cross_val_predict' above
-    for func_name in ['decision_function', 'predict_proba','predict_log_proba']:
-        if func_name == 'predict':
-            preds2 = np.zeros_like(y)
-        else:
-            preds2 = np.zeros([len(y),classes])
+    for func_name in ['decision_function', 'predict_proba', 'predict_log_proba']:
+        preds2 = np.zeros([len(y),classes])
 
         func = getattr(est, func_name)
     

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1182,14 +1182,14 @@ def test_cross_val_apply():
             est.fit(X[train], y[train])
             preds2[test] = func(X[test])
         
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
         assert_array_almost_equal(preds, preds2)
 
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name)
         assert_equal(len(preds), len(y))
 
         cv = cval.LeaveOneOut(len(y))
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
         assert_equal(len(preds), len(y))
 
         Xsp = X.copy()

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1055,14 +1055,14 @@ def test_cross_val_apply():
             est.fit(X[train], y[train])
             preds2[test] = func(X[test])
         
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
         assert_array_almost_equal(preds, preds2)
 
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name)
         assert_equal(len(preds), len(y))
 
         cv = cval.LeaveOneOut(len(y))
-        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
         assert_equal(len(preds), len(y))
 
         Xsp = X.copy()

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1169,11 +1169,8 @@ def test_cross_val_apply():
     est = LogisticRegression()
 
     # Not testing 'predict' because it is tested in 'test_cross_val_predict' above
-    for func_name in ['decision_function', 'predict_proba','predict_log_proba']:
-        if func_name == 'predict':
-            preds2 = np.zeros_like(y)
-        else:
-            preds2 = np.zeros([len(y),classes])
+    for func_name in ['decision_function', 'predict_proba', 'predict_log_proba']:
+        preds2 = np.zeros([len(y),classes])
 
         func = getattr(est, func_name)
     

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1164,21 +1164,22 @@ def test_cross_val_apply():
     shf = np.random.permutation(np.arange(len(X)))
     X = X[shf]
     y = y[shf]
-    
+
     cv = cval.KFold(len(iris.target))
     est = LogisticRegression()
 
-    # Not testing 'predict' because it is tested in 'test_cross_val_predict' above
-    for func_name in ['decision_function', 'predict_proba', 'predict_log_proba']:
-        preds2 = np.zeros([len(y),classes])
+    # Not testing 'predict', tested in 'test_cross_val_predict' above
+    for func_name in ['decision_function', 'predict_proba',
+                      'predict_log_proba']:
+        preds2 = np.zeros([len(y), classes])
 
         func = getattr(est, func_name)
-    
+
         # Naive loop (should be same as cross_val_apply):
         for train, test in cv:
             est.fit(X[train], y[train])
             preds2[test] = func(X[test])
-        
+
         preds = cval.cross_val_apply(est, X, y, apply_func=func_name, cv=cv)
         assert_array_almost_equal(preds, preds2)
 
@@ -1194,12 +1195,13 @@ def test_cross_val_apply():
         Xsp = coo_matrix(Xsp)
         preds = cval.cross_val_apply(est, Xsp, y)
         assert_array_almost_equal(len(preds), len(y))
-        
+
         def bad_cv():
             for i in range(4):
                 yield np.array([0, 1, 2, 3]), np.array([4, 5, 6, 7, 8])
 
-        assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
+        assert_raises(ValueError, cval.cross_val_predict, est, X,
+                      y, cv=bad_cv())
 
 
 def test_cross_val_predict_input_types():

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -1155,6 +1155,56 @@ def test_cross_val_predict():
     assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
 
 
+def test_cross_val_apply():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    classes = len(set(y))
+
+    # Shuffle the data before doing cross validation
+    shf = np.random.permutation(np.arange(len(X)))
+    X = X[shf]
+    y = y[shf]
+    
+    cv = cval.KFold(len(iris.target))
+    est = LogisticRegression()
+
+    # Not testing 'predict' because it is tested in 'test_cross_val_predict' above
+    for func_name in ['decision_function', 'predict_proba','predict_log_proba']:
+        if func_name == 'predict':
+            preds2 = np.zeros_like(y)
+        else:
+            preds2 = np.zeros([len(y),classes])
+
+        func = getattr(est, func_name)
+    
+        # Naive loop (should be same as cross_val_apply):
+        for train, test in cv:
+            est.fit(X[train], y[train])
+            preds2[test] = func(X[test])
+        
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        assert_array_almost_equal(preds, preds2)
+
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name)
+        assert_equal(len(preds), len(y))
+
+        cv = cval.LeaveOneOut(len(y))
+        preds = cval.cross_val_apply(est, X, y, decision_func=func_name, cv=cv)
+        assert_equal(len(preds), len(y))
+
+        Xsp = X.copy()
+        Xsp *= (Xsp > np.median(Xsp))
+        Xsp = coo_matrix(Xsp)
+        preds = cval.cross_val_apply(est, Xsp, y)
+        assert_array_almost_equal(len(preds), len(y))
+        
+        def bad_cv():
+            for i in range(4):
+                yield np.array([0, 1, 2, 3]), np.array([4, 5, 6, 7, 8])
+
+        assert_raises(ValueError, cval.cross_val_predict, est, X, y, cv=bad_cv())
+
+
 def test_cross_val_predict_input_types():
     clf = Ridge()
     # Smoke test


### PR DESCRIPTION
Modified the call signature of cross_val_predict to accept a proba keyword argument and _fit_and_predict to require a proba boolean (see signatures below). When set to true, predict_proba is called on the estimator and predict when false. Default value is False to preserve existing functionality.

<code>
    cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1, proba=False,
        verbose=0, fit_params=None, pre_dispatch='2*n_jobs')
</code>

<code>
    _fit_and_predict(estimator, X, y, train, test, verbose, fit_params, proba)
</code>
