### PR TITLE
MAINT fix the coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/scikit-learn/scikit-learn?branch=master&svg=true
 .. _AppVeyor: https://ci.appveyor.com/project/sklearn-ci/scikit-learn/history
 
-.. |Coveralls| image:: https://coveralls.io/repos/scikit-learn/scikit-learn/badge.svg?branch=master
+.. |Coveralls| image:: https://coveralls.io/repos/scikit-learn/scikit-learn/badge.svg?branch=master&service=github
 .. _Coveralls: https://coveralls.io/r/scikit-learn/scikit-learn
 
 .. |CircleCI| image:: https://circleci.com/gh/scikit-learn/scikit-learn/tree/master.svg?style=shield&circle-token=:circle-token


### PR DESCRIPTION
This PR has 2 purposes: 
- check that the coveralls hook is now reporting coverage status in PR once travis is done.
- try to fix the coveralls badge that show up as gray on the README of the project on github.
