### PR TITLE
Fixes #6066

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -685,6 +685,6 @@ candidates, the speedup compared to brute force search is approximately
      '06. 47th Annual IEEE Symposium
 
    * `“LSH Forest: Self-Tuning Indexes for Similarity Search”
-     <http://www2005.org/docs/p651.pdf>`_,
+     <http://wwwconference.org/proceedings/www2005/docs/p651.pdf>`_,
      Bawa, M., Condie, T., Ganesan, P., WWW '05 Proceedings of the 14th
      international conference on World Wide Web  Pages 651-660


### PR DESCRIPTION
Fixes the link to Bawa et al., "LSH Forest: Self-Tuning Indexes for Similarity Search", WWW'05 in the Nearest Neighbor section.
