### PR TITLE
[MRG + 1] : documentation, referencing datasets documentation in toc

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -266,3 +266,27 @@ features::
 .. include:: covtype.rst
 
 .. include:: rcv1.rst
+
+.. _boston_house_prices
+
+.. include:: ../../sklearn/datasets/descr/boston_house_prices.rst
+
+.. _breast_cancer
+
+.. include:: ../../sklearn/datasets/descr/breast_cancer.rst
+
+.. _diabetes
+
+.. include:: ../../sklearn/datasets/descr/diabetes.rst
+
+.. _digits
+
+.. include:: ../../sklearn/datasets/descr/digits.rst
+
+.. _iris
+
+.. include:: ../../sklearn/datasets/descr/iris.rst
+
+.. _linnerud
+
+.. include:: ../../sklearn/datasets/descr/linnerud.rst

--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -1,4 +1,5 @@
 Boston House Prices dataset
+===========================
 
 Notes
 ------

--- a/sklearn/datasets/descr/breast_cancer.rst
+++ b/sklearn/datasets/descr/breast_cancer.rst
@@ -1,4 +1,5 @@
 Breast Cancer Wisconsin (Diagnostic) Database
+=============================================
 
 Notes
 -----

--- a/sklearn/datasets/descr/diabetes.rst
+++ b/sklearn/datasets/descr/diabetes.rst
@@ -1,4 +1,5 @@
 Diabetes dataset
+================
 
 Notes
 -----

--- a/sklearn/datasets/descr/digits.rst
+++ b/sklearn/datasets/descr/digits.rst
@@ -1,4 +1,5 @@
  Optical Recognition of Handwritten Digits Data Set
+===================================================
 
 Notes
 -----

--- a/sklearn/datasets/descr/iris.rst
+++ b/sklearn/datasets/descr/iris.rst
@@ -1,4 +1,5 @@
 Iris Plants Database
+====================
 
 Notes
 -----

--- a/sklearn/datasets/descr/linnerud.rst
+++ b/sklearn/datasets/descr/linnerud.rst
@@ -1,4 +1,5 @@
 Linnerrud dataset
+=================
 
 Notes
 -----


### PR DESCRIPTION
Fixes #5432.

I moved the datasets rst files from sklearn/datasets/descr to doc/datasets and referenced those file in the index.rst. The involved files were : boston_house_prices.rst, breast_cancer.rst, diabetes.rst, digits.rst, iris.rst and linnerud.rst. Each of those files were slightly changed in order to use the same title levels and reference.
