### PR TITLE
eliminate zeros after summing duplicates

### DIFF
--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -148,6 +148,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         X = sp.csr_matrix((values, indices, indptr), dtype=self.dtype,
                           shape=(n_samples, self.n_features))
         X.sum_duplicates()  # also sorts the indices
+        X.eliminate_zeros()
         if self.non_negative:
             np.abs(X.data, X.data)
         return X


### PR DESCRIPTION
sum_duplicates can create zero entries in the csr matrix, which can give unexpected results in callers (see #3637).
