### PR TITLE
[MRG+2] MAINT Removing more deprecated stuff for v0.18

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -277,12 +277,6 @@ class VectorizerMixin(object):
         if len(self.vocabulary_) == 0:
             raise ValueError("Vocabulary is empty")
 
-    @property
-    @deprecated("The `fixed_vocabulary` attribute is deprecated and will be "
-                "removed in 0.18.  Please use `fixed_vocabulary_` instead.")
-    def fixed_vocabulary(self):
-        return self.fixed_vocabulary_
-
 
 class HashingVectorizer(BaseEstimator, VectorizerMixin):
     """Convert a collection of text documents to a matrix of token occurrences

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -462,7 +462,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                 positive)
         else:
             raise ValueError("Precompute should be one of True, False, "
-                             "'auto' or array-like")
+                             "'auto' or array-like. Got %r" % precompute)
         coef_, dual_gap_, eps_, n_iter_ = model
         coefs[..., i] = coef_
         dual_gaps[i] = dual_gap_
@@ -548,9 +548,8 @@ class ElasticNet(LinearModel, RegressorMixin):
 
     precompute : True | False | array-like
         Whether to use a precomputed Gram matrix to speed up
-        calculations. If set to ``'auto'`` let us decide. The Gram
-        matrix can also be passed as argument. For sparse input
-        this option is always ``True`` to preserve sparsity.
+        calculations. The Gram matrix can also be passed as argument.
+        For sparse input this option is always ``True`` to preserve sparsity.
 
     max_iter : int, optional
         The maximum number of iterations
@@ -657,11 +656,9 @@ class ElasticNet(LinearModel, RegressorMixin):
                           "well. You are advised to use the LinearRegression "
                           "estimator", stacklevel=2)
 
-        if (isinstance(self.precompute, six.string_types) and
-           self.precompute == 'auto'):
-            raise ValueError("Precompute='auto' is not supported for "
-                             "ElasticNetCV as it was found to be slower even "
-                             "when n_samples > n_features.")
+        if isinstance(self.precompute, six.string_types):
+            raise ValueError('precompute should be one of True, False or'
+                             ' array-like. Got %r' % self.precompute)
 
         # We expect X and y to be already float64 Fortran ordered arrays
         # when bypassing checks

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -659,10 +659,10 @@ class ElasticNet(LinearModel, RegressorMixin):
 
         if (isinstance(self.precompute, six.string_types) and
            self.precompute == 'auto'):
-            warnings.warn("Setting precompute to 'auto', was found to be "
-                          "slower even when n_samples > n_features. Hence "
-                          "it will be removed in 0.18.",
-                          DeprecationWarning, stacklevel=2)
+            raise ValueError("Precompute='auto' is not supported for "
+                             "ElasticNetCV as it was found to be slower even "
+                             "when n_samples > n_features.")
+
         # We expect X and y to be already float64 Fortran ordered arrays
         # when bypassing checks
         if check_input:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -511,6 +511,9 @@ def test_precompute_invalid_argument():
                 LassoCV(precompute="invalid")]:
         assert_raises(ValueError, clf.fit, X, y)
 
+    # Precompute = 'auto' is not supported for ElasticNet
+    assert_raises(ValueError, ElasticNet(precompute='auto').fit, X, y)
+
 
 def test_warm_start_convergence():
     X, y, _, _ = build_dataset()

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -16,6 +16,7 @@ from sklearn.utils.testing import SkipTest
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regex
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
@@ -509,10 +510,12 @@ def test_precompute_invalid_argument():
     X, y, _, _ = build_dataset()
     for clf in [ElasticNetCV(precompute="invalid"),
                 LassoCV(precompute="invalid")]:
-        assert_raises(ValueError, clf.fit, X, y)
+        assert_raises_regex(ValueError, ".*should be.*True.*False.*auto.*"
+                            "array-like.*Got 'invalid'", clf.fit, X, y)
 
     # Precompute = 'auto' is not supported for ElasticNet
-    assert_raises(ValueError, ElasticNet(precompute='auto').fit, X, y)
+    assert_raises_regex(ValueError, ".*should be.*True.*False.*array-like.*"
+                        "Got 'auto'", ElasticNet(precompute='auto').fit, X, y)
 
 
 def test_warm_start_convergence():

--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -538,7 +538,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
         dec = self._decision_function(X)
         if self.decision_function_shape is None and len(self.classes_) > 2:
             warnings.warn("The decision_function_shape default value will "
-                          "change from 'ovo' to 'ovr' in 0.18. This will change "
+                          "change from 'ovo' to 'ovr' in 0.19. This will change "
                           "the shape of the decision function returned by "
                           "SVC.", ChangedBehaviorWarning)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:

--- a/sklearn/svm/bounds.py
+++ b/sklearn/svm/bounds.py
@@ -53,12 +53,6 @@ def l1_min_c(X, y, loss='squared_hinge', fit_intercept=True,
     l1_min_c: float
         minimum value for C
     """
