### PR TITLE
PR addressing https://github.com/scikit-learn/scikit-learn/issues/5229

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -431,7 +431,21 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     sklearn.metrics.pairwise.kernel_metrics : List of built-in kernels.
     """
-    def __init__(self, kernel="rbf", gamma=None, coef0=1, degree=3,
+
+    KERNEL_DEFAULT_PARAMS = {
+            "additive_chi2": {},
+            "chi2": {},
+            #"chi2": [{"gamma": 1.}],
+            "cosine": {},
+            #"exp_chi2": frozenset(["gamma"]),
+            "linear": {},
+            "poly": {"gamma": None, "degree": 3, "coef0": 1},
+            "polynomial": {"gamma": None, "degree": 3, "coef0": 1},
+            "rbf": {"gamma": None},
+            "sigmoid": {"gamma": None, "coef0": 1},
+        }
+
+    def __init__(self, kernel="rbf", gamma=None, coef0=None, degree=None,
                  kernel_params=None, n_components=100, random_state=None):
         self.kernel = kernel
         self.gamma = gamma
@@ -440,6 +454,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         self.kernel_params = kernel_params
         self.n_components = n_components
         self.random_state = random_state
+        
 
     def fit(self, X, y=None):
         """Fit estimator to data.
@@ -514,8 +529,14 @@ class Nystroem(BaseEstimator, TransformerMixin):
         if params is None:
             params = {}
         if not callable(self.kernel):
-            params['gamma'] = self.gamma
-            params['degree'] = self.degree
-            params['coef0'] = self.coef0
+            if self.kernel in self.KERNEL_DEFAULT_PARAMS:
+                for k, v in self.KERNEL_DEFAULT_PARAMS[self.kernel].iteritems():
+                    params[k] = getattr(self, k)
+                    if params[k] is None:
+                        params[k] = v 
+            else: 
+                raise ValueError("Unknown kernel %r" % self.kernel)
+
+        print("Current parameters %s" % params)
 
         return params

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -11,6 +11,7 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
+import six 
 from scipy.linalg import svd
 
 from .base import BaseEstimator
@@ -528,7 +529,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
             params = {}
         if not callable(self.kernel):
             if self.kernel in self.KERNEL_DEFAULT_PARAMS:
-                for k, v in self.KERNEL_DEFAULT_PARAMS[self.kernel].iteritems():
+                for k, v in six.iteritems(self.KERNEL_DEFAULT_PARAMS[self.kernel]):
                     params[k] = getattr(self, k)
                     if params[k] is None:
                         params[k] = v 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -437,7 +437,6 @@ class Nystroem(BaseEstimator, TransformerMixin):
             "chi2": {},
             #"chi2": [{"gamma": 1.}],
             "cosine": {},
-            #"exp_chi2": frozenset(["gamma"]),
             "linear": {},
             "poly": {"gamma": None, "degree": 3, "coef0": 1},
             "polynomial": {"gamma": None, "degree": 3, "coef0": 1},

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -18,7 +18,7 @@ from .base import TransformerMixin
 from .utils import check_array, check_random_state, as_float_array
 from .utils.extmath import safe_sparse_dot
 from .utils.validation import check_is_fitted
-from .metrics.pairwise import pairwise_kernels
+from .metrics.pairwise import pairwise_kernels, KERNEL_PARAMS
 from .externals import six
 
 class RBFSampler(BaseEstimator, TransformerMixin):
