### PR TITLE
[MRG] add fast replacement for np.cov

### DIFF
--- a/sklearn/covariance/empirical_covariance_.py
+++ b/sklearn/covariance/empirical_covariance_.py
@@ -17,7 +17,7 @@ from scipy import linalg
 
 from ..base import BaseEstimator
 from ..utils import check_array
-from ..utils.extmath import fast_logdet, pinvh
+from ..utils.extmath import fast_cov, fast_logdet, pinvh
 
 
 def log_likelihood(emp_cov, precision):
@@ -76,9 +76,10 @@ def empirical_covariance(X, assume_centered=False):
                       "You may want to reshape your data array")
 
     if assume_centered:
-        covariance = np.dot(X.T, X) / X.shape[0]
+        covariance = np.dot(X.T, X)
+        covariance /= X.shape[0]
     else:
-        covariance = np.cov(X.T, bias=1)
+        covariance = fast_cov(X.T, bias=1)
 
     if covariance.ndim == 0:
         covariance = np.array([[covariance]])

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -16,7 +16,7 @@ from time import time
 
 from ..base import BaseEstimator
 from ..utils import check_random_state, check_array
-from ..utils.extmath import logsumexp
+from ..utils.extmath import fast_cov, logsumexp
 from ..utils.validation import check_is_fitted
 from .. import cluster
 
@@ -492,7 +492,7 @@ class GMM(BaseEstimator):
                     print('\tWeights have been initialized.')
 
             if 'c' in self.init_params or not hasattr(self, 'covars_'):
-                cv = np.cov(X.T) + self.min_covar * np.eye(X.shape[1])
+                cv = fast_cov(X.T) + self.min_covar * np.eye(X.shape[1])
                 if not cv.shape:
                     cv.shape = (1, 1)
                 self.covars_ = \

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import ignore_warnings
 
 from sklearn.utils.extmath import density
 from sklearn.utils.extmath import logsumexp
@@ -25,6 +26,7 @@ from sklearn.utils.extmath import row_norms
 from sklearn.utils.extmath import weighted_mode
 from sklearn.utils.extmath import cartesian
 from sklearn.utils.extmath import log_logistic
+from sklearn.utils.extmath import fast_cov
 from sklearn.utils.extmath import fast_dot, _fast_dot
 from sklearn.utils.extmath import svd_flip
 from sklearn.utils.extmath import _batch_mean_variance_update
@@ -322,6 +324,18 @@ def test_logistic_sigmoid():
 
     extreme_x = np.array([-100., 100.])
     assert_array_almost_equal(log_logistic(extreme_x), [-100, 0])
+
+
+def test_fast_cov():
+    rng = np.random.RandomState(123)
+    with ignore_warnings():
+        for X in [rng.randn(3, 19), rng.randn(14, 1), rng.randn(1, 1)]:
+            X.flags['WRITEABLE'] = False
+            assert_array_almost_equal(fast_cov(X), np.cov(X))
+            assert_array_almost_equal(fast_cov(X, bias=1), np.cov(X, bias=1))
+            X = X.astype(np.float32)
+            assert_array_almost_equal(fast_cov(X, rowvar=False),
+                                      np.cov(X, rowvar=False))
 
 
 def test_fast_dot():


### PR DESCRIPTION
This is inspired by some recent PRs over at NumPy concerning `np.cov` performance.

Timings with NumPy 1.8.2 and ATLAS:

```
>>> X = np.random.rand(13000,60)
>>> %timeit np.cov(X)
1 loops, best of 3: 2.82 s per loop
>>> %timeit fast_cov(X)
1 loops, best of 3: 1.71 s per loop
```

Memory use is also halved compared to NumPy <= 1.10, at least for `n_samples` ≫ `n_features`. NumPy 1.11 will have a more memory-efficient `cov` implementation.
