### PR TITLE
[MRG] Add balanced accuracy score in metrics

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -796,6 +796,7 @@ details.
    :template: function.rst
 
    metrics.accuracy_score
+   metrics.balanced_accuracy_score
    metrics.auc
    metrics.average_precision_score
    metrics.brier_score_loss

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -878,6 +878,44 @@ method.
 The first ``[.9, .1]`` in ``y_pred`` denotes 90% probability that the first
 sample has label 0.  The log loss is non-negative.
 
+.. _balanced_accuracy_score
+
+Balanced accuracy score
+-----------------------
+
+The :func:`balanced_accuracy_score` function computes the
+`Balanced accuracy score (BAC) <http://en.wikipedia.org/wiki/Accuracy_and_precision>`_
+for binary classes.  Quoting Wikipedia:
+
+
+    "The balanced accuracy avoids inflated performance estimates on
+    imbalanced datasets. It is defined as the arithmetic mean of sensitivity
+    and specificity, or the average accuracy obtained on either class."
+
+If :math:`tp`, :math:`tn`, :math:`fp` and :math:`fn` are respectively the
+number of true positives, true negatives, false positives and false negatives,
+the BAC metric is defined as
+
+.. math::
+
+  BAC = \frac{tp}{tp + fn) + \frac{tn}{tn + fp)
+
+Here is a small example illustrating the usage of the :func:`balanced_accuracy_score`
+function:
+
+    >>> from sklearn.metrics import accuracy_score
+    >>> from sklearn.metrics import balanced_accuracy_score
+    >>> y_true = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    >>> y_pred = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    >>> accuracy_score(y_true, y_pred)
+    0.9
+    >>> balanced_accuracy_score(y_true, y_pred)
+    0.5
+
+In this example accuracy is not the metric to use. Its value only
+reflect the imbalanced distribution of the dataset.
+See `Accuracy paradox <http://en.wikipedia.org/wiki/Accuracy_paradox>`_.
+
 .. _matthews_corrcoef:
 
 Matthews correlation coefficient

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -878,7 +878,7 @@ method.
 The first ``[.9, .1]`` in ``y_pred`` denotes 90% probability that the first
 sample has label 0.  The log loss is non-negative.
 
-.. _balanced_accuracy_score
+.. _balanced_accuracy_score:
 
 Balanced accuracy score
 -----------------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -60,6 +60,7 @@ Scoring                      Function                                    Comment
 **Classification**
 'accuracy'                   :func:`metrics.accuracy_score`
 'average_precision'          :func:`metrics.average_precision_score`
+'balanced_accuracy_score'    :func:`metrics.balanced_accuracy_score`     for binary targets
 'f1'                         :func:`metrics.f1_score`                    for binary targets
 'f1_micro'                   :func:`metrics.f1_score`                    micro-averaged
 'f1_macro'                   :func:`metrics.f1_score`                    macro-averaged
@@ -221,6 +222,7 @@ Some of these are restricted to the binary classification case:
 .. autosummary::
    :template: function.rst
 
+   balanced_accuracy_score
    matthews_corrcoef
    precision_recall_curve
    roc_curve
@@ -621,7 +623,15 @@ In this context, we can define the notions of precision, recall and F-measure:
 
 .. math::
 
-   \text{recall} = \frac{tp}{tp + fn},
+   \text{recall (also called sensitivity)} = \frac{tp}{tp + fn},
+
+.. math::
+
+   \text{specificity} = \frac{tn}{tn + fp},
+
+.. math::
+
+   \text{balanced accuracy} = 0.5 * \text{sensitivity} + 0.5 * \text{specificity},
 
 .. math::
 
@@ -636,6 +646,12 @@ Here are some small examples in binary classification::
   1.0
   >>> metrics.recall_score(y_true, y_pred)
   0.5
+  >>> metrics.balanced_accuracy_score(y_true, y_pred)
+  0.75
+  >>> metrics.balanced_accuracy_score(y_true, y_pred, weight=1)
+  0.5
+  >>> metrics.balanced_accuracy_score(y_true, y_pred, weight=0)
+  1.0
   >>> metrics.f1_score(y_true, y_pred)  # doctest: +ELLIPSIS
   0.66...
   >>> metrics.fbeta_score(y_true, y_pred, beta=0.5)  # doctest: +ELLIPSIS

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -907,8 +907,8 @@ function:
     >>> from sklearn.metrics import balanced_accuracy_score
     >>> y_true = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> y_pred = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    >>> accuracy_score(y_true, y_pred)
-    0.9
+    >>> accuracy_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.9...
     >>> balanced_accuracy_score(y_true, y_pred)
     0.5
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -648,9 +648,9 @@ Here are some small examples in binary classification::
   0.5
   >>> metrics.balanced_accuracy_score(y_true, y_pred)
   0.75
