### PR TITLE
[MRG] Added laplacian kernel

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -888,6 +888,7 @@ See the :ref:`metrics` section of the user guide for further details.
    metrics.pairwise.pairwise_kernels
    metrics.pairwise.polynomial_kernel
    metrics.pairwise.rbf_kernel
+   metrics.pairwise.laplacian_kernel
    metrics.pairwise_distances
    metrics.pairwise_distances_argmin
    metrics.pairwise_distances_argmin_min

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -133,6 +133,24 @@ between two vectors. This kernel is defined as:
 where ``x`` and ``y`` are the input vectors. If :math:`\gamma = \sigma^{-2}`
 the kernel is known as the Gaussian kernel of variance :math:`\sigma^2`.
 
+.. _laplacian_kernel:
+
+Laplacian kernel
+----------------
+The function :func:`laplacian_kernel` is a variant on the radial basis 
+function kernel defined as:
+
+.. math::
+
+    k(x, y) = \exp( -\gamma \| x-y \|_1)
+
+where ``x`` and ``y`` are the input vectors and :math:`\|x-y\|_1` is the 
+Manhattan distance between the input vectors.
+
+It has proven useful in ML applied to noiseless data.
+See e.g. `Machine learning for quantum mechanics in a nutshell
+<http://onlinelibrary.wiley.com/doi/10.1002/qua.24954/abstract/>`_.
+
 .. _chi2_kernel:
 
 Chi-squared kernel

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -184,6 +184,8 @@ Enhancements
    - Added optional parameter ``warm_start`` in
      :class:`linear_model.LogisticRegression`. If set to True, the solvers ``lbfgs``, ``newton-cg`` and ``sag`` will be initialized with the coefficients computed in the previous fit. By `Tom Dupre la Tour`_.
 
+   - Added :func:`metrics.pairwise.laplacian_kernel`.  By `Clyde Fare <https://github.com/Clyde-fare>`_.
+
 Bug fixes
 .........
 

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -51,8 +51,8 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         should return a floating point number.
 
     gamma : float, default=None
-        Gamma parameter for the RBF, polynomial, exponential chi2 and
-        sigmoid kernels. Interpretation of the default value is left to
+        Gamma parameter for the RBF, laplacian, polynomial, exponential chi2
+        and sigmoid kernels. Interpretation of the default value is left to
         the kernel; see the documentation for sklearn.metrics.pairwise.
         Ignored by other kernels.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -812,6 +812,28 @@ def rbf_kernel(X, Y=None, gamma=None):
     np.exp(K, K)    # exponentiate K in-place
     return K
 
