### PR TITLE
[MRG+1] IsolationForest max_samples warning and calculation

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -268,7 +268,8 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
             Argument to use instead of self.max_samples.
 
         max_depth : int, optional (default=None)
-            Maximum depth of the base estimator.
+            Override value used when constructing base estimator. Only
+            supported if the base estimator has a max_depth parameter.
 
         sample_weight : array-like, shape = [n_samples] or None
             Sample weights. If None, then samples are equally weighted.

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -248,9 +248,9 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         self : object
             Returns self.
         """
-        return self._fit(X, y, self.max_samples, sample_weight)
+        return self._fit(X, y, self.max_samples, sample_weight=sample_weight)
 
-    def _fit(self, X, y, max_samples, sample_weight=None):
+    def _fit(self, X, y, max_samples, max_depth=None, sample_weight=None):
         """Build a Bagging ensemble of estimators from the training
            set (X, y).
 
@@ -266,6 +266,9 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
 
         max_samples : int or float, optional (default=None)
             Argument to use instead of self.max_samples.
+
+        max_depth : int, optional (default=None)
+            Maximum depth of the base estimator.
 
         sample_weight : array-like, shape = [n_samples] or None
             Sample weights. If None, then samples are equally weighted.
@@ -288,6 +291,9 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
 
         # Check parameters
         self._validate_estimator()
+
+        if max_depth is not None:
+            self.base_estimator_.max_depth = max_depth
 
         # if max_samples is float:
         if not isinstance(max_samples, (numbers.Integral, np.integer)):

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -298,7 +298,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
 
         # if max_samples is float:
         if not isinstance(max_samples, (numbers.Integral, np.integer)):
-            max_samples = int(self.max_samples * X.shape[0])
+            max_samples = int(max_samples * X.shape[0])
 
         if not (0 < max_samples <= X.shape[0]):
             raise ValueError("max_samples must be in (0, n_samples]")

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -162,7 +162,7 @@ class IsolationForest(BaseBagging):
                                  'Valid choices are: "auto", int or'
                                  'float' % self.max_samples)
 
-        elif isinstance(self.max_samples, (numbers.Integral, np.integer)):
+        elif isinstance(self.max_samples, six.integer_types):
             if self.max_samples > n_samples:
                 warn("max_samples (%s) is greater than the "
                      "total number of samples (%s). max_samples "
@@ -263,7 +263,7 @@ def _average_path_length(n_samples_leaf):
     average_path_length : array, same shape as n_samples_leaf
 
     """
-    if isinstance(n_samples_leaf, int):
+    if isinstance(n_samples_leaf, six.integer_types):
         if n_samples_leaf <= 1:
             return 1.
         else:

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -171,8 +171,9 @@ class IsolationForest(BaseBagging):
                 max_samples = int(self.max_samples * X.shape[0])
 
         self.max_samples_ = max_samples
-        self.base_estimator.max_depth = int(np.ceil(np.log2(max(max_samples, 2))))
+        max_depth = int(np.ceil(np.log2(max(max_samples, 2))))
         super(IsolationForest, self)._fit(X, y, max_samples,
+                                          max_depth=max_depth,
                                           sample_weight=sample_weight)
         return self
 

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -152,6 +152,8 @@ class IsolationForest(BaseBagging):
 
         # ensure that max_sample is in [1, n_samples]:
         n_samples = X.shape[0]
+        # initialise here for scoping reasons, should always be set to
+        # a legal value in the following lines
         max_samples = -1
 
         if self.max_samples == 'auto':

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -13,6 +13,8 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
 
@@ -95,9 +97,20 @@ def test_iforest_error():
                   IsolationForest(max_samples=0.0).fit, X)
     assert_raises(ValueError,
                   IsolationForest(max_samples=2.0).fit, X)
+    # The dataset has less than 256 samples, explicitly setting max_samples > n_samples
+    # should result in a warning. If not set explicitly there should be no warning
     assert_warns(UserWarning,
                  IsolationForest(max_samples=1000).fit, X)
+    assert_no_warnings(IsolationForest(max_samples='auto').fit, X)
     # cannot check for string values
+
+
+def test_recalculate_max_depth():
+    """Check that max_depth is recalculated when max_samples is reset to n_samples"""
+    X = iris.data
+    clf = IsolationForest().fit(X)
+    for est in clf.estimators_:
+        assert_equal(est.max_depth, int(np.ceil(np.log2(X.shape[0]))))
 
 
 def test_iforest_parallel_regression():


### PR DESCRIPTION
In response to #5672

Introduces `max_samples='auto'` as the new default to make it possible to check if the user set a non default value. Only warn about `max_samples>n_samples` if the user set the value explicitly.

Fixes a bug where `max_depth` was not recalculated when `max_samples` has changed.

Now 256 appears as a magic value in both `fit` and `predict`, which isn't nice. I'll think about how to make it nicer, suggestions welcome.

todo:
- [x] add test that `max_depth` recalculation works
- [x] add a test to check the value of self.max_samples_ in both cases (=self.max_samples or =n_samples)?

/cc @ngoix
