### PR TITLE
[MRG + 1] Add k-modes clustering project to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -84,6 +84,9 @@ and tasks.
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes a number of additional
   estimators as well as model visualization utilities.
 
+- `kmodes <https://github.com/nicodv/kmodes>`_ k-modes clustering algorithm for categorical data, and
+  several of its variations.
+
 Statistical learning with Python
 --------------------------------
 Other packages useful for data analysis and machine learning.


### PR DESCRIPTION
The kmodes project implements k-modes for clustering categorical data, and k-prototypes for mixed numerical and categorical data. It follows the sklearn API.

I previously discussed the project with amueller on gitter and he suggested including it in the related projects page.
