### PR TITLE
[MRG+1] [BUG] AdaBoostRegressor should not raise errors if the base_estimator does not support sample_weights

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -6,6 +6,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal, assert_true
 from sklearn.utils.testing import assert_raises, assert_raises_regexp
 
+from sklearn.base import BaseEstimator
 from sklearn.cross_validation import train_test_split
 from sklearn.grid_search import GridSearchCV
 from sklearn.ensemble import AdaBoostClassifier
@@ -292,9 +293,6 @@ def test_sample_weight_missing():
     clf = AdaBoostClassifier(LogisticRegression(), algorithm="SAMME")
     assert_raises(ValueError, clf.fit, X, y_regr)
 
-    clf = AdaBoostRegressor(LogisticRegression())
-    assert_raises(ValueError, clf.fit, X, y_regr)
-
     clf = AdaBoostClassifier(KMeans(), algorithm="SAMME")
     assert_raises(ValueError, clf.fit, X, y_regr)
 
@@ -448,3 +446,23 @@ def test_sparse_regression():
 
         assert all([(t == csc_matrix or t == csr_matrix)
                    for t in types])
+
+
+def test_sample_weight_adaboost_regressor():
+    """
+    AdaBoostRegressor should work without sample_weights in the base estimator
+
+    The random weighted sampling is done internally in the _boost method in
+    AdaBoostRegressor.
+    """
+    class DummyEstimator(BaseEstimator):
+
+        def fit(self, X, y):
+            pass
+
+        def predict(self, X):
+            return np.zeros(X.shape[0])
+
+    boost = AdaBoostRegressor(DummyEstimator(), n_estimators=3)
+    boost.fit(X, y_regr)
+    assert_equal(len(boost.estimator_weights_), len(boost.estimator_errors_))

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -252,11 +252,6 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 "since base_estimator does not have a "
                 "feature_importances_ attribute")
 
-    def _check_sample_weight(self):
-        if not has_fit_parameter(self.base_estimator_, "sample_weight"):
-            raise ValueError("%s doesn't support sample_weight."
-                             % self.base_estimator_.__class__.__name__)
-
     def _validate_X_predict(self, X):
         """Ensure that X is in the proper format"""
         if (self.base_estimator is None or
@@ -422,7 +417,9 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
                     "probabilities with a predict_proba method.\n"
                     "Please change the base estimator or set "
                     "algorithm='SAMME' instead.")
-        self._check_sample_weight()
+        if not has_fit_parameter(self.base_estimator_, "sample_weight"):
+            raise ValueError("%s doesn't support sample_weight."
+                             % self.base_estimator_.__class__.__name__)
 
     def _boost(self, iboost, X, y, sample_weight):
         """Implement a single boost.
@@ -960,7 +957,6 @@ class AdaBoostRegressor(BaseWeightBoosting, RegressorMixin):
         """Check the estimator and set the base_estimator_ attribute."""
         super(AdaBoostRegressor, self)._validate_estimator(
             default=DecisionTreeRegressor(max_depth=3))
-        self._check_sample_weight()
 
     def _boost(self, iboost, X, y, sample_weight):
         """Implement a single boost for regression


### PR DESCRIPTION
AdaBoostRegressor should work without sample_weights in the base estimator

The random weighted sampling is done internally in the _boost method in AdaBoostRegressor.
