### PR TITLE
Fixes typo on clustering docs

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -196,7 +196,7 @@ As a result, the computation is often done several times, with different
 initializations of the centroids. One method to help address this issue is the
 k-means++ initialization scheme, which has been implemented in scikit-learn
 (use the ``init='kmeans++'`` parameter). This initializes the centroids to be
-(generally) distant from each other, leading to provably better results than
+(generally) distant from each other, leading to probably better results than
 random initialization, as shown in the reference.
 
 A parameter can be given to allow K-means to be run in parallel, called


### PR DESCRIPTION
I found a typo [here](http://scikit-learn.org/stable/modules/clustering.html):

"This initializes the centroids to be (generally) distant from each other, leading to **provably** better results than random initialization, as shown in the reference."
