### PR TITLE
[MRG + 1] Removed deprecated stuff in 0.18

### DIFF
--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -11,9 +11,6 @@ from ..base import TransformerMixin
 from ..utils import check_array
 from ..utils.validation import check_is_fitted
 
-import warnings
-
-
 ###############################################################################
 # Mixin class for feature agglomeration.
 
@@ -24,7 +21,7 @@ class AgglomerationTransform(TransformerMixin):
 
     pooling_func = np.mean
 
-    def transform(self, X, pooling_func=None):
+    def transform(self, X):
         """
         Transform a new matrix using the built clustering
 
@@ -34,11 +31,6 @@ class AgglomerationTransform(TransformerMixin):
             A M by N array of M observations in N dimensions or a length
             M array of M one-dimensional observations.
 
-        pooling_func : callable, default=np.mean
-            This combines the values of agglomerated features into a single
-            value, and should accept an array of shape [M, N] and the keyword
-            argument `axis=1`, and reduce it to an array of size [M].
-
         Returns
         -------
         Y : array, shape = [n_samples, n_clusters] or [n_clusters]
@@ -46,13 +38,7 @@ class AgglomerationTransform(TransformerMixin):
         """
         check_is_fitted(self, "labels_")
 
-        if pooling_func is not None:
-            warnings.warn("The pooling_func parameter is deprecated since 0.15 "
-                          "and will be removed in 0.18. "
-                          "Pass it to the constructor instead.",
-                          DeprecationWarning)
-        else:
-            pooling_func = self.pooling_func
+        pooling_func = self.pooling_func
         X = check_array(X)
         nX = []
         if len(self.labels_) != X.shape[1]:

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -9,8 +9,6 @@ DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 #
 # License: BSD 3 clause
 
-import warnings
-
 import numpy as np
 from scipy import sparse
 
@@ -24,8 +22,7 @@ from ._dbscan_inner import dbscan_inner
 
 
 def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
-           algorithm='auto', leaf_size=30, p=2, sample_weight=None,
-           random_state=None):
+           algorithm='auto', leaf_size=30, p=2, sample_weight=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
     Read more in the :ref:`User Guide <dbscan>`.
@@ -75,10 +72,6 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
         weight may inhibit its eps-neighbor from being core.
         Note that weights are absolute, and default to 1.
 
-    random_state: numpy.RandomState, optional
-        Deprecated and ignored as of version 0.16, will be removed in version
-        0.18. DBSCAN does not use random initialization.
-
     Returns
     -------
     core_samples : array [n_core_samples]
@@ -109,11 +102,6 @@ def dbscan(X, eps=0.5, min_samples=5, metric='minkowski',
     """
     if not eps > 0.0:
         raise ValueError("eps must be positive.")
-    if random_state is not None:
-        warnings.warn("The parameter random_state is deprecated in 0.16 "
-                      "and will be removed in version 0.18. "
-                      "DBSCAN is deterministic except for rare border cases.",
-                      category=DeprecationWarning)
 
     X = check_array(X, accept_sparse='csr')
     if sample_weight is not None:
@@ -195,9 +183,6 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
-    random_state: numpy.RandomState, optional
-        Deprecated and ignored as of version 0.16, will be removed in version
-        0.18. DBSCAN does not use random initialization.
 
     Attributes
     ----------
@@ -233,14 +218,13 @@ class DBSCAN(BaseEstimator, ClusterMixin):
     """
 
     def __init__(self, eps=0.5, min_samples=5, metric='euclidean',
-                 algorithm='auto', leaf_size=30, p=None, random_state=None):
+                 algorithm='auto', leaf_size=30, p=None):
         self.eps = eps
         self.min_samples = min_samples
         self.metric = metric
         self.algorithm = algorithm
         self.leaf_size = leaf_size
         self.p = p
-        self.random_state = random_state
 
     def fit(self, X, y=None, sample_weight=None):
         """Perform DBSCAN clustering from features or distance matrix.

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -85,8 +85,7 @@ def _fix_connectivity(X, connectivity, n_components=None,
 ###############################################################################
 # Hierarchical tree building functions
 
-def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
-              return_distance=False):
+def ward_tree(X, connectivity=None, n_clusters=None, return_distance=False):
     """Ward clustering based on a Feature matrix.
 
     Recursively merges the pair of clusters that minimally increases
@@ -109,12 +108,6 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
         following a given structure of the data. The matrix is assumed to
         be symmetric and only the upper triangular half is used.
         Default is None, i.e, the Ward algorithm is unstructured.
-
-    n_components : int (optional)
-        Number of connected components. If None the number of connected
-        components is estimated from the connectivity matrix.
-        NOTE: This parameter is now directly determined directly
-        from the connectivity matrix and will be removed in 0.18
 
     n_clusters : int (optional)
         Stop early the construction of the tree at n_clusters. This is
@@ -198,11 +191,6 @@ def ward_tree(X, connectivity=None, n_components=None, n_clusters=None,
         else:
             return children_, 1, n_samples, None
 
-    if n_components is not None:
-        warnings.warn(
-            "n_components is now directly calculated from the connectivity "
-            "matrix and will be removed in 0.18",
-            DeprecationWarning)
     connectivity, n_components = _fix_connectivity(X, connectivity)
     if n_clusters is None:
         n_nodes = 2 * n_samples - 1
@@ -325,12 +313,6 @@ def linkage_tree(X, connectivity=None, n_components=None,
         be symmetric and only the upper triangular half is used.
         Default is None, i.e, the Ward algorithm is unstructured.
 
-    n_components : int (optional)
-        Number of connected components. If None the number of connected
-        components is estimated from the connectivity matrix.
-        NOTE: This parameter is now directly determined directly
-        from the connectivity matrix and will be removed in 0.18
-
     n_clusters : int (optional)
         Stop early the construction of the tree at n_clusters. This is
         useful to decrease computation time if the number of clusters is
@@ -434,11 +416,6 @@ def linkage_tree(X, connectivity=None, n_components=None,
             return children_, 1, n_samples, None, distances
         return children_, 1, n_samples, None
 
-    if n_components is not None:
-        warnings.warn(
-            "n_components is now directly calculated from the connectivity "
-            "matrix and will be removed in 0.18",
-            DeprecationWarning)
     connectivity, n_components = _fix_connectivity(X, connectivity)
 
     connectivity = connectivity.tocoo()
@@ -635,12 +612,6 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    n_components : int (optional)
-        Number of connected components. If None the number of connected
-        components is estimated from the connectivity matrix.
-        NOTE: This parameter is now directly determined from the connectivity
-        matrix and will be removed in 0.18
-
     compute_full_tree : bool or 'auto' (optional)
         Stop early the construction of the tree at n_clusters. This is
         useful to decrease computation time if the number of clusters is
@@ -688,12 +659,10 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
 
     def __init__(self, n_clusters=2, affinity="euclidean",
                  memory=Memory(cachedir=None, verbose=0),
-                 connectivity=None, n_components=None,
-                 compute_full_tree='auto', linkage='ward',
-                 pooling_func=np.mean):
+                 connectivity=None, compute_full_tree='auto',
+                 linkage='ward', pooling_func=np.mean):
         self.n_clusters = n_clusters
         self.memory = memory
-        self.n_components = n_components
         self.connectivity = connectivity
         self.compute_full_tree = compute_full_tree
         self.linkage = linkage
@@ -759,7 +728,6 @@ class AgglomerativeClustering(BaseEstimator, ClusterMixin):
             kwargs['affinity'] = self.affinity
         self.children_, self.n_components_, self.n_leaves_, parents = \
             memory.cache(tree_builder)(X, connectivity,
-                                       n_components=self.n_components,
                                        n_clusters=n_clusters,
                                        **kwargs)
         # Cut the tree
@@ -805,12 +773,6 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
-
-    n_components : int (optional)
-        Number of connected components. If None the number of connected
-        components is estimated from the connectivity matrix.
-        NOTE: This parameter is now directly determined from the connectivity
-        matrix and will be removed in 0.18
 
     compute_full_tree : bool or 'auto', optional, default "auto"
         Stop early the construction of the tree at n_clusters. This is

--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -93,7 +93,7 @@ def _mean_shift_single_seed(my_mean, X, nbrs, max_iter):
 
 def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
                min_bin_freq=1, cluster_all=True, max_iter=300,
-               max_iterations=None, n_jobs=1):
+               n_jobs=1):
     """Perform mean shift clustering of data using a flat kernel.
 
     Read more in the :ref:`User Guide <mean_shift>`.
@@ -161,12 +161,6 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
     See examples/cluster/plot_meanshift.py for an example.
 
     """
