### PR TITLE
[MRG+1] Fix bug in mini batch kmeans example

### DIFF
--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -103,7 +103,7 @@ plt.text(-3.5, 1.8, 'train time: %.2fs\ninertia: %f' %
 different = (mbk_means_labels == 4)
 ax = fig.add_subplot(1, 3, 3)
 
-for l in range(n_clusters):
+for k in range(n_clusters):
     different += ((k_means_labels == k) != (mbk_means_labels == order[k]))
 
 identic = np.logical_not(different)


### PR DESCRIPTION
Fix the bug in #6047 .

The example plots all the points that are labelled differently between the two algorithms after this fix.

Before:
![before](https://cloud.githubusercontent.com/assets/2503869/11833912/7c515658-a402-11e5-8034-77afa4cc15f4.png)

After:
![download](https://cloud.githubusercontent.com/assets/2503869/11833915/7fadf504-a402-11e5-80dd-1f73b8059159.png)
