### PR TITLE
[MRG+2] raise NotFittedError in VotingClassifier

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -129,6 +129,10 @@ Bug fixes
       won't accept anymore ``min_samples_split=1`` as at least 2 samples
       are required to split a decision tree node. By `Arnaud Joly`_
 
+    - :class:`VotingClassifier` now raises ``NotFittedError`` if ``predict``,
+      ``transform`` or ``predict_proba`` are called on the non-fitted estimator.
+      by `Sebastian Raschka`_.
+
 API changes summary
 -------------------
 

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -3,6 +3,8 @@
 import numpy as np
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_raise_message
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
 from sklearn.ensemble import RandomForestClassifier
@@ -14,9 +16,34 @@ from sklearn.datasets import make_multilabel_classification
 from sklearn.svm import SVC
 from sklearn.multiclass import OneVsRestClassifier
 
+
 # Load the iris dataset and randomly permute it
 iris = datasets.load_iris()
 X, y = iris.data[:, 1:3], iris.target
+
+
+def test_estimator_init():
+    eclf = VotingClassifier(estimators=[])
+    msg = ('Invalid `estimators` attribute, `estimators` should be'
+           ' a list of (string, estimator) tuples')
+    assert_raise_message(AttributeError, msg, eclf.fit, X, y)
+
+
+def test_predictproba_hardvoting():
+    eclf = VotingClassifier(estimators=[('lr1', LogisticRegression()),
+                                        ('lr2', LogisticRegression())],
+                            voting='hard')
+    msg = "predict_proba is not available when voting='hard'"
+    assert_raise_message(AttributeError, msg, eclf.predict_proba, X)
+
+
+def test_notfitted():
+    eclf = VotingClassifier(estimators=[('lr1', LogisticRegression()),
+                                        ('lr2', LogisticRegression())],
+                            voting='soft')
+    msg = ("This VotingClassifier instance is not fitted yet. Call \'fit\'"
+           " with appropriate arguments before using this method.")
+    assert_raise_message(NotFittedError, msg, eclf.predict_proba, X)
 
 
 def test_majority_label_iris():


### PR DESCRIPTION
Raise a `NotFittedError` if `predict`, `predict_proba,` or `transform` is called on the unfitted `VottingClassifier` object.
