### PR TITLE
Added colorblind compatibility cluster examples

### DIFF
--- a/examples/cluster/plot_adjusted_for_chance_measures.py
+++ b/examples/cluster/plot_adjusted_for_chance_measures.py
@@ -57,10 +57,10 @@ def uniform_labelings_scores(score_func, n_samples, n_clusters_range,
     return scores
 
 score_funcs = [
-    metrics.adjusted_rand_score,
-    metrics.v_measure_score,
-    metrics.adjusted_mutual_info_score,
-    metrics.mutual_info_score,
+    (metrics.adjusted_rand_score, "navy"),
+    (metrics.v_measure_score, "turquoise"),
+    (metrics.adjusted_mutual_info_score, "cornflowerblue"),
+    (metrics.mutual_info_score, "darkorange")
 ]
 
 # 2 independent random clusterings with equal cluster number
@@ -72,7 +72,7 @@ plt.figure(1)
 
 plots = []
 names = []
-for score_func in score_funcs:
+for score_func, color in score_funcs:
     print("Computing %s for %d values of n_clusters and n_samples=%d"
           % (score_func.__name__, len(n_clusters_range), n_samples))
 
@@ -80,7 +80,8 @@ for score_func in score_funcs:
     scores = uniform_labelings_scores(score_func, n_samples, n_clusters_range)
     print("done in %0.3fs" % (time() - t0))
     plots.append(plt.errorbar(
-        n_clusters_range, np.median(scores, axis=1), scores.std(axis=1))[0])
+        n_clusters_range, np.median(scores, axis=1), scores.std(axis=1),
+        color=color, lw=2)[0])
     names.append(score_func.__name__)
 
 plt.title("Clustering measures for 2 random uniform labelings\n"
@@ -102,7 +103,7 @@ plt.figure(2)
 
 plots = []
 names = []
-for score_func in score_funcs:
+for score_func, color in score_funcs:
     print("Computing %s for %d values of n_clusters and n_samples=%d"
           % (score_func.__name__, len(n_clusters_range), n_samples))
 
@@ -111,7 +112,8 @@ for score_func in score_funcs:
                                       fixed_n_classes=n_classes)
     print("done in %0.3fs" % (time() - t0))
     plots.append(plt.errorbar(
-        n_clusters_range, scores.mean(axis=1), scores.std(axis=1))[0])
+        n_clusters_range, scores.mean(axis=1), scores.std(axis=1),
+        color=color, lw=2)[0])
     names.append(score_func.__name__)
 
 plt.title("Clustering measures for random uniform labeling\n"

--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -48,13 +48,14 @@ plt.close('all')
 plt.figure(1)
 plt.clf()
 
-colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
+colors = cycle(['navy', 'cyan', 'darkorange'])
 for k, col in zip(range(n_clusters_), colors):
     class_members = labels == k
     cluster_center = X[cluster_centers_indices[k]]
-    plt.plot(X[class_members, 0], X[class_members, 1], col + '.')
-    plt.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,
-             markeredgecolor='k', markersize=14)
+    plt.scatter(X[class_members, 0], X[class_members, 1], color=col,
+                marker='.', s=40)
+    plt.scatter(cluster_center[0], cluster_center[1], marker='o',
+                color=col, s=14)
     for x in X[class_members]:
         plt.plot([cluster_center[0], x[0]], [cluster_center[1], x[1]], col)
 

--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -76,7 +76,7 @@ labels = ('Waveform 1', 'Waveform 2', 'Waveform 3')
 # Plot the ground-truth labelling
 plt.figure()
 plt.axes([0, 0, 1, 1])
