### PR TITLE
[MRG] Fix fetch_california_housing

### DIFF
--- a/examples/ensemble/plot_partial_dependence.py
+++ b/examples/ensemble/plot_partial_dependence.py
@@ -59,54 +59,61 @@ from sklearn.ensemble.partial_dependence import partial_dependence
 from sklearn.datasets.california_housing import fetch_california_housing
 
 
-cal_housing = fetch_california_housing()
+def main():
+    cal_housing = fetch_california_housing()
 
-# split 80/20 train-test
-X_train, X_test, y_train, y_test = train_test_split(cal_housing.data,
-                                                    cal_housing.target,
-                                                    test_size=0.2,
-                                                    random_state=1)
-names = cal_housing.feature_names
+    # split 80/20 train-test
+    X_train, X_test, y_train, y_test = train_test_split(cal_housing.data,
+                                                        cal_housing.target,
+                                                        test_size=0.2,
+                                                        random_state=1)
+    names = cal_housing.feature_names
 
-print('_' * 80)
-print("Training GBRT...")
-clf = GradientBoostingRegressor(n_estimators=100, max_depth=4,
-                                learning_rate=0.1, loss='huber',
-                                random_state=1)
-clf.fit(X_train, y_train)
-print("done.")
+    print('_' * 80)
+    print("Training GBRT...")
+    clf = GradientBoostingRegressor(n_estimators=100, max_depth=4,
+                                    learning_rate=0.1, loss='huber',
+                                    random_state=1)
+    clf.fit(X_train, y_train)
+    print("done.")
 
-print('_' * 80)
-print('Convenience plot with ``partial_dependence_plots``')
-print
+    print('_' * 80)
+    print('Convenience plot with ``partial_dependence_plots``')
+    print
 
-features = [0, 5, 1, 2, (5, 1)]
-fig, axs = plot_partial_dependence(clf, X_train, features, feature_names=names,
-                                   n_jobs=3, grid_resolution=50)
-fig.suptitle('Partial dependence of house value on nonlocation features\n'
-             'for the California housing dataset')
-plt.subplots_adjust(top=0.9)  # tight_layout causes overlap with suptitle
+    features = [0, 5, 1, 2, (5, 1)]
+    fig, axs = plot_partial_dependence(clf, X_train, features,
+                                       feature_names=names,
+                                       n_jobs=3, grid_resolution=50)
+    fig.suptitle('Partial dependence of house value on nonlocation features\n'
+                 'for the California housing dataset')
+    plt.subplots_adjust(top=0.9)  # tight_layout causes overlap with suptitle
 
-print('_' * 80)
-print('Custom 3d plot via ``partial_dependence``')
-print
-fig = plt.figure()
+    print('_' * 80)
+    print('Custom 3d plot via ``partial_dependence``')
+    print
+    fig = plt.figure()
 
-target_feature = (1, 5)
-pdp, (x_axis, y_axis) = partial_dependence(clf, target_feature,
-                                           X=X_train, grid_resolution=50)
-XX, YY = np.meshgrid(x_axis, y_axis)
-Z = pdp.T.reshape(XX.shape).T
-ax = Axes3D(fig)
-surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu)
-ax.set_xlabel(names[target_feature[0]])
-ax.set_ylabel(names[target_feature[1]])
-ax.set_zlabel('Partial dependence')
-#  pretty init view
-ax.view_init(elev=22, azim=122)
-plt.colorbar(surf)
-plt.suptitle('Partial dependence of house value on median age and '
-             'average occupancy')
-plt.subplots_adjust(top=0.9)
+    target_feature = (1, 5)
+    pdp, (x_axis, y_axis) = partial_dependence(clf, target_feature,
+                                               X=X_train, grid_resolution=50)
+    XX, YY = np.meshgrid(x_axis, y_axis)
+    Z = pdp.T.reshape(XX.shape).T
+    ax = Axes3D(fig)
+    surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu)
+    ax.set_xlabel(names[target_feature[0]])
+    ax.set_ylabel(names[target_feature[1]])
+    ax.set_zlabel('Partial dependence')
+    #  pretty init view
+    ax.view_init(elev=22, azim=122)
+    plt.colorbar(surf)
+    plt.suptitle('Partial dependence of house value on median age and '
+                 'average occupancy')
+    plt.subplots_adjust(top=0.9)
 
