### PR TITLE
Added colorblind compatibility for feature examples

### DIFF
--- a/examples/feature_selection/plot_feature_selection.py
+++ b/examples/feature_selection/plot_feature_selection.py
@@ -54,7 +54,7 @@ selector.fit(X, y)
 scores = -np.log10(selector.pvalues_)
 scores /= scores.max()
 plt.bar(X_indices - .45, scores, width=.2,
-        label=r'Univariate score ($-Log(p_{value})$)', color='g')
+        label=r'Univariate score ($-Log(p_{value})$)', color='darkorange')
 
 ###############################################################################
 # Compare to the weights of an SVM
@@ -64,7 +64,8 @@ clf.fit(X, y)
 svm_weights = (clf.coef_ ** 2).sum(axis=0)
 svm_weights /= svm_weights.max()
 
-plt.bar(X_indices - .25, svm_weights, width=.2, label='SVM weight', color='r')
+plt.bar(X_indices - .25, svm_weights, width=.2, label='SVM weight',
+        color='navy')
 
 clf_selected = svm.SVC(kernel='linear')
 clf_selected.fit(selector.transform(X), y)
@@ -73,7 +74,7 @@ svm_weights_selected = (clf_selected.coef_ ** 2).sum(axis=0)
 svm_weights_selected /= svm_weights_selected.max()
 
 plt.bar(X_indices[selector.get_support()] - .05, svm_weights_selected,
-        width=.2, label='SVM weights after selection', color='b')
+        width=.2, label='SVM weights after selection', color='c')
 
 
 plt.title("Comparing feature selection")

--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -30,7 +30,7 @@ rfe.fit(X, y)
 ranking = rfe.ranking_.reshape(digits.images[0].shape)
 
 # Plot pixel ranking
-plt.matshow(ranking)
+plt.matshow(ranking, cmap=plt.cm.Blues)
 plt.colorbar()
 plt.title("Ranking of pixels with RFE")
 plt.show()


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_feature_selection.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10692200/23aa2936-7990-11e5-91c5-ab93aba5f948.png)

plot_rfe_digits.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10692210/3e46103e-7990-11e5-9f64-0364310b7b8a.png)
