### PR TITLE
DOC: Fixed mistype in documentation, added active_features_ attribute example

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1714,7 +1714,6 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
            [ 0.,  1.,  0.,  1.,  0.,  1.,  0.,  0.,  0.],
            [ 0.,  1.,  0.,  0.,  1.,  0.,  0.,  1.,  0.]])
 
-
     See also
     --------
     sklearn.feature_extraction.DictVectorizer : performs a one-hot encoding of

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1689,22 +1689,31 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
     Examples
     --------
-    Given a dataset with three features and two samples, we let the encoder
+    Given a dataset with three features and four samples, we let the encoder
     find the maximum value per feature and transform the data to a binary
     one-hot encoding.
 
     >>> from sklearn.preprocessing import OneHotEncoder
     >>> enc = OneHotEncoder()
-    >>> enc.fit([[0, 0, 3], [1, 1, 0], [0, 2, 1], \
-[1, 0, 2]])  # doctest: +ELLIPSIS
+    >>> enc.fit([[0, 0, 3], \
+                 [1, 1, 0], \
+                 [0, 1, 1], \
+                 [1, 4, 2]])  # doctest: +ELLIPSIS
     OneHotEncoder(categorical_features='all', dtype=<... 'numpy.float64'>,
            handle_unknown='error', n_values='auto', sparse=True)
     >>> enc.n_values_
-    array([2, 3, 4])
+    array([2, 5, 4])
     >>> enc.feature_indices_
-    array([0, 2, 5, 9])
-    >>> enc.transform([[0, 1, 1]]).toarray()
-    array([[ 1.,  0.,  0.,  1.,  0.,  0.,  1.,  0.,  0.]])
+    array([0, 2, 7, 11])
+    >>> enc.active_features_
+    array([ 0,  1,  2,  3,  6,  7,  8,  9, 10])
+    >>> enc.transform([[0, 0, 3], \
+                       [1, 1, 0], \
+                       [1, 4, 2]]).toarray()
+    array([[ 1.,  0.,  1.,  0.,  0.,  0.,  0.,  0.,  1.],
+           [ 0.,  1.,  0.,  1.,  0.,  1.,  0.,  0.,  0.],
+           [ 0.,  1.,  0.,  0.,  1.,  0.,  0.,  1.,  0.]])
+
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1704,7 +1704,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
     >>> enc.n_values_
     array([2, 5, 4])
     >>> enc.feature_indices_
-    array([0, 2, 7, 11])
+    array([ 0,  2,  7, 11])
     >>> enc.active_features_
     array([ 0,  1,  2,  3,  6,  7,  8,  9, 10])
     >>> enc.transform([[0, 0, 3], \


### PR DESCRIPTION
In current version of documentation for OneHotEncoder `active_features_` attribute explained, but example is not provided. I changed dataset and now it's a little bit more obvious what values `active_features_` and `n_values_` attributes can take in case when you don't have some values from categorical feature range.
