### PR TITLE
Added Evolutionary Algorithm Search

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -14,14 +14,20 @@ from abc import ABCMeta, abstractmethod
 from collections import Mapping, namedtuple, Sized
 from functools import partial, reduce
 from itertools import product
+from math import log, ceil
+from multiprocessing import Pool
+import copy_reg
 import operator
+import random
+import types
 import warnings
+
 
 import numpy as np
 
 from .base import BaseEstimator, is_classifier, clone
 from .base import MetaEstimatorMixin
-from .cross_validation import check_cv
+from .cross_validation import check_cv, cross_val_score
 from .cross_validation import _fit_and_score
 from .externals.joblib import Parallel, delayed
 from .externals import six
@@ -996,3 +1002,134 @@ class RandomizedSearchCV(BaseSearchCV):
                                           self.n_iter,
                                           random_state=self.random_state)
         return self._fit(X, y, sampled_params)
+
+
+def _reduce_method(m):
+    if m.im_self is None:
+        return getattr, (m.im_class, m.im_func.func_name)
+    else:
+        return getattr, (m.im_self, m.im_func.func_name)
+
+
+class EvolutionaryAlgorithmSearchCV(BaseSearchCV):
+    """Evolutionary search on hyper parameters.
+
+
+    EvolutionaryAlgorithmSearchCV implements a "fit" and a "score" method.
+    It also implements "predict", "predict_proba", "decision_function",
+    "transform" and "inverse_transform" if they are implemented in the
+    estimator used.
+
+    The parameters of the estimator used to apply these methods are optimized
+    by evolutionary algorithm search over parameter settings.
+
+    In contrast to GridSearchCV, not all parameter values are tried out, but
+    rather an evolutionary algorithm is used in order to determine which is
+    the best possible combination of parameters."""
+
+    def __init__(self, estimator, param_grid, scoring=None, cv=4,
+                 refit=True, verbose=False, population_size=50, mutation_prob=0.10,
+                 tournament_size=3, generations_number=10,
+                 n_jobs=1, iid=True, pre_dispatch='2*n_jobs', error_score='raise',
+                 fit_params=None):
+        super(EvolutionaryAlgorithmSearchCV, self).__init__(
+            estimator, scoring, fit_params, n_jobs, iid,
+            refit, cv, pre_dispatch, error_score)
+        _check_param_grid(param_grid)
+        self.param_grid = param_grid
+        self.possible_params = list(ParameterGrid(self.param_grid))
+        self.individual_size = int(ceil(log(len(self.possible_params), 2)))
+        self.population_size = population_size
+        self.generations_number = generations_number
+        self.best_estimator_ = None
+        self.best_score_ = None
+        self.best_params_ = None
+        self._individual_evals = {}
+        self.mutation_prob = mutation_prob
+        self.tournament_size = tournament_size
+
+        try:
+            import deap
+            import bitstring
+        except:
+            raise Exception('In order to use the EvolutionaryAlgorithmSearchCV'
+                            ' you need to install deap and bitstring libraries: '
+                            'pip install deap bitstring')
+
+    def _individual_to_params(self, val):
+        if val >= len(self.possible_params):
+            return False
+        return self.possible_params[val]
+
+    def _evalFunction(self, individual):
+        from bitstring import BitArray
+        individual_int = BitArray(individual).uint
+        if individual_int not in self._individual_evals:
+            params = self._individual_to_params(individual_int)
+            if not params:
+                return (0,)
+            clf = clone(self.estimator)
+            clf.set_params(**params)
+            scores = cross_val_score(clf, self.X, self.y,
+                                  cv=self.cv, scoring=self.scoring)
+            self._individual_evals[individual_int] = float(scores.mean())
+
+        return (self._individual_evals[individual_int],)
+
+    def fit(self, X, y=None):
+        from deap import base, creator, tools, algorithms
+        from bitstring import BitArray
+
+        self.X = X
+        self.y = y
+
+        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+        creator.create("Individual", list, fitness=creator.FitnessMax)
+
+        toolbox = base.Toolbox()
+        toolbox.register("attr_bool", random.randint, 0, 1)
+        toolbox.register("individual", tools.initRepeat, creator.Individual,
+                      toolbox.attr_bool, n=self.individual_size)
+        toolbox.register("population", tools.initRepeat, list,
+                      toolbox.individual)
+
+        toolbox.register("evaluate", self._evalFunction)
+        toolbox.register("mate", tools.cxTwoPoint)
+        toolbox.register("mutate", tools.mutFlipBit, indpb=self.mutation_prob)
+        toolbox.register("select", tools.selTournament, tournsize=self.tournament_size)
+
+        if self.n_jobs > 1:
+            copy_reg.pickle(types.MethodType, _reduce_method)
+            pool = Pool(processes=self.n_jobs)
+            # self.toolbox.register("map", parmap)
+            toolbox.register("map", pool.map)
+        pop = toolbox.population(n=self.population_size)
+        hof = tools.HallOfFame(1)
+        stats = tools.Statistics(lambda ind: ind.fitness.values)
+        stats.register("avg", np.mean)
+        stats.register("min", np.min)
+        stats.register("max", np.max)
+
+        if self.verbose:
+            print('--- Evolve in {0} possible combinations ---'.format(len(self.possible_params)))
+
+        pop, logbook = algorithms.eaSimple(pop, toolbox, cxpb=0.5, mutpb=0.2,
+                                           ngen=self.generations_number, stats=stats,
+                                           halloffame=hof, verbose=self.verbose)
+
+        self.best_score_ = hof[0].fitness
+        self.best_params_ = self._individual_to_params(BitArray(hof[0]).uint)
+
+        if self.verbose:
+            import json
+            print("Best individual is: %s\nwith fitness: %s" % (
+                  json.dumps(self.best_params_), hof[0].fitness)
+            )
+
+        if self.refit:
+            self.best_estimator_ = clone(self.estimator)
+            self.best_estimator_.set_params(**self.best_params_)
+            self.best_estimator_.fit(self.X, self.y)
+
+    def _fit(self, X, y, parameter_iterable):
+        raise NotImplementedError


### PR DESCRIPTION
Use EvolutionaryAlgorithmSearchCV instead of grid search in order to use an evolutionary algorithm to evolve the best parameters. It's implemented using deap library: https://github.com/deap/deap

Example of usage:

```
    from sklearn.grid_search import EvolutionaryAlgorithmSearchCV
    from sklearn import datasets
    from sklearn.decomposition import PCA
    from sklearn.pipeline import Pipeline
    from sklearn.svm import SVC

    grid = {
        'svc__C': [0.001, 0.01, 0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0, 1.3, 1.5, 1.7, 10, 100, 1000],
        'svc__kernel': ['linear', 'poly', 'rbf', 'sigmoid'],
        'pca__n_components': [1, 2, 3, 4]
    }
    iris = datasets.load_iris()
    X, y = iris.data, iris.target
    pipeline = Pipeline(steps=[
        ('pca', PCA()),
        ('svc', SVC())
    ])
    clf = EvolutionaryAlgorithmSearchCV(pipeline, grid, scoring=None, verbose=True, n_jobs=4, population_size=5)
    clf.fit(X, y)
```

Output:

```
    --- Evolve in 240 possible combinations ---
    gen nevals  avg     min         max     
    0   5       0.84188 0.615919    0.966346
    1   4       0.95438 0.926282    0.972756
    2   3       0.971581    0.966346    0.973291
    3   4       0.969017    0.952457    0.973291
    4   2       0.973291    0.973291    0.973291
    5   2       0.965171    0.932692    0.973291
    6   4       0.973291    0.973291    0.973291
    7   0       0.973291    0.973291    0.973291
    8   4       0.973291    0.973291    0.973291
    9   2       0.971902    0.966346    0.973291
    10  0       0.973291    0.973291    0.973291
    Best individual is: {"pca__n_components": 3, "svc__kernel": "linear", "svc__C": 1.0}
    with fitness: (0.9732905982905983,)
```
