### PR TITLE
[MRG+1] Reduce warnings in the model_selection tests

### DIFF
--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -246,7 +246,6 @@ def test_grid_search_labels():
 
     non_label_cvs = [StratifiedKFold(), StratifiedShuffleSplit()]
     for cv in non_label_cvs:
-        print(cv)
         gs = GridSearchCV(clf, grid, cv=cv)
         # Should not raise an error
         gs.fit(X, y)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -216,6 +216,7 @@ def test_kfold_valueerrors():
     # though all the classes are not necessarily represented at on each
     # side of the split at each split
     with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         check_cv_coverage(skf_3, X2, y, labels=None, expected_n_iter=3)
 
     # Error when number of folds is <= 1


### PR DESCRIPTION
Fix #5669
- [x] stack y, y_reversed and use it for the multi output case and set random_state to 0 (sag solver is used)... That should make the sag solver converge without any warnings...
- [x] for the `test_cross_val_predict_input_types`, use the iris dataset to prevent non-convergence... (This won't slow down the tests by any significant amount)
- [x] Use atleast 3 samples per class when using `cross_val*` which uses 3 fold cv...

@amueller 
