### PR TITLE
[MRG+1] Finish "Fix memory leak in Barnes-Hut SNE" PR

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -365,10 +365,17 @@ cdef int free_tree(Tree* tree) nogil:
     for i in range(3):
         cnt[i] = 0
     free_recursive(tree, tree.root_node, cnt)
+    if not tree.root_node.is_leaf:
+        free(tree.root_node.children)
+    free(tree.root_node.width)
+    free(tree.root_node.left_edge)
+    free(tree.root_node.center)
+    free(tree.root_node.barycenter)
+    free(tree.root_node.leaf_point_position)
     free(tree.root_node)
-    free(tree)
     check = cnt[0] == tree.n_cells
     check &= cnt[2] == tree.n_points
+    free(tree)
     free(cnt)
     return check
 


### PR DESCRIPTION
A minor tidying up of #5983, as requested by @ogrisel and because @AlexanderFabisch did not have the bandwith to tackle it.

Closes #5983 and fixes #5916.

I used the following snippet (from @ogrisel in #5983) to make sure the memory leak was fixed.

``` python

import psutil
import numpy as np
from sklearn.manifold import TSNE

X = np.random.rand(10, 10)
p = psutil.Process()

for i in range(100000):
    TSNE().fit(X)
    if i % 100 == 0:
        print(p.memory_info().rss / 1e6)
```
