### PR TITLE
[WIP] PERF: Bypassing checks in Lasso estimator in dictionary learning module

### DIFF
--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -18,9 +18,9 @@ import logging
 from time import time
 
 from numpy.random import RandomState
-import matplotlib
-matplotlib.use('QT4Agg')
-import matplotlib.pyplot as plt
+# import matplotlib
+# matplotlib.use('QT4Agg')
+# import matplotlib.pyplot as plt
 
 from sklearn.datasets import fetch_olivetti_faces
 from sklearn.decomposition.dict_learning import sparse_encode,\
@@ -91,13 +91,13 @@ print("Extracting the top %d %s..." % (n_components, name))
 t0 = time()
 data = faces
 dict_learning.fit(faces_centered)
-train_time = (time() - t0)
-print("done in %0.3fs" % train_time)
-plot_gallery('%s - Train time %.1fs' % (name, train_time),
-             dict_learning.components_[:n_components])
-
-code = dict_learning.transform(faces_centered)
-plot_gallery('%s - Reconstruction' % name,
-             code[:n_components].dot(dict_learning.components_))
-plt.show()
-plt.close()
+# train_time = (time() - t0)
+# print("done in %0.3fs" % train_time)
+# plot_gallery('%s - Train time %.1fs' % (name, train_time),
+#              dict_learning.components_[:n_components])
+#
+# code = dict_learning.transform(faces_centered)
+# plot_gallery('%s - Reconstruction' % name,
+#              code[:n_components].dot(dict_learning.components_))
+# plt.show()
+# plt.close()

--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -1,0 +1,105 @@
+"""
+============================
+Faces dataset decompositions
+============================
+
+This example applies to :ref:`olivetti_faces` online sparse PCA
+(a dictionary learning enforcing dictionary atom sparsity),
+from the module :py:mod:`sklearn.decomposition` (see the documentation chapter
+:ref:`decompositions`), and display some convergence curve.
+
+"""
+print(__doc__)
+
+# Authors: Vlad Niculae, Alexandre Gramfort
+# License: BSD 3 clause
+
+import logging
+from time import time
+
+from numpy.random import RandomState
+import matplotlib
+matplotlib.use('QT4Agg')
+import matplotlib.pyplot as plt
+
+from sklearn.datasets import fetch_olivetti_faces
+from sklearn.decomposition.dict_learning import sparse_encode,\
+    MiniBatchDictionaryLearning
+
+import numpy as np
+
+# Display progress logs on stdout
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+n_row, n_col = 5, 6
+n_components = n_row * n_col
+image_shape = (256, 512)
+rng = RandomState(0)
+
+###############################################################################
+# Load faces data
+dataset = fetch_olivetti_faces(shuffle=True, random_state=rng)
+faces = dataset.data
+
+faces = np.tile(faces, (1, 32))
+
+n_samples, n_features = faces.shape
+
+# global centering
+faces_centered = faces - faces.mean(axis=0)
+
+# local centering
+faces_centered -= faces_centered.mean(axis=1).reshape(n_samples, -1)
+
+print("Dataset consists of %d faces" % n_samples)
+
+###############################################################################
+def plot_gallery(title, images, n_col=n_col, n_row=n_row):
+    plt.figure(figsize=(1. * n_col, 1.13 * n_row))
+    plt.suptitle(title, size=16)
+    for i, comp in enumerate(images):
+        plt.subplot(n_row, n_col, i + 1)
+        vmax = max(comp.max(), -comp.min())
+        plt.imshow(comp.reshape(image_shape), cmap=plt.cm.gray,
+                   interpolation='nearest',
+                   vmin=-vmax, vmax=vmax)
+        plt.xticks(())
+        plt.yticks(())
+    plt.subplots_adjust(0.01, 0.05, 0.99, 0.93, 0.04, 0.)
+
+###############################################################################
+# It is necessary to add regularisation to sparse encoder (either l1 or l2).
+# XXX: This should be mentionned in the documentation
+dict_learning = MiniBatchDictionaryLearning(n_components=n_components,
+                                            alpha=0.1,
+                                            n_iter=20, batch_size=100,
+                                            fit_algorithm='cd',
+                                            transform_algorithm='lasso_cd',
+                                            transform_alpha=0.1,
+                                            verbose=10,
+                                            random_state=rng,
+                                            n_jobs=1)
+###############################################################################
+# Plot a sample of the input data
+
+# plot_gallery("First centered Olivetti faces", faces_centered[:n_components])
+#
+# plt.savefig('faces.pdf')
+
+###############################################################################
+# Do the estimation and plot it
+name = "Online Dictionary learning"
+print("Extracting the top %d %s..." % (n_components, name))
+t0 = time()
+data = faces
+dict_learning.fit(faces_centered)
+train_time = (time() - t0)
+print("done in %0.3fs" % train_time)
+plot_gallery('%s - Train time %.1fs' % (name, train_time),
+             dict_learning.components_[:n_components])
+
+code = dict_learning.transform(faces_centered)
+plot_gallery('%s - Reconstruction' % name,
+             code[:n_components].dot(dict_learning.components_))
+plt.show()
+plt.close()

