### PR TITLE
[MRG +1] Copy X in KernelPCA, and fixing docstring formatting

### DIFF
--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -38,7 +38,7 @@ is an estimator object::
     >>> from sklearn.svm import SVC
     >>> from sklearn.decomposition import PCA
     >>> estimators = [('reduce_dim', PCA()), ('svm', SVC())]
-    >>> clf = Pipeline(estimators)   
+    >>> clf = Pipeline(estimators)
     >>> clf # doctest: +NORMALIZE_WHITESPACE
     Pipeline(steps=[('reduce_dim', PCA(copy=True, n_components=None,
         whiten=False)), ('svm', SVC(C=1.0, cache_size=200, class_weight=None,
@@ -150,19 +150,19 @@ and ``value`` is an estimator object::
     >>> from sklearn.decomposition import PCA
     >>> from sklearn.decomposition import KernelPCA
     >>> estimators = [('linear_pca', PCA()), ('kernel_pca', KernelPCA())]
-    >>> combined = FeatureUnion(estimators)   
+    >>> combined = FeatureUnion(estimators)
     >>> combined # doctest: +NORMALIZE_WHITESPACE
     FeatureUnion(n_jobs=1, transformer_list=[('linear_pca', PCA(copy=True,
         n_components=None, whiten=False)), ('kernel_pca', KernelPCA(alpha=1.0,
-        coef0=1, degree=3, eigen_solver='auto', fit_inverse_transform=False,
-        gamma=None, kernel='linear', kernel_params=None, max_iter=None,
-        n_components=None, n_jobs=1, random_state=None, remove_zero_eig=False, tol=0))],
-        transformer_weights=None)
+        coef0=1, copy=True, degree=3, eigen_solver='auto',
+        fit_inverse_transform=False, gamma=None, kernel='linear',
+        kernel_params=None, max_iter=None, n_components=None, random_state=None,
+        remove_zero_eig=False, tol=0, n_jobs=1))], transformer_weights=None)
 
 Like pipelines, feature unions have a shorthand constructor called
 :func:`make_union` that does not require explicit naming of the components.
 
-                                                                       
+
 .. topic:: Examples:
 
  * :ref:`example_feature_stacker.py`

--- a/doc/modules/pipeline.rst
+++ b/doc/modules/pipeline.rst
@@ -153,11 +153,12 @@ and ``value`` is an estimator object::
     >>> combined = FeatureUnion(estimators)
     >>> combined # doctest: +NORMALIZE_WHITESPACE
     FeatureUnion(n_jobs=1, transformer_list=[('linear_pca', PCA(copy=True,
-        n_components=None, whiten=False)), ('kernel_pca', KernelPCA(alpha=1.0,
-        coef0=1, copy=True, degree=3, eigen_solver='auto',
-        fit_inverse_transform=False, gamma=None, kernel='linear',
-        kernel_params=None, max_iter=None, n_components=None, random_state=None,
-        remove_zero_eig=False, tol=0, n_jobs=1))], transformer_weights=None)
+           n_components=None, whiten=False)), ('kernel_pca',
+           KernelPCA(alpha=1.0, coef0=1, copy_X=True, degree=3,
+           eigen_solver='auto', fit_inverse_transform=False, gamma=None,
+           kernel='linear', kernel_params=None, max_iter=None,
+           n_components=None, n_jobs=1, random_state=None,
+           remove_zero_eig=False, tol=0))], transformer_weights=None)
 
 Like pipelines, feature unions have a shorthand constructor called
 :func:`make_union` that does not require explicit naming of the components.

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -83,11 +83,11 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     n_jobs : int, default=1
         The number of parallel jobs to run.
-        If ``-1``, then the number of jobs is set to the number of CPU cores.
+        If `-1`, then the number of jobs is set to the number of CPU cores.
 
-    copy : boolean, default=True
+    copy_X : boolean, default=True
         If True, input X is copied and stored by the model. If no further
-        changes will be done to X, setting `copy=False` saves memory by
+        changes will be done to X, setting `copy_X=False` saves memory by
         storing a reference.
 
     Attributes
@@ -106,7 +106,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Projection of the fitted data on the kernel principal components
 
     X_fit_ : (n_samples, n_features)
-        A copy of the original fitted data.
+        A copy of the original fitted data. If `copy_X=False`, X_fit_=None.
 
 
     References
