### PR TITLE
[MRG+1] Enabling sample weights for 3 of the 4 logistic regression solvers

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -184,6 +184,10 @@ Enhancements
    - Added optional parameter ``warm_start`` in
      :class:`linear_model.LogisticRegression`. If set to True, the solvers ``lbfgs``, ``newton-cg`` and ``sag`` will be initialized with the coefficients computed in the previous fit. By `Tom Dupre la Tour`_.
 
+   - Added ``sample_weight`` support to :class:`linear_model.LogisticRegression` for
+     the ``lbfgs``, ``newton-cg``, and ``sag`` solvers. By `Valentin Stolbunov`_.
+
+
 Bug fixes
 .........
 
@@ -3676,3 +3680,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Daniel Galvez: https://github.com/galv
 .. _Jacob Schreiber: https://github.com/jmschrei
 .. _Ankur Ankan: https://github.com/ankurankan
+.. _Valentin Stolbunov: http://vstolbunov.com

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -54,10 +54,10 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
     support_sample_weight = has_fit_parameter(ensemble.base_estimator_,
                                               "sample_weight")
     # Logistic regression does not support sample weights with liblinear
-    # TODO: Remove this check when liblinear is patched to support 
+    # TODO: Remove this check when liblinear is patched to support
     #       sample weights
-    if (isinstance(ensemble.base_estimator_,LogisticRegression) and 
-            (ensemble.base_estimator_.solver=='liblinear')):
+    if (isinstance(ensemble.base_estimator_, LogisticRegression) and
+            (ensemble.base_estimator_.solver == 'liblinear')):
         support_sample_weight = False
 
     if not support_sample_weight and sample_weight is not None:

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -17,6 +17,7 @@ from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
 from ..metrics import r2_score, accuracy_score
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
+from ..linear_model import LogisticRegression
 from ..utils import check_random_state, check_X_y, check_array, column_or_1d
 from ..utils.random import sample_without_replacement
 from ..utils.validation import has_fit_parameter, check_is_fitted
@@ -52,6 +53,13 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
     bootstrap_features = ensemble.bootstrap_features
     support_sample_weight = has_fit_parameter(ensemble.base_estimator_,
                                               "sample_weight")
+    # Logistic regression does not support sample weights with liblinear
+    # TODO: Remove this check when liblinear is patched to support 
+    #       sample weights
+    if (isinstance(ensemble.base_estimator_,LogisticRegression) and 
+            (ensemble.base_estimator_.solver=='liblinear')):
+        support_sample_weight = False
+
     if not support_sample_weight and sample_weight is not None:
         raise ValueError("The base estimator doesn't support sample weight")
 

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -583,7 +583,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     # and check length
     # Otherwise set them to 1 for all examples
     if sample_weight is not None:
