### PR TITLE
Creation of the attribute LDA.explained_variance_ratio_, for the eige…

### DIFF
--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -316,6 +316,7 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
         Sb = St - Sw  # between scatter
 
         evals, evecs = linalg.eigh(Sb, Sw)
+        self.explained_variance_ratio_ = np.sort(evals / np.sum(evals))[::-1]
         evecs = evecs[:, np.argsort(evals)[::-1]]  # sort eigenvectors
         # evecs /= np.linalg.norm(evecs, axis=0)  # doesn't work with numpy 1.6
         evecs /= np.apply_along_axis(np.linalg.norm, 0, evecs)

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -180,6 +180,12 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
     covariance_ : array-like, shape (n_features, n_features)
         Covariance matrix (shared by all classes).
 
+    explained_variance_ratio_ : array, [n_components]
+        Percentage of variance explained by each of the selected components.
+        If ``n_components`` is not set then all components are stored and the
+        sum of explained variances is equal to 1.0. Only available when eigen
+        solver is used.
+
     means_ : array-like, shape (n_classes, n_features)
         Class means.
 

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -180,7 +180,7 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
     covariance_ : array-like, shape (n_features, n_features)
         Covariance matrix (shared by all classes).
 
-    explained_variance_ratio_ : array, [n_components]
+    explained_variance_ratio_ : array, (n_components)
         Percentage of variance explained by each of the selected components.
         If ``n_components`` is not set then all components are stored and the
         sum of explained variances is equal to 1.0. Only available when eigen

--- a/sklearn/lda.py
+++ b/sklearn/lda.py
@@ -180,7 +180,7 @@ class LDA(BaseEstimator, LinearClassifierMixin, TransformerMixin):
     covariance_ : array-like, shape (n_features, n_features)
         Covariance matrix (shared by all classes).
 
-    explained_variance_ratio_ : array, (n_components)
+    explained_variance_ratio_ : array, shape (n_components,)
         Percentage of variance explained by each of the selected components.
         If ``n_components`` is not set then all components are stored and the
         sum of explained variances is equal to 1.0. Only available when eigen

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -85,6 +85,21 @@ def test_lda_coefs():
     assert_array_almost_equal(clf_lda_eigen.coef_, clf_lda_lsqr.coef_, 1)
 
 
+def test_lda_explained_covariance_ratio():
+    # Test if the sum of the normalized eigen vectors values equals 1
+    n_features = 2
+    n_classes = 2
+    n_samples = 1000
+    X, y = make_blobs(n_samples=n_samples, n_features=n_features,
+                      centers=n_classes, random_state=11)
+
+    clf_lda_eigen = lda.LDA(solver="eigen")
+
+    clf_lda_eigen.fit(X, y)
+
+    assert_almost_equal(clf_lda_eigen.explained_variance_ratio_.sum(), 1.0, 3)
+
+
 def test_lda_transform():
     # Test LDA transform.
     clf = lda.LDA(solver="svd", n_components=1)

--- a/sklearn/tests/test_lda.py
+++ b/sklearn/tests/test_lda.py
@@ -85,7 +85,7 @@ def test_lda_coefs():
     assert_array_almost_equal(clf_lda_eigen.coef_, clf_lda_lsqr.coef_, 1)
 
 
-def test_lda_explained_covariance_ratio():
+def test_lda_explained_variance_ratio():
     # Test if the sum of the normalized eigen vectors values equals 1
     n_features = 2
     n_classes = 2


### PR DESCRIPTION
Creation of the attribute LDA.explained_variance_ratio_, for the eigen solver. It is an analogy to PCA.explained_variance_ratio, and works in the same way.

Only one line of code has been added, there was not much to change. However, the attribute is not available for the default solver, as I'm not good enough to change this part of the code.

This is a PR to solve the issue #5210 
