### PR TITLE
[MRG + 2] Add check to regression models to raise error when targets are NaN

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -210,6 +210,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
         """
         # Validate or convert input data
         X, y = check_X_y(X, y, accept_sparse="csc", dtype=DTYPE)
+        y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
         if issparse(X):
             # Pre-sort indices to avoid that each individual tree of the
             # ensemble sorts the indices.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -209,7 +209,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
             Returns self.
         """
         # Validate or convert input data
-        X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+        X, y = check_X_y(X, y, accept_sparse="csc", dtype=DTYPE)
         if issparse(X):
             # Pre-sort indices to avoid that each individual tree of the
             # ensemble sorts the indices.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -209,7 +209,7 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
             Returns self.
         """
         # Validate or convert input data
-        X, y = check_X_y(X, y, accept_sparse="csc", dtype=DTYPE)
+        X = check_array(X, accept_sparse="csc", dtype=DTYPE)
         y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
         if issparse(X):
             # Pre-sort indices to avoid that each individual tree of the

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1642,7 +1642,7 @@ class MultiTaskElasticNet(Lasso):
         # X and y must be of type float64
         X = check_array(X, dtype=np.float64, order='F',
                         copy=self.copy_X and self.fit_intercept)
-        y = np.asarray(y, dtype=np.float64)
+        y = check_array(y, dtype=np.float64, ensure_2d=False)
 
         if hasattr(self, 'l1_ratio'):
             model_str = 'ElasticNet'

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -10,8 +10,8 @@ from . import libsvm_sparse
 from ..base import BaseEstimator, ClassifierMixin
 from ..preprocessing import LabelEncoder
 from ..multiclass import _ovr_decision_function
-from ..utils import check_array, check_random_state, column_or_1d
-from ..utils import compute_class_weight, deprecated
+from ..utils import check_array, check_random_state, column_or_1d, check_X_y
+from ..utils import ConvergenceWarning, compute_class_weight, deprecated
 from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..utils.multiclass import check_classification_targets
@@ -151,7 +151,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise TypeError("Sparse precomputed kernels are not supported.")
         self._sparse = sparse and not callable(self.kernel)
 
-        X = check_array(X, accept_sparse='csr', dtype=np.float64, order='C')
+        #X = check_array(X, accept_sparse='csr', dtype=np.float64, order='C')
+        X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
         y = self._validate_targets(y)
 
         sample_weight = np.asarray([]

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -151,7 +151,6 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise TypeError("Sparse precomputed kernels are not supported.")
         self._sparse = sparse and not callable(self.kernel)
 
-        #X = check_array(X, accept_sparse='csr', dtype=np.float64, order='C')
         X, y = check_X_y(X, y, dtype=np.float64, order='C', accept_sparse='csr')
         y = self._validate_targets(y)
 

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -11,7 +11,7 @@ from ..base import BaseEstimator, ClassifierMixin
 from ..preprocessing import LabelEncoder
 from ..multiclass import _ovr_decision_function
 from ..utils import check_array, check_random_state, column_or_1d, check_X_y
-from ..utils import ConvergenceWarning, compute_class_weight, deprecated
+from ..utils import compute_class_weight, deprecated
 from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..utils.multiclass import check_classification_targets

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -28,7 +28,7 @@ from ..base import ClassifierMixin
 from ..base import RegressorMixin
 from ..externals import six
 from ..feature_selection.from_model import _LearntSelectorMixin
-from ..utils import check_array
+from ..utils import check_array, check_X_y
 from ..utils import check_random_state
 from ..utils import compute_sample_weight
 from ..utils.multiclass import check_classification_targets
@@ -150,7 +150,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         random_state = check_random_state(self.random_state)
         if check_input:
-            X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+            X, y = check_X_y(X, y, dtype=DTYPE, accept_sparse="csc")
             if issparse(X):
                 X.sort_indices()
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -150,7 +150,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         random_state = check_random_state(self.random_state)
         if check_input:
-            X, y = check_X_y(X, y, dtype=DTYPE, accept_sparse="csc")
+            X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+            y = check_array(y, accept_sparse='csc', ensure_2d=None, dtype=None)
             if issparse(X):
                 X.sort_indices()
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -151,7 +151,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         random_state = check_random_state(self.random_state)
         if check_input:
             X = check_array(X, dtype=DTYPE, accept_sparse="csc")
-            y = check_array(y, accept_sparse='csc', ensure_2d=None, dtype=None)
+            y = check_array(y, accept_sparse='csc', ensure_2d=False, dtype=None)
             if issparse(X):
                 X.sort_indices()
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -230,10 +230,10 @@ def check_estimator(Estimator):
     Parameters
     ----------
     Estimator : class
-        Class to check.
+        Class to check. Estimator is a class object (not an instance).
 
     """
