### PR TITLE
Fix docstring signature mismatch in cython code

### DIFF
--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -156,6 +156,9 @@ def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
     X: CSR matrix, dtype float64
         The complete (pre allocated) training set as a CSR matrix.
 
+    x_squared_norms: array, shape (n_samples,)
+        Squared Euclidean norm of each data point.
+
     centers: array, shape (n_clusters, n_features)
         The cluster centers
 
@@ -163,19 +166,23 @@ def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
          The vector in which we keep track of the numbers of elements in a
          cluster
 
+    nearest_center: array, shape (n_samples,)
+        The vector in which we keep track of the nearest center of each
+        sample
+
+    old_center: array, shape (n_features,)
+        The vector in which we keep track of the old center of each feature
+
+    compute_squared_diff: integer
+
     Returns
     -------
-    inertia: float
-        The inertia of the batch prior to centers update, i.e. the sum
-        distances to the closest center for each sample. This is the objective
-        function being minimized by the k-means algorithm.
-
     squared_diff: float
         The sum of squared update (squared norm of the centers position
         change). If compute_squared_diff is 0, this computation is skipped and
         0.0 is returned instead.
 
-    Both squared diff and inertia are commonly used to monitor the convergence
+    Squared diff is commonly used to monitor the convergence
     of the algorithm.
     """
     cdef:

--- a/sklearn/linear_model/sgd_fast.pyx
+++ b/sklearn/linear_model/sgd_fast.pyx
@@ -392,7 +392,7 @@ def plain_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
         Initial state of the learning rate. This value is equal to the
         iteration count except when the learning rate is set to `optimal`.
         Default: 1.0.
-
+    intercept_decay : double
     Returns
     -------
     weights : array, shape=[n_features]
@@ -492,6 +492,7 @@ def average_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
         Initial state of the learning rate. This value is equal to the
         iteration count except when the learning rate is set to `optimal`.
         Default: 1.0.
+    intercept_decay : double
     average : int
         The number of iterations before averaging starts. average=1 is
         equivalent to averaging for all iterations.

--- a/sklearn/neighbors/binary_tree.pxi
+++ b/sklearn/neighbors/binary_tree.pxi
@@ -749,10 +749,13 @@ cdef ITYPE_t find_node_split_dim(DTYPE_t* data,
     node_indices : int pointer
         Pointer to a 1D array of length n_points.  This lists the indices of
         each of the points within the current node.
-
+    n_features : int
+        The number of features in data.
+    n_points : int
+        The number of points in the current node.
     Returns
     -------
-    i_max : int
+    j_max : int
         The index of the feature (dimension) within the node that has the
         largest spread.
 
@@ -821,7 +824,10 @@ cdef int partition_node_indices(DTYPE_t* data,
         the routine ``find_node_split_dim``
     split_index : int
         the index within node_indices around which to split the points.
-
+    n_features : int
+        The number of features in data
+    n_points : int
+        The number of points in the current node.
     Returns
     -------
     status : int

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -375,7 +375,7 @@ cdef class DistanceMetric:
             If not specified, then Y=X.
         Returns
         -------
-        dist : ndarray
+        Darr : ndarray
             The shape (Nx, Ny) array of pairwise distances between points in
             X and Y.
         """

--- a/sklearn/svm/libsvm.pyx
+++ b/sklearn/svm/libsvm.pyx
@@ -288,6 +288,15 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     Parameters
     ----------
     X: array-like, dtype=float, size=[n_samples, n_features]
+    support : array, dtype=int32
+    SV : array, dtype=float64
+    nSV : array, dtype=int32
+    sv_coef : array, dtype=float64
+    intercept : array, dtype=float64
+    probA : array, dtype=float64, optional
+        np.empty(0) by default
+    probB : array, dtype=float64, optional
+        np.empty(0) by default
     svm_type : {0, 1, 2, 3, 4}
         Type of SVM: C SVC, nu SVC, one class, epsilon SVR, nu SVR
     kernel : {'linear', 'rbf', 'poly', 'sigmoid', 'precomputed'}
@@ -298,6 +307,12 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
         Gamma parameter in RBF kernel.
     coef0 : float
         Independent parameter in poly/sigmoid kernel.
