### PR TITLE
Refactor model_selection._search to include unsupervised estimators

### DIFF
--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -1,32 +1,34 @@
+from ._search import GridSearchCV
+from ._search import GridSearchCluster
+from ._search import ParameterGrid
+from ._search import ParameterSampler
+from ._search import RandomizedSearchCV
+from ._search import RandomizedSearchCluster
+from ._search import fit_grid_point
 from ._split import BaseCrossValidator
 from ._split import KFold
 from ._split import LabelKFold
-from ._split import StratifiedKFold
+from ._split import LabelShuffleSplit
 from ._split import LeaveOneLabelOut
 from ._split import LeaveOneOut
 from ._split import LeavePLabelOut
 from ._split import LeavePOut
-from ._split import ShuffleSplit
-from ._split import LabelShuffleSplit
-from ._split import StratifiedShuffleSplit
 from ._split import PredefinedSplit
-from ._split import train_test_split
+from ._split import ShuffleSplit
+from ._split import StratifiedKFold
+from ._split import StratifiedShuffleSplit
 from ._split import check_cv
-
-from ._validation import cross_val_score
+from ._split import train_test_split
 from ._validation import cross_val_predict
+from ._validation import cross_val_score
 from ._validation import learning_curve
 from ._validation import permutation_test_score
 from ._validation import validation_curve
 
