### PR TITLE
DOC wrong default value in docstring

### DIFF
--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -264,7 +264,7 @@ X : array-like, shape = [n_samples, n_features]
     Note: if X is a C-contiguous array of doubles then data will
     not be copied. Otherwise, an internal copy will be made.
 
-leaf_size : positive integer (default = 20)
+leaf_size : positive integer (default = 40)
     Number of points at which to switch to brute-force. Changing
     leaf_size will not affect the results of a query, but can
     significantly impact the speed of a query and the memory required


### PR DESCRIPTION
Default leaf_size in docstring (leaf_size=20) of KDTree does not agree with function signature or code (leaf_size=40).
