### PR TITLE
[MRG+1] Voting Classifier: predictions are float but np.bincount can only be used on integers

### DIFF
--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -150,7 +150,7 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
                                       np.argmax(np.bincount(x,
                                                 weights=self.weights)),
                                       axis=1,
-                                      arr=predictions)
+                                      arr=predictions.astype('int'))
 
         maj = self.le_.inverse_transform(maj)
 


### PR DESCRIPTION
This fix downcasts manually the array of predictions to integers so that np.bincount does not trigger an error
