### PR TITLE
 [MRG+1] Added LatentDirichletAllocation to the "Incremental learning" page

### DIFF
--- a/doc/modules/scaling_strategies.rst
+++ b/doc/modules/scaling_strategies.rst
@@ -4,16 +4,16 @@
 Strategies to scale computationally: bigger data
 =================================================
 
-For some applications the amount of examples, features (or both) and/or the 
-speed at which they need to be processed are challenging for traditional 
-approaches. In these cases scikit-learn has a number of options you can 
-consider to make your system scale. 
+For some applications the amount of examples, features (or both) and/or the
+speed at which they need to be processed are challenging for traditional
+approaches. In these cases scikit-learn has a number of options you can
+consider to make your system scale.
 
 Scaling with instances using out-of-core learning
 =================================================
 
 Out-of-core (or "external memory") learning is a technique used to learn from
-data that cannot fit in a computer's main memory (RAM). 
+data that cannot fit in a computer's main memory (RAM).
 
 Here is sketch of a system designed to achieve this goal:
 
@@ -24,21 +24,21 @@ Here is sketch of a system designed to achieve this goal:
 Streaming instances
 -------------------
 Basically, 1. may be a reader that yields instances from files on a
-hard drive, a database, from a network stream etc. However, 
+hard drive, a database, from a network stream etc. However,
 details on how to achieve this are beyond the scope of this documentation.
 
 Extracting features
 -------------------
-\2. could be any relevant way to extract features among the 
+\2. could be any relevant way to extract features among the
 different :ref:`feature extraction <feature_extraction>` methods supported by
-scikit-learn. However, when working with data that needs vectorization and 
-where the set of features or values is not known in advance one should take 
+scikit-learn. However, when working with data that needs vectorization and
+where the set of features or values is not known in advance one should take
 explicit care. A good example is text classification where unknown terms are
-likely to be found during training. It is possible to use a statefull 
+likely to be found during training. It is possible to use a statefull
 vectorizer if making multiple passes over the data is reasonable from an
 application point of view. Otherwise, one can turn up the difficulty by using
 a stateless feature extractor. Currently the preferred way to do this is to
-use the so-called :ref:`hashing trick<feature_hashing>` as implemented by 
+use the so-called :ref:`hashing trick<feature_hashing>` as implemented by
 :class:`sklearn.feature_extraction.FeatureHasher` for datasets with categorical
 variables represented as list of Python dicts or
 :class:`sklearn.feature_extraction.text.HashingVectorizer` for text documents.
@@ -48,10 +48,10 @@ Incremental learning
 Finally, for 3. we have a number of options inside scikit-learn. Although all
 algorithms cannot learn incrementally (i.e. without seeing all the instances
 at once), all estimators implementing the ``partial_fit`` API are candidates.
-Actually, the ability to learn incrementally from a mini-batch of instances 
+Actually, the ability to learn incrementally from a mini-batch of instances
 (sometimes called "online learning") is key to out-of-core learning as it
 guarantees that at any given time there will be only a small amount of
-instances in the main memory. Choosing a good size for the mini-batch that 
+instances in the main memory. Choosing a good size for the mini-batch that
 balances relevancy and memory footprint could involve some tuning [1]_.
 
 Here is a list of incremental estimators for different tasks:
@@ -70,6 +70,7 @@ Here is a list of incremental estimators for different tasks:
   - Decomposition / feature Extraction
       + :class:`sklearn.decomposition.MiniBatchDictionaryLearning`
       + :class:`sklearn.decomposition.IncrementalPCA`
+      + :class:`sklearn.decomposition.LatentDirichletAllocation`
       + :class:`sklearn.cluster.MiniBatchKMeans`
 
 For classification, a somewhat important thing to note is that although a
@@ -105,7 +106,7 @@ algorithms with the number of processed examples.
 Now looking at the computation time of the different parts, we see that the
 vectorization is much more expensive than learning itself. From the different
 algorithms, ``MultinomialNB`` is the most expensive, but its overhead can be
-mitigated by increasing the size of the mini-batches (exercise: change 
+mitigated by increasing the size of the mini-batches (exercise: change
 ``minibatch_size`` to 100 and 10000 in the program and compare).
 
 .. |computation_time| image::  ../auto_examples/applications/images/plot_out_of_core_classification_003.png
@@ -120,6 +121,6 @@ Notes
 
 .. [1] Depending on the algorithm the mini-batch size can influence results or
        not. SGD*, PassiveAggressive*, and discrete NaiveBayes are truly online
-       and are not affected by batch size. Conversely, MiniBatchKMeans 
+       and are not affected by batch size. Conversely, MiniBatchKMeans
        convergence rate is affected by the batch size. Also, its memory
        footprint can vary dramatically with batch size.


### PR DESCRIPTION
Since the `LatentDirichletAllocation` has a `partial_fit` method now, I thought it should be added to the "incremental learning page" at http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning
