### PR TITLE
MAINT: remove unused code from TSNE

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -874,8 +874,3 @@ class TSNE(BaseEstimator):
         """
         self.fit_transform(X)
         return self
-
-    def _check_fitted(self):
-        if self.embedding_ is None:
-            raise ValueError("Cannot call `transform` unless `fit` has"
-                             "already been called")


### PR DESCRIPTION
removed unused code. It doesn't appear that this private method is used anywhere in the package.
