### PR TITLE
[MRG+1] Fix fit_transform, stability issue and scale issue in PLS

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -306,10 +306,16 @@ Bug fixes
       (`#5360 <https://github.com/scikit-learn/scikit-learn/pull/5360>`_)
       By `Tom Dupre la Tour`_.
 
+<<<<<<< HEAD
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (`#4478
       <https://github.com/scikit-learn/scikit-learn/pull/4478>`_)
       By `Andreas Müller`_, `Loic Esteve`_ and `Giorgio Patrini`_.
+=======
+    - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
+      platform dependent output, and failed on `fit_transform`.
+       By `Arthur Mensch`_.
+>>>>>>> 307d0c7... Fix fit_transform, stability issue and scale issue in PLS
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -306,16 +306,14 @@ Bug fixes
       (`#5360 <https://github.com/scikit-learn/scikit-learn/pull/5360>`_)
       By `Tom Dupre la Tour`_.
 
-<<<<<<< HEAD
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (`#4478
       <https://github.com/scikit-learn/scikit-learn/pull/4478>`_)
       By `Andreas Müller`_, `Loic Esteve`_ and `Giorgio Patrini`_.
-=======
+
     - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
       platform dependent output, and failed on `fit_transform`.
        By `Arthur Mensch`_.
->>>>>>> 307d0c7... Fix fit_transform, stability issue and scale issue in PLS
 
 API changes summary
 -------------------

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -4,6 +4,8 @@ The :mod:`sklearn.pls` module implements Partial Least Squares (PLS).
 
 # Author: Edouard Duchesnay <edouard.duchesnay@cea.fr>
 # License: BSD 3 clause
+from distutils.version import LooseVersion
+from sklearn.utils.extmath import svd_flip
 
 from ..base import BaseEstimator, RegressorMixin, TransformerMixin
 from ..utils import check_array, check_consistent_length
@@ -17,6 +19,12 @@ from ..utils import arpack
 from ..utils.validation import check_is_fitted, FLOAT_DTYPES
 
 __all__ = ['PLSCanonical', 'PLSRegression', 'PLSSVD']
+
+import scipy
+pinv2_args = {}
+if LooseVersion(scipy.__version__) >= LooseVersion('0.12'):
+    # check_finite=False is an optimization available only in scipy >=0.12
+    pinv2_args = {'check_finite': False}
 
 
 def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
@@ -38,7 +46,9 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         # 1.1 Update u: the X weights
         if mode == "B":
             if X_pinv is None:
-                X_pinv = linalg.pinv(X)   # compute once pinv(X)
+                # We use slower pinv2 (same as np.linalg.pinv) for stability
+                # reason
+                X_pinv = linalg.pinv2(X, **pinv2_args)
             x_weights = np.dot(X_pinv, y_score)
         else:  # mode A
             # Mode A regress each X column on y_score
@@ -50,7 +60,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         # 2.1 Update y_weights
         if mode == "B":
             if Y_pinv is None:
-                Y_pinv = linalg.pinv(Y)    # compute once pinv(Y)
+                Y_pinv = linalg.pinv2(Y, **pinv2_args)  # compute once pinv(Y)
             y_weights = np.dot(Y_pinv, x_score)
         else:
             # Mode A regress each Y column on x_score
@@ -257,8 +267,8 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         if self.deflation_mode not in ["canonical", "regression"]:
             raise ValueError('The deflation mode is unknown')
         # Scale (in place)
-        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_\
-            = _center_scale_xy(X, Y, self.scale)
+        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_ = (
+            _center_scale_xy(X, Y, self.scale))
         # Residuals (deflated) matrices
         Xk = X
         Yk = Y
@@ -287,6 +297,11 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
                 self.n_iter_.append(n_iter_)
             elif self.algorithm == "svd":
                 x_weights, y_weights = _svd_cross_product(X=Xk, Y=Yk)
