### PR TITLE
[MRG] Use super rather than calls to base class methods

### DIFF
--- a/sklearn/covariance/shrunk_covariance_.py
+++ b/sklearn/covariance/shrunk_covariance_.py
@@ -108,8 +108,8 @@ class ShrunkCovariance(EmpiricalCovariance):
     """
     def __init__(self, store_precision=True, assume_centered=False,
                  shrinkage=0.1):
-        EmpiricalCovariance.__init__(self, store_precision=store_precision,
-                                     assume_centered=assume_centered)
+        super(ShrunkCovariance, self).__init__(store_precision=store_precision,
+                                               assume_centered=assume_centered)
         self.shrinkage = shrinkage
 
     def fit(self, X, y=None):
@@ -362,8 +362,8 @@ class LedoitWolf(EmpiricalCovariance):
     """
     def __init__(self, store_precision=True, assume_centered=False,
                  block_size=1000):
-        EmpiricalCovariance.__init__(self, store_precision=store_precision,
-                                     assume_centered=assume_centered)
+        super(LedoitWolf, self).__init__(store_precision=store_precision,
+                                         assume_centered=assume_centered)
         self.block_size = block_size
 
     def fit(self, X, y=None):

--- a/sklearn/cross_decomposition/cca_.py
+++ b/sklearn/cross_decomposition/cca_.py
@@ -101,7 +101,7 @@ class CCA(_PLS):
 
     def __init__(self, n_components=2, scale=True,
                  max_iter=500, tol=1e-06, copy=True):
-        _PLS.__init__(self, n_components=n_components, scale=scale,
-                      deflation_mode="canonical", mode="B",
-                      norm_y_weights=True, algorithm="nipals",
-                      max_iter=max_iter, tol=tol, copy=copy)
+        super(CCA, self).__init__(n_components=n_components, scale=scale,
+                                  deflation_mode="canonical", mode="B",
+                                  norm_y_weights=True, algorithm="nipals",
+                                  max_iter=max_iter, tol=tol, copy=copy)

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -551,10 +551,11 @@ class PLSRegression(_PLS):
 
     def __init__(self, n_components=2, scale=True,
                  max_iter=500, tol=1e-06, copy=True):
-        _PLS.__init__(self, n_components=n_components, scale=scale,
-                      deflation_mode="regression", mode="A",
-                      norm_y_weights=False, max_iter=max_iter, tol=tol,
-                      copy=copy)
+        super(PLSRegression, self).__init__(
+            n_components=n_components, scale=scale,
+            deflation_mode="regression", mode="A",
+            norm_y_weights=False, max_iter=max_iter, tol=tol,
+            copy=copy)
 
 
 class PLSCanonical(_PLS):
@@ -671,10 +672,11 @@ class PLSCanonical(_PLS):
 
     def __init__(self, n_components=2, scale=True, algorithm="nipals",
                  max_iter=500, tol=1e-06, copy=True):
-        _PLS.__init__(self, n_components=n_components, scale=scale,
-                      deflation_mode="canonical", mode="A",
-                      norm_y_weights=True, algorithm=algorithm,
-                      max_iter=max_iter, tol=tol, copy=copy)
+        super(PLSCanonical, self).__init__(
+            n_components=n_components, scale=scale,
+            deflation_mode="canonical", mode="A",
+            norm_y_weights=True, algorithm=algorithm,
+            max_iter=max_iter, tol=tol, copy=copy)
 
 
 class PLSSVD(BaseEstimator, TransformerMixin):

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -46,7 +46,7 @@ class Bunch(dict):
     """
 
     def __init__(self, **kwargs):
-        dict.__init__(self, kwargs)
+        super(Bunch, self).__init__(kwargs)
 
     def __setattr__(self, key, value):
         self[key] = value

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -84,17 +84,17 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, loss="hinge", n_jobs=1, random_state=None,
                  warm_start=False, class_weight=None):
-        BaseSGDClassifier.__init__(self,
-                                   penalty=None,
-                                   fit_intercept=fit_intercept,
-                                   n_iter=n_iter,
-                                   shuffle=shuffle,
-                                   verbose=verbose,
-                                   random_state=random_state,
-                                   eta0=1.0,
-                                   warm_start=warm_start,
-                                   class_weight=class_weight,
-                                   n_jobs=n_jobs)
+        super(PassiveAggressiveClassifier, self).__init__(
+            penalty=None,
+            fit_intercept=fit_intercept,
+            n_iter=n_iter,
+            shuffle=shuffle,
+            verbose=verbose,
+            random_state=random_state,
+            eta0=1.0,
+            warm_start=warm_start,
+            class_weight=class_weight,
+            n_jobs=n_jobs)
         self.C = C
         self.loss = loss
 
@@ -231,17 +231,17 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     def __init__(self, C=1.0, fit_intercept=True, n_iter=5, shuffle=True,
                  verbose=0, loss="epsilon_insensitive",
                  epsilon=DEFAULT_EPSILON, random_state=None, warm_start=False):
-        BaseSGDRegressor.__init__(self,
-                                  penalty=None,
-                                  l1_ratio=0,
-                                  epsilon=epsilon,
-                                  eta0=1.0,
-                                  fit_intercept=fit_intercept,
-                                  n_iter=n_iter,
-                                  shuffle=shuffle,
-                                  verbose=verbose,
-                                  random_state=random_state,
-                                  warm_start=warm_start)
+        super(PassiveAggressiveRegressor, self).__init__(
+            penalty=None,
+            l1_ratio=0,
+            epsilon=epsilon,
+            eta0=1.0,
+            fit_intercept=fit_intercept,
+            n_iter=n_iter,
+            shuffle=shuffle,
+            verbose=verbose,
+            random_state=random_state,
+            warm_start=warm_start)
         self.C = C
         self.loss = loss
 


### PR DESCRIPTION
Fixes #5205.

Remaining non-super calls:

```
❯ git grep "\.__init__(self" -- `git ls-files | grep -vP "utils|externals|sphinxext"`
examples/applications/plot_out_of_core_classification.py:        html_parser.HTMLParser.__init__(self)
examples/svm/plot_rbf_parameters.py:        Normalize.__init__(self, vmin, vmax, clip)
sklearn/covariance/outlier_detection.py:        MinCovDet.__init__(self, store_precision=store_precision,
sklearn/covariance/outlier_detection.py:        OutlierDetectionMixin.__init__(self, contamination=contamination)
```

The outlier_detection need to stay I reckon because you need to call `__init__` for two of the base classes.

Not sure if we want to fix the examples too.
