### PR TITLE
Added colorblind compatibility for (unsorted) examples

### DIFF
--- a/examples/covariance/plot_lw_vs_oas.py
+++ b/examples/covariance/plot_lw_vs_oas.py
@@ -60,9 +60,9 @@ for i, n_samples in enumerate(n_samples_range):
 # plot MSE
 plt.subplot(2, 1, 1)
 plt.errorbar(n_samples_range, lw_mse.mean(1), yerr=lw_mse.std(1),
-             label='Ledoit-Wolf', color='g')
+             label='Ledoit-Wolf', color='navy', lw=2)
 plt.errorbar(n_samples_range, oa_mse.mean(1), yerr=oa_mse.std(1),
-             label='OAS', color='r')
+             label='OAS', color='darkorange', lw=2)
 plt.ylabel("Squared error")
 plt.legend(loc="upper right")
 plt.title("Comparison of covariance estimators")
@@ -71,9 +71,9 @@ plt.xlim(5, 31)
 # plot shrinkage coefficient
 plt.subplot(2, 1, 2)
 plt.errorbar(n_samples_range, lw_shrinkage.mean(1), yerr=lw_shrinkage.std(1),
-             label='Ledoit-Wolf', color='g')
+             label='Ledoit-Wolf', color='navy', lw=2)
 plt.errorbar(n_samples_range, oa_shrinkage.mean(1), yerr=oa_shrinkage.std(1),
-             label='OAS', color='r')
+             label='OAS', color='darkorange', lw=2)
 plt.xlabel("n_samples")
 plt.ylabel("Shrinkage")
 plt.legend(loc="lower right")

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -42,10 +42,11 @@ distributed data sets:
 
 References
 ----------
-.. [1] P. J. Rousseeuw. Least median of squares regression. J. Am
-    Stat Ass, 79:871, 1984.
-.. [2] Johanna Hardin, David M Rocke. Journal of Computational and
-    Graphical Statistics. December 1, 2005, 14(4): 928-946.
+.. [1] P. J. Rousseeuw. Least median of squares regression. Journal of American
+    Statistical Ass., 79:871, 1984.
+.. [2] Johanna Hardin, David M Rocke. The distribution of robust distances.
+    Journal of Computational and Graphical Statistics. December 1, 2005,
+    14(4): 928-946.
 .. [3] Zoubir A., Koivunen V., Chakhchoukh Y. and Muma M. (2012). Robust
     estimation in signal processing: A tutorial-style treatment of
     fundamental concepts. IEEE Signal Processing Magazine 29(4), 61-80.
@@ -115,15 +116,16 @@ for i, n_outliers in enumerate(range_n_outliers):
 # Display results
 font_prop = matplotlib.font_manager.FontProperties(size=11)
 plt.subplot(2, 1, 1)
+lw = 2
 plt.errorbar(range_n_outliers, err_loc_mcd.mean(1),
              yerr=err_loc_mcd.std(1) / np.sqrt(repeat),
-             label="Robust location", color='m')
+             label="Robust location", lw=lw, color='m')
 plt.errorbar(range_n_outliers, err_loc_emp_full.mean(1),
              yerr=err_loc_emp_full.std(1) / np.sqrt(repeat),
-             label="Full data set mean", color='green')
+             label="Full data set mean", lw=lw, color='green')
 plt.errorbar(range_n_outliers, err_loc_emp_pure.mean(1),
              yerr=err_loc_emp_pure.std(1) / np.sqrt(repeat),
-             label="Pure data set mean", color='black')
+             label="Pure data set mean", lw=lw, color='black')
 plt.title("Influence of outliers on the location estimation")
 plt.ylabel(r"Error ($||\mu - \hat{\mu}||_2^2$)")
 plt.legend(loc="upper left", prop=font_prop)

--- a/examples/gaussian_process/plot_compare_gpr_krr.py
+++ b/examples/gaussian_process/plot_compare_gpr_krr.py
@@ -102,17 +102,20 @@ print("Time for GPR prediction with standard-deviation: %.3f"
       % (time.time() - stime))
 
 # Plot results
