### PR TITLE
[MRG+1] Naive bayes scale (Fixes #5314)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -244,6 +244,9 @@ Bug fixes
       to use soft-max instead of one-vs-rest normalization. By `Manoj Kumar`_.
       (`#5182 <https://github.com/scikit-learn/scikit-learn/pull/5182>`_)
 
+    - Fixed a bug in :class:`naive_bayes.GaussianNB` which caused classification
+      results to depend on scale. By `Jake Vanderplas`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -324,7 +324,7 @@ class GaussianNB(BaseNB):
         # will cause numerical errors. To address this, we artificially
         # boost the variance by epsilon, a small fraction of the standard
         # deviation of the largest dimension.
-        epsilon = 1e-9 * np.var(X, 0).max()
+        epsilon = 1e-9 * np.var(X, axis=0).max()
 
         if _refit:
             self.classes_ = None

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -324,7 +324,7 @@ class GaussianNB(BaseNB):
         # will cause numerical errors. To address this, we artificially
         # boost the variance by epsilon, a small fraction of the standard
         # deviation of the largest dimension.
-        epsilon = 1e-9 * np.std(X, 0).max()
+        epsilon = 1e-9 * np.var(X, 0).max()
 
         if _refit:
             self.classes_ = None

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -318,9 +318,13 @@ class GaussianNB(BaseNB):
         self : object
             Returns self.
         """
-
         X, y = check_X_y(X, y)
-        epsilon = 1e-9
+
+        # If the ratio of data variance between dimensions is too small, it
+        # will cause numerical errors. To address this, we artificially
+        # boost the variance by epsilon, a small fraction of the standard
+        # deviation of the largest dimension.
+        epsilon = 1e-9 * np.std(X, 0).max()
 
         if _refit:
             self.classes_ = None

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -466,3 +466,13 @@ def test_bnb():
                                       0.02194787379972565]])
     predict_proba = unnorm_predict_proba / np.sum(unnorm_predict_proba)
     assert_array_almost_equal(clf.predict_proba(X_test), predict_proba)
+
+
+def test_naive_bayes_scale_invariance():
+    # Scaling the data should not change the prediction results
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    labels = [GaussianNB().fit(f * X, y).predict(f * X)
+              for f in [1E-5, 1, 1E5]]
+    assert_array_equal(labels[0], labels[1])
+    assert_array_equal(labels[0], labels[2])

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -473,6 +473,6 @@ def test_naive_bayes_scale_invariance():
     iris = load_iris()
     X, y = iris.data, iris.target
     labels = [GaussianNB().fit(f * X, y).predict(f * X)
-              for f in [1E-5, 1, 1E5]]
+              for f in [1E-10, 1, 1E10]]
     assert_array_equal(labels[0], labels[1])
-    assert_array_equal(labels[0], labels[2])
+    assert_array_equal(labels[1], labels[2])


### PR DESCRIPTION
This modifies the `epsilon` parameter in `GaussianNB` so that classifications will be scale-invariant.
