### PR TITLE
[MRG + 1] classification_report format supports long string labels

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -27,7 +27,6 @@ import numpy as np
 
 from scipy.sparse import coo_matrix
 from scipy.sparse import csr_matrix
-from scipy.spatial.distance import hamming as sp_hamming
 
 from ..preprocessing import LabelBinarizer, label_binarize
 from ..preprocessing import LabelEncoder
@@ -640,7 +639,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
     References
     ----------
-    .. [1] `Wikipedia entry for the F1-score <http://en.wikipedia.org/wiki/F1_score>`_
+    .. [1] `Wikipedia entry for the F1-score
+            <http://en.wikipedia.org/wiki/F1_score>`_
 
     Examples
     --------
@@ -1386,11 +1386,9 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     last_line_heading = 'avg / total'
 
     if target_names is None:
-        width = len(last_line_heading)
         target_names = ['%s' % l for l in labels]
-    else:
-        width = max(len(cn) for cn in target_names)
-        width = max(width, len(last_line_heading), digits)
+    name_width = max(len(cn) for cn in target_names)
+    width = max(name_width, len(last_line_heading), digits)
 
     headers = ["precision", "recall", "f1-score", "support"]
     fmt = '%% %ds' % width  # first column: class name
@@ -1508,8 +1506,10 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
         weight_average = np.mean(sample_weight)
 
     if y_type.startswith('multilabel'):
-        n_differences = count_nonzero(y_true - y_pred, sample_weight=sample_weight)
-        return (n_differences / (y_true.shape[0] * len(classes) * weight_average))
+        n_differences = count_nonzero(y_true - y_pred,
+                                      sample_weight=sample_weight)
+        return (n_differences /
+                (y_true.shape[0] * len(classes) * weight_average))
 
     elif y_type in ["binary", "multiclass"]:
         return _weighted_sum(y_true != y_pred, sample_weight, normalize=True)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -669,6 +669,27 @@ avg / total       0.51      0.53      0.47        75
         assert_equal(report, expected_report)
 
 
+def test_classification_report_multiclass_with_long_string_label():
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    labels = np.array(["blue", "green"*5, "red"])
+    y_true = labels[y_true]
+    y_pred = labels[y_pred]
+
+    expected_report = """\
+                           precision    recall  f1-score   support
+
+                     blue       0.83      0.79      0.81        24
+greengreengreengreengreen       0.33      0.10      0.15        31
+                      red       0.42      0.90      0.57        20
+
+              avg / total       0.51      0.53      0.47        75
+"""
+
+    report = classification_report(y_true, y_pred)
+    assert_equal(report, expected_report)
+
+
 def test_multilabel_classification_report():
     n_classes = 4
     n_samples = 50


### PR DESCRIPTION
Here's an improvement to the `sklearn.metrics.classification_report` output when `y_true` and `y_pred` args contain long\* string labels.

Assumption: no `target_names` arg is provided

*long in this case meaning having a length greater than the default row-title string (currently  "avg / total ") which appears in the last row of the report

**Demo:**

``` python
from __future__ import print_function
from sklearn.metrics.classification import classification_report

output = classification_report(['a', 'b'*20, 'a'], ['b'*20, 'b'*20, 'a'])
print(output)
```

before format enhancement:

```
             precision    recall  f1-score   support

          a       1.00      0.50      0.67         2
bbbbbbbbbbbbbbbbbbbb       0.50      1.00      0.67         1

avg / total       0.83      0.67      0.67         3
```

after format enhancement:

```
                      precision    recall  f1-score   support

                   a       1.00      0.50      0.67         2
bbbbbbbbbbbbbbbbbbbb       0.50      1.00      0.67         1

         avg / total       0.83      0.67      0.67         3
```

**Classification test cases:**

```
nosetests sklearn/metrics/tests/test_classification.py
```
