### PR TITLE
[MRG+1] FIX: for changing mode

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -343,7 +343,8 @@ class RegressorMixin(object):
         """
 
         from .metrics import r2_score
-        return r2_score(y, self.predict(X), sample_weight=sample_weight)
+        return r2_score(y, self.predict(X), sample_weight=sample_weight,
+                        multioutput='variance_weighted')
 
 
 ###############################################################################


### PR DESCRIPTION
Due to the changes in `r2_score`, I was getting a lot of `DeprecationWarnings`. This should preserve the old behavior.

Alternatively, an argument could be added to `score`.
