### PR TITLE
Added partial_fit method to OneVsRestClassifier

### DIFF
--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -79,6 +79,30 @@ def test_ovr_fit_predict():
     assert_greater(np.mean(iris.target == pred), 0.65)
 
 
+def test_ovr_partial_fit_predict():
+    n_iter = 5
+    # make sure partial_fit and regular fit yield the same results
+    ovr1 = OneVsRestClassifier(MultinomialNB())
+    for _ in range(n_iter):
+        ovr1 = ovr1.partial_fit(iris.data, iris.target)
+
+    pred = ovr1.predict(iris.data)
+    assert_equal(len(ovr1.estimators_), n_classes)
+
+    ovr2 = OneVsRestClassifier(MultinomialNB())
+    pred2 = ovr2.fit(iris.data, iris.target).predict(iris.data)
+
+    assert_equal(np.mean(iris.target == pred), np.mean(iris.target == pred2))
+
+    # Test on another classifier
+    ovr = OneVsRestClassifier(Perceptron())
+    for _ in range(n_iter):
+        ovr = ovr.partial_fit(iris.data, iris.target)
+
+    pred = ovr.predict(iris.data)
+    assert_greater(np.mean(iris.target == pred), 0.65)
+
+
 def test_ovr_ovo_regressor():
     # test that ovr and ovo work on regressors which don't have a decision_function
     ovr = OneVsRestClassifier(DecisionTreeRegressor())


### PR DESCRIPTION
I noticed that the OneVsRestClassifier currently does not support incremental updates via `partial_fit`, even if the underlying classifiers do. This is inconvenient when not all training data will fit into RAM.

I've fixed this, but I haven't written test cases yet, since I'm not totally familiar with how this is done for sklearn. I'd appreciate some pointers on what I'd need to add.
