### PR TITLE
[MRG + 1] Keyword arguments in FunctionTransformer

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -46,13 +46,18 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         Indicate that transform should forward the y argument to the
         inner callable.
 
+    kw_args : dict, optional
+        Dictionary of additional keyword arguments to pass to func.
+
     """
     def __init__(self, func=None, validate=True,
-                 accept_sparse=False, pass_y=False):
+                 accept_sparse=False, pass_y=False,
+                 kw_args=None):
         self.func = func
         self.validate = validate
         self.accept_sparse = accept_sparse
         self.pass_y = pass_y
+        self.kw_args = kw_args
 
     def fit(self, X, y=None):
         if self.validate:
@@ -65,4 +70,5 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
         func = self.func if self.func is not None else _identity
 
 
-        return func(X, *((y,) if self.pass_y else ()))
+        return func(X, *((y,) if self.pass_y else ()),
+                    **(self.kw_args if self.kw_args else {}))

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -1,6 +1,7 @@
 from nose.tools import assert_equal
 import numpy as np
 
+from sklearn.utils import testing
 from sklearn.preprocessing import FunctionTransformer
 
 
@@ -20,7 +21,7 @@ def test_delegate_to_func():
     args_store = []
     kwargs_store = {}
     X = np.arange(10).reshape((5, 2))
-    np.testing.assert_array_equal(
+    testing.assert_array_equal(
         FunctionTransformer(_make_func(args_store, kwargs_store)).transform(X),
         X,
         'transform should have returned X unchanged',
@@ -47,7 +48,7 @@ def test_delegate_to_func():
     kwargs_store.clear()
     y = object()
 
-    np.testing.assert_array_equal(
+    testing.assert_array_equal(
         FunctionTransformer(
             _make_func(args_store, kwargs_store),
             pass_y=True,
@@ -77,7 +78,7 @@ def test_np_log():
     X = np.arange(10).reshape((5, 2))
 
     # Test that the numpy.log example still works.
-    np.testing.assert_array_equal(
+    testing.assert_array_equal(
         FunctionTransformer(np.log1p).transform(X),
         np.log1p(X),
     )
@@ -89,7 +90,7 @@ def test_kw_arg():
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 
     # Test that rounding is correct
-    np.testing.assert_array_equal(F.transform(X),
+    testing.assert_array_equal(F.transform(X),
                                   np.around(X, decimals=3))
 
 
@@ -101,7 +102,7 @@ def test_kw_arg_update():
     F.kw_args['decimals'] = 1
 
     # Test that rounding is correct
-    np.testing.assert_array_equal(F.transform(X),
+    testing.assert_array_equal(F.transform(X),
                                   np.around(X, decimals=1))
 
 
@@ -113,5 +114,5 @@ def test_kw_arg_reset():
     F.kw_args = dict(decimals=1)
 
     # Test that rounding is correct
-    np.testing.assert_array_equal(F.transform(X),
+    testing.assert_array_equal(F.transform(X),
                                   np.around(X, decimals=1))

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -84,7 +84,7 @@ def test_np_log():
 
 
 def test_kw_arg():
-    X = np.arange(10).reshape((5, 2))
+    X = np.linspace(0, 1, num=10).reshape((5, 2))
 
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 
@@ -94,7 +94,7 @@ def test_kw_arg():
 
 
 def test_kw_arg_update():
-    X = np.arange(10).reshape((5, 2))
+    X = np.linspace(0, 1, num=10).reshape((5, 2))
 
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 
@@ -106,7 +106,7 @@ def test_kw_arg_update():
 
 
 def test_kw_arg_reset():
-    X = np.arange(10).reshape((5, 2))
+    X = np.linspace(0, 1, num=10).reshape((5, 2))
 
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -91,3 +91,27 @@ def test_kw_arg():
     # Test that rounding is correct
     np.testing.assert_array_equal(F.transform(X),
                                   np.around(X, decimals=3))
+
+
+def test_kw_arg_update():
+    X = np.arange(10).reshape((5, 2))
+
+    F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
+
+    F.kw_args['decimals'] = 1
+
+    # Test that rounding is correct
+    np.testing.assert_array_equal(F.transform(X),
+                                  np.around(X, decimals=1))
+
+
+def test_kw_arg_reset():
+    X = np.arange(10).reshape((5, 2))
+
+    F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
+
+    F.kw_args = dict(decimals=1)
+
+    # Test that rounding is correct
+    np.testing.assert_array_equal(F.transform(X),
+                                  np.around(X, decimals=1))

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -81,3 +81,13 @@ def test_np_log():
         FunctionTransformer(np.log1p).transform(X),
         np.log1p(X),
     )
+
+
+def test_kw_arg():
+    X = np.arange(10).reshape((5, 2))
+
+    F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
+
+    # Test that rounding is correct
+    np.testing.assert_array_equal(F.transform(X),
+                                  np.around(X, decimals=3))


### PR DESCRIPTION
This PR enhances the FunctionTransformer class to store optional keyword arguments for the embedded function.

The motivation is to reduce the need for lambda functions in many simple cases, which should make code more readable, and allow objects to be serialized.

For example, rather than doing:

``` python
>>> F = FunctionTransformer(lambda x : np.around(x, decimals=3))
>>> X_rounded = F.transform(X)
```

one can do:

``` python
>>> F2 = FunctionTransformer(np.around, kw_args=dict(decimals=3))
>>> X_rounded = F2.transform(X)
```

In the latter case, the `F2` object can be serialized, and its parameters are available for inspection:

``` python
>>> F
FunctionTransformer(accept_sparse=False,
          func=<function <lambda> at 0x7f6c4bd90f28>, kw_args=None,
          pass_y=False, validate=True)
>>> F2
FunctionTransformer(accept_sparse=False,
          func=<function around at 0x7f6c44173c80>,
          kw_args={'decimals': 3}, pass_y=False, validate=True)
```