--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -33,13 +33,14 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s %(message)s')
 n_row, n_col = 5, 6
 n_components = n_row * n_col
-image_shape = (64, 64)
+image_shape = (640, 64)
 rng = RandomState(0)
 
 ###############################################################################
 # Load faces data
 dataset = fetch_olivetti_faces(shuffle=True, random_state=rng)
 faces = dataset.data
+faces = np.tile(faces, (1, 10))
 
 n_samples, n_features = faces.shape
 
@@ -70,13 +71,13 @@ def plot_gallery(title, images, n_col=n_col, n_row=n_row):
 # XXX: This should be mentionned in the documentation
 dict_learning = MiniBatchDictionaryLearning(n_components=n_components,
                                             alpha=0.1,
-                                            n_iter=400, batch_size=10,
+                                            n_iter=40, batch_size=100,
                                             fit_algorithm='cd',
                                             transform_algorithm='lasso_cd',
                                             transform_alpha=0.1,
                                             verbose=10,
                                             random_state=rng,
-                                            n_jobs=1)
+                                            n_jobs=2)
 ###############################################################################
 # Plot a sample of the input data
 

--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -33,15 +33,13 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s %(message)s')
 n_row, n_col = 5, 6
 n_components = n_row * n_col
-image_shape = (256, 512)
+image_shape = (64, 64)
 rng = RandomState(0)
 
 ###############################################################################
 # Load faces data
 dataset = fetch_olivetti_faces(shuffle=True, random_state=rng)
 faces = dataset.data
-
-faces = np.tile(faces, (1, 32))
 
 n_samples, n_features = faces.shape
 
@@ -72,7 +70,7 @@ def plot_gallery(title, images, n_col=n_col, n_row=n_row):
 # XXX: This should be mentionned in the documentation
 dict_learning = MiniBatchDictionaryLearning(n_components=n_components,
                                             alpha=0.1,
-                                            n_iter=20, batch_size=100,
+                                            n_iter=400, batch_size=10,
                                             fit_algorithm='cd',
                                             transform_algorithm='lasso_cd',
                                             transform_alpha=0.1,

--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -70,13 +70,13 @@ def plot_gallery(title, images, n_col=n_col, n_row=n_row):
 # XXX: This should be mentionned in the documentation
 dict_learning = MiniBatchDictionaryLearning(n_components=n_components,
                                             alpha=0.1,
-                                            n_iter=400, batch_size=10,
+                                            n_iter=400, batch_size=100,
                                             fit_algorithm='cd',
                                             transform_algorithm='lasso_cd',
                                             transform_alpha=0.1,
                                             verbose=10,
                                             random_state=rng,
-                                            n_jobs=1)
+                                            n_jobs=3)
 ###############################################################################
 # Plot a sample of the input data
 

--- a/examples/decomposition/plot_online_sparse_pca.py
+++ b/examples/decomposition/plot_online_sparse_pca.py
@@ -70,13 +70,13 @@ def plot_gallery(title, images, n_col=n_col, n_row=n_row):
 # XXX: This should be mentionned in the documentation
 dict_learning = MiniBatchDictionaryLearning(n_components=n_components,
                                             alpha=0.1,
-                                            n_iter=400, batch_size=100,
+                                            n_iter=400, batch_size=10,
                                             fit_algorithm='cd',
                                             transform_algorithm='lasso_cd',
                                             transform_alpha=0.1,
                                             verbose=10,
                                             random_state=rng,
-                                            n_jobs=3)
+                                            n_jobs=1)
 ###############################################################################
 # Plot a sample of the input data
 
