### PR TITLE
As a user I want a function similar cross_val_predict which instead returns probabilities

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -215,6 +215,11 @@ Enhancements
      attribute to select important features of the input data. By
      `Maheshakya Wijewardena`_, `Joel Nothman`_ and `Manoj Kumar`_.
 
+    - Added predict function argument to :func:`cross_validation.cross_val_predict`, as a
+    string or list of strings. This avoids the need for multiple (potentially costly) fits if
+    multiple types of predictions are required.
+    By `Paul Triantafyllou`_.
+
 Bug fixes
 .........
 

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1194,22 +1194,28 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                       verbose=0, fit_params=None, pre_dispatch='2*n_jobs',
                       predict_function='predict'):
     """Generate cross-validated estimates for each input data point
+    Read more in the :ref:`User Guide <cross_validation>`.
     Parameters
     ----------
-    estimator : estimator must implement 'fit' and the methods(s) specified by
-        predict_function
+    estimator : estimator object implementing 'fit' and the methods(s)
+        specified by ``predict_function``.
     X : array-like
         The data to fit. Can be, for example a list, or an array at least 2d.
     y : array-like, optional, default: None
         The target variable to try to predict in the case of
         supervised learning.
-    cv : cross-validation generator or int, optional, default: None
-        A cross-validation generator to use. If int, determines
-        the number of folds in StratifiedKFold if y is binary
-        or multiclass and estimator is a classifier, or the number
-        of folds in KFold otherwise. If None, it is equivalent to cv=3.
-        This generator must include all elements in the test set exactly once.
-        Otherwise, a ValueError is raised.
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+          - None, to use the default 3-fold cross-validation,
+          - integer, to specify the number of folds.
+          - An object to be used as a cross-validation generator.
+          - An iterable yielding train/test splits.
+        For integer/None inputs, if ``y`` is binary or multiclass,
+        :class:`StratifiedKFold` used. If the estimator is a classifier
+        or if ``y`` is neither binary nor multiclass, :class:`KFold` is used.
+        Refer :ref:`User Guide <cross_validation>` for the various
+        cross-validation strategies that can be used here.
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
@@ -1230,17 +1236,13 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
               spawned
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
-    predict_function : string, or list, optional
+    predict_function : string, or list of string
         Specifies the prediction method(s) to invoke on the provided estimator.
-        For example, 'predict_proba' or 'decision_function'. If a list of
-        methods is provided, then a tuple of predictions will be returned in
-        identical order.
-
     Returns
     -------
     preds : ndarray, or tuple of ndarray
-        This is the result of calling the method(s) provided in parameter
-        predict_function.
+        This is the result of calling the method(s) specified in parameter
+        ``predict_function``.
     """
     X, y = indexable(X, y)
 
@@ -1294,11 +1296,11 @@ def _concat_arrays(arrays):
 def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
                      predict_function='predict'):
     """Fit estimator and predict values for a given dataset split.
+    Read more in the :ref:`User Guide <cross_validation>`.
     Parameters
     ----------
-    estimator : estimator object
-        estimator must implement 'fit' and the methods(s) specified by
-        predict_function
+    estimator : estimator object implementing 'fit' and the methods(s)
+        specified by ``predict_function``.
     X : array-like of shape at least 2D
         The data to fit.
     y : array-like, optional, default: None
@@ -1312,13 +1314,13 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         The verbosity level.
     fit_params : dict or None
         Parameters that will be passed to ``estimator.fit``.
-    predict_function : string, or list
+    predict_function : string, or list of string
         Specifies the prediction method(s) to invoke on the provided estimator.
     Returns
     -------
     preds : ndarray, or tuple of ndarray
-        This is the result of calling the method(s) provided in parameter
-        predict_function.
+        This is the result of calling the method(s) specified in parameter
+        ``predict_function``.
     test : array-like
         This is the value of the test parameter
     """

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1191,69 +1191,56 @@ def _index_param_value(X, v, indices):
 
 
 def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
-                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs'):
+                      verbose=0, fit_params=None, pre_dispatch='2*n_jobs',
+                      predict_function='predict'):
     """Generate cross-validated estimates for each input data point
-
-    Read more in the :ref:`User Guide <cross_validation>`.
-
     Parameters
     ----------
-    estimator : estimator object implementing 'fit' and 'predict'
-        The object to use to fit the data.
-
+    estimator : estimator must implement 'fit' and the methods(s) specified by
+        predict_function
     X : array-like
         The data to fit. Can be, for example a list, or an array at least 2d.
-
     y : array-like, optional, default: None
         The target variable to try to predict in the case of
         supervised learning.
-
-    cv : int, cross-validation generator or an iterable, optional
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
-          - None, to use the default 3-fold cross-validation,
-          - integer, to specify the number of folds.
-          - An object to be used as a cross-validation generator.
-          - An iterable yielding train/test splits.
-
-        For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`StratifiedKFold` used. If the estimator is a classifier
-        or if ``y`` is neither binary nor multiclass, :class:`KFold` is used.
-
-        Refer :ref:`User Guide <cross_validation>` for the various
-        cross-validation strategies that can be used here.
-
+    cv : cross-validation generator or int, optional, default: None
+        A cross-validation generator to use. If int, determines
+        the number of folds in StratifiedKFold if y is binary
+        or multiclass and estimator is a classifier, or the number
+        of folds in KFold otherwise. If None, it is equivalent to cv=3.
+        This generator must include all elements in the test set exactly once.
+        Otherwise, a ValueError is raised.
     n_jobs : integer, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
-
     verbose : integer, optional
         The verbosity level.
-
     fit_params : dict, optional
         Parameters to pass to the fit method of the estimator.
-
     pre_dispatch : int, or string, optional
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an
         explosion of memory consumption when more jobs get dispatched
         than CPUs can process. This parameter can be:
-
             - None, in which case all the jobs are immediately
               created and spawned. Use this for lightweight and
               fast-running jobs, to avoid delays due to on-demand
               spawning of the jobs
-
             - An int, giving the exact number of total jobs that are
               spawned
-
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
+    predict_function : string, or list, optional
+        Specifies the prediction method(s) to invoke on the provided estimator.
+        For example, 'predict_proba' or 'decision_function'. If a list of
+        methods is provided, then a tuple of predictions will be returned in
+        identical order.
 
     Returns
     -------
-    preds : ndarray
-        This is the result of calling 'predict'
+    preds : ndarray, or tuple of ndarray
+        This is the result of calling the method(s) provided in parameter
+        predict_function.
     """
     X, y = indexable(X, y)
 