-        sample_weight = np.array(sample_weight)
+        sample_weight = np.array(sample_weight, dtype=np.float64, order='C')
         check_consistent_length(y, sample_weight)
     else:
         sample_weight = np.ones(X.shape[0])

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -78,7 +78,7 @@ def _logistic_loss_and_grad(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -129,7 +129,7 @@ def _logistic_loss(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -165,7 +165,7 @@ def _logistic_grad_hess(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -242,7 +242,7 @@ def _multinomial_loss(w, X, Y, alpha, sample_weight):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -293,7 +293,7 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
 
     Returns
@@ -340,7 +340,7 @@ def _multinomial_grad_hess(w, X, Y, alpha, sample_weight):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : ndarray, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) optional
         Array of weights that are assigned to individual samples.
 
     Returns
@@ -394,7 +394,7 @@ def _multinomial_grad_hess(w, X, Y, alpha, sample_weight):
     return grad, hessp
 
 
-def _check_solver_option(solver, multi_class, penalty, dual):
+def _check_solver_option(solver, multi_class, penalty, dual, sample_weight):
     if solver not in ['liblinear', 'newton-cg', 'lbfgs', 'sag']:
         raise ValueError("Logistic Regression supports only liblinear,"
                          " newton-cg, lbfgs and sag solvers, got %s" % solver)
@@ -415,6 +415,10 @@ def _check_solver_option(solver, multi_class, penalty, dual):
             raise ValueError("Solver %s supports only "
                              "dual=False, got dual=%s" % (solver, dual))
 
+    if solver == 'liblinear' and sample_weight is not None:
+        raise ValueError("Solver %s does not support "
+                          "sample weights." % solver)
+
 
 def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                              max_iter=100, tol=1e-4, verbose=0,
@@ -422,7 +426,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                              class_weight=None, dual=False, penalty='l2',
                              intercept_scaling=1., multi_class='ovr',
                              random_state=None, check_input=True,
-                             max_squared_sum=None):
+                             max_squared_sum=None, sample_weight=None):
     """Compute a Logistic Regression model for a list of regularization
     parameters.
 
@@ -485,6 +489,9 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
 
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
+
     dual : bool
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
@@ -525,6 +532,10 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         If None, it will be computed, going through all the samples.
         The value should be precomputed to speed up cross validation.
 
+    sample_weight : array-like, shape(n_samples,) optional
+        Array of weights that are assigned to individual samples.
+        If not provided, then each sample is given unit weight.
+
     Returns
     -------
     coefs : ndarray, shape (n_cs, n_features) or (n_cs, n_features + 1)
@@ -551,7 +562,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     if isinstance(Cs, numbers.Integral):
         Cs = np.logspace(-4, 4, Cs)
 
-    _check_solver_option(solver, multi_class, penalty, dual)
+    _check_solver_option(solver, multi_class, penalty, dual, sample_weight)
 
     # Preprocessing.
     if check_input or copy:
@@ -568,10 +579,18 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         # np.unique(y) gives labels in sorted order.
         pos_class = classes[1]
 
+    # If sample weights exist, convert them to array (support for lists) 
+    # and check length
+    # Otherwise set them to 1 for all examples
+    if sample_weight is not None:
+        sample_weight = np.array(sample_weight)
+        check_consistent_length(y, sample_weight)
+    else:
+        sample_weight = np.ones(X.shape[0])
+
     # If class_weights is a dict (provided by the user), the weights
     # are assigned to the original labels. If it is "auto", then
     # the class_weights are assigned after masking the labels with a OvR.
-    sample_weight = np.ones(X.shape[0])
     le = LabelEncoder()
 
     if isinstance(class_weight, dict):
@@ -589,7 +608,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                                  "class_weight='auto'")
         else:
             class_weight_ = compute_class_weight(class_weight, classes, y)
-            sample_weight = class_weight_[le.fit_transform(y)]
+            sample_weight *= class_weight_[le.fit_transform(y)]
 
     # For doing a ovr, we need to mask the labels first. for the
     # multinomial case this is not necessary.
@@ -612,7 +631,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     if class_weight == "auto":
         class_weight_ = compute_class_weight(class_weight, mask_classes,
                                              y_bin)
-        sample_weight = class_weight_[le.fit_transform(y_bin)]
+        sample_weight *= class_weight_[le.fit_transform(y_bin)]
 
     if coef is not None:
         # it must work both giving the bias term and not
@@ -722,7 +741,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
                           verbose=0, solver='lbfgs', penalty='l2',
                           dual=False, intercept_scaling=1.,
                           multi_class='ovr', random_state=None,
-                          max_squared_sum=None):
+                          max_squared_sum=None, sample_weight=None):
     """Computes scores across logistic_regression_path
 
     Parameters
@@ -772,6 +791,9 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
 
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
+
     verbose : int
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
@@ -816,6 +838,10 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         If None, it will be computed, going through all the samples.
         The value should be precomputed to speed up cross validation.
 
+    sample_weight : array-like, shape(n_samples,) optional
+        Array of weights that are assigned to individual samples.
+        If not provided, then each sample is given unit weight.
+
     Returns
     -------
     coefs : ndarray, shape (n_cs, n_features) or (n_cs, n_features + 1)
