### PR TITLE
Colorblind compatibility for model_selection examples

### DIFF
--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -75,6 +75,8 @@ print(__doc__)
 
 import matplotlib.pyplot as plt
 import numpy as np
+from itertools import cycle
+
 from sklearn import svm, datasets
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import average_precision_score
@@ -86,6 +88,10 @@ from sklearn.multiclass import OneVsRestClassifier
 iris = datasets.load_iris()
 X = iris.data
 y = iris.target
+
+# setup plot details
+colors = cycle(['navy', 'turquoise', 'darkorange', 'cornflowerblue', 'teal'])
+lw = 2
 
 # Binarize the output
 y = label_binarize(y, classes=[0, 1, 2])
@@ -120,9 +126,11 @@ precision["micro"], recall["micro"], _ = precision_recall_curve(y_test.ravel(),
 average_precision["micro"] = average_precision_score(y_test, y_score,
                                                      average="micro")
 
+
 # Plot Precision-Recall curve
 plt.clf()
-plt.plot(recall[0], precision[0], label='Precision-Recall curve')
+plt.plot(recall[0], precision[0], lw=lw, color='navy',
+         label='Precision-Recall curve')
 plt.xlabel('Recall')
 plt.ylabel('Precision')
 plt.ylim([0.0, 1.05])
@@ -133,11 +141,11 @@ plt.show()
 
 # Plot Precision-Recall curve for each class
 plt.clf()
-plt.plot(recall["micro"], precision["micro"],
+plt.plot(recall["micro"], precision["micro"], color='gold', lw=lw,
          label='micro-average Precision-recall curve (area = {0:0.2f})'
                ''.format(average_precision["micro"]))
-for i in range(n_classes):
-    plt.plot(recall[i], precision[i],
+for i, color in zip(range(n_classes), colors):
+    plt.plot(recall[i], precision[i], color=color, lw=lw,
              label='Precision-recall curve of class {0} (area = {1:0.2f})'
                    ''.format(i, average_precision[i]))
 

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -39,6 +39,8 @@ print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
+from itertools import cycle
+
 from sklearn import svm, datasets
 from sklearn.metrics import roc_curve, auc
 from sklearn.cross_validation import train_test_split
@@ -85,8 +87,10 @@ roc_auc["micro"] = auc(fpr["micro"], tpr["micro"])
 ##############################################################################
 # Plot of a ROC curve for a specific class
 plt.figure()
-plt.plot(fpr[2], tpr[2], label='ROC curve (area = %0.2f)' % roc_auc[2])
-plt.plot([0, 1], [0, 1], 'k--')
+lw = 2
+plt.plot(fpr[2], tpr[2], color='darkorange',
+         lw=lw, label='ROC curve (area = %0.2f)' % roc_auc[2])
+plt.plot([0, 1], [0, 1], color='navy', lw=lw, linestyle='--')
 plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])
 plt.xlabel('False Positive Rate')
@@ -121,18 +125,20 @@ plt.figure()
 plt.plot(fpr["micro"], tpr["micro"],
          label='micro-average ROC curve (area = {0:0.2f})'
                ''.format(roc_auc["micro"]),
-         linewidth=2)
+         color='deeppink', linestyle=':', linewidth=4)
 
 plt.plot(fpr["macro"], tpr["macro"],
          label='macro-average ROC curve (area = {0:0.2f})'
                ''.format(roc_auc["macro"]),
-         linewidth=2)
+         color='navy', linestyle=':', linewidth=4)
 
-for i in range(n_classes):
-    plt.plot(fpr[i], tpr[i], label='ROC curve of class {0} (area = {1:0.2f})'
-                                   ''.format(i, roc_auc[i]))
+colors = cycle(['aqua', 'darkorange', 'cornflowerblue'])
+for i, color in zip(range(n_classes), colors):
+    plt.plot(fpr[i], tpr[i], color=color, lw=lw,
+             label='ROC curve of class {0} (area = {1:0.2f})'
+             ''.format(i, roc_auc[i]))
 
-plt.plot([0, 1], [0, 1], 'k--')
+plt.plot([0, 1], [0, 1], 'k--', lw=lw)
 plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])
 plt.xlabel('False Positive Rate')

