### PR TITLE
[MRG] Remove some warnings from test suit

### DIFF
--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -39,7 +39,7 @@ def test_kernel_pca():
 
             # non-regression test: previously, gamma would be 0 by default,
             # forcing all eigenvalues to 0 under the poly kernel
-            assert_not_equal(X_fit_transformed, [])
+            assert_not_equal(X_fit_transformed.size, 0)
 
             # transform new data
             X_pred_transformed = kpca.transform(X_pred)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -28,6 +28,7 @@ from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.fixes import isclose
 from ..utils.fixes import bincount
+from ..utils.fixes import array_equal
 from ..utils.stats import rankdata
 from ..utils.sparsefuncs import count_nonzero
 
@@ -295,11 +296,11 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # ensure binary classification if pos_label is not specified
     classes = np.unique(y_true)
     if (pos_label is None and
-        not (np.array_equal(classes, [0, 1]) or
-             np.array_equal(classes, [-1, 1]) or
-             np.array_equal(classes, [0]) or
-             np.array_equal(classes, [-1]) or
-             np.array_equal(classes, [1]))):
+        not (array_equal(classes, [0, 1]) or
+             array_equal(classes, [-1, 1]) or
+             array_equal(classes, [0]) or
+             array_equal(classes, [-1]) or
+             array_equal(classes, [1]))):
         raise ValueError("Data is not binary and pos_label is not specified")
     elif pos_label is None:
         pos_label = 1.

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -295,11 +295,11 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # ensure binary classification if pos_label is not specified
     classes = np.unique(y_true)
     if (pos_label is None and
-        not (np.all(classes == [0, 1]) or
-             np.all(classes == [-1, 1]) or
-             np.all(classes == [0]) or
-             np.all(classes == [-1]) or
-             np.all(classes == [1]))):
+        not (np.array_equal(classes, [0, 1]) or
+             np.array_equal(classes, [-1, 1]) or
+             np.array_equal(classes, [0]) or
+             np.array_equal(classes, [-1]) or
+             np.array_equal(classes, [1]))):
         raise ValueError("Data is not binary and pos_label is not specified")
     elif pos_label is None:
         pos_label = 1.

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -161,8 +161,7 @@ def test_precision_recall_f_binary_single_class():
 
 @ignore_warnings
 def test_precision_recall_f_extra_labels():
-    """Test handling of explicit additional (not in input) labels to PRF
-    """
+    # Test handling of explicit additional (not in input) labels to PRF
     y_true = [1, 3, 3, 2]
     y_pred = [1, 1, 3, 2]
     y_true_bin = label_binarize(y_true, classes=np.arange(5))
@@ -202,7 +201,7 @@ def test_precision_recall_f_extra_labels():
 
 @ignore_warnings
 def test_precision_recall_f_ignored_labels():
-    """Test a subset of labels may be requested for PRF"""
+    # Test a subset of labels may be requested for PRF
     y_true = [1, 1, 2, 3]
     y_pred = [1, 3, 3, 3]
     y_true_bin = label_binarize(y_true, classes=np.arange(5))
@@ -323,6 +322,7 @@ def test_cohen_kappa():
     assert_almost_equal(cohen_kappa_score(y1, y2), .8013, decimal=4)
 
 
+@ignore_warnings
 def test_matthews_corrcoef_nan():
     assert_equal(matthews_corrcoef([0], [1]), 0.0)
     assert_equal(matthews_corrcoef([0, 0], [0, 1]), 0.0)
@@ -647,8 +647,8 @@ def test_multilabel_hamming_loss():
     assert_equal(hamming_loss(y1, y2), 1 / 6)
     assert_equal(hamming_loss(y1, y1), 0)
     assert_equal(hamming_loss(y2, y2), 0)
-    assert_equal(hamming_loss(y2, np.logical_not(y2)), 1)
-    assert_equal(hamming_loss(y1, np.logical_not(y1)), 1)
+    assert_equal(hamming_loss(y2, 1 - y2), 1)
+    assert_equal(hamming_loss(y1, 1 - y1), 1)
     assert_equal(hamming_loss(y1, np.zeros(y1.shape)), 4 / 6)
     assert_equal(hamming_loss(y2, np.zeros(y1.shape)), 0.5)
 
@@ -807,6 +807,7 @@ def test_precision_recall_f1_score_multilabel_2():
                         0.1666, 2)
 
 
