### PR TITLE
[MRG + 1] Fix for uneven grids in Partial Dependence Plots example

### DIFF
--- a/examples/ensemble/plot_partial_dependence.py
+++ b/examples/ensemble/plot_partial_dependence.py
@@ -92,10 +92,10 @@ print
 fig = plt.figure()
 
 target_feature = (1, 5)
-pdp, (x_axis, y_axis) = partial_dependence(clf, target_feature,
-                                           X=X_train, grid_resolution=50)
-XX, YY = np.meshgrid(x_axis, y_axis)
-Z = pdp.T.reshape(XX.shape).T
+pdp, axes = partial_dependence(clf, target_feature,
+                               X=X_train, grid_resolution=50)
+XX, YY = np.meshgrid(axes[0], axes[1])
+Z = pdp[0].reshape(list(map(np.size, axes))).T
 ax = Axes3D(fig)
 surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu)
 ax.set_xlabel(names[target_feature[0]])


### PR DESCRIPTION
Fixes ~~5846~~ ... Sorry #5810  - The problem was not in the code base, but the shape of `Z`. The output of the example won't change, but a user can change the `grid_resolution` param such that it exceeds the number of unique values and then the shapes become invalid.
