### PR TITLE
[MRG + 1] Remove deprecated stuff from SVM

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -79,14 +79,10 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
             raise ValueError("impl should be one of %s, %s was given" % (
                 LIBSVM_IMPL, impl))
 
-        # FIXME Remove gamma=0.0 support in 0.18
         if gamma == 0:
-            msg = ("gamma=%s has been deprecated in favor of "
-                   "gamma='%s' as of 0.17. Backward compatibility"
-                   " for gamma=%s will be removed in %s")
-            invalid_gamma = 0.0
-            warnings.warn(msg % (invalid_gamma, "auto", invalid_gamma, "0.18"),
-                          DeprecationWarning)
+            msg = ("The gamma value of 0.0 is invalid. Use 'auto' to set"
+                   " gamma to a value of 1 / n_features.")
+            raise ValueError(msg)
 
         self._impl = impl
         self.kernel = kernel
@@ -175,13 +171,8 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
-        # FIXME remove (self.gamma == 0) in 0.18
-        if (self.kernel in ['poly', 'rbf']) and ((self.gamma == 0) or
-                                                 (self.gamma == 'auto')):
-            # if custom gamma is not provided ...
+        if self.gamma == 'auto':
             self._gamma = 1.0 / X.shape[1]
-        elif self.gamma == 'auto':
-            self._gamma = 0.0
         else:
             self._gamma = self.gamma
 
@@ -749,13 +740,11 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
         raise ValueError("`multi_class` must be one of `ovr`, "
                          "`crammer_singer`, got %r" % multi_class)
 
-    # FIXME loss.lower() --> loss in 0.18
-    _solver_pen = _solver_type_dict.get(loss.lower(), None)
+    _solver_pen = _solver_type_dict.get(loss, None)
     if _solver_pen is None:
         error_string = ("loss='%s' is not supported" % loss)
     else:
