### PR TITLE
MAINT: Print info message for fetch_20newsgroups

### DIFF
--- a/sklearn/datasets/twenty_newsgroups.py
+++ b/sklearn/datasets/twenty_newsgroups.py
@@ -219,6 +219,7 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
 
     if cache is None:
         if download_if_missing:
+            print('Downloading 20news dataset. This may take a few minutes.')
             cache = download_20newsgroups(target_dir=twenty_home,
                                           cache_path=cache_path)
         else:


### PR DESCRIPTION
Minor change to give a simple message to inform the user about downloading the dataset and that it is going to take some time. See issue #1346 . I have added the message when there is no cache copy and when it downloads a new one. Please let me know if something more is expected here. Thanks.
