### PR TITLE
ENH: Add feature_names_ property to PolynomialFeatures

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1151,6 +1151,10 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         features is computed by iterating over all suitably sized combinations
         of input features.
 
+    feature_names_ : list, shape [n_input_features_]
+        Represents the names of input features
+        It is of the form ``['X1', 'X2', 'X3'...]``
+
     Notes
     -----
     Be aware that the number of features in the output array scales
@@ -1171,6 +1175,11 @@ class PolynomialFeatures(BaseEstimator, TransformerMixin):
         start = int(not include_bias)
         return chain.from_iterable(comb(range(n_features), i)
                                    for i in range(start, degree + 1))
+
+    @property
+    def feature_names_(self):
+        features = ['X'+str(i+1) for i in range(degree)]
+        return features
 
     @property
     def powers_(self):


### PR DESCRIPTION
Added the property of `feature_names_` for `PolynomialFeatures` in `preprocessing`. See issue #6185. I am not totally sure this is the expected solution. Please let me know if something else needs to be done. Thanks.
