### PR TITLE
changed pls_.py to properly scale data, modified documents

### DIFF
--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -21,7 +21,6 @@ import scipy
 
 __all__ = ['PLSCanonical', 'PLSRegression', 'PLSSVD']
 
-
 pinv2_args = {}
 if LooseVersion(scipy.__version__) >= LooseVersion('0.12'):
     # check_finite=False is an optimization available only in scipy >=0.12
@@ -42,8 +41,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
     ite = 1
     X_pinv = Y_pinv = None
     eps = np.finfo(X.dtype).eps
-    # Inner loop of the Wold algo. Very similar to chemometrics::pls2_nipals
-    # in R.  Tolarence looks at changes in the X matrix rather than Y
+    # Inner loop of the Wold algorithm.
     while True:
         # 1.1 Update u: the X weights
         if mode == "B":
@@ -73,7 +71,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         # 2.3 Update y_score: the Y latent scores
         y_score = np.dot(Y, y_weights)
         x_weights_diff = x_weights - x_weights_old
-        if np.sqrt(np.dot(x_weights_diff.T, x_weights_diff)) < tol or Y.shape[1] == 1:
+        if np.dot(x_weights_diff.T, x_weights_diff) < tol or Y.shape[1] == 1:
             break
         if ite == max_iter:
             warnings.warn('Maximum number of iterations reached')
@@ -92,15 +90,7 @@ def _svd_cross_product(X, Y):
 
 
 def _center_scale_xy(X, Y, scale=True):
-    """ Center X, Y and scale if the scale parameter==True
-
-    This function always performs centering.
-    Centering substracks column means from all columns of X and Y.
-    Scaling divides X and Y by their respective column standard deviations.
-    The resulting data set is centered around the origin and varies between -1
-    and 1.
-
-    For more general case, use sklearn.preprocessing.scale()
+    """ Center X, Y, and optionally scales it
 
     Returns
     -------
@@ -113,7 +103,7 @@ def _center_scale_xy(X, Y, scale=True):
     Y -= y_mean
     # scale
     if scale:
-        x_std = X.std(axis=0, ddof=1)  # calculate variance (n-1)
+        x_std = X.std(axis=0, ddof=1)
         x_std[x_std == 0.0] = 1.0
         X /= x_std
         y_std = Y.std(axis=0, ddof=1)
@@ -151,7 +141,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
 
     n_components : int, number of components to keep. (default 2).
 
-    scale : boolean, scale data? (default True).  Data is always centered
+    scale : boolean, scale data? (default True) Data is always centered even if False
 
     deflation_mode : str, "canonical" or "regression". See notes.
 
@@ -200,7 +190,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         Y block to latents rotations.
 
     coef_: array, [p, q]
-        The coefficients of the linear model: ``Y = X coef_ + Err``, often B
+        The coefficients of the linear model: ``Y = X coef_ + Err``
 
     n_iter_ : array-like
         Number of iterations of the NIPALS inner loop for each
@@ -367,7 +357,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         else:
             self.y_rotations_ = np.ones(1)
 
-        if self.deflation_mode is "regression":
+        if True or self.deflation_mode is "regression":
             # Estimate regression coefficient
             # Regress Y on T
             # Y = TQ' + Err,
@@ -375,11 +365,6 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             # Y = X W(P'W)^-1Q' + Err = XB + Err
             # => B = W*Q' (p x q)
             self.coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
-            # self.coef_ = (1. / self.x_std_.reshape((p, 1)) * self.coef_ *
-            #               self.y_std_)
-
-        if self.deflation_mode is "canonical":
-            self.coef_ = np.dot(self.x_rotations_, self.y_weights_.T)
 
         return self
 
