### PR TITLE
[MRG+2] Fix SGD partial_fit multiclass w/ average.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -225,6 +225,10 @@ Bug fixes
       to use soft-max instead of one-vs-rest normalization. By `Manoj Kumar`_.
       (`#5182 <https://github.com/scikit-learn/scikit-learn/pull/5182>`_)
 
+    - Fixed the :func:`partial_fit` method of :class:`linear_model.SGDClassifier`
+      when called with ``average=True``. By `Andrew Lamb`_.
+      (`#5282 <https://github.com/scikit-learn/scikit-learn/pull/5282>`_)
+
 API changes summary
 -------------------
 
@@ -3681,3 +3685,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Jacob Schreiber: https://github.com/jmschrei
 .. _Ankur Ankan: https://github.com/ankurankan
 .. _Valentin Stolbunov: http://vstolbunov.com
+.. _Andrew Lamb: https://github.com/andylamb

--- a/sklearn/linear_model/stochastic_gradient.py
+++ b/sklearn/linear_model/stochastic_gradient.py
@@ -463,7 +463,7 @@ class BaseSGDClassifier(six.with_metaclass(ABCMeta, BaseSGD,
                 self.intercept_ = self.average_intercept_
             else:
                 self.coef_ = self.standard_coef_
-                self.standard_intercept_ = np.atleast_1d(intercept)
+                self.standard_intercept_ = np.atleast_1d(self.intercept_)
                 self.intercept_ = self.standard_intercept_
 
     def partial_fit(self, X, y, classes=None, sample_weight=None):

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -732,6 +732,19 @@ class DenseSGDClassifierTestCase(unittest.TestCase, CommonTest):
         # check that coef_ haven't been re-allocated
         assert_true(id1, id2)
 
+    def test_partial_fit_multiclass_average(self):
+        third = X2.shape[0] // 3
+        clf = self.factory(alpha=0.01, average=X2.shape[0])
+        classes = np.unique(Y2)
+
+        clf.partial_fit(X2[:third], Y2[:third], classes=classes)
+        assert_equal(clf.coef_.shape, (3, X2.shape[1]))
+        assert_equal(clf.intercept_.shape, (3,))
+
+        clf.partial_fit(X2[third:], Y2[third:])
+        assert_equal(clf.coef_.shape, (3, X2.shape[1]))
+        assert_equal(clf.intercept_.shape, (3,))
+
     def test_fit_then_partial_fit(self):
         # Partial_fit should work after initial fit in the multiclass case.
         # Non-regression test for #2496; fit would previously produce a


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/issues/5246#issuecomment-140062688.

`_fit_multiclass` was setting `self.intercept_` to a single element of the intercept, instead of the entire intercept.