-plt.show()
+    plt.show()
+
+
+# Needed on Windows because plot_partial_dependence uses multiprocessing
+if __name__ == '__main__':
+    main()

--- a/examples/ensemble/plot_partial_dependence.py
+++ b/examples/ensemble/plot_partial_dependence.py
@@ -59,64 +59,54 @@ from sklearn.ensemble.partial_dependence import partial_dependence
 from sklearn.datasets.california_housing import fetch_california_housing
 
 
-def main():
-    # fetch California housing dataset
-    try:
-        cal_housing = fetch_california_housing()
-    except HTTPError:
-        print("Failed downloading california housing data.")
-        return
+cal_housing = fetch_california_housing()
 
-    # split 80/20 train-test
-    X_train, X_test, y_train, y_test = train_test_split(cal_housing.data,
-                                                        cal_housing.target,
-                                                        test_size=0.2,
-                                                        random_state=1)
-    names = cal_housing.feature_names
+# split 80/20 train-test
+X_train, X_test, y_train, y_test = train_test_split(cal_housing.data,
+                                                    cal_housing.target,
+                                                    test_size=0.2,
+                                                    random_state=1)
+names = cal_housing.feature_names
 
-    print('_' * 80)
-    print("Training GBRT...")
-    clf = GradientBoostingRegressor(n_estimators=100, max_depth=4,
-                                    learning_rate=0.1, loss='huber',
-                                    random_state=1)
-    clf.fit(X_train, y_train)
-    print("done.")
+print('_' * 80)
+print("Training GBRT...")
+clf = GradientBoostingRegressor(n_estimators=100, max_depth=4,
+                                learning_rate=0.1, loss='huber',
+                                random_state=1)
+clf.fit(X_train, y_train)
+print("done.")
 
-    print('_' * 80)
-    print('Convenience plot with ``partial_dependence_plots``')
-    print
+print('_' * 80)
+print('Convenience plot with ``partial_dependence_plots``')
+print
 
-    features = [0, 5, 1, 2, (5, 1)]
-    fig, axs = plot_partial_dependence(clf, X_train, features, feature_names=names,
-                                       n_jobs=3, grid_resolution=50)
-    fig.suptitle('Partial dependence of house value on nonlocation features\n'
-                 'for the California housing dataset')
-    plt.subplots_adjust(top=0.9)  # tight_layout causes overlap with suptitle
+features = [0, 5, 1, 2, (5, 1)]
+fig, axs = plot_partial_dependence(clf, X_train, features, feature_names=names,
+                                   n_jobs=3, grid_resolution=50)
+fig.suptitle('Partial dependence of house value on nonlocation features\n'
+             'for the California housing dataset')
+plt.subplots_adjust(top=0.9)  # tight_layout causes overlap with suptitle
 
-    print('_' * 80)
-    print('Custom 3d plot via ``partial_dependence``')
-    print
-    fig = plt.figure()
+print('_' * 80)
+print('Custom 3d plot via ``partial_dependence``')
+print
+fig = plt.figure()
 
-    target_feature = (1, 5)
-    pdp, (x_axis, y_axis) = partial_dependence(clf, target_feature,
-                                               X=X_train, grid_resolution=50)
-    XX, YY = np.meshgrid(x_axis, y_axis)
-    Z = pdp.T.reshape(XX.shape).T
-    ax = Axes3D(fig)
-    surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu)
-    ax.set_xlabel(names[target_feature[0]])
-    ax.set_ylabel(names[target_feature[1]])
-    ax.set_zlabel('Partial dependence')
-    #  pretty init view
-    ax.view_init(elev=22, azim=122)
-    plt.colorbar(surf)
-    plt.suptitle('Partial dependence of house value on median age and '
-                 'average occupancy')
-    plt.subplots_adjust(top=0.9)
+target_feature = (1, 5)
+pdp, (x_axis, y_axis) = partial_dependence(clf, target_feature,
+                                           X=X_train, grid_resolution=50)
+XX, YY = np.meshgrid(x_axis, y_axis)
+Z = pdp.T.reshape(XX.shape).T
+ax = Axes3D(fig)
+surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu)
+ax.set_xlabel(names[target_feature[0]])
+ax.set_ylabel(names[target_feature[1]])
+ax.set_zlabel('Partial dependence')
+#  pretty init view
+ax.view_init(elev=22, azim=122)
+plt.colorbar(surf)
+plt.suptitle('Partial dependence of house value on median age and '
+             'average occupancy')
+plt.subplots_adjust(top=0.9)
 
