### PR TITLE
[MRG+1] Added check to ensure that NumPy and SciPy meet minimum version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,10 +115,12 @@ def configuration(parent_package='', top_path=None):
 
     return config
 
+scipy_min_version = '0.9'
+numpy_min_version = '1.6.1'
+
 def is_scipy_installed():
     try:
         import scipy
-        scipy_min_version = '0.9'
         return parse_version(scipy.__version__) >= parse_version(scipy_min_version)
     except ImportError:
         return False
@@ -126,7 +128,6 @@ def is_scipy_installed():
 def is_numpy_installed():
     try:
         import numpy
-        numpy_min_version = '1.6.1'
         return parse_version(numpy.__version__) >= parse_version(numpy_min_version)
     except ImportError:
         return False
@@ -180,12 +181,12 @@ def setup_package():
     else:
         if is_numpy_installed() is False:
             raise ImportError("An up-to-date version of Numerical Python (NumPy) is not installed.\n"
-                             "scikit-learn requires NumPy >= 1.6.1.\n"
+                             "scikit-learn requires NumPy >= {0}.\n".format(numpy_min_version)+
                              "Installation instructions are available on scikit-learn website: "
                              "http://scikit-learn.org/stable/install.html\n")
         if is_scipy_installed() is False:
             raise ImportError("An up-to-date version of Scientific Python (SciPy) is not installed.\n"
-                             "scikit-learn requires SciPy >= 0.9.\n"
+                             "scikit-learn requires SciPy >= {0}.\n".format(scipy_min_version)+
                              "Installation instructions are available on scikit-learn website: "
                              "http://scikit-learn.org/stable/install.html\n")
         from numpy.distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import sys
 import os
 import shutil
 from distutils.command.clean import clean as Clean
+from pkg_resources import parse_version
 
 
 if sys.version_info[0] < 3:
@@ -117,16 +118,18 @@ def configuration(parent_package='', top_path=None):
 def is_scipy_installed():
     try:
         import scipy
+        scipy_min_version = '0.9'
+        return parse_version(scipy.__version__) >= parse_version(scipy_min_version)
     except ImportError:
         return False
-    return True
 
 def is_numpy_installed():
     try:
         import numpy
+        numpy_min_version = '1.6.1'
+        return parse_version(numpy.__version__) >= parse_version(numpy_min_version)
     except ImportError:
         return False