-    # FIXME To be removed in 0.18
-    if max_iterations is not None:
-        warnings.warn("The `max_iterations` parameter has been renamed to "
-                      "`max_iter` from version 0.16. The `max_iterations` "
-                      "parameter will be removed in 0.18", DeprecationWarning)
-        max_iter = max_iterations
 
     if bandwidth is None:
         bandwidth = estimate_bandwidth(X)

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -101,13 +101,6 @@ class OutlierDetectionMixin(object):
 
         return is_inlier
 
-    @property
-    def threshold(self):
-        warnings.warn(("The threshold attribute is renamed to threshold_ from "
-                       "0.16 onwards and will be removed in 0.18"),
-                      DeprecationWarning, stacklevel=1)
-        return getattr(self, 'threshold_', None)
-
 
 class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
     """An object for detecting outliers in a Gaussian distributed dataset.

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -24,7 +24,7 @@ import scipy.sparse as sp
 from .base import is_classifier, clone
 from .utils import indexable, check_random_state, safe_indexing
 from .utils.validation import (_is_arraylike, _num_samples,
-                               check_array, column_or_1d)
+                               column_or_1d)
 from .utils.multiclass import type_of_target
 from .externals.joblib import Parallel, delayed, logger
 from .externals.six import with_metaclass
@@ -1857,29 +1857,10 @@ def train_test_split(*arrays, **options):
     test_size = options.pop('test_size', None)
     train_size = options.pop('train_size', None)
     random_state = options.pop('random_state', None)
-    dtype = options.pop('dtype', None)
-    if dtype is not None:
-        warnings.warn("dtype option is ignored and will be removed in 0.18.",
-                      DeprecationWarning)
-
-    allow_nd = options.pop('allow_nd', None)
-    allow_lists = options.pop('allow_lists', None)
     stratify = options.pop('stratify', None)
-
-    if allow_lists is not None:
-        warnings.warn("The allow_lists option is deprecated and will be "
-                      "assumed True in 0.18 and removed.", DeprecationWarning)
 
     if options:
         raise TypeError("Invalid parameters passed: %s" % str(options))
-    if allow_nd is not None:
-        warnings.warn("The allow_nd option is deprecated and will be "
-                      "assumed True in 0.18 and removed.", DeprecationWarning)
-    if allow_lists is False or allow_nd is False:
-        arrays = [check_array(x, 'csr', allow_nd=allow_nd,
-                              force_all_finite=False, ensure_2d=False)
-                  if x is not None else x
-                  for x in arrays]
 
     if test_size is None and train_size is None:
         test_size = 0.25

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -437,16 +437,12 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
         y = y_store_unique_indices
 
         if self.class_weight is not None:
-            valid_presets = ('auto', 'balanced', 'balanced_subsample', 'subsample', 'auto')
+            valid_presets = ('auto', 'balanced', 'balanced_subsample', 'auto')
             if isinstance(self.class_weight, six.string_types):
                 if self.class_weight not in valid_presets:
                     raise ValueError('Valid presets for class_weight include '
                                      '"balanced" and "balanced_subsample". Given "%s".'
                                      % self.class_weight)
-                if self.class_weight == "subsample":
-                    warn("class_weight='subsample' is deprecated and will be removed in 0.18."
-                         " It was replaced by class_weight='balanced_subsample' "
-                         "using the balanced strategy.", DeprecationWarning)
                 if self.warm_start:
                     warn('class_weight presets "balanced" or "balanced_subsample" are '
                          'not recommended for warm_start if the fitted data '
@@ -458,11 +454,9 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
                          'distributions. Pass the resulting weights as the '
                          'class_weight parameter.')
 
-            if (self.class_weight not in ['subsample', 'balanced_subsample'] or
+            if (self.class_weight is not 'balanced_subsample' or
                     not self.bootstrap):
-                if self.class_weight == 'subsample':
-                    class_weight = 'auto'
-                elif self.class_weight == "balanced_subsample":
+                if self.class_weight == "balanced_subsample":
                     class_weight = "balanced"
                 else:
                     class_weight = self.class_weight

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -437,12 +437,17 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
         y = y_store_unique_indices
 
         if self.class_weight is not None:
-            valid_presets = ('auto', 'balanced', 'balanced_subsample', 'auto')
+            valid_presets = ('auto', 'balanced', 'subsample', 'balanced_subsample')
             if isinstance(self.class_weight, six.string_types):
                 if self.class_weight not in valid_presets:
                     raise ValueError('Valid presets for class_weight include '
                                      '"balanced" and "balanced_subsample". Given "%s".'
                                      % self.class_weight)
+                if self.class_weight == "subsample":
+                    warn("class_weight='subsample' is deprecated in 0.17 and"
+                         "will be removed in 0.19. It was replaced by "
+                         "class_weight='balanced_subsample' using the balanced"
+                         "strategy.", DeprecationWarning)
                 if self.warm_start:
                     warn('class_weight presets "balanced" or "balanced_subsample" are '
                          'not recommended for warm_start if the fitted data '
@@ -454,9 +459,11 @@ class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,
                          'distributions. Pass the resulting weights as the '
                          'class_weight parameter.')
 
-            if (self.class_weight is not 'balanced_subsample' or
+            if (self.class_weight not in ['subsample', 'balanced_subsample'] or
                     not self.bootstrap):
-                if self.class_weight == "balanced_subsample":
+                if self.class_weight == 'subsample':
+                    class_weight = 'auto'
+                elif self.class_weight == "balanced_subsample":
                     class_weight = "balanced"
                 else:
                     class_weight = self.class_weight

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -917,8 +917,6 @@ def check_class_weight_balanced_and_bootstrap_multi_output(name):
     # smoke test for subsample and balanced subsample
     clf = ForestClassifier(class_weight='balanced_subsample', random_state=0)
     clf.fit(X, _y)
-    clf = ForestClassifier(class_weight='subsample', random_state=0)
-    ignore_warnings(clf.fit)(X, _y)
 
 
 def test_class_weight_balanced_and_bootstrap_multi_output():
@@ -937,7 +935,7 @@ def check_class_weight_errors(name):
     assert_raises(ValueError, clf.fit, X, _y)
 
     # Warning warm_start with preset
-    clf = ForestClassifier(class_weight='auto', warm_start=True,
+    clf = ForestClassifier(class_weight='balanced', warm_start=True,
                            random_state=0)
     assert_warns(UserWarning, clf.fit, X, y)
     assert_warns(UserWarning, clf.fit, X, _y)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -917,7 +917,8 @@ def check_class_weight_balanced_and_bootstrap_multi_output(name):
     # smoke test for subsample and balanced subsample
     clf = ForestClassifier(class_weight='balanced_subsample', random_state=0)
     clf.fit(X, _y)
-
+    clf = ForestClassifier(class_weight='subsample', random_state=0)
+    ignore_warnings(clf.fit)(X, _y)
 
 def test_class_weight_balanced_and_bootstrap_multi_output():
     for name in FOREST_CLASSIFIERS:
@@ -935,7 +936,7 @@ def check_class_weight_errors(name):
     assert_raises(ValueError, clf.fit, X, _y)
 
     # Warning warm_start with preset
-    clf = ForestClassifier(class_weight='balanced', warm_start=True,
+    clf = ForestClassifier(class_weight='auto', warm_start=True,
                            random_state=0)
     assert_warns(UserWarning, clf.fit, X, y)
     assert_warns(UserWarning, clf.fit, X, _y)

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -55,11 +55,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         If within (0.0, 1.0), then `step` corresponds to the percentage
         (rounded down) of features to remove at each iteration.
 
-    estimator_params : dict
-        Parameters for the external estimator.
-        This attribute is deprecated as of version 0.16 and will be removed in
-        0.18. Use estimator initialisation or set_params method instead.
-
     verbose : int, default=0
         Controls verbosity of output.
 
@@ -105,11 +100,10 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
            Mach. Learn., 46(1-3), 389--422, 2002.
     """
     def __init__(self, estimator, n_features_to_select=None, step=1,
-                 estimator_params=None, verbose=0):
+                 verbose=0):
         self.estimator = estimator
         self.n_features_to_select = n_features_to_select
         self.step = step
