### PR TITLE
Add argument `parallel_opts` to online LDA

### DIFF
--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -518,9 +518,12 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         with self._get_parallel() as parallel:
             for i in xrange(max_iter):
                 if learning_method == 'online':
-                    for idx_slice in gen_batches(n_samples, batch_size):
+                    for i, idx_slice in enumerate(gen_batches(n_samples, batch_size)):
                         self._em_step(X[idx_slice, :], total_samples=n_samples,
                                       batch_update=False, parallel=parallel)
+                        if self.verbose:
+                            print('online em step {:.2f}% done'.format(
+                                  100.0*(i + 1)*batch_size/n_samples))
                 else:
                     # batch update
                     self._em_step(X, total_samples=n_samples,


### PR DESCRIPTION
I tried to run the LDA model on a fairly big dataset, on multiple processors. Sadly, this doesn't work very well at all -- the processes require a lot of memory, and especially, their interprocess communication consumes all of the space on `/run/shm`, which is the default file-based interchange for joblib. This lets the user specify where to store these temporary files, mitigating at least one of the issues.
