### PR TITLE
Add kernel entropy component analysis to sklearn.decompostition

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1618,13 +1618,12 @@ def _score(estimator, X_test, y_test, scorer):
 
 
 def _permutation_test_score(estimator, X, y, cv, scorer):
-    """Auxiliary function for permutation_test_score"""
+    """Auxiliary function for permutation_test_score and permutation_test2_score"""
     avg_score = []
     for train, test in cv:
         estimator.fit(X[train], y[train])
         avg_score.append(scorer(estimator, X[test], y[test]))
     return np.mean(avg_score)
-
 
 def _shuffle(y, labels, random_state):
     """Return a shuffled copy of y eventually shuffle among same labels."""
@@ -1786,6 +1785,122 @@ def permutation_test_score(estimator, X, y, cv=None,
     permutation_scores = Parallel(n_jobs=n_jobs, verbose=verbose)(
         delayed(_permutation_test_score)(
             clone(estimator), X, _shuffle(y, labels, random_state), cv,
+            scorer)
+        for _ in range(n_permutations))
+    permutation_scores = np.array(permutation_scores)
+    pvalue = (np.sum(permutation_scores >= score) + 1.0) / (n_permutations + 1)
+    return score, permutation_scores, pvalue
+
+
+permutation_test_score.__test__ = False  # to avoid a pb with nosetests
+
+def permutation_test2_score(estimator, X, y, cv=None,
+                           n_permutations=100, n_jobs=1, labels=None,
+                           random_state=0, verbose=0, scoring=None):
+    """Evaluate the significance of a cross-validated score with permutations
+
+    Read more in the :ref:`User Guide <cross_validation>`.
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit'
+        The object to use to fit the data.
+
+    X : array-like of shape at least 2D
+        The data to fit.
+
+    y : array-like
+        The target variable to try to predict in the case of
+        supervised learning.
+
+    scoring : string, callable or None, optional, default: None
+        A string (see model evaluation documentation) or
+        a scorer callable object / function with signature
+        ``scorer(estimator, X, y)``.
+
+    cv : int, cross-validation generator or an iterable, optional
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+
+        - None, to use the default 3-fold cross-validation,
+        - integer, to specify the number of folds.
+        - An object to be used as a cross-validation generator.
+        - An iterable yielding train/test splits.
+
+        For integer/None inputs, if ``y`` is binary or multiclass,
+        :class:`StratifiedKFold` used. If the estimator is a classifier
+        or if ``y`` is neither binary nor multiclass, :class:`KFold` is used.
+
+        Refer :ref:`User Guide <cross_validation>` for the various
+        cross-validation strategies that can be used here.
+
+    n_permutations : integer, optional
+        Number of times to permute ``y``.
+
+    n_jobs : integer, optional
+        The number of CPUs to use to do the computation. -1 means
+        'all CPUs'.
+
+    labels : array-like of shape [n_samples] (optional)
+        Labels constrain the permutation among groups of samples with
+        a same label.
+
+    random_state : RandomState or an int seed (0 by default)
+        A random number generator instance to define the state of the
+        random permutations generator.
+
+    verbose : integer, optional
+        The verbosity level.
+
+    Returns
+    -------
+    score : float
+        The true score without permuting targets.
+
+    permutation_scores : array, shape (n_permutations,)
+        The scores obtained for each permutations.
+
+    pvalue : float
+        The returned value equals p-value if `scoring` returns bigger
+        numbers for better scores (e.g., accuracy_score). If `scoring` is
+        rather a loss function (i.e. when lower is better such as with
+        `mean_squared_error`) then this is actually the complement of the
+        p-value:  1 - p-value.
+
+    Notes
+    -----
+    This function implements Test 2 in:
+
+        Ojala and Garriga. Permutation Tests for Studying Classifier
+        Performance.  The Journal of Machine Learning Research (2010)
+        vol. 11
+
+    """
+    X, y = indexable(X, y)
+    cv = check_cv(cv, X, y, classifier=is_classifier(estimator))
+    scorer = check_scoring(estimator, scoring=scoring)
+    random_state = check_random_state(random_state)
+
+    # We clone the estimator to make sure that all the folds are
+    # independent, and that it is pickle-able.
+    score = _permutation_test_score(clone(estimator), X, y, cv, scorer)
+    def shuffledX(X,y,random_state):
+        Xs = []
+        for label in np.unique(y):
+            index = np.where(y == label)[0]
+            X.append(X[index])
+            
+        
+        newX = Xs[y[0]]
+        Xs.pop(y[0])
+        for Xc in Xs:
+            Xc = X
+            newX = np.vstack((newX,Xc))
+        return newX
+    
+    permutation_scores = Parallel(n_jobs=n_jobs, verbose=verbose)(
+        delayed(_permutation_test_score)(
+            clone(estimator), shuffledX(X,y,random_state), y, cv,
             scorer)
         for _ in range(n_permutations))
     permutation_scores = np.array(permutation_scores)

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -60,6 +60,9 @@ class KernelECA(BaseEstimator, TransformerMixin):
 	random_state : int seed, RandomState instance, or None, default : None
         A pseudo random number generator used for the initialization of the
         residuals when eigen_solver == 'arpack'.
+		
+	n_iter : default : None
+		just added to pass the tests... does nothing!
 
     Attributes
     ----------
@@ -87,7 +90,7 @@ class KernelECA(BaseEstimator, TransformerMixin):
 
     def __init__(self, n_components=None, kernel="linear",
                  gamma=None, degree=3, coef0=1, kernel_params=None, eigen_solver='auto',
-                 tol=0, max_iter=None, random_state=None):
+                 tol=0, max_iter=None, random_state=None, n_iter = None):
         self.n_components = n_components
         self.kernel = kernel
         self.kernel_params = kernel_params

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -97,8 +97,8 @@ class KernelECA(BaseEstimator, TransformerMixin):
         self.eigen_solver = eigen_solver
         self.tol = tol
         self.max_iter = max_iter
