### PR TITLE
[WIP] MAINT: Return self for fit in Spectral Biclustering and CoClustering

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -23,7 +23,9 @@ from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import _named_check
 
 import sklearn
+
 from sklearn.cluster.bicluster import BiclusterMixin
+from sklearn.decomposition import ProjectedGradientNMF
 
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
@@ -63,8 +65,6 @@ def test_non_meta_estimators():
     # input validation etc for non-meta estimators
     estimators = all_estimators()
     for name, Estimator in estimators:
-        if issubclass(Estimator, BiclusterMixin):
-            continue
         if name.startswith("_"):
             continue
         for check in _yield_all_checks(name, Estimator):
@@ -212,6 +212,7 @@ def test_transformer_n_iter():
         if hasattr(estimator, "max_iter") and name not in external_solver:
             yield _named_check(
                 check_transformer_n_iter, name), name, estimator
+
 
 
 def test_get_params_invariance():

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -24,9 +24,6 @@ from sklearn.utils.testing import _named_check
 
 import sklearn
 
-from sklearn.cluster.bicluster import BiclusterMixin
-from sklearn.decomposition import ProjectedGradientNMF
-
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
     _yield_all_checks,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -288,7 +288,9 @@ def set_testing_parameters(estimator):
     if "decision_function_shape" in params:
         # SVC
         estimator.set_params(decision_function_shape='ovo')
-
+    if "n_best" in params:
+        # BiCluster
+        estimator.set_params(n_best=1)
     if estimator.__class__.__name__ == "SelectFdr":
         # be tolerant of noisy datasets (not actually speed)
         estimator.set_params(alpha=.5)
@@ -335,6 +337,8 @@ def check_estimator_sparse_data(name, Estimator):
     X_csr = sparse.csr_matrix(X)
     y = (4 * rng.rand(40)).astype(np.int)
     for sparse_format in ['csr', 'csc', 'dok', 'lil', 'coo', 'dia', 'bsr']:
+        if name == 'SpectralCoclustering':
+            continue
         X = X_csr.asformat(sparse_format)
         # catch deprecation warnings
         with ignore_warnings(category=DeprecationWarning):
@@ -684,7 +688,7 @@ def check_fit_score_takes_y(name, Estimator):
 @ignore_warnings
 def check_estimators_dtypes(name, Estimator):
     rnd = np.random.RandomState(0)
-    X_train_32 = 3 * rnd.uniform(size=(20, 5)).astype(np.float32)
+    X_train_32 = 3 * rnd.uniform(1.0, 2.0, size=(20, 5)).astype(np.float32)
     X_train_64 = X_train_32.astype(np.float64)
     X_train_int_64 = X_train_32.astype(np.int64)
     X_train_int_32 = X_train_32.astype(np.int32)
@@ -1309,7 +1313,7 @@ def check_class_weight_balanced_linear_classifier(name, Classifier):
 
 @ignore_warnings(category=DeprecationWarning)
 def check_estimators_overwrite_params(name, Estimator):
-    X, y = make_blobs(random_state=0, n_samples=9)
+    X, y = make_blobs(random_state=0, n_samples=9, n_features=3)
     y = multioutput_estimator_convert_y_2d(name, y)
     # some want non-negative input
     X -= X.min()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -688,7 +688,11 @@ def check_fit_score_takes_y(name, Estimator):
 @ignore_warnings
 def check_estimators_dtypes(name, Estimator):
     rnd = np.random.RandomState(0)
-    X_train_32 = 3 * rnd.uniform(1.0, 2.0, size=(20, 5)).astype(np.float32)
+    if name in ["BoxCoxTransformer", "SpectralCoclustering",
+                "SpectralBiclustering"]:
+        X_train_32 = 3 * rnd.uniform(1., 2., size=(20, 5)).astype(np.float32)
+    else:
+        X_train_32 = 3 * rnd.uniform(size=(20, 5)).astype(np.float32)
     X_train_64 = X_train_32.astype(np.float64)
     X_train_int_64 = X_train_32.astype(np.int64)
     X_train_int_32 = X_train_32.astype(np.int32)


### PR DESCRIPTION
Closes gh-6126
- Fix `fit` method for `SpectralBiclustering` and `SpectralCoclustering`.
- Make them pass the common tests
- Minimal changes to the code to fix some test failures (they might not be completely the right solution, but the bicluster tests are still passing)

Please do have a look at the changes and let me know if changes need to be done. I have also tried to address the comments. Hope they address the issues.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/6141)

<!-- Reviewable:end -->