-    name = Estimator.__class__.__name__
+    name = Estimator.__name__
     check_parameters_default_constructible(name, Estimator)
     for check in _yield_all_checks(name, Estimator):
         check(name, Estimator)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -131,6 +131,22 @@ def _yield_classifier_checks(name, Classifier):
     if 'class_weight' in Classifier().get_params().keys():
         yield check_class_weight_classifiers
 
+def check_supervised_y_no_nan(name, Estimator):
+    if "MultiTask" in name:
+        # The following checks are only those that work on 1d y's
+        # TODO: Test with Multitask later
+        return
+    X = np.random.randn(10, 5)
+    y = np.random.randn(10) / 0.
+    errmsg = "Input contains NaN, infinity or a value too large for " \
+             "dtype('float64')."
+    try:
+        Estimator().fit(X, y)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Estimator {0} should have raised error on fitting "
+                         "array with NaN value.".format(Estimator.__name__))
 
 def _yield_regressor_checks(name, Regressor):
     # TODO: test with intercept
@@ -141,6 +157,7 @@ def _yield_regressor_checks(name, Regressor):
     yield check_estimators_partial_fit_n_features
     yield check_regressors_no_decision_function
     yield check_supervised_y_2d
+    yield check_supervised_y_no_nan
     if name != 'CCA':
         # check that the regressor handles int input
         yield check_regressors_int

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -136,16 +136,13 @@ def check_supervised_y_no_nan(name, Estimator):
 
     rng = np.random.RandomState(888)
     X = rng.randn(10, 5)
-    y1 = np.ones(10) * np.inf
-    y2 = np.ones((10, 2)) * np.inf
+    y = np.ones(10) * np.inf
 
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
     try:
-        if "MultiTask" in name:
-            Estimator().fit(X, y2)
-        else:
-            Estimator().fit(X, y1)
+        y = multioutput_estimator_convert_y_2d(name, y)
+        Estimator().fit(X, y)
     except ValueError as e:
         if str(e) != errmsg:
             raise ValueError("Estimator {0} raised warning as expected, but "
@@ -1469,7 +1466,7 @@ def check_non_transformer_estimators_n_iter(name, estimator,
     X, y_ = iris.data, iris.target
 
     if multi_output:
-        y_ = y_[:, np.newaxis]
+        y_ = np.reshape(y_, (-1, 1))
 
     set_random_state(estimator, 0)
     if name == 'AffinityPropagation':

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -148,8 +148,8 @@ def check_supervised_y_no_nan(name, Estimator):
             Estimator().fit(X, y1)
     except ValueError as e:
         if e.message != errmsg:
-            warnings.warn("Estimator {0} raised warning as expected, but "
-                          "does not match expected error message")
+            raise ValueError("Estimator {0} raised warning as expected, but "
+                             "does not match expected error message")
     else:
         raise ValueError("Estimator {0} should have raised error on fitting "
                          "array with NaN value.".format(Estimator.__name__))
@@ -718,6 +718,7 @@ def check_estimators_empty_data_messages(name, Estimator):
 
 
 def check_estimators_nan_inf(name, Estimator):
+    # Checks that Estimator X's do not contain NaN or inf.
     rnd = np.random.RandomState(0)
     X_train_finite = rnd.uniform(size=(10, 3))
     X_train_nan = rnd.uniform(size=(10, 3))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -153,7 +153,7 @@ def check_supervised_y_no_nan(name, Estimator):
                              .format(name))
     else:
         raise ValueError("Estimator {0} should have raised error on fitting "
-                         "array with NaN value.".format(name))
+                         "array y with NaN value.".format(name))
 
 def _yield_regressor_checks(name, Regressor):
     # TODO: test with intercept

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -135,6 +135,7 @@ def check_supervised_y_no_nan(name, Estimator):
     # Checks that the Estimator targets are not NaN.
 
     warnings.simplefilter("ignore")
+    np.random.seed(888)
     X = np.random.randn(10, 5)
     y1 = np.random.randn(10) / 0.
     y2 = np.random.randn(10, 2) / 0.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -142,17 +142,18 @@ def check_supervised_y_no_nan(name, Estimator):
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
     try:
-        if "MultiTask" in Estimator.__name__:
+        if "MultiTask" in name:
             Estimator().fit(X, y2)
         else:
             Estimator().fit(X, y1)
     except ValueError as e:
-        if e.message != errmsg:
+        if str(e) != errmsg:
             raise ValueError("Estimator {0} raised warning as expected, but "
-                             "does not match expected error message")
+                             "does not match expected error message" \
+                             .format(name))
     else:
         raise ValueError("Estimator {0} should have raised error on fitting "
-                         "array with NaN value.".format(Estimator.__name__))
+                         "array with NaN value.".format(name))
 
 def _yield_regressor_checks(name, Regressor):
     # TODO: test with intercept

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -142,7 +142,7 @@ def check_supervised_y_no_nan(name, Estimator):
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
     try:
