### PR TITLE
[MRG] Bagging's base_estimator_ attribute is a not a list

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -459,7 +459,7 @@ class BaggingClassifier(BaseBagging, ClassifierMixin):
 
     Attributes
     ----------
-    base_estimator_ : list of estimators
+    base_estimator_ : estimator
         The base estimator from which the ensemble is grown.
 
     estimators_ : list of estimators

--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -33,7 +33,7 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
 
     Attributes
     ----------
-    base_estimator_ : list of estimators
+    base_estimator_ : estimator
         The base estimator from which the ensemble is grown.
 
     estimators_ : list of estimators


### PR DESCRIPTION
Changed documentation to reflect that `base_estimator_` is a single estimator object, not a list of them. I don't think it is ever a list, at least I couldn't find any instances where it was.
