### PR TITLE
Make sure that KFold indices are shuffled.

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -77,12 +77,14 @@ class _PartitionIterator(with_metaclass(ABCMeta)):
             raise ValueError("n must be an integer")
         self.n = int(n)
 
+        self.mask_idxs = np.arange(self.n)
+
     def __iter__(self):
-        ind = np.arange(self.n)
+
         for test_index in self._iter_test_masks():
             train_index = np.logical_not(test_index)
-            train_index = ind[train_index]
-            test_index = ind[test_index]
+            train_index = self.mask_idxs[train_index]
+            test_index = self.mask_idxs[test_index]
             yield train_index, test_index
 
     # Since subclasses must implement either _iter_test_masks or
@@ -323,10 +325,10 @@ class KFold(_BaseKFold):
     def __init__(self, n, n_folds=3, shuffle=False,
                  random_state=None):
         super(KFold, self).__init__(n, n_folds, shuffle, random_state)
-        self.idxs = np.arange(n)
+        self.mask_idxs = np.arange(n)
         if shuffle:
             rng = check_random_state(self.random_state)
-            rng.shuffle(self.idxs)
+            rng.shuffle(self.mask_idxs)
 
     def _iter_test_indices(self):
         n = self.n
@@ -336,7 +338,7 @@ class KFold(_BaseKFold):
         current = 0
         for fold_size in fold_sizes:
             start, stop = current, current + fold_size
-            yield self.idxs[start:stop]
+            yield self.mask_idxs[start:stop]
             current = stop
 
     def __repr__(self):

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -540,7 +540,7 @@ def test_predefinedsplit_with_kfold_split():
     folds = -1 * np.ones(10)
     kf_train = []
     kf_test = []
-    for i, (train_ind, test_ind) in enumerate(cval.KFold(10, 5, shuffle=True)):
+    for i, (train_ind, test_ind) in enumerate(cval.KFold(10, 5, shuffle=False)):
         kf_train.append(train_ind)
         kf_test.append(test_ind)
         folds[test_ind] = i
@@ -552,6 +552,20 @@ def test_predefinedsplit_with_kfold_split():
         ps_test.append(test_ind)
     assert_array_equal(ps_train, kf_train)
     assert_array_equal(ps_test, kf_test)
+
+
+def test_kfold_shuffle():
+
+    # Indices will be returned in ascending order whithout shuffling
+    for (train_idx, test_idx) in cval.KFold(10, 2, shuffle=False):
+        assert (train_idx == np.sort(train_idx)).all()
+        assert (test_idx == np.sort(test_idx)).all()
+
+    # But will be shuffled when shuffle=True
+    for (train_idx, test_idx) in cval.KFold(10, 2, shuffle=True,
+                                            random_state=10):
+        assert not (train_idx == np.sort(train_idx)).all()
+        assert not (test_idx == np.sort(test_idx)).all()
 
 
 def test_label_shuffle_split():


### PR DESCRIPTION
At the moment, KFold returns indices sorted in ascending order ([0, 2, 4...]) regardless of the shuffle setting. This commit fixes this and adds a test.

This may break existing tests that rely on this behaviour.
