### PR TITLE
fixed plot_stock_market.py example by replacing a deprecated matplotlib function

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -146,7 +146,7 @@ symbol_dict = {
 
 symbols, names = np.array(list(symbol_dict.items())).T
 
-quotes = [finance.quotes_historical_yahoo(symbol, d1, d2, asobject=True)
+quotes = [finance.quotes_historical_yahoo_ochl(symbol, d1, d2, asobject=True)
           for symbol in symbols]
 
 open = np.array([q.open for q in quotes]).astype(np.float)


### PR DESCRIPTION
the matplotlib function finance.quotes_historical_yahoo() was deprecated as of matplotlib 1.4.x, and replaced with finance.quotes_historical_yahoo_ochl(). The example was still using the deprecated function, so I updated it. This enables the example to work for the latest version of matplotlib (1.5.0).
