### PR TITLE
correct optional arguments for FeatureHasher

### DIFF
--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -40,11 +40,11 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    dtype : numpy type, optional
+    dtype : numpy type, optional, default np.float64
         The type of feature values. Passed to scipy.sparse matrix constructors
         as the dtype argument. Do not set this to bool, np.boolean or any
         unsigned integer type.
-    input_type : string, optional
+    input_type : string, optional, default "dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.
@@ -53,7 +53,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         The feature_name is hashed to find the appropriate column for the
         feature. The value's sign might be flipped in the output (but see
         non_negative, below).
-    non_negative : boolean, optional, default np.float64
+    non_negative : boolean, optional, default False
         Whether output matrices should contain non-negative values only;
         effectively calls abs on the matrix prior to returning it.
         When True, output values can be interpreted as frequencies.
@@ -68,7 +68,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
     >>> f.toarray()
     array([[ 0.,  0., -4., -1.,  0.,  0.,  0.,  0.,  0.,  2.],
            [ 0.,  0.,  0., -2., -5.,  0.,  0.,  0.,  0.,  0.]])
-           
+
     See also
     --------
     DictVectorizer : vectorizes string-valued features using a hash table.


### PR DESCRIPTION
I noticed that the optional argumentsin the docstring for the FeatureHasher were incorrect (the default for non_negative was np.float64).  This is just a quick change to correct that as well as document the other default arguments.