-from ._search import GridSearchCV
-from ._search import RandomizedSearchCV
-from ._search import ParameterGrid
-from ._search import ParameterSampler
-from ._search import fit_grid_point
 
 __all__ = ('BaseCrossValidator',
            'GridSearchCV',
+           'GridSearchCluster',
            'KFold',
            'LabelKFold',
            'LabelShuffleSplit',
@@ -38,6 +40,7 @@ __all__ = ('BaseCrossValidator',
            'ParameterSampler',
            'PredefinedSplit',
            'RandomizedSearchCV',
+           'RandomizedSearchCluster',
            'ShuffleSplit',
            'StratifiedKFold',
            'StratifiedShuffleSplit',

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -4,40 +4,44 @@ parameters of an estimator.
 """
 from __future__ import print_function
 
-# Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>,
-#         Gael Varoquaux <gael.varoquaux@normalesup.org>
-#         Andreas Mueller <amueller@ais.uni-bonn.de>
-#         Olivier Grisel <olivier.grisel@ensta.org>
-# License: BSD 3 clause
-
 from abc import ABCMeta, abstractmethod
 from collections import Mapping, namedtuple, Sized
 from functools import partial, reduce
 from itertools import product
+import numbers
 import operator
+import time
 import warnings
 
 import numpy as np
 
 from ..base import BaseEstimator, is_classifier, clone
 from ..base import MetaEstimatorMixin, ChangedBehaviorWarning
-from ._split import check_cv
-from ._validation import _fit_and_score
-from ..externals.joblib import Parallel, delayed
 from ..externals import six
+from ..externals.joblib import Parallel, delayed
+from ..metrics.scorer import check_scoring
 from ..utils import check_random_state
 from ..utils.fixes import sp_version
+from ..utils.metaestimators import if_delegate_has_method
 from ..utils.random import sample_without_replacement
 from ..utils.validation import _num_samples, indexable
-from ..utils.metaestimators import if_delegate_has_method
-from ..metrics.scorer import check_scoring
+from ._split import check_cv
+from ._validation import _fit_and_score
+from ..exceptions import FitFailedWarning
 
 
-__all__ = ['GridSearchCV', 'ParameterGrid', 'fit_grid_point',
-           'ParameterSampler', 'RandomizedSearchCV']
+# Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>,
+#         Gael Varoquaux <gael.varoquaux@normalesup.org>
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#         Olivier Grisel <olivier.grisel@ensta.org>
+# License: BSD 3 clause
+__all__ = ['GridSearchCV', 'GridSearchCluster', 'ParameterGrid',
+           'fit_grid_point', 'ParameterSampler', 'RandomizedSearchCV',
+           'RandomizedSearchCluster']
 
 
 class ParameterGrid(object):
+
     """Grid of parameters with a discrete number of values for each.
 
     Can be used to iterate over parameter value combinations with the
@@ -158,6 +162,7 @@ class ParameterGrid(object):
 
 
 class ParameterSampler(object):
+
     """Generator on parameters sampled from given distributions.
 
     Non-deterministic iterable over random candidate combinations for hyper-
@@ -214,6 +219,7 @@ class ParameterSampler(object):
     ...                  {'b': 1.038159, 'a': 2}]
     True
     """
+
     def __init__(self, param_distributions, n_iter, random_state=None):
         self.param_distributions = param_distributions
         self.n_iter = n_iter
@@ -234,8 +240,8 @@ class ParameterSampler(object):
             if grid_size < self.n_iter:
                 raise ValueError(
                     "The total space of parameters %d is smaller "
-                    "than n_iter=%d." % (grid_size, self.n_iter)
-                    + " For exhaustive searches, use GridSearchCV.")
+                    "than n_iter=%d." % (grid_size, self.n_iter) +
+                    " For exhaustive searches, use GridSearchCV.")
             for i in sample_without_replacement(grid_size, self.n_iter,
                                                 random_state=rnd):
                 yield param_grid[i]
@@ -360,9 +366,31 @@ class _CVScoreTuple (namedtuple('_CVScoreTuple',
             self.parameters)
 
 
-class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
-                                      MetaEstimatorMixin)):
-    """Base class for hyper parameter search with cross-validation."""
+class _ScoreTuple (namedtuple('_ScoreTuple',
+                              ('parameters',
+                               'score'))):
+    # A raw namedtuple is very memory efficient as it packs the attributes
+    # in a struct to get rid of the __dict__ of attributes in particular it
+    # does not copy the string for the keys on each instance.
+    # By deriving a namedtuple class just to introduce the __repr__ method we
+    # would also reintroduce the __dict__ on the instance. By telling the
+    # Python interpreter that this subclass uses static __slots__ instead of
+    # dynamic attributes. Furthermore we don't need any additional slot in the
+    # subclass so we set __slots__ to the empty tuple.
+    __slots__ = ()
+
+    def __repr__(self):
+        """Simple custom repr to summarize the main info"""
+        return "mean: {0:.5f}, std: {1:.5f}, params: {2}".format(
+            self.mean_validation_score,
+            np.std(self.cv_validation_scores),
+            self.parameters)
+
+
+class BaseSearch(six.with_metaclass(ABCMeta, BaseEstimator,
+                                    MetaEstimatorMixin)):
+
+    """Base class for hyper parameter search."""
 
     @abstractmethod
     def __init__(self, estimator, scoring=None,
@@ -520,6 +548,456 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         """
         return self.best_estimator_.transform(Xt)
 
+
+class SearchClusterMixin(object):
+
+    """Adds unsupervised search to BaseSearch."""
+
+    def _fit(self, X, y=None, parameter_iterable=None):
+        """Draws heavily on the _fit method of BaseSearchCV.
+        """
+        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
+        estimator = self.estimator
+
+        grid_scores = list()
+        out = Parallel(n_jobs=1
+                       )(
+            delayed(fit_and_score_cluster)(clone(estimator),
+                                           X, scorer=self.scorer_,
+                                           verbose=self.verbose,
+                                           parameters=parameters,
+                                           fit_params=self.fit_params,
+                                           error_score=self.error_score)
+            for parameters in parameter_iterable)
+
+        for score, parameters, _time in out:
+            grid_scores.append(_ScoreTuple(parameters, score))
+
+        # Store the computed scores
+        self.grid_scores_ = grid_scores
+
+        # Find the best parameters by comparing on the score:
+        # note that `sorted` is deterministic in the way it breaks ties
+        best = sorted(grid_scores, key=lambda x: x.score,
+                      reverse=True)[0]
+
+        self.best_params_ = best.parameters
+        self.best_score_ = best.score
+
+        if self.refit:
+            # fit the best estimator using the entire dataset
+            # clone first to work around broken estimators
+            best_estimator = clone(estimator).set_params(
+                **best.parameters)
+            if y is not None:
+                best_estimator.fit(X, y=None, **self.fit_params)
+            else:
+                best_estimator.fit(X, **self.fit_params)
+            self.best_estimator_ = best_estimator
+        return self
+
+
+def fit_and_score_cluster(estimator, X, scorer, verbose, parameters,
+                          fit_params, y=None, error_score='raise'):
+    """Fit estimator and compute scores for a given dataset.
+
+    Parameters
+    ----------
+    estimator : estimator object implementing 'fit'
+        The object to use to fit the data.
+
+    X : array-like of shape at least 2D
+        The data to fit.
+
+        y : array-like, shape = [n_samples] or [n_samples, n_output], optional
+                Target relative to X for classification or regression;
+                None for unsupervised learning.
+
+    scorer : callable
+        A scorer callable object / function with signature
+        ``scorer(estimator, X, y)``.
+
+    verbose : integer
+        The verbosity level.
+
+    error_score : 'raise' (default) or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+
+    parameters : dict or None
+        Parameters to be set on the estimator.
+
+    fit_params : dict or None
+        Parameters that will be passed to ``estimator.fit``.
+
+    Returns
+    -------
+    score : float
+        Score on the data to fit.
+
+    parameters : dict or None, optional
+        The parameters that have been evaluated.
+
+    scoring_time : float
+        Time spent for fitting and scoring in seconds.
+
+    """
+    if parameters is not None:
+        estimator.set_params(**parameters)
+
+    start_time = time.time()
+
+    try:
+        estimator.fit(X, y, **fit_params)
+        score = scorer(estimator, X)
+    except Exception as e:
+        if error_score == 'raise':
+            raise
+        elif isinstance(error_score, numbers.Number):
+            warnings.warn("Clusterer score failed. "
+                          "The score will be set to %f. "
+                          "Details: \n%r" % (error_score, e), FitFailedWarning)
+
+            score = error_score
+        else:
+            raise ValueError("error_score must be the string 'raise' or a"
+                             " numeric value. (Hint: if using 'raise', please"
+                             " make sure that it has been spelled correctly.)"
+                             )
+    # TODO: Handle `verbose` level to produce output
+    scoring_time = time.time() - start_time
+
+    return score, parameters, scoring_time
+
+
+class GridSearchCluster(BaseSearch, SearchClusterMixin):
+
+    """Exhaustive search over specified parameter values for an estimator.
+
+    Important members are fit, predict.
+
+    GridSearch implements a "fit" and a "score" method.
+    It also implements "predict", "predict_proba", "decision_function",
+    "transform" and "inverse_transform" if they are implemented in the
+    estimator used.
+
+    The parameters of the estimator used to apply these methods are optimized
+    by grid-search over a parameter grid.
+
+    Read more in the :ref:`User Guide <grid_search>`.
+
+    Parameters
+    ----------
+    estimator : estimator object.
+        This is assumed to implement the scikit-learn estimator interface.
+        Either estimator needs to provide a ``score`` function,
+        or ``scoring`` must be passed.
+
+    param_grid : dict or list of dictionaries
+        Dictionary with parameters names (string) as keys and lists of
+        parameter settings to try as values, or a list of such
+        dictionaries, in which case the grids spanned by each dictionary
+        in the list are explored. This enables searching over any sequence
+        of parameter settings.
+
+    scoring : string, callable or None, default=None
+        A string (see model evaluation documentation) or
+        a scorer callable object / function with signature
+        ``scorer(estimator, X)``.
+        If ``None``, the ``score`` method of the estimator is used.
+
+    fit_params : dict, optional
+        Parameters to pass to the fit method.
+
+    n_jobs : int, default=1
+        Number of jobs to run in parallel.
+
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+
+            - An int, giving the exact number of total jobs that are
+              spawned
+
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    refit : boolean, default=True
+        Refit the best estimator with the entire dataset.
+        If "False", it is impossible to make predictions using
+        this GridSearchCV instance after fitting.
+
+    verbose : integer
+        Controls the verbosity: the higher, the more messages.
+
+    error_score : 'raise' (default) or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+
+
+    Examples
+    --------
+    # TODO: Add examples here
+
+
+    Attributes
+    ----------
+    grid_scores_ : list of named tuples
+        Contains scores for all parameter combinations in param_grid.
+        Each entry corresponds to one parameter setting.
+        Each named tuple has the attributes:
+
+            * ``parameters``, a dict of parameter settings
+            * ``score``, the score for the estimator
+
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score (or smallest loss if specified)
+        on the left out data. Not available if refit=False.
+
+    best_score_ : float
+        Score of best_estimator.
+
+    best_params_ : dict
+        Parameter setting that gave the best results.
+
+    scorer_ : function
+        Scorer function used to choose the best parameters for the model.
+
+    Notes
+    ------
+    The parameters selected are those that maximize the score, unless an
+    explicit score is passed in which case it is used instead.
+
+    If `n_jobs` was set to a value higher than one, the data is copied for each
+    point in the grid (and not `n_jobs` times). This is done for efficiency
+    reasons if individual jobs take very little time, but may raise errors if
+    the dataset is large and not enough memory is available.  A workaround in
+    this case is to set `pre_dispatch`. Then, the memory is copied only
+    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    n_jobs`.
+
+    See Also
+    ---------
+    :class:`ParameterGrid`:
+        generates all the combinations of a an hyperparameter grid.
+
+    :func:`sklearn.metrics.make_scorer`:
+        Make a scorer from a performance metric or loss function.
+
+    """
+
+    def __init__(self, estimator, param_grid, scoring=None, fit_params=None,
+                 n_jobs=1, refit=True, verbose=0,
+                 pre_dispatch='2*n_jobs', error_score='raise'):
+
+        super(GridSearchCluster, self).__init__(
+            estimator=estimator, scoring=scoring, fit_params=fit_params,
+            n_jobs=n_jobs, refit=refit, verbose=verbose,
+            pre_dispatch=pre_dispatch, error_score=error_score)
+        self.param_grid = param_grid
+        _check_param_grid(param_grid)
+
+    def fit(self, X, y=None):
+        """Run fit with all sets of parameters.
+
+        Parameters
+        ----------
+
+        X : array-like, shape = [n_samples, n_features]
+            Training vector, where n_samples is the number of samples and
+            n_features is the number of features.
+
+        y : array-like, shape = [n_samples] or [n_samples, n_output], optional
+            Target relative to X for classification or regression;
+            None for unsupervised learning.
+
+                        """
+        return self._fit(X, y, ParameterGrid(self.param_grid))
+
+
+class RandomizedSearchCluster(BaseSearch, SearchClusterMixin):
+
+    """Randomized search on hyper parameters.
+
+    RandomizedSearchCV implements a "fit" and a "score" method.
+    It also implements "predict", "predict_proba", "decision_function",
+    "transform" and "inverse_transform" if they are implemented in the
+    estimator used.
+
+    The parameters of the estimator used to apply these methods are optimized
+    by random search over parameter settings.
+
+    In contrast to GridSearchCluster, not all parameter values are tried out,
+    but rather a fixed number of parameter settings is sampled from the
+    specified distributions. The number of parameter settings that are tried
+    is given by n_iter.
+
+    If all parameters are presented as a list,
+    sampling without replacement is performed. If at least one parameter
+    is given as a distribution, sampling with replacement is used.
+    It is highly recommended to use continuous distributions for continuous
+    parameters.
+
+    Read more in the :ref:`User Guide <randomized_parameter_search>`.
+
+    Parameters
+    ----------
+    estimator : estimator object.
+        A object of that type is instantiated for each grid point.
+        This is assumed to implement the scikit-learn estimator interface.
+        Either estimator needs to provide a ``score`` function,
+        or ``scoring`` must be passed.
+
+    param_distributions : dict
+        Dictionary with parameters names (string) as keys and distributions
+        or lists of parameters to try. Distributions must provide a ``rvs``
+        method for sampling (such as those from scipy.stats.distributions).
+        If a list is given, it is sampled uniformly.
+
+    n_iter : int, default=10
+        Number of parameter settings that are sampled. n_iter trades
+        off runtime vs quality of the solution.
+
+    scoring : string, callable or None, default=None
+        A string (see model evaluation documentation) or
+        a scorer callable object / function with signature
+        ``scorer(estimator, X)``.
+        If ``None``, the ``score`` method of the estimator is used.
+
+    fit_params : dict, optional
+        Parameters to pass to the fit method.
+
+    n_jobs : int, default=1
+        Number of jobs to run in parallel.
+
+    pre_dispatch : int, or string, optional
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+
+            - An int, giving the exact number of total jobs that are
+              spawned
+
+            - A string, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    refit : boolean, default=True
+        Refit the best estimator with the entire dataset.
+        If "False", it is impossible to make predictions using
+        this RandomizedSearchCV instance after fitting.
+
+    verbose : integer
+        Controls the verbosity: the higher, the more messages.
+
+    random_state : int or RandomState
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
+
+    error_score : 'raise' (default) or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+
+    Attributes
+    ----------
+    grid_scores_ : list of named tuples
+        Contains scores for all parameter combinations in param_grid.
+        Each entry corresponds to one parameter setting.
+        Each named tuple has the attributes:
+
+            * ``parameters``, a dict of parameter settings
+            * ``score``, the score for the estimator
+
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score (or smallest loss if specified).
+        Not available if refit=False.
+
+    best_score_ : float
+        Score of best_estimator.
+
+    best_params_ : dict
+        Parameter setting that gave the best results.
+
+    Notes
+    -----
+    The parameters selected are those that maximize the score, according to the
+    scoring parameter.
+
+    If `n_jobs` was set to a value higher than one, the data is copied for each
+    parameter setting(and not `n_jobs` times). This is done for efficiency
+    reasons if individual jobs take very little time, but may raise errors if
+    the dataset is large and not enough memory is available.  A workaround in
+    this case is to set `pre_dispatch`. Then, the memory is copied only
+    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    n_jobs`.
+
+    See Also
+    --------
+    :class:`GridSearchCluster`:
+        Does exhaustive search over a grid of parameters.
+
+    :class:`ParameterSampler`:
+        A generator over parameter settins, constructed from
+        param_distributions.
+
+    """
+
+    def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
+                 fit_params=None, n_jobs=1, refit=True,
+                 verbose=0, pre_dispatch='2*n_jobs', random_state=None,
+                 error_score='raise'):
+
+        self.param_distributions = param_distributions
+        self.n_iter = n_iter
+        self.random_state = random_state
+        super(RandomizedSearchCluster, self).__init__(
+            estimator=estimator, scoring=scoring, fit_params=fit_params,
+            n_jobs=n_jobs, refit=refit, verbose=verbose,
+            pre_dispatch=pre_dispatch, error_score=error_score)
+
+    def fit(self, X, y=None):
+        """Run fit on the estimator with randomly drawn parameters.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+            Training vector, where n_samples in the number of samples and
+            n_features is the number of features.
+
+        y : array-like, shape = [n_samples] or [n_samples, n_output], optional
+            Target relative to X for classification or regression;
+            None for unsupervised learning.
+        """
+        sampled_params = ParameterSampler(self.param_distributions,
+                                          self.n_iter,
+                                          random_state=self.random_state)
+        return self._fit(X, y, sampled_params)
+
+
+class SearchCVMixin(object):
+
+    """Implements cross-validation for adding to BaseSearch."""
+
     def _fit(self, X, y, labels, parameter_iterable):
         """Actual fitting,  performing the search over parameters."""
 
@@ -606,7 +1084,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         return self
 
 
-class GridSearchCV(BaseSearchCV):
+class GridSearchCV(BaseSearch, SearchCVMixin):
+
     """Exhaustive search over specified parameter values for an estimator.
 
     Important members are fit, predict.
@@ -701,24 +1180,7 @@ class GridSearchCV(BaseSearchCV):
 
     Examples
     --------
-    >>> from sklearn import svm, datasets
-    >>> from sklearn.model_selection import GridSearchCV
-    >>> iris = datasets.load_iris()
-    >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> svr = svm.SVC()
-    >>> clf = GridSearchCV(svr, parameters)
-    >>> clf.fit(iris.data, iris.target)
-    ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    GridSearchCV(cv=None, error_score=...,
-           estimator=SVC(C=1.0, cache_size=..., class_weight=..., coef0=...,
-                         decision_function_shape=None, degree=..., gamma=...,
-                         kernel='rbf', max_iter=-1, probability=False,
-                         random_state=None, shrinking=True, tol=...,
-                         verbose=False),
-           fit_params={}, iid=..., n_jobs=1,
-           param_grid=..., pre_dispatch=..., refit=...,
-           scoring=..., verbose=...)
-
+    TODO: Add examples here.
 
     Attributes
     ----------
@@ -807,7 +1269,8 @@ class GridSearchCV(BaseSearchCV):
         return self._fit(X, y, labels, ParameterGrid(self.param_grid))
 
 
-class RandomizedSearchCV(BaseSearchCV):
+class RandomizedSearchCV(BaseSearch, SearchCVMixin):
+
     """Randomized search on hyper parameters.
 
     RandomizedSearchCV implements a "fit" and a "score" method.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1,69 +1,68 @@
 """Test the search module"""
 
 from collections import Iterable, Sized
-from sklearn.externals.six.moves import cStringIO as StringIO
-from sklearn.externals.six.moves import xrange
 from itertools import chain, product
+from sklearn.base import BaseEstimator
+from sklearn.base import ChangedBehaviorWarning
+from sklearn.cluster import KMeans
+from sklearn.datasets import make_blobs
+from sklearn.datasets import make_classification
+from sklearn.datasets import make_multilabel_classification
+from sklearn.metrics import f1_score
+from sklearn.metrics import silhouette_score
+from sklearn.metrics import make_scorer
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import GridSearchCV, GridSearchCluster
+from sklearn.model_selection import KFold
+from sklearn.model_selection import LabelKFold
+from sklearn.model_selection import LabelShuffleSplit
+from sklearn.model_selection import LeaveOneLabelOut
+from sklearn.model_selection import LeavePLabelOut
+from sklearn.model_selection import ParameterGrid
+from sklearn.model_selection import ParameterSampler
+from sklearn.model_selection import RandomizedSearchCV, RandomizedSearchCluster
+from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import StratifiedShuffleSplit
+from sklearn.model_selection._validation import FitFailedWarning
+from sklearn.neighbors import KernelDensity
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import Imputer
+from sklearn.svm import LinearSVC, SVC
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree import DecisionTreeRegressor
+from sklearn.utils.fixes import sp_version
+from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
+from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_false, assert_true
+from sklearn.utils.testing import assert_no_warnings
+from sklearn.utils.testing import assert_not_equal
+from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import ignore_warnings
 import pickle
 import sys
 
-import numpy as np
-import scipy.sparse as sp
-
-from sklearn.utils.fixes import sp_version
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_not_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_warns
-from sklearn.utils.testing import assert_raise_message
-from sklearn.utils.testing import assert_false, assert_true
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_no_warnings
-from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
-
 from scipy.stats import bernoulli, expon, uniform
 
+from sklearn.externals.six.moves import cStringIO as StringIO
+from sklearn.externals.six.moves import xrange
 from sklearn.externals.six.moves import zip
-from sklearn.base import BaseEstimator
-from sklearn.datasets import make_classification
-from sklearn.datasets import make_blobs
-from sklearn.datasets import make_multilabel_classification
+import numpy as np
+import scipy.sparse as sp
+from nose.tools import nottest
 
-from sklearn.model_selection import KFold
-from sklearn.model_selection import StratifiedKFold
-from sklearn.model_selection import StratifiedShuffleSplit
-from sklearn.model_selection import LeaveOneLabelOut
-from sklearn.model_selection import LeavePLabelOut
-from sklearn.model_selection import LabelKFold
-from sklearn.model_selection import LabelShuffleSplit
-from sklearn.model_selection import GridSearchCV
-from sklearn.model_selection import RandomizedSearchCV
-from sklearn.model_selection import ParameterGrid
-from sklearn.model_selection import ParameterSampler
 
 # TODO Import from sklearn.exceptions once merged.
-from sklearn.base import ChangedBehaviorWarning
-from sklearn.model_selection._validation import FitFailedWarning
-
-from sklearn.svm import LinearSVC, SVC
-from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.cluster import KMeans
-from sklearn.neighbors import KernelDensity
-from sklearn.metrics import f1_score
-from sklearn.metrics import make_scorer
-from sklearn.metrics import roc_auc_score
-from sklearn.preprocessing import Imputer
-from sklearn.pipeline import Pipeline
-
-
 # Neither of the following two estimators inherit from BaseEstimator,
 # to test hyperparameter search on user-defined classifiers.
 class MockClassifier(object):
+
     """Dummy classifier to test the parameter search algorithms"""
+
     def __init__(self, foo_param=0):
         self.foo_param = foo_param
 
@@ -93,8 +92,49 @@ class MockClassifier(object):
         return self
 
 
+class MockClusterer(object):
+
+    """Dummy clusterer to test the parameter search algorithms"""
+
+    def __init__(self, foo_param=0):
+        self.foo_param = foo_param
+
+    def fit(self, X, y=None):
+        self.labels_ = X
+        return self
+
+    def predict(self, T):
+        return T.shape[0]
+
+    predict_proba = predict
+    decision_function = predict
+    transform = predict
+
+    def score(self, X=None, y=None):
+        if self.foo_param > 1:
+            score = 1.
+        else:
+            score = 0.
+        return score
+
+    def get_params(self, deep=False):
+        return {'foo_param': self.foo_param}
+
+    def set_params(self, **params):
+        self.foo_param = params['foo_param']
+        return self
+
+
 class LinearSVCNoScore(LinearSVC):
+
     """An LinearSVC classifier that has no score method."""
+    @property
+    def score(self):
+        raise AttributeError
+
+class KMeansNoScore(KMeans):
+
+    """An KMeans clusterer that has no score method."""
     @property
     def score(self):
         raise AttributeError
@@ -168,6 +208,31 @@ def test_grid_search():
     assert_raises(ValueError, grid_search.fit, X, y)
 
 
+def test_grid_search_cluster():
+    # Test that the best estimator contains the right value for foo_param
+    clf = MockClusterer()
+    grid_search = GridSearchCluster(clf, {'foo_param': [1, 2, 3]}, verbose=3)
+    # make sure it selects the smallest parameter in case of ties
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    grid_search.fit(X)
+    sys.stdout = old_stdout
+    assert_equal(grid_search.best_estimator_.foo_param, 2)
+
+    for i, foo_i in enumerate([1, 2, 3]):
+        assert_true(grid_search.grid_scores_[i][0]
+                    == {'foo_param': foo_i})
+    # Smoke test the score etc:
+    grid_search.score(X)
+    grid_search.predict_proba(X)
+    grid_search.decision_function(X)
+    grid_search.transform(X)
+
+    # Test exception handling on scoring
+    grid_search.scoring = 'sklearn'
+    assert_raises(ValueError, grid_search.fit, X)
+
+
 @ignore_warnings
 def test_grid_search_no_score():
     # Test grid-search on classifier that has no score function.
@@ -190,6 +255,40 @@ def test_grid_search_no_score():
 
     # giving no scoring function raises an error
     grid_search_no_score = GridSearchCV(clf_no_score, {'C': Cs})
+    assert_raise_message(TypeError, "no scoring", grid_search_no_score.fit,
+                         [[1]])
+
+
+def silhouette_scorer(estimator, X, y=None):
+    return silhouette_score(X, estimator.labels_)
+
+ 
+@ignore_warnings
+def test_grid_search_cluster_no_score():
+    # Test grid-search on classifier that has no score function.
+    clf = KMeans(random_state=0)
+    X, y = make_blobs(random_state=0, centers=2)
+    n_clusters = [2, 3, 4]
+    clf_no_score = KMeansNoScore(random_state=0)
+    scorer = silhouette_scorer
+    grid_search = GridSearchCluster(clf, {'n_clusters': n_clusters},
+                                    scoring=scorer)
+    grid_search.fit(X)
+
+    grid_search_no_score = GridSearchCluster(clf_no_score, 
+                                             {'n_clusters': n_clusters},
+                                        scoring=scorer)
+    # smoketest grid search
+    grid_search_no_score.fit(X)
+
+    # check that best params are equal
+    assert_equal(grid_search_no_score.best_params_, grid_search.best_params_)
+    # check that we can call score and that it gives the correct result
+    assert_equal(grid_search.score(X), grid_search_no_score.score(X))
+
+    # giving no scoring function raises an error
+    grid_search_no_score = GridSearchCV(clf_no_score, 
+                                        {'n_clusters': n_clusters})
     assert_raise_message(TypeError, "no scoring", grid_search_no_score.fit,
                          [[1]])
 
@@ -265,11 +364,32 @@ def test_trivial_grid_scores():
     assert_true(hasattr(random_search, "grid_scores_"))
 
 
+def test_trivial_grid_scores_cluster():
+    # Test search over a "grid" with only one point.
+    # Non-regression test: grid_scores_ wouldn't be set by GridSearchCluster.
+    clf = MockClusterer()
+    grid_search = GridSearchCluster(clf, {'foo_param': [1]})
+    grid_search.fit(X)
+    assert_true(hasattr(grid_search, "grid_scores_"))
+
+    random_search = RandomizedSearchCluster(clf, {'foo_param': [0]}, n_iter=1)
+    random_search.fit(X)
+    assert_true(hasattr(random_search, "grid_scores_"))
+
+
 def test_no_refit():
     # Test that grid search can be used for model selection only
     clf = MockClassifier()
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, refit=False)
     grid_search.fit(X, y)
+    assert_true(hasattr(grid_search, "best_params_"))
+
+
+def test_no_refit_cluster():
+    # Test that grid search can be used for model selection only
+    clf = MockClusterer()
+    grid_search = GridSearchCluster(clf, {'foo_param': [1, 2, 3]}, refit=False)
+    grid_search.fit(X)
     assert_true(hasattr(grid_search, "best_params_"))
 
 
@@ -336,6 +456,21 @@ def test_grid_search_one_grid_point():
     assert_array_equal(clf.dual_coef_, cv.best_estimator_.dual_coef_)
 
 
+@nottest
+def test_grid_search_one_grid_point_cluster():
+    X_, y_ = make_blobs(random_state=0, centers=3)
+    param_dict = {"n_clusters": [3], "tol": [0.1]}
+
+    clf = KMeans()
+    cv = GridSearchCluster(clf, param_dict)
+    cv.fit(X_)
+
+    clf = KMeans(n_clusters=3, tol=0.1)
+    clf.fit(X_)
+    # TODO: Clusters are the same but with different label numbers. Why?
+    assert_array_equal(clf.labels_, cv.best_estimator_.labels_)
+
+
 def test_grid_search_bad_param_grid():
     param_dict = {"C": 1.0}
     clf = SVC()
@@ -348,6 +483,20 @@ def test_grid_search_bad_param_grid():
     param_dict = {"C": np.ones(6).reshape(3, 2)}
     clf = SVC()
     assert_raises(ValueError, GridSearchCV, clf, param_dict)
+
+
+def test_grid_search_bad_param_grid_cluster():
+    param_dict = {"n_clusters": 3}
+    clf = KMeans()
+    assert_raises(ValueError, GridSearchCluster, clf, param_dict)
+
+    param_dict = {"n_clusters": []}
+    clf = KMeans()
+    assert_raises(ValueError, GridSearchCluster, clf, param_dict)
+
+    param_dict = {"n_clusters": np.ones(6).reshape(3, 2)}
+    clf = KMeans()
+    assert_raises(ValueError, GridSearchCluster, clf, param_dict)
 
 
 def test_grid_search_sparse():
@@ -369,6 +518,27 @@ def test_grid_search_sparse():
 
     assert_true(np.mean(y_pred == y_pred2) >= .9)
     assert_equal(C, C2)
+
+
+def test_grid_search_cluster_sparse():
+    # Test that grid search works with both dense and sparse matrices
+    X_, y_ =  make_blobs(random_state=0, centers=3)
+
+    clf = KMeans()
+    clf = GridSearchCluster(clf, {'n_clusters': [2, 3]})
+    clf.fit(X_)
+    labels = clf.predict(X_)
+    n = clf.best_estimator_.n_clusters
+
+    X_ = sp.csr_matrix(X_)
+    clf = KMeans()
+    clf = GridSearchCluster(clf, {'n_clusters': [2, 3]})
+    clf.fit(X_.tocoo())
+    labels2 = clf.predict(X_)
+    n2 = clf.best_estimator_.n_clusters
+
+    assert_true(len(set(labels)) == len(set(labels2)))
+    assert_equal(n, n2)
 
 
 def test_grid_search_sparse_scoring():
@@ -454,6 +624,7 @@ def test_grid_search_precomputed_kernel_error_kernel_function():
 
 
 class BrokenClassifier(BaseEstimator):
+
     """Broken classifier that cannot be fit twice"""
 
     def __init__(self, parameter=None):
@@ -558,6 +729,17 @@ def test_unsupervised_grid_search():
     assert_equal(grid_search.best_params_["n_clusters"], 4)
 
 
+def test_unsupervised_grid_search_cluster():
+    # test grid-search with unsupervised estimator
+    X, _y = make_blobs(random_state=0)
+    clf = KMeans(random_state=0)
+
+    # Now without a score, and without y
+    grid_search = GridSearchCV(clf, param_grid=dict(n_clusters=[2, 3, 4]))
+    grid_search.fit(X)
+    assert_equal(grid_search.best_params_["n_clusters"], 4)
+
+
 def test_gridsearch_no_predict():
     # test grid-search with an estimator without predict.
     # slight duplication of a test from KDE
@@ -629,7 +811,7 @@ def test_randomized_search_grid_scores():
 
     # Check the consistency with the best_score_ and best_params_ attributes
     sorted_grid_scores = list(sorted(search.grid_scores_,
-                              key=lambda x: x.mean_validation_score))
+                                     key=lambda x: x.mean_validation_score))
     best_score = sorted_grid_scores[-1].mean_validation_score
     assert_equal(search.best_score_, best_score)
 
@@ -675,6 +857,19 @@ def test_pickle():
     random_search = RandomizedSearchCV(clf, {'foo_param': [1, 2, 3]},
                                        refit=True, n_iter=3)
     random_search.fit(X, y)
+    pickle.dumps(random_search)  # smoke test
+
+
+def test_pickle_cluster():
+    # Test that a fit search can be pickled
+    clf = MockClusterer()
+    grid_search = GridSearchCluster(clf, {'foo_param': [1, 2, 3]}, refit=True)
+    grid_search.fit(X)
+    pickle.dumps(grid_search)  # smoke test
+
+    random_search = RandomizedSearchCluster(clf, {'foo_param': [1, 2, 3]},
+                                       refit=True, n_iter=3)
+    random_search.fit(X)
     pickle.dumps(random_search)  # smoke test
 
 
@@ -740,6 +935,7 @@ def test_grid_search_allows_nans():
 
 
 class FailingClassifier(BaseEstimator):
+
     """Classifier that raises a ValueError on fit()"""
 
     FAILING_PARAMETER = 2
@@ -755,6 +951,17 @@ class FailingClassifier(BaseEstimator):
         return np.zeros(X.shape[0])
 
 
+class FailingClusterer(FailingClassifier):
+
+    """Clusterer that raises a ValueError on fit()"""
+
+    def fit(self, X, y=None):
+        if self.parameter == FailingClassifier.FAILING_PARAMETER:
+            raise ValueError("Failing classifier failed as required")
+
+        self.labels_ = self.predict(X)
+    
+    
 def test_grid_search_failing_classifier():
     # GridSearchCV with on_error != 'raise'
     # Ensures that a warning is raised and score reset where appropriate.
@@ -789,6 +996,41 @@ def test_grid_search_failing_classifier():
                FailingClassifier.FAILING_PARAMETER)
 
 
+def test_grid_search_failing_clusterer():
+    # GridSearchCluster with on_error != 'raise'
+    # Ensures that a warning is raised and score reset where appropriate.
+
+    X, _y = make_blobs(random_state=0, centers=3)
+
+    clf = FailingClusterer()
+
+    # refit=False because we only want to check that errors caused by fits
+    # will be caught and warnings raised instead. If refit was done, then an 
+    # exception would be raised on refit and not caught by grid_search 
+    # (expected behavior), and this would cause an error in this test.
+    gs = GridSearchCluster(clf, [{'parameter': [0, 1, 2]}], 
+                           scoring=silhouette_scorer, refit=False, 
+                           error_score=0.0)
+
+    assert_warns(FitFailedWarning, gs.fit, X)
+
+    # Ensure that grid scores were set to zero as required for those fits
+    # that are expected to fail.
+    assert all(np.all(this_point.score == 0.0)
+               for this_point in gs.grid_scores_
+               if this_point.parameters['parameter'] ==
+               FailingClusterer.FAILING_PARAMETER)
+
+    gs = GridSearchCluster(clf, [{'parameter': [0, 1, 2]}], 
+                           scoring=silhouette_scorer, refit=False, 
+                           error_score=float('nan'))
+    assert_warns(FitFailedWarning, gs.fit, X)
+    assert all(np.all(np.isnan(this_point.score))
+               for this_point in gs.grid_scores_
+               if this_point.parameters['parameter'] ==
+               FailingClusterer.FAILING_PARAMETER)
+
+
 def test_grid_search_failing_classifier_raise():
     # GridSearchCV with on_error == 'raise' raises the error
 
@@ -802,6 +1044,22 @@ def test_grid_search_failing_classifier_raise():
 
     # FailingClassifier issues a ValueError so this is what we look for.
     assert_raises(ValueError, gs.fit, X, y)
+
+
+def test_grid_search_failing_clusterer_raise():
+    # GridSearchCluster with on_error == 'raise' raises the error
+
+    X, _y = make_blobs(random_state=0, centers=3)
+
+    clf = FailingClusterer()
+
+    # refit=False because we want to test the behaviour of the grid search part
+    gs = GridSearchCluster(clf, [{'parameter': [0, 1, 2]}], 
+                           scoring=silhouette_scorer,
+                           refit=False, error_score='raise')
+
+    # FailingClassifier issues a ValueError so this is what we look for.
+    assert_raises(ValueError, gs.fit, X)
 
 
 def test_parameters_sampler_replacement():


### PR DESCRIPTION
This generalises `BaseSearchCV` as `BaseSearch` so that it can be used on unsupervised learning where cross-validation does not make sense. The approach is to use a pair of mixins, `SearchClusterMixin` and `SearchCVMixin` to add `_fit` methods appropriate to each type of search.

The existing `GridSearchCV` and `RandomizedSearchCV` inherit `BaseSearch` and `SearchCVMixin` while the new `GridSearchCluster` and `RandomizedSearchCluster` inherit `BaseSearch` and `SearchClusterMixin`.

See #6154 for a little more background.