+        self.random_state = random_state
         self._centerer = KernelCenterer()
-		self.random_state = random_state
 
     @property
     def _pairwise(self):

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -213,4 +213,4 @@ class KernelECA(BaseEstimator, TransformerMixin):
         return np.dot(K, self.alphas_ / np.sqrt(self.lambdas_))
 
     def inverse_transform(self, X):
-        raise ValueError("Function inverse_transform is not implemented.")
+        raise NotImplementedError("Function inverse_transform is not implemented.")

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -18,8 +18,6 @@ class KernelECA(BaseEstimator, TransformerMixin):
     Non-linear dimensionality reduction through the use of kernels (see
     :ref:`metrics`).
 
-    Read more in the :ref:`User Guide <kernel_ECA>`.
-
     Parameters
     ----------
     n_components: int or None
@@ -152,7 +150,6 @@ class KernelECA(BaseEstimator, TransformerMixin):
         
         self.sorted_entropy_index = self.entropy.argsort()[::-1]
         self.entropy = self.entropy[self.sorted_entropy_index]
-        #print(self.sorted_entropy_index)
         
         # Rearrange descending entropy components
         self.alphas_ = self.alphas_[:, self.sorted_entropy_index]
@@ -196,9 +193,6 @@ class KernelECA(BaseEstimator, TransformerMixin):
         self.fit(X, **params)
 
         X_transformed = self.alphas_ * np.sqrt(self.lambdas_)
-
-        if self.fit_inverse_transform:
-            self._fit_inverse_transform(X_transformed, X)
 
         return X_transformed
 

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -99,7 +99,7 @@ class KernelECA(BaseEstimator, TransformerMixin):
         self.max_iter = max_iter
         self._centerer = KernelCenterer()
 		self.random_state = random_state
-        
+
     @property
     def _pairwise(self):
         return self.kernel == "precomputed"

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -60,9 +60,6 @@ class KernelECA(BaseEstimator, TransformerMixin):
 	random_state : int seed, RandomState instance, or None, default : None
         A pseudo random number generator used for the initialization of the
         residuals when eigen_solver == 'arpack'.
