### PR TITLE
[MRG+1] decrease tolerance in test_logistic for appveyor failure

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -582,8 +582,7 @@ def test_logistic_regressioncv_class_weights():
 def test_logistic_regression_sample_weights():
     X, y = make_classification(n_samples=20, n_features=5, n_informative=3,
                                n_classes=2, random_state=0)
-    sample_weight = np.ones(y.shape[0])
-    sample_weight[y == 1] = 2
+    sample_weight = y + 1
 
     for LR in [LogisticRegression, LogisticRegressionCV]:
 
@@ -600,15 +599,15 @@ def test_logistic_regression_sample_weights():
         # Test that sample weights work the same with the lbfgs,
         # newton-cg, and 'sag' solvers
         clf_sw_lbfgs = LR(solver='lbfgs', fit_intercept=False)
-        clf_sw_lbfgs.fit(X, y, sample_weight=y + 1)
+        clf_sw_lbfgs.fit(X, y, sample_weight=sample_weight)
         clf_sw_n = LR(solver='newton-cg', fit_intercept=False)
-        clf_sw_n.fit(X, y, sample_weight=y + 1)
-        clf_sw_sag = LR(solver='sag', fit_intercept=False,
-                        max_iter=2000, tol=1e-7)
-        clf_sw_sag.fit(X, y, sample_weight=y + 1)
-        clf_sw_liblinear = LR(solver='liblinear', fit_intercept=False,
-                              max_iter=50, tol=1e-7)
-        clf_sw_liblinear.fit(X, y, sample_weight=y + 1)
+        clf_sw_n.fit(X, y, sample_weight=sample_weight)
+        clf_sw_sag = LR(solver='sag', fit_intercept=False, tol=1e-10)
+        # ignore convergence warning due to small dataset
+        with ignore_warnings():
+            clf_sw_sag.fit(X, y, sample_weight=sample_weight)
+        clf_sw_liblinear = LR(solver='liblinear', fit_intercept=False)
+        clf_sw_liblinear.fit(X, y, sample_weight=sample_weight)
         assert_array_almost_equal(
             clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
         assert_array_almost_equal(


### PR DESCRIPTION
This should fix appveyor failures described in #5598.

I don't get where does this regression come from,
so I just decreased the `tol` with SAG solver, from `1e-7` to `1e-10`.

Other changes are mainly cosmetic

I tested it  with appveyor on my personal fork, but let's wait for this appveyor's verdict just to be sure.
