### PR TITLE
MAINT: use xrange from six

### DIFF
--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -25,8 +25,7 @@ from . import _hierarchical
 from ._feature_agglomeration import AgglomerationTransform
 from ..utils.fast_dict import IntFloatDict
 
-if sys.version_info[0] > 2:
-    xrange = range
+from ..externals.six.moves import xrange
 
 ###############################################################################
 # For non fully-connected graphs


### PR DESCRIPTION
Small change – we should use `six` instead of doing Python 2/3 compat manually.
