### PR TITLE
Stratifying Across Classes During Training in ShuffleSplit #5965

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1160,6 +1160,10 @@ def _validate_shuffle_split(n_samples, test_size, train_size):
         raise ValueError("train_size=%d should be smaller than the number of"
                          " samples %d" % (train_size, n_samples))
 
+    # to work around UnboundLocalError
+    n_train = None
+    n_test = None
+
     # this check is necessary to ensure expected behaviour
     if (np.asarray(test_size).dtype.kind == 'f' and np.asarray(train_size).dtype.kind == 'f'
         and test_size+train_size>1.0):

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1041,7 +1041,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     def _iter_indices(self, X, y=None, labels=None):
         n_samples = _num_samples(X)
         n_train, n_test, train_size, test_size = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size, self.stratify_across_classes)
+                                                  self.train_size)
         classes, y_indices = np.unique(y, return_inverse=True)
         n_classes = classes.shape[0]
 
@@ -1145,7 +1145,7 @@ def _validate_shuffle_split_init(test_size, train_size,stratify_across_classes):
                         stratify_across_classes.__class__)
 
 
-def _validate_shuffle_split(n_samples, test_size, train_size, stratify_across_classes):
+def _validate_shuffle_split(n_samples, test_size, train_size):
     """
     Validation helper to check if the test/test sizes are meaningful wrt to the
     size of the data (n_samples)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -896,7 +896,7 @@ class ShuffleSplit(BaseShuffleSplit):
 
     def _iter_indices(self, X, y=None, labels=None):
         n_samples = _num_samples(X)
-        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
+        n_train, n_test, train_size, test_size = _validate_shuffle_split(n_samples, self.test_size,
                                                   self.train_size)
         rng = check_random_state(self.random_state)
         for i in range(self.n_iter):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -559,10 +559,13 @@ def test_stratified_shuffle_split_even():
                     counter[id] += 1
         assert_equal(n_splits, n_iter)
 
-        n_train, n_test = _validate_shuffle_split(n_samples,
+        n_train, n_test, _, _ = _validate_shuffle_split(n_samples,
                                                   test_size=1./n_folds,
                                                   train_size=1.-(1./n_folds))
 
+        # TODO need to revise this test for the proposed modification of StratifiedShuffleSplit
+        # TODO this is also to do with ensuring train_size + test_size = 1.0 when they are float
+        # TODO and similary when they are int, train_size + test_size = n_samples
         assert_equal(len(train), n_train)
         assert_equal(len(test), n_test)
         assert_equal(len(set(train).intersection(test)), 0)


### PR DESCRIPTION
This is the PR reg: Stratifying Across Classes in ShuffleSplit #5965 , in which I have done the following:
Introduced a new optional flag stratify_across_classes to StratifiedShuffleSplit.
Programmed the inner-working to achieve the expected CV splits.
Enhanced the validation of the specification for train_size and test_size (sum=1).

**Also**, I feel there might be a potential bug in the ShuffleSplit class, which primarily anchors on test_size, and doesn't handle the specification of train_size (and infer the test_size appropriately). It seems like not much testing has been performed in cases when the user only specifies train_size.
### Example outputs from running the committed code:

Class sizes:  [30, 80]
test_size:  0.3
------- specifying test_size --------
With the proposed stratification:
  Training:  21 21   Testing:  9 59
Without 
  Training:  21 56   Testing:  9 24

Class sizes:  [70, 50]
test_size:  0.3
------- specifying test_size --------
With the proposed stratification:
  Training:  35 35   Testing:  35 15
Without 
  Training:  49 35   Testing:  21 15

Class sizes:  [20, 90]
test_size:  0.1
------- specifying test_size --------
With the proposed stratification:
  Training:  18 18   Testing:  2 72
Without 
  Training:  18 81   Testing:  2 9

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/5972)

<!-- Reviewable:end -->
