### PR TITLE
Implemented step-function interpolation for average_precision_score

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -109,6 +109,10 @@ def average_precision_score(y_true, y_score, average="macro",
     """Compute average precision (AP) from prediction scores
 
     This score corresponds to the area under the precision-recall curve.
+    Interpolation between operating points is by horizontal sections.
+    For all recall values r not corresponding to an operating point, the
+    precision p is equal to the precision p' at the first operating point
+    (r', p') such that r' > r.
 
     Note: this implementation is restricted to the binary classification task
     or multilabel classification task.
@@ -166,13 +170,14 @@ def average_precision_score(y_true, y_score, average="macro",
     >>> y_true = np.array([0, 0, 1, 1])
     >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
     >>> average_precision_score(y_true, y_scores)  # doctest: +ELLIPSIS
-    0.79...
+    0.83...
 
     """
     def _binary_average_precision(y_true, y_score, sample_weight=None):
         precision, recall, thresholds = precision_recall_curve(
             y_true, y_score, sample_weight=sample_weight)
-        return auc(recall, precision)
+        return sum([(recall[i] - recall[i+1]) * precision[i]
+                    for i in xrange(len(recall) - 1)])
 
     return _average_binary_score(_binary_average_precision, y_true, y_score,
                                  average, sample_weight=sample_weight)


### PR DESCRIPTION
The current implementation of `average_precision_score` (in `metrics`) computes the area under the curve by linearly interpolating between operating points. This systematically mis-estimates the area under the precision-recall curve. As an example, consider a 'do-nothing' `y_score` of 0.5 for all examples. This is guaranteed to have an average precision score of > 0.5 (assuming at least one ground-truth positive datum) under the current implementation because it linearly interpolates between the two operating points (0, 1) and (1, _x_), where _x_ is the fraction of positive examples in the sample.

This is particularly damaging in the case of a sparse sample with very few positive examples. It is _very_ difficult to beat an average precision score of 0.5 with any genuine model, because we have to turn more false negatives into true positives than true negatives into false positives. [(See this ppt for a concrete example.)](https://github.com/scikit-learn/scikit-learn/files/67126/Problem.with.Average.Precision.Score.pptx)

I propose a first-step solution, which is to interpolate by using the precision value of the next operating point (i.e. fill in gaps with a horizontal line from the operating point to the right). There are two justifications for this:
1. If you demand a recall of 0.5, providing a precision estimate of the midpoint of 1 and _x_ (or, more generally, interpolating between _p_i_ and _p_j_ for the operating points (_r_i_, _p_i_) and (_r_j_, _p_j_) immediately to the left and right of _r_ = 0.5) is meaningless: that precision is impossible to obtain. Instead, we should back off to the lowest obtainable recall value _r'_ such that _r'_ >= 0.5.
2. If we assume that `y_scores` are continuous and we have rounded versions of them, the best guess we can make for the 'original' `y_scores` is to order them randomly. With a large sample, a random ordering of `y_scores` approximates a horizontal line (with precision equal to the positive rate in the subsample).

For more discussion of this, see for example [the discussion on the LingPipe blog](http://lingpipe-blog.com/2010/10/01/define-interpolated-precision-recall-roc-auc/) or [the chapter in Manning et al's Information Retrieval book](http://nlp.stanford.edu/IR-book/html/htmledition/evaluation-of-ranked-retrieval-results-1.html). The latter of these proposes a more extreme solution: choosing the highest _p'_ for all _r'_ > _r_, but this may be lead to unexpected behavior since many operating points will be ignored.

To recreate the problem, consider:

```
import numpy as np
from sklearn.metrics import average_precision_score, precision_recall_curve
import matplotlib.pyplot as plt

def plot_pr_curve(y_true, y_pred):
    precision, recall, threshold = precision_recall_curve(
        y_true, y_pred)
    plt.plot(recall, precision, alpha=0.5)
    plt.xlabel("Recall")
    plt.ylabel("Precision")
    plt.legend(["Average precision score: {0:0.5f}".format(
                average_precision_score(y_true, y_pred))])
    plt.show()

class_imbalance = 0.1
y_true = np.random.binomial(1, class_imbalance, 1000000)
y_random = np.random.random(len(y_true))
y_constant = 0.5 * np.ones(len(y_true))
plot_pr_curve(y_true, y_constant)
plot_pr_curve(y_true, y_random)
```

The current implementation gives average precision scores of 0.55... and 0.10... respectively, while my implementation gives 0.10... for both.

A problem with making this change would be that the graph produced by naively plotting the recall and precision lists from `precision_recall_curves` would produce a curve with an AOC clearly different from the reported average_precision_score. The amended docstring should help to clarify the difference.