@@ -832,12 +858,15 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
     n_iter : array, shape(n_cs,)
         Actual number of iteration for each Cs.
     """
-    _check_solver_option(solver, multi_class, penalty, dual)
+    _check_solver_option(solver, multi_class, penalty, dual, sample_weight)
 
     X_train = X[train]
     X_test = X[test]
     y_train = y[train]
     y_test = y[test]
+
+    if sample_weight is not None:
+        sample_weight = sample_weight[train]
 
     coefs, Cs, n_iter = logistic_regression_path(
         X_train, y_train, Cs=Cs, fit_intercept=fit_intercept,
@@ -845,7 +874,8 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         pos_class=pos_class, multi_class=multi_class,
         tol=tol, verbose=verbose, dual=dual, penalty=penalty,
         intercept_scaling=intercept_scaling, random_state=random_state,
-        check_input=False, max_squared_sum=max_squared_sum)
+        check_input=False, max_squared_sum=max_squared_sum,
+        sample_weight=sample_weight)
 
     log_reg = LogisticRegression(fit_intercept=fit_intercept)
 
@@ -948,6 +978,9 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         The "balanced" mode uses the values of y to automatically adjust
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
+
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
 
     max_iter : int
         Useful only for the newton-cg, sag and lbfgs solvers.
@@ -1060,7 +1093,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         self.warm_start = warm_start
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_weight=None):
         """Fit the model according to the given training data.
 
         Parameters
@@ -1071,6 +1104,10 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
         y : array-like, shape (n_samples,)
             Target vector relative to X.
+
+        sample_weight : array-like, shape (n_samples,) optional
+            Array of weights that are assigned to individual samples.
+            If not provided, then each sample is given unit weight.
 
         Returns
         -------
@@ -1092,7 +1129,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         n_samples, n_features = X.shape
 
         _check_solver_option(self.solver, self.multi_class, self.penalty,
-                             self.dual)
+                             self.dual, sample_weight)
 
         if self.solver == 'liblinear':
             self.coef_, self.intercept_, n_iter_ = _fit_liblinear(
@@ -1149,7 +1186,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
                       multi_class=self.multi_class, max_iter=self.max_iter,
                       class_weight=self.class_weight, check_input=False,
                       random_state=self.random_state, coef=warm_start_coef_,
-                      max_squared_sum=max_squared_sum)
+                      max_squared_sum=max_squared_sum,
+                      sample_weight=sample_weight)
             for (class_, warm_start_coef_) in zip(classes_, warm_start_coef))
 
         fold_coefs_, _, n_iter_ = zip(*fold_coefs_)
@@ -1262,6 +1300,9 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
 
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
+
     cv : integer or cross-validation generator
         The default cross-validation generator used is Stratified K-Folds.
         If an integer is provided, then it is the number of folds used.
@@ -1298,14 +1339,6 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
     max_iter : int, optional
         Maximum number of iterations of the optimization algorithm.
-
-    class_weight : dict or 'balanced', optional
-        Weights associated with classes in the form ``{class_label: weight}``.
-        If not given, all classes are supposed to have weight one.
-
-        The "balanced" mode uses the values of y to automatically adjust
-        weights inversely proportional to class frequencies in the input data
-        as ``n_samples / (n_classes * np.bincount(y))``
 
     n_jobs : int, optional
         Number of CPU cores used during the cross-validation loop. If given
@@ -1421,7 +1454,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         self.multi_class = multi_class
         self.random_state = random_state
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_weight=None):
         """Fit the model according to the given training data.
 
         Parameters
@@ -1433,13 +1466,17 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         y : array-like, shape (n_samples,)
             Target vector relative to X.
 
+        sample_weight : array-like, shape (n_samples,) optional
+            Array of weights that are assigned to individual samples.
+            If not provided, then each sample is given unit weight.
+
         Returns
         -------
         self : object
             Returns self.
         """
         _check_solver_option(self.solver, self.multi_class, self.penalty,
-                             self.dual)
+                             self.dual, sample_weight)
 
         if not isinstance(self.max_iter, numbers.Number) or self.max_iter < 0:
             raise ValueError("Maximum number of iteration must be positive;"
@@ -1510,7 +1547,9 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                       multi_class=self.multi_class,
                       intercept_scaling=self.intercept_scaling,
                       random_state=self.random_state,
-                      max_squared_sum=max_squared_sum)
+                      max_squared_sum=max_squared_sum,
+                      sample_weight=sample_weight
+                      )
             for label in iter_labels
             for train, test in folds)
 
