### PR TITLE
[MRG+1] Use kwargs instead of functools.partial to define some scorers

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,7 +19,6 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta, abstractmethod
-from functools import partial
 
 import numpy as np
 
@@ -354,5 +353,5 @@ for name, metric in [('precision', precision_score),
     SCORERS[name] = make_scorer(metric)
     for average in ['macro', 'micro', 'samples', 'weighted']:
         qualified_name = '{0}_{1}'.format(name, average)
-        SCORERS[qualified_name] = make_scorer(partial(metric, pos_label=None,
-                                                      average=average))
+        SCORERS[qualified_name] = make_scorer(metric, pos_label=None,
+                                              average=average)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -82,6 +82,12 @@ class DummyScorer(object):
         return 1
 
 
+def test_all_scorers_repr():
+    # Test that all scorers have a working repr
+    for name, scorer in SCORERS.iteritems():
+        repr(scorer)
+
+
 def test_check_scoring():
     # Test all branches of check_scoring
     estimator = EstimatorWithoutFit()

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -84,7 +84,7 @@ class DummyScorer(object):
 
 def test_all_scorers_repr():
     # Test that all scorers have a working repr
-    for name, scorer in SCORERS.iteritems():
+    for name, scorer in SCORERS.items():
         repr(scorer)
 
 


### PR DESCRIPTION
Another attempt to solve #6078. We pass the optional arguments to `make_metric` and they are used in the metric call.
