### PR TITLE
Typo on doc for default value of solver for lda.LDA

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -143,9 +143,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     ----------
     solver : string, optional
         Solver to use, possible values:
-          - 'svd': Singular value decomposition (default). Does not compute the
-                covariance matrix, therefore this solver is recommended for
-                data with a large number of features.
+          - 'svd': Singular value decomposition (default).
+                Does not compute the covariance matrix, therefore this solver is
+                recommended for data with a large number of features.
           - 'lsqr': Least squares solution, can be combined with shrinkage.
           - 'eigen': Eigenvalue decomposition, can be combined with shrinkage.
 


### PR DESCRIPTION
Fix a tiny tiny style issue on the documentation for the default value of the `solver` parameter for lda.LDA.

[sklearn.lda.LDA.html](http://scikit-learn.org/stable/modules/generated/sklearn.lda.LDA.html#sklearn.lda.LDA) displayed badly (cf screenshot): half the sentence is bold and half is not.
![bug_display_sklearn_lda_lda](https://cloud.githubusercontent.com/assets/11994719/10541397/f9729060-7410-11e5-96de-eccbc0047365.png)