@@ -122,7 +122,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
                  gamma=None, degree=3, coef0=1, kernel_params=None,
                  alpha=1.0, fit_inverse_transform=False, eigen_solver='auto',
                  tol=0, max_iter=None, remove_zero_eig=False,
-                 random_state=None, copy=True, n_jobs=1):
+                 random_state=None, copy_X=True, n_jobs=1):
         if fit_inverse_transform and kernel == 'precomputed':
             raise ValueError(
                 "Cannot fit_inverse_transform with a precomputed kernel.")
@@ -141,7 +141,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self._centerer = KernelCenterer()
         self.random_state = random_state
         self.n_jobs = n_jobs
-        self.copy = copy
+        self.copy_X = copy_X
 
     @property
     def _pairwise(self):
@@ -236,7 +236,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
             X_transformed = np.dot(self.alphas_, sqrt_lambdas)
             self._fit_inverse_transform(X_transformed, X)
 
-        self.X_fit_ = X.copy() if self.copy else X
+        self.X_fit_ = X.copy() if self.copy_X else X
         return self
 
     def fit_transform(self, X, y=None, **params):

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -58,7 +58,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Default: False
 
     eigen_solver: string ['auto'|'dense'|'arpack']
-        Select eigensolver to use.  If n_components is much less than
+        Select eigensolver to use. If n_components is much less than
         the number of training samples, arpack may be more efficient
         than the dense eigensolver.
 
@@ -81,9 +81,12 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         A pseudo random number generator used for the initialization of the
         residuals when eigen_solver == 'arpack'.
 
-    n_jobs : int, optional (default = 1)
+    n_jobs : int, default=1
         The number of parallel jobs to run.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
+
+    copy : boolean, default=True
+        If True, input X is copied and stored by the model.
 
     Attributes
     ----------
@@ -117,7 +120,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
                  gamma=None, degree=3, coef0=1, kernel_params=None,
                  alpha=1.0, fit_inverse_transform=False, eigen_solver='auto',
                  tol=0, max_iter=None, remove_zero_eig=False,
-                 random_state=None, n_jobs=1):
+                 random_state=None, copy=True, n_jobs=1):
         if fit_inverse_transform and kernel == 'precomputed':
             raise ValueError(
                 "Cannot fit_inverse_transform with a precomputed kernel.")
@@ -136,6 +139,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self._centerer = KernelCenterer()
         self.random_state = random_state
         self.n_jobs = n_jobs
+        self.copy = copy
 
     @property
     def _pairwise(self):
@@ -230,7 +234,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
             X_transformed = np.dot(self.alphas_, sqrt_lambdas)
             self._fit_inverse_transform(X_transformed, X)
 
-        self.X_fit_ = X.copy()
+        self.X_fit_ = X.copy() if self.copy else X
         return self
 
     def fit_transform(self, X, y=None, **params):

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -100,7 +100,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     dual_coef_ : array, (n_samples, n_features)
         Inverse transform matrix. If `fit_inverse_transform=False`,
-        dual_coef_=None
+        dual_coef_ is not present.
 
     X_transformed_fit_ : array, (n_samples, n_components)
         Projection of the fitted data on the kernel principal components.

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -86,7 +86,9 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         If ``-1``, then the number of jobs is set to the number of CPU cores.
 
     copy : boolean, default=True
-        If True, input X is copied and stored by the model.
+        If True, input X is copied and stored by the model. If no further
+        changes will be done to X, setting `copy=False` saves memory by
+        storing a reference.
 
     Attributes
     ----------

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -8,7 +8,7 @@ from scipy import linalg
 
 from ..utils import check_random_state
 from ..utils.arpack import eigsh
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, check_array
 from ..exceptions import NotFittedError
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import KernelCenterer
@@ -99,6 +99,10 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     X_transformed_fit_ :
         Projection of the fitted data on the kernel principal components
+
+    X_fit_ : (n_samples, n_features)
+        A copy of the original fitted data.
+
 
     References
     ----------
