### PR TITLE
[MRG] Lasso and ElasticNet should handle non-integer dtypes for fit_intercept=False

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -650,6 +650,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         # We expect X and y to be already float64 Fortran ordered arrays
         # when bypassing checks
         if check_input:
+            y = np.asarray(y, dtype=np.float64)
             X, y = check_X_y(X, y, accept_sparse='csc', dtype=np.float64,
                              order='F',
                              copy=self.copy_X and self.fit_intercept,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -666,3 +666,16 @@ def test_overrided_gram_matrix():
                          " to fit intercept, "
                          "or X was normalized : recomputing Gram matrix.",
                          clf.fit, X, y)
+
+
+def test_lasso_non_float_y():
+    X = [[0, 0], [1, 1], [-1, -1]]
+    y = [0, 1, 2]
+    y_float = [0.0, 1.0, 2.0]
+
+    for model in [ElasticNet, Lasso]:
+        clf = model(fit_intercept=False)
+        clf.fit(X, y)
+        clf_float = model(fit_intercept=False)
+        clf_float.fit(X, y_float)
+        assert_array_equal(clf.coef_, clf_float.coef_)


### PR DESCRIPTION
Quick fix for https://github.com/scikit-learn/scikit-learn/issues/5351

The reason that it was not failing for `fit_intercept=True` was that y was being centered and hence coaxed to `np.float64`
