### PR TITLE
[MRG+1] Fix test_label_binarizer on Windows

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -610,9 +610,7 @@ def _inverse_binarize_thresholding(y, output_type, classes, threshold):
             return classes[y[:, 1]]
         else:
             if len(classes) == 1:
-                y = np.empty(len(y), dtype=classes.dtype)
-                y.fill(classes[0])
-                return y
+                return np.repeat(classes[0], len(y))
             else:
                 return classes[y.ravel()]
 

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -42,6 +42,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('neighbors')
     config.add_subpackage('neural_network')
     config.add_subpackage('preprocessing')
+    config.add_subpackage('preprocessing/tests')
     config.add_subpackage('manifold')
     config.add_subpackage('metrics')
     config.add_subpackage('semi_supervised')


### PR DESCRIPTION
Fix #6280. Looks like .fill is not very friendly with unicode numpy scalar on Windows.

``` python
import numpy as np

arr = np.empty(3, dtype='<U3')
unicode_scalar = np.array(['asd'])[0]
arr.fill(unicode_scalar.tolist())  # works with python str
print(arr)

arr.fill(unicode_scalar)  # fills the array with some garbage
print(arr)  # UnicodeDecodeError
```

This pattern was used [here](https://github.com/scikit-learn/scikit-learn/blob/74475bc929960d98939a12fc2fb68c0e006895be/sklearn/preprocessing/label.py#L614)
