### PR TITLE
[MRG+3] Collapsing PCA and RandomizedPCA

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -38,13 +38,15 @@ is an estimator object::
     >>> from sklearn.svm import SVC
     >>> from sklearn.decomposition import PCA
     >>> estimators = [('reduce_dim', PCA()), ('svm', SVC())]
-    >>> clf = Pipeline(estimators)   
+    >>> clf = Pipeline(estimators)
     >>> clf # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(steps=[('reduce_dim', PCA(copy=True, n_components=None,
-        whiten=False)), ('svm', SVC(C=1.0, cache_size=200, class_weight=None,
-        coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
-        kernel='rbf', max_iter=-1, probability=False, random_state=None,
-        shrinking=True, tol=0.001, verbose=False))])
+    Pipeline(steps=[('reduce_dim', PCA(copy=True, iterated_power=4,
+    n_components=None, random_state=None, svd_solver='auto', tol=0.0,
+    whiten=False)), ('svm', SVC(C=1.0, cache_size=200, class_weight=None,
+    coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
+    kernel='rbf', max_iter=-1, probability=False, random_state=None,
+    shrinking=True, tol=0.001, verbose=False))])
+
 
 The utility function :func:`make_pipeline` is a shorthand
 for constructing pipelines;
@@ -63,22 +65,26 @@ filling in the names automatically::
 The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 
     >>> clf.steps[0]
-    ('reduce_dim', PCA(copy=True, n_components=None, whiten=False))
+    ('reduce_dim', PCA(copy=True, iterated_power=4, n_components=None, random_state=None,
+      svd_solver='auto', tol=0.0, whiten=False))
 
 and as a ``dict`` in ``named_steps``::
 
     >>> clf.named_steps['reduce_dim']
-    PCA(copy=True, n_components=None, whiten=False)
+    PCA(copy=True, iterated_power=4, n_components=None, random_state=None,
+      svd_solver='auto', tol=0.0, whiten=False)
 
 Parameters of the estimators in the pipeline can be accessed using the
 ``<estimator>__<parameter>`` syntax::
 
     >>> clf.set_params(svm__C=10) # doctest: +NORMALIZE_WHITESPACE
