### PR TITLE
[MRG] DOC: correct docstring (trivial, please review and merge)

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -1057,7 +1057,7 @@ class RidgeCV(_BaseRidgeCV, RegressorMixin):
     cv : int, cross-validation generator or an iterable, optional
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
-          - None, to use the default 3-fold cross-validation,
+          - None, to use the efficient Leave-One-Out cross-validation
           - integer, to specify the number of folds.
           - An object to be used as a cross-validation generator.
           - An iterable yielding train/test splits.


### PR DESCRIPTION
Trivial fix to correct a docstring that was wrong: None wasn't doing default 3-fold CV, but LOO in RidgeCV.
