### PR TITLE
[MRG+1] BUG: fix initialization in Isomap to work correctly with GridSearch

### DIFF
--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -94,11 +94,11 @@ class Isomap(BaseEstimator, TransformerMixin):
         self.max_iter = max_iter
         self.path_method = path_method
         self.neighbors_algorithm = neighbors_algorithm
-        self.nbrs_ = NearestNeighbors(n_neighbors=n_neighbors,
-                                      algorithm=neighbors_algorithm)
 
     def _fit_transform(self, X):
         X = check_array(X)
+        self.nbrs_ = NearestNeighbors(n_neighbors=self.n_neighbors,
+                                      algorithm=self.neighbors_algorithm)
         self.nbrs_.fit(X)
         self.training_data_ = self.nbrs_._fit_X
         self.kernel_pca_ = KernelPCA(n_components=self.n_components,

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -116,7 +116,7 @@ def test_pipeline():
 
 def test_isomap_clone_bug():
     # regression test for bug reported in #6062
-    model = Isomap()
+    model = manifold.Isomap()
     for n_neighbors in [10, 15, 20]:
         model.set_params(n_neighbors=n_neighbors)
         model.fit(np.random.rand(50, 2))

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -1,6 +1,7 @@
 from itertools import product
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_equal)
 
 from sklearn import datasets
 from sklearn import manifold
@@ -111,3 +112,13 @@ def test_pipeline():
          ('clf', neighbors.KNeighborsClassifier())])
     clf.fit(X, y)
     assert_less(.9, clf.score(X, y))
+
+
+def test_isomap_clone_bug():
+    # regression test for bug reported in #6062
+    model = Isomap()
+    for n_neighbors in [10, 15, 20]:
+        model.set_params(n_neighbors=n_neighbors)
+        model.fit(np.random.rand(50, 2))
+        assert_equal(model.nbrs_.n_neighbors,
+                     n_neighbors)


### PR DESCRIPTION
Currently, if `grid_search` changes the number of neighbors for `Isomap`, this won't be correctly reflected in the grid search results. This PR fixes that bug.