@@ -91,8 +91,8 @@ print("Extracting the top %d %s..." % (n_components, name))
 t0 = time()
 data = faces
 dict_learning.fit(faces_centered)
-# train_time = (time() - t0)
-# print("done in %0.3fs" % train_time)
+train_time = (time() - t0)
+print("done in %0.3fs" % train_time)
 # plot_gallery('%s - Train time %.1fs' % (name, train_time),
 #              dict_learning.components_[:n_components])
 #

--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -26,7 +26,7 @@ from ..linear_model import Lasso, orthogonal_mp_gram, LassoLars, Lars
 
 def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
                    regularization=None, copy_cov=True,
-                   init=None, max_iter=1000):
+                   init=None, max_iter=1000, bypass_checks=False):
     """Generic sparse coding
 
     Each column of the result is the solution to a Lasso problem.
@@ -108,7 +108,8 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
     elif algorithm == 'lasso_cd':
         alpha = float(regularization) / n_features  # account for scaling
         clf = Lasso(alpha=alpha, fit_intercept=False, precompute=gram,
-                    max_iter=max_iter, warm_start=True)
+                    max_iter=max_iter, warm_start=True,
+                    bypass_checks=bypass_checks)
         clf.coef_ = init
         clf.fit(dictionary.T, X.T)
         new_code = clf.coef_
@@ -142,7 +143,7 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
 # XXX : could be moved to the linear_model module
 def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
                   n_nonzero_coefs=None, alpha=None, copy_cov=True, init=None,
-                  max_iter=1000, n_jobs=1):
+                  max_iter=1000, n_jobs=1, bypass_checks=False, pool=None):
     """Sparse coding
 
     Each row of the result is the solution to a sparse coding problem.