@@ -1580,7 +1619,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
                     multi_class=self.multi_class,
                     verbose=max(0, self.verbose - 1),
                     random_state=self.random_state,
-                    check_input=False, max_squared_sum=max_squared_sum)
+                    check_input=False, max_squared_sum=max_squared_sum,
+                    sample_weight=sample_weight)
                 w = w[0]
 
             else:

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -230,7 +230,8 @@ def _multinomial_loss(w, X, Y, alpha, sample_weight):
 
     Parameters
     ----------
-    w : ndarray, shape (n_classes * n_features,) or (n_classes * (n_features + 1),)
+    w : ndarray, shape (n_classes * n_features,) or
+        (n_classes * (n_features + 1),)
         Coefficient vector.
 
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
@@ -281,7 +282,8 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
 
     Parameters
     ----------
-    w : ndarray, shape (n_classes * n_features,) or (n_classes * (n_features + 1),)
+    w : ndarray, shape (n_classes * n_features,) or
+        (n_classes * (n_features + 1),)
         Coefficient vector.
 
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
@@ -328,7 +330,8 @@ def _multinomial_grad_hess(w, X, Y, alpha, sample_weight):
 
     Parameters
     ----------
-    w : ndarray, shape (n_classes * n_features,) or (n_classes * (n_features + 1),)
+    w : ndarray, shape (n_classes * n_features,) or
+        (n_classes * (n_features + 1),)
         Coefficient vector.
 
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
@@ -417,7 +420,7 @@ def _check_solver_option(solver, multi_class, penalty, dual, sample_weight):
 
     if solver == 'liblinear' and sample_weight is not None:
         raise ValueError("Solver %s does not support "
-                          "sample weights." % solver)
+                         "sample weights." % solver)
 
 
 def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
@@ -579,7 +582,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         # np.unique(y) gives labels in sorted order.
         pos_class = classes[1]
 
-    # If sample weights exist, convert them to array (support for lists) 
+    # If sample weights exist, convert them to array (support for lists)
     # and check length
     # Otherwise set them to 1 for all examples
     if sample_weight is not None:
@@ -1124,7 +1127,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             raise ValueError("Tolerance for stopping criteria must be "
                              "positive; got (tol=%r)" % self.tol)
 
-        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
+        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64,
+                         order="C")
         self.classes_ = np.unique(y)
         n_samples, n_features = X.shape
 
@@ -1528,7 +1532,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
             iter_labels = [None]
 
         if self.class_weight and not(isinstance(self.class_weight, dict) or
-                                     self.class_weight in ['balanced', 'auto']):
+                                     self.class_weight in
+                                     ['balanced', 'auto']):
             raise ValueError("class_weight provided should be a "
                              "dict or 'balanced'")
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -537,7 +537,6 @@ def test_logistic_regression_solvers_multiclass():
     assert_array_almost_equal(sag.coef_, ncg.coef_, decimal=4)
     assert_array_almost_equal(sag.coef_, lbf.coef_, decimal=4)
 
-
 def test_logistic_regressioncv_class_weights():
     X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
                                n_classes=3, random_state=0)
@@ -568,6 +567,84 @@ def test_logistic_regressioncv_class_weights():
     assert_array_almost_equal(clf_lib.coef_, clf_lbf.coef_, decimal=4)
     assert_array_almost_equal(clf_sag.coef_, clf_lbf.coef_, decimal=4)
     assert_array_almost_equal(clf_lib.coef_, clf_sag.coef_, decimal=4)
