### PR TITLE
[STALLED] Optional verbosity for Pipeline

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -44,7 +44,8 @@ is an estimator object::
         whiten=False)), ('svm', SVC(C=1.0, cache_size=200, class_weight=None,
         coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
         kernel='rbf', max_iter=-1, probability=False, random_state=None,
-        shrinking=True, tol=0.001, verbose=False))])
+        shrinking=True, tol=0.001, verbose=False))],
+        verbose=False)
 
 The utility function :func:`make_pipeline` is a shorthand
 for constructing pipelines;
@@ -58,7 +59,8 @@ filling in the names automatically::
     Pipeline(steps=[('binarizer', Binarizer(copy=True, threshold=0.0)),
                     ('multinomialnb', MultinomialNB(alpha=1.0,
                                                     class_prior=None,
-                                                    fit_prior=True))])
+                                                    fit_prior=True))],
+        verbose=False)
 
 The estimators of a pipeline are stored as a list in the ``steps`` attribute::
 
@@ -78,7 +80,8 @@ Parameters of the estimators in the pipeline can be accessed using the
         whiten=False)), ('svm', SVC(C=10, cache_size=200, class_weight=None,
         coef0=0.0, decision_function_shape=None, degree=3, gamma='auto',
         kernel='rbf', max_iter=-1, probability=False, random_state=None,
-        shrinking=True, tol=0.001, verbose=False))])
+        shrinking=True, tol=0.001, verbose=False))],
+        verbose=False)
 
 This is particularly important for doing grid searches::
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -266,6 +266,10 @@ Enhancements
 
    - Added :func:`metrics.pairwise.laplacian_kernel`.  By `Clyde Fare <https://github.com/Clyde-fare>`_.
 
+   - Added optional parameter ``verbose`` in :class:`pipeline.Pipeline` for showing
+     progress and timing of each step. By Sam Zhang.
+     (`#5298 <https://github.com/scikit-learn/scikit-learn/issues/5298>`_)
+
 Bug fixes
 .........
     - Fixed non-determinism in :class:`dummy.DummyClassifier` with sparse

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -16,11 +16,12 @@ import numpy as np
 from scipy import sparse
 
 from .base import BaseEstimator, TransformerMixin
-from .externals.joblib import Parallel, delayed
+from .externals.joblib import Parallel, delayed, logger
 from .externals import six
 from .utils import tosequence
 from .utils.metaestimators import if_delegate_has_method
 from .externals.six import iteritems
+import time
 
 __all__ = ['Pipeline', 'FeatureUnion']
 
@@ -72,7 +73,8 @@ class Pipeline(BaseEstimator):
     >>> # and a parameter 'C' of the svm
     >>> anova_svm.set_params(anova__k=10, svc__C=.1).fit(X, y)
     ...                                              # doctest: +ELLIPSIS
-    Pipeline(steps=[...])
+    Pipeline(steps=[...],
+         verbose=False)
     >>> prediction = anova_svm.predict(X)
     >>> anova_svm.score(X, y)                        # doctest: +ELLIPSIS
     0.77...
@@ -86,13 +88,14 @@ class Pipeline(BaseEstimator):
 
     # BaseEstimator interface
 
-    def __init__(self, steps):
+    def __init__(self, steps, verbose=False):
         names, estimators = zip(*steps)
         if len(dict(steps)) != len(steps):
             raise ValueError("Provided step names are not unique: %s" % (names,))
 
         # shallow copy of steps
         self.steps = tosequence(steps)
+        self.verbose = verbose
         transforms = estimators[:-1]
         estimator = estimators[-1]
 
@@ -140,12 +143,19 @@ class Pipeline(BaseEstimator):
             step, param = pname.split('__', 1)
             fit_params_steps[step][param] = pval
         Xt = X
-        for name, transform in self.steps[:-1]:
+        for i, (name, transform) in enumerate(self.steps[:-1]):
+            start_time = time.time()
             if hasattr(transform, "fit_transform"):
                 Xt = transform.fit_transform(Xt, y, **fit_params_steps[name])
             else:
                 Xt = transform.fit(Xt, y, **fit_params_steps[name]) \
                               .transform(Xt)
+            if self.verbose:
+                elapsed = time.time() - start_time
+                time_str = logger.short_format_time(elapsed)
+                print('[Pipeline] (step %d of %d) %s ... %s' % (i,
+                    len(self.steps[:-1]), name, time_str))
+
         return Xt, fit_params_steps[self.steps[-1][0]]
 
     def fit(self, X, y=None, **fit_params):
