### PR TITLE
Pass pairwise attribute through MetaEstimatorMixin if present.

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -461,7 +461,11 @@ class TransformerMixin(object):
 ###############################################################################
 class MetaEstimatorMixin(object):
     """Mixin class for all meta estimators in scikit-learn."""
-    # this is just a tag for the moment
+    
+    @property
+    def _pairwise(self):
+        # Indicate if the wrapped estimator is one using a precomputed Gram matrix
+        return getattr(self.estimator, "_pairwise", False)
 
 
 ###############################################################################


### PR DESCRIPTION
I raised this issue a while back on the [mailing list](http://sourceforge.net/p/scikit-learn/mailman/message/34450663/).
When using `GridSearchCV` on a `MetaEstimator` wrapping an `SVC` (_not_ `LinearSVC`) with a `precomputed=True` the Gram matrix does not get sliced correctly.
For me this was occurring because the default One-vs-One strategy for the SVC is not what I want.
This patch tells `GridSearchCV` that the input needs to be sliced along both dimensions.

As stated before, I am not deep enough into the code base to see if this will have any drawbacks but for me this has been working well for some time and it does not change the test results i get when calling `make`.
