### PR TITLE
[MRG+1] LFW dataset: download archive to temporary directory

### DIFF
--- a/sklearn/datasets/lfw.py
+++ b/sklearn/datasets/lfw.py
@@ -23,7 +23,7 @@ detector from various online websites.
 # Copyright (c) 2011 Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
 
-from os import listdir, makedirs, remove
+from os import listdir, makedirs, remove, rename
 from os.path import join, exists, isdir
 
 from sklearn.utils import deprecated
@@ -98,9 +98,11 @@ def check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
 
         if not exists(archive_path):
             if download_if_missing:
+                archive_path_temp = archive_path + ".tmp"
                 logger.warning("Downloading LFW data (~200MB): %s",
                                archive_url)
-                urllib.urlretrieve(archive_url, archive_path)
+                urllib.urlretrieve(archive_url, archive_path_temp)
+                rename(archive_path_temp, archive_path)
             else:
                 raise IOError("%s is missing" % target_filepath)
 


### PR DESCRIPTION
This PR moves the archive download of the LFW dataset to a temporary directory. When the download is interrupted you'd have to delete the file by hand to let the download complete. This is no longer necessary.

To keep things simple this PR doesn't handle cleaning when python is interrupted by a signal, since its pretty [cumbersome](http://stackoverflow.com/questions/18557670/best-way-to-clean-a-temporary-files-if-script-can-be-interrupted). Thus it leaves a temporary directory with a partial file on disk.

Is this behavior OK? 

Another option would be to replace the calls to `urllib.urlretrieve()` by a function which downloads the file to a temporary directory and moves it in place only if the download succeeded. This function would also handle the signals.
