### PR TITLE
[MRG + 1] Add numpy dev wheel to travis build matrix (without conda)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   - $HOME/sklearn_build_ubuntu
   - $HOME/sklearn_build_oldest
   - $HOME/sklearn_build_latest
+  - $HOME/sklearn_build_numpy_dev
   - $HOME/.cache/pip
   - $HOME/download
 addons:
@@ -19,6 +20,7 @@ addons:
     packages:
       - libatlas3gf-base
       - libatlas-dev
+      # only required by the DISTRIB="ubuntu" build:
       - python-scipy
 
 env:
@@ -40,6 +42,22 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
       NUMPY_VERSION="1.10.2" SCIPY_VERSION="0.16.1" CYTHON_VERSION="0.23.4"
       CACHED_BUILD_DIR="$HOME/sklearn_build_latest"
+
+matrix:
+  include:
+    # This environment tests scikit-learn against numpy and scipy master
+    # installed from their CI wheels in a virtualenv with the Python
+    # interpreter provided by travis.
+    # Note: libatlas3gf-base is not allowed yet so we need 'sudo':
+    # https://github.com/travis-ci/apt-package-whitelist/issues/2407
+    # Once libatlas3gf-base is on the whitelist it will be possible to replace
+    # the before_install step with and addons/apt/packages declaration.
+    -  python: 3.5
+       env: DISTRIB="scipy-dev-wheels"
+            CACHED_BUILD_DIR="$HOME/sklearn_build_numpy_dev"
+       sudo: True
+       before_install: sudo apt-get install -yqq libatlas3gf-base libatlas-dev
+
 
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh

--- a/continuous_integration/circle/check_build_doc.py
+++ b/continuous_integration/circle/check_build_doc.py
@@ -51,13 +51,15 @@ if not pr_url:
 # ci
 git_range = "origin/master..%s" % commit
 try:
+    check_output("git fetch origin master".split())
     filenames = check_output("git diff --name-only".split() + [git_range])
 except CalledProcessError:
     exit("git introspection failed.")
 filenames = filenames.decode('utf-8').split()
 for filename in filenames:
     if filename.startswith(u'doc/') or filename.startswith(u'examples/'):
-        exit("detected doc impacting file modified by PR at %s" % filename)
+        exit("detected doc impacting file modified by PR in range %s: %s"
+             % (git_range, filename))
 
 # This PR does not seem to have any documentation related file changed.
 msg = "no doc impacting files detected:\n" + u"\n".join(filenames)

--- a/continuous_integration/circle/check_build_doc.py
+++ b/continuous_integration/circle/check_build_doc.py
@@ -49,7 +49,7 @@ if not pr_url:
 # Hardcode the assumption that this is a PR to origin/master of this repo
 # as apparently there is way to reliably get the target of a PR with circle
 # ci
-git_range = "origin/master..%s" % commit
+git_range = "origin/master...%s" % commit
 try:
     check_output("git fetch origin master".split())
     filenames = check_output("git diff --name-only".split() + [git_range])

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -22,8 +22,6 @@ export CXX=g++
 echo 'List files from cached directories'
 echo 'pip:'
 ls $HOME/.cache/pip
-echo 'download'
-ls $HOME/download
 
 
 if [[ "$DISTRIB" == "conda" ]]; then
@@ -78,8 +76,23 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Create a new virtualenv using system site packages for numpy and scipy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    pip install nose nose-timer
-    pip install cython
+    pip install nose nose-timer cython
+
+elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
+    # Set up our own virtualenv environment to avoid travis' numpy
+    virtualenv --python=python ~/venv
+    source ~/venv/bin/activate
+    pip install --upgrade pip setuptools
+
+    # We use the default Python virtualenv provided by travis
+    echo "Installing numpy master wheel"
+    pip install --pre --upgrade --no-index --timeout=60 \
+        --trusted-host travis-dev-wheels.scipy.org \
+        -f https://travis-dev-wheels.scipy.org/ numpy scipy
+    pip install nose nose-timer cython
+
+    # Install nose-timer via pip
+    pip install nose-timer
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -6,7 +6,6 @@
 
 # License: 3-clause BSD
 
-
 # Travis clone scikit-learn/scikit-learn repository in to a local repository.
 # We use a cached directory with three scikit-learn repositories (one for each
 # matrix entry) from which we pull from local Travis repository. This allows
