### PR TITLE
[MRG + 1] Read web pages as UTF-8 by default. Use with-blocks to open files.

### DIFF
--- a/doc/tutorial/text_analytics/data/languages/fetch_data.py
+++ b/doc/tutorial/text_analytics/data/languages/fetch_data.py
@@ -14,6 +14,8 @@ import lxml.html
 from lxml.etree import ElementTree
 import numpy as np
 
+import codecs
+
 pages = {
     u'ar': u'http://ar.wikipedia.org/wiki/%D9%88%D9%8A%D9%83%D9%8A%D8%A8%D9%8A%D8%AF%D9%8A%D8%A7',
     u'de': u'http://de.wikipedia.org/wiki/Wikipedia',
@@ -54,16 +56,15 @@ for lang, page in pages.items():
         print("Downloading %s" % page)
         request = Request(page)
         # change the User Agent to avoid being blocked by Wikipedia
-        # downloading a couple of articles ones should not be abusive
+        # downloading a couple of articles should not be considered abusive
         request.add_header('User-Agent', 'OpenAnything/1.0')
         html_content = opener.open(request).read()
         open(html_filename, 'wb').write(html_content)
 
     # decode the payload explicitly as UTF-8 since lxml is confused for some
     # reason
-    html_content = open(html_filename).read()
-    if hasattr(html_content, 'decode'):
-        html_content = html_content.decode('utf-8')
+    with codecs.open(html_filename,'r','utf-8') as html_file:
+        html_content = html_file.read()
     tree = ElementTree(lxml.html.document_fromstring(html_content))
     i = 0
     j = 0

--- a/doc/tutorial/text_analytics/data/movie_reviews/fetch_data.py
+++ b/doc/tutorial/text_analytics/data/movie_reviews/fetch_data.py
@@ -20,8 +20,15 @@ if not os.path.exists(DATA_FOLDER):
     if not os.path.exists(ARCHIVE_NAME):
         print("Downloading dataset from %s (3 MB)" % URL)
         opener = urlopen(URL)
-        open(ARCHIVE_NAME, 'wb').write(opener.read())
+        with open(ARCHIVE_NAME, 'wb') as archive:
+            archive.write(opener.read())
 
     print("Decompressing %s" % ARCHIVE_NAME)
-    tarfile.open(ARCHIVE_NAME, "r:gz").extractall(path='.')
+    try:
+        with tarfile.open(ARCHIVE_NAME, "r:gz") as archive:
+            archive.extractall(path = '.')
+    except AttributeError: # In Python 2.6, tarfile did not yet implement the context manager protocol
+        archive = tarfile.open(ARCHIVE_NAME, "r:gz")
+        archive.extractall(path = '.')
+        archive.close()
     os.remove(ARCHIVE_NAME)

--- a/doc/tutorial/text_analytics/data/twenty_newsgroups/fetch_data.py
+++ b/doc/tutorial/text_analytics/data/twenty_newsgroups/fetch_data.py
@@ -21,9 +21,16 @@ if not os.path.exists(TRAIN_FOLDER) or not os.path.exists(TEST_FOLDER):
     if not os.path.exists(ARCHIVE_NAME):
         print("Downloading dataset from %s (14 MB)" % URL)
         opener = urlopen(URL)
-        open(ARCHIVE_NAME, 'wb').write(opener.read())
+        with open(ARCHIVE_NAME,'wb') as archive:
+            archive.write(opener.read())
 
     print("Decompressing %s" % ARCHIVE_NAME)
-    tarfile.open(ARCHIVE_NAME, "r:gz").extractall(path='.')
+    try:
+        with tarfile.open(ARCHIVE_NAME, "r:gz") as archive:
+            archive.extractall(path = '.')
+    except AttributeError: # In Python 2.6, tarfile did not yet implement the context manager protocol
+        archive = tarfile.open(ARCHIVE_NAME, "r:gz")
+        archive.extractall(path = '.')
+        archive.close()
     os.remove(ARCHIVE_NAME)
 


### PR DESCRIPTION
On windows, the default encoding for `open(filename)` is cp1252. Calling `open(filename).read()` on a UTF-8 encoded file (e.g. the wikipedia pages being fetched) fails with an error when it encounters multi-byte unicode code points.

This was a blocker bug. I also wrapped the file ops in with-blocks, as is the preferred style these days.
