### PR TITLE
[MRG+1] OPTIM make (Online) LDA reuse a joblib.Parallel instance

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -306,7 +306,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         self.exp_dirichlet_component_ = np.exp(
             _dirichlet_expectation_2d(self.components_))
 
-    def _e_step(self, X, cal_sstats, random_init):
+    def _e_step(self, X, cal_sstats, random_init, parallel=None):
         """E-step in EM update.
 
         Parameters
@@ -323,6 +323,9 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
             distribution randomly in the E-step. Set it to True in training
             steps.
 
+        parallel : joblib.Parallel (optional)
+            Pre-initialized instance of joblib.Parallel.
+
         Returns
         -------
         (doc_topic_distr, suff_stats) :
@@ -334,10 +337,13 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         """
 
         # Run e-step in parallel
-        n_jobs = _get_n_jobs(self.n_jobs)
         random_state = self.random_state_ if random_init else None
 
-        results = Parallel(n_jobs=n_jobs, verbose=self.verbose)(
+        # TODO: make Parallel._effective_n_jobs public instead?
+        n_jobs = _get_n_jobs(self.n_jobs)
+        if parallel is None:
+            parallel = Parallel(n_jobs=n_jobs, verbose=self.verbose)
+        results = parallel(
             delayed(_update_doc_distribution)(X[idx_slice, :],
                                               self.exp_dirichlet_component_,
                                               self.doc_topic_prior_,
@@ -362,7 +368,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
 
         return (doc_topic_distr, suff_stats)
 
-    def _em_step(self, X, total_samples, batch_update):
+    def _em_step(self, X, total_samples, batch_update, parallel=None):
         """EM update for 1 iteration.
 
         update `_component` by batch VB or online VB.
@@ -380,6 +386,9 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
             Parameter that controls updating method.
             `True` for batch learning, `False` for online learning.
 
+        parallel : joblib.Parallel
+            Pre-initialized instance of joblib.Parallel
+
         Returns
         -------
         doc_topic_distr : array, shape=(n_samples, n_topics)
@@ -387,7 +396,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         """
 
         # E-step
-        _, suff_stats = self._e_step(X, cal_sstats=True, random_init=True)
+        _, suff_stats = self._e_step(X, cal_sstats=True, random_init=True,
+                                     parallel=parallel)
 
         # M-step
         if batch_update:
@@ -450,9 +460,13 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                 "the model was trained with feature size %d." %
                 (n_features, self.components_.shape[1]))
 
-        for idx_slice in gen_batches(n_samples, batch_size):
-            self._em_step(X[idx_slice, :], total_samples=self.total_samples,
-                          batch_update=False)
+        n_jobs = _get_n_jobs(self.n_jobs)
+        with Parallel(n_jobs=n_jobs, verbose=self.verbose) as parallel:
+            for idx_slice in gen_batches(n_samples, batch_size):
+                self._em_step(X[idx_slice, :],
+                              total_samples=self.total_samples,
+                              batch_update=False,
+                              parallel=parallel)
 
         return self
 
@@ -483,28 +497,32 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         self._init_latent_vars(n_features)
         # change to perplexity later
         last_bound = None
-        for i in xrange(max_iter):
-            if learning_method == 'online':
-                for idx_slice in gen_batches(n_samples, batch_size):
-                    self._em_step(X[idx_slice, :], total_samples=n_samples,
-                                  batch_update=False)
-            else:
-                # batch update
-                self._em_step(X, total_samples=n_samples, batch_update=True)
+        n_jobs = _get_n_jobs(self.n_jobs)
+        with Parallel(n_jobs=n_jobs, verbose=self.verbose) as parallel:
+            for i in xrange(max_iter):
+                if learning_method == 'online':
+                    for idx_slice in gen_batches(n_samples, batch_size):
+                        self._em_step(X[idx_slice, :], total_samples=n_samples,
+                                      batch_update=False, parallel=parallel)
+                else:
+                    # batch update
+                    self._em_step(X, total_samples=n_samples,
+                                  batch_update=True, parallel=parallel)
 
-            # check perplexity
-            if evaluate_every > 0 and (i + 1) % evaluate_every == 0:
-                doc_topics_distr, _ = self._e_step(X, cal_sstats=False,
-                                                   random_init=False)
-                bound = self.perplexity(X, doc_topics_distr,
-                                        sub_sampling=False)
-                if self.verbose:
-                    print('iteration: %d, perplexity: %.4f' % (i + 1, bound))
+                # check perplexity
+                if evaluate_every > 0 and (i + 1) % evaluate_every == 0:
+                    doc_topics_distr, _ = self._e_step(X, cal_sstats=False,
+                                                       random_init=False)
+                    bound = self.perplexity(X, doc_topics_distr,
+                                            sub_sampling=False)
+                    if self.verbose:
+                        print('iteration: %d, perplexity: %.4f'
+                              % (i + 1, bound))
 
-                if last_bound and abs(last_bound - bound) < self.perp_tol:
-                    break
-                last_bound = bound
-            self.n_iter_ += 1
+                    if last_bound and abs(last_bound - bound) < self.perp_tol:
+                        break
+                    last_bound = bound
+                self.n_iter_ += 1
         return self
 
     def transform(self, X):


### PR DESCRIPTION
While running the tests under Python 3 I noticed that online LDA would seriously benefit from using the new context manager API.

Under Python 2 this is less noticeable because it uses forks that hide some overhead. We should still get a good speedup anyway.
