### PR TITLE
Consistency of dataset bunches types

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -282,13 +282,12 @@ def load_iris():
 
     with open(join(module_path, 'descr', 'iris.rst')) as rst_file:
         fdescr = rst_file.read()
-
+    feature_names = np.array(['sepal length (cm)', 'sepal width (cm)',
+                              'petal length (cm)', 'petal width (cm)'])
     return Bunch(data=data, target=target,
                  target_names=target_names,
                  DESCR=fdescr,
-                 feature_names=['sepal length (cm)', 'sepal width (cm)',
-                                'petal length (cm)', 'petal width (cm)'])
-
+                 feature_names=feature_names)
 
 def load_digits(n_class=10):
     """Load and return the digits dataset (classification).

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -401,9 +401,9 @@ def load_linnerud():
                                     skiprows=1)
     # Read header
     with open(base_dir + 'linnerud_exercise.csv') as f:
-        header_exercise = f.readline().split()
+        header_exercise = np.array(f.readline().split())
     with open(base_dir + 'linnerud_physiological.csv') as f:
-        header_physiological = f.readline().split()
+        header_physiological = np.array(f.readline().split())
     with open(dirname(__file__) + '/descr/linnerud.rst') as f:
         descr = f.read()
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -125,6 +125,7 @@ def test_load_digits():
     digits = load_digits()
     assert_equal(digits.data.shape, (1797, 64))
     assert_equal(numpy.unique(digits.target).size, 10)
+    assert_equal(digits.target_names.size, 10)
 
 
 def test_load_digits_n_class_lt_10():

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -178,6 +178,7 @@ def test_load_iris():
     assert_equal(res.target.size, 150)
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
+    assert_equal(res.feature_names.size, 4)
 
 
 def test_load_boston():

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -171,6 +171,8 @@ def test_load_linnerud():
     assert_equal(res.target.shape, (20, 3))
     assert_equal(len(res.target_names), 3)
     assert_true(res.DESCR)
+    assert_equal(res.feature_names.size, 3)
+    assert_equal(res.target_names.size, 3)
 
 
 def test_load_iris():


### PR DESCRIPTION
Addresses #5318 

Comments:
- The two datasets that I added consistency to were iris and linnerud. Instead of list of strings now, they have arrays of strings. I added a few tests to enforce the consistency.
- The other datasets either did not have strings `feature_names` attribute and / or `target_names` attribute (or these fields were empty), but I added a small test case for load_digits which enforced that `digits.target_names` was a array.
