### PR TITLE
[MRG+2] Fixed plot_stock_market.py example to work with matplotlib 1.4.x+

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -68,9 +68,12 @@ import datetime
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib import finance
+try:
+     from matplotlib.finance import quotes_historical_yahoo_ochl
+except ImportError:
+     # quotes_historical_yahoo_ochl was named quotes_historical_yahoo before matplotlib 1.4
+     from matplotlib.finance import quotes_historical_yahoo as quotes_historical_yahoo_ochl
 from matplotlib.collections import LineCollection
-
 from sklearn import cluster, covariance, manifold
 
 ###############################################################################
@@ -146,7 +149,7 @@ symbol_dict = {
 
 symbols, names = np.array(list(symbol_dict.items())).T
 
-quotes = [finance.quotes_historical_yahoo(symbol, d1, d2, asobject=True)
+quotes = [quotes_historical_yahoo_ochl(symbol, d1, d2, asobject=True)
           for symbol in symbols]
 
 open = np.array([q.open for q in quotes]).astype(np.float)


### PR DESCRIPTION
I've replaced matplotlib function finance.quotes_historical_yahoo() (deprecated as of matplotlib 1.4.x) with finance.quotes_historical_yahoo_ochl(), enabling the example to work for the latest version of matplotlib (1.5.0) / anything beyond version 1.4.x.