-  >>> metrics.balanced_accuracy_score(y_true, y_pred, weight=1)
+  >>> metrics.balanced_accuracy_score(y_true, y_pred, balance=1)
   0.5
-  >>> metrics.balanced_accuracy_score(y_true, y_pred, weight=0)
+  >>> metrics.balanced_accuracy_score(y_true, y_pred, balance=0)
   1.0
   >>> metrics.f1_score(y_true, y_pred)  # doctest: +ELLIPSIS
   0.66...

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -14,6 +14,7 @@ from .ranking import roc_auc_score
 from .ranking import roc_curve
 
 from .classification import accuracy_score
+from .classification import balanced_accuracy_score
 from .classification import classification_report
 from .classification import cohen_kappa_score
 from .classification import confusion_matrix
@@ -61,6 +62,7 @@ from .scorer import get_scorer
 
 __all__ = [
     'accuracy_score',
+    'balanced_accuracy_score',
     'adjusted_mutual_info_score',
     'adjusted_rand_score',
     'auc',

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -247,8 +247,8 @@ def balanced_accuracy_score(y_true, y_pred, weight=0.5):
     y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])
 
     # assume that negative class is first label return by unique_labels
-    sensitivity = np.count_nonzero(y_pred * y_true != 0) / np.sum(y_true != 0)
-    specificity = np.count_nonzero(y_pred + y_true == 0) / np.sum(y_true == 0)
+    sensitivity = np.sum(y_pred * y_true != 0) / np.sum(y_true != 0)
+    specificity = np.sum(y_pred + y_true == 0) / np.sum(y_true == 0)
 
     return np.average([sensitivity,specificity], weights=[weight,1-weight])
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -242,8 +242,8 @@ def balanced_accuracy_score(y_true, y_pred, balance=0.5):
     if y_type is not "binary":
         raise ValueError("%s is not supported" % y_type)
 
-    cm = confusion_matrix(y_true,y_pred)
-    neg, pos = cm.sum(axis=1,dtype='float')
+    cm = confusion_matrix(y_true, y_pred)
+    neg, pos = cm.sum(axis=1, dtype='float')
     tn, tp = np.diag(cm)
 
     sensitivity = tp / pos

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -178,16 +178,20 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     return _weighted_sum(score, sample_weight, normalize)
 
 
-def balanced_accuracy_score(y_true, y_pred, weight=0.5):
+def balanced_accuracy_score(y_true, y_pred, balance=0.5):
     """Balanced accuracy classification score.
 
     The formula for the balanced accuracy score ::
 
-        balanced accuracy = weight * TP/(TP + FP) + (1 - weight) * TN/(TN + FN)
+        balanced accuracy = balance * TP/(TP + FP) + (1 - balance) * TN/(TN + FN)
 
     Because it needs true/false negative/positive notion it only
     supports binary classification.
 
+    The `balance` parameter determines the weight of sensitivity in the combined
+    score. ``balance -> 1`` lends more weight to sensitiviy, while ``balance -> 0``
+    favors specificity (``balance = 1`` considers only sensitivity, ``balance = 0``
+    only specificity).
 
     Read more in the :ref:`User Guide <balanced_accuracy_score>`.
 
@@ -199,8 +203,8 @@ def balanced_accuracy_score(y_true, y_pred, weight=0.5):
     y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
-    weight : float between 0 and 1. Cost associated with the misclassification
-        of a positive example (i-e sensitivity or recall)
+    balance : float between 0 and 1. Weight associated with the sensitivity
+        (or recall) against specificty in final score.
 
     Returns
     -------
@@ -231,26 +235,21 @@ def balanced_accuracy_score(y_true, y_pred, weight=0.5):
 
     """
 
-    if weight < 0. or 1. < weight:
-        raise ValueError("weight has to be between 0 and 1")
+    if balance < 0. or 1. < balance:
+        raise ValueError("balance has to be between 0 and 1")
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     if y_type is not "binary":
         raise ValueError("%s is not supported" % y_type)
 
-    labels = unique_labels(y_true, y_pred)
-    n_labels = labels.size
-    label_to_ind = dict((y, x) for x, y in enumerate(labels))
+    cm = confusion_matrix(y_true,y_pred)
+    neg, pos = cm.sum(axis=1,dtype='float')
+    tn, tp = np.diag(cm)
 
-    # convert yt, yp into index
-    y_pred = np.array([label_to_ind.get(x, n_labels + 1) for x in y_pred])
-    y_true = np.array([label_to_ind.get(x, n_labels + 1) for x in y_true])
+    sensitivity = tp / pos
+    specificity = tn / neg
 
