### PR TITLE
[MRG + 1] Fix joblib error in LatentDirichletAllocation (#6258)

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -520,7 +520,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
                 # check perplexity
                 if evaluate_every > 0 and (i + 1) % evaluate_every == 0:
                     doc_topics_distr, _ = self._e_step(X, cal_sstats=False,
-                                                       random_init=False)
+                                                       random_init=False,
+                                                       parallel=parallel)
                     bound = self.perplexity(X, doc_topics_distr,
                                             sub_sampling=False)
                     if self.verbose:

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -199,6 +199,7 @@ def test_lda_multi_jobs():
         rng = np.random.RandomState(0)
         lda = LatentDirichletAllocation(n_topics=n_topics, n_jobs=2,
                                         learning_method=method,
+                                        evaluate_every=1,
                                         random_state=rng)
         lda.fit(X)
 


### PR DESCRIPTION
The joblib error in #6258 is caused by `parallel` parameter not passed to `_e_step` when we evaluate perplexity.

This PR fixed it and set `evaluate_every=1` in `test_lda_multi_jobs` test to make sure it works.
