### PR TITLE
[Needs Review] Added information about gamma parameter for pairwise kernels

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -730,6 +730,9 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Y : ndarray of shape (n_samples_2, n_features)
 
+    gamma : float, default None
+        if None, defaults to 1.0 / n_samples_1
+
     coef0 : int, default 1
 
     degree : int, default 3
@@ -762,6 +765,9 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
     X : ndarray of shape (n_samples_1, n_features)
 
     Y : ndarray of shape (n_samples_2, n_features)
+
+    gamma : float, default None
+        If None, defaults to 1.0 / n_samples_1
 
     coef0 : int, default 1
 
@@ -796,7 +802,8 @@ def rbf_kernel(X, Y=None, gamma=None):
 
     Y : array of shape (n_samples_Y, n_features)
 
-    gamma : float (default = 1.0 / n_samples_X)
+    gamma : float, default None
+        If None, defaults to 1.0 / n_samples_X
 
     Returns
     -------
@@ -827,8 +834,11 @@ def laplacian_kernel(X, Y=None, gamma=None):
     Parameters
     ----------
     X : array of shape (n_samples_X, n_features)
+
     Y : array of shape (n_samples_Y, n_features)
-    gamma : float (default = 1.0 / n_samples_X)
+
+    gamma : float, default None
+        If None, defaults to 1.0 / n_samples_X
 
     Returns
     -------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -730,12 +730,12 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Y : ndarray of shape (n_samples_2, n_features)
 
+    degree : int, default 3
+
     gamma : float, default None
         if None, defaults to 1.0 / n_samples_1
 
     coef0 : int, default 1
-
-    degree : int, default 3
 
     Returns
     -------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -796,7 +796,7 @@ def rbf_kernel(X, Y=None, gamma=None):
 
     Y : array of shape (n_samples_Y, n_features)
 
-    gamma : float
+    gamma : float (default = 1.0 / n_samples_X)
 
     Returns
     -------
@@ -828,7 +828,7 @@ def laplacian_kernel(X, Y=None, gamma=None):
     ----------
     X : array of shape (n_samples_X, n_features)
     Y : array of shape (n_samples_Y, n_features)
-    gamma : float
+    gamma : float (default = 1.0 / n_samples_X)
 
     Returns
     -------


### PR DESCRIPTION
I noticed that some of the kernels in `sklearn.pairwise.metrics` were missing default parameter information. All of them didn't state the default parameter value for `gamma`, and the `polynomial_kernel` missed this parameter description completely.

This is just a quick patch to fix up some docstrings.