+
+def test_logistic_regression_sample_weights():
+    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
+                               n_classes=3, random_state=0)
+
+    # Test that liblinear fails when sample weights are provided
+    clf_lib = LogisticRegression(solver='liblinear')
+    assert_raises(ValueError, clf_lib.fit, X, y, 
+                  sample_weight=np.ones(y.shape[0]))
+
+    # Test that passing sample_weight as ones is the same as
+    # not passing them at all (default None)
+    clf_sw_none = LogisticRegression(solver='lbfgs', fit_intercept=False)
+    clf_sw_none.fit(X, y)
+    clf_sw_ones = LogisticRegression(solver='lbfgs', fit_intercept=False)
+    clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
+    assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
+
+    # Test that sample weights work the same with the lbfgs
+    # and newton-cg solvers
+    clf_sw_lbfgs = LogisticRegression(solver='lbfgs', fit_intercept=False)
+    clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
+    clf_sw_n = LogisticRegression(solver='newton-cg', fit_intercept=False)
+    clf_sw_n.fit(X, y, sample_weight=y+1)
+    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
+
+    # Test that passing class_weight as [1,2] is the same as 
+    # passing class weight = [1,1] but adjusting sample weights
+    # to be 2 for all instances of class 2
+    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
+                               n_classes=2, random_state=0)
+    clf_cw_12 = LogisticRegression(solver='lbfgs', fit_intercept=False,
+                                     class_weight = {0: 1, 1: 2})
+    clf_cw_12.fit(X, y)
+    sample_weight = np.ones(y.shape[0])
+    sample_weight[y == 1] = 2
+    clf_sw_12 = LogisticRegression(solver='lbfgs', fit_intercept=False)
+    clf_sw_12.fit(X, y, sample_weight=sample_weight)
+    assert_array_almost_equal(clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
+
+def test_logistic_regressioncv_sample_weights():
+    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
+                               n_classes=3, random_state=0)
+
+    # Test that liblinear fails when sample weights are provided
+    clf_lib = LogisticRegressionCV(solver='liblinear')
+    assert_raises(ValueError, clf_lib.fit, X, y, 
+                  sample_weight=np.ones(y.shape[0]))
+
+    # Test that passing sample_weight as ones is the same as
+    # not passing them at all (default None)
+    clf_sw_none = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
+    clf_sw_none.fit(X, y)
+    clf_sw_ones = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
+    clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
+    assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
+
+    # Test that sample weights work the same with the lbfgs
+    # and newton-cg solvers
+    clf_sw_lbfgs = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
+    clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
+    clf_sw_n = LogisticRegressionCV(solver='newton-cg', fit_intercept=False)
+    clf_sw_n.fit(X, y, sample_weight=y+1)
+    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
+
+    # Test that passing class_weight as [1,2] is the same as 
+    # passing class weight = [1,1] but adjusting sample weights
+    # to be 2 for all instances of class 2
+    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
+                               n_classes=2, random_state=0)
+    clf_cw_12 = LogisticRegressionCV(solver='lbfgs', fit_intercept=False,
+                                     class_weight = {0: 1, 1: 2})
+    clf_cw_12.fit(X, y)
+    sample_weight = np.ones(y.shape[0])
+    sample_weight[y == 1] = 2
+    clf_sw_12 = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
+    clf_sw_12.fit(X, y, sample_weight=sample_weight)
+    assert_array_almost_equal(clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
 
 
 def test_logistic_regression_convergence_warnings():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -585,13 +585,20 @@ def test_logistic_regression_sample_weights():
     clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
     assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
 
-    # Test that sample weights work the same with the lbfgs
-    # and newton-cg solvers
-    clf_sw_lbfgs = LogisticRegression(solver='lbfgs', fit_intercept=False)
+    # Test that sample weights work the same with the lbfgs,
+    # newton-cg, and 'sag' solvers
+    tol = 1e-7
+    clf_sw_lbfgs = LogisticRegression(solver='lbfgs', fit_intercept=False, 
+                                      tol=tol)
     clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
-    clf_sw_n = LogisticRegression(solver='newton-cg', fit_intercept=False)
+    clf_sw_n = LogisticRegression(solver='newton-cg', fit_intercept=False,
+                                  tol=tol)
     clf_sw_n.fit(X, y, sample_weight=y+1)
+    clf_sw_sag = LogisticRegression(solver='sag', fit_intercept=False,
+                                    max_iter=2000, tol=tol)
+    clf_sw_sag.fit(X, y, sample_weight=y+1)
     assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
+    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_sag.coef_, decimal=4)
 
     # Test that passing class_weight as [1,2] is the same as 
     # passing class weight = [1,1] but adjusting sample weights
