### PR TITLE
Fixed typo in the final ".. note::" of naive_bayes.rst

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -196,8 +196,8 @@ passed the list of all the expected class labels.
 For an overview of available strategies in scikit-learn, see also the
 :ref:`out-of-core learning <scaling_strategies>` documentation.
 
-note::
+.. note::
 
-  The ``partial_fit`` method call of naive Bayes models introduces some
-  computational overhead. It is recommended to use data chunk sizes that are as
-  large as possible, that is as the available RAM allows.
+   The ``partial_fit`` method call of naive Bayes models introduces some
+   computational overhead. It is recommended to use data chunk sizes that are as
+   large as possible, that is as the available RAM allows.


### PR DESCRIPTION
The [rST **note** admonition](http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions) syntax is `.. note::`, the two `..` were missing (the last remark displayed badly on http://scikit-learn.org/stable/modules/naive_bayes.html).

Demo of the _old_ page (now fixed):
![github_scikit-learn_naive_bayes_pull-request_06-10-15_08-26-28](https://cloud.githubusercontent.com/assets/11994719/10301570/ff567d80-6c03-11e5-959e-9e3f45e9c25e.png)
