### PR TITLE
fix math in soft VotingClassifier example

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -997,7 +997,7 @@ classifier        class 1       class 2         class 3
 classifier 1	  w1 * 0.2      w1 * 0.5        w1 * 0.3
 classifier 2	  w2 * 0.6      w2 * 0.3        w2 * 0.1
 classifier 3      w3 * 0.3      w3 * 0.4        w3 * 0.3
-weighted average  0.37	        0.4             0.3
+weighted average  0.37	        0.4             0.23
 ================  ==========    ==========      ==========
 
 Here, the predicted class label is 2, since it has the


### PR DESCRIPTION
There was a brief error in the ensemble module documentation for VotingClassifier with soft voting.