-plt.figure(figsize = (10,5))
+plt.figure(figsize=(10, 5))
+lw = 2
 plt.scatter(X, y, c='k', label='data')
-plt.plot(X_plot, np.sin(X_plot), c='k', label='True')
-plt.plot(X_plot, y_kr, c='g', label='KRR (%s)' % kr.best_params_)
-plt.plot(X_plot, y_gpr, c='r', label='GPR (%s)' % gpr.kernel_)
-plt.fill_between(X_plot[:, 0], y_gpr - y_std, y_gpr + y_std, color='r',
+plt.plot(X_plot, np.sin(X_plot), color='navy', lw=lw, label='True')
+plt.plot(X_plot, y_kr, color='turquoise', lw=lw,
+         label='KRR (%s)' % kr.best_params_)
+plt.plot(X_plot, y_gpr, color='darkorange', lw=lw,
+         label='GPR (%s)' % gpr.kernel_)
+plt.fill_between(X_plot[:, 0], y_gpr - y_std, y_gpr + y_std, color='darkorange',
                  alpha=0.2)
 plt.xlabel('data')
 plt.ylabel('target')
 plt.xlim(0, 20)
 plt.ylim(-4, 4)
 plt.title('GPR versus Kernel Ridge')
-plt.legend(loc=9, prop={'size': 10})
+plt.legend(loc="best",  scatterpoints=1, prop={'size': 8})
 plt.show()

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -61,23 +61,25 @@ npos = clf.fit_transform(npos)
 fig = plt.figure(1)
 ax = plt.axes([0., 0., 1., 1.])
 
-plt.scatter(X_true[:, 0], X_true[:, 1], c='r', s=20)
-plt.scatter(pos[:, 0], pos[:, 1], s=20, c='g')
-plt.scatter(npos[:, 0], npos[:, 1], s=20, c='b')
-plt.legend(('True position', 'MDS', 'NMDS'), loc='best')
+s = 100
+plt.scatter(X_true[:, 0], X_true[:, 1], color='navy', s=s, lw=0,
+            label='True Position')
+plt.scatter(pos[:, 0], pos[:, 1], color='turquoise', s=s, lw=0, label='MDS')
+plt.scatter(npos[:, 0], npos[:, 1], color='darkorange', s=s, lw=0, label='NMDS')
+plt.legend(scatterpoints=1, loc='best', shadow=False)
 
 similarities = similarities.max() / similarities * 100
 similarities[np.isinf(similarities)] = 0
 
 # Plot the edges
 start_idx, end_idx = np.where(pos)
-#a sequence of (*line0*, *line1*, *line2*), where::
+# a sequence of (*line0*, *line1*, *line2*), where::
 #            linen = (x0, y0), (x1, y1), ... (xm, ym)
 segments = [[X_true[i, :], X_true[j, :]]
             for i in range(len(pos)) for j in range(len(pos))]
 values = np.abs(similarities)
 lc = LineCollection(segments,
-                    zorder=0, cmap=plt.cm.hot_r,
+                    zorder=0, cmap=plt.cm.Blues,
                     norm=plt.Normalize(0, values.max()))
 lc.set_array(similarities.flatten())
 lc.set_linewidths(0.5 * np.ones(len(segments)))

--- a/examples/preprocessing/plot_function_transformer.py
+++ b/examples/preprocessing/plot_function_transformer.py
@@ -57,13 +57,16 @@ def drop_first_component(X, y):
 
 if __name__ == '__main__':
     X, y = generate_dataset()
-    plt.scatter(X[:, 0], X[:, 1], c=y, s=50)
-    plt.show()
+    lw = 0
+    plt.figure()
+    plt.scatter(X[:, 0], X[:, 1], c=y, lw=lw)
+    plt.figure()
     X_transformed, y_transformed = drop_first_component(*generate_dataset())
     plt.scatter(
         X_transformed[:, 0],
         np.zeros(len(X_transformed)),
         c=y_transformed,
-        s=50,
+        lw=lw,
+        s=60
     )
     plt.show()

--- a/examples/semi_supervised/plot_label_propagation_structure.py
+++ b/examples/semi_supervised/plot_label_propagation_structure.py
@@ -38,24 +38,24 @@ label_spread.fit(X, labels)
 output_labels = label_spread.transduction_
 plt.figure(figsize=(8.5, 4))
 plt.subplot(1, 2, 1)
-plot_outer_labeled, = plt.plot(X[labels == outer, 0],
-                               X[labels == outer, 1], 'rs')
-plot_unlabeled, = plt.plot(X[labels == -1, 0], X[labels == -1, 1], 'g.')
-plot_inner_labeled, = plt.plot(X[labels == inner, 0],
-                               X[labels == inner, 1], 'bs')
-plt.legend((plot_outer_labeled, plot_inner_labeled, plot_unlabeled),
-           ('Outer Labeled', 'Inner Labeled', 'Unlabeled'), 'upper left',
-           numpoints=1, shadow=False)
-plt.title("Raw data (2 classes=red and blue)")
+plt.scatter(X[labels == outer, 0], X[labels == outer, 1], color='navy',
+            marker='s', lw=0, label="outer labeled", s=10)
+plt.scatter(X[labels == inner, 0], X[labels == inner, 1], color='c',
+            marker='s', lw=0, label='inner labeled', s=10)
+plt.scatter(X[labels == -1, 0], X[labels == -1, 1], color='darkorange',
+            marker='.', label='unlabeled')
+plt.legend(scatterpoints=1, shadow=False, loc='upper right')
+plt.title("Raw data (2 classes=outer and inner)")
 
 plt.subplot(1, 2, 2)
 output_label_array = np.asarray(output_labels)
 outer_numbers = np.where(output_label_array == outer)[0]
 inner_numbers = np.where(output_label_array == inner)[0]
-plot_outer, = plt.plot(X[outer_numbers, 0], X[outer_numbers, 1], 'rs')
-plot_inner, = plt.plot(X[inner_numbers, 0], X[inner_numbers, 1], 'bs')
-plt.legend((plot_outer, plot_inner), ('Outer Learned', 'Inner Learned'),
-           'upper left', numpoints=1, shadow=False)
+plt.scatter(X[outer_numbers, 0], X[outer_numbers, 1], color='navy',
+            marker='s', lw=0, s=10, label="outer learned")
+plt.scatter(X[inner_numbers, 0], X[inner_numbers, 1], color='c',
+            marker='s', lw=0, s=10, label="inner learned")
+plt.legend(scatterpoints=1, shadow=False, loc='upper right')
 plt.title("Labels learned with Label Spreading (KNN)")
 
 plt.subplots_adjust(left=0.07, bottom=0.07, right=0.93, top=0.92)


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

covariance/plot_lw_vs_oas.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700031/5f7b33d0-79bb-11e5-8e88-795b4ca655dd.png)

covariance/plot_robust_vs_empirical_covariance.py
Made lines thicker and fixed (I think) reference. 
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700041/7004dbde-79bb-11e5-981e-c64c54f2d4f5.png)

gaussian_process/plot_compare_gpr_krr.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700069/9f83f8c2-79bb-11e5-8435-2532bd6113cc.png)

manifold/plot_mds.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700085/b28ab5a0-79bb-11e5-8cb5-051b8348d87a.png)

preprocessing/plot_function_transformer.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700110/f3ad90ac-79bb-11e5-993d-4ea5c2c7e226.png)
![figure_2](https://cloud.githubusercontent.com/assets/1568249/10700111/f3ae445c-79bb-11e5-9102-aed87099958e.png)

semi_supervised/plot_label_propagation_structure.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700605/2e347a26-79bf-11e5-9de6-c37dc88df096.png)
