### PR TITLE
[MRG] FIX #5485 Replaced missing plot_gp_regression with plot_gpr_co2 in ca…

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -419,7 +419,7 @@ SINGLE_IMAGE = """
 # values: (number of plot in set, height of thumbnail)
 carousel_thumbs = {'plot_classifier_comparison_001.png': (1, 600),
                    'plot_outlier_detection_001.png': (3, 372),
-                   'plot_gp_regression_001.png': (2, 250),
+                   'plot_gpr_co2_001.png': (1, 350),
                    'plot_adaboost_twoclass_001.png': (1, 372),
                    'plot_compare_methods_001.png': (1, 349)}
 

--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -149,8 +149,8 @@
 		      <img src="_images/plot_adaboost_twoclass_carousel.png"></a>
 		  </div>
 		  <div class="item">
-		    <a href="{{pathto('auto_examples/gaussian_process/plot_gp_regression') }}">
-		      <img src="_images/plot_gp_regression_carousel.png"></a>
+		    <a href="{{pathto('auto_examples/gaussian_process/plot_gpr_co2') }}">
+		      <img src="_images/plot_gpr_co2_carousel.png"></a>
 		  </div>
 		  <div class="item">
 		    <a href="{{ pathto('auto_examples/manifold/plot_compare_methods') }}">


### PR DESCRIPTION
Fixes #5485 
Replaced the now-missing plot_gp_regression with plot_gpr_co2 (the Mauna Loa example) in carousel, as discussed on the thread for this issue. The missing plot is in the 7th carousel frame at: http://scikit-learn.org/dev/.
