### PR TITLE
[MRG+1] Update joblib to 0.9.2

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -151,6 +151,9 @@ Enhancements
      and later in order to avoid possible crash with some version of BLAS such
      as vecLib / Accelerate under OSX for instance. By `Olivier Grisel`_.
 
+   - For more details about changes in joblib 0.9.2 see the release notes:
+     https://github.com/joblib/joblib/blob/master/CHANGES.rst#release-092
+
    - Improved speed (3 times per iteration) of
      :class:`decomposition.DictLearning` with coordinate descent method
      from :class:`linear_model.Lasso`. By `Arthur Mensch`_.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -139,14 +139,14 @@ Enhancements
    - RCV1 dataset loader (:func:`sklearn.datasets.fetch_rcv1`).
      By `Tom Dupre la Tour`_.
 
-   - Upgraded to joblib 0.9.0b4 to benefit from the new automatic batching of
+   - Upgraded to joblib 0.9.2 to benefit from the new automatic batching of
      short tasks. This makes it possible for scikit-learn to benefit from
      parallelism when many very short tasks are executed in parallel, for
      instance by the :class:`grid_search.GridSearchCV` meta-estimator
      with ``n_jobs > 1`` used with a large grid of parameters on a small
      dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and `Loic Esteve`_.
 
-   - Joblib 0.9.0b4 also enables the ``forkserver`` start method for
+   - Joblib 0.9.2 also enables the ``forkserver`` start method for
      multiprocessing by default under non-Windows platforms for Python 3.4
      and later in order to avoid possible crash with some version of BLAS such
      as vecLib / Accelerate under OSX for instance. By `Olivier Grisel`_.

--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -58,7 +58,6 @@ Main features
    inputs and  outputs: Python functions. Joblib can save their
    computation to disk and rerun it only if necessary::
 
-      >>> import numpy as np
       >>> from sklearn.externals.joblib import Memory
       >>> mem = Memory(cachedir='/tmp/joblib')
       >>> import numpy as np
@@ -116,7 +115,7 @@ Main features
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.9.0b4'
+__version__ = '0.9.2'
 
 
 from .memory import Memory, MemorizedResult

--- a/sklearn/externals/joblib/_compat.py
+++ b/sklearn/externals/joblib/_compat.py
@@ -4,6 +4,7 @@ Compatibility layer for Python 3/Python 2 single codebase
 
 try:
     _basestring = basestring
+    _bytes_or_unicode = (str, unicode)
 except NameError:
     _basestring = str
-
+    _bytes_or_unicode = (bytes, str)

--- a/sklearn/externals/joblib/hashing.py
+++ b/sklearn/externals/joblib/hashing.py
@@ -13,13 +13,16 @@ import hashlib
 import sys
 import types
 import struct
+from ._compat import _bytes_or_unicode
 
 import io
 
-if sys.version_info[0] < 3:
-    Pickler = pickle.Pickler
-else:
+PY3 = sys.version[0] == '3'
+
+if PY3:
     Pickler = pickle._Pickler
+else:
+    Pickler = pickle.Pickler
 
 
 class _ConsistentSet(object):
@@ -44,7 +47,11 @@ class Hasher(Pickler):
 
     def __init__(self, hash_name='md5'):
         self.stream = io.BytesIO()
-        Pickler.__init__(self, self.stream, protocol=2)
+        # By default we want a pickle protocol that only changes with
+        # the major python version and not the minor one
+        protocol = (pickle.DEFAULT_PROTOCOL if PY3
+                    else pickle.HIGHEST_PROTOCOL)
+        Pickler.__init__(self, self.stream, protocol=protocol)
         # Initialise the hash obj
         self._hash = hashlib.new(hash_name)
 
@@ -76,6 +83,15 @@ class Hasher(Pickler):
                 cls = obj.__self__.__class__
                 obj = _MyHash(func_name, inst, cls)
         Pickler.save(self, obj)
+
+    def memoize(self, obj):
+        # We want hashing to be sensitive to value instead of reference.
+        # For example we want ['aa', 'aa'] and ['aa', 'aaZ'[:2]]
+        # to hash to the same value and that's why we disable memoization
+        # for strings
+        if isinstance(obj, _bytes_or_unicode):
+            return
+        Pickler.memoize(self, obj)
 
     # The dispatch table of the pickler is not accessible in Python
     # 3, as these lines are only bugware for IPython, we skip them.
@@ -186,6 +202,20 @@ class NumpyHasher(Hasher):
 
             # The object will be pickled by the pickler hashed at the end.
             obj = (klass, ('HASHED', obj.dtype, obj.shape, obj.strides))
+        elif isinstance(obj, self.np.dtype):
+            # Atomic dtype objects are interned by their default constructor:
+            # np.dtype('f8') is np.dtype('f8')
+            # This interning is not maintained by a
+            # pickle.loads + pickle.dumps cycle, because __reduce__
+            # uses copy=True in the dtype constructor. This
+            # non-deterministic behavior causes the internal memoizer
+            # of the hasher to generate different hash values
+            # depending on the history of the dtype object.
+            # To prevent the hash from being sensitive to this, we use
+            # .descr which is a full (and never interned) description of
+            # the array dtype according to the numpy doc.
+            klass = obj.__class__
+            obj = (klass, ('HASHED', obj.descr))
         Hasher.save(self, obj)
 
 

--- a/sklearn/externals/joblib/memory.py
+++ b/sklearn/externals/joblib/memory.py
@@ -881,7 +881,8 @@ class Memory(Logger):
         """
         if warn:
             self.warn('Flushing completely the cache')
-        rm_subdirs(self.cachedir)
+        if self.cachedir is not None:
+            rm_subdirs(self.cachedir)
 
     def eval(self, func, *args, **kwargs):
         """ Eval function func with arguments `*args` and `**kwargs`,


### PR DESCRIPTION
Main change from 0.9.0b4 to 0.9.0 was to revert our attempt to make Python 2/3 compatible pickles, which proved too fragile as far as long-term maintenance was concerned.

This should fix #5241 too.

Should I add an entry into whats_new.rst ? I guess there is no new feature per se since 0.9.0b4.
