### PR TITLE
[MRG + 1] BUG: remove checks from PyFunc distance metric (fixes #6287)

### DIFF
--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -1091,17 +1091,6 @@ cdef class PyFuncDistance(DistanceMetric):
     """
     def __init__(self, func, **kwargs):
         self.func = func
-        x = np.random.random(10)
-        try:
-            d = self.func(x, x, **kwargs)
-        except TypeError:
-            raise ValueError("func must be a callable taking two arrays")
-
-        try:
-            d = float(d)
-        except TypeError:
-            raise ValueError("func must return a float")
-
         self.kwargs = kwargs
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -1100,7 +1100,13 @@ cdef class PyFuncDistance(DistanceMetric):
         with gil:
             x1arr = _buffer_to_ndarray(x1, size)
             x2arr = _buffer_to_ndarray(x2, size)
-            return self.func(x1arr, x2arr, **self.kwargs)
+            d = self.func(x1arr, x2arr, **self.kwargs)
+            try:
+                return d
+            except TypeError:
+                raise TypeError("Custom distance function must accept two "
+                                "vectors and return a float.")
+            
 
 
 cdef inline double fmax(double a, double b) nogil:

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -1102,6 +1102,8 @@ cdef class PyFuncDistance(DistanceMetric):
             x2arr = _buffer_to_ndarray(x2, size)
             d = self.func(x1arr, x2arr, **self.kwargs)
             try:
+                # Cython generates code here that results in a TypeError
+                # if d is the wrong type.
                 return d
             except TypeError:
                 raise TypeError("Custom distance function must accept two "

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -177,16 +177,6 @@ def test_bad_pyfunc_metric():
         return "1"
 
     X = np.ones((5, 2))
-    assert_raises_regex(TypeError, "a float is required",
-                        BallTree, X, metric=wrong_distance)
-
-
-def test_bad_pyfunc_metric():
-    def wrong_distance(x, y):
-        return "1"
-
-    X = np.ones((5, 2))
-
     assert_raises_regex(TypeError,
                         "Custom distance function must accept two vectors",
                         BallTree, X, metric=wrong_distance)

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -2,11 +2,12 @@ import itertools
 import pickle
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_raises_regex
 
 import scipy
 from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
+from sklearn.neighbors import BallTree
 from sklearn.utils.testing import SkipTest
 
 
@@ -169,3 +170,38 @@ def test_pyfunc_metric():
 
     assert_array_almost_equal(D1, D2)
     assert_array_almost_equal(D1_pkl, D2_pkl)
+
+
+def test_bad_pyfunc_metric():
+    def wrong_distance(x, y):
+        return "1"
+
+    X = np.ones((5, 2))
+    assert_raises_regex(TypeError, "a float is required",
+                        BallTree, X, metric=wrong_distance)
+
+
+def test_bad_pyfunc_metric():
+    def wrong_distance(x, y):
+        return "1"
+
+    X = np.ones((5, 2))
+
+    assert_raises_regex(TypeError,
+                        "Custom distance function must accept two vectors",
+                        BallTree, X, metric=wrong_distance)
+
+
+def test_input_data_size():
+    # Regression test for #6288
+    # Previoulsly, a metric requiring a particular input dimension would fail
+    def custom_metric(x, y):
+        assert x.shape[0] == 3
+        return np.sum((x - y) ** 2)
+
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 3)
+
+    pyfunc = DistanceMetric.get_metric("pyfunc", func=dist_func, p=2)
+    eucl = DistanceMetric.get_metric("euclidean")
+    assert_array_almost_equal(pyfunc.pairwise(X), eucl.pairwise(X))

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -2,13 +2,13 @@ import itertools
 import pickle
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_raises_regex
+from numpy.testing import assert_array_almost_equal
 
 import scipy
 from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.neighbors import BallTree
-from sklearn.utils.testing import SkipTest
+from sklearn.utils.testing import SkipTest, assert_raises_regex
 
 
 def dist_func(x1, x2, p):


### PR DESCRIPTION
This check makes too many assumptions about the user-defined distance, and should probably be removed. (fixes #6287)
