### PR TITLE
FIX #6076. Bug in QuantileLossFunction

### DIFF
--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -421,10 +421,10 @@ class QuantileLossFunction(RegressionLossFunction):
         mask = y > pred
         if sample_weight is None:
             loss = (alpha * diff[mask].sum() +
-                    (1.0 - alpha) * diff[~mask].sum()) / y.shape[0]
+                    (1.0 - alpha) * (-diff[~mask]).sum()) / y.shape[0]
         else:
             loss = ((alpha * np.sum(sample_weight[mask] * diff[mask]) +
-                    (1.0 - alpha) * np.sum(sample_weight[~mask] * diff[~mask])) /
+                    (1.0 - alpha) * np.sum(sample_weight[~mask] * (-diff[~mask]))) /
                     sample_weight.sum())
         return loss
 


### PR DESCRIPTION
Fixes #6076. Flipped `diff` sign for cases of `~mask`.
