### PR TITLE
[MRG+1] check_X_y should copy y also if copy is set to be True

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -458,3 +458,10 @@ def test_check_consistent_length():
     assert_raises_regexp(TypeError, 'estimator', check_consistent_length,
                          [1, 2], RandomForestRegressor())
     # XXX: We should have a test with a string, but what is correct behaviour?
+
+
+def test_check_X_y_copies_y():
+    X = np.array([[1, 2], [2, 3]])
+    y = np.array([1, 2])
+    X_copy, y_copy = check_X_y(X, y, copy=True)
+    assert_false(np.may_share_memory(y, y_copy))


### PR DESCRIPTION
Is it acceptable to expect y also to be copied when `copy` is set to True.

This makes sure that y is not modified when y is centered inplace. I hit this bug here, https://github.com/scikit-learn/scikit-learn/pull/5291/files#diff-7416ccedd45a5840c67ff7877d24e1ceR52

I also added a test case that fails in master.
