### PR TITLE
[MRG+1] Fix FAQ link at the bottom of main page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -236,7 +236,7 @@
                     <ul>
                     <li><em>About us</em> See <a href="about.html#people">authors</a></li>
                     <li><em>More Machine Learning</em> Find <a href="related_projects.html">related projects</a></li>
-                    <li><em>Questions?</em> See <a href="faq/">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
+                    <li><em>Questions?</em> See <a href="faq.html">FAQ</a> and <a href="http://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
                     <li><em>Mailing list:</em> <a href="https://lists.sourceforge.net/lists/listinfo/scikit-learn-general">scikit-learn-general@lists.sourceforge.net</a></li>
                     <li><em>IRC:</em> #scikit-learn @ <a href="http://webchat.freenode.net/">freenode</a></li>
                     </ul>


### PR DESCRIPTION
On scikit-learn.org the FAQ link at the bottom (see snapshot below) links to http://scikit-learn.org/stable/faq/ instead of http://scikit-learn.org/stable/faq.html.

![scikit-learn-faq](https://cloud.githubusercontent.com/assets/1680079/12288808/bdb62304-b9d7-11e5-9d03-704f5c7cc569.png)
