### PR TITLE
[MRG] Added colorblind compatibility for text examples

### DIFF
--- a/examples/text/document_classification_20newsgroups.py
+++ b/examples/text/document_classification_20newsgroups.py
@@ -298,9 +298,10 @@ test_time = np.array(test_time) / np.max(test_time)
 
 plt.figure(figsize=(12, 8))
 plt.title("Score")
-plt.barh(indices, score, .2, label="score", color='r')
-plt.barh(indices + .3, training_time, .2, label="training time", color='g')
-plt.barh(indices + .6, test_time, .2, label="test time", color='b')
+plt.barh(indices, score, .2, label="score", color='navy')
+plt.barh(indices + .3, training_time, .2, label="training time",
+         color='c')
+plt.barh(indices + .6, test_time, .2, label="test time", color='darkorange')
 plt.yticks(())
 plt.legend(loc='best')
 plt.subplots_adjust(left=.25)


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

document_classification_20newsgroups.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10688867/b978b5f4-7977-11e5-9f10-a129f3f32698.png)
