### PR TITLE
[MRG+1] edited the FAQ to fix a typo and include info regarding global random states

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -8,7 +8,7 @@ Here we try to give some answers to questions that regularly pop up on the maili
 
 What is the project name (a lot of people get it wrong)?
 --------------------------------------------------------
-scikit-learn, but not scikit or SciKit nor sci-kit learn. Also not scikits.learn or scikits-learn, which where previously used.
+scikit-learn, but not scikit or SciKit nor sci-kit learn. Also not scikits.learn or scikits-learn, which were previously used.
 
 How do you pronounce the project name?
 ------------------------------------------
@@ -201,7 +201,6 @@ DBSCAN with Levenshtein distances::
 Similar tricks can be used, with some care, for tree kernels, graph kernels,
 etc.
 
-
 Why do I sometime get a crash/freeze with n_jobs > 1 under OSX or Linux?
 ------------------------------------------------------------------------
 
@@ -249,9 +248,9 @@ program: Insert the following instructions in your main script::
 You can find more default on the new start methods in the `multiprocessing
 documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
 
-
 Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
 --------------------------------------------------------------------------------------------------------------------------------------
+
 Deep learning and reinforcement learning both require a rich vocabulary to
 define an architecture, with deep learning additionally requiring
 GPUs for efficient computing. However, neither of these fit within
@@ -259,9 +258,9 @@ the design constraints of scikit-learn; as a result, deep learning
 and reinforcement learning are currently out of scope for what
 scikit-learn seeks to achieve.
 
-
 Why is my pull request not getting any attention?
 -------------------------------------------------
+
 The scikit-learn review process takes a significant amount of time, and
 contributors should not be discouraged by a lack of activity or review on
 their pull request. We care a lot about getting things right
@@ -276,3 +275,12 @@ If a review of your pull request comes slowly, it is likely because the
 reviewers are busy. We ask for your understanding and request that you
 not close your pull request or discontinue your work solely because of
 this reason.
+
+How do I set a random_state for an entire execution?
+----------------------------------------------------
+
+For testing and replicability, it is often important to have the entire execution
+controlled by a single seed for the pseudo-random number generator used in algorithms
+that have a randomized component. While there is no ``random.seed(seed)`` function,
+scikit-learn uses the global random states by default and one could thus define a
+global random state that would be used throughout an execution.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -280,18 +280,20 @@ How do I set a random_state for an entire execution?
 ----------------------------------------------------
 
 For testing and replicability, it is often important to have the entire execution
-controlled by a single seed for the pseudo-random number generator used in algorithms
-that have a randomized component. Scikit-learn does not use its own global random state;
-whenever a RandomState instance or an integer random seed is not provided as an argument,
-it relies on the numpy global random state, which can be set using :func:`numpy.random.seed`.
-For example, to set an execution's numpy global random state to 42, one could execute
-the following in his or her script::
+controlled by a single seed for the pseudo-random number generator used in
+algorithms that have a randomized component. Scikit-learn does not use its own
+global random state; whenever a RandomState instance or an integer random seed
+is not provided as an argument, it relies on the numpy global random state,
+which can be set using :func:`numpy.random.seed`.
+For example, to set an execution's numpy global random state to 42, one could
+execute the following in his or her script::
 
     import numpy as np
     np.random.seed(42)
 
-However, a global random state is prone to modification by other code during execution. Thus, the only
-way to ensure replicability is to pass ``RandomState`` instances everywhere. In ``cross_val_score``
-function, there's no option to provide a ``RandomState`` instance, so replicability can only be
-ensured by creating a cross-validation generator or an iterable and passing it to ``cross_val_score``
-through the ``cv`` parameter.
+However, a global random state is prone to modification by other code during
+execution. Thus, the only way to ensure replicability is to pass ``RandomState``
+instances everywhere. In the ``cross_val_score`` function, there's no option
+to provide a ``RandomState`` instance, so replicability can only be ensured by
+creating a cross-validation generator or an iterable and passing it to
+``cross_val_score``through the ``cv`` parameter.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -8,7 +8,8 @@ Here we try to give some answers to questions that regularly pop up on the maili
 
 What is the project name (a lot of people get it wrong)?
 --------------------------------------------------------
-scikit-learn, but not scikit or SciKit nor sci-kit learn. Also not scikits.learn or scikits-learn, which were previously used.
+scikit-learn, but not scikit or SciKit nor sci-kit learn.
+Also not scikits.learn or scikits-learn, which were previously used.
 
 How do you pronounce the project name?
 ------------------------------------------
@@ -276,7 +277,7 @@ reviewers are busy. We ask for your understanding and request that you
 not close your pull request or discontinue your work solely because of
 this reason.
 
-How do I set a random_state for an entire execution?
+How do I set a ``random_state`` for an entire execution?
 ----------------------------------------------------
 
 For testing and replicability, it is often important to have the entire execution

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -281,6 +281,18 @@ How do I set a random_state for an entire execution?
 
 For testing and replicability, it is often important to have the entire execution
 controlled by a single seed for the pseudo-random number generator used in algorithms
-that have a randomized component. While there is no ``random.seed(seed)`` function,
-scikit-learn uses the global random states by default and one could thus define a
-global random state that would be used throughout an execution.
+that have a randomized component. Scikit-learn does not use its own global random state;
+whenever a RandomState instance or an integer random seed is not provided as an argument,
+it relies on the numpy global random state, which can be set using ''numpy.random.seed'' function.
+For example, to set an execution's numpy global random state to 42, one could execute
+the following in his or her script::
+
+    import numpy as np
+    np.random.seed(42)
+
+However, a global random state will not ensure replicability when parallel execution is used
+(which can be used by default by several components of scikit-learn). Thus, the only
+way to ensure replicability is to pass ''RandomState'' instances everywhere. In ''cross_val_score''
+function, there's no option to provide a ''RandomState'' instance, so replicability can only be
+ensured by creating a cross-validation generator or an iterable and passing it to ''cross_val_score''
+through the ''cv'' parameter.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -293,7 +293,5 @@ execute the following in his or her script::
 
 However, a global random state is prone to modification by other code during
 execution. Thus, the only way to ensure replicability is to pass ``RandomState``
-instances everywhere. In the :func:`cross_val_score` function, there's no option
-to provide a ``RandomState`` instance, so replicability can only be ensured by
-creating a cross-validation generator or an iterable and passing it to
-:func:`cross_val_score` through the ``cv`` parameter.
+instances everywhere and ensure that both estimators and cross-validation
+splitters have their ``random_state`` parameter set.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -293,7 +293,7 @@ execute the following in his or her script::
 
 However, a global random state is prone to modification by other code during
 execution. Thus, the only way to ensure replicability is to pass ``RandomState``
-instances everywhere. In the ``cross_val_score`` function, there's no option
+instances everywhere. In the :func:`cross_val_score` function, there's no option
 to provide a ``RandomState`` instance, so replicability can only be ensured by
 creating a cross-validation generator or an iterable and passing it to
-``cross_val_score``through the ``cv`` parameter.
+:func:`cross_val_score` through the ``cv`` parameter.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -283,16 +283,15 @@ For testing and replicability, it is often important to have the entire executio
 controlled by a single seed for the pseudo-random number generator used in algorithms
 that have a randomized component. Scikit-learn does not use its own global random state;
 whenever a RandomState instance or an integer random seed is not provided as an argument,
-it relies on the numpy global random state, which can be set using ''numpy.random.seed'' function.
+it relies on the numpy global random state, which can be set using :func:`numpy.random.seed`.
 For example, to set an execution's numpy global random state to 42, one could execute
 the following in his or her script::
 
     import numpy as np
     np.random.seed(42)
 
-However, a global random state will not ensure replicability when parallel execution is used
-(which can be used by default by several components of scikit-learn). Thus, the only
-way to ensure replicability is to pass ''RandomState'' instances everywhere. In ''cross_val_score''
-function, there's no option to provide a ''RandomState'' instance, so replicability can only be
-ensured by creating a cross-validation generator or an iterable and passing it to ''cross_val_score''
-through the ''cv'' parameter.
+However, a global random state is prone to modification by other code during execution. Thus, the only
+way to ensure replicability is to pass ``RandomState`` instances everywhere. In ``cross_val_score``
+function, there's no option to provide a ``RandomState`` instance, so replicability can only be
+ensured by creating a cross-validation generator or an iterable and passing it to ``cross_val_score``
+through the ``cv`` parameter.


### PR DESCRIPTION
Attempts to address issue https://github.com/scikit-learn/scikit-learn/issues/5781. Fixed a typo (where -> were in "Also not scikits.learn or scikits-learn, which where previously used."). Also added info regarding the scikit-learn's use of  global random states.
