### PR TITLE
Add 'predict_proba' functionality to cross_val_predict

### DIFF
--- a/examples/cv_brier_score.py
+++ b/examples/cv_brier_score.py
@@ -1,0 +1,37 @@
+"""
+===========================================
+Cross Validation, Prediction vs Probability
+===========================================
+
+Example of cross_val_predict function to evaluate classifier output quality
+using cross-validation.
+
+This example shows the difference for the brier loss function when using
+predicted labels vs when using probability estimates.
+
+"""
+print(__doc__)
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.cross_validation import cross_val_predict
+from sklearn.metrics import brier_score_loss
+from sklearn.datasets import make_classification
+
+X, y = make_classification(n_samples=400, n_features=40, n_classes=2)
+
+clf = LogisticRegression()
+
+y_pred_labels = cross_val_predict(clf, X, y, cv=10)
+y_pred_probas = cross_val_predict(clf, X, y, cv=10, predict_proba=True)
+
+
+brier_label = brier_score_loss(y, y_pred_labels)
+
+# We get the first column for each item in y_pred_probas, that is
+# the probability estimates for class label '1'
+brier_proba = brier_score_loss(y, y_pred_probas[:,1])
+
+
+
+print("Brier loss for predicted targets: {:.3f}".format(brier_label))
+print("Brier loss for probability estimates: {:.3f}".format(brier_proba))

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1191,7 +1191,8 @@ def _index_param_value(X, v, indices):
 
 
 def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
-                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs',
+                      predict_proba=False):
     """Generate cross-validated estimates for each input data point
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1250,10 +1251,13 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
+    predict_proba : bool, default: False
+        Whether to predict probability estimates instead of target.
+
     Returns
     -------
     preds : ndarray
-        This is the result of calling 'predict'
+        This is the result of calling 'predict' or 'predict_proba'
     """
     X, y = indexable(X, y)
 
@@ -1264,7 +1268,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
                                                       train, test, verbose,
-                                                      fit_params)
+                                                      fit_params,
+                                                      predict_proba)
                             for train, test in cv)
 
     preds = [p for p, _ in preds_blocks]
@@ -1282,7 +1287,8 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
     return preds[inv_locs]
 
 
-def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
+def _fit_and_predict(estimator, X, y, train, test, verbose,
+                     fit_params, predict_proba):
     """Fit estimator and predict values for a given dataset split.
 
     Read more in the :ref:`User Guide <cross_validation>`.
@@ -1311,6 +1317,9 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
 
+    predict_proba : bool
+        Whether to call 'predict' or 'predict_proba'.
+
     Returns
     -------
     preds : sequence
@@ -1331,7 +1340,11 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
         estimator.fit(X_train, **fit_params)
     else:
         estimator.fit(X_train, y_train, **fit_params)
-    preds = estimator.predict(X_test)
+
+    if predict_proba:
+        preds = estimator.predict_proba(X_test)
+    else:
+        preds = estimator.predict(X_test)
     return preds, test
 
 


### PR DESCRIPTION
Modified cross_validation.cross_val_predict to accept a boolean argument 'predict_probas' and return probability estimates instead of predicted targets. Example 'cv_brier_score.py' included.
