### PR TITLE
[MRG+2] fix confusing n_samples and n_features in topics_extraction_with_nmf_lda example

### DIFF
--- a/examples/applications/topics_extraction_with_nmf_lda.py
+++ b/examples/applications/topics_extraction_with_nmf_lda.py
@@ -51,12 +51,13 @@ print("Loading dataset...")
 t0 = time()
 dataset = fetch_20newsgroups(shuffle=True, random_state=1,
                              remove=('headers', 'footers', 'quotes'))
-data_samples = dataset.data
+data_samples = dataset.data[:n_samples]
 print("done in %0.3fs." % (time() - t0))
 
 # Use tf-idf features for NMF.
 print("Extracting tf-idf features for NMF...")
-tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2, #max_features=n_features,
+tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2,
+                                   max_features=n_features,
                                    stop_words='english')
 t0 = time()
 tfidf = tfidf_vectorizer.fit_transform(data_samples)
@@ -64,28 +65,32 @@ print("done in %0.3fs." % (time() - t0))
 
 # Use tf (raw term count) features for LDA.
 print("Extracting tf features for LDA...")
-tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2, max_features=n_features,
+tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2,
+                                max_features=n_features,
                                 stop_words='english')
 t0 = time()
 tf = tf_vectorizer.fit_transform(data_samples)
 print("done in %0.3fs." % (time() - t0))
 
 # Fit the NMF model
-print("Fitting the NMF model with tf-idf features,"
+print("Fitting the NMF model with tf-idf features, "
       "n_samples=%d and n_features=%d..."
       % (n_samples, n_features))
 t0 = time()
-nmf = NMF(n_components=n_topics, random_state=1, alpha=.1, l1_ratio=.5).fit(tfidf)
+nmf = NMF(n_components=n_topics, random_state=1,
+          alpha=.1, l1_ratio=.5).fit(tfidf)
 print("done in %0.3fs." % (time() - t0))
 
 print("\nTopics in NMF model:")
 tfidf_feature_names = tfidf_vectorizer.get_feature_names()
 print_top_words(nmf, tfidf_feature_names, n_top_words)
 
-print("Fitting LDA models with tf features, n_samples=%d and n_features=%d..."
+print("Fitting LDA models with tf features, "
+      "n_samples=%d and n_features=%d..."
       % (n_samples, n_features))
 lda = LatentDirichletAllocation(n_topics=n_topics, max_iter=5,
-                                learning_method='online', learning_offset=50.,
+                                learning_method='online',
+                                learning_offset=50.,
                                 random_state=0)
 t0 = time()
 lda.fit(tf)


### PR DESCRIPTION
Fix #5877 by adding `n_samples` to actual use and `n_features` to both NMF and LDA. 

Fix a few PEP8 warnings to the old code.
