### PR TITLE
[MRG+1] Remove redundant assignment of parameter in _split.py

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -402,7 +402,6 @@ class KFold(_BaseKFold):
     def __init__(self, n_folds=3, shuffle=False,
                  random_state=None):
         super(KFold, self).__init__(n_folds, shuffle, random_state)
-        self.shuffle = shuffle
 
     def _iter_test_indices(self, X, y=None, labels=None):
         n_samples = _num_samples(X)
@@ -557,7 +556,6 @@ class StratifiedKFold(_BaseKFold):
 
     def __init__(self, n_folds=3, shuffle=False, random_state=None):
         super(StratifiedKFold, self).__init__(n_folds, shuffle, random_state)
-        self.shuffle = shuffle
 
     def _make_test_folds(self, X, y=None, labels=None):
         if self.shuffle:


### PR DESCRIPTION
In _BaseKFold,
https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/model_selection/_split.py#L286
already set `self.shuffle = shuffle`.

However, KFold and StratifiedKFold, whose base class are _BaseKFold, reassign it again in their `__init__`, which seems redundant.
