### PR TITLE
Typo in LDA

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -144,8 +144,8 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     solver : string, optional
         Solver to use, possible values:
           - 'svd': Singular value decomposition (default).
-                Does not compute the covariance matrix, therefore this solver is
-                recommended for data with a large number of features.
+            Does not compute the covariance matrix, therefore this solver is
+            recommended for data with a large number of features.
           - 'lsqr': Least squares solution, can be combined with shrinkage.
           - 'eigen': Eigenvalue decomposition, can be combined with shrinkage.
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -143,9 +143,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     ----------
     solver : string, optional
         Solver to use, possible values:
-          - 'svd': Singular value decomposition (default). Does not compute the
-                covariance matrix, therefore this solver is recommended for
-                data with a large number of features.
+          - 'svd': Singular value decomposition (default).
+                Does not compute the covariance matrix, therefore this solver is
+                recommended for data with a large number of features.
           - 'lsqr': Least squares solution, can be combined with shrinkage.
           - 'eigen': Eigenvalue decomposition, can be combined with shrinkage.
 


### PR DESCRIPTION
This PR is the result of the discussion on this previous PR https://github.com/scikit-learn/scikit-learn/pull/5417.

It fixes a typo from this
![image](https://cloud.githubusercontent.com/assets/1908833/10687040/4a476124-796a-11e5-9ad0-75458e69e754.png)

to this
![image](https://cloud.githubusercontent.com/assets/1908833/10687043/4ef36380-796a-11e5-93c7-1aaa9d84c5de.png)