@@ -624,13 +631,20 @@ def test_logistic_regressioncv_sample_weights():
     clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
     assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
 
-    # Test that sample weights work the same with the lbfgs
-    # and newton-cg solvers
-    clf_sw_lbfgs = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
+    # Test that sample weights work the same with the lbfgs,
+    # newton-cg, and 'sag' solvers
+    tol = 1e-7
+    clf_sw_lbfgs = LogisticRegressionCV(solver='lbfgs', fit_intercept=False, 
+                                      tol=tol)
     clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
-    clf_sw_n = LogisticRegressionCV(solver='newton-cg', fit_intercept=False)
+    clf_sw_n = LogisticRegressionCV(solver='newton-cg', fit_intercept=False,
+                                  tol=tol)
     clf_sw_n.fit(X, y, sample_weight=y+1)
+    clf_sw_sag = LogisticRegressionCV(solver='sag', fit_intercept=False,
+                                    max_iter=2000, tol=tol)
+    clf_sw_sag.fit(X, y, sample_weight=y+1)
     assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
+    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_sag.coef_, decimal=4)
 
     # Test that passing class_weight as [1,2] is the same as 
     # passing class weight = [1,1] but adjusting sample weights

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -537,6 +537,7 @@ def test_logistic_regression_solvers_multiclass():
     assert_array_almost_equal(sag.coef_, ncg.coef_, decimal=4)
     assert_array_almost_equal(sag.coef_, lbf.coef_, decimal=4)
 
+
 def test_logistic_regressioncv_class_weights():
     X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
                                n_classes=3, random_state=0)
@@ -568,97 +569,48 @@ def test_logistic_regressioncv_class_weights():
     assert_array_almost_equal(clf_sag.coef_, clf_lbf.coef_, decimal=4)
     assert_array_almost_equal(clf_lib.coef_, clf_sag.coef_, decimal=4)
 
+
 def test_logistic_regression_sample_weights():
-    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
-                               n_classes=3, random_state=0)
-
-    # Test that liblinear fails when sample weights are provided
-    clf_lib = LogisticRegression(solver='liblinear')
-    assert_raises(ValueError, clf_lib.fit, X, y, 
-                  sample_weight=np.ones(y.shape[0]))
-
-    # Test that passing sample_weight as ones is the same as
-    # not passing them at all (default None)
-    clf_sw_none = LogisticRegression(solver='lbfgs', fit_intercept=False)
-    clf_sw_none.fit(X, y)
-    clf_sw_ones = LogisticRegression(solver='lbfgs', fit_intercept=False)
-    clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
-    assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
-
-    # Test that sample weights work the same with the lbfgs,
-    # newton-cg, and 'sag' solvers
-    tol = 1e-7
-    clf_sw_lbfgs = LogisticRegression(solver='lbfgs', fit_intercept=False, 
-                                      tol=tol)
-    clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
-    clf_sw_n = LogisticRegression(solver='newton-cg', fit_intercept=False,
-                                  tol=tol)
-    clf_sw_n.fit(X, y, sample_weight=y+1)
-    clf_sw_sag = LogisticRegression(solver='sag', fit_intercept=False,
-                                    max_iter=2000, tol=tol)
-    clf_sw_sag.fit(X, y, sample_weight=y+1)
-    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
-    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_sag.coef_, decimal=4)
-
-    # Test that passing class_weight as [1,2] is the same as 
-    # passing class weight = [1,1] but adjusting sample weights
-    # to be 2 for all instances of class 2
-    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
+    X, y = make_classification(n_samples=20, n_features=5, n_informative=3,
                                n_classes=2, random_state=0)
