### PR TITLE
Fixed transformation of test set via RobustScaler in example

### DIFF
--- a/examples/preprocessing/plot_robust_scaling.py
+++ b/examples/preprocessing/plot_robust_scaling.py
@@ -52,7 +52,7 @@ Xte_s = standard_scaler.transform(X_test)
 
 robust_scaler = RobustScaler()
 Xtr_r = robust_scaler.fit_transform(X_train)
-Xte_r = robust_scaler.fit_transform(X_test)
+Xte_r = robust_scaler.transform(X_test)
 
 
 # Plot data


### PR DESCRIPTION
RobustScaler should have followed the same approach of StandardScaler: fit_transform on train and only transform on test.

Results are similar:

```
Testset accuracy using standard scaler: 0.545
Testset accuracy using robust scaler:   0.705
```
