### PR TITLE
[MRG + 1] Adding Python 3 tkinter compatibility to svm_gui.py example

### DIFF
--- a/examples/applications/svm_gui.py
+++ b/examples/applications/svm_gui.py
@@ -29,7 +29,11 @@ from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg
 from matplotlib.figure import Figure
 from matplotlib.contour import ContourSet
 
-import Tkinter as Tk
+try:
+    import Tkinter as Tk    #works on Python 2
+except ImportError:
+    import tkinter as Tk    #works on Python 3
+
 import sys
 import numpy as np
 


### PR DESCRIPTION
```
modified:   examples/applications/svm_gui.py
```

For some reason, the Tkinter package is not compatible with Python 3.

```
try:
        import Tkinter as Tk #works with Python 2
except ImportError:
    import tkinter as Tk #works with Python 3
```

 I added in an additional import statement to add compatibility
