### PR TITLE
ENH: add check_estimator test to BaseEstimator

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -283,6 +283,11 @@ class BaseEstimator(object):
         return '%s(%s)' % (class_name, _pprint(self.get_params(deep=False),
                                                offset=len(class_name),),)
 
+    @classmethod
+    def check_estimator(cls):
+        from .utils.estimator_checks import check_estimator
+        check_estimator(cls)
+
 
 ###############################################################################
 class ClassifierMixin(object):


### PR DESCRIPTION
This is an idea I had to more easily expose the `check_estimator()` utility: this PR gives every sklearn estimator a `check_estimator` class method which will run the (very useful) tests in `sklearn.utils.estimator_checks`.

Mainly opened this PR to start a discussion of whether something like this would be useful.

You could use it like this:

``` python
from sklearn.linear_model import LinearRegression
LinearRegression.check_estimator()
```
