### PR TITLE
FIX: Cluster centers after fit in KMeans and MBKMeans need not be ordered in the same way

### DIFF
--- a/examples/cluster/plot_mini_batch_kmeans.py
+++ b/examples/cluster/plot_mini_batch_kmeans.py
@@ -39,9 +39,6 @@ k_means = KMeans(init='k-means++', n_clusters=3, n_init=10)
 t0 = time.time()
 k_means.fit(X)
 t_batch = time.time() - t0
-k_means_labels = k_means.labels_
-k_means_cluster_centers = k_means.cluster_centers_
-k_means_labels_unique = np.unique(k_means_labels)
 
 ##############################################################################
 # Compute clustering with MiniBatchKMeans
@@ -51,9 +48,6 @@ mbk = MiniBatchKMeans(init='k-means++', n_clusters=3, batch_size=batch_size,
 t0 = time.time()
 mbk.fit(X)
 t_mini_batch = time.time() - t0
-mbk_means_labels = mbk.labels_
-mbk_means_cluster_centers = mbk.cluster_centers_
-mbk_means_labels_unique = np.unique(mbk_means_labels)
 
 ##############################################################################
 # Plot result
@@ -65,7 +59,10 @@ colors = ['#4EACC5', '#FF9C34', '#4E9A06']
 # We want to have the same colors for the same cluster from the
 # MiniBatchKMeans and the KMeans algorithm. Let's pair the cluster centers per
 # closest one.
-
+k_means_cluster_centers = np.sort(k_means.cluster_centers_, axis=0)
+mbk_means_cluster_centers = np.sort(mbk.cluster_centers_, axis=0)
+k_means_labels = pairwise_distances_argmin(X, k_means_cluster_centers)
+mbk_means_labels = pairwise_distances_argmin(X, mbk_means_cluster_centers)
 order = pairwise_distances_argmin(k_means_cluster_centers,
                                   mbk_means_cluster_centers)
 


### PR DESCRIPTION
After printing out `k_means_cluster_centers` and `mbk_means_cluster_centers` I get

```
In [3]: mbk_means_cluster_centers
Out[3]:  
array([[ 0.95903103,  1.00100039],
   [-1.00953167, -0.96610056],
   [ 1.13870981, -1.10478529]])

In [4]: k_means_cluster_centers
Out[4]: 
array([[-1.07262225, -1.00554224],
   [ 1.07510478, -1.06937206],
   [ 0.96786467,  1.0173955 ]])
```

which means that this (https://github.com/scikit-learn/scikit-learn/blob/master/examples/cluster/plot_mini_batch_kmeans.py#L107) line will not work the way it is supposed to.

I get this

![kmeans_after](https://cloud.githubusercontent.com/assets/1867024/11916630/47145f3c-a6ad-11e5-84d0-329c0d7c2a0f.png)

as compared to this in master

![kmeans_before](https://cloud.githubusercontent.com/assets/1867024/11916638/6fdeec0c-a6ad-11e5-8b6d-a47da072a01a.png)
