### PR TITLE
[MRG] Fixed error in multiclass.py where it failed in multiple classes

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -259,7 +259,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             _partial_fit_binary)(self.estimators_[i],
             X, next(columns) if self.classes_[i] in
             self.label_binarizer_.classes_ else
-            np.zeros((1, len(y))))
+            np.zeros((1, len(y)), dtype=np.int)[0])
             for i in range(self.n_classes_))
 
         return self
@@ -408,11 +408,11 @@ def _partial_fit_ovo_binary(estimator, X, y, i, j):
 
     cond = np.logical_or(y == i, y == j)
     y = y[cond]
-    y_binary = np.zeros_like(y)
-    y_binary[y == j] = 1
-    ind = np.arange(X.shape[0])
-    return _partial_fit_binary(estimator, X[cond], y_binary)
-
+    if len(y) != 0:
+        y_binary = np.zeros_like(y)
+        y_binary[y == j] = 1
+        return _partial_fit_binary(estimator, X[cond], y_binary)
+    return estimator
 
 class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     """One-vs-one multiclass strategy

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -259,7 +259,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             _partial_fit_binary)(self.estimators_[i],
             X, next(columns) if self.classes_[i] in
             self.label_binarizer_.classes_ else
-            np.zeros((1, len(y)), dtype=np.int)[0])
+            np.zeros(len(y), dtype=np.int))
             for i in range(self.n_classes_))
 
         return self
@@ -513,6 +513,11 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
                                 range(self.n_classes_ *
                                 (self.n_classes_-1) // 2)]
 
+        # Check if mini-batch contains classes from self.classes_
+        if not set(self.classes_).issuperset(y):
+            raise ValueError("Mini-batch contains {0} while classes "
+                             "must be a subset of {1}".format(np.unique(y), 
+                                                          self.classes_))
         y = np.asarray(y)
         check_consistent_length(X, y)
         check_classification_targets(y)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -105,6 +105,14 @@ def test_ovr_partial_fit():
     assert_equal(len(ovr.estimators_), len(np.unique(iris.target)))
     assert_greater(np.mean(iris.target == pred), 0.65)
 
+    # Test for corner case, will fail unless issue #6202 is addressed
+    ovr = OneVsRestClassifier(SGDClassifier())
+    X = np.random.randn(10, 2)
+    ovr.partial_fit(X[:5], [0, 1, 2, 0, 1], [0, 1, 2])
+    ovr.partial_fit(X[5:], [0, 0, 0, 0, 0])
+    pred = ovr.predict(X)
+    assert_greater(np.mean(iris.target == pred), 0.65)
+
 
 def test_ovr_ovo_regressor():
     # test that ovr and ovo work on regressors which don't have a decision_function
@@ -488,6 +496,14 @@ def test_ovo_partial_fit_predict():
     assert_almost_equal(pred, pred2)
     assert_equal(len(ovo.estimators_), n_classes_digits * (n_classes_digits - 1) / 2)
     assert_greater(np.mean(y == pred), 0.65)
+
+    # This test fails for OvR, issue #6202 needs to be solved
+    ovo = OneVsOneClassifier(SGDClassifier())
+    X = np.random.randn(10, 2)
+    ovo.partial_fit(X[:5], [1, 1, 2, 1, 1], [0, 1, 2])
+    ovo.partial_fit(X[5:], [0, 0, 0, 0, 0])
+    pred = ovo.predict(X)
+    assert_greater(np.mean(np.array([0, 1, 2, 0, 1, 0, 0, 0, 0, 0]) == pred), 0.65)
 
 
 def test_ovo_decision_function():


### PR DESCRIPTION
Following up the recent PR #6087, implementing the feature of `partial_fit` in `OvO` and `OvR`, it contained logical error in tests(for which I am solely responsible) where it incorrectly tested for mini-batches, which doesn't contain all target classes.
Regardless I have addressed the issue here. @MechCoder @GaelVaroquaux please have a look! 
