### PR TITLE
Adding a utility function for plotting decision regions of classifiers

### DIFF
--- a/sklearn/utils/plotting.py
+++ b/sklearn/utils/plotting.py
@@ -7,10 +7,9 @@ Utility function for plotting the decision regions of a classifier.
 # Licence: BSD 3 clause
 
 from itertools import cycle
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import colors as mcolors
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
 
 
 def plot_decision_regions(X, y, clf, X_highlight=None,
@@ -70,9 +69,9 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
     marker_gen = cycle(['s', '^', 'o', 'x', 'v', '<', '>'])
 
     # make color map
-    n_classes = len(np.unique(y))
+    n_classes = len(np.unique(y.astype(int)))
     colors = ['red', 'blue', 'limegreen', 'gray', 'cyan']
-    cmap = matplotlib.colors.ListedColormap(colors[:n_classes])
+    cmap = ListedColormap(colors[:n_classes])
 
     # plot the decision surface
     if dim == '2d':
@@ -98,13 +97,13 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
 
     # plot class samples
 
-    for c in np.unique(y):
+    for c in np.unique(y.astype(int)):
         if dim == '2d':
-            y_data = X[y == c, 1]
+            y_data = X[y.astype(int) == c, 1]
         else:
-            y_data = [0 for i in X[y == c]]
+            y_data = [0 for i in X[y.astype(int) == c]]
 
-        plt.scatter(x=X[y == c, 0],
+        plt.scatter(x=X[y.astype(int) == c, 0],
                     y=y_data,
                     alpha=0.8,
                     c=cmap(c),

--- a/sklearn/utils/plotting.py
+++ b/sklearn/utils/plotting.py
@@ -1,0 +1,145 @@
+"""
+Utility function for plotting the decision regions of a classifier.
+"""
+
+# Authors: Sebastian Raschka <mail@sebastianraschka.com.com>
+#
+# Licence: BSD 3 clause
+
+from itertools import cycle
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors as mcolors
+
+
+def plot_decision_regions(X, y, clf, X_highlight=None,
+                          res=0.02, legend=1,
+                          hide_spines=True,
+                          markers='s^oxv<>',
+                          colors=['red', 'blue', 'limegreen', 'gray', 'cyan']):
+    """Plot decision regions of a classifier.
+
+    Parameters
+    ----------
+    X : array-like, shape = [n_samples, n_features]
+        Feature Matrix.
+    y : array-like, shape = [n_samples]
+        True class labels.
+    clf : Classifier object.
+        Must have a .predict method.
+    X_highlight : array-like, shape = [n_samples, n_features] (default: None)
+        An array with data points that are used to highlight samples in `X`.
+    res : float (default: 0.02)
+        Grid width. Lower values increase the resolution but
+        slow down the plotting.
+    hide_spines : bool (default: True)
+        Hide axis spines if True.
+    legend : int (default: 1)
+        Integer to specify the legend location.
+        No legend if legend is 0.
+    markers : list
+        Scatterplot markers.
+    colors : list
+        Colors.
+
+    Returns
+    ---------
+    fig : matplotlib.pyplot.figure object
+
+    """
+    # check if data is numpy array
+    fig = plt.gca()
+    for a in (X, y):
+        if not isinstance(a, np.ndarray):
+            raise ValueError('%s must be a NumPy array.' % a.__name__)
+
+    # check if test data is provided
+    plot_testdata = True
+    if not isinstance(X_highlight, np.ndarray):
+        if X_highlight is not None:
+            raise ValueError('X_test must be a NumPy array or None')
+        else:
+            plot_testdata = False
+
+    if len(X.shape) == 2 and X.shape[1] > 1:
+        dim = '2d'
+    else:
+        dim = '1d'
+
+    marker_gen = cycle(['s', '^', 'o', 'x', 'v', '<', '>'])
+
+    # make color map
+    n_classes = len(np.unique(y))
+    colors = ['red', 'blue', 'limegreen', 'gray', 'cyan']
+    cmap = matplotlib.colors.ListedColormap(colors[:n_classes])
+
+    # plot the decision surface
+    if dim == '2d':
+        y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
+    else:
+        y_min, y_max = -1, 1
+
+    x_min, x_max = X[:, 0].min() - 1, X[:, 0].max() + 1
+    xx, yy = np.meshgrid(np.arange(x_min, x_max, res),
+                         np.arange(y_min, y_max, res))
+
+    if dim == '2d':
+        y_min, y_max = X[:, 1].min() - 1, X[:, 1].max() + 1
+        Z = clf.predict(np.array([xx.ravel(), yy.ravel()]).T)
+    else:
+        y_min, y_max = -1, 1
+        Z = clf.predict(np.array([xx.ravel()]).T)
+
+    Z = Z.reshape(xx.shape)
+    plt.contourf(xx, yy, Z, alpha=0.3, cmap=cmap)
+    plt.xlim(xx.min(), xx.max())
+    plt.ylim(yy.min(), yy.max())
+
+    # plot class samples
+
+    for c in np.unique(y):
+        if dim == '2d':
+            y_data = X[y == c, 1]
+        else:
+            y_data = [0 for i in X[y == c]]
+
+        plt.scatter(x=X[y == c, 0],
+                    y=y_data,
+                    alpha=0.8,
+                    c=cmap(c),
+                    marker=next(marker_gen),
+                    label=c)
+
+    if hide_spines:
+        fig.spines['right'].set_visible(False)
+        fig.spines['top'].set_visible(False)
+        fig.spines['left'].set_visible(False)
+        fig.spines['bottom'].set_visible(False)
+    fig.yaxis.set_ticks_position('left')
+    fig.xaxis.set_ticks_position('bottom')
+    if not dim == '2d':
+        fig.axes.get_yaxis().set_ticks([])
+
+    if legend:
+        plt.legend(loc=legend, fancybox=True, framealpha=0.5)
+
+    if plot_testdata:
+        if dim == '2d':
+            plt.scatter(X_highlight[:, 0],
+                        X_highlight[:, 1],
+                        c='',
+                        alpha=1.0,
+                        linewidth=1,
+                        marker='o',
+                        s=80)
+        else:
+            plt.scatter(X_highlight,
+                        [0 for i in X_highlight],
+                        c='',
+                        alpha=1.0,
+                        linewidth=1,
+                        marker='o',
+                        s=80)
+
+    return fig

--- a/sklearn/utils/plotting.py
+++ b/sklearn/utils/plotting.py
@@ -6,13 +6,25 @@ Utility function for plotting the decision regions of a classifier.
 #
 # Licence: BSD 3 clause
 
+
+# Sebastian Raschka 2014-2016
+# mlxtend Machine Learning Library Extensions
+#
+# A function for plotting decision regions of classifiers.
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+
 from itertools import cycle
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import ListedColormap
 
 
-def plot_decision_regions(X, y, clf, X_highlight=None,
+def plot_decision_regions(X, y, clf,
+                          ax=None,
+                          X_highlight=None,
                           res=0.02, legend=1,
                           hide_spines=True,
                           markers='s^oxv<>',
@@ -27,6 +39,9 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
         True class labels.
     clf : Classifier object.
         Must have a .predict method.
+    ax : matplotlib.axes.Axes (default: None)
+        An existing matplotlib Axes. Creates
+        one if ax=None.
     X_highlight : array-like, shape = [n_samples, n_features] (default: None)
         An array with data points that are used to highlight samples in `X`.
     res : float (default: 0.02)
@@ -44,14 +59,16 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
 
     Returns
     ---------
-    fig : matplotlib.pyplot.figure object
+    ax : matplotlib.axes.Axes object
 
     """
     # check if data is numpy array
-    fig = plt.gca()
     for a in (X, y):
         if not isinstance(a, np.ndarray):
             raise ValueError('%s must be a NumPy array.' % a.__name__)
+
+    if ax is None:
+        ax = plt.gca()
 
     # check if test data is provided
     plot_testdata = True
@@ -91,9 +108,9 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
         Z = clf.predict(np.array([xx.ravel()]).T)
 
     Z = Z.reshape(xx.shape)
-    plt.contourf(xx, yy, Z, alpha=0.3, cmap=cmap)
-    plt.xlim(xx.min(), xx.max())
-    plt.ylim(yy.min(), yy.max())
+    ax.contourf(xx, yy, Z, alpha=0.3, cmap=cmap)
+
+    ax.axis(xmin=xx.min(), xmax=xx.max(), y_min=yy.min(), y_max=yy.max())
 
     # plot class samples
 
@@ -103,42 +120,48 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
         else:
             y_data = [0 for i in X[y.astype(int) == c]]
 
-        plt.scatter(x=X[y.astype(int) == c, 0],
-                    y=y_data,
-                    alpha=0.8,
-                    c=cmap(c),
-                    marker=next(marker_gen),
-                    label=c)
+        ax.scatter(x=X[y.astype(int) == c, 0],
+                   y=y_data,
+                   alpha=0.8,
+                   c=cmap(c),
+                   marker=next(marker_gen),
+                   label=c)
 
     if hide_spines:
-        fig.spines['right'].set_visible(False)
-        fig.spines['top'].set_visible(False)
-        fig.spines['left'].set_visible(False)
-        fig.spines['bottom'].set_visible(False)
-    fig.yaxis.set_ticks_position('left')
-    fig.xaxis.set_ticks_position('bottom')
+        ax.spines['right'].set_visible(False)
+        ax.spines['top'].set_visible(False)
+        ax.spines['left'].set_visible(False)
+        ax.spines['bottom'].set_visible(False)
+    ax.yaxis.set_ticks_position('left')
+    ax.xaxis.set_ticks_position('bottom')
     if not dim == '2d':
-        fig.axes.get_yaxis().set_ticks([])
+        ax.axes.get_yaxis().set_ticks([])
 
     if legend:
-        plt.legend(loc=legend, fancybox=True, framealpha=0.5)
+        legend = plt.legend(loc=legend,
+                            fancybox=True,
+                            framealpha=0.3,
+                            scatterpoints=1,
+                            borderaxespad=1)
+
+        ax.add_artist(legend)
 
     if plot_testdata:
         if dim == '2d':
-            plt.scatter(X_highlight[:, 0],
-                        X_highlight[:, 1],
-                        c='',
-                        alpha=1.0,
-                        linewidth=1,
-                        marker='o',
-                        s=80)
+            ax.scatter(X_highlight[:, 0],
+                       X_highlight[:, 1],
+                       c='',
+                       alpha=1.0,
+                       linewidth=1,
+                       marker='o',
+                       s=80)
         else:
-            plt.scatter(X_highlight,
-                        [0 for i in X_highlight],
-                        c='',
-                        alpha=1.0,
-                        linewidth=1,
-                        marker='o',
-                        s=80)
+            ax.scatter(X_highlight,
+                       [0 for i in X_highlight],
+                       c='',
+                       alpha=1.0,
+                       linewidth=1,
+                       marker='o',
+                       s=80)
 
-    return fig
+    return ax

--- a/sklearn/utils/plotting.py
+++ b/sklearn/utils/plotting.py
@@ -7,8 +7,8 @@ Utility function for plotting the decision regions of a classifier.
 # Licence: BSD 3 clause
 
 from itertools import cycle
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.colors import ListedColormap
 
 
@@ -16,7 +16,7 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
                           res=0.02, legend=1,
                           hide_spines=True,
                           markers='s^oxv<>',
-                          colors=['red', 'blue', 'limegreen', 'gray', 'cyan']):
+                          colors='red,blue,limegreen,gray,cyan'):
     """Plot decision regions of a classifier.
 
     Parameters
@@ -39,8 +39,8 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
         No legend if legend is 0.
     markers : list
         Scatterplot markers.
-    colors : list
-        Colors.
+    colors : str (default 'red,blue,limegreen,gray,cyan')
+        Comma separated list of colors.
 
     Returns
     ---------
@@ -66,11 +66,11 @@ def plot_decision_regions(X, y, clf, X_highlight=None,
     else:
         dim = '1d'
 
-    marker_gen = cycle(['s', '^', 'o', 'x', 'v', '<', '>'])
+    marker_gen = cycle(list(markers))
 
     # make color map
     n_classes = len(np.unique(y.astype(int)))
-    colors = ['red', 'blue', 'limegreen', 'gray', 'cyan']
+    colors = colors.split(',')
     cmap = ListedColormap(colors[:n_classes])
 
     # plot the decision surface


### PR DESCRIPTION
It's been a while when @amueller asked me about moving this utility function "upstream," but I finally got around it now (https://github.com/rasbt/mlxtend/issues/8) ...

Although such a function probably less useful in real-world applications (since we typically have more than 1 or 2 features in our dataset), but I think it would be a nice utility for replacing the many repeated lines of codes in the tutorials and examples on the scikit-learn website.

So, this is a simple matplotlib-wrapping convenience function to plot a decision surface of a classifier; it looks like this:

``` python
import matplotlib.pyplot as plt
from sklearn import datasets
from sklearn.svm import SVC

# Loading some example data
iris = datasets.load_iris()
X = iris.data[:, [0,2]]
y = iris.target

# Training a classifier
svm = SVC(C=0.5, kernel='linear')
svm.fit(X,y)

# Plotting decision regions
plot_decision_regions(X, y, clf=svm, res=0.02, legend=2)

# Adding axes annotations
plt.xlabel('sepal length [cm]')
plt.ylabel('petal length [cm]')
plt.title('SVM on Iris')
plt.show()
```

![plot_decision_regions_9_0](https://cloud.githubusercontent.com/assets/5618407/12995332/9d62876c-d0f4-11e5-9a7e-73f27f275a79.png)

It also supports 1D decision regions (if the input array has only one feature column) and you can highlight the test datapoint, which can be quite useful for teaching (tutorial) purposes.
![plot_decision_regions_11_0](https://cloud.githubusercontent.com/assets/5618407/12995381/e6c34f0e-d0f4-11e5-9403-db80f6176482.png)
![plot_decision_regions_14_0](https://cloud.githubusercontent.com/assets/5618407/12995384/ec6d6e4e-d0f4-11e5-99f4-d212228bede7.png)
![plot_decision_regions_16_0](https://cloud.githubusercontent.com/assets/5618407/12995390/f5260c76-d0f4-11e5-92d2-4f50a6d7d9a4.png)

<br><br>

<hr>

I am looking forward to feedback! Also, I am wondering how (or if) we implement tests for such a function?
