### PR TITLE
[MRG] Deprecate residual_metric and add support for loss in RANSAC

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,9 @@ Enhancements
    - :class:`linear_model.RANSACRegressor` now supports ``sample_weights``.
      By `Imaculate`_.
 
+   - Add parameter ``loss`` to :class:`linear_model.RANSACRegressor` to measure the
+     error on the samples for every trial. By `Manoj Kumar`_.
+
 Bug fixes
 .........
 
@@ -114,6 +117,8 @@ API changes summary
      the :mod:`model_selection` module.
      (`#4294 <https://github.com/scikit-learn/scikit-learn/pull/4294>`_) by `Raghav R V`_.
 
+   - ``residual_metric`` has been deprecated in :class:`linear_model.RANSACRegressor`.
+     Use ``loss`` instead. By `Manoj Kumar`_.
 
 .. _changes_0_17:
 

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+import warnings
 
 from ..base import BaseEstimator, MetaEstimatorMixin, RegressorMixin, clone
 from ..utils import check_random_state, check_array, check_consistent_length
@@ -134,6 +135,22 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
             lambda dy: np.sum(np.abs(dy), axis=1)
 
+        NOTE: residual_metric is deprecated from 0.18 and will be removed in 0.20
+        Use ``loss`` instead.
+
+    loss: string, callable, optional, default "absolute_loss"
+        String inputs, "absolute_loss" and "squared_loss" are supported which
+        find the absolute loss and squared loss per sample
+        respectively.
+
+        If ``loss`` is a callable, then it should be a function that takes
+        two arrays as inputs, the true and predicted value and returns a 1-D
+        array with the ``i``th value of the array corresponding to the loss
+        on `X[i]`.
+
+        If the loss on a sample is greater than the ``residual_threshold``, then
+        this sample is classified as an outlier.
+
     random_state : integer or numpy.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
@@ -163,7 +180,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
                  is_model_valid=None, max_trials=100,
                  stop_n_inliers=np.inf, stop_score=np.inf,
                  stop_probability=0.99, residual_metric=None,
-                 random_state=None):
+                 loss='absolute_loss', random_state=None):
 
         self.base_estimator = base_estimator
         self.min_samples = min_samples
@@ -176,6 +193,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         self.stop_probability = stop_probability
         self.residual_metric = residual_metric
         self.random_state = random_state
+        self.loss = loss
 
     def fit(self, X, y, sample_weight=None):
         """Fit estimator using RANSAC algorithm.
@@ -236,10 +254,33 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         else:
             residual_threshold = self.residual_threshold
 
-        if self.residual_metric is None:
-            residual_metric = lambda dy: np.sum(np.abs(dy), axis=1)
+        if self.residual_metric is not None:
+            warnings.warn(
+                "'residual_metric' will be removed in version 0.20. Use "
+                "'loss' instead.", DeprecationWarning)
+
+        if self.loss == "absolute_loss":
+            if y.ndim == 1:
+                loss_function = lambda y_true, y_pred: np.abs(y_true - y_pred)
+            else:
+                loss_function = lambda \
+                    y_true, y_pred: np.sum(np.abs(y_true - y_pred), axis=1)
+
+        elif self.loss == "squared_loss":
+            if y.ndim == 1:
+                loss_function = lambda y_true, y_pred: (y_true - y_pred) ** 2
+            else:
+                loss_function = lambda \
+                    y_true, y_pred: np.sum((y_true - y_pred) ** 2, axis=1)
+
+        elif callable(self.loss):
+            loss_function = self.loss
+
         else:
-            residual_metric = self.residual_metric
+            raise ValueError(
+                "loss should be 'absolute_loss', 'squared_loss' or a callable."
+                "Got %s. " % self.loss)
+
 
         random_state = check_random_state(self.random_state)
 
@@ -298,10 +339,15 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
             # residuals of all data for current random sample model
             y_pred = base_estimator.predict(X)
-            diff = y_pred - y
-            if diff.ndim == 1:
-                diff = diff.reshape(-1, 1)
-            residuals_subset = residual_metric(diff)
+
+            # XXX: Deprecation: Remove this if block in 0.20
+            if self.residual_metric is not None:
+                diff = y_pred - y
+                if diff.ndim == 1:
+                    diff = diff.reshape(-1, 1)
+                residuals_subset = self.residual_metric(diff)
+            else:
+                residuals_subset = loss_function(y, y_pred)
 
             # classify data into inliers and outliers
             inlier_mask_subset = residuals_subset < residual_threshold


### PR DESCRIPTION
Partly fixes https://github.com/scikit-learn/scikit-learn/issues/4740

Supply arbitrary residual metrics for 1-D targets was not possible.

```
from sklearn.linear_model import RANSACRegressor
from sklearn.datasets import make_regression
X, y = make_regression()
res_met = lambda dy: dy ** 2
ransac = RANSACRegressor(min_samples=5, residual_metric=res_met)
ransac.fit(X, y)
IndexError: too many indices for array
```

The workaround was to explicitly define res_met as accepting 2-D arrays, (since there is a reshape done) which is non-obvious.

```
res_met = lambda dy: np.sum(dy**2, axis=1)
ransac = RANSACRegressor(min_samples=5, residual_metric=res_met)
ransac.fit(X, y)
```
