### PR TITLE
[MRG+1] add pomegranate to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -53,6 +53,9 @@ and tasks.
 - `PyStruct <https://pystruct.github.io>`_ General conditional random fields
   and structured prediction.
 
+- `pomegranate <https://github.com/jmschrei/pomegranate>`_ Probabilistic modelling
+  for Python, with an emphasis on hidden Markov models.
+
 - `py-earth <https://github.com/jcrudy/py-earth>`_ Multivariate adaptive
   regression splines
 


### PR DESCRIPTION
pomegranate is my module for probabilistic modelling, including univariate distributions, general mixture models, hidden Markov models, discrete Bayesian networks, and factor graphs. It covers many forms of structures learning that don't fit into scikit-learn's estimator model, but maintains a scikit-learn interface.

I just pushed a new version, so I figured I'd update here as well. 