--- a/examples/model_selection/plot_roc_crossval.py
+++ b/examples/model_selection/plot_roc_crossval.py
@@ -34,6 +34,7 @@ print(__doc__)
 import numpy as np
 from scipy import interp
 import matplotlib.pyplot as plt
+from itertools import cycle
 
 from sklearn import svm, datasets
 from sklearn.metrics import roc_curve, auc
@@ -65,22 +66,29 @@ mean_tpr = 0.0
 mean_fpr = np.linspace(0, 1, 100)
 all_tpr = []
 
-for i, (train, test) in enumerate(cv):
+colors = cycle(['cyan', 'indigo', 'seagreen', 'yellow', 'blue', 'darkorange'])
+lw = 2
+
+i = 0
+for (train, test), color in zip(cv, colors):
     probas_ = classifier.fit(X[train], y[train]).predict_proba(X[test])
     # Compute ROC curve and area the curve
     fpr, tpr, thresholds = roc_curve(y[test], probas_[:, 1])
     mean_tpr += interp(mean_fpr, fpr, tpr)
     mean_tpr[0] = 0.0
     roc_auc = auc(fpr, tpr)
-    plt.plot(fpr, tpr, lw=1, label='ROC fold %d (area = %0.2f)' % (i, roc_auc))
+    plt.plot(fpr, tpr, lw=lw, color=color,
+             label='ROC fold %d (area = %0.2f)' % (i, roc_auc))
 
-plt.plot([0, 1], [0, 1], '--', color=(0.6, 0.6, 0.6), label='Luck')
+    i += 1
+plt.plot([0, 1], [0, 1], linestyle='--', lw=lw, color='k',
+         label='Luck')
 
 mean_tpr /= len(cv)
 mean_tpr[-1] = 1.0
 mean_auc = auc(mean_fpr, mean_tpr)
-plt.plot(mean_fpr, mean_tpr, 'k--',
-         label='Mean ROC (area = %0.2f)' % mean_auc, lw=2)
+plt.plot(mean_fpr, mean_tpr, color='g', linestyle='--',
+         label='Mean ROC (area = %0.2f)' % mean_auc, lw=lw)
 
 plt.xlim([-0.05, 1.05])
 plt.ylim([-0.05, 1.05])

--- a/examples/model_selection/plot_validation_curve.py
+++ b/examples/model_selection/plot_validation_curve.py
@@ -15,6 +15,7 @@ print(__doc__)
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from sklearn.datasets import load_digits
 from sklearn.svm import SVC
 from sklearn.learning_curve import validation_curve
@@ -35,12 +36,16 @@ plt.title("Validation Curve with SVM")
 plt.xlabel("$\gamma$")
 plt.ylabel("Score")
 plt.ylim(0.0, 1.1)
-plt.semilogx(param_range, train_scores_mean, label="Training score", color="r")
+lw = 2
+plt.semilogx(param_range, train_scores_mean, label="Training score",
+             color="darkorange", lw=lw)
 plt.fill_between(param_range, train_scores_mean - train_scores_std,
-                 train_scores_mean + train_scores_std, alpha=0.2, color="r")
+                 train_scores_mean + train_scores_std, alpha=0.2,
+                 color="darkorange", lw=lw)
 plt.semilogx(param_range, test_scores_mean, label="Cross-validation score",
-             color="g")
+             color="navy", lw=lw)
 plt.fill_between(param_range, test_scores_mean - test_scores_std,
-                 test_scores_mean + test_scores_std, alpha=0.2, color="g")
+                 test_scores_mean + test_scores_std, alpha=0.2,
+                 color="navy", lw=lw)
 plt.legend(loc="best")
 plt.show()


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_precision_recall.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699253/c36ad478-79b5-11e5-9bfb-3468712efb35.png)

plot_roc.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699765/86f11ecc-79b9-11e5-9d40-4c22622ae4a1.png)

![figure_2](https://cloud.githubusercontent.com/assets/1568249/10699274/db06bde0-79b5-11e5-93f5-873311e0a062.png)

plot_roc_crossval.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699292/f9ceb5f2-79b5-11e5-935b-d81d679ad2d5.png)

plot_validation_curve.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699330/34e070c2-79b6-11e5-83bd-c4826801940f.png)
