### PR TITLE
[MRG] Support arbitrary init estimators for Gradient Boosting

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -991,11 +991,9 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
                 if len(pred.shape) < 2:
                     if is_classifier(self.init_):
-                        y_pred = np.zeros((n_samples, n_classes))
-                        y_pred[:, pred] = 1.0
-                        if n_classes == 2:
-                            y_pred = np.log(y_pred[:, 1] / y_pred[:, 0])
-                            y_pred = y_pred.reshape(n_samples, 1)
+                        raise ValueError("init model must have a "
+                                         "'predict_proba' method if a "
+                                         "classifier")
                     else:
                         y_pred = pred.reshape(n_samples, 1)
                 else:
@@ -1131,11 +1129,9 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
             if len(pred.shape) < 2:
                 if is_classifier(self.init_):
-                    score = np.zeros((X.shape[0], self.n_classes))
-                    score[:, pred] = 1.0
-                    if self.n_classes == 2:
-                        score = np.log(score[:, 1] / score[:, 0])
-                        score = score.reshape(X.shape[0], 1)
+                    raise ValueError("init model must have a "
+                                     "'predict_proba' method if a "
+                                     "classifier")
                 else:
                     score = pred.reshape(X.shape[0], 1)
             else:

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1049,6 +1049,30 @@ def test_classification_w_init():
         acc2 = clf.score(X_test, y_test)
         assert_greater_equal(acc2, acc1)
 
+def test_binary_classification_w_init():
+    # Test that gradient boosting a previously learned model will improve
+    # the performance of that model.
+    iris = datasets.load_digits()
+    X, y = iris.data, iris.target
+    X = X[ y < 2 ]
+    y = y[ y < 2 ]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
+                                                        random_state=0)
+
+    for clf in [DecisionTreeClassifier(random_state=0),
+                RandomForestClassifier(random_state=0, n_estimators=3), 
+                SVC(random_state=0)]:
+
+        clf.fit(X_train, y_train)
+        acc1 = clf.score(X_test, y_test)
+
+        clf = GradientBoostingClassifier(random_state=0,
+                                         n_estimators=1, 
+                                         init=clf)
+        clf.fit(X_train, y_train)
+        acc2 = clf.score(X_test, y_test)
+        assert_greater_equal(acc2, acc1)
+
 
 def test_regression_w_init():
     # Test that gradient boosting a previously learned model will improve

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -7,6 +7,7 @@ import numpy as np
 from sklearn import datasets
 from sklearn.base import clone
 from sklearn.cross_validation import train_test_split
+from sklearn.ensemble import ExtraTreesClassifier, ExtraTreesRegressor
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
 from sklearn.ensemble.gradient_boosting import ZeroEstimator
@@ -1035,9 +1036,8 @@ def test_classification_w_init():
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
                                                         random_state=0)
 
-    for clf in [DecisionTreeClassifier(random_state=0),
-                RandomForestClassifier(random_state=0, n_estimators=3), 
-                SVC(random_state=0)]:
+    for clf in [ExtraTreesClassifier(random_state=0, n_estimators=3),
+                RandomForestClassifier(random_state=0, n_estimators=3)]:
 
         clf.fit(X_train, y_train)
         acc1 = clf.score(X_test, y_test)
@@ -1060,8 +1060,8 @@ def test_binary_classification_w_init():
                                                         random_state=0)
 
     for clf in [DecisionTreeClassifier(random_state=0),
-                RandomForestClassifier(random_state=0, n_estimators=3), 
-                SVC(random_state=0)]:
+                ExtraTreesClassifier(random_state=0, n_estimators=3),
+                RandomForestClassifier(random_state=0, n_estimators=3)]:
 
         clf.fit(X_train, y_train)
         acc1 = clf.score(X_test, y_test)
@@ -1083,7 +1083,8 @@ def test_regression_w_init():
                                                         random_state=0)
 
     for clf in [DecisionTreeRegressor(random_state=0), 
-                RandomForestRegressor(random_state=0, n_estimators=3), 
+                RandomForestRegressor(random_state=0, n_estimators=3),
+                ExtraTreesRegressor(random_state=0, n_estimators=3), 
                 SVR(), Ridge()]:
 
         clf.fit(X_train, y_train)
@@ -1095,3 +1096,14 @@ def test_regression_w_init():
         clf.fit(X_train, y_train)
         acc2 = clf.score(X_test, y_test)
         assert_greater_equal(acc2, acc1)
+
+def test_error_on_bad_init():
+    # Test that an error will be raised when a bad init is passed in.
+
+    boston = datasets.load_boston()
+    X, y = boston.data, boston.target
+
+    clf = GradientBoostingClassifier(random_state=0, n_estimators=2,
+                                     init=SVC())
+
+    assert_raises(ValueError, clf.fit, X, y)


### PR DESCRIPTION
In #2691, it was brought up that passing an estimator as a base class to Gradient Boosting Classifiers or Regressors would cause it to crash due to various shape issues on y. The main issue being that it was expected that the predictions of the base estimator should be of shape (n_samples, n_classes) for multinomial classification, or (n_samples, 1) for binary classification and regression. 

This PR solves this issue by handling each case separately. If the initialization estimator is one of those already in `gradient_boosting.py`, it uses those predictions as normal. However, if a classifier was passed in, it will check to see if it has a `predict_proba` method and use that if possible (collapsing into the log odds if only two classes). If the classifier does not have a `predict_proba` method, it will use the `predict` method and hot encode that into a matrix. If this needs to be collapsed because there are only two classes, it adds a small epsilon to the matrix before calculating the log odds. If a regressor is passed in, then the predictions are just reshaped to make sense.

I also reordered the code a little bit for it to be more organized, and added two unit tests to make sure that it works. It now works with arbitrary estimators, as long as they take sample weights into their fit method, and the unit test includes tests on Support Vector Machines and ridge regression initializations.

ping @ogrisel @agramfort @glouppe @pprett 
