### PR TITLE
[MRG+1] add multinomial SAG solver for LogisticRegression

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,24 +40,29 @@ Enhancements
 
    - The random forest, extra trees and decision tree estimators now has a
      method ``decision_path`` which returns the decision path of samples in
-     the tree. By `Arnaud Joly`_
+     the tree. By `Arnaud Joly`_.
 
 
    - The random forest, extra tree and decision tree estimators now has a
      method ``decision_path`` which returns the decision path of samples in
-     the tree. By `Arnaud Joly`_
+     the tree. By `Arnaud Joly`_.
 
    - A new example has been added unveling the decision tree structure.
-     By `Arnaud Joly`_
+     By `Arnaud Joly`_.
 
    - Random forest, extra trees, decision trees and gradient boosting estimator
      accept the parameter ``min_samples_split`` and ``min_samples_leaf``
      provided as a percentage of the training samples. By
-     `yelite`_ and `Arnaud Joly`_
+     `yelite`_ and `Arnaud Joly`_.
 
-    - Codebase does not contain C/C++ cython generated files: they are
-    generated during build. Distribution packages will still contain generated
-    C/C++ files. By `Arthur Mensch`_
+   - Codebase does not contain C/C++ cython generated files: they are
+     generated during build. Distribution packages will still contain generated
+     C/C++ files. By `Arthur Mensch`_.
+
+   - In :class:`linear_model.LogisticRegression`, the SAG solver is now
+     available in the multinomial case.
+     (`#5251 <https://github.com/scikit-learn/scikit-learn/pull/5251>`_)
+     By `Tom Dupre la Tour`_.
 
 Bug fixes
 .........
@@ -154,10 +159,6 @@ New features
      ``l1_ratio`` control L1 and L2 regularization, and ``shuffle`` adds a
      shuffling step in the ``cd`` solver.
      By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
-
-   - **IndexError** bug `#5495
-     <https://github.com/scikit-learn/scikit-learn/issues/5495>`_ when
-     doing OVR(SVC(decision_function_shape="ovr")). Fixed by `Elvis Dohmatob`_.
 
 Enhancements
 ............
@@ -434,6 +435,10 @@ Bug fixes
       :class:`linear_model.LogisticRegressionCV` when using
       ``class_weight='balanced'```or ``class_weight='auto'``.
       By `Tom Dupre la Tour`_.
+
+    - Fixed bug `#5495 <https://github.com/scikit-learn/scikit-learn/issues/5495>`_ when
+      doing OVR(SVC(decision_function_shape="ovr")). Fixed by `Elvis Dohmatob`_.
+
 
 API changes summary
 -------------------

--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -1,0 +1,70 @@
+"""
+====================================================
+Plot multinomial and One-vs-Rest Logistic Regression
+====================================================
+
+Plot decision surface of multinomial and One-vs-Rest Logistic Regression.
+The hyperplanes corresponding to the three One-vs-Rest (OVR) classifiers
+are represented by the dashed lines.
+"""
+print(__doc__)
+# Authors: Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
+# Licence: BSD 3 clause
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
+
+# make 3-class dataset for classification
+centers = [[-5, 0], [0, 1.5], [5, -1]]
+X, y = make_blobs(n_samples=1000, centers=centers, random_state=40)
+transformation = [[0.4, 0.2], [-0.4, 1.2]]
+X = np.dot(X, transformation)
+
+for multi_class in ('multinomial', 'ovr'):
+    clf = LogisticRegression(solver='sag', max_iter=100, random_state=42,
+                             multi_class=multi_class).fit(X, y)
+
+    # print the training scores
+    print("training score : %.3f (%s)" % (clf.score(X, y), multi_class))
+
+    # create a mesh to plot in
+    h = .02  # step size in the mesh
+    x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1
+    y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
+    xx, yy = np.meshgrid(np.arange(x_min, x_max, h),
+                         np.arange(y_min, y_max, h))
+
+    # Plot the decision boundary. For that, we will assign a color to each
+    # point in the mesh [x_min, m_max]x[y_min, y_max].
+    Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
+    # Put the result into a color plot
+    Z = Z.reshape(xx.shape)
+    plt.figure()
+    plt.contourf(xx, yy, Z, cmap=plt.cm.Paired)
+    plt.title("Decision surface of LogisticRegression (%s)" % multi_class)
+    plt.axis('tight')
+
+    # Plot also the training points
+    colors = "bry"
+    for i, color in zip(clf.classes_, colors):
+        idx = np.where(y == i)
+        plt.scatter(X[idx, 0], X[idx, 1], c=color, cmap=plt.cm.Paired)
+
+    # Plot the three one-against-all classifiers
+    xmin, xmax = plt.xlim()
+    ymin, ymax = plt.ylim()
+    coef = clf.coef_
+    intercept = clf.intercept_
+
+    def plot_hyperplane(c, color):
+        def line(x0):
+            return (-(x0 * coef[c, 0]) - intercept[c]) / coef[c, 1]
+        plt.plot([xmin, xmax], [line(xmin), line(xmax)],
+                 ls="--", color=color)
+
+    for i, color in zip(clf.classes_, colors):
+        plot_hyperplane(i, color)
+
+plt.show()

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -61,8 +61,8 @@ def make_dataset(X, y, sample_weight, random_state=None):
     seed = rng.randint(1, np.iinfo(np.int32).max)
 
     if sp.issparse(X):
-        dataset = CSRDataset(X.data, X.indptr, X.indices,
-                             y, sample_weight, seed=seed)
+        dataset = CSRDataset(X.data, X.indptr, X.indices, y, sample_weight,
+                             seed=seed)
         intercept_decay = SPARSE_INTERCEPT_DECAY
     else:
         dataset = ArrayDataset(X, y, sample_weight, seed=seed)

--- a/sklearn/linear_model/logistic.py
+++ b/sklearn/linear_model/logistic.py
@@ -18,7 +18,6 @@ from scipy import optimize, sparse
 
 from .base import LinearClassifierMixin, SparseCoefMixin, BaseEstimator
 from .sag import sag_solver
-from .sag_fast import get_max_squared_sum
 from ..feature_selection.from_model import _LearntSelectorMixin
 from ..preprocessing import LabelEncoder, LabelBinarizer
 from ..svm.base import _fit_liblinear
@@ -26,6 +25,7 @@ from ..utils import check_array, check_consistent_length, compute_class_weight
 from ..utils import check_random_state
 from ..utils.extmath import (logsumexp, log_logistic, safe_sparse_dot,
                              softmax, squared_norm)
+from ..utils.extmath import row_norms
 from ..utils.optimize import newton_cg
 from ..utils.validation import check_X_y
 from ..exceptions import DataConversionWarning
@@ -260,6 +260,11 @@ def _multinomial_loss(w, X, Y, alpha, sample_weight):
 
     w : ndarray, shape (n_classes, n_features)
         Reshaped param vector excluding intercept terms.
+
+    Reference
+    ---------
+    Bishop, C. M. (2006). Pattern recognition and machine learning.
+    Springer. (Chapter 4.3.4)
     """
     n_classes = Y.shape[1]
     n_features = X.shape[1]
@@ -312,6 +317,11 @@ def _multinomial_loss_grad(w, X, Y, alpha, sample_weight):
 
     p : ndarray, shape (n_samples, n_classes)
         Estimated class probabilities
+
+    Reference
+    ---------
+    Bishop, C. M. (2006). Pattern recognition and machine learning.
+    Springer. (Chapter 4.3.4)
     """
     n_classes = Y.shape[1]
     n_features = X.shape[1]
@@ -409,7 +419,7 @@ def _check_solver_option(solver, multi_class, penalty, dual):
         raise ValueError("multi_class should be either multinomial or "
                          "ovr, got %s" % multi_class)
 
-    if multi_class == 'multinomial' and solver in ['liblinear', 'sag']:
+    if multi_class == 'multinomial' and solver == 'liblinear':
         raise ValueError("Solver %s does not support "
                          "a multinomial backend." % solver)
 
@@ -524,7 +534,7 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
-        shuffling the data.
+        shuffling the data. Used only in solvers 'sag' and 'liblinear'.
 
     check_input : bool, default True
         If False, the input arrays X and y will not be checked.
@@ -629,11 +639,17 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             sample_weight *= class_weight_[le.fit_transform(y_bin)]
 
     else:
