### PR TITLE
Added link to profile in whats_new.rst

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4053,3 +4053,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Andrea Bravi: https://github.com/AndreaBravi
 
+.. _Devashish Deshpande: https://github.com/dsquareindia
+


### PR DESCRIPTION
Sorry for forgetting to include it in #6182. Should link to my profile from [here](http://scikit-learn.org/dev/whats_new#bug-fixes).