-        self.estimator_params = estimator_params
         self.verbose = verbose
 
     @property
@@ -146,13 +140,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         if step <= 0:
             raise ValueError("Step must be >0")
 
-        if self.estimator_params is not None:
-            warnings.warn("The parameter 'estimator_params' is deprecated as "
-                          "of version 0.16 and will be removed in 0.18. The "
-                          "parameter is no longer necessary because the value "
-                          "is set via the estimator initialisation or "
-                          "set_params method.", DeprecationWarning)
-
         support_ = np.ones(n_features, dtype=np.bool)
         ranking_ = np.ones(n_features, dtype=np.int)
 
@@ -166,8 +153,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
             # Rank the remaining features
             estimator = clone(self.estimator)
-            if self.estimator_params:
-                estimator.set_params(**self.estimator_params)
             if self.verbose > 0:
                 print("Fitting estimator with %d features." % np.sum(support_))
 
@@ -206,8 +191,6 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         # Set final attributes
         features = np.arange(n_features)[support_]
         self.estimator_ = clone(self.estimator)
-        if self.estimator_params:
-            self.estimator_.set_params(**self.estimator_params)
         self.estimator_.fit(X[:, features], y)
 
         # Compute step score when only n_features_to_select features left
@@ -310,11 +293,6 @@ class RFECV(RFE, MetaEstimatorMixin):
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    estimator_params : dict
-        Parameters for the external estimator.
-        This attribute is deprecated as of version 0.16 and will be removed in
-        0.18. Use estimator initialisation or set_params method instead.
-
     verbose : int, default=0
         Controls verbosity of output.
 
@@ -371,13 +349,11 @@ class RFECV(RFE, MetaEstimatorMixin):
            for cancer classification using support vector machines",
            Mach. Learn., 46(1-3), 389--422, 2002.
     """
-    def __init__(self, estimator, step=1, cv=None, scoring=None,
-                 estimator_params=None, verbose=0):
+    def __init__(self, estimator, step=1, cv=None, scoring=None, verbose=0):
         self.estimator = estimator
         self.step = step
         self.cv = cv
         self.scoring = scoring
-        self.estimator_params = estimator_params
         self.verbose = verbose
 
     def fit(self, X, y):
@@ -395,12 +371,7 @@ class RFECV(RFE, MetaEstimatorMixin):
             regression).
         """
         X, y = check_X_y(X, y, "csr")
-        if self.estimator_params is not None:
-            warnings.warn("The parameter 'estimator_params' is deprecated as "
-                          "of version 0.16 and will be removed in 0.18. "
-                          "The parameter is no longer necessary because the "
-                          "value is set via the estimator initialisation or "
-                          "set_params method.", DeprecationWarning)
+
         # Initialization
         cv = check_cv(self.cv, X, y, is_classifier(self.estimator))
         scorer = check_scoring(self.estimator, scoring=self.scoring)
@@ -417,8 +388,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
             rfe = RFE(estimator=self.estimator,
                       n_features_to_select=n_features_to_select,
-                      step=self.step, estimator_params=self.estimator_params,
-                      verbose=self.verbose - 1)
+                      step=self.step, verbose=self.verbose - 1)
 
             rfe._fit(X_train, y_train, lambda estimator, features:
                      _score(estimator, X_test[:, features], y_test, scorer))
@@ -433,8 +403,7 @@ class RFECV(RFE, MetaEstimatorMixin):
                                                  self.step))
         # Re-execute an elimination with best_k over the whole set
         rfe = RFE(estimator=self.estimator,
-                  n_features_to_select=n_features_to_select,
-                  step=self.step, estimator_params=self.estimator_params)
+                  n_features_to_select=n_features_to_select, step=self.step)
 
         rfe.fit(X, y)
 
