### PR TITLE
[MRG]Circle ci push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   cache_directories:
     - "~/scikit_learn_data"
+    - "~/scikit-learn.github.io"
   # Various dependencies
   pre:
     - sudo apt-get update
@@ -22,6 +23,11 @@ test:
   # Grep error on the documentation
   override:
     - cat ~/log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi
+deployment:
+  push:
+    branch: master
+    commands:
+      - bash continuous_integration/push_doc.sh
 general:
   # Open the doc to the API
   artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     PYTHONPATH: "/usr/lib/python2.7/dist-packages"
 dependencies:
   cache_directories:
-    - "~/scikit_learn_data"
+    - "~/sklearn_data_home"
     - "~/scikit-learn.github.io"
   # Various dependencies
   pre:

--- a/continuous_integration/push_doc.sh
+++ b/continuous_integration/push_doc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This script is meant to be called in the "deploy" step defined in 
+# circle.yml. See https://circleci.com/docs/ for more details.
+# The behavior of the script is controlled by environment variable defined
+# in the circle.yml in the top level folder of the project.
+
+
+if [ -z $CIRCLE_PROJECT_USERNAME ];
+then USERNAME="sklearn-ci";
+else USERNAME=$CIRCLE_PROJECT_USERNAME;
+fi
+
+DOC_REPO="scikit-learn.github.io"
+
+MSG="Pushing the docs for revision for branch: $CIRCLE_BRANCH, commit $CIRCLE_SHA1"
+
+cd $HOME
+if [ ! -d $DOC_REPO ];
+then git clone "git@github.com:scikit-learn/"$DOC_REPO".git";
+fi
+cd $DOC_REPO
+git checkout master
+git reset --hard origin/master
+git rm -rf dev/ && rm -rf dev/
+cp -R $HOME/scikit-learn/doc/_build/html/stable dev
+git config --global user.email "olivier.grisel+sklearn-ci@gmail.com"
+git config --global user.name $USERNAME
+git config --global push.default matching
+git add -f dev/
+git commit -m "$MSG" dev
+git push
+
+echo $MSG 


### PR DESCRIPTION
This allows circleCI to push the documentation directly to github.io/dev if everything goes well (no Traceback).

The script in continous_integration works on his own from the root of the project (you need to have the ssh private key setup to access the github.io repository though)
