### PR TITLE
Remove exit call in topic extraction example

### DIFF
--- a/examples/applications/topics_extraction_with_nmf_lda.py
+++ b/examples/applications/topics_extraction_with_nmf_lda.py
@@ -76,7 +76,6 @@ print("Fitting the NMF model with tf-idf features,"
       % (n_samples, n_features))
 t0 = time()
 nmf = NMF(n_components=n_topics, random_state=1, alpha=.1, l1_ratio=.5).fit(tfidf)
-exit()
 print("done in %0.3fs." % (time() - t0))
 
 print("\nTopics in NMF model:")


### PR DESCRIPTION
Addresses #5767 
This call came from 
https://github.com/scikit-learn/scikit-learn/commit/47a85f3f3470dc07fa4a6f621e9ebaef4525827b

Was most likely introduced for debugging. 
