### PR TITLE
Go to easy _open_ issues page

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -214,7 +214,7 @@ Easy Issues
 
 A great way to start contributing to scikit-learn is to pick an item from the
 list of `Easy issues
-<https://github.com/scikit-learn/scikit-learn/issues?labels=Easy>`_
+<https://github.com/scikit-learn/scikit-learn/labels/Easy>`_
 in the issue tracker. Resolving these issues allow you to start contributing
 to the project without much prior knowledge. Your assistance in this area will
 be greatly appreciated by the more experienced developers as it helps free up


### PR DESCRIPTION
Currently the link to the easy open issues page lists open and closed issues. When trying to get people involved, it'd be more valuable to just show the open issues.
