### PR TITLE
fixed target link to isotonic regression example

### DIFF
--- a/doc/modules/isotonic.rst
+++ b/doc/modules/isotonic.rst
@@ -19,5 +19,5 @@ elements the closest in terms of mean squared error. In practice this list
 of elements forms a function that is piecewise linear.
 
 .. figure:: ../auto_examples/images/plot_isotonic_regression_001.png
-   :target: ../auto_examples/images/plot_isotonic_regression.html
+   :target: ../auto_examples/plot_isotonic_regression.html
    :align: center


### PR DESCRIPTION
[Current link](http://scikit-learn.org/stable/auto_examples/images/plot_isotonic_regression.html) leads to page note found, so I fixed the link to the correct [example link](http://scikit-learn.org/stable/auto_examples/plot_isotonic_regression.html)
