### PR TITLE
[MRG] DOC: Correct confusing docs of n_values in OneHotEncoder

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -411,6 +411,18 @@ Then we fit the estimator, and transform a data point.
 In the result, the first two numbers encode the gender, the next set of three
 numbers the continent and the last four the web browser.
 
+Note that, if there is a possibilty that the training data might have missing categorical
+features, one has to explicitly set ``n_values``. For example,
+
+    >>> enc = preprocessing.OneHotEncoder(n_values=[2, 3, 4])
+    >>> # Note that for there are missing categorical values for the 2nd and 3rd
+    >>> # feature
+    >>> enc.fit([[1, 2, 3], [0, 2, 0]])  # doctest: +ELLIPSIS
+    OneHotEncoder(categorical_features='all', dtype=<... 'numpy.float64'>,
+           handle_unknown='error', n_values=[2, 3, 4], sparse=True)
+    >>> enc.transform([[1, 0, 0]]).toarray()
+    array([[ 0.,  1.,  1.,  0.,  0.,  1.,  0.,  0.,  0.]])
+
 See :ref:`dict_feature_extraction` for categorical features that are represented
 as a dict, not as integers.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1650,8 +1650,10 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         Number of values per feature.
 
         - 'auto' : determine value range from training data.
-        - int : maximum value for all features.
-        - array : maximum value per feature.
+        - int : number of categorical values per feature.
+                Each feature value should be in ``range(n_values)``
+        - array : ``n_values[i]`` is the number of categorical values in
+                  ``X[:, i]``. Each feature value should be in ``range(n_values[i])``
 
     categorical_features: "all" or array of indices or mask
         Specify what features are treated as categorical.


### PR DESCRIPTION
The current doc states that `n_values` is the maximum value of every categorical feature. However it should be the number of values per categorical feature

```
from sklearn.preprocessing import OneHotEncoder
X = [[1, 2, 3], [0, 2, 0]]
    onehotenc = OneHotEncoder(n_values=[1, 2, 3])
    onehotenc.fit(X)
    ValueError: column index exceeds matrix dimensions
    onehotenc = OneHotEncoder(n_values=[2, 3, 4]) # works
```

Also added docs on when it is better to explicitly set these values.
