### PR TITLE
[MRG+2] In roc_curve: drop some suboptimal thresholds

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -206,6 +206,9 @@ Enhancements
      and :class:`ensemble.GradientBoostingClassifier`, keeping default behavior
      the same. This allows gradient boosters to turn off presorting when building
      deep trees or using sparse data. By `Jacob Schreiber`_.
+   
+   - Altered :func:`metrics.roc_curve` to drop unnecessary thresholds by
+     default. By `Graham Clenaghan`_.
 
 Bug fixes
 .........
@@ -3721,3 +3724,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Valentin Stolbunov: http://vstolbunov.com
 .. _Jean Kossaifi: https://github.com/JeanKossaifi
 .. _Andrew Lamb: https://github.com/andylamb
+.. _Graham Clenaghan: https://github.com/gclenaghan

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -126,14 +126,16 @@ def _average_precision(y_true, y_score):
 def test_roc_curve():
     # Test Area under Receiver Operating Characteristic (ROC) curve
     y_true, _, probas_pred = make_prediction(binary=True)
-
-    fpr, tpr, thresholds = roc_curve(y_true, probas_pred)
-    roc_auc = auc(fpr, tpr)
     expected_auc = _auc(y_true, probas_pred)
-    assert_array_almost_equal(roc_auc, expected_auc, decimal=2)
-    assert_almost_equal(roc_auc, roc_auc_score(y_true, probas_pred))
-    assert_equal(fpr.shape, tpr.shape)
-    assert_equal(fpr.shape, thresholds.shape)
+
+    for drop in [True, False]:
+        fpr, tpr, thresholds = roc_curve(y_true, probas_pred,
+                                         drop_intermediate=drop)
+        roc_auc = auc(fpr, tpr)
+        assert_array_almost_equal(roc_auc, expected_auc, decimal=2)
+        assert_almost_equal(roc_auc, roc_auc_score(y_true, probas_pred))
+        assert_equal(fpr.shape, tpr.shape)
+        assert_equal(fpr.shape, thresholds.shape)
 
 
 def test_roc_curve_end_points():
@@ -142,7 +144,7 @@ def test_roc_curve_end_points():
     rng = np.random.RandomState(0)
     y_true = np.array([0] * 50 + [1] * 50)
     y_pred = rng.randint(3, size=100)
-    fpr, tpr, thr = roc_curve(y_true, y_pred)
+    fpr, tpr, thr = roc_curve(y_true, y_pred, drop_intermediate=True)
     assert_equal(fpr[0], 0)
     assert_equal(fpr[-1], 1)
     assert_equal(fpr.shape, tpr.shape)
@@ -187,7 +189,7 @@ def test_roc_nonrepeating_thresholds():
     y_true = [yy < 5 for yy in y[test]]
 
     # Check for repeating values in the thresholds
-    fpr, tpr, thresholds = roc_curve(y_true, y_score)
+    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=False)
     assert_equal(thresholds.size, np.unique(np.round(thresholds, 2)).size)
 
 
@@ -346,6 +348,23 @@ def test_roc_curve_toydata():
     assert_almost_equal(roc_auc_score(y_true, y_score, average="weighted"), .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), .5)
+
+
+def test_roc_curve_drop_intermediate():
+    # Test that drop_intermediate drops the correct thresholds
+    y_true = [0, 0, 0, 0, 1, 1]
+    y_score = [0., 0.2, 0.5, 0.6, 0.7, 1.0]
+    tpr, fpr, thresholds = roc_curve(y_true, y_score)
+    assert_array_almost_equal(thresholds, [1., 0.7, 0.])
+
+    # Test dropping thresholds with repeating scores
+    y_true = [0, 0, 0, 0, 0, 0, 0,
+              1, 1, 1, 1, 1, 1]
+    y_score = [0., 0.1, 0.6, 0.6, 0.7, 0.8, 0.9,
+               0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
+    tpr, fpr, thresholds = roc_curve(y_true, y_score)
+    assert_array_almost_equal(thresholds,
+                              [1.0, 0.9, 0.7, 0.6, 0.])
 
 
 def test_auc():


### PR DESCRIPTION
Currently, the roc_curve function returns a value for every distinct possible threshold. For many classification routines this is close to the number of data points, and the results of this can get very unwieldy. For instance, with a large test set, the plotted ROC curve is unsuitable for a vector graphics format since the image file will be large and slow to load. Moreover, many of the thresholds are suboptimal: one could choose a different threshold for a higher TPR at the same FPR or a lower FPR at the same TPR.

I've added an option keep_all_thresholds to the roc_curve function which drops thresholds which are invisible on a plotted ROC curve when set to false (by default it is set to true to ensure compatibility). Basically, in the sorted list of scores, if two of the same class appear consecutively, it will drop threshold corresponding to the first.

Here are some tests:

```
In [21]:
t1, t2
import sklearn.datasets
import sklearn.metrics as met
import time
probas_pred, y_true = sklearn.datasets.make_classification(n_samples=1000000,
                                    n_features=1, n_informative=1,
                                    n_redundant=0, n_clusters_per_class=1,
                                    random_state=1031)
​
t0 = time.time()
fpr, tpr, thr = met.roc_curve(y_true, probas_pred)
t1 = time.time() - t0
​
t0 = time.time()
fpr2, tpr2, thr2 = met.roc_curve(y_true, probas_pred, keep_all_thresholds=False)
t2 = time.time() - t0
​
t1, t2

Out[21]:
(0.2661151885986328, 0.24276185035705566)

In [18]:

fpr.shape, fpr2.shape

Out[18]:
((990748,), (9843,))

In [19]:

met.auc(fpr, tpr) - met.auc(fpr2, tpr2)

Out[19]:
-2.2459999415858078e-09
```

With this option roc_curve is faster and returns many fewer results (how many fewer depends on how good the classifier is, results may vary).

I've also changed some tests to use the new option.

I've been doing something similar to this with the results of roc_curve but it would be quicker and easier to have it directly in the function. Please let me know if there is anything I forgot to do!
