### PR TITLE
BUG: Normalize LDA transform's return value (fixes #6320)

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -562,6 +562,8 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
 
         doc_topic_distr, _ = self._e_step(X, cal_sstats=False,
                                           random_init=False)
+        # normalize doc_topic_distr
+        doc_topic_distr /= doc_topic_distr.sum(axis=1)[:, np.newaxis]
         return doc_topic_distr
 
     def _approx_bound(self, X, doc_topic_distr, sub_sampling):

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -108,13 +108,14 @@ def test_lda_dense_input():
 
 def test_lda_transform():
     # Test LDA transform.
-    # Transform result cannot be negative
+    # Transform result cannot be negative and should be normalized
     rng = np.random.RandomState(0)
     X = rng.randint(5, size=(20, 10))
     n_topics = 3
     lda = LatentDirichletAllocation(n_topics=n_topics, random_state=rng)
     X_trans = lda.fit_transform(X)
     assert_true((X_trans > 0.0).any())
+    assert_array_almost_equal(np.sum(X_trans, axis=1), np.ones(X_trans.shape[0]))
 
 
 def test_lda_fit_transform():


### PR DESCRIPTION
Normalize output of LDA's `transform` function since it represents document topic distribution for X.

Fixes issue #6320 

Can @larsmans please have a look?
Thanks!