-        # FIME penalty.lower() --> penalty in 0.18
-        _solver_dual = _solver_pen.get(penalty.lower(), None)
+        _solver_dual = _solver_pen.get(penalty, None)
         if _solver_dual is None:
             error_string = ("The combination of penalty='%s' "
                             "and loss='%s' is not supported"
@@ -863,23 +852,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     n_iter_ : int
         Maximum number of iterations run across all classes.
     """
-    # FIXME Remove case insensitivity in 0.18 ---------------------
-    loss_l, penalty_l = loss.lower(), penalty.lower()
-
-    msg = ("loss='%s' has been deprecated in favor of "
-           "loss='%s' as of 0.16. Backward compatibility"
-           " for the uppercase notation will be removed in %s")
-    if (not loss.islower()) and loss_l not in ('l1', 'l2'):
-        warnings.warn(msg % (loss, loss_l, "0.18"),
-                      DeprecationWarning)
-    if not penalty.islower():
-        warnings.warn(msg.replace("loss", "penalty")
-                      % (penalty, penalty_l, "0.18"),
-                      DeprecationWarning)
-    # -------------------------------------------------------------
-
-    # FIXME loss_l --> loss in 0.18
-    if loss_l not in ['epsilon_insensitive', 'squared_epsilon_insensitive']:
+    if loss not in ['epsilon_insensitive', 'squared_epsilon_insensitive']:
         enc = LabelEncoder()
         y_ind = enc.fit_transform(y)
         classes_ = enc.classes_

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -453,7 +453,7 @@ class SVC(BaseSVC):
         Hard limit on iterations within solver, or -1 for no limit.
 
     decision_function_shape : 'ovo', 'ovr' or None, default=None
-        Whether to return a one-vs-rest ('ovr') ecision function of shape
+        Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
         (n_samples, n_classes * (n_classes - 1) / 2).
@@ -600,7 +600,7 @@ class NuSVC(BaseSVC):
         Hard limit on iterations within solver, or -1 for no limit.
 
     decision_function_shape : 'ovo', 'ovr' or None, default=None
-        Whether to return a one-vs-rest ('ovr') ecision function of shape
+        Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
         (n_samples, n_classes * (n_classes - 1) / 2).

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -533,56 +533,42 @@ def test_linearsvx_loss_penalty_deprecations():
            " for the %s will be removed in %s")
 
     # LinearSVC
-    # loss l1/L1 --> hinge
+    # loss l1 --> hinge
     assert_warns_message(DeprecationWarning,
                          msg % ("l1", "hinge", "loss='l1'", "1.0"),
                          svm.LinearSVC(loss="l1").fit, X, y)
 
-    # loss l2/L2 --> squared_hinge
+    # loss l2 --> squared_hinge
     assert_warns_message(DeprecationWarning,
-                         msg % ("L2", "squared_hinge", "loss='L2'", "1.0"),
-                         svm.LinearSVC(loss="L2").fit, X, y)
+                         msg % ("l2", "squared_hinge", "loss='l2'", "1.0"),
+                         svm.LinearSVC(loss="l2").fit, X, y)
 
     # LinearSVR
-    # loss l1/L1 --> epsilon_insensitive
+    # loss l1 --> epsilon_insensitive
     assert_warns_message(DeprecationWarning,
-                         msg % ("L1", "epsilon_insensitive", "loss='L1'",
+                         msg % ("l1", "epsilon_insensitive", "loss='l1'",
                                 "1.0"),
-                         svm.LinearSVR(loss="L1").fit, X, y)
+                         svm.LinearSVR(loss="l1").fit, X, y)
 
-    # loss l2/L2 --> squared_epsilon_insensitive
+    # loss l2 --> squared_epsilon_insensitive
     assert_warns_message(DeprecationWarning,
                          msg % ("l2", "squared_epsilon_insensitive",
                                 "loss='l2'", "1.0"),
                          svm.LinearSVR(loss="l2").fit, X, y)
 
 
-# FIXME remove in 0.18
-def test_linear_svx_uppercase_loss_penalty():
-    # Check if Upper case notation is supported by _fit_liblinear
+def test_linear_svx_uppercase_loss_penality_raises_error():
+    # Check if Upper case notation raises error at _fit_liblinear
     # which is called by fit
+
     X, y = [[0.0], [1.0]], [0, 1]
 
-    msg = ("loss='%s' has been deprecated in favor of "
-           "loss='%s' as of 0.16. Backward compatibility"
-           " for the uppercase notation will be removed in %s")
+    assert_raise_message(ValueError, "loss='SQuared_hinge' is not supported",
+                         svm.LinearSVC(loss="SQuared_hinge").fit, X, y)
 
-    # loss SQUARED_hinge --> squared_hinge
-    assert_warns_message(DeprecationWarning,
-                         msg % ("SQUARED_hinge", "squared_hinge", "0.18"),
-                         svm.LinearSVC(loss="SQUARED_hinge").fit, X, y)
-
-    # penalty L2 --> l2
-    assert_warns_message(DeprecationWarning,
-                         msg.replace("loss", "penalty")
-                         % ("L2", "l2", "0.18"),
+    assert_raise_message(ValueError, ("The combination of penalty='L2'"
+                         " and loss='squared_hinge' is not supported"),
                          svm.LinearSVC(penalty="L2").fit, X, y)
-
-    # loss EPSILON_INSENSITIVE --> epsilon_insensitive
-    assert_warns_message(DeprecationWarning,
-                         msg % ("EPSILON_INSENSITIVE", "epsilon_insensitive",
-                                "0.18"),
-                         svm.LinearSVR(loss="EPSILON_INSENSITIVE").fit, X, y)
 
 
 def test_linearsvc():


### PR DESCRIPTION
For issue at #5434 
- [x] Remove support for `gamma = 0.0` and set `gamma` to `1 / n_features` when `'auto'` is used...
- [x] Remove support for uppercase values for loss in sv\* (test in file `svm/tests/test_svm.py`, uppercase support in `_fit_liblinear` function in `svm/base.py`, Refer #4261 and #4260 also svm/classes.py L192)