+    class_weight : array, dtype float64, shape (n_classes,), optional
+        np.empty(0) by default.
+    sample_weight : array, dtype float64, shape (n_samples,), optional
+        np.empty(0) by default.
+    cache_size : float64, optional
+        Cache size for gram matrix columns (in megabytes). 100 by default.
 
     Returns
     -------

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -82,6 +82,8 @@ cdef class Splitter:
 
         random_state: object
             The user inputted random state to be used for pseudo-randomness
+
+        presort: bint
         """
 
         self.criterion = criterion
@@ -137,6 +139,9 @@ cdef class Splitter:
             The weights of the samples, where higher weighted samples are fit
             closer than lower weight samples. If not provided, all samples
             are assumed to have uniform weight.
+
+        X_idx_sorted: numpy.ndarray (optional)
+            If presort is
         """
 
         self.rand_r_state = self.random_state.randint(0, RAND_R_MAX)

--- a/sklearn/utils/graph_shortest_path.pyx
+++ b/sklearn/utils/graph_shortest_path.pyx
@@ -52,8 +52,8 @@ def graph_shortest_path(dist_matrix, directed=True, method='auto'):
 
     Returns
     -------
-    G : np.ndarray, float, shape = [N,N]
-        G[i,j] gives the shortest distance from point i to point j
+    graph : np.ndarray, float, shape = [N,N]
+        graph[i,j] gives the shortest distance from point i to point j
         along the graph.
 
     Notes
@@ -163,13 +163,10 @@ cdef np.ndarray dijkstra(dist_matrix,
 
     Parameters
     ----------
-    graph : array or sparse matrix
+    dist_matrix : array or sparse matrix
         dist_matrix is the matrix of distances betweeen connected points.
         unconnected points have distance=0.  It will be converted to
         a csr_matrix internally
-    indptr :
-        These arrays encode a distance matrix in compressed-sparse-row
-        format.
     graph : ndarray
         on input, graph is the matrix of distances betweeen connected points.
         unconnected points have distance=0

--- a/sklearn/utils/seq_dataset.pyx
+++ b/sklearn/utils/seq_dataset.pyx
@@ -171,6 +171,9 @@ cdef class ArrayDataset(SequentialDataset):
 
         sample_weights : ndarray, dtype=double, ndim=1, mode='c'
             The weight of each sample, of shape(n_samples,)
+
+        seed : unsigned integer
+            Seed for XorShift Random Number Generator
         """
         if X.shape[0] > INT_MAX or X.shape[1] > INT_MAX:
             raise ValueError("More than %d samples or features not supported;"
@@ -248,6 +251,9 @@ cdef class CSRDataset(SequentialDataset):
 
         sample_weights : ndarray, dtype=double, ndim=1, mode='c'
             The weight of each sample.
+
+        seed : unsigned integer
+            Seed for XorShift Random Number Generator
         """
         # keep a reference to the data to prevent garbage collection
         self.X_data = X_data

--- a/sklearn/utils/sparsetools/_graph_tools.pyx
+++ b/sklearn/utils/sparsetools/_graph_tools.pyx
@@ -94,6 +94,8 @@ def csgraph_masked_from_dense(graph,
         are treated as null edges.
     nan_null : bool
         If True (default), then NaN entries are treated as non-edges
+    copy : bool
+        If True (default), then the graph array is copied
 
     Returns
     -------


### PR DESCRIPTION
Fixes #6110 

@rvraghav93 Hi Raghav, I'm new to scikit-learn, so I was reading the source code to get familiar with it. Here is the list of files that has some mistake in the docstring.
- [ ] sklearn/cluster/_k_means.pyx
- [ ] sklearn/utils/graph_shortest_path.pyx
- [ ] sklearn/utils/sparsetools/_graph_tools.pyx
- [ ] sklearn/linear_model/sgd_fast.pyx
- [ ] sklearn/neighbors/binary_tree.pxi
- [ ] sklearn/neighbors/dist_metrics.pyx
- [ ] sklearn/svm/libsvm.pyx
- [ ] sklearn/tree/_splitter.pyx
- [ ] sklearn/utils/seq_dataset.pyx

We can check a particular file once all the discrepancies related to docstrings are removed. 
Hope that's OK? Please let me know if you have any other suggestions.
