### PR TITLE
[MRG+1] Remove shuffling in LabelKFold

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -361,13 +361,6 @@ class LabelKFold(_BaseKFold):
     n_folds : int, default=3
         Number of folds. Must be at least 2.
 
-    shuffle : boolean, optional
-        Whether to shuffle the data before splitting into batches.
-
-    random_state : None, int or RandomState
-        When shuffle=True, pseudo-random number generator state used for
-        shuffling. If None, use default numpy RNG for shuffling.
-
     Examples
     --------
     >>> from sklearn.cross_validation import LabelKFold
@@ -399,9 +392,9 @@ class LabelKFold(_BaseKFold):
     LeaveOneLabelOut for splitting the data according to explicit,
     domain-specific stratification of the dataset.
     """
-    def __init__(self, labels, n_folds=3, shuffle=False, random_state=None):
-        super(LabelKFold, self).__init__(len(labels), n_folds, shuffle,
-                                         random_state)
+    def __init__(self, labels, n_folds=3):
+        super(LabelKFold, self).__init__(len(labels), n_folds,
+                                         shuffle=False, random_state=None)
 
         unique_labels, labels = np.unique(labels, return_inverse=True)
         n_labels = len(unique_labels)
@@ -411,16 +404,6 @@ class LabelKFold(_BaseKFold):
                     ("Cannot have number of folds n_folds={0} greater"
                      " than the number of labels: {1}.").format(n_folds,
                                                                 n_labels))
-
-        if shuffle:
-            # In case of ties in label weights, label names are indirectly
-            # used to assign samples to folds. When shuffle=True, label names
-            # are randomized to obtain random fold assigments.
-            rng = check_random_state(self.random_state)
-            unique_labels = np.arange(n_labels, dtype=np.int)
-            rng.shuffle(unique_labels)
-            labels = unique_labels[labels]
-            unique_labels, labels = np.unique(labels, return_inverse=True)
 
         # Weight labels by their number of occurences
         n_samples_per_label = np.bincount(labels)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -359,7 +359,7 @@ def test_kfold_can_detect_dependent_samples_on_digits():  # see #2372
     assert_greater(mean_score, 0.85)
 
 
-def check_label_kfold(shuffle):
+def test_label_kfold():
     rng = np.random.RandomState(0)
 
     # Parameters of the test
@@ -370,10 +370,7 @@ def check_label_kfold(shuffle):
     # Construct the test data
     tolerance = 0.05 * n_samples  # 5 percent error allowed
     labels = rng.randint(0, n_labels, n_samples)
-    folds = cval.LabelKFold(labels,
-                            n_folds=n_folds,
-                            shuffle=shuffle,
-                            random_state=rng).idxs
+    folds = cval.LabelKFold(labels, n_folds=n_folds).idxs
     ideal_n_labels_per_fold = n_samples // n_folds
 
     # Check that folds have approximately the same size
@@ -388,10 +385,7 @@ def check_label_kfold(shuffle):
 
     # Check that no label is on both sides of the split
     labels = np.asarray(labels, dtype=object)
-    for train, test in cval.LabelKFold(labels,
-                                       n_folds=n_folds,
-                                       shuffle=shuffle,
-                                       random_state=rng):
+    for train, test in cval.LabelKFold(labels, n_folds=n_folds):
         assert_equal(len(np.intersect1d(labels[train], labels[test])), 0)
 
     # Construct the test data
@@ -408,10 +402,7 @@ def check_label_kfold(shuffle):
     n_samples = len(labels)
     n_folds = 5
     tolerance = 0.05 * n_samples  # 5 percent error allowed
-    folds = cval.LabelKFold(labels,
-                            n_folds=n_folds,
-                            shuffle=shuffle,
-                            random_state=rng).idxs
+    folds = cval.LabelKFold(labels, n_folds=n_folds).idxs
     ideal_n_labels_per_fold = n_samples // n_folds
 
     # Check that folds have approximately the same size
@@ -425,20 +416,12 @@ def check_label_kfold(shuffle):
         assert_equal(len(np.unique(folds[labels == label])), 1)
 
     # Check that no label is on both sides of the split
-    for train, test in cval.LabelKFold(labels,
-                                       n_folds=n_folds,
-                                       shuffle=shuffle,
-                                       random_state=rng):
+    for train, test in cval.LabelKFold(labels, n_folds=n_folds):
         assert_equal(len(np.intersect1d(labels[train], labels[test])), 0)
 
     # Should fail if there are more folds than labels
     labels = np.array([1, 1, 1, 2, 2])
     assert_raises(ValueError, cval.LabelKFold, labels, n_folds=3)
-
-
-def test_label_kfold():
-    for shuffle in [False, True]:
-        yield check_label_kfold, shuffle
 
 
 def test_shuffle_split():


### PR DESCRIPTION
This PR removes shuffling from LabelKFold, in lack of a consensus on the best way to shuffle in that case. Better to back-paddle now and not ship that with release 0.17. 

See also #5396 and #5390.

CC @ogrisel @GaelVaroquaux @JeanKossaifi @andreasvc 