@@ -217,6 +221,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self : object
             Returns the instance itself.
         """
+        X = check_array(X, accept_sparse='csr')
         K = self._get_kernel(X)
         self._fit_transform(K)
 
@@ -225,7 +230,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
             X_transformed = np.dot(self.alphas_, sqrt_lambdas)
             self._fit_inverse_transform(X_transformed, X)
 
-        self.X_fit_ = X
+        self.X_fit_ = X.copy()
         return self
 
     def fit_transform(self, X, y=None, **params):

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -86,9 +86,9 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         If `-1`, then the number of jobs is set to the number of CPU cores.
 
     copy_X : boolean, default=True
-        If True, input X is copied and stored by the model. If no further
-        changes will be done to X, setting `copy_X=False` saves memory by
-        storing a reference.
+        If True, input X is copied and stored by the model in the `X_fit_`
+        attribute. If no further changes will be done to X, setting
+        `copy_X=False` saves memory by storing a reference.
 
     Attributes
     ----------
@@ -109,7 +109,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Projection of the fitted data on the kernel principal components.
 
     X_fit_ : (n_samples, n_features)
-        A copy of the original fitted data. If `copy_X=False`, X_fit_=None.
+        The data used to fit the model.
 
 
     References

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -29,7 +29,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Number of components. If None, all non-zero components are kept.
 
     kernel : "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "precomputed"
-        Kernel. Default: "linear"
+        Kernel. Default="linear".
 
     degree : int, default=3
         Degree for poly kernels. Ignored by other kernels.
@@ -65,7 +65,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     max_iter : int, default=None
         Maximum number of iterations for arpack. If None, optimal value will
-        be chosen by arpack
+        be chosen by arpack.
 
     remove_zero_eig : boolean, default=False
         If True, then all components with zero eigenvalues are removed, so
@@ -106,8 +106,8 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Projection of the fitted data on the kernel principal components.
 
     X_fit_ : (n_samples, n_features)
-        The data used to fit the model.
-
+        The data used to fit the model. If `copy_X=False`, then `X_fit_` is
+        a reference.
 
     References
     ----------

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -25,12 +25,11 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    n_components: int or None
+    n_components : int, default=None
         Number of components. If None, all non-zero components are kept.
 
-    kernel: "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "precomputed"
-        Kernel.
-        Default: "linear"
+    kernel : "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "precomputed"
+        Kernel. Default: "linear"
 
     degree : int, default=3
         Degree for poly kernels. Ignored by other kernels.
@@ -47,28 +46,26 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         Parameters (keyword arguments) and values for kernel passed as
         callable object. Ignored by other kernels.
 
-    alpha: int
+    alpha : int, default=1.0
         Hyperparameter of the ridge regression that learns the
         inverse transform (when fit_inverse_transform=True).
-        Default: 1.0
 
-    fit_inverse_transform: bool
+    fit_inverse_transform : bool, default=False
         Learn the inverse transform for non-precomputed kernels.
         (i.e. learn to find the pre-image of a point)
-        Default: False
 
-    eigen_solver: string ['auto'|'dense'|'arpack']
+    eigen_solver : string ['auto'|'dense'|'arpack']
         Select eigensolver to use. If n_components is much less than
         the number of training samples, arpack may be more efficient
         than the dense eigensolver.
 
-    tol: float
-        convergence tolerance for arpack.
-        Default: 0 (optimal value will be chosen by arpack)
+    tol : float, default=0
+        Convergence tolerance for arpack. If zero, optimal value will be
+        chosen by arpack.
 
-    max_iter : int
-        maximum number of iterations for arpack
-        Default: None (optimal value will be chosen by arpack)
+    max_iter : int, default=None
+        Maximum number of iterations for arpack. If None, optimal value will
+        be chosen by arpack
 
     remove_zero_eig : boolean, default=False
         If True, then all components with zero eigenvalues are removed, so
@@ -77,7 +74,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         When n_components is None, this parameter is ignored and components
         with zero eigenvalues are removed regardless.
 
-    random_state : int seed, RandomState instance, or None, default : None
+    random_state : int seed, RandomState instance, or None, default=None
         A pseudo random number generator used for the initialization of the
         residuals when eigen_solver == 'arpack'.
 

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -227,7 +227,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
         self : object
             Returns the instance itself.
         """
-        X = check_array(X, accept_sparse='csr')
+        X = check_array(X, accept_sparse='csr', copy=self.copy_X)
         K = self._get_kernel(X)
         self._fit_transform(K)
 
@@ -236,7 +236,7 @@ class KernelPCA(BaseEstimator, TransformerMixin):
             X_transformed = np.dot(self.alphas_, sqrt_lambdas)
             self._fit_inverse_transform(X_transformed, X)
 
