### PR TITLE
BestFirstTreeBuilder should ignore tree.max_depth

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -430,8 +430,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
             impurity = splitter.node_impurity()
 
         n_node_samples = end - start
-        is_leaf = ((depth > self.max_depth) or
-                   (n_node_samples < self.min_samples_split) or
+        is_leaf = ((n_node_samples < self.min_samples_split) or
                    (n_node_samples < 2 * self.min_samples_leaf) or
                    (weighted_n_node_samples < self.min_weight_leaf) or
                    (impurity <= MIN_IMPURITY_SPLIT))


### PR DESCRIPTION
According to the [documentation](http://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier), **max_depth** should be ignored when **max_leaf_nodes** is not None. But in the current release of scikit-learn it's not. 

I tracked down the problem to BestFirstTreeBuilder, whose [docstring](https://github.com/ceshine/scikit-learn/blob/a42b4e2154d137419b6b507c586240aa9c04b790/sklearn/tree/_tree.pyx#L285) states 

> NOTE: this TreeBuilder will ignore `tree.max_depth`

But in one of its methods **_add_split_node**, **self.max_depth** has been [referenced](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tree/_tree.pyx#L433) when trying to determine if a node is a leaf node.

I figure that condition should be removed to yield the right behaviour. Otherwise the documentation will need to be updated to avoid confusion. 
