### PR TITLE
Deprecate residues_ in LinearRegression

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -392,6 +392,12 @@ class LinearRegression(LinearModel, RegressorMixin):
         self.copy_X = copy_X
         self.n_jobs = n_jobs
 
+    @property
+    @deprecated("residues_ is deprecated and will be removed in 0.19")
+    def residues_(self):
+        """Get the residues of the fitted model."""
+        return self._residues
+
     def fit(self, X, y, sample_weight=None):
         """
         Fit linear model.
@@ -440,7 +446,7 @@ class LinearRegression(LinearModel, RegressorMixin):
                 self.coef_ = np.vstack(out[0] for out in outs)
                 self.residues_ = np.vstack(out[3] for out in outs)
         else:
-            self.coef_, self.residues_, self.rank_, self.singular_ = \
+            self.coef_, self._residues, self.rank_, self.singular_ = \
                 linalg.lstsq(X, y)
             self.coef_ = self.coef_.T
 


### PR DESCRIPTION
Residues can be empty if the rank of X does not satisfy the
conditions described in scipy.linalg.lstsq documentation.
As residues are not that useful (i.e. we're not doing
stat testing), this property is deprecated and will be
removed in sklearn 0.19.
See issue https://github.com/scikit-learn/scikit-learn/issues/5313
