### PR TITLE
Fix for OvR partial_fit in various edge cases

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -47,7 +47,8 @@ from .utils.validation import _num_samples
 from .utils.validation import check_consistent_length
 from .utils.validation import check_is_fitted
 from .utils.multiclass import (_check_partial_fit_first_call,
-                               check_classification_targets)
+                               check_classification_targets,
+                               type_of_target)
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
 from .externals.six.moves import zip as izip
@@ -250,16 +251,25 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         # outperform or match a dense label binarizer in all cases and has also
         # resulted in less or equal memory consumption in the fit_ovr function
         # overall.
+        if not set(self.classes_).issuperset(y):
+            raise ValueError("Mini-batch contains {0} while classes "
+                             "must be subset of {1}".format(np.unique(y),
+                                                    self.classes_))
         self.label_binarizer_ = LabelBinarizer(sparse_output=True)
         Y = self.label_binarizer_.fit_transform(y)
         Y = Y.tocsc()
-        columns = (col.toarray().ravel() for col in Y.T)
-
+        Y = Y.T.toarray()
+        if len(self.label_binarizer_.classes_) == 2:
+            # The sparse output gives a single array, but we require
+            # two as we have to train two estimator
+            Y = np.array(((Y[0]-1)*-1, Y[0]))
+        columns = (col.ravel() for col in Y)
+        
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(delayed(
             _partial_fit_binary)(self.estimators_[i],
             X, next(columns) if self.classes_[i] in
             self.label_binarizer_.classes_ else
-            np.zeros((1, len(y))))
+            np.zeros(len(y), dtype=np.int))
             for i in range(self.n_classes_))
 
         return self
@@ -285,7 +295,12 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             thresh = .5
 
         n_samples = _num_samples(X)
-        if self.label_binarizer_.y_type_ == "multiclass":
+        # In case mini-batches from partial_fit contains binary classes, 
+        # but `type_of_target(y) == 'multiclass'`, it won't go to the
+        # else part.
+        if ((self.label_binarizer_.y_type_ == 'multiclass' or 
+        self.label_binarizer_.y_type_ == 'binary') and
+        type_of_target(self.classes_) != 'binary'):
             maxima = np.empty(n_samples, dtype=float)
             maxima.fill(-np.inf)
             argmaxima = np.zeros(n_samples, dtype=int)


### PR DESCRIPTION
There are many corner cases when not all classes are present in `partial_fit` call that needs to be addressed.
- [x] `partial_fit` works perfectly fine in cases where `target classes` are present in each mini-batch iteration. Although when some `classes` are missing in some mini batch, `ovr.predict(X)` gives unpredictable results.

``` python
X = np.random.randn(14, 2)
y = [0, 0, 1, 1, 2, 3, 3, 0, 1, 2, 3, 0, 2, 3]
ovr = OneVsRestClassifier(SGDClassifier())
ovr.partial_fit(X[:7], y[:7], np.unique(y))
ovr.partial_fit(X[7:], y[7:])
pred = ovr.predict(X)
ovr1 = OneVsRestClassifier(SGDClassifier())
pred1 = ovr1.fit(X, y).predict(X)

In [46]: np.mean(pred==y)
Out[46]: 0.35714285714285715

In [47]: np.mean(pred1==y)
Out[47]: 0.5
```

I think they should give the same result, like they do when all `target classes` are present in each iteration of mini-batch.
- [x] When mini-batch contain binary classes but all classes are not binary, `ovr.predict(X)` will give an error as `self.label_binarizer_.y_type_` is not `multiclass`. 

``` python
ovr = OneVsRestClassifier(SGDClassifier())
X, y = iris.data, iris.target
ovr.partial_fit(X[:60], y[:60], np.unique(y))
ovr.partial_fit(X[60:], y[60:])
In [54]: pred = ovr.predict(X)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-54-48d087b7f7f3> in <module>()
----> 1 pred = ovr.predict(X)

/home/kaichogami/codes/development_scikit-learn/scikit-learn/sklearn/multiclass.py in predict(self, X)
    307             indicator = sp.csc_matrix((data, indices, indptr),
    308                                       shape=(n_samples, len(self.estimators_)))
--> 309             return self.label_binarizer_.inverse_transform(indicator)
    310 
    311     def predict_proba(self, X):

/home/kaichogami/codes/development_scikit-learn/scikit-learn/sklearn/preprocessing/label.pyc in inverse_transform(self, Y, threshold)
    369         else:
    370             y_inv = _inverse_binarize_thresholding(Y, self.y_type_,
--> 371                                                    self.classes_, threshold)
    372 
    373         if self.sparse_input_:

/home/kaichogami/codes/development_scikit-learn/scikit-learn/sklearn/preprocessing/label.pyc in _inverse_binarize_thresholding(y, output_type, classes, threshold)
    582     if output_type == "binary" and y.ndim == 2 and y.shape[1] > 2:
    583         raise ValueError("output_type='binary', but y.shape = {0}".
--> 584                          format(y.shape))
    585 
    586     if output_type != "binary" and y.shape[1] != len(classes):

ValueError: output_type='binary', but y.shape = (150, 3)
```
- [ ] When mini-batch contain only one class. 

``` python
ovr.partial_fit(X[:20], y[:20], np.unique(y))
/home/kaichogami/codes/development_scikit-learn/scikit-learn/sklearn/multiclass.py in partial_fit(self, X, y, classes)
    253         self.label_binarizer_ = LabelBinarizer(sparse_output=True)
    254         Y = self.label_binarizer_.fit_transform(y)
--> 255         Y = Y.tocsc()
    256         Y = Y.T.toarray()
    257         if len(self.label_binarizer_.classes_) == 2:

AttributeError: 'numpy.ndarray' object has no attribute 'toc
```

This will be resolved once #6202 is solved.

Solving the first issue here takes priority, and I am unable to figure out where it goes wrong. 
@MechCoder 