@@ -218,14 +219,17 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
     sklearn.linear_model.Lasso
     SparseCoder
     """
-    dictionary = check_array(dictionary)
-    X = check_array(X)
+    # Probably never useful
+    if not bypass_checks:
+        dictionary = check_array(dictionary, dtype=np.float64)
+        X = check_array(X, dtype=np.float64)
     n_samples, n_features = X.shape
     n_components = dictionary.shape[0]
 
     if gram is None and algorithm != 'threshold':
-        gram = np.dot(dictionary, dictionary.T)
-    if cov is None:
+        gram = np.dot(dictionary, dictionary.T).T
+
+    if cov is None and algorithm != 'lasso_cd':
         copy_cov = False
         cov = np.dot(dictionary, X.T)
 
@@ -238,22 +242,36 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         if regularization is None:
             regularization = 1.
 
-    if n_jobs == 1 or algorithm == 'threshold':
-        return _sparse_encode(X, dictionary, gram, cov=cov,
+    if (pool is None and n_jobs == 1) or algorithm == 'threshold':
+        code = _sparse_encode(X,
+                              dictionary, gram, cov=cov,
                               algorithm=algorithm,
                               regularization=regularization, copy_cov=copy_cov,
-                              init=init, max_iter=max_iter)
+                              init=init,
+                              max_iter=max_iter,
+                              bypass_checks=bypass_checks)
+        if code.ndim == 1:
+            code = code[np.newaxis, :]
+        return code
+    elif pool is None:
+        pool = Parallel(n_jobs=n_jobs)
+    else:
+        # Ignoring provided n_jobs argument
+        n_jobs = pool.n_jobs
 
     # Enter parallel code block
     code = np.empty((n_samples, n_components))
     slices = list(gen_even_slices(n_samples, _get_n_jobs(n_jobs)))
 
-    code_views = Parallel(n_jobs=n_jobs)(
+    code_views = pool(
         delayed(_sparse_encode)(
-            X[this_slice], dictionary, gram, cov[:, this_slice], algorithm,
+            X[this_slice], dictionary, gram,
+            cov[:, this_slice] if cov is not None else None,
+            algorithm,
             regularization=regularization, copy_cov=copy_cov,
             init=init[this_slice] if init is not None else None,
-            max_iter=max_iter)
+            max_iter=max_iter,
+            bypass_checks=bypass_checks)
         for this_slice in slices)
     for this_slice, this_view in zip(slices, code_views):
         code[this_slice] = this_view
@@ -650,6 +668,10 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     else:
         X_train = X
 
+    dictionary = check_array(dictionary, order='F', dtype=np.float64,
+                             copy=False)
+    X_train = check_array(X_train, order='C', dtype=np.float64, copy=False)
+
     batches = gen_batches(n_samples, batch_size)
     batches = itertools.cycle(batches)
 
@@ -665,41 +687,45 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     # If n_iter is zero, we need to return zero.
     ii = iter_offset - 1
 
-    for ii, batch in zip(range(iter_offset, iter_offset + n_iter), batches):
-        this_X = X_train[batch]
-        dt = (time.time() - t0)
-        if verbose == 1:
-            sys.stdout.write(".")
-            sys.stdout.flush()
-        elif verbose:
-            if verbose > 10 or ii % ceil(100. / verbose) == 0:
-                print ("Iteration % 3i (elapsed time: % 3is, % 4.1fmn)"
-                       % (ii, dt, dt / 60))
+    backend = 'threading' if method == 'lasso_cd' else 'multiprocessing'
+    with Parallel(n_jobs=n_jobs, backend=backend) as parallel:
+        for ii, batch in zip(range(iter_offset, iter_offset + n_iter), batches):
+            this_X = X_train[batch]
+            dt = (time.time() - t0)
+            if verbose == 1:
+                sys.stdout.write(".")
+                sys.stdout.flush()
+            elif verbose:
+                if verbose > 10 or ii % ceil(100. / verbose) == 0:
+                    print ("Iteration % 3i (elapsed time: % 3is, % 4.1fmn)"
+                           % (ii, dt, dt / 60))
 
-        this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
-                                  alpha=alpha, n_jobs=n_jobs).T
+            this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
+                                      alpha=alpha,
+                                      pool=parallel,
+                                      bypass_checks=True).T
 
-        # Update the auxiliary variables
-        if ii < batch_size - 1:
-            theta = float((ii + 1) * batch_size)
-        else:
-            theta = float(batch_size ** 2 + ii + 1 - batch_size)
-        beta = (theta + 1 - batch_size) / (theta + 1)
+            # Update the auxiliary variables
+            if ii < batch_size - 1:
+                theta = float((ii + 1) * batch_size)
+            else:
+                theta = float(batch_size ** 2 + ii + 1 - batch_size)
+            beta = (theta + 1 - batch_size) / (theta + 1)
 
-        A *= beta
-        A += np.dot(this_code, this_code.T)
-        B *= beta
-        B += np.dot(this_X.T, this_code.T)
+            A *= beta
+            A += np.dot(this_code, this_code.T)
+            B *= beta
+            B += np.dot(this_X.T, this_code.T)
 
-        # Update dictionary
-        dictionary = _update_dict(dictionary, B, A, verbose=verbose,
-                                  random_state=random_state)
-        # XXX: Can the residuals be of any use?
+            # Update dictionary
+            dictionary = _update_dict(dictionary, B, A, verbose=verbose,
+                                      random_state=random_state)
+            # XXX: Can the residuals be of any use?
 
-        # Maybe we need a stopping criteria based on the amount of
-        # modification in the dictionary
-        if callback is not None:
-            callback(locals())
+            # Maybe we need a stopping criteria based on the amount of
+            # modification in the dictionary
+            if callback is not None:
+                callback(locals())
 
     if return_inner_stats:
         if return_n_iter:
@@ -763,7 +789,7 @@ class SparseCodingMixin(TransformerMixin):
         check_is_fitted(self, 'components_')
 
         # XXX : kwargs is not documented
-        X = check_array(X)
+        X = check_array(X, dtype=np.float64)
         n_samples, n_features = X.shape
 
         code = sparse_encode(

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -66,9 +66,11 @@ def test_dict_learning_lassocd_readonly_data():
     n_components = 12
     with TempMemmap(X) as X_read_only:
         dico = DictionaryLearning(n_components, transform_algorithm='lasso_cd',
-                                  transform_alpha=0.001, random_state=0, n_jobs=-1)
+                                  transform_alpha=0.001, random_state=0,
+                                  n_jobs=2)
         code = dico.fit(X_read_only).transform(X_read_only)
-        assert_array_almost_equal(np.dot(code, dico.components_), X_read_only, decimal=2)
+        assert_array_almost_equal(np.dot(code, dico.components_), X_read_only,
+                                  decimal=2)
 
 
 def test_dict_learning_nonzero_coefs():

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -397,7 +397,8 @@ class LinearRegression(LinearModel, RegressorMixin):
         return self
 
 
-def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy):
+def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy,
+             bypass_precompute_checks=False):
     """Aux function used at beginning of fit in linear models"""
     n_samples, n_features = X.shape
     if sparse.isspmatrix(X):
@@ -409,12 +410,14 @@ def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy):
         X, y, X_mean, y_mean, X_std = center_data(
             X, y, fit_intercept, normalize, copy=copy)
 
-    if hasattr(precompute, '__array__') \
-            and not np.allclose(X_mean, np.zeros(n_features)) \
-            and not np.allclose(X_std, np.ones(n_features)):
-        # recompute Gram
-        precompute = 'auto'
-        Xy = None
+    if bypass_precompute_checks:
+        # This check is costly, we provide a way to bypass it
+        if hasattr(precompute, '__array__') \
+                and not np.allclose(X_mean, np.zeros(n_features)) \
+                and not np.allclose(X_std, np.ones(n_features)):
+            # recompute Gram
+            precompute = 'auto'
+            Xy = None
 
     # precompute if n_samples > n_features
     if precompute == 'auto':

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -398,7 +398,7 @@ class LinearRegression(LinearModel, RegressorMixin):
 
 
 def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy,
-             bypass_precompute_checks=False):
+             check_input=True):
     """Aux function used at beginning of fit in linear models"""
     n_samples, n_features = X.shape
     if sparse.isspmatrix(X):
@@ -410,14 +410,13 @@ def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy,
         X, y, X_mean, y_mean, X_std = center_data(
             X, y, fit_intercept, normalize, copy=copy)
 
-    if not bypass_precompute_checks:
-        # This check is costly, we provide a way to bypass it
-        if hasattr(precompute, '__array__') \
-                and not np.allclose(X_mean, np.zeros(n_features)) \
-                and not np.allclose(X_std, np.ones(n_features)):
-            # recompute Gram
-            precompute = 'auto'
-            Xy = None
+    # This check is costly, we provide a way to bypass it
+    if check_input and hasattr(precompute, '__array__') \
+            and not np.allclose(X_mean, np.zeros(n_features)) \
+            and not np.allclose(X_std, np.ones(n_features)):
+        # recompute Gram
+        precompute = 'auto'
+        Xy = None
 
     # precompute if n_samples > n_features
     if precompute == 'auto':

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -421,12 +421,14 @@ def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy):
         precompute = (n_samples > n_features)
 
     if precompute is True:
-        precompute = np.dot(X.T, X)
+        # precompute is a Fortran array
+        precompute = np.dot(X.T, X).T
 
     if not hasattr(precompute, '__array__'):
         Xy = None  # cannot use Xy if precompute is not Gram
 
     if hasattr(precompute, '__array__') and Xy is None:
-        Xy = np.dot(X.T, y)
+        # Xy is a Fortran array
+        Xy = np.dot(y.T, X).T
 
     return X, y, X_mean, y_mean, X_std, precompute, Xy

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -410,7 +410,7 @@ def _pre_fit(X, y, Xy, precompute, normalize, fit_intercept, copy,
         X, y, X_mean, y_mean, X_std = center_data(
             X, y, fit_intercept, normalize, copy=copy)
 
-    if bypass_precompute_checks:
+    if not bypass_precompute_checks:
         # This check is costly, we provide a way to bypass it
         if hasattr(precompute, '__array__') \
                 and not np.allclose(X_mean, np.zeros(n_features)) \

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -373,7 +373,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         y = check_array(y, 'csc', dtype=np.float64, order='F', copy=False,
                         ensure_2d=False)
         if Xy is not None:
-            Xy = check_array(Xy, 'csc', dtype=np.float64, order='F', copy=False,
+            Xy = check_array(Xy, 'csc', dtype=np.float64, order='F',
+                             copy=False,
                              ensure_2d=False)
     n_samples, n_features = X.shape
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -866,9 +866,9 @@ class Lasso(ElasticNet):
     >>> from sklearn import linear_model
     >>> clf = linear_model.Lasso(alpha=0.1)
     >>> clf.fit([[0,0], [1, 1], [2, 2]], [0, 1, 2])
-    Lasso(alpha=0.1, copy_X=True, fit_intercept=True, max_iter=1000,
-       normalize=False, positive=False, precompute=False, random_state=None,
-       selection='cyclic', tol=0.0001, warm_start=False)
+    Lasso(alpha=0.1, bypass_checks=False, copy_X=True, fit_intercept=True,
+       max_iter=1000, normalize=False, positive=False, precompute=False,
+       random_state=None, selection='cyclic', tol=0.0001, warm_start=False)
     >>> print(clf.coef_)
     [ 0.85  0.  ]
     >>> print(clf.intercept_)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -670,12 +670,6 @@ class ElasticNet(LinearModel, RegressorMixin):
             _pre_fit(X, y, None, self.precompute, self.normalize,
                      self.fit_intercept, copy=True,
                      bypass_precompute_checks=self.bypass_checks)
-        # else:
-        #     Xy = np.dot(y.T, X).T
-        #     precompute = self.precompute
-        #     X_mean = 0.
-        #     X_std = 1.
-        #     y_mean = 0.
 
         if y.ndim == 1:
             y = y[:, np.newaxis]

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -15,7 +15,8 @@ from scipy import sparse
 from .base import LinearModel, _pre_fit
 from ..base import RegressorMixin
 from .base import center_data, sparse_center_data
-from ..utils import check_array, check_X_y, deprecated
+from ..utils import check_array, check_X_y, deprecated, gen_even_slices, \
+    _get_n_jobs
 from ..utils.validation import check_random_state
 from ..cross_validation import check_cv
 from ..externals.joblib import Parallel, delayed
@@ -255,7 +256,6 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
               precompute='auto', Xy=None, copy_X=True, coef_init=None,
               verbose=False, return_n_iter=False, positive=False,
-              bypass_checks=False, pre_fit=True,
               **params):
     """Compute elastic net path with coordinate descent
 
