### PR TITLE
[MRG+1] Fix memory leak in Barnes-Hut SNE

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -365,10 +365,17 @@ cdef int free_tree(Tree* tree) nogil:
     for i in range(3):
         cnt[i] = 0
     free_recursive(tree, tree.root_node, cnt)
+    if not tree.root_node.is_leaf:
+        free(tree.root_node.children)
+    free(tree.root_node.width)
+    free(tree.root_node.left_edge)
+    free(tree.root_node.center)
+    free(tree.root_node.barycenter)
+    free(tree.root_node.leaf_point_position)
     free(tree.root_node)
-    free(tree)
     check = cnt[0] == tree.n_cells
     check &= cnt[2] == tree.n_points
+    free(tree)
     free(cnt)
     return check
 


### PR DESCRIPTION
That seems to fix #5916 for me. @vighneshbirodkar still seems to have problems.

Here is a test program:

``` python
import numpy as np
from sklearn.manifold import TSNE
X = np.random.rand(10, 10)
t = TSNE()
t.fit(X)
```

You can run it with `valgrind --leak-check=full --track-origins=yes python test_tsne.py 2> logfile` and search for "barnes" in the logfile.
