### PR TITLE
[MRG] DOC: Fix typo in LDA parameter's doc

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -193,7 +193,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
 
     evaluate_every : int optional (default=0)
         How often to evaluate perplexity. Only used in `fit` method.
-        set it to 0 or and negative number to not evalute perplexity in
+        set it to 0 or negative number to not evalute perplexity in
         training at all. Evaluating perplexity can help you check convergence
         in training process, but it will also increase total training time.
         Evaluating perplexity in every iteration might increase training time


### PR DESCRIPTION
I've removed redundant "and" in parameter `evaluate_every`'s doc string.

Can @agramfort @GaelVaroquaux @ogrisel please review this?
Thanks!