@@ -405,11 +390,9 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         """
         check_is_fitted(self, 'x_mean_')
         X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)
-        # Center
-        X -= self.x_mean_
         # Normalize
-        if self.scale is True:
-            X /= self.x_std_
+        X -= self.x_mean_
+        X /= self.x_std_
         # Apply rotation
         x_scores = np.dot(X, self.x_rotations_)
         if Y is not None:
@@ -417,8 +400,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             if Y.ndim == 1:
                 Y = Y.reshape(-1, 1)
             Y -= self.y_mean_
-            if self.scale is True:
-                Y /= self.y_std_
+            Y /= self.y_std_
             y_scores = np.dot(Y, self.y_rotations_)
             return x_scores, y_scores
 
@@ -443,16 +425,11 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
         """
         check_is_fitted(self, 'x_mean_')
         X = check_array(X, copy=copy, dtype=FLOAT_DTYPES)
-        # Center
+        # Normalize
         X -= self.x_mean_
-        # Scale
-        if self.scale is True:
-            X /= self.x_std_
+        X /= self.x_std_
         Ypred = np.dot(X, self.coef_)
-        if self.scale is True:
-            return(Ypred * self.y_std_) + self.y_mean_
-        else:
-            return(Ypred + self.y_mean_)
+        return(Ypred * self.y_std_) + self.y_mean_
 
     def fit_transform(self, X, y=None, **fit_params):
         """Learn and apply the dimension reduction on the train data.
@@ -493,8 +470,7 @@ class PLSRegression(_PLS):
         Number of components to keep.
 
     scale : boolean, (default True)
-        whether to scale the data by its variance
-        Note:  data is always centered by this function
+        whether to scale the data
 
     max_iter : an integer, (default 500)
         the maximum number of iterations of the NIPALS inner loop (used
@@ -843,20 +819,12 @@ class PLSSVD(BaseEstimator, TransformerMixin):
         """Apply the dimension reduction learned on the train data."""
         check_is_fitted(self, 'x_mean_')
         X = check_array(X, dtype=np.float64)
-        # Center Xr
-        Xr = X - self.x_mean_
-        # Scale Xr
-        if self.scale is True:
-            Xr /= self.x_std_
+        Xr = (X - self.x_mean_) / self.x_std_
         x_scores = np.dot(Xr, self.x_weights_)
         if Y is not None:
             if Y.ndim == 1:
                 Y = Y.reshape(-1, 1)
-            # Center Yr
-            Yr = Y - self.y_mean_
-            # Scale Yr
-            if self.scale is True:
-                Yr /= self.y_std_
+            Yr = (Y - self.y_mean_) / self.y_std_
             y_scores = np.dot(Yr, self.y_weights_)
             return x_scores, y_scores
         return x_scores
@@ -879,3 +847,4 @@ class PLSSVD(BaseEstimator, TransformerMixin):
         x_scores if Y is not given, (x_scores, y_scores) otherwise.
         """
         return self.fit(X, y, **fit_params).transform(X, y)
+        


### PR DESCRIPTION
1.  In many instances of the variable `scale` setting was ignored.  Data was always centered, and always scaled.  The data is now scaled appropriately when `scale=True` is set, and not scaled when it's `False`
2. The return from the `predict()` function was always de-centered, but never de-scaled, so that we got:
   `Ypred = Ypred + self.y_mean_`  for all cases
   instead of:
   `Ypred = (Ypred * self.y_std_) + self.y_mean_` when `scale=True`
3. In the nipals algorithm, either C and Q matrices are used for deflation modes (regression or canonical).  This is now implemented.  The #FIXME note is now not necessary, as `coef_` is calculated differently depending on those two cases.  The calculated `coef_` was also scaled unnecesarily by standard deviations of X and Y: this is now commented out.  Only matrices W and C are scaled by their norms in the inner loop.  The outer loop scales P, Q, and C (canonical and regression) matrices by `T.T*T` or `U.T*U`
4. Some documentation was changed to reflect code modifications.  Also, instructions to use `sklearn.preprocessing.scale` are included, as that could be a useful step for most users.
5. It should be noted that the example included in the comment sections now gives better predictions of Y.
6. if X and Y are scaled using `sklearn.preprocessing.scale` (or column mean centered and column variance scaled), the pls_ functions all return the SAME results when `scale=True` and  `scale=False` this was not the case in the previous version of the code