@@ -432,17 +432,6 @@ class Nystroem(BaseEstimator, TransformerMixin):
     sklearn.metrics.pairwise.kernel_metrics : List of built-in kernels.
     """
 
-    KERNEL_DEFAULT_PARAMS = {
-            "additive_chi2": {},
-            "chi2": {"gamma": 1.},
-            "cosine": {},
-            "linear": {},
-            "poly": {"gamma": None, "degree": 3, "coef0": 1},
-            "polynomial": {"gamma": None, "degree": 3, "coef0": 1},
-            "rbf": {"gamma": None},
-            "sigmoid": {"gamma": None, "coef0": 1},
-        }
-
     def __init__(self, kernel="rbf", gamma=None, coef0=None, degree=None,
                  kernel_params=None, n_components=100, random_state=None):
         self.kernel = kernel
@@ -526,8 +515,8 @@ class Nystroem(BaseEstimator, TransformerMixin):
         if params is None:
             params = {}
         if not callable(self.kernel):
-            if self.kernel in self.KERNEL_DEFAULT_PARAMS:
-                for k, v in six.iteritems(self.KERNEL_DEFAULT_PARAMS[self.kernel]):
+            if self.kernel in KERNEL_PARAMS:
+                for k, v in six.iteritems(KERNEL_PARAMS[self.kernel]):
                     params[k] = getattr(self, k)
                     if params[k] is None:
                         params[k] = v 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -454,7 +454,6 @@ class Nystroem(BaseEstimator, TransformerMixin):
         self.n_components = n_components
         self.random_state = random_state
         
-
     def fit(self, X, y=None):
         """Fit estimator to data.
 
@@ -535,7 +534,4 @@ class Nystroem(BaseEstimator, TransformerMixin):
                         params[k] = v 
             else: 
                 raise ValueError("Unknown kernel %r" % self.kernel)
-
-        print("Current parameters %s" % params)
-
         return params

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -434,8 +434,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
 
     KERNEL_DEFAULT_PARAMS = {
             "additive_chi2": {},
-            "chi2": {},
-            #"chi2": [{"gamma": 1.}],
+            "chi2": {"gamma": 1.},
             "cosine": {},
             "linear": {},
             "poly": {"gamma": None, "degree": 3, "coef0": 1},

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -11,7 +11,6 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
-import six 
 from scipy.linalg import svd
 
 from .base import BaseEstimator
@@ -20,7 +19,7 @@ from .utils import check_array, check_random_state, as_float_array
 from .utils.extmath import safe_sparse_dot
 from .utils.validation import check_is_fitted
 from .metrics.pairwise import pairwise_kernels
-
+from .externals import six
 
 class RBFSampler(BaseEstimator, TransformerMixin):
     """Approximates feature map of an RBF kernel by Monte Carlo approximation

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -453,7 +453,7 @@ class Nystroem(BaseEstimator, TransformerMixin):
         self.kernel_params = kernel_params
         self.n_components = n_components
         self.random_state = random_state
-        
+
     def fit(self, X, y=None):
         """Fit estimator to data.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1215,15 +1215,14 @@ def kernel_metrics():
 
 
 KERNEL_PARAMS = {
-    "additive_chi2": (),
-    "chi2": (),
-    "cosine": (),
-    "exp_chi2": frozenset(["gamma"]),
-    "linear": (),
-    "poly": frozenset(["gamma", "degree", "coef0"]),
-    "polynomial": frozenset(["gamma", "degree", "coef0"]),
-    "rbf": frozenset(["gamma"]),
-    "sigmoid": frozenset(["gamma", "coef0"]),
+            "additive_chi2": {},
+            "chi2": {"gamma": 1.},
+            "cosine": {},
+            "linear": {},
+            "poly": {"gamma": None, "degree": 3, "coef0": 1},
+            "polynomial": {"gamma": None, "degree": 3, "coef0": 1},
+            "rbf": {"gamma": None},
+            "sigmoid": {"gamma": None, "coef0": 1},
 }
 
 


### PR DESCRIPTION
1. Generated a class variable: KERNEL_DEFAULT_PARAMS dictionary of kernel default parameters. I removed "exp_chi2" kernel from the dictionary as discussed in https://github.com/scikit-learn/scikit-learn/pull/5211. The current "chi2" kernel is missing the gamma parameter. This has to be changed in sklearn/metrics/pairwise.py (see https://github.com/scikit-learn/scikit-learn/pull/5211) in order to work. Let me know if I should do that. 
2. Modified **init**(): Set default values for kernel parameters to Null (default parameters will be obtained from dictionary) 
3. Modified _get_kernel_parameters(): if self.kernel is not callable, it checks
   if the kernel is contained in the dictionary. If so, it assigns the default parameters contained KERNEL_DEFAULT_PARAMS if not specified in__init__()