@@ -443,8 +412,6 @@ class RFECV(RFE, MetaEstimatorMixin):
         self.n_features_ = rfe.n_features_
         self.ranking_ = rfe.ranking_
         self.estimator_ = clone(self.estimator)
-        if self.estimator_params:
-            self.estimator_.set_params(**self.estimator_params)
         self.estimator_.fit(self.transform(X), y)
 
         # Fixing a normalization error, n is equal to len(cv) - 1

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -57,24 +57,6 @@ class MockClassifier(object):
         return self
 
 
-def test_rfe_set_params():
-    generator = check_random_state(0)
-    iris = load_iris()
-    X = np.c_[iris.data, generator.normal(size=(len(iris.data), 6))]
-    y = iris.target
-    clf = SVC(kernel="linear")
-    rfe = RFE(estimator=clf, n_features_to_select=4, step=0.1)
-    y_pred = rfe.fit(X, y).predict(X)
-
-    clf = SVC()
-    with warnings.catch_warnings(record=True):
-        # estimator_params is deprecated
-        rfe = RFE(estimator=clf, n_features_to_select=4, step=0.1,
-                  estimator_params={'kernel': 'linear'})
-        y_pred2 = rfe.fit(X, y).predict(X)
-    assert_array_equal(y_pred, y_pred2)
-
-
 def test_rfe_features_importance():
     generator = check_random_state(0)
     iris = load_iris()
@@ -93,29 +75,6 @@ def test_rfe_features_importance():
 
     # Check if the supports are equal
     assert_array_equal(rfe.get_support(), rfe_svc.get_support())
-
-
-def test_rfe_deprecation_estimator_params():
-    deprecation_message = ("The parameter 'estimator_params' is deprecated as "
-                           "of version 0.16 and will be removed in 0.18. The "
-                           "parameter is no longer necessary because the "
-                           "value is set via the estimator initialisation or "
-                           "set_params method.")
-    generator = check_random_state(0)
-    iris = load_iris()
-    X = np.c_[iris.data, generator.normal(size=(len(iris.data), 6))]
-    y = iris.target
-    assert_warns_message(DeprecationWarning, deprecation_message,
-                         RFE(estimator=SVC(), n_features_to_select=4, step=0.1,
-                             estimator_params={'kernel': 'linear'}).fit,
-                         X=X,
-                         y=y)
-
-    assert_warns_message(DeprecationWarning, deprecation_message,
-                         RFECV(estimator=SVC(), step=1, cv=5,
-                               estimator_params={'kernel': 'linear'}).fit,
-                         X=X,
-                         y=y)
 
 
 def test_rfe():

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -531,13 +531,11 @@ class ElasticNet(LinearModel, RegressorMixin):
     normalize : boolean, optional, default False
         If ``True``, the regressors X will be normalized before regression.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | array-like
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
         this option is always ``True`` to preserve sparsity.
-        WARNING : The ``'auto'`` option is deprecated and will
-        be removed in 0.18.
 
     max_iter : int, optional
         The maximum number of iterations
@@ -644,12 +642,6 @@ class ElasticNet(LinearModel, RegressorMixin):
                           "well. You are advised to use the LinearRegression "
                           "estimator", stacklevel=2)
 
-        if (isinstance(self.precompute, six.string_types)
-                and self.precompute == 'auto'):
-            warnings.warn("Setting precompute to 'auto', was found to be "
-                          "slower even when n_samples > n_features. Hence "
-                          "it will be removed in 0.18.",
-                          DeprecationWarning, stacklevel=2)
         # We expect X and y to be already float64 Fortran ordered arrays
         # when bypassing checks
         if check_input:
@@ -790,13 +782,11 @@ class Lasso(ElasticNet):
     copy_X : boolean, optional, default True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | array-like, default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
         this option is always ``True`` to preserve sparsity.
-        WARNING : The ``'auto'`` option is deprecated and will
-        be removed in 0.18.
 
     max_iter : int, optional
         The maximum number of iterations

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -603,16 +603,6 @@ def test_random_descent():
     assert_raises(ValueError, clf_random.fit, X, y)
 
 
-def test_deprection_precompute_enet():
-    # Test that setting precompute="auto" gives a Deprecation Warning.
-
-    X, y, _, _ = build_dataset(n_samples=20, n_features=10)
-    clf = ElasticNet(precompute="auto")
-    assert_warns(DeprecationWarning, clf.fit, X, y)
-    clf = Lasso(precompute="auto")
-    assert_warns(DeprecationWarning, clf.fit, X, y)
-
-
 def test_enet_path_positive():
     # Test that the coefs returned by positive=True in enet_path are positive
 

--- a/sklearn/mixture/dpgmm.py
+++ b/sklearn/mixture/dpgmm.py
@@ -200,11 +200,11 @@ class DPGMM(GMM):
     """
 
     def __init__(self, n_components=1, covariance_type='diag', alpha=1.0,
-                 random_state=None, thresh=None, tol=1e-3, verbose=0,
-                 min_covar=None, n_iter=10, params='wmc', init_params='wmc'):
+                 random_state=None, tol=1e-3, verbose=0, min_covar=None,
+                 n_iter=10, params='wmc', init_params='wmc'):
         self.alpha = alpha
         super(DPGMM, self).__init__(n_components, covariance_type,
-                                    random_state=random_state, thresh=thresh,
+                                    random_state=random_state,
                                     tol=tol, min_covar=min_covar,
                                     n_iter=n_iter, params=params,
                                     init_params=init_params, verbose=verbose)
@@ -578,10 +578,6 @@ class DPGMM(GMM):
         # reset self.converged_ to False
         self.converged_ = False
 
-        # this line should be removed when 'thresh' is removed in v0.18
-        tol = (self.tol if self.thresh is None
-               else self.thresh / float(n_samples))
-
         for i in range(self.n_iter):
             prev_log_likelihood = current_log_likelihood
             # Expectation step
@@ -591,11 +587,9 @@ class DPGMM(GMM):
                 curr_logprob.mean() + self._logprior(z) / n_samples)
 
             # Check for convergence.
-            # (should compare to self.tol when dreprecated 'thresh' is
-            # removed in v0.18)
             if prev_log_likelihood is not None:
                 change = abs(current_log_likelihood - prev_log_likelihood)
-                if change < tol:
+                if change < self.tol:
                     self.converged_ = True
                     break
 
@@ -698,11 +692,11 @@ class VBGMM(DPGMM):
     """
 
     def __init__(self, n_components=1, covariance_type='diag', alpha=1.0,
-                 random_state=None, thresh=None, tol=1e-3, verbose=0,
+                 random_state=None, tol=1e-3, verbose=0,
                  min_covar=None, n_iter=10, params='wmc', init_params='wmc'):
         super(VBGMM, self).__init__(
             n_components, covariance_type, random_state=random_state,
-            thresh=thresh, tol=tol, verbose=verbose, min_covar=min_covar,
+            tol=tol, verbose=verbose, min_covar=min_covar,
             n_iter=n_iter, params=params, init_params=init_params)
         self.alpha = float(alpha) / n_components
 

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -211,7 +211,7 @@ class GMM(BaseEstimator):
     >>> g.fit(obs) # doctest: +NORMALIZE_WHITESPACE
     GMM(covariance_type='diag', init_params='wmc', min_covar=0.001,
             n_components=2, n_init=1, n_iter=100, params='wmc',
-            random_state=None, thresh=None, tol=0.001, verbose=0)
+            random_state=None, tol=0.001, verbose=0)
     >>> np.round(g.weights_, 2)
     array([ 0.75,  0.25])
     >>> np.round(g.means_, 2)
