### PR TITLE
[MRG+1] Update copyright year in the doc footer (2014 → 2015)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u('scikit-learn')
-copyright = u('2010 - 2014, scikit-learn developers (BSD License)')
+copyright = u('2010 - 2015, scikit-learn developers (BSD License)')
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Simply updating copyright year in the doc footer (present on every page), from _2010 - 2014_ to _2010 - 2015_.
![2010-2014](https://cloud.githubusercontent.com/assets/11994719/10955360/842ae53a-8353-11e5-9dec-7233ce12ce3f.png)
↓
![2010-2015](https://cloud.githubusercontent.com/assets/11994719/10955362/86194378-8353-11e5-9654-9f9b80d9d5ab.png)
