### PR TITLE
[MRG+1] Fix for coveralls not sending coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,26 +22,26 @@ addons:
       - python-scipy
 
 env:
+  global:
+    # Directory where tests are run from
+    - TEST_DIR=/tmp/sklearn
   matrix:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Precise 12.04
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" COVERAGE="true"
-      CYTHON_VERSION="0.23.4" NAME="ubuntu"
+      CYTHON_VERSION="0.23.4" CACHED_BUILD_DIR="$HOME/sklearn_build_ubuntu"
     # This environment tests the oldest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.6" INSTALL_MKL="false"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.21"
-      NAME="oldest"
+      CACHED_BUILD_DIR="$HOME/sklearn_build_oldest"
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
       NUMPY_VERSION="1.10.1" SCIPY_VERSION="0.16.0" CYTHON_VERSION="0.23.4"
-      NAME="latest"
+      CACHED_BUILD_DIR="$HOME/sklearn_build_latest"
+
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh
-after_success:
-    # Ignore coveralls failures as the coveralls server is not very reliable
-    # but we don't want travis to report a failure in the github UI just
-    # because the coverage report failed to be published.
-    - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
+after_success: source continuous_integration/after_success.sh
 notifications:
   webhooks:
     urls:

--- a/continuous_integration/after_success.sh
+++ b/continuous_integration/after_success.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This script is meant to be called by the "after_success" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+
+# License: 3-clause BSD
+
+set -e
+
+if [[ "$COVERAGE" == "true" ]]; then
+    # Need to run coveralls from a git checkout, so we copy .coverage
+    # from TEST_DIR where nosetests has been run
+    cp $TEST_DIR/.coverage $TRAVIS_BUILD_DIR
+    cd $TRAVIS_BUILD_DIR
+    # Ignore coveralls failures as the coveralls server is not
+    # very reliable but we don't want travis to report a failure
+    # in the github UI just because the coverage report failed to
+    # be published.
+    coveralls || echo "Coveralls upload failed"
+fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -83,17 +83,14 @@ if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi
 
-GIT_TRAVIS_REPO=$(pwd)
-echo $GIT_TRAVIS_REPO
-
-cd $HOME
-if [ ! -d "sklearn_build_$NAME" ]; then
-    mkdir sklearn_build_$NAME
+if [ ! -d "$CACHED_BUILD_DIR" ]; then
+    mkdir -p $CACHED_BUILD_DIR
 fi
 
-rsync -av --exclude='.git/' --exclude='testvenv/' $GIT_TRAVIS_REPO \
-    sklearn_build_${NAME}
-cd sklearn_build_${NAME}/scikit-learn
+rsync -av --exclude '.git/' --exclude='testvenv/' \
+      $TRAVIS_BUILD_DIR $CACHED_BUILD_DIR
+
+cd $CACHED_BUILD_DIR/scikit-learn
 
 # Build scikit-learn in the install.sh script to collapse the verbose
 # build output in the travis output when it succeeds.

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -10,8 +10,10 @@ set -e
 
 # Get into a temp directory to run test from the installed scikit learn and
 # check if we do not leave artifacts
-mkdir -p /tmp/sklearn_tmp
-cd /tmp/sklearn_tmp
+mkdir -p $TEST_DIR
+# We need the setup.cfg for the nose settings
+cp setup.cfg $TEST_DIR
+cd $TEST_DIR
 
 python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
@@ -29,8 +31,8 @@ else
 fi
 
 # Is directory still empty ?
-ls
+ls -ltra
 
 # Test doc
-cd $HOME/sklearn_build_$NAME/scikit-learn
+cd $CACHED_BUILD_DIR/scikit-learn
 make test-doc test-sphinxext


### PR DESCRIPTION
coveralls needs to be run from a git checkout, so keeping .git when copying folder in continuous_integration/install.sh.

Talked with @arthurmensch and he said that excluding .git from the copy was just to save a bit of time (~10s).

For reference, the error from coveralls from this Travis [log](https://travis-ci.org/scikit-learn/scikit-learn/jobs/93359303#L2977):

```
Traceback (most recent call last):
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/bin/coveralls", line 11, in <module>
    sys.exit(main())
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/cli.py", line 62, in main
    result = coverallz.wear()
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/api.py", line 89, in wear
    json_string = self.create_report()
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/api.py", line 107, in create_report
    data = self.create_data()
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/api.py", line 157, in create_data
    self._data.update(self.git_info())
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/api.py", line 197, in git_info
    rev = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD').strip()
  File "/home/travis/build/scikit-learn/scikit-learn/testvenv/local/lib/python2.7/site-packages/coveralls/api.py", line 240, in run_command
    'STDERR: "%s"' % (cmd.returncode, stdout, stderr))
AssertionError: command return code 128, STDOUT: ""
STDERR: "fatal: Not a git repository (or any of the parent directories): .git
```
