### PR TITLE
[MRG] Fix #6031: changed calculation of explained_variance_ratio_, SVD solver

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -93,6 +93,10 @@ Bug fixes
       won't accept anymore ``min_samples_split=1`` as at least 2 samples
       are required to split a decision tree node. By `Arnaud Joly`_
 
+    - Attribute `explained_variance_ratio` calculated with the SVD solver of
+      :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results. By `JPFrancoia`_
+
+
 API changes summary
 -------------------
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -397,7 +397,8 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         # (n_classes) centers
         _, S, V = linalg.svd(X, full_matrices=0)
 
-        self.explained_variance_ratio_ = np.sort(S**2 / np.sum(S**2))[::-1]
+        self.explained_variance_ratio_ = np.sort(S**2 / np.sum(S**2))[::-1][:
+                self.n_components]
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -397,8 +397,8 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         # (n_classes) centers
         _, S, V = linalg.svd(X, full_matrices=0)
 
-        self.explained_variance_ratio_ = np.sort(S**2 / np.sum(S**2))[::-1][:
-                self.n_components]
+        self.explained_variance_ratio_ = (S**2 / np.sum(
+            S**2))[:self.n_components]
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -398,7 +398,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         _, S, V = linalg.svd(X, full_matrices=0)
 
         self.explained_variance_ratio_ = (S**2 / np.sum(
-            S**2))[:self.n_components]
+                S**2))[:self.n_components]
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -397,7 +397,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         # (n_classes) centers
         _, S, V = linalg.svd(X, full_matrices=0)
 
-        self.explained_variance_ratio_ = S[:self.n_components] / S.sum()
+        self.explained_variance_ratio_ = np.sort(S**2 / np.sum(S**2))[::-1]
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -163,11 +163,10 @@ def test_lda_explained_variance_ratio():
     # Also tests whether the explained_variance_ratio_ formed by the
     # eigen solver is the same as the explained_variance_ratio_ formed
     # by the svd solver
-    n_features = 2
-    n_classes = 2
-    n_samples = 1000
-    X, y = make_blobs(n_samples=n_samples, n_features=n_features,
-                      centers=n_classes, random_state=11)
+
+    state = np.random.RandomState(0)
+    X = state.normal(loc=0, scale=100, size=(40, 20))
+    y = state.randint(0, 3, size=(40, 1))
 
     clf_lda_eigen = LinearDiscriminantAnalysis(solver="eigen")
     clf_lda_eigen.fit(X, y)
@@ -176,8 +175,12 @@ def test_lda_explained_variance_ratio():
     clf_lda_svd = LinearDiscriminantAnalysis(solver="svd")
     clf_lda_svd.fit(X, y)
     assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
+
+    # NOTE: clf_lda_eigen.explained_variance_ratio_ is not of n_components
+    # length. Make it the same length as clf_lda_svd.explained_variance_ratio_
+    # before comparison.
     assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
-                              clf_lda_eigen.explained_variance_ratio_)
+            clf_lda_eigen.explained_variance_ratio_[:3])
 
 
 def test_lda_orthogonality():

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -176,11 +176,14 @@ def test_lda_explained_variance_ratio():
     clf_lda_svd.fit(X, y)
     assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
 
+    tested_length = min(clf_lda_svd.explained_variance_ratio_.shape[0],
+                        clf_lda_eigen.explained_variance_ratio_.shape[0])
+
     # NOTE: clf_lda_eigen.explained_variance_ratio_ is not of n_components
     # length. Make it the same length as clf_lda_svd.explained_variance_ratio_
     # before comparison.
     assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
-            clf_lda_eigen.explained_variance_ratio_[:3])
+            clf_lda_eigen.explained_variance_ratio_[:tested_length])
 
 
 def test_lda_orthogonality():


### PR DESCRIPTION
solver. See issue #5216. However, this attribute is corrected from the
previous commit which might not return the expected values.