+@ignore_warnings
 def test_precision_recall_f1_score_with_an_empty_prediction():
     y_true = np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 1, 1, 0]])
     y_pred = np.array([[0, 0, 0, 0], [0, 0, 0, 1], [0, 1, 1, 0]])
@@ -1142,11 +1143,11 @@ def test_hinge_loss_binary():
 
 def test_hinge_loss_multiclass():
     pred_decision = np.array([
-        [0.36, -0.17, -0.58, -0.99],
+        [+0.36, -0.17, -0.58, -0.99],
         [-0.54, -0.37, -0.48, -0.58],
         [-1.45, -0.58, -0.38, -0.17],
         [-0.54, -0.38, -0.48, -0.58],
-        [-2.36, -0.79, -0.27,  0.24],
+        [-2.36, -0.79, -0.27, +0.24],
         [-1.45, -0.58, -0.38, -0.17]
     ])
     y_true = np.array([0, 1, 2, 1, 3, 2])
@@ -1167,10 +1168,10 @@ def test_hinge_loss_multiclass():
 def test_hinge_loss_multiclass_missing_labels_with_labels_none():
     y_true = np.array([0, 1, 2, 2])
     pred_decision = np.array([
-        [1.27, 0.034, -0.68, -1.40],
+        [+1.27, 0.034, -0.68, -1.40],
         [-1.45, -0.58, -0.38, -0.17],
-        [-2.36, -0.79, -0.27,  0.24],
-        [-2.36, -0.79, -0.27,  0.24]
+        [-2.36, -0.79, -0.27, +0.24],
+        [-2.36, -0.79, -0.27, +0.24]
     ])
     error_message = ("Please include all labels in y_true "
                      "or pass labels as third argument")
