### PR TITLE
[MRG+2] use distinct filenames for pickled datasets under Python 2 and 3

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -244,6 +244,10 @@ Bug fixes
       to use soft-max instead of one-vs-rest normalization. By `Manoj Kumar`_.
       (`#5182 <https://github.com/scikit-learn/scikit-learn/pull/5182>`_)
 
+    - Dataset fetchers use different filenames under Python 2 and Python 3 to
+      avoid pickling compatibility issues. By `Olivier Grisel`_.
+      (`#5355 <https://github.com/scikit-learn/scikit-learn/pull/5355>`_)
+
 API changes summary
 -------------------
 

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -22,7 +22,7 @@ Statistics and Probability Letters, 33 (1997) 291-297.
 # License: BSD 3 clause
 
 from io import BytesIO
-from os.path import join, exists
+from os.path import exists
 from os import makedirs
 from zipfile import ZipFile
 try:
@@ -35,6 +35,7 @@ except ImportError:
 import numpy as np
 
 from .base import get_data_home, Bunch
+from .base import _pkl_filepath
 from ..externals import joblib
 
 
@@ -86,7 +87,8 @@ def fetch_california_housing(data_home=None, download_if_missing=True):
     data_home = get_data_home(data_home=data_home)
     if not exists(data_home):
         makedirs(data_home)
-    if not exists(join(data_home, TARGET_FILENAME)):
+    filepath = _pkl_filepath(data_home, TARGET_FILENAME)
+    if not exists(filepath):
         print('downloading Cal. housing from %s to %s' % (DATA_URL, data_home))
         fhandle = urlopen(DATA_URL)
         buf = BytesIO(fhandle.read())
@@ -96,12 +98,11 @@ def fetch_california_housing(data_home=None, download_if_missing=True):
             cadata = BytesIO(cadata_fd.read())
             # skip the first 27 lines (documentation)
             cal_housing = np.loadtxt(cadata, skiprows=27)
-            joblib.dump(cal_housing, join(data_home, TARGET_FILENAME),
-                        compress=6)
+            joblib.dump(cal_housing, filepath, compress=6)
         finally:
             zip_file.close()
     else:
-        cal_housing = joblib.load(join(data_home, TARGET_FILENAME))
+        cal_housing = joblib.load(filepath)
 
     feature_names = ["MedInc", "HouseAge", "AveRooms", "AveBedrms",
                      "Population", "AveOccup", "Latitude", "Longitude"]

--- a/sklearn/datasets/covtype.py
+++ b/sklearn/datasets/covtype.py
@@ -14,7 +14,6 @@ Courtesy of Jock A. Blackard and Colorado State University.
 #         Peter Prettenhofer <peter.prettenhofer@gmail.com>
 # License: BSD 3 clause
 
-import sys
 from gzip import GzipFile
 from io import BytesIO
 import logging
@@ -28,6 +27,7 @@ import numpy as np
 
 from .base import get_data_home
 from .base import Bunch
+from .base import _pkl_filepath
 from ..utils.fixes import makedirs
 from ..externals import joblib
 from ..utils import check_random_state
