### PR TITLE
[MRG] MLP: train_test_split is now in model_selection

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -16,13 +16,13 @@ from ..base import BaseEstimator, ClassifierMixin, RegressorMixin
 from ._base import logistic, softmax
 from ._base import ACTIVATIONS, DERIVATIVES, LOSS_FUNCTIONS
 from ._stochastic_optimizers import SGDOptimizer, AdamOptimizer
-from ..cross_validation import train_test_split
+from ..exceptions import ConvergenceWarning
 from ..externals import six
+from ..model_selection import train_test_split
 from ..preprocessing import LabelBinarizer
 from ..utils import gen_batches, check_random_state
 from ..utils import shuffle
 from ..utils import check_array, check_X_y, column_or_1d
-from ..exceptions import ConvergenceWarning
 from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import check_is_fitted
 from ..utils.multiclass import _check_partial_fit_first_call


### PR DESCRIPTION
This fixes a spurious warning of the multi-layer perceptron, which was still importing `train_test_split` from `cross_validation`. 