@@ -162,7 +172,15 @@ class Pipeline(BaseEstimator):
             the pipeline.
         """
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
+        start_time = time.time()
         self.steps[-1][-1].fit(Xt, y, **fit_params)
+        if self.verbose:
+            elapsed = time.time() - start_time
+            time_str = logger.short_format_time(elapsed)
+            print('[Pipeline] (step %d of %d) %s ... %s' %
+                    (len(self.steps[:-1]), len(self.steps[:-1]),
+                        self.steps[-1][0], time_str))
+
         return self
 
     def fit_transform(self, X, y=None, **fit_params):
@@ -181,10 +199,19 @@ class Pipeline(BaseEstimator):
             the pipeline.
         """
         Xt, fit_params = self._pre_transform(X, y, **fit_params)
+        start_time = time.time()
         if hasattr(self.steps[-1][-1], 'fit_transform'):
-            return self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
+            ret = self.steps[-1][-1].fit_transform(Xt, y, **fit_params)
         else:
-            return self.steps[-1][-1].fit(Xt, y, **fit_params).transform(Xt)
+            ret = self.steps[-1][-1].fit(Xt, y, **fit_params).transform(Xt)
+
+        if self.verbose:
+            elapsed = time.time() - start_time
+            time_str = logger.short_format_time(elapsed)
+            print('[Pipeline] (step %d of %d) %s ... %s' %
+                    (len(self.steps[:-1]), len(self.steps[:-1]),
+                        self.steps[-1][0], time_str))
+        return ret
 
     @if_delegate_has_method(delegate='_final_estimator')
     def predict(self, X):
@@ -379,7 +406,8 @@ def make_pipeline(*steps):
     >>> make_pipeline(StandardScaler(), GaussianNB())    # doctest: +NORMALIZE_WHITESPACE
     Pipeline(steps=[('standardscaler',
                      StandardScaler(copy=True, with_mean=True, with_std=True)),
-                    ('gaussiannb', GaussianNB())])
+                    ('gaussiannb', GaussianNB())],
+         verbose=False)
 
     Returns
     -------

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1,10 +1,12 @@
 """
 Test the pipeline module.
 """
+import sys
 import numpy as np
 from scipy import sparse
 
 from sklearn.externals.six.moves import zip
+from sklearn.externals.six import StringIO
 from sklearn.utils.testing import assert_raises, assert_raises_regex, assert_raise_message
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_false
@@ -449,7 +451,6 @@ def test_feature_union_feature_names():
         assert_true("chars__" in feat or "words__" in feat)
     assert_equal(len(feature_names), 35)
 
-
 def test_classes_property():
     iris = load_iris()
     X = iris.data
@@ -464,10 +465,34 @@ def test_classes_property():
     clf.fit(X, y)
     assert_array_equal(clf.classes_, np.unique(y))
 
-
 def test_X1d_inverse_transform():
     transformer = TransfT()
     pipeline = make_pipeline(transformer)
     X = np.ones(10)
     msg = "1d X will not be reshaped in pipeline.inverse_transform"
     assert_warns_message(FutureWarning, msg, pipeline.inverse_transform, X)
+
+def test_verbosity():
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+
+    old_stdout = sys.stdout
+    try:
+        out = StringIO()
+        sys.stdout = out
+
+        nonverbose_reg = Pipeline([
+            ('kbest', SelectKBest(k=1)), ('lr', LinearRegression())
+        ], verbose=False)
+        nonverbose_reg.fit(X, y)
+        assert_true("[Pipeline]" not in out.getvalue())
+
+        verbose_reg = Pipeline([
+            ('kbest', SelectKBest(k=1)), ('lr', LinearRegression())
+        ], verbose=True)
+        verbose_reg.fit(X, y)
+        assert_true("[Pipeline] (step 0 of 1) kbest ..." in out.getvalue())
+        assert_true("[Pipeline] (step 1 of 1) lr ..." in out.getvalue())
+    finally:
+        sys.stdout = old_stdout


### PR DESCRIPTION
Adds named verbosity argument in Pipeline constructor.

After each step, verbose pipelines print to standard output lines like:

`[Pipeline] <step name>, <action> (fit or transform), <duration>`
#5298
