### PR TITLE
[MRG] Update joblib to 0.9.3

### DIFF
--- a/sklearn/externals/joblib/__init__.py
+++ b/sklearn/externals/joblib/__init__.py
@@ -115,7 +115,7 @@ Main features
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 
 
 from .memory import Memory, MemorizedResult

--- a/sklearn/externals/joblib/parallel.py
+++ b/sklearn/externals/joblib/parallel.py
@@ -49,14 +49,13 @@ MIN_IDEAL_BATCH_DURATION = .2
 # on a single worker while other workers have no work to process any more.
 MAX_IDEAL_BATCH_DURATION = 2
 
-# Under Python 3.4+ use the 'forkserver' start method by default: this makes it
-# possible to avoid crashing 3rd party libraries that manage an internal thread
-# pool that does not tolerate forking
-if hasattr(mp, 'get_start_method'):
-    method = os.environ.get('JOBLIB_START_METHOD')
-    if (method is None and mp.get_start_method() == 'fork'
-            and 'forkserver' in mp.get_all_start_methods()):
-        method = 'forkserver'
+# Under Linux or OS X the default start method of multiprocessing
+# can cause third party libraries to crash. Under Python 3.4+ it is possible
+# to set an environment variable to switch the default start method from
+# 'fork' to 'forkserver' or 'spawn' to avoid this issue albeit at the cost
+# of causing semantic changes and some additional pool instanciation overhead.
+if hasattr(mp, 'get_context'):
+    method = os.environ.get('JOBLIB_START_METHOD', '').strip() or None
     DEFAULT_MP_CONTEXT = mp.get_context(method=method)
 else:
     DEFAULT_MP_CONTEXT = None


### PR DESCRIPTION
Bug fix release to fix https://github.com/joblib/joblib/issues/263: interactively defined functions can not be used in parallel for Python 3 (because the default start method is forkserver).

This needs to be merged for 0.17 I believe: ping @ogrisel.