-    # assume that negative class is first label return by unique_labels
-    sensitivity = np.sum(y_pred * y_true != 0) / np.sum(y_true != 0)
-    specificity = np.sum(y_pred + y_true == 0) / np.sum(y_true == 0)
-
-    return np.average([sensitivity,specificity], weights=[weight,1-weight])
+    return balance * sensitivity + (1 - balance) * specificity
 
 
 def confusion_matrix(y_true, y_pred, labels=None):

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -28,6 +28,7 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.mocking import MockDataFrame
 
 from sklearn.metrics import accuracy_score
+from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import classification_report
 from sklearn.metrics import cohen_kappa_score
@@ -115,6 +116,41 @@ def test_multilabel_accuracy_score_subset_accuracy():
     assert_equal(accuracy_score(y1, np.logical_not(y1)), 0)
     assert_equal(accuracy_score(y1, np.zeros(y1.shape)), 0)
     assert_equal(accuracy_score(y2, np.zeros(y1.shape)), 0)
+
+
+def test_balanced_accuracy_score_binary():
+    # Test balanced accuracy score for binary classification task
+
+    # with numeric labels
+    y_pred = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    y_true = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    assert_equal(balanced_accuracy_score(y_true,y_pred), 0.5)
+
+    # with string labels
+    y_pred = ["ant", "cat", "ant", "cat", "ant"]
+    y_true = ["cat", "cat", "ant", "ant", "ant"]
+
+    assert_equal(balanced_accuracy_score(y_true,y_pred), 0.5*2/3 + 0.5*1/2)
+
+    # with specific weight
+    y_pred = [0, 0, 1]
+    y_true = [0, 1, 1]
+    assert_equal(balanced_accuracy_score(y_true, y_pred, weight=0.75), 0.625)
+
+    # with wrong weight
+    assert_raise_message(ValueError, "weight has to be between 0 and 1",
+            balanced_accuracy_score, y_true, y_pred, weight=2)
+
+
+def test_balanced_accuracy_score_no_binary():
+    # Test balanced_accuracy_score returns an error when trying to
+    # compute score for multiclass
+    y_pred = [0, 2, 1, 3]
+    y_true = [0, 1, 2, 3]
+
+    assert_raise_message(ValueError, "multiclass is not supported",
+                         balanced_accuracy_score, y_true, y_pred)
 
 
 def test_precision_recall_f1_score_binary():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -133,14 +133,17 @@ def test_balanced_accuracy_score_binary():
 
     assert_equal(balanced_accuracy_score(y_true,y_pred), 0.5*2/3 + 0.5*1/2)
 
-    # with specific weight
+    # with specific balance
     y_pred = [0, 0, 1]
     y_true = [0, 1, 1]
-    assert_equal(balanced_accuracy_score(y_true, y_pred, weight=0.75), 0.625)
 
-    # with wrong weight
-    assert_raise_message(ValueError, "weight has to be between 0 and 1",
-            balanced_accuracy_score, y_true, y_pred, weight=2)
+    assert_equal(balanced_accuracy_score(y_true, y_pred, balance=0.75), 0.625)
+
+    # with wrong balance
+    assert_raise_message(ValueError, "balance has to be between 0 and 1",
+            balanced_accuracy_score, y_true, y_pred, balance=2)
+    assert_raise_message(ValueError, "balance has to be between 0 and 1",
+            balanced_accuracy_score, y_true, y_pred, balance=-1)
 
 
 def test_balanced_accuracy_score_no_binary():

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -23,6 +23,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics import accuracy_score
+from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import cohen_kappa_score
@@ -98,6 +99,7 @@ REGRESSION_METRICS = {
 
 CLASSIFICATION_METRICS = {
     "accuracy_score": accuracy_score,
+    "balanced_accuracy_score": balanced_accuracy_score,
     "unnormalized_accuracy_score": partial(accuracy_score, normalize=False),
     "confusion_matrix": confusion_matrix,
     "hamming_loss": hamming_loss,
@@ -207,6 +209,7 @@ METRIC_UNDEFINED_BINARY = [
     "micro_average_precision_score",
     "macro_average_precision_score",
     "samples_average_precision_score",
+    "balanced_accuracy_score",
 
     "label_ranking_loss",
     "label_ranking_average_precision_score",
@@ -340,6 +343,7 @@ SYMMETRIC_METRICS = [
 # Asymmetric with respect to their input arguments y_true and y_pred
 # metric(y_true, y_pred) != metric(y_pred, y_true).
 NOT_SYMMETRIC_METRICS = [
+    "balanced_accuracy_score",
     "explained_variance_score",
     "r2_score",
     "confusion_matrix",
@@ -359,6 +363,7 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
+    "balanced_accuracy_score",
     "cohen_kappa_score",
     "confusion_matrix",
     "median_absolute_error",


### PR DESCRIPTION
I work on this one : #3506 (adding balanced accuracy score) during the sprint. It's my first contribution.
There was already 3 PRs on that issue but not completed : #4300 #3929 #3511

I implement a simple version which works only for binary classification case. I also add test and doc inputs.

Thanks for the feed back