+def laplacian_kernel(X, Y=None, gamma=None):
+    """
+    Compute the laplacian kernel between X and Y::
+        K(x, y) = exp(-gamma ||x-y||_1)
+    for each pair of rows x in X and y in Y.
+    Read more in the :ref:`User Guide <laplacian_kernel>`.
+    Parameters
+    ----------
+    X : array of shape (n_samples_X, n_features)
+    Y : array of shape (n_samples_Y, n_features)
+    gamma : float
+    Returns
+    -------
+    kernel_matrix : array of shape (n_samples_X, n_samples_Y)
+    """
+    X, Y = check_pairwise_arrays(X, Y)
+    if gamma is None:
+        gamma = 1.0 / X.shape[1]
+
+    K = -gamma * manhattan_distances(X, Y)
+    np.exp(K, K)    # exponentiate K in-place
+    return K
 
 def cosine_similarity(X, Y=None, dense_output=True):
     """Compute cosine similarity between samples in X and Y.
@@ -1184,6 +1206,7 @@ PAIRWISE_KERNEL_FUNCTIONS = {
     'polynomial': polynomial_kernel,
     'poly': polynomial_kernel,
     'rbf': rbf_kernel,
+    'laplacian': laplacian_kernel,
     'sigmoid': sigmoid_kernel,
     'cosine': cosine_similarity, }
 
@@ -1205,6 +1228,7 @@ def kernel_metrics():
       'poly'            sklearn.pairwise.polynomial_kernel
       'polynomial'      sklearn.pairwise.polynomial_kernel
       'rbf'             sklearn.pairwise.rbf_kernel
+      'laplacian'       sklearn.pairwise.laplacian_kernel
       'sigmoid'         sklearn.pairwise.sigmoid_kernel
       'cosine'          sklearn.pairwise.cosine_similarity
       ===============   ========================================
@@ -1223,6 +1247,7 @@ KERNEL_PARAMS = {
     "poly": frozenset(["gamma", "degree", "coef0"]),
     "polynomial": frozenset(["gamma", "degree", "coef0"]),
     "rbf": frozenset(["gamma"]),
+    "laplacian": frozenset(["gamma"]),
     "sigmoid": frozenset(["gamma", "coef0"]),
 }
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -21,6 +21,7 @@ from sklearn.metrics.pairwise import linear_kernel
 from sklearn.metrics.pairwise import chi2_kernel, additive_chi2_kernel
 from sklearn.metrics.pairwise import polynomial_kernel
 from sklearn.metrics.pairwise import rbf_kernel
+from sklearn.metrics.pairwise import laplacian_kernel
 from sklearn.metrics.pairwise import sigmoid_kernel
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.metrics.pairwise import cosine_distances
@@ -197,15 +198,14 @@ def callable_rbf_kernel(x, y, **kwds):
     return K
 
 
-def test_pairwise_kernels():
-    # Test the pairwise_kernels helper function.
+def test_pairwise_kernels():    # Test the pairwise_kernels helper function.
 
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
     Y = rng.random_sample((2, 4))
     # Test with all metrics that should be in PAIRWISE_KERNEL_FUNCTIONS.
-    test_metrics = ["rbf", "sigmoid", "polynomial", "linear", "chi2",
-                    "additive_chi2"]
+    test_metrics = ["rbf", "laplacian", "sigmoid", "polynomial", "linear",
+                    "chi2", "additive_chi2"]
     for metric in test_metrics:
         function = PAIRWISE_KERNEL_FUNCTIONS[metric]
         # Test with Y=None
@@ -244,6 +244,7 @@ def test_pairwise_kernels():
     K1 = pairwise_kernels(X, Y=X, metric=metric, **kwds)
     K2 = rbf_kernel(X, Y=X, **kwds)
     assert_array_almost_equal(K1, K2)
+
 
 
 def test_pairwise_kernels_filter_param():
@@ -467,7 +468,7 @@ def test_kernel_symmetry():
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
     for kernel in (linear_kernel, polynomial_kernel, rbf_kernel,
-                   sigmoid_kernel, cosine_similarity):
+                   laplacian_kernel, sigmoid_kernel, cosine_similarity):
         K = kernel(X, X)
         assert_array_almost_equal(K, K.T, 15)
 
@@ -477,7 +478,7 @@ def test_kernel_sparse():
     X = rng.random_sample((5, 4))
     X_sparse = csr_matrix(X)
     for kernel in (linear_kernel, polynomial_kernel, rbf_kernel,
-                   sigmoid_kernel, cosine_similarity):
+                   laplacian_kernel, sigmoid_kernel, cosine_similarity):
         K = kernel(X, X)
         K2 = kernel(X_sparse, X_sparse)
         assert_array_almost_equal(K, K2)
@@ -497,6 +498,18 @@ def test_rbf_kernel():
     K = rbf_kernel(X, X)
     # the diagonal elements of a rbf kernel are 1
     assert_array_almost_equal(K.flat[::6], np.ones(5))
+
+
+def test_laplacian_kernel():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    K = laplacian_kernel(X, X)
+    # the diagonal elements of a laplacian kernel are 1
+    assert_array_almost_equal(np.diag(K), np.ones(5))
+    
+    # off-diagonal elements are < 1 but > 0:
+    assert_true(np.all(K > 0))
+    assert_true(np.all(K - np.diag(np.diag(K)) < 1))
 
 
 def test_cosine_similarity_sparse_output():


### PR DESCRIPTION
Almost identical to the rbf_kernel but uses l1 norm for the distance. 

Tried to mimick rbf_kernel updated the references/comments and added a test.