@@ -368,7 +368,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     """
     # We expect X and y to be already float64 Fortran ordered when bypassing
     # checks
-    if not bypass_checks:
+    check_input = params.pop('check_input', True)
+    if check_input:
         X = check_array(X, 'csc', dtype=np.float64, order='F', copy=copy_X)
         y = check_array(y, 'csc', dtype=np.float64, order='F', copy=False,
                         ensure_2d=False)
@@ -394,12 +395,11 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     # X should be normalized and fit already if function is called
     # from ElasticNet.fit
-    if pre_fit:
+    if check_input:
         X, y, X_mean, y_mean, X_std, precompute, Xy = \
             _pre_fit(X, y, Xy, precompute, normalize=False,
                      fit_intercept=False,
-                     copy=False,
-                     bypass_precompute_checks=bypass_checks)
+                     copy=False)
     if alphas is None:
         # No need to normalize of fit_intercept: it has been done
         # above
@@ -447,7 +447,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         elif isinstance(precompute, np.ndarray):
             # We expect precompute to be already Fortran ordered when bypassing
             # checks
-            if not bypass_checks:
+            if check_input:
                 precompute = check_array(precompute, 'csc', dtype=np.float64,
                                          order='F')
             model = cd_fast.enet_coordinate_descent_gram(
@@ -574,10 +574,10 @@ class ElasticNet(LinearModel, RegressorMixin):
         a random feature to update. Useful only when selection is set to
         'random'.
 
-    bypass_checks : bool, default False
-        If set to True, X, y and precompute are expected to be
-        double fortran-ordered arrays, with X and y centered and normalized,
-        and input checking will be byapssed for efficiency
+    check_input : bool, default True
+        If set to False, X, y, and precompute if provided are expected to be
+        double fortran-ordered arrays
+        and input checking will be bypassed for efficiency
 
     Attributes
     ----------
@@ -611,7 +611,8 @@ class ElasticNet(LinearModel, RegressorMixin):
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
                  normalize=False, precompute=False, max_iter=1000,
                  copy_X=True, tol=1e-4, warm_start=False, positive=False,
-                 random_state=None, selection='cyclic', bypass_checks=False):
+                 random_state=None, selection='cyclic', n_jobs=1, pool=None,
+                 check_input=True):
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         self.coef_ = None
@@ -626,7 +627,9 @@ class ElasticNet(LinearModel, RegressorMixin):
         self.intercept_ = 0.0
         self.random_state = random_state
         self.selection = selection
-        self.bypass_checks = bypass_checks
+        self.check_input = check_input
+        self.n_jobs = n_jobs
+        self.pool = pool
 
     def fit(self, X, y):
         """Fit model with coordinate descent.
