### PR TITLE
[MRG+1] DOC update AUTHORS.rst to better reflect team

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -88,6 +88,15 @@ People
 
   * `Arnaud Joly <http://www.ajoly.org>`_
 
-  * `Kemal Eren <http://www.kemaleren.com>`_
-
-  * `Michael Becker <http://beckerfuffle.com>`_
+  * `Jaques Grobler <https://github.com/jaquesgrobler>`_
+  
+  * `Joel Nothman <http://joelnothman.com>`_
+  
+  * `Noel Dawe <http://noel.dawe.me>`_
+  
+  * `Kyle Kastner <http://kastnerkyle.github.io>`_
+  
+  * `Manoj Kumar <https://manojbits.wordpress.com>`_
+  
+  * Alexander Fabisch
+  

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,84 +20,45 @@ been leading the development.
 People
 ------
 
-.. hlist::
-
-  * David Cournapeau
 The following people have been core contributors to scikit-learn's development and maintenance:
 
-  * Jarrod Millman
-
-  * `Matthieu Brucher <http://matt.eifelle.com/>`_
-
-  * `Fabian Pedregosa <http://fseoane.net/blog/>`_
-
-  * `Gael Varoquaux <http://gael-varoquaux.info/blog/>`_
-
-  * `Jake VanderPlas <http://www.astro.washington.edu/users/vanderplas/>`_
-
-  * `Alexandre Gramfort <http://alexandre.gramfort.net>`_
-
-  * `Olivier Grisel <http://twitter.com/ogrisel>`_
-
-  * Bertrand Thirion
-
-  * Vincent Michel
-
-  * Chris Filo Gorgolewski
-
-  * `Angel Soler Gollonet <http://webylimonada.com>`_
-
-  * `Yaroslav Halchenko <http://www.onerussian.com/>`_
-
-  * Ron Weiss
-
-  * `Virgile Fritsch
-    <http://parietal.saclay.inria.fr/Members/virgile-fritsch>`_
+.. hlist::
 
   * `Mathieu Blondel <http://mblondel.org>`_
-
-  * `Peter Prettenhofer
-    <http://sites.google.com/site/peterprettenhofer/>`_
-
-  * Vincent Dubourg
-
-  * `Alexandre Passos <http://atpassos.posterous.com>`_
-
-  * `Vlad Niculae <http://vene.ro>`_
-
-  * Edouard Duchesnay
-
-  * Thouis (Ray) Jones
-
+  * `Matthieu Brucher <http://matt.eifelle.com/>`_
   * Lars Buitinck
-
-  * Paolo Losi
-
-  * Nelle Varoquaux
-
-  * `Brian Holt <http://info.ee.surrey.ac.uk/Personal/B.Holt/>`_
-
-  * Robert Layton
-
-  * `Gilles Louppe <http://www.montefiore.ulg.ac.be/~glouppe>`_
-
-  * `Andreas Müller <http://peekaboo-vision.blogspot.com>`_ (release manager)
-
-  * `Satra Ghosh <http://www.mit.edu/~satra>`_
-
-  * `Wei Li <http://kuantkid.github.com>`_
-
-  * `Arnaud Joly <http://www.ajoly.org>`_
-
-  * `Jaques Grobler <https://github.com/jaquesgrobler>`_
-  
-  * `Joel Nothman <http://joelnothman.com>`_
-  
+  * David Cournapeau
   * `Noel Dawe <http://noel.dawe.me>`_
-  
-  * `Kyle Kastner <http://kastnerkyle.github.io>`_
-  
-  * `Manoj Kumar <https://manojbits.wordpress.com>`_
-  
+  * Vincent Dubourg
+  * Edouard Duchesnay
   * Alexander Fabisch
-  
+  * `Virgile Fritsch <http://parietal.saclay.inria.fr/Members/virgile-fritsch>`_
+  * `Satra Ghosh <http://www.mit.edu/~satra>`_
+  * `Angel Soler Gollonet <http://webylimonada.com>`_
+  * Chris Filo Gorgolewski
+  * `Alexandre Gramfort <http://alexandre.gramfort.net>`_
+  * `Olivier Grisel <http://twitter.com/ogrisel>`_
+  * `Jaques Grobler <https://github.com/jaquesgrobler>`_
+  * `Yaroslav Halchenko <http://www.onerussian.com/>`_
+  * `Brian Holt <http://info.ee.surrey.ac.uk/Personal/B.Holt/>`_
+  * `Arnaud Joly <http://www.ajoly.org>`_
+  * Thouis (Ray) Jones
+  * `Kyle Kastner <http://kastnerkyle.github.io>`_
+  * `Manoj Kumar <https://manojbits.wordpress.com>`_
+  * Robert Layton
+  * `Wei Li <http://kuantkid.github.com>`_
+  * Paolo Losi
+  * `Gilles Louppe <http://www.montefiore.ulg.ac.be/~glouppe>`_
+  * Vincent Michel
+  * Jarrod Millman
+  * `Andreas Müller <http://peekaboo-vision.blogspot.com>`_ (release manager)
+  * `Vlad Niculae <http://vene.ro>`_
+  * `Joel Nothman <http://joelnothman.com>`_
+  * `Alexandre Passos <http://atpassos.posterous.com>`_
+  * `Fabian Pedregosa <http://fseoane.net/blog/>`_
+  * `Peter Prettenhofer <http://sites.google.com/site/peterprettenhofer/>`_
+  * Bertrand Thirion
+  * `Jake VanderPlas <http://www.astro.washington.edu/users/vanderplas/>`_
+  * Nelle Varoquaux
+  * `Gael Varoquaux <http://gael-varoquaux.info/blog/>`_
+  * Ron Weiss

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ People
 .. hlist::
 
   * David Cournapeau
+The following people have been core contributors to scikit-learn's development and maintenance:
 
   * Jarrod Millman
 


### PR DESCRIPTION
This removes a couple of names that seem to have been misplaced (I don't know if there are other names added here incorrectly, and am not brave enough to suggest so), while adding some members of the [owners/reviewers teams](https://github.com/orgs/scikit-learn/teams) that were absent from `AUTHORS.rst`. Members of that team that are not added by this PR are:
- David Warde-Farley: very few contribs, limited to datasets
- Shiqiao Du: relatively few contribs, to HMM which is now external

~~Perhaps a statement "the following people have been core contributors to scikit-learn's development and maintenance." is also due.~~ Now included.

~~Name order is intended to roughly match chronology (which can be estimated with `grep -n "^ .*<name>" doc/whats_new.rst | tail -n1`).~~ Now alphabetical by surname.
