### PR TITLE
[MRG+1] added missing 0.17 support link

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -93,6 +93,7 @@ Documentation resources
 This documentation is relative to |release|. Documentation for other
 versions can be found here:
 
+    * `0.17 <http://scikit-learn.org/0.17/>`_
     * `0.16 <http://scikit-learn.org/0.16/>`_
     * `0.15 <http://scikit-learn.org/0.15/>`_
 


### PR DESCRIPTION
As requested here: https://github.com/scikit-learn/scikit-learn/pull/5923 I'm adding 0.16 and 0.17 support links to the /dev website, as well as removing the old links (< 0.14) which are not supported anymore.
