### PR TITLE
[MRG + 1] Fix check in `compute_class_weight`.

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -71,7 +71,7 @@ def compute_class_weight(class_weight, classes, y):
                              " got: %r" % class_weight)
         for c in class_weight:
             i = np.searchsorted(classes, c)
-            if classes[i] != c:
+            if i >= len(classes) or classes[i] != c:
                 raise ValueError("Class label %d not present." % c)
             else:
                 weight[i] = class_weight[c]

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -38,6 +38,7 @@ def test_compute_class_weight_not_present():
     assert_raises(ValueError, compute_class_weight, "auto", classes, y)
     assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
 
+
 def test_compute_class_weight_dict():
     classes = np.arange(3)
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0}
@@ -52,14 +53,12 @@ def test_compute_class_weight_dict():
     # should get raised
     msg = 'Class label 4 not present.'
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
-    assert_raise_message(
-        ValueError, msg, compute_class_weight, class_weights, classes, y
-    )
+    assert_raise_message(ValueError, msg, compute_class_weight, class_weights,
+                         classes, y)
     msg = 'Class label -1 not present.'
     class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
-    assert_raise_message(
-        ValueError, msg, compute_class_weight, class_weights, classes, y
-    )
+    assert_raise_message(ValueError, msg, compute_class_weight, class_weights,
+                         classes, y)
 
 
 def test_compute_class_weight_invariance():

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -9,6 +9,7 @@ from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_warns
@@ -45,14 +46,20 @@ def test_compute_class_weight_dict():
 
     # When the user specifies class weights, compute_class_weights should just
     # return them.
-    assert_array_almost_equal(class_weights.values(), cw)
+    assert_array_almost_equal(np.asarray([1.0, 2.0, 3.0]), cw)
 
     # When a class weight is specified that isn't in classes, a ValueError
     # should get raised
+    msg = 'Class label 4 not present.'
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
-    assert_raises(ValueError, compute_class_weight, class_weights, classes, y)
+    assert_raise_message(
+        ValueError, msg, compute_class_weight, class_weights, classes, y
+    )
+    msg = 'Class label -1 not present.'
     class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
-    assert_raises(ValueError, compute_class_weight, class_weights, classes, y)
+    assert_raise_message(
+        ValueError, msg, compute_class_weight, class_weights, classes, y
+    )
 
 
 def test_compute_class_weight_invariance():

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -37,6 +37,23 @@ def test_compute_class_weight_not_present():
     assert_raises(ValueError, compute_class_weight, "auto", classes, y)
     assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
 
+def test_compute_class_weight_dict():
+    classes = np.arange(3)
+    class_weights = {0: 1.0, 1: 2.0, 2: 3.0}
+    y = np.asarray([0, 0, 1, 2])
+    cw = compute_class_weight(class_weights, classes, y)
+
+    # When the user specifies class weights, compute_class_weights should just
+    # return them.
+    assert_array_almost_equal(class_weights.values(), cw)
+
+    # When a class weight is specified that isn't in classes, a ValueError
+    # should get raised
+    class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
+    assert_raises(ValueError, compute_class_weight, class_weights, classes, y)
+    class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
+    assert_raises(ValueError, compute_class_weight, class_weights, classes, y)
+
 
 def test_compute_class_weight_invariance():
     # Test that results with class_weight="balanced" is invariant wrt


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/issues/4921, if a key in `class_weights`, a user-specified dictionary of classes, is not present in `classes`, an error should be raised.

Added unittest.
