### PR TITLE
[MRG+2] Use uniform_average as default multioutput parameter of r2_score function

### DIFF
--- a/sklearn/metrics/regression.py
+++ b/sklearn/metrics/regression.py
@@ -393,8 +393,9 @@ def r2_score(y_true, y_pred,
                 'variance_weighted'] or None or array-like of shape (n_outputs)
         Defines aggregating of multiple output scores.
         Array-like value defines weights used to average scores.
-        Default value correponds to 'variance_weighted', but
-        will be changed to 'uniform_average' in next versions.
+        Default value correponds to 'variance_weighted', this behaviour is
+        deprecated since version 0.17 and will be changed to 'uniform_average' 
+        starting from 0.19.
 
         'raw_values' :
             Returns a full set of scores in case of multioutput input.
@@ -461,10 +462,10 @@ def r2_score(y_true, y_pred,
     # y_true is not interesting for scoring a regression anyway
     output_scores[nonzero_numerator & ~nonzero_denominator] = 0.
     if multioutput is None and y_true.shape[1] != 1:
-        # @FIXME change in 0.18
         warnings.warn("Default 'multioutput' behavior now corresponds to "
-                      "'variance_weighted' value, it will be changed "
-                      "to 'uniform_average' in 0.18.",
+                      "'variance_weighted' value which is deprecated since "
+                      "0.17, it will be changed to 'uniform_average' "
+                      "starting from 0.19.",
                       DeprecationWarning)
         multioutput = 'variance_weighted'
     if isinstance(multioutput, string_types):


### PR DESCRIPTION
Partly fixed metrics deprecated code (#5434)
