### PR TITLE
DOC: fix shape lambda_ attribute in BayesianRidge

### DIFF
--- a/sklearn/linear_model/bayes.py
+++ b/sklearn/linear_model/bayes.py
@@ -81,8 +81,8 @@ class BayesianRidge(LinearModel, RegressorMixin):
     alpha_ : float
        estimated precision of the noise.
 
-    lambda_ : array, shape = (n_features)
-       estimated precisions of the weights.
+    lambda_ : float
+       estimated precision of the weights.
 
     scores_ : float
         if computed, value of the objective function (to be maximized)


### PR DESCRIPTION
supersedes #5912 I run into problems during rebase and started over with a new PR. @agramfort 

Attributes for `BayesianRidge` currently read:

```
`lambda_` : array, shape = (n_features)
   estimated precisions of the weights.
```

but should be

```
`lambda_` : float
   estimated precision of the weights.
```

`ARDRegression` estimates `lambda_` for each feature. However, `BayesianRidge` estimates only one `lambda_`.

Best,
Matthias
