### PR TITLE
DOC: Link to LDA in example

### DIFF
--- a/examples/applications/topics_extraction_with_nmf_lda.py
+++ b/examples/applications/topics_extraction_with_nmf_lda.py
@@ -3,8 +3,8 @@
 Topic extraction with Non-negative Matrix Factorization and Latent Dirichlet Allocation
 =======================================================================================
 
-This is an example of applying Non-negative Matrix Factorization
-and Latent Dirichlet Allocation on a corpus of documents and
+This is an example of applying :class:`sklearn.decomposition.NMF`
+and :class:`sklearn.decomposition.LatentDirichletAllocation` on a corpus of documents and
 extract additive models of the topic structure of the corpus.
 The output is a list of topics, each represented as a list of terms
 (weights are not shown).


### PR DESCRIPTION
Provide link to LDA and NMF in the example tutorial closes #5876.

I have tried including the link to LDA and NMF in the example. In my local build, the link to NMF is active, but the link to LDA isn't getting active.

Please do check out the branch and let me know if something is wrong in my local build. This is my first  PR in scikit-learn.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/5984)

<!-- Reviewable:end -->