-for l, c, n in zip(range(n_clusters), 'rgb',
+for l, c, n in zip(range(n_clusters), ['navy', 'yellowgreen', 'darkorange'],
                    labels):
     lines = plt.plot(X[y == l].T, c=c, alpha=.5)
     lines[0].set_label(n)
@@ -111,7 +111,7 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     plt.suptitle("Interclass %s distances" % metric, size=18)
     plt.tight_layout()
 
-
+colors = ['navy', 'c', 'yellowgreen', 'darkorange']
 # Plot clustering results
 for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     model = AgglomerativeClustering(n_clusters=n_clusters,
@@ -119,7 +119,7 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     model.fit(X)
     plt.figure()
     plt.axes([0, 0, 1, 1])
-    for l, c in zip(np.arange(model.n_clusters), 'rgbk'):
+    for l, c in zip(np.arange(model.n_clusters), colors):
         plt.plot(X[model.labels_ == l].T, c=c, alpha=.5)
     plt.axis('tight')
     plt.axis('off')

--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -52,7 +52,7 @@ import matplotlib.pyplot as plt
 
 # Black removed and is used for noise instead.
 unique_labels = set(labels)
-colors = plt.cm.Spectral(np.linspace(0, 1, len(unique_labels)))
+colors = plt.cm.gnuplot(np.linspace(0, 1, len(unique_labels)))
 for k, col in zip(unique_labels, colors):
     if k == -1:
         # Black used for noise.

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -74,13 +74,14 @@ plots = []
 legends = []
 
 cases = [
-    (KMeans, 'k-means++', {}),
-    (KMeans, 'random', {}),
-    (MiniBatchKMeans, 'k-means++', {'max_no_improvement': 3}),
-    (MiniBatchKMeans, 'random', {'max_no_improvement': 3, 'init_size': 500}),
+    (KMeans, 'k-means++', {}, 'navy'),
+    (KMeans, 'random', {}, 'c'),
+    (MiniBatchKMeans, 'k-means++', {'max_no_improvement': 3}, 'cornflowerblue'),
+    (MiniBatchKMeans, 'random', {'max_no_improvement': 3, 'init_size': 500},
+     'darkorange'),
 ]
 
-for factory, init, params in cases:
+for factory, init, params, color in cases:
     print("Evaluation of %s with %s init" % (factory.__name__, init))
     inertia = np.empty((len(n_init_range), n_runs))
 
@@ -90,7 +91,8 @@ for factory, init, params in cases:
             km = factory(n_clusters=n_clusters, init=init, random_state=run_id,
                          n_init=n_init, **params).fit(X)
             inertia[i, run_id] = km.inertia_
-    p = plt.errorbar(n_init_range, inertia.mean(axis=1), inertia.std(axis=1))
+    p = plt.errorbar(n_init_range, inertia.mean(axis=1), inertia.std(axis=1),
+                     color=color, lw=2)
     plots.append(p[0])
     legends.append("%s with %s init" % (factory.__name__, init))
 

--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -45,12 +45,13 @@ from itertools import cycle
 plt.figure(1)
 plt.clf()
 
-colors = cycle('bgrcmykbgrcmykbgrcmykbgrcmyk')
-for k, col in zip(range(n_clusters_), colors):
+colors = cycle(['cornflowerblue', 'c', 'darkorange'])
+for k, color in zip(range(n_clusters_), colors):
     my_members = labels == k
     cluster_center = cluster_centers[k]
-    plt.plot(X[my_members, 0], X[my_members, 1], col + '.')
-    plt.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=col,
-             markeredgecolor='k', markersize=14)
+    plt.plot(X[my_members, 0], X[my_members, 1], 'o', markerfacecolor=color,
+             markeredgecolor=color, markersize=4)
+    plt.plot(cluster_center[0], cluster_center[1], 'o', markerfacecolor=color,
+             markeredgecolor='k', lw=3, markersize=14)
 plt.title('Estimated number of clusters: %d' % n_clusters_)
 plt.show()


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_adjusted_for_chance_measures.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691613/b3f34ff0-798a-11e5-8772-95a33b4a6fea.png)
![figure_2](https://cloud.githubusercontent.com/assets/1568249/10691612/b3f33290-798a-11e5-91cb-f8f1bcd152bd.png)

plot_affinity_propagation.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691560/435c73ac-798a-11e5-9871-ae64178b6255.png)

plot_agglomerative_clustering_metrics.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691648/09e1fe8e-798b-11e5-9c77-0ed46a172649.png)
![figure_5](https://cloud.githubusercontent.com/assets/1568249/10691649/09e30252-798b-11e5-82b9-eb43d9aae864.png)
![figure_6](https://cloud.githubusercontent.com/assets/1568249/10691647/09e07b68-798b-11e5-9618-b451668ab49d.png)
![figure_7](https://cloud.githubusercontent.com/assets/1568249/10691646/09e0701e-798b-11e5-8ab8-f64087b80242.png)

plot_dbscan.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691715/a333a2fe-798b-11e5-97b3-ba75e574d94f.png)

plot_kmeans_stability_low_dim_dense.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691733/c1d20fe8-798b-11e5-87cf-7ae776f04b93.png)

plot_mean_shift.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10691754/e2e9edfe-798b-11e5-83fd-a32dbc80297a.png)
