### PR TITLE
[MRG+1] Raise error when y is passed as a sparse matrix into dump_svmlight_file (fixes #6301)

### DIFF
--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -385,6 +385,8 @@ def dump_svmlight_file(X, y, f,  zero_based=True, comment=None, query_id=None,
         if six.b("\0") in comment:
             raise ValueError("comment string contains NUL byte")
 
+    if sp.issparse(y):
+        raise ValueError("y should not be a sparse matrix")
     y = np.asarray(y)
     if y.ndim != 1 and not multilabel:
         raise ValueError("expected y of shape (n_samples,), got %r"


### PR DESCRIPTION
According to the doc of `dump_svmlight_file`:

```
    X : {array-like, sparse matrix}, shape = [n_samples, n_features]
        Training vectors, where n_samples is the number of samples and
        n_features is the number of features.

    y : array-like, shape = [n_samples] or [n_samples, n_labels]
        Target values. Class labels must be an integer or float, or array-like
        objects of integer or float for multilabel classifications.
```

y should not be passed in this function as a sparse matrix.

Fix #6301 
