### PR TITLE
[MRG] Deprecate fit params in qda and lda

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -253,6 +253,17 @@ API changes summary
       to be explicitly shaped ``(n_samples, n_features)``.
       By `Vighnesh Birodkar`_.
 
+    - :class:`lda.LDA` and :class:`qda.QDA` have been moved to
+      :class:`discriminant_analysis.LinearDiscriminantAnalysis` and 
+      :class:`discriminant_analysis.QuadraticDiscriminantAnalysis`.
+
+    - The ``store_covariance`` and ``tol`` parameters have been moved from
+      the fit method to the constructor in
+      :class:`discriminant_analysis.LinearDiscriminantAnalysis` and the
+      ``store_covariances`` and ``tol`` parameters have been moved from the
+      fit method to the constructor in
+      :class:`discriminant_analysis.QuadraticDiscriminantAnalysis`.
+
 .. _changes_0_1_16:
 
 Version 0.16.1

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -260,7 +260,7 @@ def test_qda_store_covariances():
     assert_true(not hasattr(clf, 'covariances_'))
 
     # Test the actual attribute:
-    clf = QuadraticDiscriminantAnalysis().fit(X6, y6, store_covariances=True)
+    clf = QuadraticDiscriminantAnalysis(store_covariances=True).fit(X6, y6)
     assert_true(hasattr(clf, 'covariances_'))
 
     assert_array_almost_equal(


### PR DESCRIPTION
@amueller ... I believe this fixes #4107 and supercedes #4112 as `LinearDiscriminantAnalysis` and `QuadraticDiscriminantAnalysis` have moved to `discriminant_analysis.py` and that PR appears to have gone stale.
