### PR TITLE
[MRG+1] MAINT bump joblib to 0.9.0b4 to use forkserver for Py3 & POSIX

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -225,9 +225,13 @@ consider the lack of fork-safety in Accelerate / vecLib as a bug.
 
 In Python 3.4+ it is now possible to configure ``multiprocessing`` to use the
 'forkserver' or 'spawn' start methods (instead of the default 'fork') to manage
-the process pools. This should make it possible to not be subject to this issue
-anymore. To set the 'forkserver' mode globally for your program, insert the
-following instructions in your main script::
+the process pools. This makes it possible to not be subject to this issue
+anymore. The version of joblib shipped with scikit-learn automatically uses
+that setting by default (under Python 3.4 and later).
+
+If you have custom code that uses ``multiprocessing`` directly instead of using
+it via joblib you can enable the the 'forkserver' mode globally for your
+program: Insert the following instructions in your main script::
 
     import multiprocessing
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -111,12 +111,17 @@ Enhancements
    - RCV1 dataset loader (:func:`sklearn.datasets.fetch_rcv1`).
      By `Tom Dupre la Tour`_.
 
-   - Upgraded to joblib 0.9.0b2 to benefit from the new automatic batching of
+   - Upgraded to joblib 0.9.0b4 to benefit from the new automatic batching of
      short tasks. This makes it possible for scikit-learn to benefit from
      parallelism when many very short tasks are executed in parallel, for
      instance by the :class:`grid_search.GridSearchCV` meta-estimator
      with ``n_jobs > 1`` used with a large grid of parameters on a small
      dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and `Loic Esteve`_.
+
+   - Joblib 0.9.0b4 also enables the ``forkserver`` start method for
+     multiprocessing by default under non-Windows platforms for Python 3.4
+     and later in order to avoid possible crash with some version of BLAS such
+     as vecLib / Accelerate under OSX for instance. By `Olivier Grisel`_.
 
    - Improved speed (3 times per iteration) of
      :class:`decomposition.DictLearning` with coordinate descent method

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -15,7 +15,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import if_not_mac_os
+from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.utils.validation import DataConversionWarning
 from sklearn.utils.extmath import row_norms
@@ -193,15 +193,11 @@ def test_k_means_new_centers():
         np.testing.assert_array_equal(this_labels, labels)
 
 
-def _has_blas_lib(libname):
-    from numpy.distutils.system_info import get_info
-    return libname in get_info('blas_opt').get('libraries', [])
-
-
-@if_not_mac_os()
+@if_safe_multiprocessing_with_blas
 def test_k_means_plus_plus_init_2_jobs():
-    if _has_blas_lib('openblas'):
-        raise SkipTest('Multi-process bug with OpenBLAS (see issue #636)')
+    if sys.version_info[:2] < (3, 4):
+        raise SkipTest(
+            "Possible multi-process bug with some BLAS under Python < 3.4")
 
     km = KMeans(init="k-means++", n_clusters=n_clusters, n_jobs=2,
                 random_state=42).fit(X)
@@ -263,7 +259,7 @@ def test_k_means_n_init():
 
 
 def test_k_means_fortran_aligned_data():
-    # Check the KMeans will work well, even if X is a fortran-aligned data. 
+    # Check the KMeans will work well, even if X is a fortran-aligned data.
     X = np.asfortranarray([[0, 0], [0, 1], [0, 1]])
     centers = np.array([[0, 0], [0, 1]])
     labels = np.array([0, 1, 1])

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -13,7 +13,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import assert_raises_regexp
-from sklearn.utils.testing import if_not_mac_os
+from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.utils.validation import NotFittedError
 from sklearn.externals.six.moves import xrange
@@ -187,7 +187,7 @@ def test_lda_transform_mismatch():
     assert_raises_regexp(ValueError, r"^The provided data has", lda.partial_fit, X_2)
 
 
-@if_not_mac_os()
+@if_safe_multiprocessing_with_blas
 def test_lda_multi_jobs():
     # Test LDA batch training with multi CPU
     for method in ('online', 'batch'):
@@ -203,7 +203,7 @@ def test_lda_multi_jobs():
             assert_true(tuple(sorted(top_idx)) in correct_idx_grps)
 
 
-@if_not_mac_os()
+@if_safe_multiprocessing_with_blas
 def test_lda_partial_fit_multi_jobs():
     # Test LDA online training with multi CPU
     rng = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -11,7 +11,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import if_not_mac_os
+from sklearn.utils.testing import if_safe_multiprocessing_with_blas
 
 from sklearn.decomposition import SparsePCA, MiniBatchSparsePCA
 from sklearn.utils import check_random_state
@@ -71,7 +71,7 @@ def test_fit_transform():
     assert_array_almost_equal(spca_lasso.components_, spca_lars.components_)
 
 
-@if_not_mac_os()
+@if_safe_multiprocessing_with_blas
 def test_fit_transform_parallel():
     alpha = 1
     rng = np.random.RandomState(0)

--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -116,7 +116,7 @@ Main features
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.9.0b3'
+__version__ = '0.9.0b4'
 
 
 from .memory import Memory, MemorizedResult

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -49,6 +49,18 @@ MIN_IDEAL_BATCH_DURATION = .2
 # on a single worker while other workers have no work to process any more.
 MAX_IDEAL_BATCH_DURATION = 2
 
+# Under Python 3.4+ use the 'forkserver' start method by default: this makes it
+# possible to avoid crashing 3rd party libraries that manage an internal thread
+# pool that does not tolerate forking
+if hasattr(mp, 'get_start_method'):
+    method = os.environ.get('JOBLIB_START_METHOD')
+    if (method is None and mp.get_start_method() == 'fork'
+            and 'forkserver' in mp.get_all_start_methods()):
+        method = 'forkserver'
+    DEFAULT_MP_CONTEXT = mp.get_context(method=method)
+else:
+    DEFAULT_MP_CONTEXT = None
+
 
 class BatchedCalls(object):
     """Wrap a sequence of (func, args, kwargs) tuples as a single callable"""
@@ -406,10 +418,10 @@ class Parallel(Logger):
          [Parallel(n_jobs=2)]: Done   6 out of   6 | elapsed:    0.0s finished
     '''
     def __init__(self, n_jobs=1, backend='multiprocessing', verbose=0,
-                 pre_dispatch='2 * n_jobs', batch_size='auto', temp_folder=None,
-                 max_nbytes='1M', mmap_mode='r'):
+                 pre_dispatch='2 * n_jobs', batch_size='auto',
+                 temp_folder=None, max_nbytes='1M', mmap_mode='r'):
         self.verbose = verbose
-        self._mp_context = None
+        self._mp_context = DEFAULT_MP_CONTEXT
         if backend is None:
             # `backend=None` was supported in 0.8.2 with this effect
             backend = "multiprocessing"


### PR DESCRIPTION
This upgrades joblib to use the safer forkserver mode of multiprocessing under Python 3.4 and later by default.
