### PR TITLE
[MRG+1] Train test split conserves type doc

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -678,6 +678,9 @@ Enhancements
    - :class:`svm.SVC` fitted on sparse input now implements ``decision_function``.
      By `Rob Zinkov`_ and `Andreas Müller`_.
 
+   - :func:`cross_validation.train_test_split` now preserves the input type,
+     instead of converting to numpy arrays.
+
 
 Documentation improvements
 ..........................

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1799,14 +1799,15 @@ def train_test_split(*arrays, **options):
 
     Parameters
     ----------
-    *arrays : Sequence of arrays, scipy.sparse matrices or
-        Pandas DataFrames with same shape[0]. 
-        .. versionadded:: 0.6
-        Preserves input type instead of always casting to numpy array.
-        
-        Output type is the same as the input type.
-        
- 
+    *arrays : sequence of indexables with same length / shape[0]
+
+        allowed inputs are lists, numpy arrays, scipy-sparse
+        matrices or pandas dataframes.
+
+        .. versionadded:: 0.16
+            preserves input type instead of always casting to numpy array.
+
+
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
@@ -1829,12 +1830,11 @@ def train_test_split(*arrays, **options):
 
     Returns
     -------
-    splitting : length = 2 * len(arrays),
+    splitting : list, length = 2 * len(arrays),
+        List containing train-test split of inputs.
+
         .. versionadded:: 0.16
-        Preserves input type instead of always casting to numpy array.
-        
-        Output type is the same as the input type. 
-        The output will contain the train-test split.
+            Output type is the same as the input type.
 
     Examples
     --------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1799,10 +1799,14 @@ def train_test_split(*arrays, **options):
 
     Parameters
     ----------
-    *arrays : sequence of arrays or scipy.sparse matrices with same shape[0]
-        Python lists or tuples occurring in arrays are converted to 1D numpy
-        arrays.
-
+    *arrays : Sequence of arrays, scipy.sparse matrices or
+        Pandas DataFrames with same shape[0]. 
+        .. versionadded:: 0.6
+        Preserves input type instead of always casting to numpy array.
+        
+        Output type is the same as the input type.
+        
+ 
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
@@ -1825,8 +1829,12 @@ def train_test_split(*arrays, **options):
 
     Returns
     -------
-    splitting : list of arrays, length=2 * len(arrays)
-        List containing train-test split of input array.
+    splitting : length = 2 * len(arrays),
+        .. versionadded:: 0.16
+        Preserves input type instead of always casting to numpy array.
+        
+        Output type is the same as the input type. 
+        The output will contain the train-test split.
 
     Examples
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1372,9 +1372,13 @@ def train_test_split(*arrays, **options):
 
     Parameters
     ----------
-    *arrays : sequence of arrays or scipy.sparse matrices with same shape[0]
-        Python lists or tuples occurring in arrays are converted to 1D numpy
-        arrays.
+    *arrays : sequence of indexables with same length / shape[0]
+
+        allowed inputs are lists, numpy arrays, scipy-sparse
+        matrices or pandas dataframes.
+
+        .. versionadded:: 0.16
+            preserves input type instead of always casting to numpy array.
 
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
@@ -1398,8 +1402,11 @@ def train_test_split(*arrays, **options):
 
     Returns
     -------
-    splitting : list of arrays, length=2 * len(arrays)
-        List containing train-test split of input array.
+    splitting : list, length=2 * len(arrays)
+        List containing train-test split of inputs.
+
+        .. versionadded:: 0.16
+            Output type is the same as the input type.
 
     Examples
     --------


### PR DESCRIPTION
Continuation of #5476.

Checked the rendering.
I'd like to merge and backport this to 0.17 soon.
