### PR TITLE
skip downloading newsgroup data file with working_with_text_data

### DIFF
--- a/doc/tutorial/text_analytics/working_with_text_data_fixture.py
+++ b/doc/tutorial/text_analytics/working_with_text_data_fixture.py
@@ -9,7 +9,7 @@ check_skip_network for more details).
 
 """
 from sklearn.utils.testing import check_skip_network
-
+from sklearn.utils.testing import SkipTest
 
 def setup_module():
-    check_skip_network()
+    raise SkipTest("Skipping dataset loading doctests")


### PR DESCRIPTION
While processing "working_with_text_data.rst", twenty_newsgroups.download_20newsgroups() gets called.  For some reason, if this gets called before test_20news.py, the newsgroup data file, "20news-bydate.pkz", gets created in the cache and the test get run.  If the test in test_20news.py execute first, "20news-bydate.pkz" doesn't get downloaded and the tests are skipped.  This doesn't fix the issue with Bundle in the unit tests but the data file shouldn't get download with "working_with_text_data.rst". 