@@ -649,6 +652,9 @@ class ElasticNet(LinearModel, RegressorMixin):
         To avoid memory re-allocation it is advised to allocate the
         initial data in memory directly using that format.
         """
+        if self.pool is None or not isinstance(self.pool, Parallel):
+            self.pool = Parallel(n_jobs=self.n_jobs)
+
         if self.alpha == 0:
             warnings.warn("With alpha=0, this algorithm does not converge "
                           "well. You are advised to use the LinearRegression "
@@ -661,15 +667,14 @@ class ElasticNet(LinearModel, RegressorMixin):
                           DeprecationWarning, stacklevel=2)
         # We expect X and y to be already float64 Fortran ordered arrays
         # when bypassing checks
-        if not self.bypass_checks:
+        if self.check_input:
             X, y = check_X_y(X, y, accept_sparse='csc', dtype=np.float64,
                              order='F',
                              copy=self.copy_X and self.fit_intercept,
                              multi_output=True, y_numeric=True)
         X, y, X_mean, y_mean, X_std, precompute, Xy = \
             _pre_fit(X, y, None, self.precompute, self.normalize,
-                     self.fit_intercept, copy=True,
-                     bypass_precompute_checks=self.bypass_checks)
+                     self.fit_intercept, copy=True, check_input=False)
 
         if y.ndim == 1:
             y = y[:, np.newaxis]
@@ -692,28 +697,25 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         dual_gaps_ = np.zeros(n_targets, dtype=np.float64)
         self.n_iter_ = []
-
+        # (_, coef_, dual_gap, n_iter) list
+        results = self.pool(delayed(self.path)(
+                X, y[:, k],
+                l1_ratio=self.l1_ratio, eps=None,
+                n_alphas=None, alphas=[self.alpha],
+                precompute=precompute,
+                Xy=Xy[:, k] if Xy is not None else None,
+                fit_intercept=False, normalize=False, copy_X=True,
+                verbose=False, tol=self.tol, positive=self.positive,
+                X_mean=X_mean, X_std=X_std,
+                return_n_iter=True,
+                coef_init=coef_[k], max_iter=self.max_iter,
+                random_state=self.random_state,
+                selection=self.selection,
+                check_input=False) for k in xrange(n_targets))
         for k in xrange(n_targets):
-            if Xy is not None:
-                this_Xy = Xy[:, k]
-            else:
-                this_Xy = None
-            _, this_coef, this_dual_gap, this_iter = \
-                self.path(X, y[:, k],
-                          l1_ratio=self.l1_ratio, eps=None,
-                          n_alphas=None, alphas=[self.alpha],
-                          precompute=precompute, Xy=this_Xy,
-                          fit_intercept=False, normalize=False, copy_X=True,
-                          verbose=False, tol=self.tol, positive=self.positive,
-                          X_mean=X_mean, X_std=X_std, return_n_iter=True,
-                          coef_init=coef_[k], max_iter=self.max_iter,
-                          random_state=self.random_state,
-                          selection=self.selection,
-                          pre_fit=False,
-                          bypass_checks=self.bypass_checks)
-            coef_[k] = this_coef[:, 0]
-            dual_gaps_[k] = this_dual_gap[0]
-            self.n_iter_.append(this_iter[0])
+            coef_[k] = results[k][1][:, 0]
+            dual_gaps_[k] = results[k][2][0]
+            self.n_iter_.append(results[k][3][0])
 
         if n_targets == 1:
             self.n_iter_ = self.n_iter_[0]
@@ -889,13 +891,15 @@ class Lasso(ElasticNet):
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  precompute=False, copy_X=True, max_iter=1000,
                  tol=1e-4, warm_start=False, positive=False,
-                 random_state=None, selection='cyclic', bypass_checks=False):
+                 random_state=None, selection='cyclic', check_input=True,
+                 n_jobs=1, pool=None):
         super(Lasso, self).__init__(
             alpha=alpha, l1_ratio=1.0, fit_intercept=fit_intercept,
             normalize=normalize, precompute=precompute, copy_X=copy_X,
             max_iter=max_iter, tol=tol, warm_start=warm_start,
             positive=positive, random_state=random_state,
-            selection=selection, bypass_checks=bypass_checks)
+            selection=selection, check_input=check_input, n_jobs=n_jobs,
+            pool=pool)
 
 
 ###############################################################################

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -397,7 +397,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                              normalize=False, copy_X=False)
     else:
         if len(alphas) > 1:
-            alphas = np.sort(alphas.copy())[::-1]  # make sure alphas are properly ordered
+            alphas = np.sort(alphas)[::-1]  # make sure alphas are properly ordered
     n_alphas = len(alphas)
     tol = params.get('tol', 1e-4)
     max_iter = params.get('max_iter', 1000)

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -333,6 +333,11 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     positive : bool, default False
         If set to True, forces coefficients to be positive.
 
+    bypass_checks : bool, default False
+        If set to True, X, y and precompute are expected to be
+        double fortran-ordered arrays, with X and y centered and normalized,
+        and input checking will be byapssed for efficiency
+
     Returns
     -------
     alphas : array, shape (n_alphas,)
@@ -566,6 +571,11 @@ class ElasticNet(LinearModel, RegressorMixin):
         The seed of the pseudo random number generator that selects
         a random feature to update. Useful only when selection is set to
         'random'.
+
+    bypass_checks : bool, default False
+        If set to True, X, y and precompute are expected to be
+        double fortran-ordered arrays, with X and y centered and normalized,
+        and input checking will be byapssed for efficiency
 
     Attributes
     ----------
@@ -828,6 +838,11 @@ class Lasso(ElasticNet):
         The seed of the pseudo random number generator that selects
         a random feature to update. Useful only when selection is set to
         'random'.
+
+    bypass_checks : bool, default False
+        If set to True, X, y and precompute are expected to be
+        double fortran-ordered arrays, with X and y centered and normalized,
+        and input checking will be byapssed for efficiency
 
     Attributes
     ----------

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -428,6 +428,22 @@ def test_enet_multitarget():
         assert_array_almost_equal(dual_gap[k], estimator.dual_gap_)
 
 
+def test_enet_multitarget_multiprocessing():
+    n_targets = 3
+    X, y, _, _ = build_dataset(n_samples=10, n_features=8,
+                               n_informative_features=10, n_targets=n_targets)
+    estimator = ElasticNet(alpha=0.01, fit_intercept=True, n_jobs=2)
+    estimator.fit(X, y)
+    coef, intercept, dual_gap = (estimator.coef_, estimator.intercept_,
+                                 estimator.dual_gap_)
+
+    for k in range(n_targets):
+        estimator.fit(X, y[:, k])
+        assert_array_almost_equal(coef[k, :], estimator.coef_)
+        assert_array_almost_equal(intercept[k], estimator.intercept_)
+        assert_array_almost_equal(dual_gap[k], estimator.dual_gap_)
+
+
 def test_multioutput_enetcv_error():
     X = np.random.randn(10, 2)
     y = np.random.randn(10, 2)


### PR DESCRIPTION
This work intend to improve dictionary learning performance using coordinate descent backend.

I initially wanted to take advantage of multiprocessing using @ogrisel context manager for Parallel pool in joblib. However, this did not show improvement at all. It turned out that a lot of computation was spent on checking input way too often, due to multiple calls to `Lasso.fit` in `_sparse_encode`.

I added a `bypass` flag to allow us to bypass these checks, performing them initially in dictionary learning module. We gain a 2x to 3x performance using `lasso_cd` algorithm in dictionary learning functions with this tweak. It complexifies the code a little and add a strange flag (`bypass_checks`) to the Lasso API, which should not be used by the end user, but I believe the performance gain is worth it.

I then added the context manager improvement to the dictionary learning module. I do not have precise benchmark yet, but it turns out that we gain a little performance with high dimensional samples and relatively large batches : I obtained a 10% performance gain with `n_features = 128000` and `batch_size = 100`, and I believe that this gain imrpove with sample dimensionality (more precision to come).

Also this is quite disappointing, this was somehow expected, as our dictionary learning algorithm is only partly parallelizable : the block coordinate descent update of the dictionary is sequential, which causes our pool to spend considerable time waiting for all workers to finish at each `sparse_encode` step.
