### PR TITLE
Added colorblind compatibility for decomposition example

### DIFF
--- a/examples/decomposition/plot_incremental_pca.py
+++ b/examples/decomposition/plot_incremental_pca.py
@@ -40,11 +40,13 @@ X_ipca = ipca.fit_transform(X)
 pca = PCA(n_components=n_components)
 X_pca = pca.fit_transform(X)
 
+colors = ['navy', 'turquoise', 'darkorange']
+
 for X_transformed, title in [(X_ipca, "Incremental PCA"), (X_pca, "PCA")]:
     plt.figure(figsize=(8, 8))
-    for c, i, target_name in zip("rgb", [0, 1, 2], iris.target_names):
+    for color, i, target_name in zip(colors, [0, 1, 2], iris.target_names):
         plt.scatter(X_transformed[y == i, 0], X_transformed[y == i, 1],
-                    c=c, label=target_name)
+                    color=color, lw=2, label=target_name)
 
     if "Incremental" in title:
         err = np.abs(np.abs(X_pca) - np.abs(X_ipca)).mean()
@@ -52,7 +54,7 @@ for X_transformed, title in [(X_ipca, "Incremental PCA"), (X_pca, "PCA")]:
                   "%.6f" % err)
     else:
         plt.title(title + " of iris dataset")
-    plt.legend(loc="best")
+    plt.legend(loc="best", shadow=False, scatterpoints=1)
     plt.axis([-4, 4, -1.5, 1.5])
 
 plt.show()

--- a/examples/decomposition/plot_pca_vs_lda.py
+++ b/examples/decomposition/plot_pca_vs_lda.py
@@ -41,15 +41,20 @@ print('explained variance ratio (first two components): %s'
       % str(pca.explained_variance_ratio_))
 
 plt.figure()
-for c, i, target_name in zip("rgb", [0, 1, 2], target_names):
-    plt.scatter(X_r[y == i, 0], X_r[y == i, 1], c=c, label=target_name)
-plt.legend()
+colors = ['navy', 'turquoise', 'darkorange']
+lw = 2
+
+for color, i, target_name in zip(colors, [0, 1, 2], target_names):
+    plt.scatter(X_r[y == i, 0], X_r[y == i, 1], color=color, alpha=.8, lw=lw,
+                label=target_name)
+plt.legend(loc='best', shadow=False, scatterpoints=1)
 plt.title('PCA of IRIS dataset')
 
 plt.figure()
-for c, i, target_name in zip("rgb", [0, 1, 2], target_names):
-    plt.scatter(X_r2[y == i, 0], X_r2[y == i, 1], c=c, label=target_name)
-plt.legend()
+for color, i, target_name in zip(colors, [0, 1, 2], target_names):
+    plt.scatter(X_r2[y == i, 0], X_r2[y == i, 1], alpha=.8, color=color,
+                label=target_name)
+plt.legend(loc='best', shadow=False, scatterpoints=1)
 plt.title('LDA of IRIS dataset')
 
 plt.show()

--- a/examples/decomposition/plot_sparse_coding.py
+++ b/examples/decomposition/plot_sparse_coding.py
@@ -17,7 +17,7 @@ is performed in order to stay on the same order of magnitude.
 print(__doc__)
 
 import numpy as np
-import matplotlib.pylab as pl
+import matplotlib.pylab as plt
 
 from sklearn.decomposition import SparseCoder
 
@@ -61,24 +61,27 @@ y[np.logical_not(first_quarter)] = -1.
 
 # List the different sparse coding methods in the following format:
 # (title, transform_algorithm, transform_alpha, transform_n_nozero_coefs)
-estimators = [('OMP', 'omp', None, 15), ('Lasso', 'lasso_cd', 2, None), ]
+estimators = [('OMP', 'omp', None, 15, 'navy'),
+              ('Lasso', 'lasso_cd', 2, None, 'turquoise'), ]
+lw = 2
 
-pl.figure(figsize=(13, 6))
+plt.figure(figsize=(13, 6))
 for subplot, (D, title) in enumerate(zip((D_fixed, D_multi),
                                          ('fixed width', 'multiple widths'))):
-    pl.subplot(1, 2, subplot + 1)
-    pl.title('Sparse coding against %s dictionary' % title)
-    pl.plot(y, ls='dotted', label='Original signal')
+    plt.subplot(1, 2, subplot + 1)
+    plt.title('Sparse coding against %s dictionary' % title)
+    plt.plot(y, lw=lw, linestyle='--', label='Original signal')
     # Do a wavelet approximation
-    for title, algo, alpha, n_nonzero in estimators:
+    for title, algo, alpha, n_nonzero, color in estimators:
         coder = SparseCoder(dictionary=D, transform_n_nonzero_coefs=n_nonzero,
                             transform_alpha=alpha, transform_algorithm=algo)
         x = coder.transform(y)
         density = len(np.flatnonzero(x))
         x = np.ravel(np.dot(x, D))
         squared_error = np.sum((y - x) ** 2)
-        pl.plot(x, label='%s: %s nonzero coefs,\n%.2f error'
-                % (title, density, squared_error))
+        plt.plot(x, color=color, lw=lw,
+                 label='%s: %s nonzero coefs,\n%.2f error'
+                 % (title, density, squared_error))
 
     # Soft thresholding debiasing
     coder = SparseCoder(dictionary=D, transform_algorithm='threshold',
@@ -88,10 +91,10 @@ for subplot, (D, title) in enumerate(zip((D_fixed, D_multi),
     x[0, idx], _, _, _ = np.linalg.lstsq(D[idx, :].T, y)
     x = np.ravel(np.dot(x, D))
     squared_error = np.sum((y - x) ** 2)
-    pl.plot(x,
-            label='Thresholding w/ debiasing:\n%d nonzero coefs, %.2f error' %
-            (len(idx), squared_error))
-    pl.axis('tight')
-    pl.legend()
-pl.subplots_adjust(.04, .07, .97, .90, .09, .2)
-pl.show()
+    plt.plot(x, color='darkorange', lw=lw,
+             label='Thresholding w/ debiasing:\n%d nonzero coefs, %.2f error'
+             % (len(idx), squared_error))
+    plt.axis('tight')
+    plt.legend(shadow=False, loc='best')
+plt.subplots_adjust(.04, .07, .97, .90, .09, .2)
+plt.show()


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_incremental_pca.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699827/fb7ab65e-79b9-11e5-83e4-13063884da14.png)
![figure_2](https://cloud.githubusercontent.com/assets/1568249/10699826/fb7a7752-79b9-11e5-93f6-f566a2abc2ce.png)

plot_pca_vs_lda.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699897/652b7afc-79ba-11e5-8c80-b589575647ad.png)

![figure_2](https://cloud.githubusercontent.com/assets/1568249/10699840/0cdfd7ee-79ba-11e5-9b30-8bf84e3e5bd0.png)

plot_sparse_coding.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10699858/22063366-79ba-11e5-9c5c-0a800927afc6.png)