-    plt.show()
-
-
-if __name__ == "__main__":
-    main()
+plt.show()

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -21,6 +21,7 @@ Statistics and Probability Letters, 33 (1997) 291-297.
 # Authors: Peter Prettenhofer
 # License: BSD 3 clause
 
+from io import BytesIO
 import os
 from os.path import exists
 from os import makedirs
@@ -28,10 +29,10 @@ import tarfile
 
 try:
     # Python 2
-    import urllib.request as urllib
+    from urllib2 import urlopen
 except ImportError:
     # Python 3+
-    import urllib
+    from urllib.request import urlopen
 
 import numpy as np
 
@@ -41,7 +42,6 @@ from ..externals import joblib
 
 
 DATA_URL = "http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz"
-ARCHIVE_NAME = "cal_housing.tgz"
 TARGET_FILENAME = "cal_housing.pkz"
 
 # Grab the module-level docstring to use as a description of the
@@ -90,12 +90,12 @@ def fetch_california_housing(data_home=None, download_if_missing=True):
         makedirs(data_home)
     filepath = _pkl_filepath(data_home, TARGET_FILENAME)
     if not exists(filepath):
-        archive_path = os.path.join(data_home, ARCHIVE_NAME)
-        print('downloading Cal. housing from %s to %s' % (DATA_URL, archive_path))
-        urllib.urlretrieve(DATA_URL, archive_path)
-        fileobj = tarfile.open(archive_path, "r:gz").extractfile(
-            'CaliforniaHousing/cal_housing.data')
-        os.remove(archive_path)
+        print('downloading Cal. housing from %s to %s' % (DATA_URL, data_home))
+        archive_fileobj = BytesIO(urlopen(DATA_URL).read())
+        fileobj = tarfile.open(
+            mode="r:gz",
+            fileobj=archive_fileobj).extractfile(
+                'CaliforniaHousing/cal_housing.data')
 
         cal_housing = np.loadtxt(fileobj, delimiter=',')
         # Columns are not in the same order compared to the previous

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -93,12 +93,11 @@ def fetch_california_housing(data_home=None, download_if_missing=True):
         archive_path = os.path.join(data_home, ARCHIVE_NAME)
         print('downloading Cal. housing from %s to %s' % (DATA_URL, archive_path))
         urllib.urlretrieve(DATA_URL, archive_path)
-        tarfile.open(archive_path, "r:gz").extractall(path=data_home)
+        fileobj = tarfile.open(archive_path, "r:gz").extractfile(
+            'CaliforniaHousing/cal_housing.data')
         os.remove(archive_path)
 
-        data_path = os.path.join(data_home, 'CaliforniaHousing',
-                                 'cal_housing.data')
-        cal_housing = np.loadtxt(data_path, delimiter=',')
+        cal_housing = np.loadtxt(fileobj, delimiter=',')
         # Columns are not in the same order compared to the previous
         # URL resource on lib.stat.cmu.edu
         columns_index = [8, 7, 2, 3, 4, 5, 6, 1, 0]


### PR DESCRIPTION
Fix #5953.

I used http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz.

I still has an old cal_housing.pkz (i.e. before lib.stat.cmu.edu got broken)  in ~/scikit_learn_data so I double-checked that the content of the pickles were matching exactly.

Here are the plots from examples/ensemble/plot_partial_dependence.py:
![figure_1](https://cloud.githubusercontent.com/assets/1680079/11844040/edd15922-a40c-11e5-8c72-b819e7689c53.png)

![figure_2](https://cloud.githubusercontent.com/assets/1680079/11844049/f519ccaa-a40c-11e5-8ca1-b26ff607df87.png)

They match the ones from the [stable doc](http://scikit-learn.org/stable/auto_examples/ensemble/plot_partial_dependence.html)

![](http://scikit-learn.org/stable/_images/plot_partial_dependence_001.png)
![](http://scikit-learn.org/stable/_images/plot_partial_dependence_002.png)
