### PR TITLE
[MRG+2] Fix 5687: Floating point indexing in MiniBatchDictionaryLearning

### DIFF
--- a/sklearn/decomposition/dict_learning.py
+++ b/sklearn/decomposition/dict_learning.py
@@ -146,9 +146,10 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
 
     elif algorithm == 'omp':
         # TODO: Should verbose argument be passed to this?
-        new_code = orthogonal_mp_gram(gram, cov, regularization, None,
-                                      row_norms(X, squared=True),
-                                      copy_Xy=copy_cov).T
+        new_code = orthogonal_mp_gram(
+            Gram=gram, Xy=cov, n_nonzero_coefs=int(regularization),
+            tol=None, norms_squared=row_norms(X, squared=True),
+            copy_Xy=copy_cov).T
     else:
         raise ValueError('Sparse coding method must be "lasso_lars" '
                          '"lasso_cd",  "lasso", "threshold" or "omp", got %s.'


### PR DESCRIPTION
The regularization parameter is not an integer so it must be rounded to be passed as n_nonzero_coefs, which is done with the other algorithms which need integers but not orthogonal_mp_gram. I made the parameters verbose to make it easier to read without referring to the definition as well.

Closes #5687.