-    Pipeline(steps=[('reduce_dim', PCA(copy=True, n_components=None,
+    Pipeline(steps=[('reduce_dim', PCA(copy=True, iterated_power=4,
+        n_components=None, random_state=None, svd_solver='auto', tol=0.0,
         whiten=False)), ('svm', SVC(C=10, cache_size=200, class_weight=None,
         coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
         kernel='rbf', max_iter=-1, probability=False, random_state=None,
         shrinking=True, tol=0.001, verbose=False))])
+
 
 This is particularly important for doing grid searches::
 
@@ -150,19 +156,22 @@ and ``value`` is an estimator object::
     >>> from sklearn.decomposition import PCA
     >>> from sklearn.decomposition import KernelPCA
     >>> estimators = [('linear_pca', PCA()), ('kernel_pca', KernelPCA())]
-    >>> combined = FeatureUnion(estimators)   
+    >>> combined = FeatureUnion(estimators)
     >>> combined # doctest: +NORMALIZE_WHITESPACE
-    FeatureUnion(n_jobs=1, transformer_list=[('linear_pca', PCA(copy=True,
-        n_components=None, whiten=False)), ('kernel_pca', KernelPCA(alpha=1.0,
-        coef0=1, degree=3, eigen_solver='auto', fit_inverse_transform=False,
-        gamma=None, kernel='linear', kernel_params=None, max_iter=None,
-        n_components=None, n_jobs=1, random_state=None, remove_zero_eig=False, tol=0))],
+    FeatureUnion(n_jobs=1, transformer_list=[('linear_pca',  PCA(copy=True,
+        iterated_power=4, n_components=None, random_state=None,
+        svd_solver='auto', tol=0.0, whiten=False)), ('kernel_pca',
+        KernelPCA(alpha=1.0, coef0=1, degree=3, eigen_solver='auto',
+        fit_inverse_transform=False, gamma=None, kernel='linear',
+        kernel_params=None, max_iter=None, n_components=None, n_jobs=1,
+        random_state=None, remove_zero_eig=False, tol=0))],
         transformer_weights=None)
+
 
 Like pipelines, feature unions have a shorthand constructor called
 :func:`make_union` that does not require explicit naming of the components.
 
-                                                                       
+
 .. topic:: Examples:
 
  * :ref:`example_feature_stacker.py`

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -275,7 +275,8 @@ data by projecting on a principal subspace.
     >>> from sklearn import decomposition
     >>> pca = decomposition.PCA()
     >>> pca.fit(X)
-    PCA(copy=True, n_components=None, whiten=False)
+    PCA(copy=True, iterated_power=4, n_components=None, random_state=None,
+      svd_solver='auto', tol=0.0, whiten=False)
     >>> print(pca.explained_variance_)  # doctest: +SKIP
     [  2.18565811e+00   1.19346747e+00   8.43026679e-32]
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,15 @@ New features
      :class:`feature_selection.SelectPercentile` as score functions.
      By `Andrea Bravi`_ and `Nikolay Mayorov`_.
 
+   - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
+     and it is available calling with parameter ``svd_solver='randomized'``.
+     The default number of ``n_iter`` for ``'randomized'`` has changed to 4. The old
+     behavior of PCA is recovered by ``svd_solver='full'``. An additional solver
+     calls `arpack` and performs truncated (non-randomized) SVD. By default,
+     the best solver is selected depending on the size of the input and the
+     number of components requested.
+     (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
+
    - The Gaussian Process module has been reimplemented and now offers classification
      and regression estimators through :class:`gaussian_process.GaussianProcessClassifier`
      and  :class:`gaussian_process.GaussianProcessRegressor`. Among other things, the new
@@ -114,17 +123,26 @@ Bug fixes
     - :class:`StratifiedKFold` now raises error if all n_labels for individual classes is less than n_folds.
       (`#6182 <https://github.com/scikit-learn/scikit-learn/pull/6182>`_) by `Devashish Deshpande`_.
 
-    - :class:`RandomizedPCA` default number of `iterated_power` is 2 instead of 3.
-      This is a speed up with a minor precision decrease. (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+    - :class:`RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
+      (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
 
-    - :func:`randomized_svd` performs 2 power iterations by default, instead or 0.
-      In practice this is often enough for obtaining a good approximation of the
-      true eigenvalues/vectors in the presence of noise. (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+    - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.
+      In practice this is enough for obtaining a good approximation of the
+      true eigenvalues/vectors in the presence of noise. When `n_components` is
+      small (< .1 * min(X.shape)) `n_iter` is set to 7, unless the user specifies
+      a higher number. This improves precision with few components.
+      (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
 
-    - :func:`randomized_range_finder` is more numerically stable when many
+    - :func:`utils.extmath.randomized_range_finder` is more numerically stable when many
       power iterations are requested, since it applies LU normalization by default.
       If `n_iter<2` numerical issues are unlikely, thus no normalization is applied.
-      Other normalization options are available: 'none', 'LU' and 'QR'. (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+      Other normalization options are available: 'none', 'LU' and 'QR'.
+      (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+
+    - Whiten/non-whiten inconsistency between components of :class:`decomposition.PCA`
+      and :class:`decomposition.RandomizedPCA` (now factored into PCA, see the
+      New features) is fixed. `components_` are stored with no whitening.
+      (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
 
     - Fixed bug in :func:`manifold.spectral_embedding` where diagonal of unnormalized
       Laplacian matrix was incorrectly set to 1. (`#4995 <https://github.com/scikit-learn/scikit-learn/pull/4995>`_) By `Peter Fischer`_.
@@ -213,7 +231,8 @@ Changelog
 
 New features
 ............
-   - All the Scaler classes but :class:`RobustScaler` can be fitted online by
+
+   - All the Scaler classes but :class:`preprocessing.RobustScaler` can be fitted online by
      calling `partial_fit`. By `Giorgio Patrini`_.
 
    - The new class :class:`ensemble.VotingClassifier` implements a
@@ -445,6 +464,7 @@ Enhancements
 
 Bug fixes
 .........
+
     - Fixed non-determinism in :class:`dummy.DummyClassifier` with sparse
       multi-label output. By `Andreas Müller`_.
 

--- a/examples/decomposition/plot_pca_vs_fa_model_selection.py
+++ b/examples/decomposition/plot_pca_vs_fa_model_selection.py
@@ -23,7 +23,6 @@ Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
 by Thomas P. Minka is also compared.
 
 """
-print(__doc__)
 
 # Authors: Alexandre Gramfort
 #          Denis A. Engemann
@@ -37,6 +36,8 @@ from sklearn.decomposition import PCA, FactorAnalysis
 from sklearn.covariance import ShrunkCovariance, LedoitWolf
 from sklearn.model_selection import cross_val_score
 from sklearn.model_selection import GridSearchCV
+
+print(__doc__)
 
 ###############################################################################
 # Create the data
@@ -61,7 +62,7 @@ n_components = np.arange(0, n_features, 5)  # options for n_components
 
 
 def compute_scores(X):
-    pca = PCA()
+    pca = PCA(svd_solver='full')
     fa = FactorAnalysis()
 
     pca_scores, fa_scores = [], []
@@ -90,7 +91,7 @@ for X, title in [(X_homo, 'Homoscedastic Noise'),
     n_components_pca = n_components[np.argmax(pca_scores)]
     n_components_fa = n_components[np.argmax(fa_scores)]
 
-    pca = PCA(n_components='mle')
+    pca = PCA(svd_solver='full', n_components='mle')
     pca.fit(X)
     n_components_pca_mle = pca.n_components_
 
@@ -105,7 +106,8 @@ for X, title in [(X_homo, 'Homoscedastic Noise'),
     plt.axvline(n_components_pca, color='b',
                 label='PCA CV: %d' % n_components_pca, linestyle='--')
     plt.axvline(n_components_fa, color='r',
-                label='FactorAnalysis CV: %d' % n_components_fa, linestyle='--')
+                label='FactorAnalysis CV: %d' % n_components_fa,
+                linestyle='--')
     plt.axvline(n_components_pca_mle, color='k',
                 label='PCA MLE: %d' % n_components_pca_mle, linestyle='--')
 

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -6,6 +6,7 @@
 #         Mathieu Blondel <mathieu@mblondel.org>
 #         Denis A. Engemann <d.engemann@fz-juelich.de>
 #         Michael Eickenberg <michael.eickenberg@inria.fr>
+#         Giorgio Patrini <giorgio.patrini@anu.edu.au>
 #
 # License: BSD 3 clause
 
@@ -15,11 +16,16 @@ import numpy as np
 from scipy import linalg
 from scipy.special import gammaln
 
+from ..externals import six
+
+from .base import _BasePCA
 from ..base import BaseEstimator, TransformerMixin
+from ..utils import deprecated
 from ..utils import check_random_state, as_float_array
 from ..utils import check_array
-from ..utils.extmath import fast_dot, fast_logdet, randomized_svd
+from ..utils.extmath import fast_dot, fast_logdet, randomized_svd, svd_flip
 from ..utils.validation import check_is_fitted
+from ..utils.arpack import svds
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
@@ -55,8 +61,8 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
 
     pu = -rank * log(2.)
     for i in range(rank):
-        pu += (gammaln((n_features - i) / 2.)
-               - log(np.pi) * (n_features - i) / 2.)
+        pu += (gammaln((n_features - i) / 2.) -
+               log(np.pi) * (n_features - i) / 2.)
 
     pl = np.sum(np.log(spectrum[:rank]))
     pl = -pl * n_samples / 2.
@@ -96,41 +102,39 @@ def _infer_dimension_(spectrum, n_samples, n_features):
     return ll.argmax()
 
 
-class PCA(BaseEstimator, TransformerMixin):
+class PCA(_BasePCA):
     """Principal component analysis (PCA)
 
     Linear dimensionality reduction using Singular Value Decomposition of the
-    data and keeping only the most significant singular vectors to project the
-    data to a lower dimensional space.
+    data to project it to a lower dimensional space.
 
-    This implementation uses the scipy.linalg implementation of the singular
-    value decomposition. It only works for dense arrays and is not scalable to
-    large dimensional data.
-
-    The time complexity of this implementation is ``O(n ** 3)`` assuming
-    n ~ n_samples ~ n_features.
+    It uses the scipy.linalg ARPACK implementation of the SVD or a randomized
+    SVD by the method of Halko et al. 2009, depending on which is the most
+    efficient.
 
     Read more in the :ref:`User Guide <PCA>`.
 
     Parameters
     ----------
-    n_components : int, None or string
+    n_components : int, float, None or string
         Number of components to keep.
         if n_components is not set all components are kept::
 
             n_components == min(n_samples, n_features)
 
-        if n_components == 'mle', Minka\'s MLE is used to guess the dimension
-        if ``0 < n_components < 1``, select the number of components such that
-        the amount of variance that needs to be explained is greater than the
-        percentage specified by n_components
+        if n_components == 'mle' and svd_solver == 'full', Minka\'s MLE is used
+        to guess the dimension
+        if ``0 < n_components < 1`` and svd_solver == 'full', select the number
+        of components such that the amount of variance that needs to be
+        explained is greater than the percentage specified by n_components
+        n_components cannot be equal to n_features for svd_solver == 'arpack'.
 
-    copy : bool
+    copy : bool (default True)
         If False, data passed to fit are overwritten and running
         fit(X).transform(X) will not yield the expected results,
         use fit_transform(X) instead.
 
-    whiten : bool, optional
+    whiten : bool, optional (default False)
         When True (False by default) the `components_` vectors are multiplied
         by the square root of n_samples and then divided by the singular values
         to ensure uncorrelated outputs with unit component-wise variances.
@@ -138,7 +142,41 @@ class PCA(BaseEstimator, TransformerMixin):
         Whitening will remove some information from the transformed signal
         (the relative variance scales of the components) but can sometime
         improve the predictive accuracy of the downstream estimators by
-        making there data respect some hard-wired assumptions.
+        making their data respect some hard-wired assumptions.
+
+    svd_solver : string {'auto', 'full', 'arpack', 'randomized'}
+        auto :
+            the solver is selected by a default policy based on `X.shape` and
+            `n_components` which favors 'randomized' when the problem is
+            computationally demanding for 'full' PCA
+        full :
+            run exact SVD calling ARPACK solver via
+            `scipy.linalg.svd` and select the components by postprocessing
+        arpack :
+            run SVD truncated to n_components calling ARPACK solver via
+            `scipy.sparse.linalg.svds`. It requires strictly
+            0 < n_components < X.shape[1]
+        randomized :
+            run randomized SVD by the method of Halko et al.
+
+        .. versionadded:: 0.18.0
+
+    tol : float >= 0, optional (default .0)
+        Tolerance for singular values computed by svd_solver == 'arpack'.
+
+        .. versionadded:: 0.18.0
+
+    iterated_power : int >= 0, optional (default 4)
+        Number of iterations for the power method computed by
+        svd_solver == 'randomized'.
+
+        .. versionadded:: 0.18.0
+
+    random_state : int or RandomState instance or None (default None)
+        Pseudo Random Number generator seed control. If None, use the
+        numpy.random singleton. Used by svd_solver == 'arpack' or 'randomized'.
+
+        .. versionadded:: 0.18.0
 
     Attributes
     ----------
@@ -162,9 +200,10 @@ class PCA(BaseEstimator, TransformerMixin):
         Equal to `X.mean(axis=1)`.
 
     n_components_ : int
-        The estimated number of components. Relevant when `n_components` is set
-        to 'mle' or a number between 0 and 1 to select using explained
-        variance.
+        The estimated number of components. When n_components is set
+        to 'mle' or a number between 0 and 1 (with svd_solver == 'full') this
+        number is estimated from input data. Otherwise it equals the parameter
+        n_components, or n_features if n_components is None.
 
     noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model
@@ -173,9 +212,9 @@ class PCA(BaseEstimator, TransformerMixin):
         http://www.miketipping.com/papers/met-mppca.pdf. It is required to
         computed the estimated data covariance and score samples.
 
-    Notes
-    -----
-    For n_components='mle', this class uses the method of `Thomas P. Minka:
+    References
+    ----------
+    For n_components == 'mle', this class uses the method of `Thomas P. Minka:
     Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604`
 
     Implements the probabilistic PCA model from:
@@ -184,37 +223,60 @@ class PCA(BaseEstimator, TransformerMixin):
     via the score and score_samples methods.
     See http://www.miketipping.com/papers/met-mppca.pdf
 
-    Due to implementation subtleties of the Singular Value Decomposition (SVD),
-    which is used in this implementation, running fit twice on the same matrix
-    can lead to principal components with signs flipped (change in direction).
-    For this reason, it is important to always use the same estimator object to
-    transform data in a consistent fashion.
+    For svd_solver == 'arpack', refer to `scipy.sparse.linalg.svds`.
+
+    For svd_solver == 'randomized', see:
+    `Finding structure with randomness: Stochastic algorithms
+    for constructing approximate matrix decompositions Halko, et al., 2009
+    (arXiv:909)`
+    `A randomized algorithm for the decomposition of matrices
+    Per-Gunnar Martinsson, Vladimir Rokhlin and Mark Tygert`
+
 
     Examples
     --------
-
     >>> import numpy as np
     >>> from sklearn.decomposition import PCA
     >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
     >>> pca = PCA(n_components=2)
     >>> pca.fit(X)
-    PCA(copy=True, n_components=2, whiten=False)
-    >>> print(pca.explained_variance_) # doctest: +ELLIPSIS
-    [ 6.6162...  0.05038...]
+    PCA(copy=True, iterated_power=4, n_components=2, random_state=None,
+      svd_solver='auto', tol=0.0, whiten=False)
     >>> print(pca.explained_variance_ratio_) # doctest: +ELLIPSIS
     [ 0.99244...  0.00755...]
 
+    >>> pca = PCA(n_components=2, svd_solver='full')
+    >>> pca.fit(X)                 # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    PCA(copy=True, iterated_power=4, n_components=2, random_state=None,
+      svd_solver='full', tol=0.0, whiten=False)
+    >>> print(pca.explained_variance_ratio_) # doctest: +ELLIPSIS
+    [ 0.99244...  0.00755...]
+
+    >>> pca = PCA(n_components=1, svd_solver='arpack')
+    >>> pca.fit(X)
+    PCA(copy=True, iterated_power=4, n_components=1, random_state=None,
+      svd_solver='arpack', tol=0.0, whiten=False)
+    >>> print(pca.explained_variance_ratio_) # doctest: +ELLIPSIS
+    [ 0.99244...]
+
     See also
     --------
-    RandomizedPCA
     KernelPCA
     SparsePCA
     TruncatedSVD
+    IncrementalPCA
     """
-    def __init__(self, n_components=None, copy=True, whiten=False):
+
+    def __init__(self, n_components=None, copy=True, whiten=False,
+                 svd_solver='auto', tol=0.0, iterated_power=4,
+                 random_state=None):
         self.n_components = n_components
         self.copy = copy
         self.whiten = whiten
+        self.svd_solver = svd_solver
+        self.tol = tol
+        self.iterated_power = iterated_power
+        self.random_state = random_state
 
     def fit(self, X, y=None):
         """Fit the model with X.
@@ -260,52 +322,71 @@ class PCA(BaseEstimator, TransformerMixin):
         return U
 
     def _fit(self, X):
-        """Fit the model on X
+        """Dispatch to the right submethod depending on the chosen solver."""
+        X = check_array(X, dtype=[np.float64], ensure_2d=True,
+                        copy=self.copy)
 
-        Parameters
-        ----------
-        X: array-like, shape (n_samples, n_features)
-            Training vector, where n_samples in the number of samples and
-            n_features is the number of features.
+        # Handle n_components==None
+        if self.n_components is None:
+            n_components = X.shape[1]
+        else:
+            n_components = self.n_components
 
-        Returns
-        -------
-        U, s, V : ndarrays
-            The SVD of the input data, copied and centered when
-            requested.
-        """
-        X = check_array(X)
+        # Handle svd_solver
+        svd_solver = self.svd_solver
+        if svd_solver == 'auto':
+            # Small problem, just call full PCA
+            if max(X.shape) <= 500:
+                svd_solver = 'full'
+            elif n_components >= 1 and n_components < .8 * min(X.shape):
+                svd_solver = 'randomized'
+            # This is also the case of n_components in (0,1)
+            else:
+                svd_solver = 'full'
+
+        # Call different fits for either full or truncated SVD
+        if svd_solver == 'full':
+            return self._fit_full(X, n_components)
+        elif svd_solver in ['arpack', 'randomized']:
+            return self._fit_truncated(X, n_components, svd_solver)
+
+    def _fit_full(self, X, n_components):
+        """Fit the model by computing full SVD on X"""
         n_samples, n_features = X.shape
-        X = as_float_array(X, copy=self.copy)
-        # Center data
-        self.mean_ = np.mean(X, axis=0)
-        X -= self.mean_
-        U, S, V = linalg.svd(X, full_matrices=False)
-        explained_variance_ = (S ** 2) / n_samples
-        explained_variance_ratio_ = (explained_variance_ /
-                                     explained_variance_.sum())
 
-        components_ = V
-
-        n_components = self.n_components
-        if n_components is None:
-            n_components = n_features
-        elif n_components == 'mle':
+        if n_components == 'mle':
             if n_samples < n_features:
                 raise ValueError("n_components='mle' is only supported "
                                  "if n_samples >= n_features")
-
-            n_components = _infer_dimension_(explained_variance_,
-                                             n_samples, n_features)
         elif not 0 <= n_components <= n_features:
-            raise ValueError("n_components=%r invalid for n_features=%d"
+            raise ValueError("n_components=%r must be between 0 and "
+                             "n_features=%r with svd_solver='full'"
                              % (n_components, n_features))
 
-        if 0 < n_components < 1.0:
-            # number of components for which the cumulated explained variance
-            # percentage is superior to the desired threshold
+        # Center data
+        self.mean_ = np.mean(X, axis=0)
+        X -= self.mean_
+
+        U, S, V = linalg.svd(X, full_matrices=False)
+        # flip eigenvectors' sign to enforce deterministic output
+        U, V = svd_flip(U, V)
+
+        components_ = V
+
+        # Get variance explained by singular values
+        explained_variance_ = (S ** 2) / n_samples
+        total_var = explained_variance_.sum()
+        explained_variance_ratio_ = explained_variance_ / total_var
+
+        # Postprocess the number of components required
+        if n_components == 'mle':
+            n_components = \
+                _infer_dimension_(explained_variance_, n_samples, n_features)
+        elif 0 < n_components < 1.0:
+            # number of components for which the cumulated explained
+            # variance percentage is superior to the desired threshold
             ratio_cumsum = explained_variance_ratio_.cumsum()
-            n_components = np.sum(ratio_cumsum < n_components) + 1
+            n_components = np.searchsorted(ratio_cumsum, n_components) + 1
 
         # Compute noise covariance using Probabilistic PCA model
         # The sigma2 maximum likelihood (cf. eq. 12.46)
@@ -314,120 +395,73 @@ class PCA(BaseEstimator, TransformerMixin):
         else:
             self.noise_variance_ = 0.
 
-        # store n_samples to revert whitening when getting covariance
-        self.n_samples_ = n_samples
-
+        self.n_samples_, self.n_features_ = n_samples, n_features
         self.components_ = components_[:n_components]
+        self.n_components_ = n_components
         self.explained_variance_ = explained_variance_[:n_components]
-        explained_variance_ratio_ = explained_variance_ratio_[:n_components]
-        self.explained_variance_ratio_ = explained_variance_ratio_
+        self.explained_variance_ratio_ = \
+            explained_variance_ratio_[:n_components]
+
+        return U, S, V
+
+    def _fit_truncated(self, X, n_components, svd_solver):
+        """Fit the model by computing truncated SVD (by ARPACK or randomized)
+        on X
+        """
+        n_samples, n_features = X.shape
+
+        if isinstance(n_components, six.string_types):
+            raise ValueError("n_components=%r cannot be a string "
+                             "with svd_solver='%s'"
+                             % (n_components, svd_solver))
+        elif not 1 <= n_components <= n_features:
+            raise ValueError("n_components=%r must be between 1 and "
+                             "n_features=%r with svd_solver='%s'"
+                             % (n_components, n_features, svd_solver))
+        elif svd_solver == 'arpack' and n_components == n_features:
+            raise ValueError("n_components=%r must be stricly less than "
+                             "n_features=%r with svd_solver='%s'"
+                             % (n_components, n_features, svd_solver))
+
+        random_state = check_random_state(self.random_state)
+
+        # Center data
+        self.mean_ = np.mean(X, axis=0)
+        X -= self.mean_
+
+        if svd_solver == 'arpack':
+            # random init solution, as ARPACK does it internally
+            v0 = random_state.uniform(-1, 1, size=min(X.shape))
+            U, S, V = svds(X, k=n_components, tol=self.tol, v0=v0)
+            # svds doesn't abide by scipy.linalg.svd/randomized_svd
+            # conventions, so reverse its outputs.
+            S = S[::-1]
+            # flip eigenvectors' sign to enforce deterministic output
+            U, V = svd_flip(U[:, ::-1], V[::-1])
+
+        elif svd_solver == 'randomized':
+            # sign flipping is done inside
+            U, S, V = randomized_svd(X, n_components=n_components,
+                                     n_iter=self.iterated_power,
+                                     flip_sign=True,
+                                     random_state=random_state)
+
+        self.n_samples_, self.n_features_ = n_samples, n_features
+        self.components_ = V
         self.n_components_ = n_components
 
-        return (U, S, V)
-
-    def get_covariance(self):
-        """Compute data covariance with the generative model.
-
-        ``cov = components_.T * S**2 * components_ + sigma2 * eye(n_features)``
-        where  S**2 contains the explained variances.
-
-        Returns
-        -------
-        cov : array, shape=(n_features, n_features)
-            Estimated covariance of data.
-        """
-        components_ = self.components_
-        exp_var = self.explained_variance_
-        if self.whiten:
-            components_ = components_ * np.sqrt(exp_var[:, np.newaxis])
-        exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
-        cov = np.dot(components_.T * exp_var_diff, components_)
-        cov.flat[::len(cov) + 1] += self.noise_variance_  # modify diag inplace
-        return cov
-
-    def get_precision(self):
-        """Compute data precision matrix with the generative model.
-
-        Equals the inverse of the covariance but computed with
-        the matrix inversion lemma for efficiency.
-
-        Returns
-        -------
-        precision : array, shape=(n_features, n_features)
-            Estimated precision of data.
-        """
-        n_features = self.components_.shape[1]
-
-        # handle corner cases first
-        if self.n_components_ == 0:
-            return np.eye(n_features) / self.noise_variance_
-        if self.n_components_ == n_features:
-            return linalg.inv(self.get_covariance())
-
-        # Get precision using matrix inversion lemma
-        components_ = self.components_
-        exp_var = self.explained_variance_
-        exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
-        precision = np.dot(components_, components_.T) / self.noise_variance_
-        precision.flat[::len(precision) + 1] += 1. / exp_var_diff
-        precision = np.dot(components_.T,
-                           np.dot(linalg.inv(precision), components_))
-        precision /= -(self.noise_variance_ ** 2)
-        precision.flat[::len(precision) + 1] += 1. / self.noise_variance_
-        return precision
-
-    def transform(self, X):
-        """Apply the dimensionality reduction on X.
-
-        X is projected on the first principal components previous extracted
-        from a training set.
-
-        Parameters
-        ----------
-        X : array-like, shape (n_samples, n_features)
-            New data, where n_samples is the number of samples
-            and n_features is the number of features.
-
-        Returns
-        -------
-        X_new : array-like, shape (n_samples, n_components)
-
-        """
-        check_is_fitted(self, 'mean_')
-
-        X = check_array(X)
-        if self.mean_ is not None:
-            X = X - self.mean_
-        X_transformed = fast_dot(X, self.components_.T)
-        if self.whiten:
-            X_transformed /= np.sqrt(self.explained_variance_)
-        return X_transformed
-
-    def inverse_transform(self, X):
-        """Transform data back to its original space using `n_components_`.
-
-        Returns an input X_original whose transform would be X.
-
-        Parameters
-        ----------
-        X : array-like, shape (n_samples, n_components)
-            New data, where n_samples is the number of samples
-            and n_components is the number of components. X represents
-            data from the projection on to the principal components.
-
-        Returns
-        -------
-        X_original array-like, shape (n_samples, n_features)
-        """
-        check_is_fitted(self, 'mean_')
-
-        if self.whiten:
-            return fast_dot(
-                X,
-                np.sqrt(self.explained_variance_[:, np.newaxis]) *
-                self.components_) + self.mean_
+        # Get variance explained by singular values
+        self.explained_variance_ = (S ** 2) / n_samples
+        total_var = np.var(X, axis=0)
+        self.explained_variance_ratio_ = \
+            self.explained_variance_ / total_var.sum()
+        if self.n_components_ < n_features:
+            self.noise_variance_ = (total_var.sum() -
+                                    self.explained_variance_.sum())
         else:
-            return fast_dot(X, self.components_) + self.mean_
+            self.noise_variance_ = 0.
+
+        return U, S, V
 
     def score_samples(self, X):
         """Return the log-likelihood of each sample.
@@ -454,8 +488,8 @@ class PCA(BaseEstimator, TransformerMixin):
         log_like = np.zeros(X.shape[0])
         precision = self.get_precision()
         log_like = -.5 * (Xr * (np.dot(Xr, precision))).sum(axis=1)
-        log_like -= .5 * (n_features * log(2. * np.pi)
-                          - fast_logdet(precision))
+        log_like -= .5 * (n_features * log(2. * np.pi) -
+                          fast_logdet(precision))
         return log_like
 
     def score(self, X, y=None):
@@ -478,6 +512,9 @@ class PCA(BaseEstimator, TransformerMixin):
         return np.mean(self.score_samples(X))
 
 
+@deprecated("RandomizedPCA will be removed in 0.20. "
+            "Use PCA(svd_solver='randomized') instead. The new implementation "
+            "DOES NOT store whiten components_. Apply transform to get them.")
 class RandomizedPCA(BaseEstimator, TransformerMixin):
     """Principal component analysis (PCA) using randomized SVD
 

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -13,8 +13,11 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.decomposition import FactorAnalysis
+from sklearn.utils.testing import ignore_warnings
 
 
+# Ignore warnings from switching to more power iterations in randomized_svd
+@ignore_warnings
 def test_factor_analysis():
     # Test FactorAnalysis ability to recover the data covariance structure
     rng = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -1,4 +1,5 @@
 import numpy as np
+from itertools import product
 
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -7,6 +8,9 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_no_warnings
+from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import assert_less
 
 from sklearn import datasets
 from sklearn.decomposition import PCA
@@ -15,36 +19,117 @@ from sklearn.decomposition.pca import _assess_dimension_
 from sklearn.decomposition.pca import _infer_dimension_
 
 iris = datasets.load_iris()
+solver_list = ['full', 'arpack', 'randomized', 'auto']
 
 
 def test_pca():
     # PCA on dense arrays
-    pca = PCA(n_components=2)
     X = iris.data
-    X_r = pca.fit(X).transform(X)
-    np.testing.assert_equal(X_r.shape[1], 2)
 
-    X_r2 = pca.fit_transform(X)
-    assert_array_almost_equal(X_r, X_r2)
+    for n_comp in np.arange(X.shape[1]):
+        pca = PCA(n_components=n_comp, svd_solver='full')
 
-    pca = PCA()
-    pca.fit(X)
-    assert_almost_equal(pca.explained_variance_ratio_.sum(), 1.0, 3)
+        X_r = pca.fit(X).transform(X)
+        np.testing.assert_equal(X_r.shape[1], n_comp)
 
-    X_r = pca.transform(X)
-    X_r2 = pca.fit_transform(X)
+        X_r2 = pca.fit_transform(X)
+        assert_array_almost_equal(X_r, X_r2)
 
-    assert_array_almost_equal(X_r, X_r2)
+        X_r = pca.transform(X)
+        X_r2 = pca.fit_transform(X)
+        assert_array_almost_equal(X_r, X_r2)
 
-    # Test get_covariance and get_precision with n_components == n_features
-    # with n_components < n_features and with n_components == 0
-    for n_components in [0, 2, X.shape[1]]:
-        pca.n_components = n_components
-        pca.fit(X)
+        # Test get_covariance and get_precision
         cov = pca.get_covariance()
         precision = pca.get_precision()
         assert_array_almost_equal(np.dot(cov, precision),
                                   np.eye(X.shape[1]), 12)
+
+    # test explained_variance_ratio_ == 1 with all components
+    pca = PCA(svd_solver='full')
+    pca.fit(X)
+    assert_almost_equal(pca.explained_variance_ratio_.sum(), 1.0, 3)
+
+
+def test_pca_arpack_solver():
+    # PCA on dense arrays
+    X = iris.data
+    d = X.shape[1]
+
+    # Loop excluding the extremes, invalid inputs for arpack
+    for n_comp in np.arange(1, d):
+        pca = PCA(n_components=n_comp, svd_solver='arpack', random_state=0)
+
+        X_r = pca.fit(X).transform(X)
+        np.testing.assert_equal(X_r.shape[1], n_comp)
+
+        X_r2 = pca.fit_transform(X)
+        assert_array_almost_equal(X_r, X_r2)
+
+        X_r = pca.transform(X)
+        assert_array_almost_equal(X_r, X_r2)
+
+        # Test get_covariance and get_precision
+        cov = pca.get_covariance()
+        precision = pca.get_precision()
+        assert_array_almost_equal(np.dot(cov, precision),
+                                  np.eye(d), 12)
+
+    pca = PCA(n_components=0, svd_solver='arpack', random_state=0)
+    assert_raises(ValueError, pca.fit, X)
+    # Check internal state
+    assert_equal(pca.n_components,
+                 PCA(n_components=0,
+                     svd_solver='arpack', random_state=0).n_components)
+    assert_equal(pca.svd_solver,
+                 PCA(n_components=0,
+                     svd_solver='arpack', random_state=0).svd_solver)
+
+    pca = PCA(n_components=d, svd_solver='arpack', random_state=0)
+    assert_raises(ValueError, pca.fit, X)
+    assert_equal(pca.n_components,
+                 PCA(n_components=d,
+                     svd_solver='arpack', random_state=0).n_components)
+    assert_equal(pca.svd_solver,
+                 PCA(n_components=0,
+                     svd_solver='arpack', random_state=0).svd_solver)
+
+
+def test_pca_randomized_solver():
+    # PCA on dense arrays
+    X = iris.data
+
+    # Loop excluding the 0, invalid for randomized
+    for n_comp in np.arange(1, X.shape[1]):
+        pca = PCA(n_components=n_comp, svd_solver='randomized', random_state=0)
+
+        X_r = pca.fit(X).transform(X)
+        np.testing.assert_equal(X_r.shape[1], n_comp)
+
+        X_r2 = pca.fit_transform(X)
+        assert_array_almost_equal(X_r, X_r2)
+
+        X_r = pca.transform(X)
+        assert_array_almost_equal(X_r, X_r2)
+
+        # Test get_covariance and get_precision
+        cov = pca.get_covariance()
+        precision = pca.get_precision()
+        assert_array_almost_equal(np.dot(cov, precision),
+                                  np.eye(X.shape[1]), 12)
+
+    pca = PCA(n_components=0, svd_solver='randomized', random_state=0)
+    assert_raises(ValueError, pca.fit, X)
+
+    pca = PCA(n_components=0, svd_solver='randomized', random_state=0)
+    assert_raises(ValueError, pca.fit, X)
+    # Check internal state
+    assert_equal(pca.n_components,
+                 PCA(n_components=0,
+                     svd_solver='randomized', random_state=0).n_components)
+    assert_equal(pca.svd_solver,
+                 PCA(n_components=0,
+                     svd_solver='randomized', random_state=0).svd_solver)
 
 
 def test_no_empty_slice_warning():
@@ -75,15 +160,13 @@ def test_whitening():
     assert_equal(X.shape, (n_samples, n_features))
 
     # the component-wise variance is thus highly varying:
-    assert_almost_equal(X.std(axis=0).std(), 43.9, 1)
+    assert_greater(X.std(axis=0).std(), 43.8)
 
-    for this_PCA, copy in [(x, y) for x in (PCA, RandomizedPCA)
-                           for y in (True, False)]:
+    for solver, copy in product(solver_list, (True, False)):
         # whiten the data while projecting to the lower dim subspace
         X_ = X.copy()  # make sure we keep an original across iterations.
-        pca = this_PCA(n_components=n_components, whiten=True, copy=copy)
-        if hasattr(pca, 'random_state'):
-            pca.random_state = rng
+        pca = PCA(n_components=n_components, whiten=True, copy=copy,
+                  svd_solver=solver, random_state=0, iterated_power=7)
         # test fit_transform
         X_whitened = pca.fit_transform(X_.copy())
         assert_equal(X_whitened.shape, (n_samples, n_components))
@@ -91,12 +174,12 @@ def test_whitening():
         assert_array_almost_equal(X_whitened, X_whitened2)
 
         assert_almost_equal(X_whitened.std(axis=0), np.ones(n_components),
-                            decimal=4)
+                            decimal=6)
         assert_almost_equal(X_whitened.mean(axis=0), np.zeros(n_components))
 
         X_ = X.copy()
-        pca = this_PCA(n_components=n_components, whiten=False,
-                       copy=copy).fit(X_)
+        pca = PCA(n_components=n_components, whiten=False, copy=copy,
+                  svd_solver=solver).fit(X_)
         X_unwhitened = pca.transform(X_)
         assert_equal(X_unwhitened.shape, (n_samples, n_components))
 
@@ -105,6 +188,8 @@ def test_whitening():
         # we always center, so no test for non-centering.
 
 
+# Ignore warnings from switching to more power iterations in randomized_svd
+@ignore_warnings
 def test_explained_variance():
     # Check that PCA output has unit-variance
     rng = np.random.RandomState(0)
@@ -113,14 +198,26 @@ def test_explained_variance():
 
     X = rng.randn(n_samples, n_features)
 
-    pca = PCA(n_components=2).fit(X)
-    rpca = RandomizedPCA(n_components=2, random_state=rng).fit(X)
+    pca = PCA(n_components=2, svd_solver='full').fit(X)
+    apca = PCA(n_components=2, svd_solver='arpack', random_state=0).fit(X)
+    assert_array_almost_equal(pca.explained_variance_,
+                              apca.explained_variance_, 1)
+    assert_array_almost_equal(pca.explained_variance_ratio_,
+                              apca.explained_variance_ratio_, 3)
+
+    rpca = PCA(n_components=2, svd_solver='randomized', random_state=42).fit(X)
+    assert_array_almost_equal(pca.explained_variance_,
+                              rpca.explained_variance_, 1)
     assert_array_almost_equal(pca.explained_variance_ratio_,
                               rpca.explained_variance_ratio_, 1)
 
     # compare to empirical variances
     X_pca = pca.transform(X)
     assert_array_almost_equal(pca.explained_variance_,
+                              np.var(X_pca, axis=0))
+
+    X_pca = apca.transform(X)
+    assert_array_almost_equal(apca.explained_variance_,
                               np.var(X_pca, axis=0))
 
     X_rpca = rpca.transform(X)
@@ -133,7 +230,8 @@ def test_explained_variance():
                                      random_state=rng)[0]
 
     pca = PCA(n_components=2).fit(X)
-    rpca = RandomizedPCA(n_components=2, random_state=rng).fit(X)
+    rpca = PCA(n_components=2, svd_solver='randomized',
+               random_state=rng).fit(X)
     assert_array_almost_equal(pca.explained_variance_ratio_,
                               rpca.explained_variance_ratio_, 5)
 
@@ -146,10 +244,11 @@ def test_pca_check_projection():
     X[:10] += np.array([3, 4, 5])
     Xt = 0.1 * rng.randn(1, p) + np.array([3, 4, 5])
 
-    Yt = PCA(n_components=2).fit(X).transform(Xt)
-    Yt /= np.sqrt((Yt ** 2).sum())
+    for solver in solver_list:
+        Yt = PCA(n_components=2, svd_solver=solver).fit(X).transform(Xt)
+        Yt /= np.sqrt((Yt ** 2).sum())
 
-    assert_almost_equal(np.abs(Yt[0][0]), 1., 1)
+        assert_almost_equal(np.abs(Yt[0][0]), 1., 1)
 
 
 def test_pca_inverse():
@@ -162,51 +261,55 @@ def test_pca_inverse():
 
     # same check that we can find the original data from the transformed
     # signal (since the data is almost of rank n_components)
-    pca = PCA(n_components=2).fit(X)
+    pca = PCA(n_components=2, svd_solver='full').fit(X)
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
     assert_almost_equal(X, Y_inverse, decimal=3)
 
     # same as above with whitening (approximate reconstruction)
-    pca = PCA(n_components=2, whiten=True)
-    pca.fit(X)
-    Y = pca.transform(X)
-    Y_inverse = pca.inverse_transform(Y)
-    assert_almost_equal(X, Y_inverse, decimal=3)
+    for solver in solver_list:
+        pca = PCA(n_components=2, whiten=True, svd_solver=solver)
+        pca.fit(X)
+        Y = pca.transform(X)
+        Y_inverse = pca.inverse_transform(Y)
+        assert_almost_equal(X, Y_inverse, decimal=3)
 
 
 def test_pca_validation():
     X = [[0, 1], [1, 0]]
-    for n_components in [-1, 3]:
-        assert_raises(ValueError, PCA(n_components).fit, X)
+    for solver in solver_list:
+        for n_components in [-1, 3]:
+            assert_raises(ValueError,
+                          PCA(n_components, svd_solver=solver).fit, X)
 
 
 def test_randomized_pca_check_projection():
-    # Test that the projection by RandomizedPCA on dense data is correct
+    # Test that the projection by randomized PCA on dense data is correct
     rng = np.random.RandomState(0)
     n, p = 100, 3
     X = rng.randn(n, p) * .1
     X[:10] += np.array([3, 4, 5])
     Xt = 0.1 * rng.randn(1, p) + np.array([3, 4, 5])
 
-    Yt = RandomizedPCA(n_components=2, random_state=0).fit(X).transform(Xt)
+    Yt = PCA(n_components=2, svd_solver='randomized',
+             random_state=0).fit(X).transform(Xt)
     Yt /= np.sqrt((Yt ** 2).sum())
 
     assert_almost_equal(np.abs(Yt[0][0]), 1., 1)
 
 
 def test_randomized_pca_check_list():
-    # Test that the projection by RandomizedPCA on list data is correct
+    # Test that the projection by randomized PCA on list data is correct
     X = [[1.0, 0.0], [0.0, 1.0]]
-    X_transformed = RandomizedPCA(n_components=1,
-                                  random_state=0).fit(X).transform(X)
+    X_transformed = PCA(n_components=1, svd_solver='randomized',
+                        random_state=0).fit(X).transform(X)
     assert_equal(X_transformed.shape, (2, 1))
     assert_almost_equal(X_transformed.mean(), 0.00, 2)
     assert_almost_equal(X_transformed.std(), 0.71, 2)
 
 
 def test_randomized_pca_inverse():
-    # Test that RandomizedPCA is inversible on dense data
+    # Test that randomized PCA is inversible on dense data
     rng = np.random.RandomState(0)
     n, p = 50, 3
     X = rng.randn(n, p)  # spherical data
@@ -215,18 +318,18 @@ def test_randomized_pca_inverse():
 
     # same check that we can find the original data from the transformed signal
     # (since the data is almost of rank n_components)
-    pca = RandomizedPCA(n_components=2, random_state=0).fit(X)
+    pca = PCA(n_components=2, svd_solver='randomized', random_state=0).fit(X)
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
     assert_almost_equal(X, Y_inverse, decimal=2)
 
     # same as above with whitening (approximate reconstruction)
-    pca = RandomizedPCA(n_components=2, whiten=True,
-                        random_state=0).fit(X)
+    pca = PCA(n_components=2, whiten=True, svd_solver='randomized',
+              random_state=0).fit(X)
     Y = pca.transform(X)
     Y_inverse = pca.inverse_transform(Y)
     relative_max_delta = (np.abs(X - Y_inverse) / np.abs(X).mean()).max()
-    assert_almost_equal(relative_max_delta, 0.11, decimal=2)
+    assert_less(relative_max_delta, 1e-5)
 
 
 def test_pca_dim():
@@ -235,7 +338,7 @@ def test_pca_dim():
     n, p = 100, 5
     X = rng.randn(n, p) * .1
     X[:10] += np.array([3, 4, 5, 1, 2])
-    pca = PCA(n_components='mle').fit(X)
+    pca = PCA(n_components='mle', svd_solver='full').fit(X)
     assert_equal(pca.n_components, 'mle')
     assert_equal(pca.n_components_, 1)
 
@@ -245,9 +348,9 @@ def test_infer_dim_1():
     # Or at least use explicit variable names...
     n, p = 1000, 5
     rng = np.random.RandomState(0)
-    X = (rng.randn(n, p) * .1 + rng.randn(n, 1) * np.array([3, 4, 5, 1, 2])
-         + np.array([1, 0, 7, 4, 6]))
-    pca = PCA(n_components=p)
+    X = (rng.randn(n, p) * .1 + rng.randn(n, 1) * np.array([3, 4, 5, 1, 2]) +
+         np.array([1, 0, 7, 4, 6]))
+    pca = PCA(n_components=p, svd_solver='full')
     pca.fit(X)
     spect = pca.explained_variance_
     ll = []
@@ -265,7 +368,7 @@ def test_infer_dim_2():
     X = rng.randn(n, p) * .1
     X[:10] += np.array([3, 4, 5, 1, 2])
     X[10:20] += np.array([6, 0, 7, 2, -1])
-    pca = PCA(n_components=p)
+    pca = PCA(n_components=p, svd_solver='full')
     pca.fit(X)
     spect = pca.explained_variance_
     assert_greater(_infer_dimension_(spect, n, p), 1)
@@ -278,7 +381,7 @@ def test_infer_dim_3():
     X[:10] += np.array([3, 4, 5, 1, 2])
     X[10:20] += np.array([6, 0, 7, 2, -1])
     X[30:40] += 2 * np.array([-1, 1, -1, 1, -1])
-    pca = PCA(n_components=p)
+    pca = PCA(n_components=p, svd_solver='full')
     pca.fit(X)
     spect = pca.explained_variance_
     assert_greater(_infer_dimension_(spect, n, p), 2)
@@ -286,12 +389,12 @@ def test_infer_dim_3():
 
 def test_infer_dim_by_explained_variance():
     X = iris.data
-    pca = PCA(n_components=0.95)
+    pca = PCA(n_components=0.95, svd_solver='full')
     pca.fit(X)
     assert_equal(pca.n_components, 0.95)
     assert_equal(pca.n_components_, 2)
 
-    pca = PCA(n_components=0.01)
+    pca = PCA(n_components=0.01, svd_solver='full')
     pca.fit(X)
     assert_equal(pca.n_components, 0.01)
     assert_equal(pca.n_components_, 1)
@@ -299,7 +402,7 @@ def test_infer_dim_by_explained_variance():
     rng = np.random.RandomState(0)
     # more features than samples
     X = rng.rand(5, 20)
-    pca = PCA(n_components=.5).fit(X)
+    pca = PCA(n_components=.5, svd_solver='full').fit(X)
     assert_equal(pca.n_components, 0.5)
     assert_equal(pca.n_components_, 2)
 
@@ -309,11 +412,12 @@ def test_pca_score():
     n, p = 1000, 3
     rng = np.random.RandomState(0)
     X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
-    pca = PCA(n_components=2)
-    pca.fit(X)
-    ll1 = pca.score(X)
-    h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
-    np.testing.assert_almost_equal(ll1 / h, 1, 0)
+    for solver in solver_list:
+        pca = PCA(n_components=2, svd_solver=solver)
+        pca.fit(X)
+        ll1 = pca.score(X)
+        h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
+        np.testing.assert_almost_equal(ll1 / h, 1, 0)
 
 
 def test_pca_score2():
@@ -321,31 +425,85 @@ def test_pca_score2():
     n, p = 100, 3
     rng = np.random.RandomState(0)
     X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
-    pca = PCA(n_components=2)
-    pca.fit(X)
-    ll1 = pca.score(X)
-    ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
-    assert_greater(ll1, ll2)
+    for solver in solver_list:
+        pca = PCA(n_components=2, svd_solver=solver)
+        pca.fit(X)
+        ll1 = pca.score(X)
+        ll2 = pca.score(rng.randn(n, p) * .2 + np.array([3, 4, 5]))
+        assert_greater(ll1, ll2)
 
-    # Test that it gives the same scores if whiten=True
-    pca = PCA(n_components=2, whiten=True)
-    pca.fit(X)
-    ll2 = pca.score(X)
-    assert_almost_equal(ll1, ll2)
+        # Test that it gives different scores if whiten=True
+        pca = PCA(n_components=2, whiten=True, svd_solver=solver)
+        pca.fit(X)
+        ll2 = pca.score(X)
+        assert_true(ll1 > ll2)
 
 
 def test_pca_score3():
     # Check that probabilistic PCA selects the right model
     n, p = 200, 3
     rng = np.random.RandomState(0)
-    Xl = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5])
-          + np.array([1, 0, 7]))
-    Xt = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5])
-          + np.array([1, 0, 7]))
+    Xl = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5]) +
+          np.array([1, 0, 7]))
+    Xt = (rng.randn(n, p) + rng.randn(n, 1) * np.array([3, 4, 5]) +
+          np.array([1, 0, 7]))
     ll = np.zeros(p)
     for k in range(p):
-        pca = PCA(n_components=k)
+        pca = PCA(n_components=k, svd_solver='full')
         pca.fit(Xl)
         ll[k] = pca.score(Xt)
 
     assert_true(ll.argmax() == 1)
+
+
+def test_svd_solver_auto():
+    rng = np.random.RandomState(0)
+    X = rng.uniform(size=(1000, 50))
+
+    # case: n_components in (0,1) => 'full'
+    pca = PCA(n_components=.5)
+    pca.fit(X)
+    pca_test = PCA(n_components=.5, svd_solver='full')
+    pca_test.fit(X)
+    assert_array_almost_equal(pca.components_, pca_test.components_)
+
+    # case: max(X.shape) <= 500 => 'full'
+    pca = PCA(n_components=5, random_state=0)
+    Y = X[:10, :]
+    pca.fit(Y)
+    pca_test = PCA(n_components=5, svd_solver='full', random_state=0)
+    pca_test.fit(Y)
+    assert_array_almost_equal(pca.components_, pca_test.components_)
+
+    # case: n_components >= .8 * min(X.shape) => 'full'
+    pca = PCA(n_components=50)
+    pca.fit(X)
+    pca_test = PCA(n_components=50, svd_solver='full')
+    pca_test.fit(X)
+    assert_array_almost_equal(pca.components_, pca_test.components_)
+
+    # n_components >= 1 and n_components < .8 * min(X.shape) => 'randomized'
+    pca = PCA(n_components=10, random_state=0)
+    pca.fit(X)
+    pca_test = PCA(n_components=10, svd_solver='randomized', random_state=0)
+    pca_test.fit(X)
+    assert_array_almost_equal(pca.components_, pca_test.components_)
+
+
+def test_deprecation_randomized_pca():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+
+    depr_message = ("Class RandomizedPCA is deprecated; RandomizedPCA will be "
+                    "removed in 0.20. Use PCA(svd_solver='randomized') "
+                    "instead. The new implementation DOES NOT store "
+                    "whiten components_. Apply transform to get them.")
+
+    def fit_deprecated(X):
+        global Y
+        rpca = RandomizedPCA(random_state=0)
+        Y = rpca.fit_transform(X)
+
+    assert_warns_message(DeprecationWarning, depr_message, fit_deprecated, X)
+    Y_pca = PCA(svd_solver='randomized', random_state=0).fit_transform(X)
+    assert_array_almost_equal(Y, Y_pca)

--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -82,9 +82,9 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
     >>> from sklearn.decomposition import TruncatedSVD
     >>> from sklearn.random_projection import sparse_random_matrix
     >>> X = sparse_random_matrix(100, 100, density=0.01, random_state=42)
-    >>> svd = TruncatedSVD(n_components=5, random_state=42)
+    >>> svd = TruncatedSVD(n_components=5, n_iter=7, random_state=42)
     >>> svd.fit(X) # doctest: +NORMALIZE_WHITESPACE
-    TruncatedSVD(algorithm='randomized', n_components=5, n_iter=5,
+    TruncatedSVD(algorithm='randomized', n_components=5, n_iter=7,
             random_state=42, tol=0.0)
     >>> print(svd.explained_variance_ratio_) # doctest: +ELLIPSIS
     [ 0.0782... 0.0552... 0.0544... 0.0499... 0.0413...]

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -566,6 +566,8 @@ def test_random_trees_dense_equal():
     assert_array_equal(X_transformed_sparse.toarray(), X_transformed_dense)
 
 
+# Ignore warnings from switching to more power iterations in randomized_svd
+@ignore_warnings
 def test_random_hasher():
     # test random forest hashing on circles dataset
     # make sure that it is linearly separable.

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -18,7 +18,7 @@ from ..base import BaseEstimator
 from ..utils import check_array
 from ..utils import check_random_state
 from ..utils.extmath import _ravel
-from ..decomposition import RandomizedPCA
+from ..decomposition import PCA
 from ..metrics.pairwise import pairwise_distances
 from . import _utils
 from . import _barnes_hut_tsne
@@ -695,7 +695,8 @@ class TSNE(BaseEstimator):
                             'memory. Otherwise consider dimensionality '
                             'reduction techniques (e.g. TruncatedSVD)')
         else:
-            X = check_array(X, accept_sparse=['csr', 'csc', 'coo'], dtype=np.float64)
+            X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
+                            dtype=np.float64)
         random_state = check_random_state(self.random_state)
 
         if self.early_exaggeration < 1.0:
@@ -763,8 +764,8 @@ class TSNE(BaseEstimator):
                                 "or then equal to one")
 
         if self.init == 'pca':
-            pca = RandomizedPCA(n_components=self.n_components,
-                                random_state=random_state)
+            pca = PCA(n_components=self.n_components, svd_solver='randomized',
+                      random_state=random_state)
             X_embedded = pca.fit_transform(X)
         elif isinstance(self.init, np.ndarray):
             X_embedded = self.init

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -89,7 +89,8 @@ class Pipeline(BaseEstimator):
     def __init__(self, steps):
         names, estimators = zip(*steps)
         if len(dict(steps)) != len(steps):
-            raise ValueError("Provided step names are not unique: %s" % (names,))
+            raise ValueError("Provided step names are not unique: %s"
+                             % (names,))
 
         # shallow copy of steps
         self.steps = tosequence(steps)
@@ -195,8 +196,8 @@ class Pipeline(BaseEstimator):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step of
-            the pipeline.
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
         """
         Xt = X
         for name, transform in self.steps[:-1]:
@@ -232,8 +233,8 @@ class Pipeline(BaseEstimator):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step of
-            the pipeline.
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
         """
         Xt = X
         for name, transform in self.steps[:-1]:
@@ -249,8 +250,8 @@ class Pipeline(BaseEstimator):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step of
-            the pipeline.
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
         """
         Xt = X
         for name, transform in self.steps[:-1]:
@@ -266,8 +267,8 @@ class Pipeline(BaseEstimator):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step of
-            the pipeline.
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
         """
         Xt = X
         for name, transform in self.steps[:-1]:
@@ -283,8 +284,8 @@ class Pipeline(BaseEstimator):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step of
-            the pipeline.
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
         """
         Xt = X
         for name, transform in self.steps:
@@ -294,8 +295,8 @@ class Pipeline(BaseEstimator):
     @if_delegate_has_method(delegate='_final_estimator')
     def inverse_transform(self, X):
         """Applies inverse transform to the data.
-        Starts with the last step of the pipeline and applies ``inverse_transform`` in
-        inverse order of the pipeline steps.
+        Starts with the last step of the pipeline and applies
+        ``inverse_transform`` in inverse order of the pipeline steps.
         Valid only if all steps of the pipeline implement inverse_transform.
 
         Parameters
@@ -326,8 +327,8 @@ class Pipeline(BaseEstimator):
             pipeline.
 
         y : iterable, default=None
-            Targets used for scoring. Must fulfill label requirements for all steps of
-            the pipeline.
+            Targets used for scoring. Must fulfill label requirements for all
+            steps of the pipeline.
         """
         Xt = X
         for name, transform in self.steps[:-1]:
@@ -559,13 +560,16 @@ def make_union(*transformers):
     >>> from sklearn.decomposition import PCA, TruncatedSVD
     >>> make_union(PCA(), TruncatedSVD())    # doctest: +NORMALIZE_WHITESPACE
     FeatureUnion(n_jobs=1,
-                 transformer_list=[('pca', PCA(copy=True, n_components=None,
-                                               whiten=False)),
-                                   ('truncatedsvd',
-                                    TruncatedSVD(algorithm='randomized',
-                                                 n_components=2, n_iter=5,
-                                                 random_state=None, tol=0.0))],
-                 transformer_weights=None)
+           transformer_list=[('pca',
+                              PCA(copy=True, iterated_power=4,
+                                  n_components=None, random_state=None,
+                                  svd_solver='auto', tol=0.0, whiten=False)),
+                             ('truncatedsvd',
+                              TruncatedSVD(algorithm='randomized',
+                              n_components=2, n_iter=5,
+                              random_state=None, tol=0.0))],
+           transformer_weights=None)
+
 
     Returns
     -------

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -5,7 +5,9 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.externals.six.moves import zip
-from sklearn.utils.testing import assert_raises, assert_raises_regex, assert_raise_message
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
@@ -20,7 +22,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import LinearRegression
 from sklearn.cluster import KMeans
 from sklearn.feature_selection import SelectKBest, f_classif
-from sklearn.decomposition import PCA, RandomizedPCA, TruncatedSVD
+from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
@@ -195,7 +197,7 @@ def test_pipeline_methods_pca_svm():
     y = iris.target
     # Test with PCA + SVC
     clf = SVC(probability=True, random_state=0)
-    pca = PCA(n_components='mle', whiten=True)
+    pca = PCA(svd_solver='full', n_components='mle', whiten=True)
     pipe = Pipeline([('pca', pca), ('svc', clf)])
     pipe.fit(X, y)
     pipe.predict(X)
@@ -212,7 +214,7 @@ def test_pipeline_methods_preprocessing_svm():
     n_samples = X.shape[0]
     n_classes = len(np.unique(y))
     scaler = StandardScaler()
-    pca = RandomizedPCA(n_components=2, whiten=True)
+    pca = PCA(n_components=2, svd_solver='randomized', whiten=True)
     clf = SVC(probability=True, random_state=0, decision_function_shape='ovr')
 
     for preprocessing in [scaler, pca]:
@@ -258,7 +260,7 @@ def test_fit_predict_on_pipeline_without_fit_predict():
     # tests that a pipeline does not have fit_predict method when final
     # step of pipeline does not have fit_predict defined
     scaler = StandardScaler()
-    pca = PCA()
+    pca = PCA(svd_solver='full')
     pipe = Pipeline([('scaler', scaler), ('pca', pca)])
     assert_raises_regex(AttributeError,
                         "'PCA' object has no attribute 'fit_predict'",
@@ -301,7 +303,7 @@ def test_feature_union():
 
 
 def test_make_union():
-    pca = PCA()
+    pca = PCA(svd_solver='full')
     mock = TransfT()
     fu = make_union(pca, mock)
     names, transformers = zip(*fu.transformer_list)
@@ -314,7 +316,7 @@ def test_pipeline_transform():
     # Also test pipeline.transform and pipeline.inverse_transform
     iris = load_iris()
     X = iris.data
-    pca = PCA(n_components=2)
+    pca = PCA(n_components=2, svd_solver='full')
     pipeline = Pipeline([('pca', pca)])
 
     # test transform and fit_transform:
@@ -364,7 +366,7 @@ def test_feature_union_weights():
     iris = load_iris()
     X = iris.data
     y = iris.target
-    pca = RandomizedPCA(n_components=2, random_state=0)
+    pca = PCA(n_components=2, svd_solver='randomized', random_state=0)
     select = SelectKBest(k=1)
     # test using fit followed by transform
     fs = FeatureUnion([("pca", pca), ("select", select)],

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -189,7 +189,7 @@ def safe_sparse_dot(a, b, dense_output=False):
         return fast_dot(a, b)
 
 
-def randomized_range_finder(A, size, n_iter=2,
+def randomized_range_finder(A, size, n_iter,
                             power_iteration_normalizer='auto',
                             random_state=None):
     """Computes an orthonormal matrix whose range approximates the range of A.
@@ -197,7 +197,7 @@ def randomized_range_finder(A, size, n_iter=2,
     Parameters
     ----------
     A: 2D array
-        The input data matrix.
+        The input data matrix
 
     size: integer
         Size of the return array
@@ -267,7 +267,7 @@ def randomized_range_finder(A, size, n_iter=2,
     return Q
 
 
-def randomized_svd(M, n_components, n_oversamples=10, n_iter=2,
+def randomized_svd(M, n_components, n_oversamples=10, n_iter=4,
                    power_iteration_normalizer='auto', transpose='auto',
                    flip_sign=True, random_state=0):
     """Computes a truncated randomized SVD
@@ -287,9 +287,11 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=2,
         number can improve speed but can negatively impact the quality of
         approximation of singular vectors and singular values.
 
-    n_iter: int (default is 2)
-        Number of power iterations (can be used to deal with very noisy
-        problems).
+    n_iter: int (default is 4)
+        Number of power iterations. It can be used to deal with very noisy
+        problems. When `n_components` is small (< .1 * min(X.shape)) `n_iter`
+        is set to 7, unless the user specifies a higher number. This improves
+        precision with few components.
 
         .. versionchanged:: 0.18
 
@@ -326,7 +328,9 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=2,
     This algorithm finds a (usually very good) approximate truncated
     singular value decomposition using randomization to speed up the
     computations. It is particularly fast on large matrices on which
-    you wish to extract only a small number of components.
+    you wish to extract only a small number of components. In order to
+    obtain further speed up, `n_iter` can be set <=2 (at the cost of
+    loss of precision).
 
     References
     ----------
@@ -350,6 +354,12 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=2,
     if transpose:
         # this implementation is a bit faster with smaller shape[1]
         M = M.T
+
+    # Adjust n_iter. 7 was found a good compromise for PCA. See #5299
+    if n_components < .1 * min(M.shape) and n_iter < 7:
+        warnings.warn("The number of power iterations is increased to 7 to "
+                      "achieve higher precision.")
+        n_iter = 7
 
     Q = randomized_range_finder(M, n_random, n_iter,
                                 power_iteration_normalizer, random_state)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -110,10 +110,11 @@ def test_randomized_svd_low_rank():
     # compute the singular values of X using the slow exact method
     U, s, V = linalg.svd(X, full_matrices=False)
 
-    for normalizer in ['auto', 'none', 'LU', 'QR']:
+    for normalizer in ['auto', 'LU', 'QR']:  # 'none' would not be stable
         # compute the singular values of X using the fast approximate method
         Ua, sa, Va = \
-            randomized_svd(X, k, power_iteration_normalizer=normalizer)
+            randomized_svd(X, k, power_iteration_normalizer=normalizer,
+                           random_state=0)
         assert_equal(Ua.shape, (n_samples, k))
         assert_equal(sa.shape, (k,))
         assert_equal(Va.shape, (k, n_features))
@@ -130,7 +131,8 @@ def test_randomized_svd_low_rank():
 
         # compute the singular values of X using the fast approximate method
         Ua, sa, Va = \
-            randomized_svd(X, k, power_iteration_normalizer=normalizer)
+            randomized_svd(X, k, power_iteration_normalizer=normalizer,
+                           random_state=0)
         assert_almost_equal(s[:rank], sa[:rank])
 
 
@@ -177,7 +179,8 @@ def test_randomized_svd_low_rank_with_noise():
         # compute the singular values of X using the fast approximate
         # method without the iterated power method
         _, sa, _ = randomized_svd(X, k, n_iter=0,
-                                  power_iteration_normalizer=normalizer)
+                                  power_iteration_normalizer=normalizer,
+                                  random_state=0)
 
         # the approximation does not tolerate the noise:
         assert_greater(np.abs(s[:k] - sa).max(), 0.01)
@@ -185,7 +188,8 @@ def test_randomized_svd_low_rank_with_noise():
         # compute the singular values of X using the fast approximate
         # method with iterated power method
         _, sap, _ = randomized_svd(X, k,
-                                   power_iteration_normalizer=normalizer)
+                                   power_iteration_normalizer=normalizer,
+                                   random_state=0)
 
         # the iterated power method is helping getting rid of the noise:
         assert_almost_equal(s[:k], sap, decimal=3)
@@ -280,13 +284,15 @@ def test_randomized_svd_power_iteration_normalizer():
 
     for normalizer in ['LU', 'QR', 'auto']:
         U, s, V = randomized_svd(X, n_components, n_iter=2,
-                                 power_iteration_normalizer=normalizer)
+                                 power_iteration_normalizer=normalizer,
+                                 random_state=0)
         A = X - U.dot(np.diag(s).dot(V))
         error_2 = linalg.norm(A, ord='fro')
 
         for i in [5, 10, 50]:
             U, s, V = randomized_svd(X, n_components, n_iter=i,
-                                     power_iteration_normalizer=normalizer)
+                                     power_iteration_normalizer=normalizer,
+                                     random_state=0)
             A = X - U.dot(np.diag(s).dot(V))
             error = linalg.norm(A, ord='fro')
             assert_greater(15, np.abs(error_2 - error))


### PR DESCRIPTION
Fixes #5243  and #3930.

to do
- [x] collapse the two classes
- [x] old tests passing
- [x] integrate `svd_solver=='arpack'`
- [x] benchmark the 3 solvers and establish the best `auto` policy
- [x] fix docstrings
- [x] uniform with `IncrementalPCA` by inheritance from `_BasePCA`; see  #3285
- [x] ~~add `flip_sign` param, True by default~~ we flip by default, without introducing a param for controlling the behaviour
- [x] arpack backport updated
