### PR TITLE
Added colorblind capability for mixture examples

### DIFF
--- a/examples/mixture/plot_gmm.py
+++ b/examples/mixture/plot_gmm.py
@@ -46,7 +46,8 @@ gmm.fit(X)
 dpgmm = mixture.DPGMM(n_components=5, covariance_type='full')
 dpgmm.fit(X)
 
-color_iter = itertools.cycle(['r', 'g', 'b', 'c', 'm'])
+color_iter = itertools.cycle(['navy', 'c', 'cornflowerblue', 'gold',
+                              'darkorange'])
 
 for i, (clf, title) in enumerate([(gmm, 'GMM'),
                                   (dpgmm, 'Dirichlet Process GMM')]):

--- a/examples/mixture/plot_gmm_classifier.py
+++ b/examples/mixture/plot_gmm_classifier.py
@@ -38,8 +38,9 @@ from sklearn.externals.six.moves import xrange
 from sklearn.mixture import GMM
 
 
+colors = ['navy', 'turquoise', 'darkorange']
 def make_ellipses(gmm, ax):
-    for n, color in enumerate('rgb'):
+    for n, color in enumerate(colors):
         v, w = np.linalg.eigh(gmm._get_covars()[n][:2, :2])
         u = w[0] / np.linalg.norm(w[0])
         angle = np.arctan2(u[1], u[0])
@@ -91,14 +92,15 @@ for index, (name, classifier) in enumerate(classifiers.items()):
     h = plt.subplot(2, n_classifiers / 2, index + 1)
     make_ellipses(classifier, h)
 
-    for n, color in enumerate('rgb'):
+    for n, color in enumerate(colors):
         data = iris.data[iris.target == n]
-        plt.scatter(data[:, 0], data[:, 1], 0.8, color=color,
+        plt.scatter(data[:, 0], data[:, 1], s=0.8, color=color,
                     label=iris.target_names[n])
     # Plot the test data with crosses
-    for n, color in enumerate('rgb'):
+    for n, color in enumerate(colors):
         data = X_test[y_test == n]
-        plt.plot(data[:, 0], data[:, 1], 'x', color=color)
+        print(color)
+        plt.scatter(data[:, 0], data[:, 1], marker='x', color=color)
 
     y_train_pred = classifier.predict(X_train)
     train_accuracy = np.mean(y_train_pred.ravel() == y_train.ravel()) * 100

--- a/examples/mixture/plot_gmm_selection.py
+++ b/examples/mixture/plot_gmm_selection.py
@@ -49,7 +49,8 @@ for cv_type in cv_types:
             best_gmm = gmm
 
 bic = np.array(bic)
-color_iter = itertools.cycle(['k', 'r', 'g', 'b', 'c', 'm', 'y'])
+color_iter = itertools.cycle(['navy', 'turquoise', 'cornflowerblue',
+                              'darkorange'])
 clf = best_gmm
 bars = []
 

--- a/examples/mixture/plot_gmm_sin.py
+++ b/examples/mixture/plot_gmm_sin.py
@@ -37,9 +37,8 @@ for i in xrange(X.shape[0]):
     X[i, 0] = x + np.random.normal(0, 0.1)
     X[i, 1] = 3 * (np.sin(x) + np.random.normal(0, .2))
 
-
-color_iter = itertools.cycle(['r', 'g', 'b', 'c', 'm'])
-
+color_iter = itertools.cycle(['navy', 'turquoise', 'cornflowerblue',
+                              'darkorange'])
 
 for i, (clf, title) in enumerate([
         (mixture.GMM(n_components=10, covariance_type='full', n_iter=100),
@@ -63,7 +62,7 @@ for i, (clf, title) in enumerate([
         # components.
         if not np.any(Y_ == i):
             continue
-        plt.scatter(X[Y_ == i, 0], X[Y_ == i, 1], .8, color=color)
+        plt.scatter(X[Y_ == i, 0], X[Y_ == i, 1], color=color, s=4)
 
         # Plot an ellipse to show the Gaussian component
         angle = np.arctan(u[1] / u[0])


### PR DESCRIPTION
Colorblind compatibility as discussed in #5435.

plot_gmm.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700235/a47ed170-79bc-11e5-86e4-28001284e5b5.png)

plot_gmm_classifier.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700253/b240480c-79bc-11e5-9428-a224bdf04b41.png)

plot_gmm_selection.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700259/c14f771e-79bc-11e5-9e07-166208d5722a.png)

plot_gmm_sin.py
![figure_1](https://cloud.githubusercontent.com/assets/1568249/10700273/e1dc81fc-79bc-11e5-8980-8d2dfb628b84.png)
