### PR TITLE
[MRG] Add error message when X passed to silhouette score is 1d (fixes #6190)

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -8,6 +8,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises_regexp
+from sklearn.utils.testing import assert_raise_message
 
 
 def test_silhouette():
@@ -50,6 +51,16 @@ def test_no_nan():
     D = np.random.RandomState(0).rand(len(labels), len(labels))
     silhouette = silhouette_score(D, labels, metric='precomputed')
     assert_false(np.isnan(silhouette))
+
+
+def test_correct_Xsize():
+    random_state = np.random.RandomState(seed=0)
+    random_clusters = random_state.rand(10)
+    random_clusters2 = random_state.rand(10)
+
+    assert_raise_message(ValueError,
+                         'X must not be 1D: shape is %r' % (random_clusters.shape,),
+                         silhouette_score, random_clusters, random_clusters2)
 
 
 def test_correct_labelsize():

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ...utils import check_random_state
 from ...utils import check_X_y
+from ...utils import check_array
 from ..pairwise import pairwise_distances
 from ...preprocessing import LabelEncoder
 
@@ -81,6 +82,9 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <http://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
+    X = np.asarray(X)
+    if X.ndim == 1:
+        raise ValueError("X must not be 1D: shape is %r" % (X.shape,))
     X, labels = check_X_y(X, labels)
     le = LabelEncoder()
     labels = le.fit_transform(labels)


### PR DESCRIPTION
I've added an error message to tell user that first argument passed into `silhouette_score` cannot be 1d.

Solve #6190 
Can @amueller please review this?