+            # Forces sign stability of x_weights and y_weights
+            # Sign undeterminacy issue from svd if algorithm == "svd"
+            # and from platform dependent computation if algorithm == 'nipals'
+            x_weights, y_weights = svd_flip(x_weights, y_weights.T)
+            y_weights = y_weights.T
             # compute scores
             x_scores = np.dot(Xk, x_weights)
             if self.norm_y_weights:
@@ -333,11 +348,13 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         # U = Y C(Q'C)^-1 = YC* (W* : q x k matrix)
         self.x_rotations_ = np.dot(
             self.x_weights_,
-            linalg.pinv(np.dot(self.x_loadings_.T, self.x_weights_)))
+            linalg.pinv2(np.dot(self.x_loadings_.T, self.x_weights_),
+                         **pinv2_args))
         if Y.shape[1] > 1:
             self.y_rotations_ = np.dot(
                 self.y_weights_,
-                linalg.pinv(np.dot(self.y_loadings_.T, self.y_weights_)))
+                linalg.pinv2(np.dot(self.y_loadings_.T, self.y_weights_),
+                             **pinv2_args))
         else:
             self.y_rotations_ = np.ones(1)
 
@@ -437,7 +454,6 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         -------
         x_scores if Y is not given, (x_scores, y_scores) otherwise.
         """
-        check_is_fitted(self, 'x_mean_')
         return self.fit(X, y, **fit_params).transform(X, y)
 
 
@@ -505,8 +521,32 @@ class PLSRegression(_PLS):
 
     Notes
     -----
+    Matrices :
+        T: x_scores_
+        U: y_scores_
+        W: x_weights_
+        C: y_weights_
+        P: x_loadings_
+        Q: y_loadings__
+
+    Are computed such that:
+        X = T P.T + Err and Y = U Q.T + Err
+        T[:, k] = Xk W[:, k] for k in range(n_components)
+        U[:, k] = Yk C[:, k] for k in range(n_components)
+        x_rotations_ = W (P.T W)^(-1)
+        y_rotations_ = C (Q.T C)^(-1)
+    where Xk and Yk are residual matrices at iteration k.
+
+    Slides explaining PLS
+    :ref:http://www.eigenvector.com/Docs/Wise_pls_properties.pdf
+
     For each component k, find weights u, v that optimizes:
-    ``max corr(Xk u, Yk v) * var(Xk u) var(Yk u)``, such that ``|u| = 1``
+<<<<<<< HEAD
+    ``max corr(Xk W[:, k], Yk C[:, k]) * var(Xk W[:, k]) var(Yk C[:, k])``,
+     such that ``|C[:, k]| = 1``
+=======
+    ``max corr(Xk u, Yk v) * std(Xk u) std(Yk u)``, such that ``|u| = 1``
+>>>>>>> Adressed comments
 
     Note that it maximizes both the correlations between the scores and the
     intra-block variances.
@@ -620,8 +660,33 @@ class PLSCanonical(_PLS):
 
     Notes
     -----
+    Matrices :
+        T: x_scores_
+        U: y_scores_
+        W: x_weights_
+        C: y_weights_
+        P: x_loadings_
+        Q: y_loadings__
+
+    Are computed such that:
+        X = T P.T + Err and Y = U Q.T + Err
+        T[:, k] = Xk W[:, k] for k in range(n_components)
+        U[:, k] = Yk C[:, k] for k in range(n_components)
+        x_rotations_ = W (P.T W)^(-1)
+        y_rotations_ = C (Q.T C)^(-1)
+    where Xk and Yk are residual matrices at iteration k.
+
+    Slides explaining PLS
+    :ref:http://www.eigenvector.com/Docs/Wise_pls_properties.pdf
+
+<<<<<<< HEAD
+    For each component k, find weights u, v that optimizes:
+    ``max corr(Xk W[:, k], Yk C[:, k]) * var(Xk W[:, k]) var(Yk C[:, k])``,
+     such that ``|C[:, k]| = 1``
+=======
     For each component k, find weights u, v that optimize::
-    max corr(Xk u, Yk v) * var(Xk u) var(Yk u), such that ``|u| = |v| = 1``
+    max corr(Xk u, Yk v) * std(Xk u) std(Yk u), such that ``|u| = |v| = 1``
+>>>>>>> Adressed comments
 
     Note that it maximizes both the correlations between the scores and the
     intra-block variances.
@@ -735,7 +800,7 @@ class PLSSVD(BaseEstimator, TransformerMixin):
                              % (self.n_components, str(X.shape), str(Y.shape)))
 
         # Scale (in place)
-        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_ =\
+        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_ = \
             _center_scale_xy(X, Y, self.scale)
         # svd(X'Y)
         C = np.dot(X.T, Y)
@@ -748,6 +813,8 @@ class PLSSVD(BaseEstimator, TransformerMixin):
             U, s, V = linalg.svd(C, full_matrices=False)
         else:
             U, s, V = arpack.svds(C, k=self.n_components)
+        # Deterministic output
+        U, V = svd_flip(U, V)
         V = V.T
         self.x_scores_ = np.dot(X, U)
         self.y_scores_ = np.dot(Y, V)

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -47,7 +47,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         if mode == "B":
             if X_pinv is None:
                 # We use slower pinv2 (same as np.linalg.pinv) for stability
-                # reason
+                # reasons
                 X_pinv = linalg.pinv2(X, **pinv2_args)
             x_weights = np.dot(X_pinv, y_score)
         else:  # mode A

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -541,12 +541,7 @@ class PLSRegression(_PLS):
     :ref:http://www.eigenvector.com/Docs/Wise_pls_properties.pdf
 
     For each component k, find weights u, v that optimizes:
-<<<<<<< HEAD
-    ``max corr(Xk W[:, k], Yk C[:, k]) * var(Xk W[:, k]) var(Yk C[:, k])``,
-     such that ``|C[:, k]| = 1``
-=======
     ``max corr(Xk u, Yk v) * std(Xk u) std(Yk u)``, such that ``|u| = 1``
->>>>>>> Adressed comments
 
     Note that it maximizes both the correlations between the scores and the
     intra-block variances.
@@ -679,14 +674,8 @@ class PLSCanonical(_PLS):
     Slides explaining PLS
     :ref:http://www.eigenvector.com/Docs/Wise_pls_properties.pdf
 
-<<<<<<< HEAD
-    For each component k, find weights u, v that optimizes:
-    ``max corr(Xk W[:, k], Yk C[:, k]) * var(Xk W[:, k]) var(Yk C[:, k])``,
-     such that ``|C[:, k]| = 1``
-=======
     For each component k, find weights u, v that optimize::
     max corr(Xk u, Yk v) * std(Xk u) std(Yk u), such that ``|u| = |v| = 1``
->>>>>>> Adressed comments
 
     Note that it maximizes both the correlations between the scores and the
     intra-block variances.
@@ -800,8 +789,8 @@ class PLSSVD(BaseEstimator, TransformerMixin):
                              % (self.n_components, str(X.shape), str(Y.shape)))
 
         # Scale (in place)
-        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_ = \
-            _center_scale_xy(X, Y, self.scale)
+        X, Y, self.x_mean_, self.y_mean_, self.x_std_, self.y_std_ = (
+            _center_scale_xy(X, Y, self.scale))
         # svd(X'Y)
         C = np.dot(X.T, Y)
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,8 +1,9 @@
 import numpy as np
 from sklearn.utils.testing import (assert_array_almost_equal,
-                                   assert_array_equal, assert_true, assert_raise_message)
+                                   assert_array_equal, assert_true,
+                                   assert_raise_message)
 from sklearn.datasets import load_linnerud
-from sklearn.cross_decomposition import pls_
+from sklearn.cross_decomposition import pls_, CCA
 from nose.tools import assert_equal
 
 
@@ -21,13 +22,13 @@ def test_pls():
     # check equalities of loading (up to the sign of the second column)
     assert_array_almost_equal(
         pls_bynipals.x_loadings_,
-        np.multiply(pls_bysvd.x_loadings_, np.array([1, -1, 1])), decimal=5,
-        err_msg="nipals and svd implementation lead to different x loadings")
+        pls_bysvd.x_loadings_, decimal=5,
+        err_msg="nipals and svd implementations lead to different x loadings")
 
     assert_array_almost_equal(
         pls_bynipals.y_loadings_,
-        np.multiply(pls_bysvd.y_loadings_, np.array([1, -1, 1])), decimal=5,
-        err_msg="nipals and svd implementation lead to different y loadings")
+        pls_bysvd.y_loadings_, decimal=5,
+        err_msg="nipals and svd implementations lead to different y loadings")
 
     # Check PLS properties (with n_components=X.shape[1])
     # ---------------------------------------------------
@@ -83,25 +84,40 @@ def test_pls():
         [[-0.61330704,  0.25616119, -0.74715187],
          [-0.74697144,  0.11930791,  0.65406368],
          [-0.25668686, -0.95924297, -0.11817271]])
-    assert_array_almost_equal(pls_ca.x_weights_, x_weights)
+    # x_weights_sign_flip holds columns of 1 or -1, depending on sign flip
+    # between R and python
+    x_weights_sign_flip = pls_ca.x_weights_ / x_weights
 
     x_rotations = np.array(
         [[-0.61330704,  0.41591889, -0.62297525],
          [-0.74697144,  0.31388326,  0.77368233],
          [-0.25668686, -0.89237972, -0.24121788]])
-    assert_array_almost_equal(pls_ca.x_rotations_, x_rotations)
+    x_rotations_sign_flip = pls_ca.x_rotations_ / x_rotations
 
     y_weights = np.array(
         [[+0.58989127,  0.7890047,   0.1717553],
          [+0.77134053, -0.61351791,  0.16920272],
          [-0.23887670, -0.03267062,  0.97050016]])
-    assert_array_almost_equal(pls_ca.y_weights_, y_weights)
+    y_weights_sign_flip = pls_ca.y_weights_ / y_weights
 
     y_rotations = np.array(
         [[+0.58989127,  0.7168115,  0.30665872],
          [+0.77134053, -0.70791757,  0.19786539],
          [-0.23887670, -0.00343595,  0.94162826]])
-    assert_array_almost_equal(pls_ca.y_rotations_, y_rotations)
+    y_rotations_sign_flip = pls_ca.y_rotations_ / y_rotations
+
+    # x_weights = X.dot(x_rotation)
+    # Hence R/python sign flip should be the same in x_weight and x_rotation
+    assert_array_almost_equal(x_rotations_sign_flip, x_weights_sign_flip)
+    # This test that R / python give the same result up to colunm
+    # sign indeterminacy
+    assert_array_almost_equal(np.abs(x_rotations_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(x_weights_sign_flip), 1, 4)
+
+
+    assert_array_almost_equal(y_rotations_sign_flip, y_weights_sign_flip)
+    assert_array_almost_equal(np.abs(y_rotations_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(y_weights_sign_flip), 1, 4)
 
     # 2) Regression PLS (PLS2): "Non regression test"
     # ===============================================
@@ -113,25 +129,34 @@ def test_pls():
         [[-0.61330704, -0.00443647,  0.78983213],
          [-0.74697144, -0.32172099, -0.58183269],
          [-0.25668686,  0.94682413, -0.19399983]])
-    assert_array_almost_equal(pls_2.x_weights_, x_weights)
+    x_weights_sign_flip = pls_2.x_weights_ / x_weights
 
     x_loadings = np.array(
         [[-0.61470416, -0.24574278,  0.78983213],
          [-0.65625755, -0.14396183, -0.58183269],
          [-0.51733059,  1.00609417, -0.19399983]])
-    assert_array_almost_equal(pls_2.x_loadings_, x_loadings)
+    x_loadings_sign_flip = pls_2.x_loadings_ / x_loadings
 
     y_weights = np.array(
         [[+0.32456184,  0.29892183,  0.20316322],
          [+0.42439636,  0.61970543,  0.19320542],
          [-0.13143144, -0.26348971, -0.17092916]])
-    assert_array_almost_equal(pls_2.y_weights_, y_weights)
+    y_weights_sign_flip = pls_2.y_weights_ / y_weights
 
     y_loadings = np.array(
         [[+0.32456184,  0.29892183,  0.20316322],
          [+0.42439636,  0.61970543,  0.19320542],
          [-0.13143144, -0.26348971, -0.17092916]])
-    assert_array_almost_equal(pls_2.y_loadings_, y_loadings)
+    y_loadings_sign_flip = pls_2.y_loadings_ / y_loadings
+
+    # x_loadings[:, i] = Xi.dot(x_weights[:, i]) \forall i
+    assert_array_almost_equal(x_loadings_sign_flip, x_weights_sign_flip, 4)
+    assert_array_almost_equal(np.abs(x_loadings_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(x_weights_sign_flip), 1, 4)
+
+    assert_array_almost_equal(y_loadings_sign_flip, y_weights_sign_flip, 4)
+    assert_array_almost_equal(np.abs(y_loadings_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(y_weights_sign_flip), 1, 4)
 
     # 3) Another non-regression test of Canonical PLS on random dataset
     # =================================================================
@@ -169,7 +194,8 @@ def test_pls():
          [-0.03572177,  0.0945091,  0.3414855],
          [0.05584937, -0.02028961, -0.57682568],
          [0.05744254, -0.01482333, -0.17431274]])
-    assert_array_almost_equal(pls_ca.x_weights_, x_weights)
+    x_weights_sign_flip = pls_ca.x_weights_ / x_weights
+
 
     x_loadings = np.array(
         [[0.65649254,  0.1847647,  0.15270699],
@@ -186,7 +212,7 @@ def test_pls():
          [-0.05292828,  0.0953533,  0.31916881],
          [0.04031924, -0.01961045, -0.65174036],
          [0.06172484, -0.06597366, -0.1244497]])
-    assert_array_almost_equal(pls_ca.x_loadings_, x_loadings)
+    x_loadings_sign_flip = pls_ca.x_loadings_ / x_loadings
 
     y_weights = np.array(
         [[0.66101097,  0.18672553,  0.22826092],
@@ -198,7 +224,7 @@ def test_pls():
          [-0.00917056,  0.04322147,  0.10062478],
          [-0.01909512,  0.06182718,  0.28830475],
          [0.01756709,  0.04797666,  0.32225745]])
-    assert_array_almost_equal(pls_ca.y_weights_, y_weights)
+    y_weights_sign_flip = pls_ca.y_weights_ / y_weights
 
     y_loadings = np.array(
         [[0.68568625,  0.1674376,  0.0969508],
@@ -210,7 +236,15 @@ def test_pls():
          [-0.02196918, -0.01377169,  0.09564505],
          [-0.03288952,  0.09039729,  0.31858973],
          [0.04287624,  0.05254676,  0.27836841]])
-    assert_array_almost_equal(pls_ca.y_loadings_, y_loadings)
+    y_loadings_sign_flip = pls_ca.y_loadings_ / y_loadings
+
+    assert_array_almost_equal(x_loadings_sign_flip, x_weights_sign_flip, 4)
+    assert_array_almost_equal(np.abs(x_weights_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(x_loadings_sign_flip), 1, 4)
+
+    assert_array_almost_equal(y_loadings_sign_flip, y_weights_sign_flip, 4)
+    assert_array_almost_equal(np.abs(y_weights_sign_flip), 1, 4)
+    assert_array_almost_equal(np.abs(y_loadings_sign_flip), 1, 4)
 
     # Orthogonality of weights
     # ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -273,19 +307,50 @@ def test_predict_transform_copy():
     assert_true(np.all(X.mean(axis=0) != 0))
 
 
-def test_scale():
+def test_scale_and_stability():
+    # We test scale=True parameter
+    # This allows to check numerical stability over platforms as well
+
     d = load_linnerud()
-    X = d.data
-    Y = d.target
-
+    X1 = d.data
+    Y1 = d.target
     # causes X[:, -1].std() to be zero
-    X[:, -1] = 1.0
+    X1[:, -1] = 1.0
 
-    for clf in [pls_.PLSCanonical(), pls_.PLSRegression(),
-                pls_.PLSSVD()]:
-        clf.set_params(scale=True)
-        clf.fit(X, Y)
+    # From bug #2821
+    # Test with X2, T2 s.t. clf.x_score[:, 1] == 0, clf.y_score[:, 1] == 0
+    # This test robustness of algorithm when dealing with value close to 0
+    X2 = np.array([[0., 0., 1.],
+                   [1., 0., 0.],
+                   [2., 2., 2.],
+                   [3., 5., 4.]])
+    Y2 = np.array([[0.1, -0.2],
+                   [0.9, 1.1],
+                   [6.2, 5.9],
+                   [11.9, 12.3]])
 
+    for (X, Y) in [(X1, Y1), (X2, Y2)]:
+        X_std = X.std(axis=0, ddof=1)
+        X_std[X_std == 0] = 1
+        Y_std = Y.std(axis=0, ddof=1)
+        Y_std[Y_std == 0] = 1
+
+        X_s = (X - X.mean(axis=0)) / X_std
+        Y_s = (Y - Y.mean(axis=0)) / Y_std
+
+        for clf in [CCA(), pls_.PLSCanonical(), pls_.PLSRegression(),
+                    pls_.PLSSVD()]:
+            clf.set_params(scale=True)
+            X_score, Y_score = clf.fit_transform(X, Y)
+            clf.set_params(scale=False)
+            X_s_score, Y_s_score = clf.fit_transform(X_s, Y_s)
+            assert_array_almost_equal(X_s_score, X_score)
+            assert_array_almost_equal(Y_s_score, Y_score)
+            # Scaling should be idempotent
+            clf.set_params(scale=True)
+            X_score, Y_score = clf.fit_transform(X_s, Y_s)
+            assert_array_almost_equal(X_s_score, X_score)
+            assert_array_almost_equal(Y_s_score, Y_score)
 
 def test_pls_errors():
     d = load_linnerud()

--- a/sklearn/externals/joblib/format_stack.py
+++ b/sklearn/externals/joblib/format_stack.py
@@ -284,6 +284,7 @@ def format_records(records):   # , print_globals=False):
                   "The following traceback may be corrupted or invalid\n"
                   "The error message is: %s\n" % (file, msg))
             print(_m)
+            raise msg
 
         # prune names list of duplicates, but keep the right order
         unique_names = uniq_stable(names)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -540,7 +540,10 @@ def _check_transformer(name, Transformer, X, y):
         y_ = y
 
     transformer.fit(X, y_)
-    X_pred = transformer.fit_transform(X, y=y_)
+    # fit_transform method should work on non fitted estimator
+    transformer_clone = clone(transformer)
+    X_pred = transformer_clone.fit_transform(X, y=y_)
+
     if isinstance(X_pred, tuple):
         for x_pred in X_pred:
             assert_equal(x_pred.shape[0], n_samples)


### PR DESCRIPTION
This PR fixes stability issue and sign indeterminacy in PLS and CCA (see bug #2821).

Three issues were adressed:
- `fit_transform` did not work for obvious reason. I fixed this and change estimator_checks so that it do not overlook Transformer unable to perform `fit_transform` without a previous `fit`
- scipy.linalg.pinv is based on `lstsq` and is subject to more numerical instability than `scipy.linalg.pinv2`, which, quite amusingly, is the same as `numpy.linalg.pinv`, and is based on SVD decomposition
- PLS is subject to sign indeterminacy (like any matrix decomposition method). Similar to `svd_flip`, we fix this within PLS code.

The signs of `x_loadings_`, `x_score_`, `x_weights_`, `x_rotations_` can differ columnwise from R implementation, as there is a sign indeterminacy that we seek to raise (cf SVD with `svd_flip`).
- [x] Since `test_pls` is based on R output, I still need to change it so that it does not fail because of sign differences.

ping @twiecki, @Fenugreek for PLS proficient reviews