@@ -83,17 +83,9 @@ def fetch_covtype(data_home=None, download_if_missing=True,
     """
 
     data_home = get_data_home(data_home=data_home)
-    if sys.version_info[0] == 3:
-        # The zlib compression format use by joblib is not compatible when
-        # switching from Python 2 to Python 3, let us use a separate folder
-        # under Python 3:
-        dir_suffix = "-py3"
-    else:
-        # Backward compat for Python 2 users
-        dir_suffix = ""
-    covtype_dir = join(data_home, "covertype" + dir_suffix)
-    samples_path = join(covtype_dir, "samples")
-    targets_path = join(covtype_dir, "targets")
+    covtype_dir = join(data_home, "covertype")
+    samples_path = _pkl_filepath(covtype_dir, "samples")
+    targets_path = _pkl_filepath(covtype_dir, "targets")
     available = exists(samples_path)
 
     if download_if_missing and not available:

--- a/sklearn/datasets/olivetti_faces.py
+++ b/sklearn/datasets/olivetti_faces.py
@@ -23,7 +23,7 @@ consists of 64x64 images.
 # License: BSD 3 clause
 
 from io import BytesIO
-from os.path import join, exists
+from os.path import exists
 from os import makedirs
 try:
     # Python 2
@@ -38,6 +38,7 @@ import numpy as np
 from scipy.io.matlab import loadmat
 
 from .base import get_data_home, Bunch
+from .base import _pkl_filepath
 from ..utils import check_random_state
 from ..externals import joblib
 
@@ -108,17 +109,18 @@ def fetch_olivetti_faces(data_home=None, shuffle=False, random_state=0,
     data_home = get_data_home(data_home=data_home)
     if not exists(data_home):
         makedirs(data_home)
-    if not exists(join(data_home, TARGET_FILENAME)):
+    filepath = _pkl_filepath(data_home, TARGET_FILENAME)
+    if not exists(filepath):
         print('downloading Olivetti faces from %s to %s'
               % (DATA_URL, data_home))
         fhandle = urlopen(DATA_URL)
         buf = BytesIO(fhandle.read())
         mfile = loadmat(buf)
         faces = mfile['faces'].T.copy()
-        joblib.dump(faces, join(data_home, TARGET_FILENAME), compress=6)
+        joblib.dump(faces, filepath, compress=6)
         del mfile
     else:
-        faces = joblib.load(join(data_home, TARGET_FILENAME))
+        faces = joblib.load(filepath)
     # We want floating point data, but float32 is enough (there is only
     # one byte of precision in the original uint8s anyway)
     faces = np.float32(faces)

--- a/sklearn/datasets/rcv1.py
+++ b/sklearn/datasets/rcv1.py
@@ -21,6 +21,7 @@ import scipy.sparse as sp
 
 from .base import get_data_home
 from .base import Bunch
+from .base import _pkl_filepath
 from ..utils.fixes import makedirs
 from ..externals import joblib
 from .svmlight_format import load_svmlight_files
@@ -113,10 +114,10 @@ def fetch_rcv1(data_home=None, subset='all', download_if_missing=True,
     if download_if_missing:
         makedirs(rcv1_dir, exist_ok=True)
 
-    samples_path = join(rcv1_dir, "samples.pkl")
-    sample_id_path = join(rcv1_dir, "sample_id.pkl")
-    sample_topics_path = join(rcv1_dir, "sample_topics.pkl")
-    topics_path = join(rcv1_dir, "topics_names.pkl")
+    samples_path = _pkl_filepath(rcv1_dir, "samples.pkl")
+    sample_id_path = _pkl_filepath(rcv1_dir, "sample_id.pkl")
+    sample_topics_path = _pkl_filepath(rcv1_dir, "sample_topics.pkl")
+    topics_path = _pkl_filepath(rcv1_dir, "topics_names.pkl")
 
     # load data (X) and sample_id
     if download_if_missing and (not exists(samples_path) or

--- a/sklearn/datasets/species_distributions.py
+++ b/sklearn/datasets/species_distributions.py
@@ -37,7 +37,6 @@ Notes:
 
 from io import BytesIO
 from os import makedirs
-from os.path import join
 from os.path import exists
 
 try:
@@ -52,12 +51,13 @@ except ImportError:
 import numpy as np
 
 from sklearn.datasets.base import get_data_home, Bunch
+from sklearn.datasets.base import _pkl_filepath
 from sklearn.externals import joblib
 
 DIRECTORY_URL = "http://www.cs.princeton.edu/~schapire/maxent/datasets/"
 
-SAMPLES_URL = join(DIRECTORY_URL, "samples.zip")
-COVERAGES_URL = join(DIRECTORY_URL, "coverages.zip")
+SAMPLES_URL = DIRECTORY_URL + "samples.zip"
+COVERAGES_URL = DIRECTORY_URL + "coverages.zip"
 
 DATA_ARCHIVE_NAME = "species_coverage.pkz"
 
@@ -72,9 +72,8 @@ def _load_coverage(F, header_length=6, dtype=np.int16):
     header = dict([make_tuple(line) for line in header])
 
     M = np.loadtxt(F, dtype=dtype)
-    nodata = header[b'NODATA_value']
+    nodata = int(header[b'NODATA_value'])
     if nodata != -9999:
-        print(nodata)
         M[nodata] = -9999
     return M
 
@@ -220,7 +219,9 @@ def fetch_species_distributions(data_home=None,
                         grid_size=0.05)
     dtype = np.int16
 
-    if not exists(join(data_home, DATA_ARCHIVE_NAME)):
+    archive_path = _pkl_filepath(data_home, DATA_ARCHIVE_NAME)
+
+    if not exists(archive_path):
         print('Downloading species data from %s to %s' % (SAMPLES_URL,
                                                           data_home))
         X = np.load(BytesIO(urlopen(SAMPLES_URL).read()))
@@ -248,8 +249,8 @@ def fetch_species_distributions(data_home=None,
                       test=test,
                       train=train,
                       **extra_params)
-        joblib.dump(bunch, join(data_home, DATA_ARCHIVE_NAME), compress=9)
+        joblib.dump(bunch, archive_path, compress=9)
     else:
-        bunch = joblib.load(join(data_home, DATA_ARCHIVE_NAME))
+        bunch = joblib.load(archive_path)
 
     return bunch

--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -49,6 +49,7 @@ import scipy.sparse as sp
 from .base import get_data_home
 from .base import Bunch
 from .base import load_files
+from .base import _pkl_filepath
 from ..utils import check_random_state
 from ..feature_extraction.text import CountVectorizer
 from ..preprocessing import normalize
@@ -200,7 +201,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     """
 
     data_home = get_data_home(data_home=data_home)
-    cache_path = os.path.join(data_home, CACHE_NAME)
+    cache_path = _pkl_filepath(data_home, CACHE_NAME)
     twenty_home = os.path.join(data_home, "20news_home")
     cache = None
     if os.path.exists(cache_path):
@@ -324,7 +325,7 @@ def fetch_20newsgroups_vectorized(subset="train", remove=(), data_home=None):
     filebase = '20newsgroup_vectorized'
     if remove:
         filebase += 'remove-' + ('-'.join(remove))
-    target_file = os.path.join(data_home, filebase + ".pk")
+    target_file = _pkl_filepath(data_home, filebase + ".pkl")
 
     # we shuffle but use a fixed seed for the memoization
     data_train = fetch_20newsgroups(data_home=data_home,


### PR DESCRIPTION
This is a fix for #3596.

Note that I changed the covtype loader to be consistent with the others even though that might re-trigger a useless download once.
