### PR TITLE
[MRG] Fix check_cv error message

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1359,7 +1359,7 @@ def check_cv(cv=3, y=None, classifier=False):
         if not isinstance(cv, Iterable) or isinstance(cv, str):
             raise ValueError("Expected cv as an integer, cross-validation "
                              "object (from sklearn.model_selection) "
-                             "or and iterable. Got %s." % cv)
+                             "or an iterable. Got %s." % cv)
         return _CVIterableWrapper(cv)
 
     return cv  # New style cv objects are passed without any modification


### PR DESCRIPTION
ValueError message in `check_cv` should be `or an iterable.` instead of `or and iterable.`.
