### PR TITLE
[MRG+1] Fix reading of Bunch pickles that have been generated with scikit-learn < 0.17

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -158,6 +158,13 @@ Bug fixes
       on datasets larger than 1MB:
       https://github.com/joblib/joblib/blob/0.9.4/CHANGES.rst
 
+    - Fixed reading of Bunch pickles generated with scikit-learn
+      version <= 0.16. This can affect users who have already
+      downloaded a dataset with scikit-learn 0.16 and are loading it
+      with scikit-learn 0.17. See `#6196
+      <https://github.com/scikit-learn/scikit-learn/issues/6196>`_ for
+      how this affected :func:`datasets.fetch_20newsgroups`. By `Loic
+      Esteve`_.
 
 .. _changes_0_17:
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -57,8 +57,16 @@ class Bunch(dict):
         except KeyError:
             raise AttributeError(key)
 
-    def __getstate__(self):
-        return self.__dict__
+    def __setstate__(self, state):
+        # Bunch pickles generated with scikit-learn 0.16.* have an non
+        # empty __dict__. This causes a surprising behaviour when
+        # loading these pickles scikit-learn 0.17: reading bunch.key
+        # uses __dict__ but assigning to bunch.key use __setattr__ and
+        # only changes bunch['key']. More details can be found at:
+        # https://github.com/scikit-learn/scikit-learn/issues/6196.
+        # Overriding __setstate__ to be a noop has the effect of
+        # ignoring the pickled __dict__
+        pass
 
 
 def get_data_home(data_home=None):

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -202,3 +202,24 @@ def test_loads_dumps_bunch():
     bunch_from_pkl = loads(dumps(bunch))
     bunch_from_pkl.x = "y"
     assert_equal(bunch_from_pkl['x'], bunch_from_pkl.x)
+
+
+def test_bunch_pickle_generated_with_0_16_and_read_with_0_17():
+    bunch = Bunch(key='original')
+    # This reproduces a problem when Bunch pickles have been created
+    # with scikit-learn 0.16 and are read with 0.17. Basically there
+    # is a suprising behaviour because reading bunch.key uses
+    # bunch.__dict__ (which is non empty for 0.16 Bunch objects)
+    # whereas assigning into bunch.key uses bunch.__setattr__. See
+    # https://github.com/scikit-learn/scikit-learn/issues/6196 for
+    # more details
+    bunch.__dict__['key'] = 'set from __dict__'
+    bunch_from_pkl = loads(dumps(bunch))
+    # After loading from pickle the __dict__ should have been ignored
+    assert_equal(bunch_from_pkl.key, 'original')
+    assert_equal(bunch_from_pkl['key'], 'original')
+    # Making sure that changing the attr does change the value
+    # associated with __getitem__ as well
+    bunch_from_pkl.key = 'changed'
+    assert_equal(bunch_from_pkl.key, 'changed')
+    assert_equal(bunch_from_pkl['key'], 'changed')


### PR DESCRIPTION
Fix #6196.
