### PR TITLE
[MRG+1] DOC Updated documentation for cv parameter

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -991,11 +991,13 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
         The target variable to try to predict in the case of
         supervised learning.
 
-    cv : cross-validation generator or int, optional, default: None
-        A cross-validation generator to use. If int, determines
-        the number of folds in StratifiedKFold if y is binary
-        or multiclass and estimator is a classifier, or the number
-        of folds in KFold otherwise. If None, it is equivalent to cv=3.
+    cv : integer or cross-validation generator, default=3
+        A cross-validation generator to use. If int, determines the number 
+        of folds in StratifiedKFold if estimator is a classifier and the 
+        target y is binary or multiclass, or the number of folds in KFold 
+        otherwise.
+        Specific cross-validation objects can be passed, see 
+        sklearn.cross_validation module for the list of possible objects.
         This generator must include all elements in the test set exactly once.
         Otherwise, a ValueError is raised.
 
@@ -1158,11 +1160,13 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    cv : cross-validation generator or int, optional, default: None
-        A cross-validation generator to use. If int, determines
-        the number of folds in StratifiedKFold if y is binary
-        or multiclass and estimator is a classifier, or the number
-        of folds in KFold otherwise. If None, it is equivalent to cv=3.
+    cv : integer or cross-validation generator, default=3
+        A cross-validation generator to use. If int, determines the number 
+        of folds in StratifiedKFold if estimator is a classifier and the 
+        target y is binary or multiclass, or the number of folds in KFold 
+        otherwise.
+        Specific cross-validation objects can be passed, see 
+        sklearn.cross_validation module for the list of possible objects.
 
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
@@ -1477,9 +1481,12 @@ def permutation_test_score(estimator, X, y, cv=None,
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    cv : integer or cross-validation generator, optional
-        If an integer is passed, it is the number of fold (default 3).
-        Specific cross-validation objects can be passed, see
+    cv : integer or cross-validation generator, default=3
+        A cross-validation generator to use. If int, determines the number 
+        of folds in StratifiedKFold if estimator is a classifier and the 
+        target y is binary or multiclass, or the number of folds in KFold 
+        otherwise.
+        Specific cross-validation objects can be passed, see 
         sklearn.cross_validation module for the list of possible objects.
 
     n_permutations : integer, optional

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -991,7 +991,7 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
         The target variable to try to predict in the case of
         supervised learning.
 
-    cv : integer or cross-validation generator, default=3
+    cv : integer or cross-validation generator, optional, default=3
         A cross-validation generator to use. If int, determines the number 
         of folds in StratifiedKFold if estimator is a classifier and the 
         target y is binary or multiclass, or the number of folds in KFold 
@@ -1160,7 +1160,7 @@ def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    cv : integer or cross-validation generator, default=3
+    cv : integer or cross-validation generator, optional, default=3
         A cross-validation generator to use. If int, determines the number 
         of folds in StratifiedKFold if estimator is a classifier and the 
         target y is binary or multiclass, or the number of folds in KFold 
@@ -1481,7 +1481,7 @@ def permutation_test_score(estimator, X, y, cv=None,
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    cv : integer or cross-validation generator, default=3
+    cv : integer or cross-validation generator, optional, default=3
         A cross-validation generator to use. If int, determines the number 
         of folds in StratifiedKFold if estimator is a classifier and the 
         target y is binary or multiclass, or the number of folds in KFold 

--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -59,7 +59,7 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
         be big enough to contain at least one sample from each class.
         (default: np.linspace(0.1, 1.0, 5))
 
-    cv : integer or cross-validation generator, default=3
+    cv : integer or cross-validation generator, optional, default=3
         A cross-validation generator to use. If int, determines the number 
         of folds in StratifiedKFold if estimator is a classifier and the 
         target y is binary or multiclass, or the number of folds in KFold 

--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -59,10 +59,13 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
         be big enough to contain at least one sample from each class.
         (default: np.linspace(0.1, 1.0, 5))
 
-    cv : integer, cross-validation generator, optional
-        If an integer is passed, it is the number of folds (defaults to 3).
-        Specific cross-validation objects can be passed, see
-        sklearn.cross_validation module for the list of possible objects
+    cv : integer or cross-validation generator, default=3
+        A cross-validation generator to use. If int, determines the number 
+        of folds in StratifiedKFold if estimator is a classifier and the 
+        target y is binary or multiclass, or the number of folds in KFold 
+        otherwise.
+        Specific cross-validation objects can be passed, see 
+        sklearn.cross_validation module for the list of possible objects.
 
     scoring : string, callable or None, optional, default: None
         A string (see model evaluation documentation) or


### PR DESCRIPTION
Updated cv parameter documentation in : 

def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
def cross_val_score(estimator, X, y=None, scoring=None, cv=None, n_jobs=1,
def permutation_test_score(estimator, X, y, cv=None,
in cross_validation.py

and

def validation_curve(estimator, X, y, param_name, param_range, cv=None,
in validation_curve.py

Fix for issue #4533.
