### PR TITLE
[MRG] English language changed to IsolationTree docs

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -2,7 +2,7 @@ Documentation for scikit-learn
 -------------------------------
 
 This section contains the full manual and web page as displayed in
-http://scikit-learn.sf.net. To generate the full web page, including
+http://scikit-learn.org. To generate the full web page, including
 the example gallery (this might take a while):
 
     make html

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -197,21 +197,20 @@ Isolation Forest
 
 One efficient way of performing outlier detection in high-dimensional datasets
 is to use random forests.
-:class:`ensemble.IsolationForest` consists in 'isolating' the observations
-by randomly selecting a feature and then randomly selecting a split value
-between the maximum and minimum values of the selected feature.
+The :class:`ensemble.IsolationForest` 'isolates' observations by randomly selecting
+a feature and then randomly selecting a split value between the maximum and
+minimum values of the selected feature.
 
 Since recursive partitioning can be represented by a tree structure, the
-number of splitting required to isolate a point is equivalent to the path
-length from the root node to a terminating node.
+number of splittings required to isolate a sample is equivalent to the path
+length from the root node to the terminating node.
 
-This path length, averaged among a forest of such random trees, is a
+This path length, averaged over a forest of such random trees, is a
 measure of abnormality and our decision function.
 
-Indeed random partitioning produces noticeable shorter paths for anomalies.
+Random partitioning produces noticeably shorter paths for anomalies.
 Hence, when a forest of random trees collectively produce shorter path
-lengths for some particular points, then they are highly likely to be
-anomalies.
+lengths for particular samples, they are highly likely to be anomalies.
 
 This strategy is illustrated below.
 

--- a/examples/ensemble/plot_isolation_forest.py
+++ b/examples/ensemble/plot_isolation_forest.py
@@ -5,20 +5,20 @@ IsolationForest example
 
 An example using IsolationForest for anomaly detection.
 
-IsolationForest consists in 'isolating' the observations by randomly selecting
-a feature and then randomly selecting a split value between the maximum and
-minimum values of the selected feature.
+The IsolationForest 'isolates' observations by randomly selecting a feature
+and then randomly selecting a split value between the maximum and minimum
+values of the selected feature.
 
 Since recursive partitioning can be represented by a tree structure, the
-number of splitting required to isolate a sample is equivalent to the path
-length from the root node to a terminating node.
+number of splittings required to isolate a sample is equivalent to the path
+length from the root node to the terminating node.
 
-This path length, averaged among a forest of such random trees, is a measure
+This path length, averaged over a forest of such random trees, is a measure
 of abnormality and our decision function.
 
-Indeed random partitioning produces noticeable shorter paths for anomalies.
+Random partitioning produces noticeable shorter paths for anomalies.
 Hence, when a forest of random trees collectively produce shorter path lengths
-for some particular samples, then they are highly likely to be anomalies.
+for particular samples, they are highly likely to be anomalies.
 
 .. [1] Liu, Fei Tony, Ting, Kai Ming and Zhou, Zhi-Hua. "Isolation forest."
     Data Mining, 2008. ICDM'08. Eighth IEEE International Conference on.

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -24,23 +24,22 @@ __all__ = ["IsolationForest"]
 class IsolationForest(BaseBagging):
     """Isolation Forest Algorithm
 
-    Return the anomaly score of each sample with the IsolationForest algorithm
+    Return the anomaly score of each sample using the IsolationForest algorithm
 
-    IsolationForest consists in 'isolate' the observations by randomly
-    selecting a feature and then randomly selecting a split value
-    between the maximum and minimum values of the selected feature.
+    The IsolationForest 'isolates' observations by randomly selecting a feature
+    and then randomly selecting a split value between the maximum and minimum
+    values of the selected feature.
 
     Since recursive partitioning can be represented by a tree structure, the
-    number of splitting required to isolate a point is equivalent to the path
-    length from the root node to a terminating node.
+    number of splittings required to isolate a sample is equivalent to the path
+    length from the root node to the terminating node.
 
-    This path length, averaged among a forest of such random trees, is a
+    This path length, averaged over a forest of such random trees, is a
     measure of abnormality and our decision function.
 
-    Indeed random partitioning produces noticeable shorter paths for anomalies.
+    Random partitioning produces noticeably shorter paths for anomalies.
     Hence, when a forest of random trees collectively produce shorter path
-    lengths for some particular points, then they are highly likely to be
-    anomalies.
+    lengths for particular samples, they are highly likely to be anomalies.
 
 
     Parameters
@@ -52,8 +51,8 @@ class IsolationForest(BaseBagging):
         The number of samples to draw from X to train each base estimator.
             - If int, then draw `max_samples` samples.
             - If float, then draw `max_samples * X.shape[0]` samples.
-        If max_samples is larger than number of samples provided,
-        all samples with be used for all trees (no sampling).
+        If max_samples is larger than the number of samples provided,
+        all samples will be used for all trees (no sampling).
 
     max_features : int or float, optional (default=1.0)
         The number of features to draw from X to train each base estimator.
@@ -169,12 +168,12 @@ class IsolationForest(BaseBagging):
         """Predict anomaly score of X with the IsolationForest algorithm.
 
         The anomaly score of an input sample is computed as
-        the mean anomaly scores of the trees in the forest.
+        the mean anomaly score of the trees in the forest.
 
         The measure of normality of an observation given a tree is the depth
         of the leaf containing this observation, which is equivalent to
-        the number of splitting required to isolate this point. In case of
-        several observations n_left in the leaf, the average length path of
+        the number of splittings required to isolate this point. In case of
+        several observations n_left in the leaf, the average path length of
         a n_left samples isolation tree is added.
 
         Parameters


### PR DESCRIPTION
`IsolationTrees` looks very nice! I was reading the documentation and example to get a feel for them and think the following small changes to the language would improve the docs.

There is one more point on [`ensemble/iforest.py:176+`](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/ensemble/iforest.py#L176) where I don't understand what the doc string is trying to tell me. Looking at the code itself I get L206 but 208 confuses me. Maybe together we can improve the doc string. In particular the "why" of doing this.

@ngoix could you check that the language change does not change the meaning?

The second commit changes the URL mentioned in `doc/README`, is it Ok to sneak it in here?
