### PR TITLE
FIX Changed zorder so support vectors are clearly visible

### DIFF
--- a/examples/plot_kernel_ridge_regression.py
+++ b/examples/plot_kernel_ridge_regression.py
@@ -100,8 +100,9 @@ print("KRR prediction for %d inputs in %.3f s"
 #############################################################################
 # look at the results
 sv_ind = svr.best_estimator_.support_
-plt.scatter(X[sv_ind], y[sv_ind], c='r', s=50, label='SVR support vectors')
-plt.scatter(X[:100], y[:100], c='k', label='data')
+plt.scatter(X[sv_ind], y[sv_ind], c='r', s=50, label='SVR support vectors',
+            zorder=2)
+plt.scatter(X[:100], y[:100], c='k', label='data', zorder=1)
 plt.hold('on')
 plt.plot(X_plot, y_svr, c='r',
          label='SVR (fit: %.3fs, predict: %.3fs)' % (svr_fit, svr_predict))


### PR DESCRIPTION
In the plot:
http://scikit-learn.org/dev/_images/plot_kernel_ridge_regression_001.png 
the points for the support vectors do not appear to match the legend. This is because they are also data points, and the data is plotted on top of them. I fixed it by setting zorder in case the code gets moved around. It looks like this now:
![after](https://cloud.githubusercontent.com/assets/12852502/11831482/6924465c-a363-11e5-8c0c-748ca889d9e4.png)