@@ -229,23 +229,18 @@ class GMM(BaseEstimator):
     >>> g.fit(20 * [[0]] +  20 * [[10]]) # doctest: +NORMALIZE_WHITESPACE
     GMM(covariance_type='diag', init_params='wmc', min_covar=0.001,
             n_components=2, n_init=1, n_iter=100, params='wmc',
-            random_state=None, thresh=None, tol=0.001, verbose=0)
+            random_state=None, tol=0.001, verbose=0)
     >>> np.round(g.weights_, 2)
     array([ 0.5,  0.5])
 
     """
 
     def __init__(self, n_components=1, covariance_type='diag',
-                 random_state=None, thresh=None, tol=1e-3, min_covar=1e-3,
+                 random_state=None, tol=1e-3, min_covar=1e-3,
                  n_iter=100, n_init=1, params='wmc', init_params='wmc',
                  verbose=0):
-        if thresh is not None:
-            warnings.warn("'thresh' has been replaced by 'tol' in 0.16 "
-                          " and will be removed in 0.18.",
-                          DeprecationWarning)
         self.n_components = n_components
         self.covariance_type = covariance_type
-        self.thresh = thresh
         self.tol = tol
         self.min_covar = min_covar
         self.random_state = random_state
@@ -507,10 +502,6 @@ class GMM(BaseEstimator):
             # reset self.converged_ to False
             self.converged_ = False
 
-            # this line should be removed when 'thresh' is removed in v0.18
-            tol = (self.tol if self.thresh is None
-                   else self.thresh / float(X.shape[0]))
-
             for i in range(self.n_iter):
                 if self.verbose > 0:
                     print('\tEM iteration ' + str(i + 1))
@@ -521,13 +512,11 @@ class GMM(BaseEstimator):
                 current_log_likelihood = log_likelihoods.mean()
 
                 # Check for convergence.
-                # (should compare to self.tol when deprecated 'thresh' is
-                # removed in v0.18)
                 if prev_log_likelihood is not None:
                     change = abs(current_log_likelihood - prev_log_likelihood)
                     if self.verbose > 1:
                         print('\t\tChange: ' + str(change))
-                    if change < tol:
+                    if change < self.tol:
                         self.converged_ = True
                         if self.verbose > 0:
                             print('\t\tEM algorithm converged.')

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -108,16 +108,7 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def _init_params(self, n_neighbors=None, radius=None,
                      algorithm='auto', leaf_size=30, metric='minkowski',
-                     p=2, metric_params=None, n_jobs=1, **kwargs):
-        if kwargs:
-            warnings.warn("Passing additional arguments to the metric "
-                          "function as **kwargs is deprecated "
-                          "and will no longer be supported in 0.18. "
-                          "Use metric_params instead.",
-                          DeprecationWarning, stacklevel=3)
-            if metric_params is None:
-                metric_params = {}
-            metric_params.update(kwargs)
+                     p=2, metric_params=None, n_jobs=1):
 
         self.n_neighbors = n_neighbors
         self.radius = radius

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -23,22 +23,8 @@ def _check_params(X, metric, p, metric_params):
                     func_param, param_name, est_params[param_name]))
 
 
-def _query_include_self(X, include_self, mode):
+def _query_include_self(X, include_self):
     """Return the query based on include_self param"""
-    # Done to preserve backward compatibility.
-    if include_self is None:
-        if mode == "connectivity":
-            warnings.warn(
-                "The behavior of 'kneighbors_graph' when mode='connectivity' "
-                "will change in version 0.18. Presently, the nearest neighbor "
-                "of each sample is the sample itself. Beginning in version "
-                "0.18, the default behavior will be to exclude each sample "
-                "from being its own nearest neighbor. To maintain the current "
-                "behavior, set include_self=True.", DeprecationWarning)
-            include_self = True
-        else:
-            include_self = False
-
     if include_self:
         query = X._fit_X
     else:
@@ -48,7 +34,7 @@ def _query_include_self(X, include_self, mode):
 
 
 def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
-                     p=2, metric_params=None, include_self=None):
+                     p=2, metric_params=None, include_self=False):
     """Computes the (weighted) graph of k-Neighbors for points in X
 
     Read more in the :ref:`User Guide <unsupervised_neighbors>`.
@@ -73,12 +59,10 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
         The default distance is 'euclidean' ('minkowski' metric with the p
         param equal to 2.)
 
-    include_self: bool, default backward-compatible.
+    include_self: bool, default=False.
         Whether or not to mark each sample as the first nearest neighbor to
         itself. If `None`, then True is used for mode='connectivity' and False
-        for mode='distance' as this will preserve backwards compatibilty. From
-        version 0.18, the default value will be False, irrespective of the
-        value of `mode`.
+        for mode='distance' as this will preserve backwards compatibilty.
 
     p : int, default 2
         Power parameter for the Minkowski metric. When p = 1, this is
@@ -97,7 +81,7 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
     --------
     >>> X = [[0], [3], [1]]
     >>> from sklearn.neighbors import kneighbors_graph
