### PR TITLE
[MRG+1] PDF documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -100,3 +100,6 @@ download-data:
 optipng:
 	find _build auto_examples */generated -name '*.png' -print0 \
 	  | xargs -0 -n 1 -P 4 optipng -o10
+
+dist: html latexpdf
+	cp _build/latex/user_guide.pdf _build/html/stable/_downloads/scikit-learn-docs.pdf

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -69,6 +69,7 @@ provided funding for Fabian Pedregosa (2010-2012), Jaques Grobler
 full-time. It also hosts coding sprints and other events.
 
 .. image:: images/inria-logo.jpg
+   :width: 200pt
    :align: center
 
 `Paris-Saclay Center for Data Science <http://www.datascience-paris-saclay.fr>`_
@@ -76,6 +77,7 @@ funded one year for a developer to work on the project full-time
 (2014-2015).
 
 .. image:: images/cds-logo.png
+   :width: 200pt
    :align: center
 
 The following students were sponsored by `Google <http://code.google.com/opensource/>`_
@@ -162,30 +164,30 @@ The 2013' Paris international sprint
 
 
 .. |telecom| image:: http://f.hypotheses.org/wp-content/blogs.dir/331/files/2011/03/Logo-TPT.jpg
-   :width: 150px
+   :width: 120pt
    :target: http://www.telecom-paristech.fr/
 
 
 .. |tinyclues| image:: http://www.tinyclues.com/static/img/logo.png
-   :width: 150px
+   :width: 120pt
    :target: http://www.tinyclues.com/
 
 
 .. |afpy| image:: http://www.afpy.org/logo.png
-   :width: 150px
+   :width: 120pt
    :target: http://www.afpy.org
 
 
 .. |SGR| image:: http://www.svi.cnrs-bellevue.fr/wikimedia/images/Logo_svi_inp.png
-   :width: 150px
+   :width: 120pt
    :target: http://www.svi.cnrs-bellevue.fr
 
 .. |FNRS| image:: http://www.fnrs.be/uploaddocs/images/COMMUNIQUER/FRS-FNRS_rose_transp.png
-   :width: 150px
+   :width: 120pt
    :target: http://www.frs-fnrs.be/
 
 .. figure:: http://sites.uclouvain.be/dysco/pmwiki/uploads/Main/dysco.gif
-   :width: 150px
+   :width: 120pt
    :target: http://sites.uclouvain.be/dysco/
 
    IAP VII/19 - DYSCO

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,344 +1,346 @@
-.. raw:: html
+.. only:: html
 
-    <!-- Block section -->
-    <div class="container-index">
-    <div class="container index-upper">
-    <div class="row-fluid">
+    .. raw:: html
 
