### PR TITLE
check_X_y: Added mention that function returns y array

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -490,6 +490,9 @@ def check_X_y(X, y, accept_sparse=None, dtype="numeric", order=None, copy=False,
     -------
     X_converted : object
         The converted and validated X.
+
+    y_converted : object
+        The converted and validated y.
     """
     X = check_array(X, accept_sparse, dtype, order, copy, force_all_finite,
                     ensure_2d, allow_nd, ensure_min_samples,


### PR DESCRIPTION
I noticed that the documentation for `sklearn.utils.check_X_y` didn't specify that the function returned a `y` array. This is a quick fix to add that.

![screenshot 2015-09-12 18 13 10](https://cloud.githubusercontent.com/assets/1865885/9834294/05fe47fe-597a-11e5-98ea-450e957306ca.png)
