### PR TITLE
[MRG] pairwise_distances outputs Nan and negative values

### DIFF
--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -573,4 +573,5 @@ def test_constant_row_all():
                 tsne = TSNE(metric=metric)
                 tsne.fit_transform(Y)
             except ValueError:
+                print(metric + ' raised a ValueError.')
                 assert False

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -25,6 +25,7 @@ from scipy.optimize import check_grad
 from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
 from sklearn.metrics.pairwise import pairwise_distances
+from sklearn.metrics.pairwise import _VALID_METRICS
 
 
 def test_gradient_descent_stops():
@@ -542,3 +543,34 @@ def test_index_offset():
     # Make sure translating between 1D and N-D indices are preserved
     assert_equal(_barnes_hut_tsne.test_index2offset(), 1)
     assert_equal(_barnes_hut_tsne.test_index_offset(), 1)
+
+
+def test_constant_row_all():
+    binary_dist = ['yule', 'matching', 'dice', 'kulsinski', 'rogerstanimoto',
+                   'russellrao', 'sokalmichener', 'sokalsneath']
+
+    # Test correct handling of costant columns - real vectors
+    np.random.seed(42)
+    X = np.random.rand(10, 3)
+    for const in [0, 1]:
+        X[-1, :] = const
+        for metric in _VALID_METRICS:
+            # wminkowski is not compatible with tsne
+            if metric in binary_dist or metric == 'wminkowski':
+                continue
+            try:
+                tsne = TSNE(metric=metric)
+                tsne.fit_transform(X)
+            except ValueError:
+                assert False
+
+    # Test correct handling of costant columns - binary vectors
+    Y = np.random.randint(0, 1, (10, 10))
+    for const in [0, 1]:
+        Y[-1, :] = const
+        for metric in binary_dist:
+            try:
+                tsne = TSNE(metric=metric)
+                tsne.fit_transform(Y)
+            except ValueError:
+                assert False

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -556,6 +556,15 @@ def cosine_distances(X, Y=None):
     S = cosine_similarity(X, Y)
     S *= -1
     S += 1
+
+    # Ensure non negativity.
+    # This may not be the case due to floating point rounding errors.
+    np.maximum(S, 0, out=S)
+    if X is Y:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        S.flat[::S.shape[0] + 1] = 0.0
+
     return S
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -7,12 +7,14 @@
 #          Philippe Gervais <philippe.gervais@inria.fr>
 #          Lars Buitinck <larsmans@gmail.com>
 #          Joel Nothman <joel.nothman@gmail.com>
+#          Giorgio Parini <giorgio.patrini@anu.edu.au>
 # License: BSD 3 clause
 
 import itertools
 
 import numpy as np
 from scipy.spatial import distance
+from scipy.spatial.distance import yule, dice, sokalsneath
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
 
