### PR TITLE
Ridge path - another perspective

### DIFF
--- a/examples/linear_model/plot_ridge_path.py
+++ b/examples/linear_model/plot_ridge_path.py
@@ -8,52 +8,88 @@ Shows the effect of collinearity in the coefficients of an estimator.
 .. currentmodule:: sklearn.linear_model
 
 :class:`Ridge` Regression is the estimator used in this example.
-Each color represents a different feature of the
+Each color in the upper plot represents a different feature of the
 coefficient vector, and this is displayed as a function of the
 regularization parameter.
 
-At the end of the path, as alpha tends toward zero
-and the solution tends towards the ordinary least squares, coefficients
-exhibit big oscillations.
+In this example the dependent variable Y is set as a function
+of the input features: Y = Xb + e. The coefficient vector b is
+randomly sampled from a normal distribution.
+
+As alpha tends toward zero the coefficients found by Ridge
+regression stabilize towards the randomly sampled vector b.
+For big alpha (strong regularisation) the coefficients
+are smaller (eventually converging at 0) leading to a
+simpler and biased solution.
+These dependencies can be observed on the left plot.
+
+The right plot shows the mean squared error between the
+coefficients found by the model and the chosen vector b.
+Less regularised models find the coefficients without
+trouble (0 error), stronger regularised models increase
+the error.
 """
 
-# Author: Fabian Pedregosa -- <fabian.pedregosa@inria.fr>
-# License: BSD 3 clause
+# Author: Kornel Kielczewski -- <kornel.k@plusnet.pl>
 
 print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn import linear_model
+from sklearn.linear_model import Ridge
+from matplotlib import pyplot
+from sklearn.metrics import mean_squared_error
 
-# X is the 10x10 Hilbert matrix
-X = 1. / (np.arange(1, 11) + np.arange(0, 10)[:, np.newaxis])
-y = np.ones(10)
+def generate_test_data(N, p):
+    """Generate N samples of p dimensions"""
+    features = [np.random.randn(p) for x in range(N)]
+    b = np.random.normal(size = p)
+    e = np.random.randn()
+    e = 0
+    Y = map(lambda row: sum(row * b) + e, features)
 
-###############################################################################
-# Compute paths
+    return (b, features, Y)
 
-n_alphas = 200
-alphas = np.logspace(-10, -2, n_alphas)
-clf = linear_model.Ridge(fit_intercept=False)
+
+clf = Ridge()
+
+(b, features, Y) = generate_test_data(N = 10, p = 10)
 
 coefs = []
+err = []
+
+alphas = np.logspace(-6, 6, 200)
+
+# Train the model with different regularisation strengths
 for a in alphas:
     clf.set_params(alpha=a)
-    clf.fit(X, y)
+    clf.fit(features, Y)
     coefs.append(clf.coef_)
+    err.append(mean_squared_error(clf.coef_, b))
 
-###############################################################################
+
+
 # Display results
+plt.figure(figsize=(20, 6))
 
+plt.subplot(121)
 ax = plt.gca()
 ax.set_color_cycle(['b', 'r', 'g', 'c', 'k', 'y', 'm'])
-
 ax.plot(alphas, coefs)
 ax.set_xscale('log')
-ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
 plt.xlabel('alpha')
 plt.ylabel('weights')
 plt.title('Ridge coefficients as a function of the regularization')
 plt.axis('tight')
+
+
+plt.subplot(122)
+ax = plt.gca()
+ax.plot(alphas, err)
+ax.set_xscale('log')
+plt.xlabel('alpha')
+plt.ylabel('error')
+plt.title('Coefficient error as a function of the regularization')
+plt.axis('tight')
+
 plt.show()


### PR DESCRIPTION
I've been looking at the example and found it confusing that we have to set fit_intercept=False. This was because Y = 1, hence an optimal solution exists where the intercept is 1 and all other coefficients are zero. That's why I've decided to play around with this example.

Here I propose another perspective, where we set Y = bX + e, an solution which is easy to find for the estimator, and two plots: one where we can see how the coefficients are selected properly and another where we see how the error (estimator.coef_ - b) changes.

What do you think?
