### PR TITLE
[MRG+1] The code was raising an exception while plotting 2nd curve

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -441,7 +441,8 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
 
     drop_intermediate : boolean, optional (default=True)
         Whether to drop some suboptimal thresholds which would not appear
-        on a plotted ROC curve.
+        on a plotted ROC curve. This is useful in order to create lighter
+        ROC curves.
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -354,7 +354,7 @@ def test_roc_curve_drop_intermediate():
     # Test that drop_intermediate drops the correct thresholds
     y_true = [0, 0, 0, 0, 1, 1]
     y_score = [0., 0.2, 0.5, 0.6, 0.7, 1.0]
-    tpr, fpr, thresholds = roc_curve(y_true, y_score)
+    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds, [1., 0.7, 0.])
 
     # Test dropping thresholds with repeating scores
@@ -362,7 +362,7 @@ def test_roc_curve_drop_intermediate():
               1, 1, 1, 1, 1, 1]
     y_score = [0., 0.1, 0.6, 0.6, 0.7, 0.8, 0.9,
                0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
-    tpr, fpr, thresholds = roc_curve(y_true, y_score)
+    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds,
                               [1.0, 0.9, 0.7, 0.6, 0.])
 


### PR DESCRIPTION
To compute macro-average roc we needed to compute the mean of fpr computed for each class. If we do not set drop_intermediate=False this leads to an error as our fpr arrays have different shapes.
