### PR TITLE
[MRG+1] Added documentation to PCA docstring

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -144,18 +144,25 @@ class PCA(BaseEstimator, TransformerMixin):
     ----------
     components_ : array, [n_components, n_features]
         Principal axes in feature space, representing the directions of
-        maximum variance in the data.
+        maximum variance in the data. The components are sorted by
+        explained_variance_.
+
+    explained_variance_ : array, [n_components]
+        The amount of variance explained by each of the selected components.
 
     explained_variance_ratio_ : array, [n_components]
         Percentage of variance explained by each of the selected components.
+
         If ``n_components`` is not set then all components are stored and the
-        sum of explained variances is equal to 1.0
+        sum of explained variances is equal to 1.0.
 
     mean_ : array, [n_features]
         Per-feature empirical mean, estimated from the training set.
 
+        Equal to `X.mean(axis=1)`.
+
     n_components_ : int
-        The estimated number of components. Relevant when n_components is set
+        The estimated number of components. Relevant when `n_components` is set
         to 'mle' or a number between 0 and 1 to select using explained
         variance.
 
@@ -192,6 +199,8 @@ class PCA(BaseEstimator, TransformerMixin):
     >>> pca = PCA(n_components=2)
     >>> pca.fit(X)
     PCA(copy=True, n_components=2, whiten=False)
+    >>> print(pca.explained_variance_) # doctest: +ELLIPSIS
+    [ 6.6162...  0.05038...]
     >>> print(pca.explained_variance_ratio_) # doctest: +ELLIPSIS
     [ 0.99244...  0.00755...]
 
@@ -395,14 +404,16 @@ class PCA(BaseEstimator, TransformerMixin):
         return X_transformed
 
     def inverse_transform(self, X):
-        """Transform data back to its original space, i.e.,
-        return an input X_original whose transform would be X
+        """Transform data back to its original space using `n_components_`.
+
+        Returns an input X_original whose transform would be X.
 
         Parameters
         ----------
         X : array-like, shape (n_samples, n_components)
             New data, where n_samples is the number of samples
-            and n_components is the number of components.
+            and n_components is the number of components. X represents
+            data from the projection on to the principal components.
 
         Returns
         -------
@@ -419,7 +430,7 @@ class PCA(BaseEstimator, TransformerMixin):
             return fast_dot(X, self.components_) + self.mean_
 
     def score_samples(self, X):
-        """Return the log-likelihood of each sample
+        """Return the log-likelihood of each sample.
 
         See. "Pattern Recognition and Machine Learning"
         by C. Bishop, 12.2.1 p. 574
@@ -448,7 +459,7 @@ class PCA(BaseEstimator, TransformerMixin):
         return log_like
 
     def score(self, X, y=None):
-        """Return the average log-likelihood of all samples
+        """Return the average log-likelihood of all samples.
 
         See. "Pattern Recognition and Machine Learning"
         by C. Bishop, 12.2.1 p. 574


### PR DESCRIPTION
Addresses #5751. Some things that I added:
- Mentioned that `components_` is sorted by `explained_variance_`
- Added the `explained_variance_` attribute to the docstring. Apparently this was being stored before, but it wasn't documented.
- One doctest with `pca.explained_variance_`
- Some very minor punctuation changes.

One thing I was hoping to add to the documentation was how to smooth data using PCA. To do this, one would say `pca.inverse_transform(pca.transform(X))`. Is there any interest in me writing an example in the docstring of how to smooth data using PCA?
