### PR TITLE
[MRG+1] Fixed make_pipeline documentation to provide more details about component naming

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -369,8 +369,8 @@ def make_pipeline(*steps):
     """Construct a Pipeline from the given estimators.
 
     This is a shorthand for the Pipeline constructor; it does not require, and
-    does not permit, naming the estimators. Instead, they will be given names
-    automatically based on their types.
+    does not permit, naming the estimators. Instead, their names will be set
+    to the lowercase of their types automatically.
 
     Examples
     --------


### PR DESCRIPTION
In this PR, I clarified that make_pipeline sets the components of the pipeline's names to their type, lowercased. Addresses https://github.com/scikit-learn/scikit-learn/issues/5943