-		
-	n_iter : default : None
-		just added to pass the tests... does nothing!
 
     Attributes
     ----------
@@ -90,7 +87,7 @@ class KernelECA(BaseEstimator, TransformerMixin):
 
     def __init__(self, n_components=None, kernel="linear",
                  gamma=None, degree=3, coef0=1, kernel_params=None, eigen_solver='auto',
-                 tol=0, max_iter=None, random_state=None, n_iter = None):
+                 tol=0, max_iter=None, random_state=None):
         self.n_components = n_components
         self.kernel = kernel
         self.kernel_params = kernel_params

--- a/sklearn/decomposition/kernel_eca.py
+++ b/sklearn/decomposition/kernel_eca.py
@@ -1,0 +1,222 @@
+"""Kernel Entropy Components Analysis"""
+
+# Author: Tobias Sterbak <sterbak-it@outlook.com>
+# License: BSD 3 clause
+
+import numpy as np
+from scipy import linalg
+
+from sklearn.utils.arpack import eigsh
+from sklearn.utils.validation import check_is_fitted
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.preprocessing import KernelCenterer
+from sklearn.metrics.pairwise import pairwise_kernels
+
+class KernelECA(BaseEstimator, TransformerMixin):
+    """Kernel Entropy component analysis (KECA)
+
+    Non-linear dimensionality reduction through the use of kernels (see
+    :ref:`metrics`).
+
+    Read more in the :ref:`User Guide <kernel_ECA>`.
+
+    Parameters
+    ----------
+    n_components: int or None
+        Number of components. If None, all non-zero components are kept.
+
+    kernel: "linear" | "poly" | "rbf" | "sigmoid" | "cosine" | "precomputed"
+        Kernel.
+        Default: "linear"
+
+    degree : int, default=3
+        Degree for poly kernels. Ignored by other kernels.
+
+    gamma : float, optional
+        Kernel coefficient for rbf and poly kernels. Default: 1/n_features.
+        Ignored by other kernels.
+
+    coef0 : float, optional
+        Independent term in poly and sigmoid kernels.
+        Ignored by other kernels.
+
+    kernel_params : mapping of string to any, optional
+        Parameters (keyword arguments) and values for kernel passed as
+        callable object. Ignored by other kernels.
+
+
+    eigen_solver: string ['auto'|'dense'|'arpack']
+        Select eigensolver to use.  If n_components is much less than
+        the number of training samples, arpack may be more efficient
+        than the dense eigensolver.
+
+    tol: float
+        convergence tolerance for arpack.
+        Default: 0 (optimal value will be chosen by arpack)
+
+    max_iter : int
+        maximum number of iterations for arpack
+        Default: None (optimal value will be chosen by arpack)
+
+    Attributes
+    ----------
+
+    lambdas_ :
+        Eigenvalues of the centered kernel matrix
+
+    alphas_ :
+        Eigenvectors of the centered kernel matrix
+
+    dual_coef_ :
+        Inverse transform matrix
+
+    X_transformed_fit_ :
+        Projection of the fitted data on the kernel entropy components
+
+    References
+    ----------
+    Kernel ECA based on:
+    (c) Robert Jenssen, University of Tromso, Norway, 2010 
+        R. Jenssen, "Kernel Entropy Component Analysis,"
+        IEEE Trans. Patt. Anal. Mach. Intel., 32(5), 847-860, 2010.
+
+    """
+
+    def __init__(self, n_components=None, kernel="linear",
+                 gamma=None, degree=3, coef0=1, kernel_params=None, eigen_solver='auto',
+                 tol=0, max_iter=None):
+        self.n_components = n_components
+        self.kernel = kernel
+        self.kernel_params = kernel_params
+        self.gamma = gamma
+        self.degree = degree
+        self.coef0 = coef0
+        self.eigen_solver = eigen_solver
+        self.tol = tol
+        self.max_iter = max_iter
+        self._centerer = KernelCenterer()
+        
+    @property
+    def _pairwise(self):
+        return self.kernel == "precomputed"
+
+    def _get_kernel(self, X, Y=None):
+        if callable(self.kernel):
+            params = self.kernel_params or {}
+        else:
+            params = {"gamma": self.gamma,
+                      "degree": self.degree,
+                      "coef0": self.coef0}
+        return pairwise_kernels(X, Y, metric=self.kernel,
+                                filter_params=True, **params)
+
+    def _fit_transform(self, K):
+        """ Fit's using kernel K"""
+        # center kernel
+        K = self._centerer.fit_transform(K)
+
+        if self.n_components is None:
+            n_components = K.shape[0]
+        else:
+            n_components = min(K.shape[0], self.n_components)
+
+        # compute eigenvectors
+        if self.eigen_solver == 'auto':
+            if K.shape[0] > 200 and n_components < 10:
+                eigen_solver = 'arpack'
+            else:
+                eigen_solver = 'dense'
+        else:
+            eigen_solver = self.eigen_solver
+
+        if eigen_solver == 'dense':
+            self.lambdas_, self.alphas_ = linalg.eigh(
+                K, eigvals=(K.shape[0] - n_components, K.shape[0] - 1))
+        elif eigen_solver == 'arpack':
+            self.lambdas_, self.alphas_ = eigsh(K, n_components,
+                                                which="LA",
+                                                tol=self.tol,
+                                                maxiter=self.max_iter)
+
+        # sort eigenvectors in descending order
+        indices = self.lambdas_.argsort()[::-1]
+        self.lambdas_ = self.lambdas_[indices]
+        self.alphas_ = self.alphas_[:, indices]
+        
+        # Computing sorted kernel ECA entropy terms
+        N = len(self.alphas_[0])
+        s = 0
+        for i in range(N):
+            s += (np.sqrt(self.lambdas_[i]) * self.alphas_[i].T * np.ones(N))**2
+        self.entropy = (1/(N**2)) * s
+        
+        self.sorted_entropy_index = self.entropy.argsort()[::-1]
+        self.entropy = self.entropy[self.sorted_entropy_index]
+        #print(self.sorted_entropy_index)
+        
+        # Rearrange descending entropy components
+        self.alphas_ = self.alphas_[:, self.sorted_entropy_index]
+        self.lambdas_ = self.lambdas_[self.sorted_entropy_index]
+
+        return K
+
+    def fit(self, X, y=None):
+        """Fit the model from data in X.
+
+        Parameters
+        ----------
+        X: array-like, shape (n_samples, n_features)
+            Training vector, where n_samples in the number of samples
+            and n_features is the number of features.
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+        """
+        K = self._get_kernel(X)
+        self._fit_transform(K)
+
+        self.X_fit_ = X
+        return self
+
+    def fit_transform(self, X, y=None, **params):
+        """Fit the model from data in X and transform X.
+
+        Parameters
+        ----------
+        X: array-like, shape (n_samples, n_features)
+            Training vector, where n_samples in the number of samples
+            and n_features is the number of features.
+
+        Returns
+        -------
+        X_new: array-like, shape (n_samples, n_components)
+        """
+        self.fit(X, **params)
+
+        X_transformed = self.alphas_ * np.sqrt(self.lambdas_)
+
+        if self.fit_inverse_transform:
+            self._fit_inverse_transform(X_transformed, X)
+
+        return X_transformed
+
+    def transform(self, X):
+        """Transform X.
+
+        Parameters
+        ----------
+        X: array-like, shape (n_samples, n_features)
+
+        Returns
+        -------
+        X_new: array-like, shape (n_samples, n_components)
+        """
+        check_is_fitted(self, 'X_fit_')
+
+        K = self._centerer.transform(self._get_kernel(X, self.X_fit_))
+        return np.dot(K, self.alphas_ / np.sqrt(self.lambdas_))
+
+    def inverse_transform(self, X):
+        raise ValueError("Function inverse_transform is not implemented.")


### PR DESCRIPTION
This adds the functionality of _kernel entropy component analysis_ to sklearn. 
Its a method similar to kernel PCA but based on an estimate of Rényi quadratic entropy. 

**I used this method for generating better features in a remote sensing context.**