@@ -65,23 +64,23 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # Install nose-timer via pip
     pip install nose-timer
 
-    # Resolve MKL usage
-
-
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis
     # virtualenv but we want to used numpy installed through apt-get
     # install.
     deactivate
-    # Create a new virtualenv using system site packages for numpy and scipy
+    # Create a new virtualenv using system site packages for python, numpy
+    # and scipy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
     pip install nose nose-timer cython
 
 elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
-    # Set up our own virtualenv environment to avoid travis' numpy
-    virtualenv --python=python ~/venv
-    source ~/venv/bin/activate
+    # Set up our own virtualenv environment to avoid travis' numpy.
+    # This venv points to the python interpreter of the travis build
+    # matrix.
+    virtualenv --python=python ~/testvenv
+    source ~/testvenv/bin/activate
     pip install --upgrade pip setuptools
 
     # We use the default Python virtualenv provided by travis
@@ -90,9 +89,6 @@ elif [[ "$DISTRIB" == "scipy-dev-wheels" ]]; then
         --trusted-host travis-dev-wheels.scipy.org \
         -f https://travis-dev-wheels.scipy.org/ numpy scipy
     pip install nose nose-timer cython
-
-    # Install nose-timer via pip
-    pip install nose-timer
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -410,7 +410,7 @@ class SelectPercentile(_BaseFilter):
         mask = scores > treshold
         ties = np.where(scores == treshold)[0]
         if len(ties):
-            max_feats = len(scores) * self.percentile // 100
+            max_feats = int(len(scores) * self.percentile / 100)
             kept_ties = ties[:max_feats - mask.sum()]
             mask[kept_ties] = True
         return mask

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -134,7 +134,7 @@ def test_sample_statistics():
         samples = gpr.sample_y(X2, 300000)
 
         # More digits accuracy would require many more samples
-        assert_almost_equal(y_mean, np.mean(samples, 1), 2)
+        assert_almost_equal(y_mean, np.mean(samples, 1), 1)
         assert_almost_equal(np.diag(y_cov) / np.diag(y_cov).max(),
                             np.var(samples, 1) / np.diag(y_cov).max(), 1)
 
@@ -227,7 +227,7 @@ def test_y_normalization():
 
 def test_y_multioutput():
     """ Test that GPR can deal with multi-dimensional target values"""
-    y_2d = np.vstack((y, y*2)).T
+    y_2d = np.vstack((y, y * 2)).T
 
     # Test for fixed kernel that first dimension of 2d GP equals the output
     # of 1d GP and that second dimension is twice as large

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pickle
 
@@ -166,7 +167,12 @@ def test_isotonic_regression_auto_decreasing():
 
     # Create model and fit_transform
     ir = IsotonicRegression(increasing='auto')
-    y_ = assert_no_warnings(ir.fit_transform, x, y)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        y_ = ir.fit_transform(x, y)
+        # work-around for pearson divide warnings in scipy <= 0.17.0
+        assert_true(all(["invalid value encountered in "
+                         in str(warn.message) for warn in w]))
 
     # Check that relationship decreases
     is_increasing = y_[0] < y_[-1]

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -186,7 +186,12 @@ def test_isotonic_regression_auto_increasing():
 
     # Create model and fit_transform
     ir = IsotonicRegression(increasing='auto')
-    y_ = assert_no_warnings(ir.fit_transform, x, y)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        y_ = ir.fit_transform(x, y)
+        # work-around for pearson divide warnings in scipy <= 0.17.0
+        assert_true(all(["invalid value encountered in "
+                         in str(warn.message) for warn in w]))
 
     # Check that relationship increases
     is_increasing = y_[0] < y_[-1]

--- a/sklearn/utils/seq_dataset.pxd
+++ b/sklearn/utils/seq_dataset.pxd
@@ -30,7 +30,7 @@ cdef class ArrayDataset(SequentialDataset):
     cdef np.ndarray Y
     cdef np.ndarray sample_weights
     cdef Py_ssize_t n_features
-    cdef int X_stride
+    cdef np.npy_intp X_stride
     cdef double *X_data_ptr
     cdef double *Y_data_ptr
     cdef np.ndarray feature_indices


### PR DESCRIPTION
This is a follow-up on #6332 to try to simplify the configuration to not rely on the setup of a conda env when testing against travis-dev-wheels.

<dev>This also tries to no require the `sudo` based legacy env.</dev> This requires the sudo mode just for that build.
