### PR TITLE
added missing chi2 gamma parameter

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1215,7 +1215,7 @@ def kernel_metrics():
 
 KERNEL_PARAMS = {
     "additive_chi2": (),
-    "chi2": (),
+    "chi2": frozenset(["gamma"]),
     "cosine": (),
     "exp_chi2": frozenset(["gamma"]),
     "linear": (),


### PR DESCRIPTION
chi2 kernel gamma parameter was missing in `KERNEL_PARAMS` dictionary, which caused the passed `gamma` to be ignored when using `filter_params = True` in `pairwise_kernels(X, filter_params = True, metric = 'chi2', gamma = gamma)`