-    clf_cw_12 = LogisticRegression(solver='lbfgs', fit_intercept=False,
-                                     class_weight = {0: 1, 1: 2})
-    clf_cw_12.fit(X, y)
-    sample_weight = np.ones(y.shape[0])
-    sample_weight[y == 1] = 2
-    clf_sw_12 = LogisticRegression(solver='lbfgs', fit_intercept=False)
-    clf_sw_12.fit(X, y, sample_weight=sample_weight)
-    assert_array_almost_equal(clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
 
-def test_logistic_regressioncv_sample_weights():
-    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
-                               n_classes=3, random_state=0)
+    for LR in [LogisticRegression, LogisticRegressionCV]:
+        # Test that liblinear fails when sample weights are provided
+        clf_lib = LR(solver='liblinear')
+        assert_raises(ValueError, clf_lib.fit, X, y,
+                      sample_weight=np.ones(y.shape[0]))
 
-    # Test that liblinear fails when sample weights are provided
-    clf_lib = LogisticRegressionCV(solver='liblinear')
-    assert_raises(ValueError, clf_lib.fit, X, y, 
-                  sample_weight=np.ones(y.shape[0]))
+        # Test that passing sample_weight as ones is the same as
+        # not passing them at all (default None)
+        clf_sw_none = LR(solver='lbfgs', fit_intercept=False)
+        clf_sw_none.fit(X, y)
+        clf_sw_ones = LR(solver='lbfgs', fit_intercept=False)
+        clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
+        assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
 
-    # Test that passing sample_weight as ones is the same as
-    # not passing them at all (default None)
-    clf_sw_none = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
-    clf_sw_none.fit(X, y)
-    clf_sw_ones = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
-    clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
-    assert_array_almost_equal(clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
+        # Test that sample weights work the same with the lbfgs,
+        # newton-cg, and 'sag' solvers
+        clf_sw_lbfgs = LR(solver='lbfgs', fit_intercept=False)
+        clf_sw_lbfgs.fit(X, y, sample_weight=y + 1)
+        clf_sw_n = LR(solver='newton-cg', fit_intercept=False)
+        clf_sw_n.fit(X, y, sample_weight=y + 1)
+        clf_sw_sag = LR(solver='sag', fit_intercept=False,
+                        max_iter=2000, tol=1e-7)
+        clf_sw_sag.fit(X, y, sample_weight=y + 1)
+        assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
+        assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_sag.coef_, decimal=4)
 