-    >>> A = kneighbors_graph(X, 2)
+    >>> A = kneighbors_graph(X, 2, mode='connectivity', include_self=True)
     >>> A.toarray()
     array([[ 1.,  0.,  1.],
            [ 0.,  1.,  1.],
@@ -113,12 +97,12 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
     else:
         _check_params(X, metric, p, metric_params)
 
-    query = _query_include_self(X, include_self, mode)
+    query = _query_include_self(X, include_self)
     return X.kneighbors_graph(X=query, n_neighbors=n_neighbors, mode=mode)
 
 
 def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
-                           p=2, metric_params=None, include_self=None):
+                           p=2, metric_params=None, include_self=False):
     """Computes the (weighted) graph of Neighbors for points in X
 
     Neighborhoods are restricted the points at a distance lower than
@@ -146,12 +130,10 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
         gives a list of available metrics. The default distance is
         'euclidean' ('minkowski' metric with the param equal to 2.)
 
-    include_self: bool, default None
+    include_self: bool, default=False
         Whether or not to mark each sample as the first nearest neighbor to
         itself. If `None`, then True is used for mode='connectivity' and False
-        for mode='distance' as this will preserve backwards compatibilty. From
-        version 0.18, the default value will be False, irrespective of the
-        value of `mode`.
+        for mode='distance' as this will preserve backwards compatibilty.
 
     p : int, default 2
         Power parameter for the Minkowski metric. When p = 1, this is
@@ -170,7 +152,7 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
     --------
     >>> X = [[0], [3], [1]]
     >>> from sklearn.neighbors import radius_neighbors_graph
-    >>> A = radius_neighbors_graph(X, 1.5)
+    >>> A = radius_neighbors_graph(X, 1.5, mode='connectivity', include_self=True)
     >>> A.toarray()
     array([[ 1.,  0.,  1.],
            [ 0.,  1.,  0.],
@@ -186,5 +168,5 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
     else:
         _check_params(X, metric, p, metric_params)
 
-    query = _query_include_self(X, include_self, mode)
+    query = _query_include_self(X, include_self)
     return X.radius_neighbors_graph(query, radius, mode)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -776,7 +776,7 @@ def test_kneighbors_graph():
     X = np.array([[0, 1], [1.01, 1.], [2, 0]])
 
     # n_neighbors = 1
-    A = neighbors.kneighbors_graph(X, 1, mode='connectivity')
+    A = neighbors.kneighbors_graph(X, 1, mode='connectivity', include_self=True)
     assert_array_equal(A.toarray(), np.eye(A.shape[0]))
 
     A = neighbors.kneighbors_graph(X, 1, mode='distance')
@@ -787,7 +787,7 @@ def test_kneighbors_graph():
          [0.00, 1.40716026, 0.]])
 
     # n_neighbors = 2
-    A = neighbors.kneighbors_graph(X, 2, mode='connectivity')
+    A = neighbors.kneighbors_graph(X, 2, mode='connectivity', include_self=True)
     assert_array_equal(
         A.toarray(),
         [[1., 1., 0.],
@@ -802,7 +802,7 @@ def test_kneighbors_graph():
          [2.23606798, 1.40716026, 0.]])
 
     # n_neighbors = 3
-    A = neighbors.kneighbors_graph(X, 3, mode='connectivity')
+    A = neighbors.kneighbors_graph(X, 3, mode='connectivity', include_self=True)
     assert_array_almost_equal(
         A.toarray(),
         [[1, 1, 1], [1, 1, 1], [1, 1, 1]])
@@ -830,7 +830,8 @@ def test_radius_neighbors_graph():
     # Test radius_neighbors_graph to build the Nearest Neighbor graph.
     X = np.array([[0, 1], [1.01, 1.], [2, 0]])
 
-    A = neighbors.radius_neighbors_graph(X, 1.5, mode='connectivity')
+    A = neighbors.radius_neighbors_graph(X, 1.5, mode='connectivity',
+                                         include_self=True)
     assert_array_equal(
         A.toarray(),
         [[1., 1., 0.],
@@ -976,8 +977,6 @@ def test_callable_metric():
 
 
 def test_metric_params_interface():
-    assert_warns(DeprecationWarning, neighbors.KNeighborsClassifier,
-                 metric='wminkowski', w=np.ones(10))
     assert_warns(SyntaxWarning, neighbors.KNeighborsClassifier,
                  metric_params={'p': 3})
 
@@ -1005,14 +1004,16 @@ def test_non_euclidean_kneighbors():
     # Test kneighbors_graph
     for metric in ['manhattan', 'chebyshev']:
         nbrs_graph = neighbors.kneighbors_graph(
-            X, 3, metric=metric).toarray()
+            X, 3, metric=metric, mode='connectivity',
+            include_self=True).toarray()
         nbrs1 = neighbors.NearestNeighbors(3, metric=metric).fit(X)
         assert_array_equal(nbrs_graph, nbrs1.kneighbors_graph(X).toarray())
 
     # Test radiusneighbors_graph
     for metric in ['manhattan', 'chebyshev']:
         nbrs_graph = neighbors.radius_neighbors_graph(
-            X, radius, metric=metric).toarray()
+            X, radius, metric=metric, mode='connectivity',
+            include_self=True).toarray()
         nbrs1 = neighbors.NearestNeighbors(metric=metric, radius=radius).fit(X)
         assert_array_equal(nbrs_graph, nbrs1.radius_neighbors_graph(X).A)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -214,20 +214,9 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         'continuous-multioutput', 'binary', 'multiclass',
         'mutliclass-multioutput', 'multilabel-indicator', and 'unknown'.
 
-    multilabel_ : boolean
-        True if the transformer was fitted on a multilabel rather than a
-        multiclass set of labels. The ``multilabel_`` attribute is deprecated
-        and will be removed in 0.18
-
     sparse_input_ : boolean,
         True if the input data to transform is given as a sparse matrix, False
         otherwise.
-
-    indicator_matrix_ : str
-        'sparse' when the input data to tansform is a multilable-indicator and
-        is sparse, None otherwise. The ``indicator_matrix_`` attribute is
-        deprecated as of version 0.16 and will be removed in 0.18
-
 
     Examples
     --------

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -786,7 +786,7 @@ def test_train_test_split():
 
     # conversion of lists to arrays (deprecated?)
     with warnings.catch_warnings(record=True):
-        split = cval.train_test_split(X, X_s, y.tolist(), allow_lists=False)
+        split = cval.train_test_split(X, X_s, y.tolist())
     X_train, X_test, X_s_train, X_s_test, y_train, y_test = split
     assert_array_equal(X_train, X_s_train.toarray())
     assert_array_equal(X_test, X_s_test.toarray())
@@ -835,16 +835,12 @@ def train_test_split_pandas():
         assert_true(isinstance(X_train, InputFeatureType))
         assert_true(isinstance(X_test, InputFeatureType))
 
-
 def train_test_split_mock_pandas():
     # X mock dataframe
     X_df = MockDataFrame(X)
     X_train, X_test = cval.train_test_split(X_df)
     assert_true(isinstance(X_train, MockDataFrame))
     assert_true(isinstance(X_test, MockDataFrame))
-    X_train_arr, X_test_arr = cval.train_test_split(X_df, allow_lists=False)
-    assert_true(isinstance(X_train_arr, np.ndarray))
-    assert_true(isinstance(X_test_arr, np.ndarray))
 
 
 def test_cross_val_score_with_score_func_classification():

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -54,7 +54,12 @@ def compute_class_weight(class_weight, classes, y):
 
         # inversely proportional to the number of samples in the class
         if class_weight == 'auto':
-            raise ValueError('auto keyword is not supported anymore.')
+            recip_freq = 1. / bincount(y_ind)
+            weight = recip_freq[le.transform(classes)] / np.mean(recip_freq)
+            warnings.warn("The class_weight='auto' heuristic is deprecated in"
+                          " 0.17 in favor of a new heuristic "
+                          "class_weight='balanced'. 'auto' will be removed in"
+                          " 0.19", DeprecationWarning)
         else:
             recip_freq = len(y) / (len(le.classes_) *
                                    bincount(y_ind).astype(np.float64))

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -54,11 +54,7 @@ def compute_class_weight(class_weight, classes, y):
 
         # inversely proportional to the number of samples in the class
         if class_weight == 'auto':
-            recip_freq = 1. / bincount(y_ind)
-            weight = recip_freq[le.transform(classes)] / np.mean(recip_freq)
-            warnings.warn("The class_weight='auto' heuristic is deprecated in"
-                          " favor of a new heuristic class_weight='balanced'."
-                          " 'auto' will be removed in 0.18", DeprecationWarning)
+            raise ValueError('auto keyword is not supported anymore.')
         else:
             recip_freq = len(y) / (len(le.classes_) *
                                    bincount(y_ind).astype(np.float64))

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -19,10 +19,6 @@ def test_compute_class_weight():
     # Test (and demo) compute_class_weight.
     y = np.asarray([2, 2, 2, 3, 3, 4])
     classes = np.unique(y)
-    cw = assert_warns(DeprecationWarning,
-                      compute_class_weight, "auto", classes, y)
-    assert_almost_equal(cw.sum(), classes.shape)
-    assert_true(cw[0] < cw[1] < cw[2])
 
     cw = compute_class_weight("balanced", classes, y)
     # total effect of samples is preserved
@@ -94,24 +90,12 @@ def test_compute_class_weight_auto_negative():
     # Test with balanced class labels.
     classes = np.array([-2, -1, 0])
     y = np.asarray([-1, -1, 0, 0, -2, -2])
-    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
-                      classes, y)
-    assert_almost_equal(cw.sum(), classes.shape)
-    assert_equal(len(cw), len(classes))
-    assert_array_almost_equal(cw, np.array([1., 1., 1.]))
-
     cw = compute_class_weight("balanced", classes, y)
     assert_equal(len(cw), len(classes))
     assert_array_almost_equal(cw, np.array([1., 1., 1.]))
 
     # Test with unbalanced class labels.
     y = np.asarray([-1, 0, 0, -2, -2, -2])
-    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
-                      classes, y)
-    assert_almost_equal(cw.sum(), classes.shape)
-    assert_equal(len(cw), len(classes))
-    assert_array_almost_equal(cw, np.array([0.545, 1.636, 0.818]), decimal=3)
-
     cw = compute_class_weight("balanced", classes, y)
     assert_equal(len(cw), len(classes))
     class_counts = np.bincount(y + 2)
@@ -123,12 +107,6 @@ def test_compute_class_weight_auto_unordered():
     # Test compute_class_weight when classes are unordered
     classes = np.array([1, 0, 3])
     y = np.asarray([1, 0, 0, 3, 3, 3])
-    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
-                      classes, y)
-    assert_almost_equal(cw.sum(), classes.shape)
-    assert_equal(len(cw), len(classes))
-    assert_array_almost_equal(cw, np.array([1.636, 0.818, 0.545]), decimal=3)
-
     cw = compute_class_weight("balanced", classes, y)
     class_counts = np.bincount(y)[classes]
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
@@ -139,9 +117,6 @@ def test_compute_sample_weight():
     # Test (and demo) compute_sample_weight.
     # Test with balanced classes
     y = np.asarray([1, 1, 1, 2, 2, 2])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
@@ -151,18 +126,11 @@ def test_compute_sample_weight():
 
     # Test with column vector of balanced classes
     y = np.asarray([[1], [1], [1], [2], [2], [2]])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with unbalanced classes
     y = np.asarray([1, 1, 1, 2, 2, 2, 3])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    expected_auto = np.asarray([.6, .6, .6, .6, .6, .6, 1.8])
-    assert_array_almost_equal(sample_weight, expected_auto)
     sample_weight = compute_sample_weight("balanced", y)
     expected_balanced = np.array([0.7777, 0.7777, 0.7777, 0.7777, 0.7777, 0.7777, 2.3333])
     assert_array_almost_equal(sample_weight, expected_balanced, decimal=4)
@@ -173,9 +141,6 @@ def test_compute_sample_weight():
 
     # Test with multi-output of balanced classes
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
@@ -186,9 +151,6 @@ def test_compute_sample_weight():
 
     # Test with multi-output of unbalanced classes
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1], [3, -1]])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, expected_auto ** 2)
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, expected_balanced ** 2, decimal=3)
 
@@ -197,60 +159,38 @@ def test_compute_sample_weight_with_subsample():
     # Test compute_sample_weight with subsamples specified.
     # Test with balanced classes and all samples present
     y = np.asarray([1, 1, 1, 2, 2, 2])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with column vector of balanced classes and all samples present
     y = np.asarray([[1], [1], [1], [2], [2], [2]])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y)
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with a subsample
     y = np.asarray([1, 1, 1, 2, 2, 2])
-    sample_weight = assert_warns(DeprecationWarning,
-                                 compute_sample_weight, "auto", y, range(4))
-    assert_array_almost_equal(sample_weight, [.5, .5, .5, 1.5, 1.5, 1.5])
     sample_weight = compute_sample_weight("balanced", y, range(4))
     assert_array_almost_equal(sample_weight, [2. / 3, 2. / 3,
                                               2. / 3, 2., 2., 2.])
 
     # Test with a bootstrap subsample
     y = np.asarray([1, 1, 1, 2, 2, 2])
-    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
-                                 "auto", y, [0, 1, 1, 2, 2, 3])
-    expected_auto = np.asarray([1 / 3., 1 / 3., 1 / 3., 5 / 3., 5 / 3., 5 / 3.])
-    assert_array_almost_equal(sample_weight, expected_auto)
     sample_weight = compute_sample_weight("balanced", y, [0, 1, 1, 2, 2, 3])
     expected_balanced = np.asarray([0.6, 0.6, 0.6, 3., 3., 3.])
     assert_array_almost_equal(sample_weight, expected_balanced)
 
     # Test with a bootstrap subsample for multi-output
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
-    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
-                                 "auto", y, [0, 1, 1, 2, 2, 3])
-    assert_array_almost_equal(sample_weight, expected_auto ** 2)
     sample_weight = compute_sample_weight("balanced", y, [0, 1, 1, 2, 2, 3])
     assert_array_almost_equal(sample_weight, expected_balanced ** 2)
 
     # Test with a missing class
     y = np.asarray([1, 1, 1, 2, 2, 2, 3])
-    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
-                                 "auto", y, range(6))
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
 
     # Test with a missing class for multi-output
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1], [2, 2]])
-    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
-                                 "auto", y, range(6))
-    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -19,6 +19,10 @@ def test_compute_class_weight():
     # Test (and demo) compute_class_weight.
     y = np.asarray([2, 2, 2, 3, 3, 4])
     classes = np.unique(y)
+    cw = assert_warns(DeprecationWarning,
+                      compute_class_weight, "auto", classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_true(cw[0] < cw[1] < cw[2])
 
     cw = compute_class_weight("balanced", classes, y)
     # total effect of samples is preserved
@@ -90,12 +94,24 @@ def test_compute_class_weight_auto_negative():
     # Test with balanced class labels.
     classes = np.array([-2, -1, 0])
     y = np.asarray([-1, -1, 0, 0, -2, -2])
+    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
+                      classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([1., 1., 1.]))
+
     cw = compute_class_weight("balanced", classes, y)
     assert_equal(len(cw), len(classes))
     assert_array_almost_equal(cw, np.array([1., 1., 1.]))
 
     # Test with unbalanced class labels.
     y = np.asarray([-1, 0, 0, -2, -2, -2])
+    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
+                      classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([0.545, 1.636, 0.818]), decimal=3)
+
     cw = compute_class_weight("balanced", classes, y)
     assert_equal(len(cw), len(classes))
     class_counts = np.bincount(y + 2)
@@ -107,6 +123,12 @@ def test_compute_class_weight_auto_unordered():
     # Test compute_class_weight when classes are unordered
     classes = np.array([1, 0, 3])
     y = np.asarray([1, 0, 0, 3, 3, 3])
+    cw = assert_warns(DeprecationWarning, compute_class_weight, "auto",
+                      classes, y)
+    assert_almost_equal(cw.sum(), classes.shape)
+    assert_equal(len(cw), len(classes))
+    assert_array_almost_equal(cw, np.array([1.636, 0.818, 0.545]), decimal=3)
+
     cw = compute_class_weight("balanced", classes, y)
     class_counts = np.bincount(y)[classes]
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
@@ -117,6 +139,9 @@ def test_compute_sample_weight():
     # Test (and demo) compute_sample_weight.
     # Test with balanced classes
     y = np.asarray([1, 1, 1, 2, 2, 2])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
@@ -126,11 +151,18 @@ def test_compute_sample_weight():
 
     # Test with column vector of balanced classes
     y = np.asarray([[1], [1], [1], [2], [2], [2]])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with unbalanced classes
     y = np.asarray([1, 1, 1, 2, 2, 2, 3])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    expected_auto = np.asarray([.6, .6, .6, .6, .6, .6, 1.8])
+    assert_array_almost_equal(sample_weight, expected_auto)
     sample_weight = compute_sample_weight("balanced", y)
     expected_balanced = np.array([0.7777, 0.7777, 0.7777, 0.7777, 0.7777, 0.7777, 2.3333])
     assert_array_almost_equal(sample_weight, expected_balanced, decimal=4)
@@ -141,6 +173,9 @@ def test_compute_sample_weight():
 
     # Test with multi-output of balanced classes
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
@@ -151,6 +186,9 @@ def test_compute_sample_weight():
 
     # Test with multi-output of unbalanced classes
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1], [3, -1]])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, expected_auto ** 2)
     sample_weight = compute_sample_weight("balanced", y)
     assert_array_almost_equal(sample_weight, expected_balanced ** 2, decimal=3)
 
@@ -159,38 +197,60 @@ def test_compute_sample_weight_with_subsample():
     # Test compute_sample_weight with subsamples specified.
     # Test with balanced classes and all samples present
     y = np.asarray([1, 1, 1, 2, 2, 2])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with column vector of balanced classes and all samples present
     y = np.asarray([[1], [1], [1], [2], [2], [2]])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y)
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1.])
 
     # Test with a subsample
     y = np.asarray([1, 1, 1, 2, 2, 2])
+    sample_weight = assert_warns(DeprecationWarning,
+                                 compute_sample_weight, "auto", y, range(4))
+    assert_array_almost_equal(sample_weight, [.5, .5, .5, 1.5, 1.5, 1.5])
     sample_weight = compute_sample_weight("balanced", y, range(4))
     assert_array_almost_equal(sample_weight, [2. / 3, 2. / 3,
                                               2. / 3, 2., 2., 2.])
 
     # Test with a bootstrap subsample
     y = np.asarray([1, 1, 1, 2, 2, 2])
+    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
+                                 "auto", y, [0, 1, 1, 2, 2, 3])
+    expected_auto = np.asarray([1 / 3., 1 / 3., 1 / 3., 5 / 3., 5 / 3., 5 / 3.])
+    assert_array_almost_equal(sample_weight, expected_auto)
     sample_weight = compute_sample_weight("balanced", y, [0, 1, 1, 2, 2, 3])
     expected_balanced = np.asarray([0.6, 0.6, 0.6, 3., 3., 3.])
     assert_array_almost_equal(sample_weight, expected_balanced)
 
     # Test with a bootstrap subsample for multi-output
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
+    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
+                                 "auto", y, [0, 1, 1, 2, 2, 3])
+    assert_array_almost_equal(sample_weight, expected_auto ** 2)
     sample_weight = compute_sample_weight("balanced", y, [0, 1, 1, 2, 2, 3])
     assert_array_almost_equal(sample_weight, expected_balanced ** 2)
 
     # Test with a missing class
     y = np.asarray([1, 1, 1, 2, 2, 2, 3])
+    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
+                                 "auto", y, range(6))
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
 
     # Test with a missing class for multi-output
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1], [2, 2]])
+    sample_weight = assert_warns(DeprecationWarning, compute_sample_weight,
+                                 "auto", y, range(6))
+    assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
     sample_weight = compute_sample_weight("balanced", y, range(6))
     assert_array_almost_equal(sample_weight, [1., 1., 1., 1., 1., 1., 0.])
 


### PR DESCRIPTION
Contributes to #5434.

Removes the following deprecated code:
- [x] `pooling_func` in transform of `AgglomerationTransform` in file `cluster/_feature_agglomeration.py`
- [x] `random_state` parameter in `cluster/dbscan_.py`
- [x] `n_components` in `cluster/hierarchical.py`
- [x] `max_iterations` in `cluster/mean_shift_.py`
- [x] support for `class_weight="subsample"` in `utils/class_weight.py`
- [x] `allow_lists` and `allow_nd/ in`sklearn/cross_validation.py`.
- [x] `estimator_params` in `sklearn/feature_selection/rfe.py`
- [x] `threshold_` in 'OutlierDetectionMixin`at file`sklearn/covariance/outlier_detection.py`
- [x] `precompute="auto"` in `sklearn/linear_models/coordinate_descent.py` and `sklearn/utils/class_weight.py`
- [x] `thresh` in `sklearn/mixture/dpgmm.py` and `sklearn/mixture/gmm.py`.
- [x] deprecation warnings in `sklearn/multiclass.py`.
- [x] deprecation warnings in `sklearn/neighbors`.
- [x] deprecation warnings in `sklearn/preprocessing`.
- [x] deprecation warnings in `sklearn/utils/classs_weight.py`
