### PR TITLE
[MRG+1] MAINT: Refactor and speed up silhoutte_score (samples)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -82,6 +82,10 @@ Enhancements
    - Add parameter ``loss`` to :class:`linear_model.RANSACRegressor` to measure the
      error on the samples for every trial. By `Manoj Kumar`_.
 
+   - Speed up :func:`metrics.silhouette_score` by using vectorized operations.
+     By `Manoj Kumar`_.
+
+
 Bug fixes
 .........
 

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -4,7 +4,9 @@ from scipy.sparse import csr_matrix
 from sklearn import datasets
 from sklearn.metrics.cluster.unsupervised import silhouette_score
 from sklearn.metrics import pairwise_distances
-from sklearn.utils.testing import assert_false, assert_almost_equal
+from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises_regexp
 
 
@@ -68,3 +70,19 @@ def test_correct_labelsize():
                          'Number of labels is %d\. Valid values are 2 '
                          'to n_samples - 1 \(inclusive\)' % len(np.unique(y)),
                          silhouette_score, X, y)
+
+
+def test_non_encoded_labels():
+    dataset = datasets.load_iris()
+    X = dataset.data
+    labels = dataset.target
+    assert_equal(
+        silhouette_score(X, labels + 10), silhouette_score(X, labels))
+
+
+def test_non_numpy_labels():
+    dataset = datasets.load_iris()
+    X = dataset.data
+    y = dataset.target
+    assert_equal(
+        silhouette_score(list(X), list(y)), silhouette_score(X, y))


### PR DESCRIPTION
A refactor of `metrics.silhouette_score`. Able to get at least 2 times speedup in most cases.

```
 n_samples=10000, n_labels=6
 In this branch: 13.4s, in master:23.2s
 n_samples=10000, n_labels=4
 In this branch: 14.4s, in master:23.9s

 n_samples=1000, n_labels=6
 In this branch: 115ms, in master:287ms
 n_samples=1000, n_labels=4
 In this branch: 110ms, in master:249ms

 n_samples=100, n_labels=6
 In this branch: 1.87ms, in master:7.13ms
 n_samples=100, n_labels=4
 In this branch: 1.54ms, in master:5.84ms
```

Also fixed a bug related to non-encoded labels.
