### PR TITLE
[MRG + 1] OneHotEncoder warn fix - fixes #5671

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1816,7 +1816,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
                                  "unknown got %s" % self.handle_unknown)
             if self.handle_unknown == 'error':
                 raise ValueError("unknown categorical feature present %s "
-                                 "during transform." % X[~mask])
+                                 "during transform." % X.ravel()[~mask])
 
         column_indices = (X + indices[:-1]).ravel()[mask]
         row_indices = np.repeat(np.arange(n_samples, dtype=np.int32),

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1391,6 +1391,8 @@ def test_one_hot_encoder_sparse():
     # test that an error is raised when out of bounds:
     X_too_large = [[0, 2, 1], [0, 1, 1]]
     assert_raises(ValueError, enc.transform, X_too_large)
+    error_msg = "unknown categorical feature present \[2\] during transform."
+    assert_raises_regex(ValueError, error_msg, enc.transform, X_too_large)
     assert_raises(ValueError, OneHotEncoder(n_values=2).fit_transform, X)
 
     # test that error is raised when wrong number of features


### PR DESCRIPTION
`nosetests -sv sklearn/preprocessing/tests/test_data.py -m test_one_hot_encoder_sparse` now passes without warning locally on py2.7.10 with numpy 1.10.1.

```
enc = OneHotEncoder(n_values=[3, 2, 2])
X = [[1, 0, 1], [0, 1, 1]]
X_trans = enc.fit_transform(X)
X_too_large = [[0, 2, 1], [0, 1, 1]]
enc.transform(X_too_large)
```

Used to give:

```
/home/trev/.virtualenvs/ve/lib/python2.7/site-packages/sklearn/preprocessing/data.py:1819: VisibleDeprecationWarning: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 6
  "during transform." % X[~mask])

ValueError: unknown categorical feature present [[0 1 1]] during transform.
```

Now:

```
ValueError: unknown categorical feature present [2] during transform.
```

And

```
enc = OneHotEncoder(n_values=[3, 2, 2])
X = [[1, 0, 1], [0, 1, 1]]
X_trans = enc.fit_transform(X)
X_too_large = [[0, 2, 2], [0, 1, 1]]
enc.transform(X_too_large)
```

Used to give:

```
/home/trev/.virtualenvs/ve/lib/python2.7/site-packages/sklearn/preprocessing/data.py:1819: VisibleDeprecationWarning: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 6
  "during transform." % X[~mask])

IndexError: index 2 is out of bounds for axis 0 with size 2
```

Now:

```
ValueError: unknown categorical feature present [2 2] during transform.
```
