### PR TITLE
[MRG] make appveyor fail on old builds when PR is updated

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,16 @@ environment:
 
 
 install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds.
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
   - "powershell ./continuous_integration/appveyor/install.ps1"


### PR DESCRIPTION
Snippet taken from JuliaLang via: https://github.com/numpy/numpy/pull/7247
