### PR TITLE
[MRG] DOC clarifies that sparse matrices are scipy

### DIFF
--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -842,8 +842,8 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
     It can also have a regularization term added to the loss function
     that shrinks model parameters to prevent overfitting.
 
-    This implementation works with data represented as dense and sparse numpy
-    arrays of floating point values.
+    This implementation works with data represented as dense numpy arrays or
+    sparse scipy arrays of floating point values for the features.
 
     References
     ----------


### PR DESCRIPTION
Currently, the language states that the MLP operates on numpy sparse matrices, while the rest of scikit-learn's documentation uses different language clearly stating that they use scipy.sparse matrices. 

I was rather confused when I went to add this into my standard list of algorithms to test, given that my library works only with scipy.sparse matrices. I was quite happy to find that this does, indeed, work with scipy.sparse matrices. 

I copied the language directly from another algorithm, so it should be highly consistent. 

Thanks for the awesome new MLP! This is much more user-friendly when a user is already working with scikit-learn than trying to integrate a third-party option. 
