### PR TITLE
[MRG+1] ENH/FIX std error is computed for mean across a set of 3 scores, not len(X)

### DIFF
--- a/examples/exercises/plot_cv_diabetes.py
+++ b/examples/exercises/plot_cv_diabetes.py
@@ -8,6 +8,7 @@ A tutorial exercise which uses cross-validation with linear models.
 This exercise is used in the :ref:`cv_estimators_tut` part of the
 :ref:`model_selection_tut` section of the :ref:`stat_learn_tut_index`.
 """
+
 from __future__ import print_function
 print(__doc__)
 
@@ -24,25 +25,34 @@ diabetes = datasets.load_diabetes()
 X = diabetes.data[:150]
 y = diabetes.target[:150]
 
-lasso = Lasso()
-alphas = np.logspace(-4, -.5, 30)
+lasso = Lasso(random_state=0)
+alphas = np.logspace(-4, -0.5, 30)
 
 scores = list()
 scores_std = list()
 
+n_folds = 3
+
 for alpha in alphas:
     lasso.alpha = alpha
-    this_scores = cross_val_score(lasso, X, y, n_jobs=1)
+    this_scores = cross_val_score(lasso, X, y, cv=n_folds, n_jobs=1)
     scores.append(np.mean(this_scores))
     scores_std.append(np.std(this_scores))
 
-plt.figure(figsize=(4, 3))
+scores, scores_std = np.array(scores), np.array(scores_std)
+
+plt.figure().set_size_inches(8, 6)
 plt.semilogx(alphas, scores)
+
 # plot error lines showing +/- std. errors of the scores
-plt.semilogx(alphas, np.array(scores) + np.array(scores_std) / np.sqrt(len(X)),
-             'b--')
-plt.semilogx(alphas, np.array(scores) - np.array(scores_std) / np.sqrt(len(X)),
-             'b--')
+std_error = scores_std / np.sqrt(n_folds)
+
+plt.semilogx(alphas, scores + std_error, 'b--')
+plt.semilogx(alphas, scores - std_error, 'b--')
+
+# alpha=0.2 controls the translucency of the fill color
+plt.fill_between(alphas, scores + std_error, scores - std_error, alpha=0.2)
+
 plt.ylabel('CV score')
 plt.xlabel('alpha')
 plt.axhline(np.max(scores), linestyle='--', color='.5')
@@ -55,7 +65,7 @@ plt.axhline(np.max(scores), linestyle='--', color='.5')
 # performs cross-validation on the training data it receives).
 # We use external cross-validation to see how much the automatically obtained
 # alphas differ across different cross-validation folds.
-lasso_cv = LassoCV(alphas=alphas)
+lasso_cv = LassoCV(alphas=alphas, random_state=0)
 k_fold = KFold(3)
 
 print("Answer to the bonus question:",


### PR DESCRIPTION
Fixes #6059 

Also
- adds a fill between the error margins
- sets size in inches to make the x/y labels visible
- sets `random_state`.

The new plot looks like this -

![](https://i.imgur.com/6iGIw17.png)

The old plot was - 

![](http://scikit-learn.org/stable/_images/plot_cv_diabetes_001.png)

@agramfort @eyaler
