### PR TITLE
doc/fix: edited inaccuracies in nearest centroid classification example

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -498,11 +498,11 @@ In the example below, using a small shrink threshold increases the accuracy of
 the model from 0.81 to 0.82.
 
 .. |nearest_centroid_1| image:: ../auto_examples/neighbors/images/plot_nearest_centroid_001.png
-   :target: ../auto_examples/neighbors/plot_classification.html
+   :target: ../auto_examples/neighbors/plot_nearest_centroid.html
    :scale: 50
 
 .. |nearest_centroid_2| image:: ../auto_examples/neighbors/images/plot_nearest_centroid_002.png
-   :target: ../auto_examples/neighbors/plot_classification.html
+   :target: ../auto_examples/neighbors/plot_nearest_centroid.html
    :scale: 50
 
 .. centered:: |nearest_centroid_1| |nearest_centroid_2|

--- a/examples/neighbors/plot_nearest_centroid.py
+++ b/examples/neighbors/plot_nearest_centroid.py
@@ -28,7 +28,7 @@ h = .02  # step size in the mesh
 cmap_light = ListedColormap(['#FFAAAA', '#AAFFAA', '#AAAAFF'])
 cmap_bold = ListedColormap(['#FF0000', '#00FF00', '#0000FF'])
 
-for shrinkage in [None, 0.1]:
+for shrinkage in [None, .2]:
     # we create an instance of Neighbours Classifier and fit the data.
     clf = NearestCentroid(shrink_threshold=shrinkage)
     clf.fit(X, y)


### PR DESCRIPTION
I was going to completely rework the example, but decided that would be better suited for a separate PR as I haven't found a suitable dataset where a changing the shrink threshold would also result in a noticeable change in the plot / large performance gains. For now, I've simply fixed the previously existing inaccuracies. Addresses https://github.com/scikit-learn/scikit-learn/issues/5931
