### PR TITLE
Updated dead link to publication. 

### DIFF
--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -182,5 +182,5 @@ The chi squared kernel is most commonly used on histograms (bags) of visual word
       Local features and kernels for classification of texture and object
       categories: A comprehensive study
       International Journal of Computer Vision 2007
-      http://eprints.pascal-network.org/archive/00002309/01/Zhang06-IJCV.pdf
+      http://research.microsoft.com/en-us/um/people/manik/projects/trade-off/papers/ZhangIJCV06.pdf
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -895,7 +895,7 @@ def additive_chi2_kernel(X, Y=None):
       Local features and kernels for classification of texture and object
       categories: A comprehensive study
       International Journal of Computer Vision 2007
-      http://eprints.pascal-network.org/archive/00002309/01/Zhang06-IJCV.pdf
+      http://research.microsoft.com/en-us/um/people/manik/projects/trade-off/papers/ZhangIJCV06.pdf
 
 
     See also
@@ -953,7 +953,7 @@ def chi2_kernel(X, Y=None, gamma=1.):
       Local features and kernels for classification of texture and object
       categories: A comprehensive study
       International Journal of Computer Vision 2007
-      http://eprints.pascal-network.org/archive/00002309/01/Zhang06-IJCV.pdf
+      http://research.microsoft.com/en-us/um/people/manik/projects/trade-off/papers/ZhangIJCV06.pdf
 
     See also
     --------


### PR DESCRIPTION
Updated link: Original link to ZhangIJCV06 paper "Local Features and Kernels for Classification of Texture and Object Categories: A Comprehensive Study"  was dead. 

Replaced all occurances of "http://eprints.pascal-network.org/archive/00002309/01/Zhang06-IJCV.pdf" with "http://research.microsoft.com/en-us/um/people/manik/projects/trade-off/papers/ZhangIJCV06.pdf"