-    return True
 
 def setup_package():
     metadata = dict(name=DISTNAME,

--- a/setup.py
+++ b/setup.py
@@ -179,13 +179,13 @@ def setup_package():
         metadata['version'] = VERSION
     else:
         if is_numpy_installed() is False:
-            raise ImportError("Numerical Python (NumPy) is not installed.\n"
-                             "scikit-learn requires NumPy.\n"
+            raise ImportError("An up-to-date version of Numerical Python (NumPy) is not installed.\n"
+                             "scikit-learn requires NumPy >= 1.6.1.\n"
                              "Installation instructions are available on scikit-learn website: "
                              "http://scikit-learn.org/stable/install.html\n")
         if is_scipy_installed() is False:
-            raise ImportError("Scientific Python (SciPy) is not installed.\n"
-                             "scikit-learn requires SciPy.\n"
+            raise ImportError("An up-to-date version of Scientific Python (SciPy) is not installed.\n"
+                             "scikit-learn requires SciPy >= 0.9.\n"
                              "Installation instructions are available on scikit-learn website: "
                              "http://scikit-learn.org/stable/install.html\n")
         from numpy.distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -118,19 +118,24 @@ def configuration(parent_package='', top_path=None):
 scipy_min_version = '0.9'
 numpy_min_version = '1.6.1'
 
+
 def is_scipy_installed():
     try:
         import scipy
-        return parse_version(scipy.__version__) >= parse_version(scipy_min_version)
+        return parse_version(scipy.__version__) >= parse_version(
+            scipy_min_version)
     except ImportError:
         return False
+
 
 def is_numpy_installed():
     try:
         import numpy
-        return parse_version(numpy.__version__) >= parse_version(numpy_min_version)
+        return parse_version(numpy.__version__) >= parse_version(
+            numpy_min_version)
     except ImportError:
         return False
+
 
 def setup_package():
     metadata = dict(name=DISTNAME,
@@ -180,15 +185,21 @@ def setup_package():
         metadata['version'] = VERSION
     else:
         if is_numpy_installed() is False:
-            raise ImportError("An up-to-date version of Numerical Python (NumPy) is not installed.\n"
-                             "scikit-learn requires NumPy >= {0}.\n".format(numpy_min_version)+
-                             "Installation instructions are available on scikit-learn website: "
-                             "http://scikit-learn.org/stable/install.html\n")
+            raise ImportError("An up-to-date version of Numerical Python "
+                              "(NumPy) is not installed.\n"
+                              "scikit-learn requires NumPy >= {0}.\n"
+                              .format(numpy_min_version) +
+                              "Installation instructions are available "
+                              "on the scikit-learn website: "
+                              "http://scikit-learn.org/stable/install.html\n")
         if is_scipy_installed() is False:
-            raise ImportError("An up-to-date version of Scientific Python (SciPy) is not installed.\n"
-                             "scikit-learn requires SciPy >= {0}.\n".format(scipy_min_version)+
-                             "Installation instructions are available on scikit-learn website: "
-                             "http://scikit-learn.org/stable/install.html\n")
+            raise ImportError("An up-to-date version of Scientific Python "
+                              "(SciPy) is not installed.\n"
+                              "scikit-learn requires SciPy >= {0}.\n"
+                              .format(scipy_min_version) +
+                              "Installation instructions are available "
+                              "on the scikit-learn website: "
+                              "http://scikit-learn.org/stable/install.html\n")
         from numpy.distutils.core import setup
 
         metadata['configuration'] = configuration

--- a/setup.py
+++ b/setup.py
@@ -119,22 +119,42 @@ scipy_min_version = '0.9'
 numpy_min_version = '1.6.1'
 
 
-def is_scipy_installed():
+def get_scipy_status():
+    """
+    Returns a dictionary containing a boolean specifying whether SciPy
+    is up-to-date, along with the version string (empty string if
+    not installed).
+    """
+    scipy_status = {}
     try:
         import scipy
-        return parse_version(scipy.__version__) >= parse_version(
-            scipy_min_version)
+        scipy_version = scipy.__version__
+        scipy_status['up_to_date'] = parse_version(
+            scipy_version) >= parse_version(scipy_min_version)
+        scipy_status['version'] = scipy_version
     except ImportError:
-        return False
+        scipy_status['up_to_date'] = False
+        scipy_status['version'] = ""
+    return scipy_status
 
 
-def is_numpy_installed():
+def get_numpy_status():
+    """
+    Returns a dictionary containing a boolean specifying whether NumPy
+    is up-to-date, along with the version string (empty string if
+    not installed).
+    """
+    numpy_status = {}
     try:
         import numpy
-        return parse_version(numpy.__version__) >= parse_version(
-            numpy_min_version)
+        numpy_version = numpy.__version__
+        numpy_status['up_to_date'] = parse_version(
+            numpy_version) >= parse_version(numpy_min_version)
+        numpy_status['version'] = numpy_version
     except ImportError:
-        return False
+        numpy_status['up_to_date'] = False
+        numpy_status['version'] = ""
+    return numpy_status
 
 
 def setup_package():
@@ -184,22 +204,38 @@ def setup_package():
 
         metadata['version'] = VERSION
     else:
-        if is_numpy_installed() is False:
-            raise ImportError("An up-to-date version of Numerical Python "
-                              "(NumPy) is not installed.\n"
-                              "scikit-learn requires NumPy >= {0}.\n"
-                              .format(numpy_min_version) +
-                              "Installation instructions are available "
-                              "on the scikit-learn website: "
-                              "http://scikit-learn.org/stable/install.html\n")
-        if is_scipy_installed() is False:
-            raise ImportError("An up-to-date version of Scientific Python "
-                              "(SciPy) is not installed.\n"
-                              "scikit-learn requires SciPy >= {0}.\n"
-                              .format(scipy_min_version) +
-                              "Installation instructions are available "
-                              "on the scikit-learn website: "
-                              "http://scikit-learn.org/stable/install.html\n")
+        numpy_status = get_numpy_status()
+        numpy_req_str = "scikit-learn requires NumPy >= {0}.\n".format(
+                        numpy_min_version)
+        scipy_status = get_scipy_status()
+        scipy_req_str = "scikit-learn requires SciPy >= {0}.\n".format(
+                        scipy_min_version)
+
+        instructions = ("Installation instructions are available on the "
+                        "scikit-learn website: "
+                        "http://scikit-learn.org/stable/install.html\n")
+
+        if numpy_status['up_to_date'] is False:
+            if numpy_status['version']:
+                raise ImportError("Your installation of Numerical Python "
+                                  "(NumPy) {0} is out-of-date.\n{1}{2}"
+                                  .format(numpy_status['version'],
+                                          numpy_req_str, instructions))
+            else:
+                raise ImportError("Numerical Python (NumPy) is not "
+                                  "installed.\n{0}{1}"
+                                  .format(numpy_req_str, instructions))
+        if scipy_status['up_to_date'] is False:
+            if scipy_status['version']:
+                raise ImportError("Your installation of Scientific Python "
+                                  "(SciPy) {0} is out-of-date.\n{1}{2}"
+                                  .format(scipy_status['version'],
+                                          scipy_req_str, instructions))
+            else:
+                raise ImportError("Scientific Python (SciPy) is not "
+                                  "installed.\n{0}{1}"
+                                  .format(scipy_req_str, instructions))
+
         from numpy.distutils.core import setup
 
         metadata['configuration'] = configuration


### PR DESCRIPTION
Added a check to the build process to ensure that NumPy and SciPy meet minimum version requirements (NumPy >= 1.6.1 and SciPy >= 0.9), as suggested in issue #5202.  

The check is performed by the [`parse_version`](http://pythonhosted.org/setuptools/pkg_resources.html#parsing-utilities) function defined in `setuptools`, which is the function used by `pip` and `easy_install` to handle version comparison.  Using this utility, versions are parsed according to the sorting algorithm defined in [PEP 0440](https://www.python.org/dev/peps/pep-0440/).  
