### PR TITLE
[MRG+1] Added colorblind compatibility for trees examples

### DIFF
--- a/examples/tree/plot_tree_regression.py
+++ b/examples/tree/plot_tree_regression.py
@@ -39,9 +39,9 @@ y_2 = regr_2.predict(X_test)
 
 # Plot the results
 plt.figure()
-plt.scatter(X, y, c="k", label="data")
-plt.plot(X_test, y_1, c="g", label="max_depth=2", linewidth=2)
-plt.plot(X_test, y_2, c="r", label="max_depth=5", linewidth=2)
+plt.scatter(X, y, c="darkorange", label="data")
+plt.plot(X_test, y_1, color="cornflowerblue", label="max_depth=2", linewidth=2)
+plt.plot(X_test, y_2, color="yellowgreen", label="max_depth=5", linewidth=2)
 plt.xlabel("data")
 plt.ylabel("target")
 plt.title("Decision Tree Regression")

--- a/examples/tree/plot_tree_regression_multioutput.py
+++ b/examples/tree/plot_tree_regression_multioutput.py
@@ -42,10 +42,11 @@ y_3 = regr_3.predict(X_test)
 
 # Plot the results
 plt.figure()
-plt.scatter(y[:, 0], y[:, 1], c="k", label="data")
-plt.scatter(y_1[:, 0], y_1[:, 1], c="g", label="max_depth=2")
-plt.scatter(y_2[:, 0], y_2[:, 1], c="r", label="max_depth=5")
-plt.scatter(y_3[:, 0], y_3[:, 1], c="b", label="max_depth=8")
+s = 50
+plt.scatter(y[:, 0], y[:, 1], c="navy", s=s, label="data")
+plt.scatter(y_1[:, 0], y_1[:, 1], c="cornflowerblue", s=s, label="max_depth=2")
+plt.scatter(y_2[:, 0], y_2[:, 1], c="c", s=s, label="max_depth=5")
+plt.scatter(y_3[:, 0], y_3[:, 1], c="orange", s=s, label="max_depth=8")
 plt.xlim([-6, 6])
 plt.ylim([-6, 6])
 plt.xlabel("data")


### PR DESCRIPTION
Added colorblind compatibility as discussed in #5435.

plot_tree_regression.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10689025/84ca88e0-7978-11e5-98f3-60d9c060a746.png)

plot_tree_regression_multioutput.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10689177/87b53342-7979-11e5-93c9-a20fffbbb2fa.png)