-    # Test that sample weights work the same with the lbfgs,
-    # newton-cg, and 'sag' solvers
-    tol = 1e-7
-    clf_sw_lbfgs = LogisticRegressionCV(solver='lbfgs', fit_intercept=False, 
-                                      tol=tol)
-    clf_sw_lbfgs.fit(X, y, sample_weight=y+1)
-    clf_sw_n = LogisticRegressionCV(solver='newton-cg', fit_intercept=False,
-                                  tol=tol)
-    clf_sw_n.fit(X, y, sample_weight=y+1)
-    clf_sw_sag = LogisticRegressionCV(solver='sag', fit_intercept=False,
-                                    max_iter=2000, tol=tol)
-    clf_sw_sag.fit(X, y, sample_weight=y+1)
-    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
-    assert_array_almost_equal(clf_sw_lbfgs.coef_, clf_sw_sag.coef_, decimal=4)
-
-    # Test that passing class_weight as [1,2] is the same as 
-    # passing class weight = [1,1] but adjusting sample weights
-    # to be 2 for all instances of class 2
-    X, y = make_classification(n_samples=20, n_features=20, n_informative=10,
-                               n_classes=2, random_state=0)
-    clf_cw_12 = LogisticRegressionCV(solver='lbfgs', fit_intercept=False,
-                                     class_weight = {0: 1, 1: 2})
-    clf_cw_12.fit(X, y)
-    sample_weight = np.ones(y.shape[0])
-    sample_weight[y == 1] = 2
-    clf_sw_12 = LogisticRegressionCV(solver='lbfgs', fit_intercept=False)
-    clf_sw_12.fit(X, y, sample_weight=sample_weight)
-    assert_array_almost_equal(clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
+        # Test that passing class_weight as [1,2] is the same as
+        # passing class weight = [1,1] but adjusting sample weights
+        # to be 2 for all instances of class 2
+        clf_cw_12 = LR(solver='lbfgs', fit_intercept=False,
+                       class_weight={0: 1, 1: 2})
+        clf_cw_12.fit(X, y)
+        sample_weight = np.ones(y.shape[0])
+        sample_weight[y == 1] = 2
+        clf_sw_12 = LR(solver='lbfgs', fit_intercept=False)
+        clf_sw_12.fit(X, y, sample_weight=sample_weight)
+        assert_array_almost_equal(clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
 
 
 def test_logistic_regression_convergence_warnings():
@@ -799,11 +751,11 @@ def test_logreg_cv_penalty():
 
 
 def test_logreg_predict_proba_multinomial():
-    X, y = make_classification(
-        n_samples=10, n_features=20, random_state=0, n_classes=3, n_informative=10)
+    X, y = make_classification(n_samples=10, n_features=20, random_state=0,
+                               n_classes=3, n_informative=10)
 
-    # Predicted probabilites using the true-entropy loss should give a smaller loss
-    # than those using the ovr method.
+    # Predicted probabilites using the true-entropy loss should give a
+    # smaller loss than those using the ovr method.
     clf_multi = LogisticRegression(multi_class="multinomial", solver="lbfgs")
     clf_multi.fit(X, y)
     clf_multi_loss = log_loss(y, clf_multi.predict_proba(X))
@@ -812,8 +764,8 @@ def test_logreg_predict_proba_multinomial():
     clf_ovr_loss = log_loss(y, clf_ovr.predict_proba(X))
     assert_greater(clf_ovr_loss, clf_multi_loss)
 
-    # Predicted probabilites using the soft-max function should give a smaller loss
-    # than those using the logistic function.
+    # Predicted probabilites using the soft-max function should give a
+    # smaller loss than those using the logistic function.
     clf_multi_loss = log_loss(y, clf_multi.predict_proba(X))
     clf_wrong_loss = log_loss(y, clf_multi._predict_proba_lr(X))
     assert_greater(clf_wrong_loss, clf_multi_loss)


### PR DESCRIPTION
I observed that logistic regression could not be trained with sample weights. By digging deeper I found that two of the three solvers (`lbfgs` and `newton-cg`) could handle sample weights, while the default solver (`liblinear`) could not and as a result sample weights were hidden from the user completely. To remedy this, I have:
- added a `ValueError` when the `liblinear` solver is used with sample weights
- allowed for `sample_weight` to be a parameter in both `LogisticRegression.fit()` and `LogisticRegressionCV.fit()`
- documented the parameter everywhere it can be passed
- updated the documentation for the `class_weight` parameter to note that it will be multiplied by `sample_weight` if `sample_weight` is provided in `.fit()`
- handled sample weights appropriately throughout the fitting by passing them to `logistic_regression_path` and `_log_reg_scoring_path`
- added a new test function in test_logistic.py with four different tests to make sure:
  - that a `ValueError` is thrown when `liblinear` is used with sample weights
  - that passing sample weights as `np.ones` is the same as not passing them (default `None`)
  - passing sample weights to both `lbfgs` and `newton-cg` solvers yields the same results
  - passing class weights to scale classes is the same as passing sample weights that scale the training examples of those classes