-    <!-- Classification -->
-    <div class="span4 box">
-    <h2 >
-
-:ref:`Classification <supervised-learning>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Identifying to which category an object belongs to.</p>
-    <div class="box-links">
-    <strong>Applications</strong>: Spam detection, Image recognition.</br>
-    <strong>Algorithms</strong>:&nbsp;
-
-:ref:`SVM<svm>`, :ref:`nearest neighbors<classification>`, :ref:`random forest<forest>`, ...
-
-.. raw:: html
-
-    <small class="float-right box-example-links">
-
-:ref:`Examples<general_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-    <!-- Regression -->
-    <div class="span4 box">
-    <h2>
-
-:ref:`Regression <supervised-learning>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Predicting a continuous-valued attribute associated with an object.</p>
-    <div class="box-links">
-    <strong>Applications</strong>: Drug response, Stock prices.</br>
-    <strong>Algorithms</strong>:&nbsp;
-
-:ref:`SVR<svm>`, :ref:`ridge regression<ridge_regression>`, :ref:`Lasso<lasso>`, ...
-
-.. raw:: html
-
-    <small class="float-right box-example-links">
-
-:ref:`Examples<general_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-    <!-- Clustering -->
-    <div class="span4 box">
-    <h2>
-
-:ref:`Clustering<clustering>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Automatic grouping of similar objects into sets.</p>
-    <div class="box-links">
-    <strong>Applications</strong>: Customer segmentation, Grouping experiment outcomes</br>
-    <strong>Algorithms</strong>:&nbsp;
-
-:ref:`k-Means<k_means>`, :ref:`spectral clustering<spectral_clustering>`, :ref:`mean-shift<mean_shift>`, ...
-
-.. raw:: html
-
-    <small class="float-right example-links">
-
-:ref:`Examples<cluster_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-    <!-- row -->
-    </div>
-    <div class="row-fluid">
-
-    <!-- Dimension reduction -->
-    <div class="span4 box">
-    <h2>
-
-:ref:`Dimensionality reduction<decompositions>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Reducing the number of random variables to consider.</p>
-    <div class="box-links">
-    <strong>Applications</strong>: Visualization, Increased efficiency</br>
-    <strong>Algorithms</strong>:&nbsp;
-
-:ref:`PCA<PCA>`, :ref:`feature selection<feature_selection>`, :ref:`non-negative matrix factorization<NMF>`.
-
-.. raw:: html
-
-    <small class="float-right example-links">
-
-:ref:`Examples<decomposition_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-    <!-- Model selection -->
-    <div class="span4 box">
-    <h2>
-
-:ref:`Model selection<model_selection>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Comparing, validating and choosing parameters and models.</p>
-    <div class="box-links">
-    <strong>Goal</strong>: Improved accuracy via parameter tuning</br>
-    <strong>Modules</strong>:&nbsp;
-
-:ref:`grid search<grid_search>`, :ref:`cross validation<cross_validation>`, :ref:`metrics<model_evaluation>`.
-
-.. raw:: html
-
-    <small class="float-right example-links">
-
-:ref:`Examples<general_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-
-    <!-- Preprocessing -->
-    <div class="span4 box">
-    <h2>
-
-:ref:`Preprocessing<preprocessing>`
-
-.. raw:: html
-
-    </h2>
-    <blockquote>
-    <p>Feature extraction and normalization.</p>
-    <div class="box-links">
-    <strong>Application</strong>: Transforming input data such as text for use with machine learning algorithms.</br>
-    <strong>Modules</strong>:&nbsp;
-
-:ref:`preprocessing<preprocessing>`, :ref:`feature extraction<feature_extraction>`.
-
-.. raw:: html
-
-    <span class="example-links">
-    <small class="float-right example-links">
-
-:ref:`Examples<general_examples>`
-
-.. raw:: html
-
-    </small>
-    </div>
-    </blockquote>
-    </div>
-
-    <!-- row -->
-    </div>
-    </div> <!-- container -->
-
-
-    <div class="container index-lower">
+        <!-- Block section -->
+        <div class="container-index">
+        <div class="container index-upper">
         <div class="row-fluid">
-            <!-- News -->
-            <div class="span4">
-                <h4>News</h4>
-                <ul>
-                <li><em>On-going development:</em>
-                <a href="whats_new.html"><em>What's new</em> (changelog)</a>
-                </li>
-                <li><em>March 2015.</em> scikit-learn 0.16.0 is available for download (<a href="whats_new.html">Changelog</a>).
-                </li>
-                <li><em>July 2014.</em> scikit-learn 0.15.0 is available for download (<a href="whats_new.html">Changelog</a>).
-                </li>
-                <li><em>July 14-20th, 2014: international sprint.</em>
-                During this week-long sprint, we gathered 18 of the core
-                contributors in Paris.
-                We want to thank our sponsors:
-                <a href="http://www.campus-paris-saclay.fr/en/Idex-Paris-Saclay/Les-Lidex/Paris-Saclay-Center-for-Data-Science">
-                Paris-Saclay Center for Data Science</a>
-                & <a href="https://digicosme.lri.fr">Digicosme</a> and our
-                hosts <a href="http://lapaillasse.org">La Paillasse</a>,
-                <a href="http://www.criteo.com/">Criteo</a>,
-                <a href="http://www.inria.fr/">Inria</a>,
-                and <a href="http://www.tinyclues.com/">tinyclues</a>.
-                </li>
-                <li><em>August 2013.</em> scikit-learn 0.14 is available for download (<a href="whats_new.html">Changelog</a>).
-                </li>
-                </ul>
-            </div>
 
-            <!-- Community -->
-            <div class="span4">
-                <h4>Community</h4>
-                <ul>
-                <li><em>About us</em> See <a href="about.html#people">authors</a></li>
-                <li><em>More Machine Learning</em> Find <a href="related_projects.html">related projects</a></li>
-                <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
-                <li><em>Mailing list:</em> <a href="https://lists.sourceforge.net/lists/listinfo/scikit-learn-general">scikit-learn-general@lists.sourceforge.net</a></li>
-                <li><em>IRC:</em> #scikit-learn @ <a href="http://webchat.freenode.net/">freenode</a></li>
-                </ul>
+        <!-- Classification -->
+        <div class="span4 box">
+        <h2 >
 
-                <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">
-                    <input type="hidden" value="_s-xclick" name="cmd">
-                    <input type="hidden" value="74EYUMF3FTSW8" name="hosted_button_id">
-                </form>
+    :ref:`Classification <supervised-learning>`
 
