### PR TITLE
[MRG] BUG: fix pickling of DistanceMetric instances (fixes #6269)

### DIFF
--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -242,7 +242,7 @@ cdef class DistanceMetric:
             self.kwargs = state[4]
         self.vec_ptr = get_vec_ptr(self.vec)
         self.mat_ptr = get_mat_ptr(self.mat)
-        self.size = 1
+        self.size = self.vec.shape[0]
 
     @classmethod
     def get_metric(cls, metric, **kwargs):
@@ -644,6 +644,9 @@ cdef class MahalanobisDistance(DistanceMetric):
     """
     def __init__(self, V=None, VI=None):
         if VI is None:
+            if V is None:
+                raise ValueError("Must provide either V or VI "
+                                 "for Mahalanobis distance")
             VI = np.linalg.inv(V)
         if VI.ndim != 2 or VI.shape[0] != VI.shape[1]:
             raise ValueError("V/VI must be square")

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -104,6 +104,30 @@ class TestMetrics:
         D12 = dm.pairwise(self.X1_bool)
         assert_array_almost_equal(D12, D_true)
 
+    def test_pickle(self):
+        for metric, argdict in self.metrics.items():
+            keys = argdict.keys()
+            for vals in itertools.product(*argdict.values()):
+                kwargs = dict(zip(keys, vals))
+                yield self.check_pickle, metric, kwargs
+
+        for metric in self.bool_metrics:
+            yield self.check_pickle_bool, metric
+
+    def check_pickle_bool(self, metric):
+        dm = DistanceMetric.get_metric(metric)
+        D1 = dm.pairwise(self.X1_bool)
+        dm2 = pickle.loads(pickle.dumps(dm))
+        D2 = dm2.pairwise(self.X1_bool)
+        assert_array_almost_equal(D1, D2)
+
+    def check_pickle(self, metric, kwargs):
+        dm = DistanceMetric.get_metric(metric, **kwargs)
+        D1 = dm.pairwise(self.X1)
+        dm2 = pickle.loads(pickle.dumps(dm))
+        D2 = dm2.pairwise(self.X1)
+        assert_array_almost_equal(D1, D2)
+
 
 def test_haversine_metric():
     def haversine_slow(x1, x2):


### PR DESCRIPTION
This fixes an issue when pickling & unpickling DistanceMetric objects (and by extension, nearest neighbors methods that use them).