@@ -1264,58 +1251,74 @@ def cross_val_predict(estimator, X, y=None, cv=None, n_jobs=1,
                         pre_dispatch=pre_dispatch)
     preds_blocks = parallel(delayed(_fit_and_predict)(clone(estimator), X, y,
                                                       train, test, verbose,
-                                                      fit_params)
+                                                      fit_params, predict_function)
                             for train, test in cv)
 
-    preds = [p for p, _ in preds_blocks]
+    # obtain original indexes from parallelized predictions
     locs = np.concatenate([loc for _, loc in preds_blocks])
     if not _check_is_partition(locs, _num_samples(X)):
         raise ValueError('cross_val_predict only works for partitions')
     inv_locs = np.empty(len(locs), dtype=int)
     inv_locs[locs] = np.arange(len(locs))
 
-    # Check for sparse predictions
-    if sp.issparse(preds[0]):
-        preds = sp.vstack(preds, format=preds[0].format)
+    # create predictions with correct indexes
+    if isinstance(predict_function, str):
+        concat_pred = _concat_arrays([p for p, _ in preds_blocks])
+        preds = concat_pred[inv_locs]
     else:
-        preds = np.concatenate(preds)
-    return preds[inv_locs]
+        func_preds = list()
+        for func_pred in zip(*(p_tuple for p_tuple, _ in preds_blocks)):
+            concat_pred = _concat_arrays(func_pred)
+            func_preds.append(concat_pred[inv_locs])
+        preds = tuple(func_preds)
+    return preds
 
 
-def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
-    """Fit estimator and predict values for a given dataset split.
-
-    Read more in the :ref:`User Guide <cross_validation>`.
-
+def _concat_arrays(arrays):
+    '''Concatenates a sequence of dense or sparse arrays
     Parameters
     ----------
-    estimator : estimator object implementing 'fit' and 'predict'
-        The object to use to fit the data.
-
-    X : array-like of shape at least 2D
-        The data to fit.
-
-    y : array-like, optional, default: None
-        The target variable to try to predict in the case of
-        supervised learning.
-
-    train : array-like, shape (n_train_samples,)
-        Indices of training samples.
-
-    test : array-like, shape (n_test_samples,)
-        Indices of test samples.
-
-    verbose : integer
-        The verbosity level.
-
-    fit_params : dict or None
-        Parameters that will be passed to ``estimator.fit``.
+    arrays : sequence of array
 
     Returns
     -------
-    preds : sequence
-        Result of calling 'estimator.predict'
+    concat_array : array
+        Concatenated array
+    '''
+    if sp.issparse(arrays[0]):
+        return sp.vstack(arrays, format=arrays[0].format)
+    else:
+        return np.concatenate(arrays)
 
+
+def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
+                     predict_function='predict'):
+    """Fit estimator and predict values for a given dataset split.
+    Parameters
+    ----------
+    estimator : estimator object
+        estimator must implement 'fit' and the methods(s) specified by
+        predict_function
+    X : array-like of shape at least 2D
+        The data to fit.
+    y : array-like, optional, default: None
+        The target variable to try to predict in the case of
+        supervised learning.
+    train : array-like, shape (n_train_samples,)
+        Indices of training samples.
+    test : array-like, shape (n_test_samples,)
+        Indices of test samples.
+    verbose : integer
+        The verbosity level.
+    fit_params : dict or None
+        Parameters that will be passed to ``estimator.fit``.
+    predict_function : string, or list
+        Specifies the prediction method(s) to invoke on the provided estimator.
+    Returns
+    -------
+    preds : ndarray, or tuple of ndarray
+        This is the result of calling the method(s) provided in parameter
+        predict_function.
     test : array-like
         This is the value of the test parameter
     """
@@ -1331,7 +1334,11 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params):
         estimator.fit(X_train, **fit_params)
     else:
         estimator.fit(X_train, y_train, **fit_params)
-    preds = estimator.predict(X_test)
+
+    if isinstance(predict_function, str):
+        preds = getattr(estimator, predict_function)(X_test)
+    else:
+        preds = tuple(getattr(estimator, func)(X_test) for func in predict_function)
     return preds, test
 
 


### PR DESCRIPTION
### Introduction

This pull request targets issue #5090 and enables cross_val_predict to return a prediction or sequence of predictions, controlled by a new `predict_function`parameter. The benefit of this feature lies in the fact that multiple predictions can be returned with only a single fit of an estimator.
### Related
- Issue #5127 