-                <a class="btn btn-warning btn-big" onclick="document.getElementById('paypal-form').submit(); return false;">Help us, <strong>donate!</strong></a>
-                <a class="btn btn-warning btn-big cite-us" href="./about.html#citing-scikit-learn"><strong>Cite us!</strong></a>
+    .. raw:: html
 
-                <small style="display: block; margin-top: 10px"><a href="about.html#funding">Read more about donations</a></small>
-            </div>
+        </h2>
+        <blockquote>
+        <p>Identifying to which category an object belongs to.</p>
+        <div class="box-links">
+        <strong>Applications</strong>: Spam detection, Image recognition.</br>
+        <strong>Algorithms</strong>:&nbsp;
 
-            <!-- who using -->
-            <div class="span4">
-                <h4>Who uses scikit-learn?</h4>
+    :ref:`SVM<svm>`, :ref:`nearest neighbors<classification>`, :ref:`random forest<forest>`, ...
 
-                <div id="testimonials_carousel" class="carousel slide">
-                    <div class="carousel-inner">
-                        <div class="active item">
-                          <img src="_images/inria.png" class="thumbnail" />
-                          <p>
-                          <em>"We use scikit-learn to support leading-edge basic research [...]"</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/spotify.png" class="thumbnail" />
-                          <p>
-                          <em>"I think it's the most well-designed ML package I've seen so far."</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/change-logo.png" class="thumbnail" />
-                          <p>
-                          <em>"scikit-learn's ease-of-use, performance and overall variety of algorithms implemented has proved invaluable [...]."</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/evernote.png" class="thumbnail" />
-                          <p>
-                          <em>"For these tasks, we relied on the excellent scikit-learn package for Python."</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/telecomparistech.jpg"
-                               class="thumbnail" />
-                          <p>
-                          <em>"The great benefit of scikit-learn is its fast learning curve [...]"</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/aweber.png" class="thumbnail" />
-                          <p>
-                          <em>"It allows us to do AWesome stuff we would not otherwise accomplish"</em>
-                          </p>
-                        </div>
-                        <div class="item">
-                          <img src="_images/yhat.png" class="thumbnail" />
-                          <p>
-                          <em>"scikit-learn makes doing advanced analysis in Python accessible to anyone."</em>
-                          </p>
+    .. raw:: html
+
+        <small class="float-right box-example-links">
+
+    :ref:`Examples<general_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+        <!-- Regression -->
+        <div class="span4 box">
+        <h2>
+
+    :ref:`Regression <supervised-learning>`
+
+    .. raw:: html
+
+        </h2>
+        <blockquote>
+        <p>Predicting a continuous-valued attribute associated with an object.</p>
+        <div class="box-links">
+        <strong>Applications</strong>: Drug response, Stock prices.</br>
+        <strong>Algorithms</strong>:&nbsp;
+
+    :ref:`SVR<svm>`, :ref:`ridge regression<ridge_regression>`, :ref:`Lasso<lasso>`, ...
+
+    .. raw:: html
+
+        <small class="float-right box-example-links">
+
+    :ref:`Examples<general_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+        <!-- Clustering -->
+        <div class="span4 box">
+        <h2>
+
+    :ref:`Clustering<clustering>`
+
+    .. raw:: html
+
+        </h2>
+        <blockquote>
+        <p>Automatic grouping of similar objects into sets.</p>
+        <div class="box-links">
+        <strong>Applications</strong>: Customer segmentation, Grouping experiment outcomes</br>
+        <strong>Algorithms</strong>:&nbsp;
+
+    :ref:`k-Means<k_means>`, :ref:`spectral clustering<spectral_clustering>`, :ref:`mean-shift<mean_shift>`, ...
+
+    .. raw:: html
+
+        <small class="float-right example-links">
+
+    :ref:`Examples<cluster_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+        <!-- row -->
+        </div>
+        <div class="row-fluid">
+
+        <!-- Dimension reduction -->
+        <div class="span4 box">
+        <h2>
+
+    :ref:`Dimensionality reduction<decompositions>`
+
+    .. raw:: html
+
+        </h2>
+        <blockquote>
+        <p>Reducing the number of random variables to consider.</p>
+        <div class="box-links">
+        <strong>Applications</strong>: Visualization, Increased efficiency</br>
+        <strong>Algorithms</strong>:&nbsp;
+
+    :ref:`PCA<PCA>`, :ref:`feature selection<feature_selection>`, :ref:`non-negative matrix factorization<NMF>`.
+
+    .. raw:: html
+
+        <small class="float-right example-links">
+
+    :ref:`Examples<decomposition_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+        <!-- Model selection -->
+        <div class="span4 box">
+        <h2>
+
+    :ref:`Model selection<model_selection>`
+
+    .. raw:: html
+
+        </h2>
+        <blockquote>
+        <p>Comparing, validating and choosing parameters and models.</p>
+        <div class="box-links">
+        <strong>Goal</strong>: Improved accuracy via parameter tuning</br>
+        <strong>Modules</strong>:&nbsp;
+
+    :ref:`grid search<grid_search>`, :ref:`cross validation<cross_validation>`, :ref:`metrics<model_evaluation>`.
+
+    .. raw:: html
+
+        <small class="float-right example-links">
+
+    :ref:`Examples<general_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+
+        <!-- Preprocessing -->
+        <div class="span4 box">
+        <h2>
+
+    :ref:`Preprocessing<preprocessing>`
+
+    .. raw:: html
+
+        </h2>
+        <blockquote>
+        <p>Feature extraction and normalization.</p>
+        <div class="box-links">
+        <strong>Application</strong>: Transforming input data such as text for use with machine learning algorithms.</br>
+        <strong>Modules</strong>:&nbsp;
+
+    :ref:`preprocessing<preprocessing>`, :ref:`feature extraction<feature_extraction>`.
+
+    .. raw:: html
+
+        <span class="example-links">
+        <small class="float-right example-links">
+
+    :ref:`Examples<general_examples>`
+
+    .. raw:: html
+
+        </small>
+        </div>
+        </blockquote>
+        </div>
+
+        <!-- row -->
+        </div>
+        </div> <!-- container -->
+
+
+        <div class="container index-lower">
+            <div class="row-fluid">
+                <!-- News -->
+                <div class="span4">
+                    <h4>News</h4>
+                    <ul>
+                    <li><em>On-going development:</em>
+                    <a href="whats_new.html"><em>What's new</em> (changelog)</a>
+                    </li>
+                    <li><em>March 2015.</em> scikit-learn 0.16.0 is available for download (<a href="whats_new.html">Changelog</a>).
+                    </li>
+                    <li><em>July 2014.</em> scikit-learn 0.15.0 is available for download (<a href="whats_new.html">Changelog</a>).
+                    </li>
+                    <li><em>July 14-20th, 2014: international sprint.</em>
+                    During this week-long sprint, we gathered 18 of the core
+                    contributors in Paris.
+                    We want to thank our sponsors:
+                    <a href="http://www.campus-paris-saclay.fr/en/Idex-Paris-Saclay/Les-Lidex/Paris-Saclay-Center-for-Data-Science">
+                    Paris-Saclay Center for Data Science</a>
+                    & <a href="https://digicosme.lri.fr">Digicosme</a> and our
+                    hosts <a href="http://lapaillasse.org">La Paillasse</a>,
+                    <a href="http://www.criteo.com/">Criteo</a>,
+                    <a href="http://www.inria.fr/">Inria</a>,
+                    and <a href="http://www.tinyclues.com/">tinyclues</a>.
+                    </li>
+                    <li><em>August 2013.</em> scikit-learn 0.14 is available for download (<a href="whats_new.html">Changelog</a>).
+                    </li>
+                    </ul>
+                </div>
+
+                <!-- Community -->
+                <div class="span4">
+                    <h4>Community</h4>
+                    <ul>
+                    <li><em>About us</em> See <a href="about.html#people">authors</a></li>
+                    <li><em>More Machine Learning</em> Find <a href="related_projects.html">related projects</a></li>
+                    <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
+                    <li><em>Mailing list:</em> <a href="https://lists.sourceforge.net/lists/listinfo/scikit-learn-general">scikit-learn-general@lists.sourceforge.net</a></li>
+                    <li><em>IRC:</em> #scikit-learn @ <a href="http://webchat.freenode.net/">freenode</a></li>
+                    </ul>
+
+                    <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">
+                        <input type="hidden" value="_s-xclick" name="cmd">
+                        <input type="hidden" value="74EYUMF3FTSW8" name="hosted_button_id">
+                    </form>
+
+                    <a class="btn btn-warning btn-big" onclick="document.getElementById('paypal-form').submit(); return false;">Help us, <strong>donate!</strong></a>
+                    <a class="btn btn-warning btn-big cite-us" href="./about.html#citing-scikit-learn"><strong>Cite us!</strong></a>
+
+                    <small style="display: block; margin-top: 10px"><a href="about.html#funding">Read more about donations</a></small>
+                </div>
+
+                <!-- who using -->
+                <div class="span4">
+                    <h4>Who uses scikit-learn?</h4>
+
+                    <div id="testimonials_carousel" class="carousel slide">
+                        <div class="carousel-inner">
+                            <div class="active item">
+                              <img src="_images/inria.png" class="thumbnail" />
+                              <p>
+                              <em>"We use scikit-learn to support leading-edge basic research [...]"</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/spotify.png" class="thumbnail" />
+                              <p>
+                              <em>"I think it's the most well-designed ML package I've seen so far."</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/change-logo.png" class="thumbnail" />
+                              <p>
+                              <em>"scikit-learn's ease-of-use, performance and overall variety of algorithms implemented has proved invaluable [...]."</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/evernote.png" class="thumbnail" />
+                              <p>
+                              <em>"For these tasks, we relied on the excellent scikit-learn package for Python."</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/telecomparistech.jpg"
+                                   class="thumbnail" />
+                              <p>
+                              <em>"The great benefit of scikit-learn is its fast learning curve [...]"</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/aweber.png" class="thumbnail" />
+                              <p>
+                              <em>"It allows us to do AWesome stuff we would not otherwise accomplish"</em>
+                              </p>
+                            </div>
+                            <div class="item">
+                              <img src="_images/yhat.png" class="thumbnail" />
+                              <p>
+                              <em>"scikit-learn makes doing advanced analysis in Python accessible to anyone."</em>
+                              </p>
+                            </div>
                         </div>
                     </div>
+                    <p align="right">
+                    <small class="example-link">
+                    <a href="testimonials/testimonials.html">More testimonials</a>
+                    </small>
+                    </p>
                 </div>
-                <p align="right">
-                <small class="example-link">
-                <a href="testimonials/testimonials.html">More testimonials</a>
-                </small>
-                </p>
+
             </div>
-
         </div>
-    </div>
 
-    <!--Bottom of index page contributions logos-->
-    <div class="container index-upper" >
-	<div class="row-fluid">
-	  <div class="footer">
-	      <div class="span4">
-	        Generous funding provided by INRIA, Google and others.
-	      </div>
-	      <div class="span4">
-   	         <a class="reference internal" href="about.html#funding" style="text-decoration: none" >
-    	           <img id="index-funding-logo-big" src="_static/img/inria-small.png" title="INRIA">
-	           <img id="index-funding-logo-small" src="_static/img/google.png" title="Google">
-	           <!--Due to Télécom ParisTech's logo text being smaller, a style has been added to improve readability-->
-	           <img id="index-funding-logo-small" src="_static/img/telecom.png" title="Télécom ParisTech" style="max-height: 36px">
-	           <img id="index-funding-logo-small" src="_static/img/FNRS-logo.png" title="FNRS">
-	         </a>
-	     </div>
-	     <div class="span4">
-	        <a class="reference internal" href="about.html#funding">
-	           More information on our contributors
-	        </a>
-	     </div>
-	  </div>
-	</div>
-      </div>
-    </div>
+        <!--Bottom of index page contributions logos-->
+        <div class="container index-upper" >
+        <div class="row-fluid">
+          <div class="footer">
+              <div class="span4">
+                Generous funding provided by INRIA, Google and others.
+              </div>
+              <div class="span4">
+                 <a class="reference internal" href="about.html#funding" style="text-decoration: none" >
+                       <img id="index-funding-logo-big" src="_static/img/inria-small.png" title="INRIA">
+                   <img id="index-funding-logo-small" src="_static/img/google.png" title="Google">
+                   <!--Due to Télécom ParisTech's logo text being smaller, a style has been added to improve readability-->
+                   <img id="index-funding-logo-small" src="_static/img/telecom.png" title="Télécom ParisTech" style="max-height: 36px">
+                   <img id="index-funding-logo-small" src="_static/img/FNRS-logo.png" title="FNRS">
+                 </a>
+             </div>
+             <div class="span4">
+                <a class="reference internal" href="about.html#funding">
+                   More information on our contributors
+                </a>
+             </div>
+          </div>
+        </div>
+          </div>
+        </div>
 
 
-    <script>
-      $('#testimonials_carousel').carousel()
-    </script>
+        <script>
+          $('#testimonials_carousel').carousel()
+        </script>
 
 .. Define an order for the Table of Contents:
 

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -564,7 +564,7 @@ def line_count_sort(file_list, target_dir):
     return np.array(unsorted[index][:, 0]).tolist()
 
 
-def _thumbnail_div(subdir, full_dir, fname, snippet):
+def _thumbnail_div(subdir, full_dir, fname, snippet, is_backref=False):
     """Generates RST to place a thumbnail in a gallery"""
     thumb = os.path.join(full_dir, 'images', 'thumb', fname[:-3] + '.png')
     link_name = os.path.join(full_dir, fname).replace(os.path.sep, '_')
@@ -576,19 +576,19 @@ def _thumbnail_div(subdir, full_dir, fname, snippet):
 
 .. raw:: html
 
-
     <div class="thumbnailContainer" tooltip="{}">
 
 """.format(snippet))
 
-    out.append('.. figure:: %s\n' % thumb)
+    out.append('.. only:: html\n\n')
+    out.append('  .. figure:: %s\n' % thumb)
     if link_name.startswith('._'):
         link_name = link_name[2:]
     if full_dir != '.':
-        out.append('   :target: ./%s/%s.html\n\n' % (full_dir, fname[:-3]))
+        out.append('    :target: ./%s/%s.html\n\n' % (full_dir, fname[:-3]))
     else:
-        out.append('   :target: ./%s.html\n\n' % link_name[:-3])
-    out.append("""   :ref:`example_%s`
+        out.append('    :target: ./%s.html\n\n' % link_name[:-3])
+    out.append("""    :ref:`example_%s`
 
 
 .. raw:: html
@@ -596,6 +596,8 @@ def _thumbnail_div(subdir, full_dir, fname, snippet):
     </div>
 
 """ % (ref_name))
+    if is_backref:
+        out.append('.. only:: not html\n\n  * :ref:`example_%s`' % ref_name)
     return ''.join(out)
 
 
@@ -651,7 +653,7 @@ def generate_dir_rst(directory, fhindex, example_dir, root_dir, plot_gallery, se
                               file=ex_file)
                         print(file=ex_file)
                     rel_dir = os.path.join('../../auto_examples', directory)
-                    ex_file.write(_thumbnail_div(directory, rel_dir, fname, snippet))
+                    ex_file.write(_thumbnail_div(directory, rel_dir, fname, snippet, is_backref=True))
                     seen_backrefs.add(backref)
     fhindex.write("""
 .. raw:: html

--- a/doc/testimonials/testimonials.rst
+++ b/doc/testimonials/testimonials.rst
@@ -19,6 +19,7 @@ Who is using scikit-learn?
     <div class="logo">
 
 .. image:: images/spotify.png
+    :width: 120pt
     :target: http://www.spotify.com
 
 .. raw:: html
@@ -49,7 +50,8 @@ Erik Bernhardsson, Engineering Manager Music Discovery & Machine Learning, Spoti
   <div class="logo">
 
 .. image:: images/inria.png
-   :target: http://www.inria.fr
+    :width: 120pt
+    :target: http://www.inria.fr
 
 .. raw:: html
 
@@ -88,7 +90,8 @@ Gaël Varoquaux, research at Parietal
   <div class="logo">
 
 .. image:: images/evernote.png
-   :target: https://evernote.com
+    :width: 120pt
+    :target: https://evernote.com
 
 .. raw:: html
 
@@ -121,7 +124,8 @@ Mark Ayzenshtat, VP, Augmented Intelligence
   <div class="logo">
 
 .. image:: images/telecomparistech.jpg
-   :target: https://www.telecom-paristech.fr
+    :width: 120pt
+    :target: https://www.telecom-paristech.fr
 
 .. raw:: html
 
@@ -153,7 +157,8 @@ Alexandre Gramfort, Assistant Professor
   <div class="logo">
 
 .. image:: images/aweber.png
-   :target: http://aweber.com/
+    :width: 120pt
+    :target: http://aweber.com/
 
 .. raw:: html
 
@@ -191,7 +196,8 @@ Michael Becker, Software Engineer, Data Analysis and Management Ninjas
   <div class="logo">
 
 .. image:: images/yhat.png
-   :target: http://yhathq.com/
+    :width: 120pt
+    :target: http://yhathq.com/
 
 .. raw:: html
 
@@ -223,7 +229,8 @@ Greg Lamp, Co-founder Yhat
   <div class="logo">
 
 .. image:: images/rangespan.png
-   :target: https://www.rangespan.com
+    :width: 120pt
+    :target: https://www.rangespan.com
 
 .. raw:: html
 
@@ -255,7 +262,8 @@ Jurgen Van Gael, Data Science Director at Rangespan Ltd
   <div class="logo">
 
 .. image:: images/birchbox.jpg
-   :target: https://www.birchbox.com
+    :width: 120pt
+    :target: https://www.birchbox.com
 
 .. raw:: html
 
@@ -289,7 +297,8 @@ Thierry Bertin-Mahieux, Birchbox, Data Scientist
   <div class="logo">
 
 .. image:: images/bestofmedia-logo.png
-   :target: http://www.bestofmedia.com
+    :width: 120pt
+    :target: http://www.bestofmedia.com
 
 .. raw:: html
 
@@ -321,7 +330,8 @@ Eustache Diemert, Lead Scientist Bestofmedia Group
   <div class="logo">
 
 .. image:: images/change-logo.png
-   :target: http://www.change.org
+    :width: 120pt
+    :target: http://www.change.org
 
 .. raw:: html
 
@@ -351,7 +361,8 @@ Vijay Ramesh, Software Engineer in Data/science at Change.org
   <div class="logo">
 
 .. image:: images/phimeca.png
-   :target: http://www.phimeca.com/?lang=en
+    :width: 120pt
+    :target: http://www.phimeca.com/?lang=en
 
 .. raw:: html
 
@@ -385,7 +396,8 @@ Vincent Dubourg, PHIMECA Engineering, PhD Engineer
   <div class="logo">
 
 .. image:: images/howaboutwe.png
-   :target: http://www.howaboutwe.com/
+    :width: 120pt
+    :target: http://www.howaboutwe.com/
 
 .. raw:: html
 
@@ -419,7 +431,8 @@ Daniel Weitzenfeld, Senior Data Scientist at HowAboutWe
   <div class="logo">
 
 .. image:: images/peerindex.png
-   :target: http://www.peerindex.com/
+    :width: 120pt
+    :target: http://www.peerindex.com/
 
 .. raw:: html
 
@@ -454,6 +467,7 @@ Ferenc Huszar - Senior Data Scientist at Peerindex
     <div class="logo">
 
 .. image:: images/datarobot.png
+    :width: 120pt
     :target: http://www.datarobot.com
 
 .. raw:: html
@@ -481,6 +495,7 @@ Jeremy Achin, CEO & Co-founder DataRobot Inc.
     <div class="logo">
 
 .. image:: images/okcupid.png
+    :width: 120pt
     :target: https://www.okcupid.com
 
 .. raw:: html
@@ -512,6 +527,7 @@ David Koh - Senior Data Scientist at OkCupid
     <div class="logo">
 
 .. image:: images/lovely.png
+    :width: 120pt
     :target: https://www.livelovely.com
 
 .. raw:: html
@@ -546,6 +562,7 @@ Simon Frid - Data Scientist, Lead at Lovely
     <div class="logo">
 
 .. image:: images/datapublica.png
+    :width: 120pt
     :target: http://www.data-publica.com/
 
 .. raw:: html
@@ -578,7 +595,8 @@ Guillaume Lebourgeois & Samuel Charron - Data Scientists at Data Publica
    <div class="logo">
 
 .. image:: images/machinalis.png
-   :target: http://www.machinalis.com
+    :width: 120pt
+    :target: http://www.machinalis.com
 
 .. raw:: html
 
@@ -611,7 +629,8 @@ Rafael Carrascosa, Lead developer
    <div class="logo">
 
 .. image:: images/solido_logo.png
-   :target: http://www.solidodesign.com
+    :width: 120pt
+    :target: http://www.solidodesign.com
 
 .. raw:: html
 
@@ -648,7 +667,8 @@ Trent McConaghy, founder, Solido Design Automation Inc.
    <div class="logo">
 
 .. image:: images/infonea.jpg
-   :target: http://www.infonea.com/en
+    :width: 120pt
+    :target: http://www.infonea.com/en
 
 .. raw:: html
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -80,6 +80,7 @@
             <li class="divider"></li>
                 <li><a href="http://scikit-learn.org/stable/documentation.html">Scikit-learn 0.16.1 (stable)</a></li>
                 <li><a href="http://scikit-learn.org/0.15/documentation.html">Scikit-learn 0.15</a></li>
+				<li><a href="{{ pathto('_downloads/user_guide.pdf', 1) }}">PDF documentation</a></li>
               </ul>
             </div>
         </li>

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,8 +6,8 @@
 Release history
 ===============
 
-0.17
-====
+Version 0.17
+============
 
 
 Changelog
@@ -157,8 +157,8 @@ API changes summary
 
 .. _changes_0_1_16:
 
-0.16.1
-=======
+Version 0.16.1
+===============
 
 Changelog
 ---------
@@ -189,8 +189,8 @@ Bug fixes
 
 .. _changes_0_16:
 
-0.16
-====
+Version 0.16
+============
 
 Highlights
 -----------
@@ -652,8 +652,8 @@ API changes summary
 
 .. _changes_0_15_2:
 
-0.15.2
-======
+Version 0.15.2
+==============
 
 Bug fixes
 ---------
@@ -694,8 +694,8 @@ Bug fixes
 
 .. _changes_0_15_1:
 
-0.15.1
-======
+Version 0.15.1
+==============
 
 Bug fixes
 ---------
@@ -733,8 +733,8 @@ Bug fixes
 
 .. _changes_0_15:
 
-0.15
-====
+Version 0.15
+============
 
 Highlights
 -----------
@@ -1261,8 +1261,8 @@ List of contributors for release 0.15 by number of commits.
 
 .. _changes_0_14:
 
-0.14
-=======
+Version 0.14
+===============
 
 Changelog
 ---------
@@ -1644,8 +1644,8 @@ List of contributors for release 0.14 by number of commits.
 
 .. _changes_0_13_1:
 
-0.13.1
-======
+Version 0.13.1
+==============
 
 The 0.13.1 release only fixes some bugs and does not add any new functionality.
 
@@ -1690,8 +1690,8 @@ List of contributors for release 0.13.1 by number of commits.
 
 .. _changes_0_13:
 
-0.13
-====
+Version 0.13
+============
 
 New Estimator Classes
 ---------------------
@@ -2028,8 +2028,8 @@ List of contributors for release 0.13 by number of commits.
 
 .. _changes_0_12.1:
 
-0.12.1
-=======
+Version 0.12.1
+===============
 
 The 0.12.1 release is a bug-fix release with no additional features, but is
 instead a set of bug fixes
@@ -2073,8 +2073,8 @@ People
 
 .. _changes_0_12:
 
-0.12
-====
+Version 0.12
+============
 
 Changelog
 ---------
@@ -2266,8 +2266,8 @@ People
 
 .. _changes_0_11:
 
-0.11
-====
+Version 0.11
+============
 
 Changelog
 ---------
@@ -2501,8 +2501,8 @@ People
 
 .. _changes_0_10:
 
-0.10
-====
+Version 0.10
+============
 
 Changelog
 ---------
@@ -2686,8 +2686,8 @@ The following people contributed to scikit-learn since last release:
 
 .. _changes_0_9:
 
-0.9
-===
+Version 0.9
+===========
 
 scikit-learn 0.9 was released on September 2011, three months after the 0.8
 release and includes the new modules :ref:`manifold`, :ref:`dirichlet_process`
@@ -2923,8 +2923,8 @@ People
 
 .. _changes_0_8:
 
-0.8
-===
+Version 0.8
+===========
 
 scikit-learn 0.8 was released on May 2011, one month after the first
 "international" `scikit-learn coding sprint
