### PR TITLE
[MRG+1] LDA: explained_variance_ratio_ can be found using svd solver

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -195,7 +195,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         Percentage of variance explained by each of the selected components.
         If ``n_components`` is not set then all components are stored and the
         sum of explained variances is equal to 1.0. Only available when eigen
-        solver is used.
+        or svd solver is used.
 
     means_ : array-like, shape (n_classes, n_features)
         Class means.
@@ -397,6 +397,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         # (n_classes) centers
         _, S, V = linalg.svd(X, full_matrices=0)
 
+        self.explained_variance_ratio_ = S[:self.n_components] / S.sum()
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -158,7 +158,10 @@ def test_lda_transform():
 
 
 def test_lda_explained_variance_ratio():
-    # Test if the sum of the normalized eigen vectors values equals 1
+    # Test if the sum of the normalized eigen vectors values equals 1,
+    # Also tests whether the explained_variance_ratio_ formed by the
+    # eigen solver is the same as the explained_variance_ratio_ formed
+    # by the svd solver
     n_features = 2
     n_classes = 2
     n_samples = 1000
@@ -168,6 +171,12 @@ def test_lda_explained_variance_ratio():
     clf_lda_eigen = LinearDiscriminantAnalysis(solver="eigen")
     clf_lda_eigen.fit(X, y)
     assert_almost_equal(clf_lda_eigen.explained_variance_ratio_.sum(), 1.0, 3)
+
+    clf_lda_svd = LinearDiscriminantAnalysis(solver="svd")
+    clf_lda_svd.fit(X, y)
+    assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
+    assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
+                              clf_lda_eigen.explained_variance_ratio_)
 
 
 def test_lda_orthogonality():


### PR DESCRIPTION
Previously, the only way to get the `explained_variance_ratio_` from Linear Discriminant Analysis was through using the `eigen` solver option. A small modification to the source lets you also find the `explained_variance_ratio_`'s from the SVD solver.

Overall, this is just an incremental change to the source code.
## PR includes
- Changed source code to extract `explained_variance_ratio_` from the SVD solver
- Change to docstring for LDA
- Test case
