### PR TITLE
[MRG] Update to Out of Bag Score Documentation for Random Forest

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -66,7 +66,7 @@ specifying the strategy to draw random subsets. In particular, ``max_samples``
 and ``max_features`` control the size of the subsets (in terms of samples and
 features), while ``bootstrap`` and ``bootstrap_features`` control whether
 samples and features are drawn with or without replacement. When using a subset
-of the available samples the generalization error can be estimated with the
+of the available samples the generalization accuracy can be estimated with the
 out-of-bag samples by setting ``oob_score=True``. As an example, the
 snippet below illustrates how to instantiate a bagging ensemble of
 :class:`KNeighborsClassifier` base estimators, each built on random subsets of
@@ -209,7 +209,7 @@ should always be cross-validated. In addition, note that in random forests,
 bootstrap samples are used by default (``bootstrap=True``)
 while the default strategy for extra-trees is to use the whole dataset
 (``bootstrap=False``).
-When using bootstrap sampling the generalization error can be estimated
+When using bootstrap sampling the generalization accuracy can be estimated
 on the left out or out-of-bag samples. This can be enabled by
 setting ``oob_score=True``.
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -815,7 +815,7 @@ class RandomForestClassifier(ForestClassifier):
 
     oob_score : bool
         Whether to use out-of-bag samples to estimate
-        the generalization error.
+        the generalization accuracy.
 
     n_jobs : integer, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
@@ -1008,7 +1008,7 @@ class RandomForestRegressor(ForestRegressor):
 
     oob_score : bool, optional (default=False)
         whether to use out-of-bag samples to estimate
-        the generalization error.
+        the R^2 on unseen data.
 
     n_jobs : integer, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
@@ -1167,7 +1167,7 @@ class ExtraTreesClassifier(ForestClassifier):
 
     oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate
-        the generalization error.
+        the generalization accuracy.
 
     n_jobs : integer, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.
@@ -1359,7 +1359,7 @@ class ExtraTreesRegressor(ForestRegressor):
         Whether bootstrap samples are used when building trees.
 
     oob_score : bool, optional (default=False)
-        Whether to use out-of-bag samples to estimate the generalization error.
+        Whether to use out-of-bag samples to estimate the R^2 on unseen data.
 
     n_jobs : integer, optional (default=1)
         The number of jobs to run in parallel for both `fit` and `predict`.


### PR DESCRIPTION
Many have been confused about whether the score represents the model's accuracy/R-squared or its error, examples in issue 'Meaning of oob_score_ in RandomForestClassifier #5838' and Stack overflow post here: http://stackoverflow.com/questions/31438476/parameter-oob-score-in-scikit-learn-equals-accuracy-or-error.

The score represents the accuracy/R-squared; I've made some changes in the code documentation to make this clear.
