### PR TITLE
[MRG] fixes issue #5482, disambiguation of parameter analyzer

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -217,7 +217,11 @@ class VectorizerMixin(object):
         return _check_stop_list(self.stop_words)
 
     def build_analyzer(self):
-        """Return a callable that handles preprocessing and tokenization"""
+        """Return a callable that handles preprocessing and tokenization
+
+        If a callable is passed as init paramater, no preprocessing or tokenization
+        is added"""
+        
         if callable(self.analyzer):
             return self.analyzer
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -219,8 +219,9 @@ class VectorizerMixin(object):
     def build_analyzer(self):
         """Return a callable that handles preprocessing and tokenization
 
-        If a callable is passed as init paramater, no preprocessing or tokenization
-        is added"""
+        If a callable is passed as init paramater, additional preprocessing 
+        and tokenization is not applied.
+        """
 
         if callable(self.analyzer):
             return self.analyzer

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -221,7 +221,7 @@ class VectorizerMixin(object):
 
         If a callable is passed as init paramater, no preprocessing or tokenization
         is added"""
-        
+
         if callable(self.analyzer):
             return self.analyzer
 
@@ -554,7 +554,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         If analyzer is a callable, data from fit is directly passed to the 
         callable. The expected output being a sequence of features. All
-        preprocessing steps like reading from files and preprocessing is 
+        preprocessing steps like reading from files and preprocessing are 
         skipped.
 
     preprocessor : callable or None (default)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -524,7 +524,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         object) that is called to fetch the bytes in memory.
 
         Otherwise the input is expected to be the sequence strings or
-        bytes items are expected to be analyzed directly.
+        bytes items that are passed into the analyzer.
 
     encoding : string, 'utf-8' by default.
         If bytes or files are given to analyze, this encoding is used to
@@ -548,9 +548,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         Option 'char_wb' creates character n-grams only from text inside
         word boundaries.
 
-        If a callable is passed it is used to extract the sequence of features
-        out of the raw, unprocessed input.
-        Only applies if ``analyzer == 'word'``.
+        If analyzer is a callable, data from fit is directly passed to the 
+        callable. The expected output being a sequence of features. All
+        preprocessing steps like reading from files and preprocessing is 
+        skipped.
 
     preprocessor : callable or None (default)
         Override the preprocessing (string transformation) stage while


### PR DESCRIPTION
Docs have been updated with which steps are actually skipped when providing a callable as analyzer for CountVectorizer.
Additionally, previous docstring wrongly indicated that this behavior only applies if "analyzer=='word'"
