### PR TITLE
[MRG+1] Much faster prediction with isotonic regression

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -99,6 +99,9 @@ Enhancements
      now accept score functions that take X, y as input and return only the scores.
      By `Nikolay Mayorov`_.
 
+   - Prediction of out-of-sample events with Isotonic Regression is now much
+     faster (over 1000x in tests with synthetic data). By `Jonathan Arfa`_.
+
 Bug fixes
 .........
 
@@ -139,6 +142,9 @@ API changes summary
 
    - ``residual_metric`` has been deprecated in :class:`linear_model.RANSACRegressor`.
      Use ``loss`` instead. By `Manoj Kumar`_.
+
+   - Access to public attributes ``.X_`` and ``.y_`` has been deprecated in
+     :class:`isotonic.IsotonicRegression`. By `Jonathan Arfa`_.
 
 
 .. _changes_0_17_1:
@@ -4071,3 +4077,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Andrea Bravi: https://github.com/AndreaBravi
 
 .. _Devashish Deshpande: https://github.com/dsquareindia
+
+.. _Jonathan Arfa: https://github.com/jarfa

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -98,9 +98,9 @@ def test_isotonic_regression():
 
 def test_isotonic_regression_ties_min():
     # Setup examples with ties on minimum
-    x = [0, 1, 1, 2, 3, 4, 5]
-    y = [0, 1, 2, 3, 4, 5, 6]
-    y_true = [0, 1.5, 1.5, 3, 4, 5, 6]
+    x = [1, 1, 2, 3, 4, 5]
+    y = [1, 2, 3, 4, 5, 6]
+    y_true = [1.5, 1.5, 3, 4, 5, 6]
 
     # Check that we get identical results for fit/transform and fit_transform
     ir = IsotonicRegression()


### PR DESCRIPTION
This change add an optional parameter to IsotonicRegression.fit(), fast_predict. Setting this to 'True' speeds up prediction by 3 orders of magnitude on my tests, doesn't have a meaningful effect on training time, and has no effect at all on the values that are predicted. 

Unless a user cares about storing the fitted values of the training data, it's an unqualified improvement. However, in order to avoid breaking legacy code that depends values like self.X_ and self.y_, I left the default value of fast_predict to False (in other words, no speedup).

This is my first contribution to sklearn, so please let me know if I need anything else to get this merged into master. Sample output from the examples/fast_isotonic.py script (also in this pull request) is below:

Training sample size: 100000
Prediction sample size: 100000
Training the old model took 0.03661 seconds.
Training the new model took 0.03391 seconds.
Predicting with the old model took 3.60884 seconds.
Predicting with the new model took 0.00439 seconds.
Maximum absolute difference between new and old predictions: 0.000000
