### PR TITLE
[MRG + 1] remove complicated equality checks in clone as __init__ shouldn't touch anything.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -292,6 +292,11 @@ Enhancements
      See :ref:`example_plot_compare_reduction.py`. By `Joel Nothman`_ and
      `Robert McGibbon`_.
 
+   - Simplification of the ``clone`` function, deprecate support for estimators
+     that modify parameters in ``__init__``.
+     (`#5540 <https://github.com/scikit-learn/scikit-learn/pull/5540>_`)
+     By `Andreas Müller`_.
+
 Bug fixes
 .........
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -113,8 +113,10 @@ def clone(estimator, safe=True):
             params_set_val = params_set[name]
             # The following construct is required to check equality on special
             # singletons such as np.nan that are not equal to them-selves:
-            equality_test = (new_obj_val == params_set_val or
-                             new_obj_val is params_set_val)
+            if new_obj_val is params_set_val:
+                equality_test = True
+            else:
+                equality_test = new_obj_val == params_set_val
         if not equality_test:
             raise RuntimeError('Cannot clone object %s, as the constructor '
                                'does not seem to set parameter %s' %

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -115,9 +115,9 @@ def clone(estimator, safe=True):
             # fall back on standard equality
             equality_test = param1 == param2
         if equality_test:
-            warnings.warn("Estimator %s modifies parameters in "
-                          "__init__. This behavior is deprecated as of 0.18 and "
-                          " support for this behavior will be removed in 0.20."
+            warnings.warn("Estimator %s modifies parameters in __init__."
+                          " This behavior is deprecated as of 0.18 and "
+                          "support for this behavior will be removed in 0.20."
                           % type(estimator).__name__, DeprecationWarning)
         else:
             raise RuntimeError('Cannot clone object %s, as the constructor '

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -73,6 +73,11 @@ def clone(estimator, safe=True):
     for name in new_object_params:
         param1 = new_object_params[name]
         param2 = params_set[name]
+        if param1 is param2:
+            # this should always happen
+            continue
+        # if we reach this, we should raise a deprecation warning
+        # once we fixed #5549 (GP kernels) and #5547 (VBGMM)
         if isinstance(param1, np.ndarray):
             # For most ndarrays, we do not test for complete equality
             if not isinstance(param2, type(param1)):
@@ -109,14 +114,8 @@ def clone(estimator, safe=True):
                     and param1.shape == param2.shape
                 )
         else:
-            new_obj_val = new_object_params[name]
-            params_set_val = params_set[name]
-            # The following construct is required to check equality on special
-            # singletons such as np.nan that are not equal to them-selves:
-            if new_obj_val is params_set_val:
-                equality_test = True
-            else:
-                equality_test = new_obj_val == params_set_val
+            # fall back on standard equality
+            equality_test = param1 == param2
         if not equality_test:
             raise RuntimeError('Cannot clone object %s, as the constructor '
                                'does not seem to set parameter %s' %

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -76,9 +76,6 @@ def clone(estimator, safe=True):
         if param1 is param2:
             # this should always happen
             continue
-        warnings.warn(DeprecationWarning, "Estimator %s modifies parameters in "
-                      "__init__. This behavior is deprecated as of 0.18 and "
-                      " support for this behavior will be removed in 0.20.")
         if isinstance(param1, np.ndarray):
             # For most ndarrays, we do not test for complete equality
             if not isinstance(param2, type(param1)):
@@ -117,7 +114,12 @@ def clone(estimator, safe=True):
         else:
             # fall back on standard equality
             equality_test = param1 == param2
-        if not equality_test:
+        if equality_test:
+            warnings.warn("Estimator %s modifies parameters in "
+                          "__init__. This behavior is deprecated as of 0.18 and "
+                          " support for this behavior will be removed in 0.20."
+                          % type(estimator).__name__, DeprecationWarning)
+        else:
             raise RuntimeError('Cannot clone object %s, as the constructor '
                                'does not seem to set parameter %s' %
                                (estimator, name))

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -76,8 +76,9 @@ def clone(estimator, safe=True):
         if param1 is param2:
             # this should always happen
             continue
-        # if we reach this, we should raise a deprecation warning
-        # once we fixed #5549 (GP kernels) and #5547 (VBGMM)
+        warnings.warn(DeprecationWarning, "Estimator %s modifies parameters in "
+                      "__init__. This behavior is deprecated as of 0.18 and "
+                      " support for this behavior will be removed in 0.20.")
         if isinstance(param1, np.ndarray):
             # For most ndarrays, we do not test for complete equality
             if not isinstance(param2, type(param1)):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -162,7 +162,7 @@ def test_clone_copy_init_params():
     # test for deprecation warning when copying or casting an init parameter
     est = ModifyInitParams()
     message = ("Estimator ModifyInitParams modifies parameters in __init__. "
-               "This behavior is deprecated as of 0.18 and  support "
+               "This behavior is deprecated as of 0.18 and support "
                "for this behavior will be removed in 0.20.")
 
     assert_warns_message(DeprecationWarning, message, clone, est)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -257,13 +257,9 @@ def test_score_sample_weight():
 
 
 def test_clone_pandas_dataframe():
-    class MockDataFrameWithEq(MockDataFrame):
-        """implemenets __eq__ operator to leverage the current test."""
-        def __eq__(self, other):
-            return self.array == other.array
 
     class DummyEstimator(BaseEstimator, TransformerMixin):
-        """This is a dummpy class for generating numerical features
+        """This is a dummy class for generating numerical features
 
         This feature extractor extracts numerical features from pandas data
         frame.
@@ -277,9 +273,9 @@ def test_clone_pandas_dataframe():
         Notes
         -----
         """
-        def __init__(self, df, toto):
+        def __init__(self, df=None, scalar_param=1):
             self.df = df
-            self.toto = toto
+            self.scalar_param = scalar_param
 
         def fit(self, X, y=None):
             pass
@@ -289,9 +285,10 @@ def test_clone_pandas_dataframe():
 
     # build and clone estimator
     d = np.arange(10)
-    df = MockDataFrameWithEq(d)
-    e = DummyEstimator(df, toto=1)
+    df = MockDataFrame(d)
+    e = DummyEstimator(df, scalar_param=1)
     cloned_e = clone(e)
 
     # the test
-    assert_equal(e.toto, cloned_e.toto)
+    assert_true((e.df == cloned_e.df).values.all())
+    assert_equal(e.scalar_param, cloned_e.scalar_param)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -12,6 +12,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns_message
 
 from sklearn.base import BaseEstimator, clone, is_classifier
 from sklearn.svm import SVC
@@ -21,6 +22,7 @@ from sklearn.utils import deprecated
 
 from sklearn.base import TransformerMixin
 from sklearn.utils.mocking import MockDataFrame
+
 
 #############################################################################
 # A few test classes
@@ -41,6 +43,15 @@ class T(BaseEstimator):
     def __init__(self, a=None, b=None):
         self.a = a
         self.b = b
+
+
+class ModifyInitParams(BaseEstimator):
+    """Deprecated behavior.
+    Equal parameters but with a type cast.
+    Doesn't fulfill a is a
+    """
+    def __init__(self, a=np.array([0])):
+        self.a = a.copy()
 
 
 class DeprecatedAttributeEstimator(BaseEstimator):
@@ -145,6 +156,16 @@ def test_clone_nan():
     clf2 = clone(clf)
 
     assert_true(clf.empty is clf2.empty)
+
+
+def test_clone_copy_init_params():
+    # test for deprecation warning when copying or casting an init parameter
+    est = ModifyInitParams()
+    message = ("Estimator ModifyInitParams modifies parameters in __init__. "
+               "This behavior is deprecated as of 0.18 and  support "
+               "for this behavior will be removed in 0.20.")
+
+    assert_warns_message(DeprecationWarning, message, clone, est)
 
 
 def test_clone_sparse_matrices():

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -19,6 +19,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
 from sklearn.utils import deprecated
 
+from sklearn.base import TransformerMixin
+from sklearn.utils.mocking import MockDataFrame
 
 #############################################################################
 # A few test classes
@@ -252,3 +254,44 @@ def test_score_sample_weight():
                                    sample_weight=sample_weight),
                          msg="Unweighted and weighted scores "
                              "are unexpectedly equal")
+
+
+def test_clone_pandas_dataframe():
+    class MockDataFrameWithEq(MockDataFrame):
+        """implemenets __eq__ operator to leverage the current test."""
+        def __eq__(self, other):
+            return self.array == other.array
+
+    class DummyEstimator(BaseEstimator, TransformerMixin):
+        """This is a dummpy class for generating numerical features
+
+        This feature extractor extracts numerical features from pandas data
+        frame.
+
+        Parameters
+        ----------
+
+        df: pandas data frame
+            The pandas data frame parameter.
+
+        Notes
+        -----
+        """
+        def __init__(self, df, toto):
+            self.df = df
+            self.toto = toto
+
+        def fit(self, X, y=None):
+            pass
+
+        def transform(self, X, y=None):
+            pass
+
+    # build and clone estimator
+    d = np.arange(10)
+    df = MockDataFrameWithEq(d)
+    e = DummyEstimator(df, toto=1)
+    cloned_e = clone(e)
+
+    # the test
+    assert_equal(e.toto, cloned_e.toto)

--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -18,6 +18,7 @@ class MockDataFrame(object):
     # have shape an length but don't support indexing.
     def __init__(self, array):
         self.array = array
+        self.values = array
         self.shape = array.shape
         self.ndim = array.ndim
         # ugly hack to make iloc work.
@@ -31,6 +32,9 @@ class MockDataFrame(object):
         # input validation in cross-validation does not try to call that
         # method.
         return self.array
+
+    def __eq__(self, other):
+        return MockDataFrame(self.array == other.array)
 
 
 class CheckingClassifier(BaseEstimator, ClassifierMixin):


### PR DESCRIPTION
Simplifies the check in `clone` that checks if `__init__` and `get_params` play nicely together.

Previously, we could clone objects that copy numpy arrays in `__init__`. Afterwards we can not.

Doing anything in init is not a good idea.
I have an additional check for `==` because `Pipeline` is evil.
Working on it.

Note: this is a fix for #5522.