-        if "MultiTask" in name:
+        if "MultiTask" in Estimator.__name__:
             Estimator().fit(X, y2)
         else:
             Estimator().fit(X, y1)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -134,11 +134,10 @@ def _yield_classifier_checks(name, Classifier):
 def check_supervised_y_no_nan(name, Estimator):
     # Checks that the Estimator targets are not NaN.
 
-    warnings.simplefilter("ignore")
     np.random.seed(888)
     X = np.random.randn(10, 5)
-    y1 = np.random.randn(10) / 0.
-    y2 = np.random.randn(10, 2) / 0.
+    y1 = np.ones(10) * np.inf
+    y2 = np.ones((10, 2)) * np.inf
 
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
@@ -1457,9 +1456,8 @@ def check_parameters_default_constructible(name, Estimator):
 def multioutput_estimator_convert_y_2d(name, y):
     # Estimators in mono_output_task_error raise ValueError if y is of 1-D
     # Convert into a 2-D y for those estimators.
-    if name in (['MultiTaskElasticNetCV', 'MultiTaskLassoCV',
-                 'MultiTaskLasso', 'MultiTaskElasticNet']):
-        return y[:, np.newaxis]
+    if "MultiTask" in name:
+        return np.reshape(y, (-1, 1))
     return y
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -132,18 +132,24 @@ def _yield_classifier_checks(name, Classifier):
         yield check_class_weight_classifiers
 
 def check_supervised_y_no_nan(name, Estimator):
-    if "MultiTask" in name:
-        # The following checks are only those that work on 1d y's
-        # TODO: Test with Multitask later
-        return
+    # Checks that the Estimator targets are not NaN.
+
+    warnings.simplefilter("ignore")
     X = np.random.randn(10, 5)
-    y = np.random.randn(10) / 0.
+    y1 = np.random.randn(10) / 0.
+    y2 = np.random.randn(10, 2) / 0.
+
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
     try:
-        Estimator().fit(X, y)
-    except ValueError:
-        pass
+        if "MultiTask" in name:
+            Estimator().fit(X, y2)
+        else:
+            Estimator().fit(X, y1)
+    except ValueError as e:
+        if e.message != errmsg:
+            warnings.warn("Estimator {0} raised warning as expected, but "
+                          "does not match expected error message")
     else:
         raise ValueError("Estimator {0} should have raised error on fitting "
                          "array with NaN value.".format(Estimator.__name__))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -137,11 +137,11 @@ def check_supervised_y_no_nan(name, Estimator):
     rng = np.random.RandomState(888)
     X = rng.randn(10, 5)
     y = np.ones(10) * np.inf
+    y = multioutput_estimator_convert_y_2d(name, y)
 
     errmsg = "Input contains NaN, infinity or a value too large for " \
              "dtype('float64')."
     try:
-        y = multioutput_estimator_convert_y_2d(name, y)
         Estimator().fit(X, y)
     except ValueError as e:
         if str(e) != errmsg:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -134,8 +134,8 @@ def _yield_classifier_checks(name, Classifier):
 def check_supervised_y_no_nan(name, Estimator):
     # Checks that the Estimator targets are not NaN.
 
-    np.random.seed(888)
-    X = np.random.randn(10, 5)
+    rng = np.random.RandomState(888)
+    X = rng.randn(10, 5)
     y1 = np.ones(10) * np.inf
     y2 = np.ones((10, 2)) * np.inf
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -8,6 +8,7 @@ from sklearn.utils.testing import assert_raises_regex, assert_true
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import check_estimators_unfitted
 from sklearn.ensemble import AdaBoostClassifier
+from sklearn.linear_model import MultiTaskElasticNet
 from sklearn.utils.validation import check_X_y, check_array
 
 
@@ -93,6 +94,7 @@ def test_check_estimator():
 
     # doesn't error on actual estimator
     check_estimator(AdaBoostClassifier)
+    check_estimator(MultiTaskElasticNet)
 
 
 def test_check_estimators_unfitted():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -75,7 +75,8 @@ def test_check_estimator():
     msg = "Estimator doesn't check for NaN and inf in predict"
     assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)
     # check for sparse matrix input handling
-    msg = "Estimator type doesn't seem to fail gracefully on sparse data"
+    name = NoSparseClassifier.__name__
+    msg = "Estimator " + name + " doesn't seem to fail gracefully on sparse data"
     # the check for sparse input handling prints to the stdout,
     # instead of raising an error, so as not to remove the original traceback.
     # that means we need to jump through some hoops to catch it.


### PR DESCRIPTION
Addressing issue #5322.

This pull request addresses the following issues:
- [x] Having regression models raise errors when targets are nan / inf
  -  [x] Addresses change in at least 4 files that include models
  -  [x] Regression tests for this error
- [x] A bug in `_yield_regressor_checks` that prevents tests from being run on certain models
  - [x] Regression test added in 0977c9f