-        self.X_fit_ = X.copy() if self.copy_X else X
+        self.X_fit_ = X
         return self
 
     def fit_transform(self, X, y=None, **params):

--- a/sklearn/decomposition/kernel_pca.py
+++ b/sklearn/decomposition/kernel_pca.py
@@ -92,18 +92,21 @@ class KernelPCA(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
+    lambdas_ : array, (n_components,)
+        Eigenvalues of the centered kernel matrix in decreasing order.
+        If `n_components` and `remove_zero_eig` are not set,
+        then all values are stored.
 
-    lambdas_ :
-        Eigenvalues of the centered kernel matrix
+    alphas_ : array, (n_samples, n_components)
+        Eigenvectors of the centered kernel matrix. If `n_components` and
+        `remove_zero_eig` are not set, then all components are stored.
 
-    alphas_ :
-        Eigenvectors of the centered kernel matrix
+    dual_coef_ : array, (n_samples, n_features)
+        Inverse transform matrix. If `fit_inverse_transform=False`,
+        dual_coef_=None
 
-    dual_coef_ :
-        Inverse transform matrix
-
-    X_transformed_fit_ :
-        Projection of the fitted data on the kernel principal components
+    X_transformed_fit_ : array, (n_samples, n_components)
+        Projection of the fitted data on the kernel principal components.
 
     X_fit_ : (n_samples, n_features)
         A copy of the original fitted data. If `copy_X=False`, X_fit_=None.

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -56,6 +56,7 @@ def test_kernel_pca_invalid_parameters():
     assert_raises(ValueError, KernelPCA, 10, fit_inverse_transform=True,
                   kernel='precomputed')
 
+
 def test_kernel_pca_consistent_transform():
     # X_fit_ needs to retain the old, unmodified copy of X
     state = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -52,9 +52,21 @@ def test_kernel_pca():
                 assert_equal(X_pred2.shape, X_pred.shape)
 
 
-def test_invalid_parameters():
+def test_kernel_pca_invalid_parameters():
     assert_raises(ValueError, KernelPCA, 10, fit_inverse_transform=True,
                   kernel='precomputed')
+
+def test_kernel_pca_consistent_transform():
+    # X_fit_ needs to retain the old, unmodified copy of X
+    state = np.random.RandomState(0)
+    X = state.rand(10, 10)
+    kpca = KernelPCA(random_state=state).fit(X)
+    transformed1 = kpca.transform(X)
+
+    X_copy = X.copy()
+    X[:, 0] = 666
+    transformed2 = kpca.transform(X_copy)
+    assert_array_almost_equal(transformed1, transformed2)
 
 
 def test_kernel_pca_sparse():


### PR DESCRIPTION
# Pull Request Includes

This PR fixes two issues. (Sorry, I know fixing multiple issues in one is discouraged.)
1. Defect in KernelPCA when `X` is not copied
2. Formatting issues.
## First Issue
- [x] Fixes a defect in `KernelPCA` when the `X` used to fit `KernelPCA` is modified
  - [x] Added parameter option `copy_X` to optionally copy the input array to avoid the defect
- [x] Added regression tests to prevent further occurrences of the defect
## Second Issue
- [x] Added more documentation to attributes of `kernel_pca.py` to avoid "double colon"

<img width="801" alt="screenshot 2016-02-18 14 44 16" src="https://cloud.githubusercontent.com/assets/1865885/13158025/8870cd1c-d650-11e5-995a-38d1280d775e.png">
- [x] Fixed a formatting defect when a space between colons is ignored; parameter values are bolded when they should not be.

<img width="528" alt="screenshot 2016-02-19 11 14 21" src="https://cloud.githubusercontent.com/assets/1865885/13183030/6eca839e-d6fa-11e5-8e28-f41896a71a17.png">

---
# Original post

Previously, the following script created an AssertionError:

```
>>>    state = np.random.RandomState(0)
>>>    X = state.rand(10, 10)
>>>    kpca = KernelPCA(random_state=state).fit(X)
>>>    transformed1 = kpca.transform(X)
>>>
>>>    X_copy = X.copy()
>>>    X[:, 0] = 666
>>>    transformed2 = kpca.transform(X_copy)
>>>    assert_array_almost_equal(transformed1, transformed2)
```

That's because `KernelPCA.fit_X` has a reference to the original `X` for `transform`. I made a one line change to make sure this was not the case.

As far as I know, I think @mblondel did not intend for the following above to raise an error.