-        lbin = LabelBinarizer()
-        Y_binarized = lbin.fit_transform(y)
-        if Y_binarized.shape[1] == 1:
-            Y_binarized = np.hstack([1 - Y_binarized, Y_binarized])
-        w0 = np.zeros((Y_binarized.shape[1], n_features + int(fit_intercept)),
+        if solver != 'sag':
+            lbin = LabelBinarizer()
+            Y_multi = lbin.fit_transform(y)
+            if Y_multi.shape[1] == 1:
+                Y_multi = np.hstack([1 - Y_multi, Y_multi])
+        else:
+            # SAG multinomial solver needs LabelEncoder, not LabelBinarizer
+            le = LabelEncoder()
+            Y_multi = le.fit_transform(y)
+
+        w0 = np.zeros((classes.size, n_features + int(fit_intercept)),
                       order='F')
 
     if coef is not None:
@@ -647,11 +663,11 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         else:
             # For binary problems coef.shape[0] should be 1, otherwise it
             # should be classes.size.
-            n_vectors = classes.size
-            if n_vectors == 2:
-                n_vectors = 1
+            n_classes = classes.size
+            if n_classes == 2:
+                n_classes = 1
 
-            if (coef.shape[0] != n_vectors or
+            if (coef.shape[0] != n_classes or
                     coef.shape[1] not in (n_features, n_features + 1)):
                 raise ValueError(
                     'Initialization coef is of shape (%d, %d), expected '
@@ -662,14 +678,16 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
 
     if multi_class == 'multinomial':
         # fmin_l_bfgs_b and newton-cg accepts only ravelled parameters.
-        w0 = w0.ravel()
-        target = Y_binarized
+        if solver in ['lbfgs', 'newton-cg']:
+            w0 = w0.ravel()
+        target = Y_multi
         if solver == 'lbfgs':
             func = lambda x, *args: _multinomial_loss_grad(x, *args)[0:2]
         elif solver == 'newton-cg':
             func = lambda x, *args: _multinomial_loss(x, *args)[0]
             grad = lambda x, *args: _multinomial_loss_grad(x, *args)[1]
             hess = _multinomial_grad_hess
+        warm_start_sag = {'coef': w0.T}
     else:
         target = y_bin
         if solver == 'lbfgs':
@@ -678,9 +696,9 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
             func = _logistic_loss
             grad = lambda x, *args: _logistic_loss_and_grad(x, *args)[1]
             hess = _logistic_grad_hess
+        warm_start_sag = {'coef': np.expand_dims(w0, axis=1)}
 
     coefs = list()
-    warm_start_sag = {'coef': w0}
     n_iter = np.zeros(len(Cs), dtype=np.int32)
     for i, C in enumerate(Cs):
         if solver == 'lbfgs':
@@ -717,10 +735,16 @@ def logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                 w0 = coef_.ravel()
 
         elif solver == 'sag':
+            if multi_class == 'multinomial':
+                target = target.astype(np.float64)
+                loss = 'multinomial'
+            else:
+                loss = 'log'
+
             w0, n_iter_i, warm_start_sag = sag_solver(
-                X, target, sample_weight, 'log', 1. / C, max_iter, tol,
-                verbose, random_state, False, max_squared_sum,
-                warm_start_sag)
+                X, target, sample_weight, loss, 1. / C, max_iter, tol,
+                verbose, random_state, False, max_squared_sum, warm_start_sag)
+
         else:
             raise ValueError("solver must be one of {'liblinear', 'lbfgs', "
                              "'newton-cg', 'sag'}, got '%s' instead" % solver)
@@ -835,7 +859,7 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
-        shuffling the data.
+        shuffling the data. Used only in solvers 'sag' and 'liblinear'.
 
     max_squared_sum : float, default None
         Maximum squared sum of X over samples. Used only in SAG solver.
@@ -926,28 +950,28 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
     """Logistic Regression (aka logit, MaxEnt) classifier.
 
     In the multiclass case, the training algorithm uses the one-vs-rest (OvR)
-    scheme if the 'multi_class' option is set to 'ovr' and uses the
-    cross-entropy loss, if the 'multi_class' option is set to 'multinomial'.
-    (Currently the 'multinomial' option is supported only by the 'lbfgs' and
-    'newton-cg' solvers.)
+    scheme if the 'multi_class' option is set to 'ovr' and uses the cross-
+    entropy loss, if the 'multi_class' option is set to 'multinomial'.
+    (Currently the 'multinomial' option is supported only by the 'lbfgs',
+    'sag' and 'newton-cg' solvers.)
 
     This class implements regularized logistic regression using the
-    `liblinear` library, newton-cg and lbfgs solvers. It can handle both
-    dense and sparse input. Use C-ordered arrays or CSR matrices containing
-    64-bit floats for optimal performance; any other input format will be
-    converted (and copied).
+    'liblinear' library, 'newton-cg', 'sag' and 'lbfgs' solvers. It can handle
+    both dense and sparse input. Use C-ordered arrays or CSR matrices
+    containing 64-bit floats for optimal performance; any other input format
+    will be converted (and copied).
 
-    The newton-cg and lbfgs solvers support only L2 regularization with primal
-    formulation. The liblinear solver supports both L1 and L2 regularization,
-    with a dual formulation only for the L2 penalty.
+    The 'newton-cg', 'sag', and 'lbfgs' solvers support only L2 regularization
+    with primal formulation. The 'liblinear' solver supports both L1 and L2
+    regularization, with a dual formulation only for the L2 penalty.
 
     Read more in the :ref:`User Guide <logistic_regression>`.
 
     Parameters
     ----------
     penalty : str, 'l1' or 'l2'
-        Used to specify the norm used in the penalization. The newton-cg and
-        lbfgs solvers support only l2 penalties.
+        Used to specify the norm used in the penalization. The newton-cg, sag
+        and lbfgs solvers support only l2 penalties.
 
     dual : bool
         Dual or primal formulation. Dual formulation is only implemented for
@@ -987,7 +1011,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         through the fit method) if sample_weight is specified.
 
         .. versionadded:: 0.17
-           *class_weight='balanced'* instead of deprecated *class_weight='auto'*.
+           *class_weight='balanced'* instead of deprecated
+           *class_weight='auto'*.
 
     max_iter : int
         Useful only for the newton-cg, sag and lbfgs solvers.
@@ -995,16 +1020,16 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
-        shuffling the data.
+        shuffling the data. Used only in solvers 'sag' and 'liblinear'.
 
     solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag'}
         Algorithm to use in the optimization problem.
 
         - For small datasets, 'liblinear' is a good choice, whereas 'sag' is
             faster for large ones.
-        - For multiclass problems, only 'newton-cg' and 'lbfgs' handle
-            multinomial loss; 'sag' and 'liblinear' are limited to
-            one-versus-rest schemes.
+        - For multiclass problems, only 'newton-cg', 'sag' and 'lbfgs' handle
+            multinomial loss; 'liblinear' is limited to one-versus-rest
+            schemes.
         - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty.
 
         Note that 'sag' fast convergence is only guaranteed on features with
@@ -1021,8 +1046,8 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         Multiclass option can be either 'ovr' or 'multinomial'. If the option
         chosen is 'ovr', then a binary problem is fit for each label. Else
         the loss minimised is the multinomial loss fit across
-        the entire probability distribution. Works only for the 'lbfgs'
-        solver.
+        the entire probability distribution. Works only for the 'newton-cg',
+        'sag' and 'lbfgs' solver.
 
     verbose : int
         For the liblinear and lbfgs solvers set verbose to any positive
@@ -1155,8 +1180,10 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
             self.n_iter_ = np.array([n_iter_])
             return self
 
-        max_squared_sum = get_max_squared_sum(X) if self.solver == 'sag' \
-            else None
+        if self.solver == 'sag':
+            max_squared_sum = row_norms(X, squared=True).max()
+        else:
+            max_squared_sum = None
 
         n_classes = len(self.classes_)
         classes_ = self.classes_
@@ -1347,12 +1374,19 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
         - For small datasets, 'liblinear' is a good choice, whereas 'sag' is
             faster for large ones.
-        - For multiclass problems, only 'newton-cg' and 'lbfgs' handle
-            multinomial loss; 'sag' and 'liblinear' are limited to
-            one-versus-rest schemes.
+        - For multiclass problems, only 'newton-cg', 'sag' and 'lbfgs' handle
+            multinomial loss; 'liblinear' is limited to one-versus-rest
+            schemes.
         - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty.
         - 'liblinear' might be slower in LogisticRegressionCV because it does
             not handle warm-starting.
+
+        Note that 'sag' fast convergence is only guaranteed on features with
+        approximately the same scale. You can preprocess the data with a
+        scaler from sklearn.preprocessing.
+
+        .. versionadded:: 0.17
+           Stochastic Average Gradient descent solver.
 
     tol : float, optional
         Tolerance for stopping criteria.
@@ -1379,8 +1413,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         Multiclass option can be either 'ovr' or 'multinomial'. If the option
         chosen is 'ovr', then a binary problem is fit for each label. Else
         the loss minimised is the multinomial loss fit across
-        the entire probability distribution. Works only for 'lbfgs' and
-        'newton-cg' solvers.
+        the entire probability distribution. Works only for the 'newton-cg',
+        'sag' and 'lbfgs' solver.
 
     intercept_scaling : float, default 1.
         Useful only if solver is liblinear.
@@ -1507,8 +1541,12 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
         X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64,
                          order="C")
-        max_squared_sum = get_max_squared_sum(X) if self.solver == 'sag' \
-            else None
+
+        if self.solver == 'sag':
+            max_squared_sum = row_norms(X, squared=True).max()
+        else:
+            max_squared_sum = None
+
         check_classification_targets(y)
 
         if y.ndim == 2 and y.shape[1] == 1:

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -19,9 +19,9 @@ from scipy.sparse import linalg as sp_linalg
 
 from .base import LinearClassifierMixin, LinearModel, _rescale_data
 from .sag import sag_solver
-from .sag_fast import get_max_squared_sum
 from ..base import RegressorMixin
 from ..utils.extmath import safe_sparse_dot
+from ..utils.extmath import row_norms
 from ..utils import check_X_y
 from ..utils import check_array
 from ..utils import check_consistent_length
@@ -265,7 +265,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
-        shuffling the data. Used in 'sag' solver.
+        shuffling the data. Used only in 'sag' solver.
 
     return_n_iter : boolean, default False
         If True, the method also returns `n_iter`, the actual number of
@@ -391,17 +391,17 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     elif solver == 'sag':
         # precompute max_squared_sum for all targets
-        max_squared_sum = get_max_squared_sum(X)
+        max_squared_sum = row_norms(X, squared=True).max()
 
         coef = np.empty((y.shape[1], n_features))
         n_iter = np.empty(y.shape[1], dtype=np.int32)
         intercept = np.zeros((y.shape[1], ))
         for i, (alpha_i, target) in enumerate(zip(alpha, y.T)):
-            start = {'coef': np.zeros(n_features + int(return_intercept))}
+            init = {'coef': np.zeros((n_features + int(return_intercept), 1))}
             coef_, n_iter_, _ = sag_solver(
                 X, target.ravel(), sample_weight, 'squared', alpha_i,
                 max_iter, tol, verbose, random_state, False, max_squared_sum,
-                start)
+                init)
             if return_intercept:
                 coef[i] = coef_[:-1]
                 intercept[i] = coef_[-1]
@@ -554,7 +554,7 @@ class Ridge(_BaseRidge, RegressorMixin):
 
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use when
-        shuffling the data. Used in 'sag' solver.
+        shuffling the data. Used only in 'sag' solver.
 
         .. versionadded:: 0.17
            *random_state* to support Stochastic Average Gradient.

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -9,9 +9,9 @@ import warnings
 
 from ..exceptions import ConvergenceWarning
 from ..utils import check_array
+from ..utils.extmath import row_norms
 from .base import make_dataset
-from .sgd_fast import Log, SquaredLoss
-from .sag_fast import sag, get_max_squared_sum
+from .sag_fast import sag
 
 
 def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept):
@@ -41,8 +41,13 @@ def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept):
     step_size : float
         Step size used in SAG solver.
 
+    References
+    ----------
+    Schmidt, M., Roux, N. L., & Bach, F. (2013).
+    Minimizing finite sums with the stochastic average gradient
+    https://hal.inria.fr/hal-00860051/PDF/sag_journal.pdf
     """
-    if loss == 'log':
+    if loss in ('log', 'multinomial'):
         # inverse Lipschitz constant for log loss
         return 4.0 / (max_squared_sum + int(fit_intercept)
                       + 4.0 * alpha_scaled)
@@ -84,15 +89,18 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
         Training data
 
     y : numpy array, shape (n_samples,)
-        Target values
+        Target values. With loss='multinomial', y must be label encoded
+        (see preprocessing.LabelEncoder).
 
     sample_weight : array-like, shape (n_samples,), optional
         Weights applied to individual samples (1. for unweighted).
 
-    loss : 'log' | 'squared'
-        Loss function that will be optimized.
-        'log' is used for classification, like in LogisticRegression.
-        'squared' is used for regression, like in Ridge.
+    loss : 'log' | 'squared' | 'multinomial'
+        Loss function that will be optimized:
+        -'log' is the binary logistic loss, as used in LogisticRegression.
+        -'squared' is the squared loss, as used in Ridge.
+        -'multinomial' is the multinomial logistic loss, as used in
+         LogisticRegression.
 
     alpha : float, optional
         Constant that multiplies the regularization term. Defaults to 1.
@@ -121,8 +129,18 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
         to speed up cross validation.
 
     warm_start_mem: dict, optional
-        The initialization parameters used for warm starting. It is currently
-        not used in Ridge.
+        The initialization parameters used for warm starting. Warm starting is
+        currently used in LogisticRegression but not in Ridge.
+        It contains:
+            - 'coef': the weight vector, with the intercept in last line
+                if the intercept is fitted.
+            - 'gradient_memory': the scalar gradient for all seen samples.
+            - 'sum_gradient': the sum of gradient over all seen samples,
+                for each feature.
+            - 'intercept_sum_gradient': the sum of gradient over all seen
+                samples, for the intercept.
+            - 'seen': array of boolean describing the seen samples.
+            - 'num_seen': the number of seen samples.
 
     Returns
     -------
@@ -133,7 +151,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
         The number of full pass on all samples.
 
     warm_start_mem : dict
-        Contains a 'coef' key with the fitted result, and eventually the
+        Contains a 'coef' key with the fitted result, and possibly the
         fitted intercept at the end of the array. Contains also other keys
         used for warm starting.
 
@@ -186,6 +204,9 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     # As in SGD, the alpha is scaled by n_samples.
     alpha_scaled = float(alpha) / n_samples
 
+    # if loss == 'multinomial', y should be label encoded.
+    n_classes = int(y.max()) + 1 if loss == 'multinomial' else 1
+
     # initialization
     if sample_weight is None:
         sample_weight = np.ones(n_samples, dtype=np.float64, order='C')
@@ -193,31 +214,34 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     if 'coef' in warm_start_mem.keys():
         coef_init = warm_start_mem['coef']
     else:
-        coef_init = np.zeros(n_features, dtype=np.float64, order='C')
+        # assume fit_intercept is False
+        coef_init = np.zeros((n_features, n_classes), dtype=np.float64,
+                             order='C')
 
     # coef_init contains possibly the intercept_init at the end.
     # Note that Ridge centers the data before fitting, so fit_intercept=False.
-    fit_intercept = coef_init.size == (n_features + 1)
+    fit_intercept = coef_init.shape[0] == (n_features + 1)
     if fit_intercept:
-        intercept_init = coef_init[-1]
-        coef_init = coef_init[:-1]
+        intercept_init = coef_init[-1, :]
+        coef_init = coef_init[:-1, :]
     else:
-        intercept_init = 0.0
+        intercept_init = np.zeros(n_classes, dtype=np.float64)
 
     if 'intercept_sum_gradient' in warm_start_mem.keys():
-        intercept_sum_gradient_init = warm_start_mem['intercept_sum_gradient']
+        intercept_sum_gradient = warm_start_mem['intercept_sum_gradient']
     else:
-        intercept_sum_gradient_init = 0.0
+        intercept_sum_gradient = np.zeros(n_classes, dtype=np.float64)
 
     if 'gradient_memory' in warm_start_mem.keys():
         gradient_memory_init = warm_start_mem['gradient_memory']
     else:
-        gradient_memory_init = np.zeros(n_samples, dtype=np.float64,
-                                        order='C')
+        gradient_memory_init = np.zeros((n_samples, n_classes),
+                                        dtype=np.float64, order='C')
     if 'sum_gradient' in warm_start_mem.keys():
         sum_gradient_init = warm_start_mem['sum_gradient']
     else:
-        sum_gradient_init = np.zeros(n_features, dtype=np.float64, order='C')
+        sum_gradient_init = np.zeros((n_features, n_classes),
+                                     dtype=np.float64, order='C')
 
     if 'seen' in warm_start_mem.keys():
         seen_init = warm_start_mem['seen']
@@ -232,7 +256,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
     dataset, intercept_decay = make_dataset(X, y, sample_weight, random_state)
 
     if max_squared_sum is None:
-        max_squared_sum = get_max_squared_sum(X)
+        max_squared_sum = row_norms(X, squared=True).max()
     step_size = get_auto_step_size(max_squared_sum, alpha_scaled, loss,
                                    fit_intercept)
 
@@ -240,41 +264,35 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1.,
         raise ZeroDivisionError("Current sag implementation does not handle "
                                 "the case step_size * alpha_scaled == 1")
 
-    if loss == 'log':
-        class_loss = Log()
-    elif loss == 'squared':
-        class_loss = SquaredLoss()
-    else:
-        raise ValueError("Invalid loss parameter: got %r instead of "
-                         "one of ('log', 'squared')" % loss)
-
-    intercept_, num_seen, n_iter_, intercept_sum_gradient = \
-        sag(dataset, coef_init.ravel(),
-            intercept_init, n_samples,
-            n_features, tol,
-            max_iter,
-            class_loss,
-            step_size, alpha_scaled,
-            sum_gradient_init.ravel(),
-            gradient_memory_init.ravel(),
-            seen_init.ravel(),
-            num_seen_init,
-            fit_intercept,
-            intercept_sum_gradient_init,
-            intercept_decay,
-            verbose)
-
+    num_seen, n_iter_ = sag(dataset, coef_init,
+                            intercept_init, n_samples,
+                            n_features, n_classes, tol,
+                            max_iter,
+                            loss,
+                            step_size, alpha_scaled,
+                            sum_gradient_init,
+                            gradient_memory_init,
+                            seen_init,
+                            num_seen_init,
+                            fit_intercept,
+                            intercept_sum_gradient,
+                            intercept_decay,
+                            verbose)
     if n_iter_ == max_iter:
         warnings.warn("The max_iter was reached which means "
                       "the coef_ did not converge", ConvergenceWarning)
 
-    coef_ = coef_init
     if fit_intercept:
-        coef_ = np.append(coef_, intercept_)
+        coef_init = np.vstack((coef_init, intercept_init))
 
-    warm_start_mem = {'coef': coef_, 'sum_gradient': sum_gradient_init,
+    warm_start_mem = {'coef': coef_init, 'sum_gradient': sum_gradient_init,
                       'intercept_sum_gradient': intercept_sum_gradient,
                       'gradient_memory': gradient_memory_init,
                       'seen': seen_init, 'num_seen': num_seen}
+
+    if loss == 'multinomial':
+        coef_ = coef_init.T
+    else:
+        coef_ = coef_init[:, 0]
 
     return coef_, n_iter_, warm_start_mem

--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -6,24 +6,19 @@
 #          Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
 #
 # Licence: BSD 3 clause
-
 import numpy as np
 cimport numpy as np
 import scipy.sparse as sp
-from libc.math cimport fabs
+from libc.math cimport fabs, exp, log
 from libc.time cimport time, time_t
 
 from ..utils.seq_dataset cimport SequentialDataset
 from .sgd_fast cimport LossFunction
+from .sgd_fast cimport Log, SquaredLoss
+
 
 cdef extern from "sgd_fast_helpers.h":
     bint skl_isfinite(double) nogil
-
-# This sparse implementation is taken from section 4.3 of "Minimizing Finite
-# Sums with the Stochastic Average Gradient" by
-# Mark Schmidt, Nicolas Le Roux, Francis Bach. 2013. <hal-00860051>
-#
-# https://hal.inria.fr/hal-00860051/PDF/sag_journal.pdf
 
 
 cdef inline double fmax(double x, double y) nogil:
@@ -32,62 +27,271 @@ cdef inline double fmax(double x, double y) nogil:
     return y
 
 
+cdef double _logsumexp(double* arr, int n_classes) nogil:
+    """Computes the sum of arr assuming arr is in the log domain.
+
+    Returns log(sum(exp(arr))) while minimizing the possibility of
+    over/underflow.
+    """
+    # Use the max to normalize, as with the log this is what accumulates
+    # the less errors
+    cdef double vmax = arr[0]
+    cdef double out = 0.0
+    cdef int i
+
+    for i in range(1, n_classes):
+        if vmax < arr[i]:
+            vmax = arr[i]
+
+    for i in range(n_classes):
+        out += exp(arr[i] - vmax)
+
+    return log(out) + vmax
+
+
+cdef class MultinomialLogLoss:
+    cdef double _loss(self, double* prediction, double y, int n_classes,
+                      double sample_weight) nogil:
+        """Multinomial Logistic regression loss.
+
+        The multinomial logistic loss for one sample is:
+        loss = - sw \sum_c \delta_{y,c} (prediction[c] - logsumexp(prediction))
+             = sw (logsumexp(prediction) - prediction[y])
+
+        where:
+            prediction = dot(x_sample, weights) + intercept
+            \delta_{y,c} = 1 if (y == c) else 0
+            sw = sample_weight
+
+        Parameters
+        ----------
+        prediction : pointer to a np.ndarray[double] of shape (n_classes,)
+            Prediction of the multinomial classifier, for current sample.
+
+        y : double, between 0 and n_classes - 1
+            Indice of the correct class for current sample (i.e. label encoded).
+
+        n_classes : integer
+            Total number of classes.
+
+        sample_weight : double
+            Weight of current sample.
+
+        Returns
+        -------
+        loss : double
+            Multinomial loss for current sample.
+
+        Reference
+        ---------
+        Bishop, C. M. (2006). Pattern recognition and machine learning.
+        Springer. (Chapter 4.3.4)
+        """
+        cdef double logsumexp_prediction = _logsumexp(prediction, n_classes)
+        cdef double loss
+
+        # y is the indice of the correct class of current sample.
+        loss = (logsumexp_prediction - prediction[int(y)]) * sample_weight
+        return loss
+
+    cdef void _dloss(self, double* prediction, double y, int n_classes,
+                     double sample_weight, double* gradient_ptr) nogil:
+        """Multinomial Logistic regression gradient of the loss.
+
+        The gradient of the multinomial logistic loss with respect to a class c,
+        and for one sample is:
+        grad_c = - sw * (p[c] - \delta_{y,c})
+
+        where:
+            p[c] = exp(logsumexp(prediction) - prediction[c])
+            prediction = dot(sample, weights) + intercept
+            \delta_{y,c} = 1 if (y == c) else 0
+            sw = sample_weight
+
+        Note that to obtain the true gradient, this value has to be multiplied
+        by the sample vector x.
+
+        Parameters
+        ----------
+        prediction : pointer to a np.ndarray[double] of shape (n_classes,)
+            Prediction of the multinomial classifier, for current sample.
+
+        y : double, between 0 and n_classes - 1
+            Indice of the correct class for current sample (i.e. label encoded)
+
+        n_classes : integer
+            Total number of classes.
+
+        sample_weight : double
+            Weight of current sample.
+
+        gradient_ptr : pointer to a np.ndarray[double] of shape (n_classes,)
+            Gradient vector to be filled.
+
+        Reference
+        ---------
+        Bishop, C. M. (2006). Pattern recognition and machine learning.
+        Springer. (Chapter 4.3.4)
+        """
+        cdef double logsumexp_prediction = _logsumexp(prediction, n_classes)
+        cdef int class_ind
+
+        for class_ind in range(n_classes):
+            gradient_ptr[class_ind] = exp(prediction[class_ind] -
+                                          logsumexp_prediction)
+
+            # y is the indice of the correct class of current sample.
+            if class_ind == y:
+                gradient_ptr[class_ind] -= 1.0
+
+            gradient_ptr[class_ind] *= sample_weight
+
+    def __reduce__(self):
+        return MultinomialLogLoss, ()
+
+
+def _multinomial_grad_loss_all_samples(
+        SequentialDataset dataset,
+        np.ndarray[double, ndim=2, mode='c'] weights_array,
+        np.ndarray[double, ndim=1, mode='c'] intercept_array,
+        int n_samples, int n_features, int n_classes):
+    """Compute multinomial gradient and loss across all samples.
+
+    Used for testing purpose only.
+    """
+    cdef double* weights = <double * >weights_array.data
+    cdef double* intercept = <double * >intercept_array.data
+
+    cdef double *x_data_ptr = NULL
+    cdef int *x_ind_ptr = NULL
+    cdef int xnnz = -1
+    cdef double y
+    cdef double sample_weight
+
+    cdef double wscale = 1.0
+    cdef int i, j, class_ind, feature_ind
+    cdef double val
+    cdef double sum_loss = 0.0
+
+    cdef MultinomialLogLoss multiloss = MultinomialLogLoss()
+
+    cdef np.ndarray[double, ndim=2] sum_gradient_array = \
+        np.zeros((n_features, n_classes), dtype=np.double, order="c")
+    cdef double* sum_gradient = <double*> sum_gradient_array.data
+
+    cdef np.ndarray[double, ndim=1] prediction_array = \
+        np.zeros(n_classes, dtype=np.double, order="c")
+    cdef double* prediction = <double*> prediction_array.data
+
+    cdef np.ndarray[double, ndim=1] gradient_array = \
+        np.zeros(n_classes, dtype=np.double, order="c")
+    cdef double* gradient = <double*> gradient_array.data
+
+    with nogil:
+        for i in range(n_samples):
+            # get next sample on the dataset
+            dataset.next(&x_data_ptr, &x_ind_ptr, &xnnz,
+                         &y, &sample_weight)
+
+            # prediction of the multinomial classifier for the sample
+            predict_sample(x_data_ptr, x_ind_ptr, xnnz, weights, wscale,
+                           intercept, prediction, n_classes)
+
+            # compute the gradient for this sample, given the prediction
+            multiloss._dloss(prediction, y, n_classes, sample_weight, gradient)
+
+            # compute the loss for this sample, given the prediction
+            sum_loss += multiloss._loss(prediction, y, n_classes, sample_weight)
+
+            # update the sum of the gradient
+            for j in range(xnnz):
+                feature_ind = x_ind_ptr[j]
+                val = x_data_ptr[j]
+                for class_ind in range(n_classes):
+                    sum_gradient[feature_ind * n_classes + class_ind] += \
+                        gradient[class_ind] * val
+
+    return sum_loss, sum_gradient_array
+
+
 def sag(SequentialDataset dataset,
-        np.ndarray[double, ndim=1, mode='c'] weights_array,
-        double intercept,
+        np.ndarray[double, ndim=2, mode='c'] weights_array,
+        np.ndarray[double, ndim=1, mode='c'] intercept_array,
         int n_samples,
         int n_features,
+        int n_classes,
         double tol,
         int max_iter,
-        LossFunction loss,
+        str loss_function,
         double step_size,
         double alpha,
-        np.ndarray[double, ndim=1, mode='c'] sum_gradient_init,
-        np.ndarray[double, ndim=1, mode='c'] gradient_memory_init,
+        np.ndarray[double, ndim=2, mode='c'] sum_gradient_init,
+        np.ndarray[double, ndim=2, mode='c'] gradient_memory_init,
         np.ndarray[bint, ndim=1, mode='c'] seen_init,
         int num_seen,
         bint fit_intercept,
-        double intercept_sum_gradient,
+        np.ndarray[double, ndim=1, mode='c'] intercept_sum_gradient_init,
         double intercept_decay,
         bint verbose):
+    """Stochastic Average Gradient (SAG) solver.
 
-    # true if the weights or intercept are NaN or infinity
-    cdef bint infinity = False
-    # the pointer to the coef_ or weights
-    cdef double* weights = <double * >weights_array.data
-    # the data pointer for X, the training set
-    cdef double *x_data_ptr
+    Used in Ridge and LogisticRegression.
+
+    Reference
+    ---------
+    Schmidt, M., Roux, N. L., & Bach, F. (2013).
+    Minimizing finite sums with the stochastic average gradient
+    https://hal.inria.fr/hal-00860051/PDF/sag_journal.pdf
+    (section 4.3)
+    """
+    # the data pointer for x, the current sample
+    cdef double *x_data_ptr = NULL
     # the index pointer for the column of the data
-    cdef int *x_ind_ptr
-    # the label for the sample
+    cdef int *x_ind_ptr = NULL
+    # the number of non-zero features for current sample
+    cdef int xnnz = -1
+    # the label value for curent sample
     cdef double y
-    # the prediction for y
-    cdef double p
     # the sample weight
     cdef double sample_weight
-    # the number of non-zero features for this sample
-    cdef int xnnz
+
     # helper variable for indexes
-    cdef int idx
+    cdef int f_idx, s_idx, feature_ind, class_ind, j
     # the number of pass through all samples
     cdef int n_iter = 0
     # helper to track iterations through samples
-    cdef int itr
+    cdef int sample_itr
     # the index (row number) of the current sample
-    cdef int current_index
+    cdef int sample_ind
+
     # the maximum change in weights, used to compute stopping criterea
     cdef double max_change
     # a holder variable for the max weight, used to compute stopping criterea
     cdef double max_weight
+
     # the start time of the fit
     cdef time_t start_time
     # the end time of the fit
     cdef time_t end_time
+
     # precomputation since the step size does not change in this implementation
     cdef double wscale_update = 1.0 - step_size * alpha
 
     # vector of booleans indicating whether this sample has been seen
     cdef bint* seen = <bint*> seen_init.data
+
+    # helper for cumulative sum
+    cdef double cum_sum
+
+    # the pointer to the coef_ or weights
+    cdef double* weights = <double * >weights_array.data
+    # the pointer to the intercept_array
+    cdef double* intercept = <double * >intercept_array.data
+
+    # the pointer to the intercept_sum_gradient
+    cdef double* intercept_sum_gradient = \
+        <double * >intercept_sum_gradient_init.data
+
     # the sum of gradients for each feature
     cdef double* sum_gradient = <double*> sum_gradient_init.data
     # the previously seen gradient for each sample
@@ -97,247 +301,263 @@ def sag(SequentialDataset dataset,
     cdef np.ndarray[double, ndim=1] cumulative_sums_array = \
         np.empty(n_samples, dtype=np.double, order="c")
     cdef double* cumulative_sums = <double*> cumulative_sums_array.data
+
     # the index for the last time this feature was updated
     cdef np.ndarray[int, ndim=1] feature_hist_array = \
         np.zeros(n_features, dtype=np.int32, order="c")
     cdef int* feature_hist = <int*> feature_hist_array.data
+
     # the previous weights to use to compute stopping criteria
-    cdef np.ndarray[double, ndim=1] previous_weights_array = \
-        np.zeros(n_features, dtype=np.double, order="c")
+    cdef np.ndarray[double, ndim=2] previous_weights_array = \
+        np.zeros((n_features, n_classes), dtype=np.double, order="c")
     cdef double* previous_weights = <double*> previous_weights_array.data
+
+    cdef np.ndarray[double, ndim=1] prediction_array = \
+        np.zeros(n_classes, dtype=np.double, order="c")
+    cdef double* prediction = <double*> prediction_array.data
+
+    cdef np.ndarray[double, ndim=1] gradient_array = \
+        np.zeros(n_classes, dtype=np.double, order="c")
+    cdef double* gradient = <double*> gradient_array.data
 
     # the scalar used for multiplying z
     cdef double wscale = 1.0
 
-    # helpers
-    cdef double val, cum_sum, gradient_change
-    cdef int j
-
     # the cumulative sums for each iteration for the sparse implementation
     cumulative_sums[0] = 0.0
 
+    # Loss function to optimize
+    cdef LossFunction loss
+    # Wether the loss function is multinomial
+    cdef bint multinomial = False
+    # Multinomial loss function
+    cdef MultinomialLogLoss multiloss
+
+    if loss_function == "multinomial":
+        multinomial = True
+        multiloss = MultinomialLogLoss()
+    elif loss_function == "log":
+        loss = Log()
+    elif loss_function == "squared":
+        loss = SquaredLoss()
+    else:
+        raise ValueError("Invalid loss parameter: got %s instead of "
+                         "one of ('log', 'squared', 'multinomial')"
+                         % loss_function)
+
     with nogil:
         start_time = time(NULL)
-        while True:
-            for itr in range(n_samples):
+        for n_iter in range(max_iter):
+            for sample_itr in range(n_samples):
 
                 # extract a random sample
-                current_index = dataset.random(&x_data_ptr,
-                                               &x_ind_ptr,
-                                               &xnnz,
-                                               &y,
-                                               &sample_weight)
+                sample_ind = dataset.random(&x_data_ptr, &x_ind_ptr, &xnnz,
+                                              &y, &sample_weight)
+
+                # cached index for gradient_memory
+                s_idx = sample_ind * n_classes
 
                 # update the number of samples seen and the seen array
-                if seen[current_index] == 0:
+                if seen[sample_ind] == 0:
                     num_seen += 1
-                    seen[current_index] = 1
+                    seen[sample_ind] = 1
 
                 # make the weight updates
-                if itr > 0:
+                if sample_itr > 0:
                     for j in range(xnnz):
-                        idx = x_ind_ptr[j]
+                        feature_ind = x_ind_ptr[j]
+                        # cached index for sum_gradient and weights
+                        f_idx = feature_ind * n_classes
 
-                        cum_sum = cumulative_sums[itr - 1]
-                        if feature_hist[idx] != 0:
-                            cum_sum -= cumulative_sums[feature_hist[idx] - 1]
+                        cum_sum = cumulative_sums[sample_itr - 1]
+                        if feature_hist[feature_ind] != 0:
+                            cum_sum -= \
+                                cumulative_sums[feature_hist[feature_ind] - 1]
 
-                        weights[idx] -= cum_sum * sum_gradient[idx]
+                        for class_ind in range(n_classes):
+                            weights[f_idx + class_ind] -= \
+                                cum_sum * sum_gradient[f_idx + class_ind]
 
-                        feature_hist[idx] = itr
+                            # check to see that the weight is not inf or NaN
+                            if not skl_isfinite(weights[f_idx + class_ind]):
+                                with gil:
+                                    raise_infinite_error(n_iter)
 
-                        # check to see that the weight is not inf or NaN
-                        if not skl_isfinite(weights[idx]):
-                            infinity = True
-                            break
+                        feature_hist[feature_ind] = sample_itr
 
-                # check to see that the intercept is not inf or NaN
-                if infinity or not skl_isfinite(intercept):
-                    infinity = True
-                    break
+                # find the current prediction
+                predict_sample(x_data_ptr, x_ind_ptr, xnnz, weights, wscale,
+                               intercept, prediction, n_classes)
 
-                # find the current prediction, gradient
-                p = (wscale * sparse_dot(x_data_ptr, x_ind_ptr, xnnz,
-                                         weights)) + intercept
-                gradient = loss._dloss(p, y) * sample_weight
+                # compute the gradient for this sample, given the prediction
+                if multinomial:
+                    multiloss._dloss(prediction, y, n_classes, sample_weight,
+                                     gradient)
+                else:
+                    gradient[0] = loss._dloss(prediction[0], y) * sample_weight
 
                 # make the updates to the sum of gradients
-                gradient_change = gradient - gradient_memory[current_index]
                 for j in range(xnnz):
-                    idx = x_ind_ptr[j]
+                    feature_ind = x_ind_ptr[j]
                     val = x_data_ptr[j]
-                    sum_gradient[idx] += gradient_change * val
+                    f_idx = feature_ind * n_classes
+                    for class_ind in range(n_classes):
+                        sum_gradient[f_idx + class_ind] += \
+                            val * (gradient[class_ind] -
+                                   gradient_memory[s_idx + class_ind])
 
+                # fit the intercept
                 if fit_intercept:
-                    intercept_sum_gradient += gradient_change
-                    intercept -= (step_size * intercept_sum_gradient
-                                  / num_seen * intercept_decay)
+                    for class_ind in range(n_classes):
+                        intercept_sum_gradient[class_ind] += \
+                            (gradient[class_ind] -
+                             gradient_memory[s_idx + class_ind])
+                        intercept[class_ind] -= \
+                            (step_size * intercept_sum_gradient[class_ind] /
+                             num_seen * intercept_decay)
+
+                        # check to see that the intercept is not inf or NaN
+                        if not skl_isfinite(intercept[class_ind]):
+                            with gil:
+                                raise_infinite_error(n_iter)
 
                 # update the gradient memory for this sample
-                gradient_memory[current_index] = gradient
+                for class_ind in range(n_classes):
+                    gradient_memory[s_idx + class_ind] = gradient[class_ind]
 
                 # L2 regularization by simply rescaling the weights
                 wscale *= wscale_update
 
-                if itr == 0:
+                if sample_itr == 0:
                     cumulative_sums[0] = step_size / (wscale * num_seen)
                 else:
-                    cumulative_sums[itr] = (cumulative_sums[itr - 1]
-                                            + step_size / (wscale * num_seen))
+                    cumulative_sums[sample_itr] = \
+                        (cumulative_sums[sample_itr - 1] +
+                         step_size / (wscale * num_seen))
 
-                # if wscale gets too small, we need to reset the scale
+                # If wscale gets too small, we need to reset the scale.
                 if wscale < 1e-9:
                     if verbose:
                         with gil:
                             print("rescaling...")
-                    scale_weights(weights, wscale, n_features, n_samples,
-                                  itr, cumulative_sums, feature_hist,
-                                  sum_gradient)
-                    wscale = 1.0
+                    wscale = scale_weights(
+                        weights, wscale, n_features, n_samples, n_classes,
+                        sample_itr, cumulative_sums, feature_hist, sum_gradient)
 
-            if infinity:
-                break
+            # we scale the weights every n_samples iterations and reset the
+            # just-in-time update system for numerical stability.
+            wscale = scale_weights(weights, wscale, n_features, n_samples,
+                                   n_classes, n_samples - 1, cumulative_sums,
+                                   feature_hist, sum_gradient)
 
             # check if the stopping criteria is reached
-            scale_weights(weights, wscale, n_features, n_samples, n_samples - 1,
-                          cumulative_sums, feature_hist, sum_gradient)
-            wscale = 1.0
-            
             max_change = 0.0
             max_weight = 0.0
-            for j in range(n_features):
-                max_weight = fmax(max_weight, fabs(weights[j]))
-            for j in range(n_features):
+            for feature_ind in range(n_features):
+                max_weight = fmax(max_weight, fabs(weights[feature_ind]))
                 max_change = fmax(max_change,
-                                  fabs(weights[j] - previous_weights[j]))
-                previous_weights[j] = weights[j]
+                                  fabs(weights[feature_ind] -
+                                       previous_weights[feature_ind]))
+                previous_weights[feature_ind] = weights[feature_ind]
 
-            n_iter += 1
             if max_change / max_weight <= tol:
                 if verbose:
                     end_time = time(NULL)
                     with gil:
                         print("convergence after %d epochs took %d seconds" %
-                              (n_iter, end_time - start_time))
+                              (n_iter + 1, end_time - start_time))
                 break
+    n_iter += 1
 
-            if n_iter >= max_iter:
-                if verbose:
-                    end_time = time(NULL)
-                    with gil:
-                        print(("max_iter reached after %d seconds") %
-                              (end_time - start_time))
-                break
+    if verbose and n_iter >= max_iter:
+        end_time = time(NULL)
+        print(("max_iter reached after %d seconds") %
+              (end_time - start_time))
 
-    if infinity:
-        raise ValueError(("Floating-point under-/overflow occurred at epoch"
-                          " #%d. Lowering the step_size or scaling the input"
-                          " data with StandardScaler or"
-                          " MinMaxScaler might help.") % (n_iter + 1))
+    return num_seen, n_iter
 
 
-    return intercept, num_seen, n_iter, intercept_sum_gradient
+cdef void raise_infinite_error(int n_iter):
+    raise ValueError("Floating-point under-/overflow occurred at "
+                     "epoch #%d. Lowering the step_size or "
+                     "scaling the input data with StandardScaler "
+                     "or MinMaxScaler might help." % (n_iter + 1))
 
 
-cdef void scale_weights(double* weights, double wscale, int n_features,
-                        int n_samples, int itr, double* cumulative_sums,
-                        int* feature_hist, double* sum_gradient) nogil:
-    cdef int j
-    cdef double cum_sum
-    for j in range(n_features):
-        cum_sum = cumulative_sums[itr]
-        if feature_hist[j] != 0:
-            cum_sum -= cumulative_sums[feature_hist[j] - 1]
+cdef double scale_weights(double* weights, double wscale, int n_features,
+                          int n_samples, int n_classes, int sample_itr,
+                          double* cumulative_sums, int* feature_hist,
+                          double* sum_gradient) nogil:
+    """Scale the weights with wscale for numerical stability.
 
-        weights[j] -= cum_sum * sum_gradient[j]
-
-        weights[j] *= wscale
-        feature_hist[j] = (itr + 1) % n_samples
-
-    cumulative_sums[itr % n_samples] = 0.0
-
-
-cdef double sparse_dot(double* x_data_ptr, int* x_ind_ptr, int xnnz,
-                       double* w_data_ptr) nogil:
-    """Compute dot product between sparse vector x and dense vector w."""
-    cdef int j, idx
-    cdef double innerprod = 0.0
-
-    # only consider nonzero values of x
-    for j in range(xnnz):
-        idx = x_ind_ptr[j]
-        innerprod += w_data_ptr[idx] * x_data_ptr[j]
-    return innerprod
-
-
-def get_max_squared_sum(X):
-    """Maximum squared sum of X over samples. 
-
-    Used in ``get_auto_step_size()``, for SAG solver.
-
-    Parameter
-    ---------
-    X : {numpy array, scipy CSR sparse matrix}, shape (n_samples, n_features)
-        Training vector. X must be in C order.
-
-    Returns
-    -------
-    max_squared_sum : double
-        Maximum squared sum of X over samples.
+    wscale = (1 - step_size * alpha) ** (n_iter * n_samples + sample_itr)
+    can become very small, so we reset it every n_samples iterations to 1.0 for
+    numerical stability. To be able to scale, we first need to update every
+    coefficients and reset the just-in-time update system.
+    This also limits the size of `cumulative_sums`.
     """
+    cdef int feature_ind, class_ind, idx
+    cdef double cum_sum
+    idx = -1
+    for feature_ind in range(n_features):
+        cum_sum = cumulative_sums[sample_itr]
+        if feature_hist[feature_ind] != 0:
+            cum_sum -= cumulative_sums[feature_hist[feature_ind] - 1]
 
-    # CSR sparse matrix X
-    cdef np.ndarray[double] X_data
-    cdef np.ndarray[int] X_indptr
-    cdef double *X_data_ptr
-    cdef int *X_indptr_ptr
-    cdef int offset
+        for class_ind in range(n_classes):
+            idx += 1  # idx = feature_ind * n_classes + class_ind
+            weights[idx] -= cum_sum * sum_gradient[idx]
+            weights[idx] *= wscale
 
-    # Dense numpy array X
-    cdef np.ndarray[double, ndim=2] X_ndarray
-    cdef int stride
+        feature_hist[feature_ind] = (sample_itr + 1) % n_samples
 
-    # Both cases
-    cdef bint sparse = sp.issparse(X)
-    cdef double *x_data_ptr
-    cdef double max_squared_sum = 0.0
-    cdef double current_squared_sum = 0.0
-    cdef int n_samples = X.shape[0]
-    cdef int nnz = X.shape[1]
-    cdef int i, j
-    cdef double val
+    cumulative_sums[sample_itr % n_samples] = 0.0
 
-    if sparse:
-        X_data = X.data
-        X_indptr = X.indptr
-        X_data_ptr = <double *>X_data.data
-        X_indptr_ptr = <int *>X_indptr.data
-    else:
-        X_ndarray = X
-        stride = X_ndarray.strides[0] / X_ndarray.itemsize
-        x_data_ptr = <double *>X_ndarray.data - stride
-
-    with nogil:
-        for i in range(n_samples):
-            # find next sample data
-            if sparse:
-                offset = X_indptr_ptr[i]
-                nnz = X_indptr_ptr[i + 1] - offset
-                x_data_ptr = X_data_ptr + offset
-            else:
-                x_data_ptr += stride
-
-            # sum of squared non-zero features
-            for j in range(nnz):
-                val = x_data_ptr[j]
-                current_squared_sum += val * val
-
-            if current_squared_sum > max_squared_sum:
-                max_squared_sum = current_squared_sum
-            current_squared_sum = 0.0
+    # reset wscale to 1.0
+    return 1.0
 
 
-    if not skl_isfinite(max_squared_sum):
-        raise ValueError("Floating-point under-/overflow occurred")
+cdef void predict_sample(double* x_data_ptr, int* x_ind_ptr, int xnnz,
+                         double* w_data_ptr, double wscale, double* intercept,
+                         double* prediction, int n_classes) nogil:
+    """Compute the prediction given sparse sample x and dense weight w.
 
-    return max_squared_sum
+    Parameters
+    ----------
+    x_data_ptr : pointer
+        Pointer to the data of the sample x
+
+    x_ind_ptr : pointer
+        Pointer to the indices of the sample  x
+
+    xnnz : int
+        Number of non-zero element in the sample  x
+
+    w_data_ptr : pointer
+        Pointer to the data of the weights w
+
+    wscale : double
+        Scale of the weights w
+
+    intercept : pointer
+        Pointer to the intercept
+
+    prediction : pointer
+        Pointer to store the resulting prediction
+
+    n_classes : int
+        Number of classes in multinomial case. Equals 1 in binary case.
+
+    """
+    cdef int feature_ind, class_ind, j
+    cdef double innerprod
+
+    for class_ind in range(n_classes):
+        innerprod = 0.0
+        # Compute the dot product only on non-zero elements of x
+        for j in range(xnnz):
+            feature_ind = x_ind_ptr[j]
+            innerprod += (w_data_ptr[feature_ind * n_classes + class_ind] *
+                          x_data_ptr[j])
+
+        prediction[class_ind] = wscale * innerprod + intercept[class_ind]

--- a/sklearn/linear_model/sgd_fast.pyx
+++ b/sklearn/linear_model/sgd_fast.pyx
@@ -603,11 +603,8 @@ def _plain_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
             if shuffle:
                 dataset.shuffle(seed)
             for i in range(n_samples):
-                dataset.next(&x_data_ptr,
-                             &x_ind_ptr,
-                             &xnnz,
-                             &y,
-                             &sample_weight)
+                dataset.next(&x_data_ptr, &x_ind_ptr, &xnnz,
+                             &y, &sample_weight)
 
                 p = w.dot(x_data_ptr, x_ind_ptr, xnnz) + intercept
                 if learning_rate == OPTIMAL:

--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -8,18 +8,25 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.linear_model.sag import get_auto_step_size
-from sklearn.linear_model.sag_fast import get_max_squared_sum
+from sklearn.linear_model.sag_fast import _multinomial_grad_loss_all_samples
 from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.linear_model.base import make_dataset
+from sklearn.linear_model.logistic import _multinomial_loss_grad
 
+from sklearn.utils.extmath import logsumexp
+from sklearn.utils.extmath import row_norms
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils import compute_class_weight
-from sklearn.preprocessing import LabelEncoder
-from sklearn.datasets import make_blobs
+from sklearn.utils import check_random_state
+from sklearn.preprocessing import LabelEncoder, LabelBinarizer
+from sklearn.datasets import make_blobs, load_iris
 from sklearn.base import clone
+
+iris = load_iris()
 
 
 # this is used for sag classification
@@ -378,7 +385,7 @@ def test_get_auto_step_size():
     fit_intercept = False
     # sum the squares of the second sample because that's the largest
     max_squared_sum = 4 + 9 + 16
-    max_squared_sum_ = get_max_squared_sum(X)
+    max_squared_sum_ = row_norms(X, squared=True).max()
     assert_almost_equal(max_squared_sum, max_squared_sum_, decimal=4)
 
     for fit_intercept in (True, False):
@@ -397,24 +404,6 @@ def test_get_auto_step_size():
     msg = 'Unknown loss function for SAG solver, got wrong instead of'
     assert_raise_message(ValueError, msg, get_auto_step_size,
                          max_squared_sum_, alpha, "wrong", fit_intercept)
-
-
-def test_get_max_squared_sum():
-    n_samples = 100
-    n_features = 10
-    rng = np.random.RandomState(42)
-    X = rng.randn(n_samples, n_features).astype(np.float64)
-
-    mask = rng.randn(n_samples, n_features)
-    X[mask > 0] = 0.
-    X_csr = sp.csr_matrix(X)
-
-    X[0, 3] = 0.
-    X_csr[0, 3] = 0.
-
-    sum_X = get_max_squared_sum(X)
-    sum_X_csr = get_max_squared_sum(X_csr)
-    assert_almost_equal(sum_X, sum_X_csr)
 
 
 @ignore_warnings
@@ -722,3 +711,70 @@ def test_step_size_alpha_error():
 
     clf2 = Ridge(fit_intercept=fit_intercept, solver='sag', alpha=alpha)
     assert_raise_message(ZeroDivisionError, msg, clf2.fit, X, y)
+
+
+def test_multinomial_loss():
+    # test if the multinomial loss and gradient computations are consistent
+    X, y = iris.data, iris.target.astype(np.float64)
+    n_samples, n_features = X.shape
+    n_classes = len(np.unique(y))
+
+    rng = check_random_state(42)
+    weights = rng.randn(n_features, n_classes)
+    intercept = rng.randn(n_classes)
+    sample_weights = rng.randn(n_samples)
+    np.abs(sample_weights, sample_weights)
+
+    # compute loss and gradient like in multinomial SAG
+    dataset, _ = make_dataset(X, y, sample_weights, random_state=42)
+    loss_1, grad_1 = _multinomial_grad_loss_all_samples(dataset, weights,
+                                                        intercept, n_samples,
+                                                        n_features, n_classes)
+    # compute loss and gradient like in multinomial LogisticRegression
+    lbin = LabelBinarizer()
+    Y_bin = lbin.fit_transform(y)
+    weights_intercept = np.vstack((weights, intercept)).T.ravel()
+    loss_2, grad_2, _ = _multinomial_loss_grad(weights_intercept, X, Y_bin,
+                                               0.0, sample_weights)
+    grad_2 = grad_2.reshape(n_classes, -1)
+    grad_2 = grad_2[:, :-1].T
+
+    # comparison
+    assert_array_almost_equal(grad_1, grad_2)
+    assert_almost_equal(loss_1, loss_2)
+
+
+def test_multinomial_loss_ground_truth():
+    # n_samples, n_features, n_classes = 4, 2, 3
+    n_classes = 3
+    X = np.array([[1.1, 2.2], [2.2, -4.4], [3.3, -2.2], [1.1, 1.1]])
+    y = np.array([0, 1, 2, 0])
+    lbin = LabelBinarizer()
+    Y_bin = lbin.fit_transform(y)
+
+    weights = np.array([[0.1, 0.2, 0.3], [1.1, 1.2, -1.3]])
+    intercept = np.array([1., 0, -.2])
+    sample_weights = np.array([0.8, 1, 1, 0.8])
+
+    prediction = np.dot(X, weights) + intercept
+    logsumexp_prediction = logsumexp(prediction, axis=1)
+    p = prediction - logsumexp_prediction[:, np.newaxis]
+    loss_1 = -(sample_weights[:, np.newaxis] * p * Y_bin).sum()
+    diff = sample_weights[:, np.newaxis] * (np.exp(p) - Y_bin)
+    grad_1 = np.dot(X.T, diff)
+
+    weights_intercept = np.vstack((weights, intercept)).T.ravel()
+    loss_2, grad_2, _ = _multinomial_loss_grad(weights_intercept, X, Y_bin,
+                                               0.0, sample_weights)
+    grad_2 = grad_2.reshape(n_classes, -1)
+    grad_2 = grad_2[:, :-1].T
+
+    assert_almost_equal(loss_1, loss_2)
+    assert_array_almost_equal(grad_1, grad_2)
+
+    # ground truth
+    loss_gt = 11.680360354325961
+    grad_gt = np.array([[-0.557487, -1.619151, +2.176638],
+                        [-0.903942, +5.258745, -4.354803]])
+    assert_almost_equal(loss_1, loss_gt)
+    assert_array_almost_equal(grad_1, grad_gt)

--- a/sklearn/utils/seq_dataset.pxd
+++ b/sklearn/utils/seq_dataset.pxd
@@ -12,8 +12,6 @@ cdef class SequentialDataset:
     cdef Py_ssize_t n_samples
     cdef np.uint32_t seed
 
-    cdef void next(self, double **x_data_ptr, int **x_ind_ptr,
-                   int *nnz, double *y, double *sample_weight) nogil
     cdef void shuffle(self, np.uint32_t seed) nogil
     cdef int _get_next_index(self) nogil
     cdef int _get_random_index(self) nogil
@@ -21,6 +19,8 @@ cdef class SequentialDataset:
     cdef void _sample(self, double **x_data_ptr, int **x_ind_ptr,
                       int *nnz, double *y, double *sample_weight,
                       int current_index) nogil
+    cdef void next(self, double **x_data_ptr, int **x_ind_ptr,
+                   int *nnz, double *y, double *sample_weight) nogil
     cdef int random(self, double **x_data_ptr, int **x_ind_ptr,
                     int *nnz, double *y, double *sample_weight) nogil
 
@@ -30,12 +30,13 @@ cdef class ArrayDataset(SequentialDataset):
     cdef np.ndarray Y
     cdef np.ndarray sample_weights
     cdef Py_ssize_t n_features
-    cdef int stride
+    cdef int X_stride
     cdef double *X_data_ptr
     cdef double *Y_data_ptr
     cdef np.ndarray feature_indices
     cdef int *feature_indices_ptr
     cdef double *sample_weight_data
+
 
 cdef class CSRDataset(SequentialDataset):
     cdef np.ndarray X_data
@@ -43,11 +44,8 @@ cdef class CSRDataset(SequentialDataset):
     cdef np.ndarray X_indices
     cdef np.ndarray Y
     cdef np.ndarray sample_weights
-    cdef int stride
     cdef double *X_data_ptr
     cdef int *X_indptr_ptr
     cdef int *X_indices_ptr
     cdef double *Y_data_ptr
-    cdef np.ndarray feature_indices
-    cdef int *feature_indices_ptr
     cdef double *sample_weight_data

--- a/sklearn/utils/seq_dataset.pyx
+++ b/sklearn/utils/seq_dataset.pyx
@@ -42,8 +42,8 @@ cdef class SequentialDataset:
             The weight of the next example.
         """
         cdef int current_index = self._get_next_index()
-        self._sample(x_data_ptr, x_ind_ptr, nnz, y,
-                     sample_weight, current_index)
+        self._sample(x_data_ptr, x_ind_ptr, nnz, y, sample_weight,
+                     current_index)
 
     cdef int random(self, double **x_data_ptr, int **x_ind_ptr,
                     int *nnz, double *y, double *sample_weight) nogil:
@@ -75,8 +75,8 @@ cdef class SequentialDataset:
             The index sampled
         """
         cdef int current_index = self._get_random_index()
-        self._sample(x_data_ptr, x_ind_ptr, nnz, y,
-                     sample_weight, current_index)
+        self._sample(x_data_ptr, x_ind_ptr, nnz, y, sample_weight,
+                     current_index)
         return current_index
 
     cdef void shuffle(self, np.uint32_t seed) nogil:
@@ -127,7 +127,7 @@ cdef class SequentialDataset:
         """python function used for easy testing"""
         cdef double* x_data_ptr
         cdef int* x_indices_ptr
-        cdef int nnz
+        cdef int nnz, j
         cdef double y, sample_weight
 
         # call _sample in cython
@@ -164,16 +164,13 @@ cdef class ArrayDataset(SequentialDataset):
         Parameters
         ----------
         X : ndarray, dtype=double, ndim=2, mode='c'
-            The samples; a two-dimensional c-continuous numpy array of
-            dtype double.
+            The sample array, of shape(n_samples, n_features)
 
         Y : ndarray, dtype=double, ndim=1, mode='c'
-            The target values; a one-dimensional c-continuous numpy array of
-            dtype double.
+            The target array, of shape(n_samples, )
 
         sample_weights : ndarray, dtype=double, ndim=1, mode='c'
-            The weight of each sample; a one-dimensional c-continuous numpy
-            array of dtype double.
+            The weight of each sample, of shape(n_samples,)
         """
         if X.shape[0] > INT_MAX or X.shape[1] > INT_MAX:
             raise ValueError("More than %d samples or features not supported;"
@@ -187,13 +184,14 @@ cdef class ArrayDataset(SequentialDataset):
 
         self.n_samples = X.shape[0]
         self.n_features = X.shape[1]
-        cdef np.ndarray[int, ndim=1, mode='c'] feature_indices = np.arange(
-            0, self.n_features, dtype=np.intc)
 
+        cdef np.ndarray[int, ndim=1, mode='c'] feature_indices = \
+            np.arange(0, self.n_features, dtype=np.intc)
         self.feature_indices = feature_indices
         self.feature_indices_ptr = <int *> feature_indices.data
+
         self.current_index = -1
-        self.stride = X.strides[0] / X.itemsize
+        self.X_stride = X.strides[0] / X.itemsize
         self.X_data_ptr = <double *>X.data
         self.Y_data_ptr = <double *>Y.data
         self.sample_weight_data = <double *>sample_weights.data
@@ -210,7 +208,7 @@ cdef class ArrayDataset(SequentialDataset):
                       int *nnz, double *y, double *sample_weight,
                       int current_index) nogil:
         cdef long long sample_idx = self.index_data_ptr[current_index]
-        cdef long long offset = sample_idx * self.stride
+        cdef long long offset = sample_idx * self.X_stride
 
         y[0] = self.Y_data_ptr[sample_idx]
         x_data_ptr[0] = self.X_data_ptr + offset
@@ -237,24 +235,19 @@ cdef class CSRDataset(SequentialDataset):
         Parameters
         ----------
         X_data : ndarray, dtype=double, ndim=1, mode='c'
-            The data array of the CSR matrix; a one-dimensional c-continuous
-            numpy array of dtype double.
+            The data array of the CSR features matrix.
 
         X_indptr : ndarray, dtype=np.intc, ndim=1, mode='c'
-            The index pointer array of the CSR matrix; a one-dimensional
-            c-continuous numpy array of dtype np.intc.
+            The index pointer array of the CSR features matrix.
 
         X_indices : ndarray, dtype=np.intc, ndim=1, mode='c'
-            The column indices array of the CSR matrix; a one-dimensional
-            c-continuous numpy array of dtype np.intc.
+            The column indices array of the CSR features matrix.
 
         Y : ndarray, dtype=double, ndim=1, mode='c'
-            The target values; a one-dimensional c-continuous numpy array of
-            dtype double.
+            The target values.
 
         sample_weights : ndarray, dtype=double, ndim=1, mode='c'
-            The weight of each sample; a one-dimensional c-continuous numpy
-            array of dtype double.
+            The weight of each sample.
         """
         # keep a reference to the data to prevent garbage collection
         self.X_data = X_data
@@ -268,8 +261,10 @@ cdef class CSRDataset(SequentialDataset):
         self.X_data_ptr = <double *>X_data.data
         self.X_indptr_ptr = <int *>X_indptr.data
         self.X_indices_ptr = <int *>X_indices.data
+
         self.Y_data_ptr = <double *>Y.data
         self.sample_weight_data = <double *>sample_weights.data
+
         # Use index array for fast shuffling
         cdef np.ndarray[int, ndim=1, mode='c'] idx = np.arange(self.n_samples,
                                                                dtype=np.intc)

--- a/sklearn/utils/tests/test_seq_dataset.py
+++ b/sklearn/utils/tests/test_seq_dataset.py
@@ -18,6 +18,16 @@ X_csr = sp.csr_matrix(X)
 sample_weight = np.arange(y.size, dtype=np.float64)
 
 
+def assert_csr_equal(X, Y):
+    X.eliminate_zeros()
+    Y.eliminate_zeros()
+    assert_equal(X.shape[0], Y.shape[0])
+    assert_equal(X.shape[1], Y.shape[1])
+    assert_array_equal(X.data, Y.data)
+    assert_array_equal(X.indices, Y.indices)
+    assert_array_equal(X.indptr, Y.indptr)
+
+
 def test_seq_dataset():
     dataset1 = ArrayDataset(X, y, sample_weight, seed=42)
     dataset2 = CSRDataset(X_csr.data, X_csr.indptr, X_csr.indices,
@@ -29,9 +39,7 @@ def test_seq_dataset():
             xi_, yi, swi, idx = dataset._next_py()
             xi = sp.csr_matrix((xi_), shape=(1, X.shape[1]))
 
-            assert_array_equal(xi.data, X_csr[idx].data)
-            assert_array_equal(xi.indices, X_csr[idx].indices)
-            assert_array_equal(xi.indptr, X_csr[idx].indptr)
+            assert_csr_equal(xi, X_csr[idx])
             assert_equal(yi, y[idx])
             assert_equal(swi, sample_weight[idx])
 
@@ -39,9 +47,7 @@ def test_seq_dataset():
             xi_, yi, swi, idx = dataset._random_py()
             xi = sp.csr_matrix((xi_), shape=(1, X.shape[1]))
 
-            assert_array_equal(xi.data, X_csr[idx].data)
-            assert_array_equal(xi.indices, X_csr[idx].indices)
-            assert_array_equal(xi.indptr, X_csr[idx].indptr)
+            assert_csr_equal(xi, X_csr[idx])
             assert_equal(yi, y[idx])
             assert_equal(swi, sample_weight[idx])
 


### PR DESCRIPTION
I added multinomial sag solver in LogisticRegression.
The results are identical to lbfgs and newton-cg multinomial solvers.

---

The benchmark [(gist)](https://gist.github.com/TomDLT/da7c44fa277003e7549e) on RCV1 dataset is very promising. I only took 4 classes of the dataset, and removed samples that have more than one classe.

``` python
n_samples_train = 129073
n_samples_test = 23149
n_features = 47236
n_classes = 4
```

![dloss](https://cloud.githubusercontent.com/assets/11065596/9814439/73b5f374-588e-11e5-94f4-adc82287026b.png)
![train_score](https://cloud.githubusercontent.com/assets/11065596/9814441/76b4dd60-588e-11e5-8183-7a6fb733fc13.png)
![test_score](https://cloud.githubusercontent.com/assets/11065596/9814440/7578b106-588e-11e5-874c-c56f4ac607f4.png)

---

I also added a `plot_logistic_multinomial.py` to show the difference between OvR and Multinomial.
![ovr](https://cloud.githubusercontent.com/assets/11065596/9814355/8e521902-588d-11e5-8c2b-a962200e1e66.png)
![multinomial](https://cloud.githubusercontent.com/assets/11065596/9814356/8f41eea0-588d-11e5-8f16-47bce1e89dce.png)

---

In the same spirit, I could probably add a multinomial LogisticRegression in SGD (previously proposed in #849). Do we want it?
