### PR TITLE
[MRG+1] DOC: plot_svm_anova.py-and-"all-CPU's" typo fix

### DIFF
--- a/examples/svm/plot_svm_anova.py
+++ b/examples/svm/plot_svm_anova.py
@@ -42,7 +42,7 @@ percentiles = (1, 3, 6, 10, 15, 20, 30, 40, 60, 80, 100)
 
 for percentile in percentiles:
     clf.set_params(anova__percentile=percentile)
-    # Compute cross-validation score using all CPUs
+    # Compute cross-validation score using 1 CPU
     this_scores = cross_val_score(clf, X, y, n_jobs=1)
     score_means.append(this_scores.mean())
     score_stds.append(this_scores.std())


### PR DESCRIPTION
Fix of typo: If you want to use all cpu's - it's better to leave default n_jobs, or use -1