@@ -1181,7 +1182,7 @@ def test_hinge_loss_multiclass_missing_labels_with_labels_none():
 
 def test_hinge_loss_multiclass_with_missing_labels():
     pred_decision = np.array([
-        [0.36, -0.17, -0.58, -0.99],
+        [+0.36, -0.17, -0.58, -0.99],
         [-0.55, -0.38, -0.48, -0.58],
         [-1.45, -0.58, -0.38, -0.17],
         [-0.55, -0.38, -0.48, -0.58],
@@ -1209,12 +1210,12 @@ def test_hinge_loss_multiclass_invariance_lists():
     y_true = ['blue', 'green', 'red',
               'green', 'white', 'red']
     pred_decision = [
-        [0.36, -0.17, -0.58, -0.99],
+        [+0.36, -0.17, -0.58, -0.99],
         [-0.55, -0.38, -0.48, -0.58],
-        [-1.45, -0.58, -0.38,  -0.17],
+        [-1.45, -0.58, -0.38, -0.17],
         [-0.55, -0.38, -0.48, -0.58],
-        [-2.36, -0.79, -0.27,  0.24],
-        [-1.45, -0.58, -0.38,  -0.17]]
+        [-2.36, -0.79, -0.27, +0.24],
+        [-1.45, -0.58, -0.38, -0.17]]
     dummy_losses = np.array([
         1 - pred_decision[0][0] + pred_decision[0][1],
         1 - pred_decision[1][1] + pred_decision[1][2],

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -93,7 +93,7 @@ REGRESSION_METRICS = {
     "mean_squared_error": mean_squared_error,
     "median_absolute_error": median_absolute_error,
     "explained_variance_score": explained_variance_score,
-    "r2_score": r2_score,
+    "r2_score": partial(r2_score, multioutput='variance_weighted'),
 }
 
 CLASSIFICATION_METRICS = {

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -111,7 +111,9 @@ X_sparse = coo_matrix(X)
 W_sparse = coo_matrix((np.array([1]), (np.array([1]), np.array([0]))),
                       shape=(10, 1))
 P_sparse = coo_matrix(np.eye(5))
-y = np.arange(10) // 2
+
+# avoid StratifiedKFold's Warning about least populated class in y
+y = np.arange(10) % 3
 
 ##############################################################################
 # Tests
@@ -289,12 +291,10 @@ def test_shuffle_kfold():
 
     all_folds = None
     for train, test in kf:
-        sorted_array = np.arange(100)
-        assert_true(np.any(sorted_array != ind[train]))
-        sorted_array = np.arange(101, 200)
-        assert_true(np.any(sorted_array != ind[train]))
-        sorted_array = np.arange(201, 300)
-        assert_true(np.any(sorted_array != ind[train]))
+        assert_true(np.any(np.arange(100) != ind[test]))
+        assert_true(np.any(np.arange(100, 200) != ind[test]))
+        assert_true(np.any(np.arange(200, 300) != ind[test]))
+
         if all_folds is None:
             all_folds = ind[test].copy()
         else:
@@ -396,6 +396,7 @@ def test_label_kfold():
               'Robert', 'Marion', 'David', 'Tony', 'Abel', 'Becky',
               'Madmood', 'Cary', 'Mary', 'Alexandre', 'David', 'Francis',
               'Barack', 'Abdoul', 'Rasha', 'Xi', 'Silvia']
+    labels = np.asarray(labels, dtype=object)
 
     n_labels = len(np.unique(labels))
     n_samples = len(labels)
@@ -415,7 +416,6 @@ def test_label_kfold():
         assert_equal(len(np.unique(folds[labels == label])), 1)
 
     # Check that no label is on both sides of the split
-    labels = np.asarray(labels, dtype=object)
     for train, test in cval.LabelKFold(labels, n_folds=n_folds):
         assert_equal(len(np.intersect1d(labels[train], labels[test])), 0)
 
@@ -560,7 +560,7 @@ def test_label_shuffle_split():
 
     for y in ys:
         n_iter = 6
-        test_size = 1./3
+        test_size = 1. / 3
         slo = cval.LabelShuffleSplit(y, n_iter, test_size=test_size,
                                      random_state=0)
 

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -429,6 +429,7 @@ class BrokenClassifier(BaseEstimator):
         return np.zeros(X.shape[0])
 
 
+@ignore_warnings
 def test_refit():
     # Regression test for bug in refitting
     # Simulates re-fitting a broken estimator; this used to break with

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -375,3 +375,17 @@ else:
             if (not exist_ok or e.errno != errno.EEXIST
                     or not os.path.isdir(name)):
                 raise
+
+
+if np_version < (1, 8, 1):
+    def array_equal(a1, a2):
+        # copy-paste from numpy 1.8.1
+        try:
+            a1, a2 = np.asarray(a1), np.asarray(a2)
+        except:
+            return False
+        if a1.shape != a2.shape:
+            return False
+        return bool(np.asarray(a1 == a2).all())
+else:
+    from numpy import array_equal

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -19,10 +19,9 @@ from scipy.sparse import lil_matrix
 import numpy as np
 
 from ..externals.six import string_types
-
 from .validation import check_array
-
 from ..utils.fixes import bincount
+from ..utils.fixes import array_equal
 
 
 def _unique_multiclass(y):
@@ -283,7 +282,7 @@ def _check_partial_fit_first_call(clf, classes=None):
 
     elif classes is not None:
         if getattr(clf, 'classes_', None) is not None:
-            if not np.array_equal(clf.classes_, unique_labels(classes)):
+            if not array_equal(clf.classes_, unique_labels(classes)):
                 raise ValueError(
                     "`classes=%r` is not the same as on last call "
                     "to partial_fit, was: %r" % (classes, clf.classes_))

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -148,7 +148,7 @@ def is_multilabel(y):
     if issparse(y):
         if isinstance(y, (dok_matrix, lil_matrix)):
             y = y.tocsr()
-        return (len(y.data) == 0 or np.ptp(y.data) == 0 and
+        return (len(y.data) == 0 or np.unique(y.data).size == 1 and
                 (y.dtype.kind in 'biu' or  # bool, int, uint
                  _is_integral_float(np.unique(y.data))))
     else:
@@ -283,7 +283,7 @@ def _check_partial_fit_first_call(clf, classes=None):
 
     elif classes is not None:
         if getattr(clf, 'classes_', None) is not None:
-            if not np.all(clf.classes_ == unique_labels(classes)):
+            if not np.array_equal(clf.classes_, unique_labels(classes)):
                 raise ValueError(
                     "`classes=%r` is not the same as on last call "
                     "to partial_fit, was: %r" % (classes, clf.classes_))


### PR DESCRIPTION
I removed some warnings from the test suit.
- (1 left) "DeprecationWarning: elementwise comparison failed; this will raise the error in the future"
- (0 left) "Warning: The least populated class in y has only 2 members, which is too few. The minimum number of labels for any class cannot be less than 3"
- (0 left) "DeprecationWarning: Default 'multioutput' behavior now corresponds to 'variance_weighted' value, it will be changed to 'uniform_average' in 0.18"
- (some left) "UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 due to no predicted samples."

Issue #5089 
Complementary work #5277