@@ -3023,8 +3023,8 @@ People that made this release possible preceded by number of commits:
 
 .. _changes_0_7:
 
-0.7
-===
+Version 0.7
+===========
 
 scikit-learn 0.7 was released in March 2011, roughly three months
 after the 0.6 release. This release is marked by the speed
@@ -3114,8 +3114,8 @@ People that made this release possible preceded by number of commits:
 
 .. _changes_0_6:
 
-0.6
-===
+Version 0.6
+===========
 
 scikit-learn 0.6 was released on December 2010. It is marked by the
 inclusion of several new modules and a general renaming of old
@@ -3214,8 +3214,8 @@ People that made this release possible preceded by number of commits:
 .. _changes_0_5:
 
 
-0.5
-===
+Version 0.5
+===========
 
 Changelog
 ---------
@@ -3326,8 +3326,8 @@ number of commits:
      *   1  Ariel Rokem
      *   1  Matthieu Brucher
 
-0.4
-===
+Version 0.4
+===========
 
 Changelog
 ---------


### PR DESCRIPTION
There has been some interest, apparently, in PDF documentation. I can see it provides a few benefits, even if it's certainly not how the documentation is intended.

We've fixed up a few glitches with it previously. This PR combines a few further fixes:
- a patch to example gallery generation that has been accepted to Sphinx-Gallery (https://github.com/sphinx-gallery/sphinx-gallery/pull/59)
- image sizes (Sphinx image sizes in px are ignored when generating latex)
- some other HTML-specific content that was showing up strangely
- making what's new substantially more readable in PDF

The last change is likely more controversial: I've added a Makefile command `dist` to compile the PDF and copy into into the html directory structure, where it is linked from `layout.html`.
