### PR TITLE
correcting information criterion calculation in least_angle.py

### DIFF
--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -1424,6 +1424,7 @@ class LassoLarsIC(LassoLars):
 
         R = y[:, np.newaxis] - np.dot(X, coef_path_)  # residuals
         mean_squared_error = np.mean(R ** 2, axis=0)
+        sigma = np.var(y)
 
         df = np.zeros(coef_path_.shape[1], dtype=np.int)  # Degrees of freedom
         for k, coef in enumerate(coef_path_.T):
@@ -1437,7 +1438,7 @@ class LassoLarsIC(LassoLars):
 
         self.alphas_ = alphas_
         with np.errstate(divide='ignore'):
-            self.criterion_ = n_samples * np.log(mean_squared_error) + K * df
+            self.criterion_ = n_samples * mean_squared_error/sigma + K * df
         n_best = np.argmin(self.criterion_)
 
         self.alpha_ = alphas_[n_best]


### PR DESCRIPTION
The information criterion calculation is not compatible with the original paper 
Zou, Hui, Trevor Hastie, and Robert Tibshirani. "On the “degrees of freedom” of the lasso." The Annals of Statistics 35.5 (2007): 2173-2192.
APA