@@ -527,6 +529,54 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     return D.reshape((-1, X.shape[1]))
 
 
+def _center_and_normalize(X, copy=False):
+    tol = np.finfo(X.dtype).eps * 100
+    # Make implicit copy
+    X = X - np.mean(X, axis=0)
+
+    norms = row_norms(X)
+    non_const_row = np.abs(norms) > tol
+    if non_const_row.all():  # if they are all above treshold
+        X /= norms[:, np.newaxis]
+    elif non_const_row.any() is False:
+        X[non_const_row, :] /= norms[non_const_row]
+        X[not non_const_row, :] = 0.0  # this hack will set correlation to 0
+    return X
+
+
+def _correlation_similarity(X, Y):
+    X, Y = check_pairwise_arrays(X, Y)
+
+    X_normalized = _center_and_normalize(X, copy=True)
+    if X is Y:
+        Y_normalized = X_normalized
+    else:
+        Y_normalized = _center_and_normalize(Y, copy=True)
+
+    K = safe_sparse_dot(X_normalized, Y_normalized.T)
+    return K
+
+
+def _correlation_distances(X, Y=None):
+    """
+    Fix for scipy.spatial.distance.correlation with constant input.
+    """
+
+    S = _correlation_similarity(X, Y)
+    S *= -1
+    S += 1
+
+    # Ensure non negativity.
+    # This may not be the case due to floating point rounding errors.
+    np.maximum(S, 0, out=S)
+    if X is Y:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        S.flat[::S.shape[0] + 1] = 0.0
+
+    return S
+
+
 def cosine_distances(X, Y=None):
     """Compute cosine distance between samples in X and Y.
 
@@ -566,6 +616,39 @@ def cosine_distances(X, Y=None):
         S.flat[::S.shape[0] + 1] = 0.0
 
     return S
+
+
+def _scipy_wrapper_binary_distances(X, Y, metric):
+    """
+    Catch those errors and return 0 instead
+        scipy.spatial.distance.yule         -> ZeroDivisionError
+        scipy.spatial.distance.dice         -> ZeroDivisionError
+        scipy.spatial.distance.sokalsneath  -> ValueError
+    """
+    if metric == 'yule' or metric == 'dice':
+        if metric == 'yule':
+            func = yule
+        else:
+            func = dice
+        error = ZeroDivisionError
+    elif metric == 'sokalsneath':
+        func = sokalsneath
+        error = ValueError
+
+    # They will be cast to float, but it's OK
+    X, Y = check_pairwise_arrays(X, Y)
+
+    mX, mY = X.shape[0], Y.shape[0]
+    K = np.zeros((mX, mY), dtype=np.double)
+
+    for i in np.arange(0, mX):
+        for j in np.arange(0, mY):
+            try:
+                K[i, j] = func(X[i, :], Y[j, :])
+            except error:
+                K[i, j] = 0.0
+
+    return K
 
 
 # Paired distances
@@ -1218,6 +1301,13 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
             raise TypeError("scipy distance metrics do not"
                             " support sparse matrices.")
         X, Y = check_pairwise_arrays(X, Y)
+
+        # Fixes errors raised by scipy with (almost) constant inputs
+        if metric == 'correlation':
+            return _correlation_distances(X, Y)
+        elif metric in ['yule', 'dice', 'sokalsneath']:
+            return _scipy_wrapper_binary_distances(X, Y, metric)
+
         if n_jobs == 1 and X is Y:
             return distance.squareform(distance.pdist(X, metric=metric,
                                                       **kwds))

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -115,6 +115,17 @@ def test_pairwise_distances():
     assert_raises(ValueError, pairwise_distances, X, Y, metric="blah")
 
 
+def test_constant_row_cosine():
+    # Test correct handling of costant columns
+    np.random.seed(42)
+    X1 = np.random.rand(10, 3)
+    for const in [0, 1]:
+        X1[-1, :] = const
+        for X2 in [X1, -X1, X1 + np.arange(3)]:
+            dist = pairwise_distances(X1, X2, metric='cosine')
+            assert_true(dist.all() >= 0.0)
+
+
 def test_pairwise_precomputed():
     for func in [pairwise_distances, pairwise_kernels]:
         # Test correct shape

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -115,15 +115,56 @@ def test_pairwise_distances():
     assert_raises(ValueError, pairwise_distances, X, Y, metric="blah")
 
 
-def test_constant_row_cosine():
-    # Test correct handling of costant columns
+def test_constant_row():
+    # Test correct handling of costant columns for cosine and correlation
     np.random.seed(42)
     X1 = np.random.rand(10, 3)
+
     for const in [0, 1]:
         X1[-1, :] = const
         for X2 in [X1, -X1, X1 + np.arange(3)]:
             dist = pairwise_distances(X1, X2, metric='cosine')
             assert_true(dist.all() >= 0.0)
+
+            dist = pairwise_distances(X1, X2, metric='correlation')
+            assert_true(dist.all() >= 0.0)
+
+    # Test also that ALMOST constant do not return negative or nan
+    X1 = np.array([1, 1, 1]).reshape(-1, 1)
+    noise = np.array([.5, 0, -.01]).reshape(-1, 1)
+    X2 = np.array([2, 4, 6]).reshape(-1, 1)
+    for eps in np.linspace(-1e-15, .0, 50):
+        dist = pairwise_distances(X1 + eps * noise, X2, metric='cosine')
+        assert_true(dist.all() >= 0.0)
+
+        dist = pairwise_distances(X1 + eps * noise, X2, metric='correlation')
+        assert_true(np.all(dist >= 0))
+
+    # Test a case in which scipy's yule distance would raise ZeroDivisionError
+    np.random.seed(42)
+    X1 = np.random.rand(10, 3)
+    X1[-1, :] = np.ones([1, 1, 1])
+    try:
+        dist = pairwise_distances(X1, X1, metric='yule')
+        assert_true(np.all(dist >= 0))
+    except:
+        assert False
+
+    X1 = np.random.randint(0, 1, (10, 10))
+    X1[-1, :] = 0
+    # dice ->  ZeroDivisionError
+    try:
+        dist = pairwise_distances(X1, metric='dice')
+        assert_true(np.all(dist >= 0))
+    except:
+        assert False
+
+    # sokalsneath -> ValueError
+    try:
+        dist = pairwise_distances(X1, X1, metric='sokalsneath')
+        assert_true(np.all(dist >= 0))
+    except:
+        assert False
 
 
 def test_pairwise_precomputed():


### PR DESCRIPTION
Fixes #4475 . The problem is about pairwise distances and not T-SNE. Refer to the issue for discussion. 
#4495 deals with the same issue but it does not seem active any more.

Tests for problems related with negative values now pass. Regarding `nan` I am going to see if a fix on the scipy's side is possible. Until then, I have written wrappers of the scipy's functions. 

Changes
- [x] added breaking tests for `TSNE` as from #4475 but covering all distances from `sklearn.metrics.pairwise.pairwise_distances`
- [x] added breaking tests for the same `pairwise_distances`
- [x] implemented a robust sklearn's version of `correlation`, almost the same as `cosine`
- [x] wrote wrappers for scipy's 'yule', 'dice', 'sokalsneath'
