### PR TITLE
[MRG+1] Optimize sklearn.manifold._graph_is_connected

### DIFF
--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -47,15 +47,17 @@ def _graph_connected_component(graph, node_id):
     nodes_to_explore = np.zeros(shape=(graph.shape[0]), dtype=np.bool)
     nodes_to_explore[node_id] = True
     n_node = graph.shape[0]
+    nodes_to_add = np.zeros(shape=(graph.shape[0]), dtype=np.bool)
     for i in range(n_node):
-        nodes_to_add = np.zeros(shape=(graph.shape[0]), dtype=np.bool)
+        nodes_to_add.fill(False)
         for i in np.where(nodes_to_explore)[0]:
             nodes_to_add = np.logical_or(nodes_to_add, graph[i] != 0)
         connected_components_matrix = np.logical_or(
             connected_components_matrix, nodes_to_explore)
         if not nodes_to_add.any():
             break
-        nodes_to_explore = nodes_to_add
+        # Swap arrays
+        nodes_to_explore, nodes_to_add = nodes_to_add, nodes_to_explore
     return connected_components_matrix
 
 

--- a/sklearn/manifold/spectral_embedding_.py
+++ b/sklearn/manifold/spectral_embedding_.py
@@ -44,14 +44,18 @@ def _graph_connected_component(graph, node_id):
     """
     connected_components_matrix = np.zeros(
         shape=(graph.shape[0]), dtype=np.bool)
-    connected_components_matrix[node_id] = True
+    nodes_to_explore = np.zeros(shape=(graph.shape[0]), dtype=np.bool)
+    nodes_to_explore[node_id] = True
     n_node = graph.shape[0]
     for i in range(n_node):
-        last_num_component = connected_components_matrix.sum()
-        _, node_to_add = np.where(graph[connected_components_matrix] != 0)
-        connected_components_matrix[node_to_add] = True
-        if last_num_component >= connected_components_matrix.sum():
+        nodes_to_add = np.zeros(shape=(graph.shape[0]), dtype=np.bool)
+        for i in np.where(nodes_to_explore)[0]:
+            nodes_to_add = np.logical_or(nodes_to_add, graph[i] != 0)
+        connected_components_matrix = np.logical_or(
+            connected_components_matrix, nodes_to_explore)
+        if not nodes_to_add.any():
             break
+        nodes_to_explore = nodes_to_add
     return connected_components_matrix
 
 

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -11,6 +11,7 @@ from nose.plugins.skip import SkipTest
 
 from sklearn.manifold.spectral_embedding_ import SpectralEmbedding
 from sklearn.manifold.spectral_embedding_ import _graph_is_connected
+from sklearn.manifold.spectral_embedding_ import _graph_connected_component
 from sklearn.manifold import spectral_embedding
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.metrics import normalized_mutual_info_score
@@ -56,6 +57,15 @@ def test_spectral_embedding_two_components(seed=36):
     # second component
     affinity[n_sample::,
              n_sample::] = np.abs(random_state.randn(n_sample, n_sample)) + 2
+
+    # Test of internal _graph_connected_component before connection
+    component = _graph_connected_component(affinity, 0)
+    assert_true(component[:n_sample].all())
+    assert_true(not component[n_sample:].any())
+    component = _graph_connected_component(affinity, -1)
+    assert_true(not component[:n_sample].any())
+    assert_true(component[n_sample:].all())
+
     # connection
     affinity[0, n_sample + 1] = 1
     affinity[n_sample + 1, 0] = 1


### PR DESCRIPTION
Fix #5024.

This is a naive fix where I use a temporary array to store the nodes to be explored and another one with the nodes to add in the current loop. This can probably be optimized by using a single integer array but the code would be less intuitive and the memory saved would be very small.

I can switch to cython if needed but the current proposition seems optimized enough. I did not add doc since variable names are self explanatory.

I tested it with a degenerated graph using the following code:

``` python
size = 2000
a = np.zeros((size, size), dtype=float)

for i in range(size - 1):
    a[i, i + 1] = 1.

_graph_connected_component(a, 0)
```

Before optimization, memory consumption looks like:
![before](https://cloud.githubusercontent.com/assets/1647301/10574882/15541f52-7659-11e5-8c4a-a433326b5446.png)
And after:
![after](https://cloud.githubusercontent.com/assets/1647301/10574887/1ad61cb4-7659-11e5-8911-bdea60722f22.png)

It is faster and consumes less memory.
