### PR TITLE
Added colorblind compatibility neighbors examples

### DIFF
--- a/examples/neighbors/plot_approximate_nearest_neighbors_hyperparameters.py
+++ b/examples/neighbors/plot_approximate_nearest_neighbors_hyperparameters.py
@@ -102,13 +102,15 @@ for i, n_estimators in enumerate(n_estimators_values):
 ###############################################################################
 # Plot the accuracy variation with `n_candidates`
 plt.figure()
-colors = ['c', 'm', 'y']
+colors = ['navy', 'cornflowerblue', 'darkorange']
+lines = ['-', '.', '--']
+lw = 2
 for i, n_estimators in enumerate(n_estimators_for_candidate_value):
     label = 'n_estimators = %d ' % n_estimators
     plt.plot(n_candidates_values, accuracies_c[i, :],
-             'o-', c=colors[i], label=label)
+             color=colors[i], lw=lw, marker='o', label=label)
     plt.errorbar(n_candidates_values, accuracies_c[i, :],
-                 stds_accuracies[i, :], c=colors[i])
+                 stds_accuracies[i, :], color=colors[i], lw=lw)
 
 plt.legend(loc='upper left', prop=dict(size='small'))
 plt.ylim([0, 1.2])

--- a/examples/neighbors/plot_classification.py
+++ b/examples/neighbors/plot_classification.py
@@ -17,15 +17,16 @@ n_neighbors = 15
 
 # import some data to play with
 iris = datasets.load_iris()
-X = iris.data[:, :2]  # we only take the first two features. We could
-                      # avoid this ugly slicing by using a two-dim dataset
+# we only take the first two features. We could
+# avoid this ugly slicing by using a two-dim dataset
+X = iris.data[:, :2]
 y = iris.target
 
 h = .02  # step size in the mesh
 
 # Create color maps
-cmap_light = ListedColormap(['#FFAAAA', '#AAFFAA', '#AAAAFF'])
-cmap_bold = ListedColormap(['#FF0000', '#00FF00', '#0000FF'])
+cmap_light = ListedColormap(['orange', 'cyan', 'cornflowerblue'])
+cmap_bold = ListedColormap(['darkorange', 'c', 'darkblue'])
 
 for weights in ['uniform', 'distance']:
     # we create an instance of Neighbours Classifier and fit the data.

--- a/examples/neighbors/plot_kde_1d.py
+++ b/examples/neighbors/plot_kde_1d.py
@@ -34,7 +34,7 @@ from scipy.stats import norm
 from sklearn.neighbors import KernelDensity
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Plot the progression of histograms to kernels
 np.random.seed(1)
 N = 20
@@ -77,7 +77,7 @@ for axi in ax[:, 0]:
 for axi in ax[1, :]:
     axi.set_xlabel('x')
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Plot all available kernels
 X_plot = np.linspace(-6, 6, 1000)[:, None]
 X_src = np.zeros((1, 1))
@@ -112,7 +112,7 @@ for i, kernel in enumerate(['gaussian', 'tophat', 'epanechnikov',
 
 ax[0, 1].set_title('Available Kernels')
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Plot a 1D density example
 N = 100
 np.random.seed(1)
@@ -127,12 +127,15 @@ true_dens = (0.3 * norm(0, 1).pdf(X_plot[:, 0])
 fig, ax = plt.subplots()
 ax.fill(X_plot[:, 0], true_dens, fc='black', alpha=0.2,
         label='input distribution')
+colors = ['navy', 'cornflowerblue', 'darkorange']
+kernels = ['gaussian', 'tophat', 'epanechnikov']
+lw = 2
 
-for kernel in ['gaussian', 'tophat', 'epanechnikov']:
+for color, kernel in zip(colors, kernels):
     kde = KernelDensity(kernel=kernel, bandwidth=0.5).fit(X)
     log_dens = kde.score_samples(X_plot)
-    ax.plot(X_plot[:, 0], np.exp(log_dens), '-',
-            label="kernel = '{0}'".format(kernel))
+    ax.plot(X_plot[:, 0], np.exp(log_dens), color=color, lw=lw,
+            linestyle='-', label="kernel = '{0}'".format(kernel))
 
 ax.text(6, 0.38, "N={0} points".format(N))
 

--- a/examples/neighbors/plot_nearest_centroid.py
+++ b/examples/neighbors/plot_nearest_centroid.py
@@ -18,15 +18,17 @@ n_neighbors = 15
 
 # import some data to play with
 iris = datasets.load_iris()
-X = iris.data[:, :2]  # we only take the first two features. We could
-                      # avoid this ugly slicing by using a two-dim dataset
+
+# We only take the first two features. We could
+# avoid this ugly slicing by using a two-dim dataset
+X = iris.data[:, :2]
 y = iris.target
 
 h = .02  # step size in the mesh
 
 # Create color maps
-cmap_light = ListedColormap(['#FFAAAA', '#AAFFAA', '#AAAAFF'])
-cmap_bold = ListedColormap(['#FF0000', '#00FF00', '#0000FF'])
+cmap_light = ListedColormap(['orange', 'cyan', 'cornflowerblue'])
+cmap_bold = ListedColormap(['darkorange', 'c', 'darkblue'])
 
 for shrinkage in [None, 0.1]:
     # we create an instance of Neighbours Classifier and fit the data.

--- a/examples/neighbors/plot_regression.py
+++ b/examples/neighbors/plot_regression.py
@@ -39,8 +39,8 @@ for i, weights in enumerate(['uniform', 'distance']):
     y_ = knn.fit(X, y).predict(T)
 
     plt.subplot(2, 1, i + 1)
-    plt.scatter(X, y, c='k', label='data')
-    plt.plot(T, y_, c='g', label='prediction')
+    plt.scatter(X, y, color='darkorange', label='data')
+    plt.plot(T, y_, color='navy', label='prediction')
     plt.axis('tight')
     plt.legend()
     plt.title("KNeighborsRegressor (k = %i, weights = '%s')" % (n_neighbors,


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_approximate_nearest_neighbors_hyperparameters.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10688599/afc95c0e-7975-11e5-9335-ccd768deae8b.png)

plot_classification.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10688537/3e67b0ec-7975-11e5-9078-2b0e86285544.png)
![figure_2](https://cloud.githubusercontent.com/assets/1568249/10688536/3e63f650-7975-11e5-9e99-66dc23f53f57.png)

plot_kde_1d.py
![figure_3](https://cloud.githubusercontent.com/assets/1568249/10688621/ddb59bc8-7975-11e5-80eb-716098e34d94.png)

plot_nearest_centroid.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10688553/6c47eed2-7975-11e5-87c6-bd1f4fc33eb8.png)
![figure_2](https://cloud.githubusercontent.com/assets/1568249/10688554/6c48a5fc-7975-11e5-8d23-bda637fb1c90.png)

plot_regression.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10688568/7fb92a1c-7975-11e5-9776-e26b3d611112.png)
