### PR TITLE
[MRG+1] BLD: fix build issue with pip and ATLAS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ import sklearn
 
 VERSION = sklearn.__version__
 
-from sklearn._build_utils import cythonize
-
 # Optional setuptools features
 # We need to import setuptools early, if we want setuptools features,
 # as it monkey-patches the 'setup' function
@@ -178,7 +176,12 @@ def get_numpy_status():
 def generate_cython():
     cwd = os.path.abspath(os.path.dirname(__file__))
     print("Cythonizing sources")
-    cythonize.main(cwd)
+    p = subprocess.call([sys.executable, os.path.join(cwd, 'sklearn',
+                                        '_build_utils', 'cythonize.py'),
+                         'sklearn'],
+                        cwd=cwd)
+    if p != 0:
+        raise RuntimeError("Running cythonize failed!")
 
 
 def setup_package():

--- a/sklearn/_build_utils/cythonize.py
+++ b/sklearn/_build_utils/cythonize.py
@@ -74,7 +74,7 @@ def process_pyx(fromfile, tofile):
                 raise Exception('Cython failed')
         except OSError:
             # There are ways of installing Cython that don't result in a cython
-            # executable on the path, see gh-2397.
+            # executable on the path, see scipy issue gh-2397.
             r = subprocess.call([sys.executable, '-c',
                                  'import sys; from Cython.Compiler.Main '
                                  'import setuptools_main as main;'


### PR DESCRIPTION
Issue introduced by gh-5492 (auto-cythonizing).

On current master, pip installs are failing when compiling against ATLAS (see https://github.com/numpy/numpy/issues/7235). This is due to a distutils-setuptools issue with monkeypatching that is triggered if Cython is imported.

The second issue fixed here is that `pip install scikit-learn`, `pip install .` and `python setup.py develop` behave differently from `python setup.py build`, `python setup.py install` and `python setup.py build_ext -i`. That's the main reason that no one has run into this build issue yet.

EDIT: for searchability, here the relevant part of the original issue reported to numpy by @amueller, from [here](https://travis-ci.org/scikit-learn/scikit-learn/jobs/108684942#L501):

```
line 1176, in calc_info
    atlas_version, atlas_extra_info = get_atlas_version(**atlas)
  File "/home/travis/miniconda/envs/testenv/lib/python3.5/site-packages/numpy/distutils/system_info.py", line 1409, in get_atlas_version
    c = cmd_config(Distribution())
  File "/home/travis/miniconda/envs/testenv/lib/python3.5/distutils/cmd.py", line 57, in __init__
    raise TypeError("dist must be a Distribution instance")
TypeError: dist must be a Distribution instance
```