-
-    if loss == "l2":
-        warn("loss='l2' will be impossible from 0.18 onwards."
-             " Use loss='squared_hinge' instead.",
-             DeprecationWarning)
-        loss = "squared_hinge"
     if loss not in ('squared_hinge', 'log'):
         raise ValueError('loss type not in ("squared_hinge", "log", "l2")')
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -183,16 +183,13 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
             Returns self.
         """
         # FIXME Remove l1/l2 support in 1.0 -----------------------------------
-        loss_l = self.loss.lower()
-
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
 
-        # FIXME change loss_l --> self.loss after 0.18
-        if loss_l in ('l1', 'l2'):
+        if self.loss in ('l1', 'l2'):
             old_loss = self.loss
-            self.loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(loss_l)
+            self.loss = {'l1': 'hinge', 'l2': 'squared_hinge'}.get(self.loss)
             warnings.warn(msg % (old_loss, self.loss, old_loss, '1.0'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
@@ -347,18 +344,15 @@ class LinearSVR(LinearModel, RegressorMixin):
             Returns self.
         """
         # FIXME Remove l1/l2 support in 1.0 -----------------------------------
-        loss_l = self.loss.lower()
-
         msg = ("loss='%s' has been deprecated in favor of "
                "loss='%s' as of 0.16. Backward compatibility"
                " for the loss='%s' will be removed in %s")
 
-        # FIXME change loss_l --> self.loss after 0.18
-        if loss_l in ('l1', 'l2'):
+        if self.loss in ('l1', 'l2'):
             old_loss = self.loss
             self.loss = {'l1': 'epsilon_insensitive',
                          'l2': 'squared_epsilon_insensitive'
-                         }.get(loss_l)
+                         }.get(self.loss)
             warnings.warn(msg % (old_loss, self.loss, old_loss, '1.0'),
                           DeprecationWarning)
         # ---------------------------------------------------------------------
@@ -457,7 +451,7 @@ class SVC(BaseSVC):
         (n_samples, n_classes * (n_classes - 1) / 2).
         The default of None will currently behave as 'ovo' for backward
         compatibility and raise a deprecation warning, but will change 'ovr'
-        in 0.18.
+        in 0.19.
 
         .. versionadded:: 0.17
            *decision_function_shape='ovr'* is recommended.
@@ -610,7 +604,7 @@ class NuSVC(BaseSVC):
         (n_samples, n_classes * (n_classes - 1) / 2).
         The default of None will currently behave as 'ovo' for backward
         compatibility and raise a deprecation warning, but will change 'ovr'
-        in 0.18.
+        in 0.19.
 
         .. versionadded:: 0.17
            *decision_function_shape='ovr'* is recommended.
@@ -1025,8 +1019,8 @@ class OneClassSVM(BaseLibSVM):
         If X is not a C-ordered contiguous array it is copied.
 
         """
-        super(OneClassSVM, self).fit(X, np.ones(_num_samples(X)), sample_weight=sample_weight,
-                                     **params)
+        super(OneClassSVM, self).fit(X, np.ones(_num_samples(X)),
+                                     sample_weight=sample_weight, **params)
         return self
 
     def decision_function(self, X):

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -1,6 +1,7 @@
 import nose
 from nose.tools import assert_equal, assert_true
 from sklearn.utils.testing import clean_warning_registry
+from sklearn.utils.testing import assert_raise_message
 import warnings
 
 import numpy as np
@@ -37,13 +38,9 @@ def test_l1_min_c():
                                           intercept_label))
                     yield check
 
-
-def test_l2_deprecation():
-    clean_warning_registry()
-    with warnings.catch_warnings(record=True) as w:
-        assert_equal(l1_min_c(dense_X, Y1, "l2"),
-                     l1_min_c(dense_X, Y1, "squared_hinge"))
-        assert_equal(w[0].category, DeprecationWarning)
+    # loss='l2' should raise ValueError
+    assert_raise_message(ValueError, "loss type not in",
+                         l1_min_c, dense_X, Y1, "l2")
 
 
 def check_l1_min_c(X, y, loss, fit_intercept=True, intercept_scaling=None):


### PR DESCRIPTION
Fully fixes #5434 
- [x] `fixed_vocabulary_`
- [x] Remove support for precompute='auto' in `ElasticNet`
- [x] Remove support for `loss='l2'` in `l1_min_c`
- [x] Make all the old/new tests pass
