### PR TITLE
lda_qda doc: QDA vs Naive Bayes correction

### DIFF
--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -96,7 +96,7 @@ In the case of QDA, there are no assumptions on the covariance matrices
 .. note:: **Relation with Gaussian Naive Bayes**
 
 	  If in the QDA model one assumes that the covariance matrices are diagonal,
-	  then this means that we assume the classes are conditionally independent,
+	  then this means that we assume the input features are conditionally independent given the label,
 	  and the resulting classifier is equivalent to the Gaussian Naive Bayes
 	  classifier :class:`naive_bayes.GaussianNB`.
 

--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -96,7 +96,7 @@ In the case of QDA, there are no assumptions on the covariance matrices
 .. note:: **Relation with Gaussian Naive Bayes**
 
 	  If in the QDA model one assumes that the covariance matrices are diagonal,
-	  then this means that we assume the input features are conditionally independent given the label,
+	  then the inputs are assumed to be conditionally independent in each class,
 	  and the resulting classifier is equivalent to the Gaussian Naive Bayes
 	  classifier :class:`naive_bayes.GaussianNB`.
 


### PR DESCRIPTION
Small correction in lda_qda.rst re: comparison of QDA with diagonal covariance matrices and Naive Bayes.

In Naive Bayes, it doesn't make sense to talk about conditional independence between the classes. The Naive Bayes assumptions states that given the label, the input features are conditionally independent. This is reflected in the QDA by assuming diagonal covariance matrices for each class.
