### PR TITLE
[MRG] doc+rfc: deprecate `train_size`, update examples that use it, and enhance its documentation.

### DIFF
--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -108,7 +108,7 @@ scoring method.
 
     - :class:`KFold` **(n_folds, shuffle, random_state)**
 
-    - :class:`StratifiedKFold` **(n_iter, test_size, train_size, random_state)**
+    - :class:`StratifiedKFold` **(n_iter, test_size, random_state)**
 
     - :class:`LabelKFold` **(n_folds, shuffle, random_state)**
 
@@ -126,7 +126,7 @@ scoring method.
 
    *
 
-    - :class:`ShuffleSplit` **(n_iter, test_size, train_size, random_state)**
+    - :class:`ShuffleSplit` **(n_iter, test_size, random_state)**
 
     - :class:`StratifiedShuffleSplit`
 

--- a/examples/applications/plot_prediction_latency.py
+++ b/examples/applications/plot_prediction_latency.py
@@ -102,7 +102,7 @@ def generate_dataset(n_train, n_test, n_features, noise=0.1, verbose=False):
 
     random_seed = 13
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, train_size=n_train, random_state=random_seed)
+        X, y, test_size=n_test, random_state=random_seed)
     X_train, y_train = shuffle(X_train, y_train, random_state=random_seed)
 
     X_scaler = StandardScaler()

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -128,7 +128,8 @@ for fignum, (clf, cs, X, y) in enumerate(clf_sets):
         # To get nice curve, we need a large number of iterations to
         # reduce the variance
         grid = GridSearchCV(clf, refit=False, param_grid=param_grid,
-                            cv=ShuffleSplit(train_size=train_size, n_iter=250,
+                            cv=ShuffleSplit(test_size=(1 - train_size),
+                                            n_iter=250,
                                             random_state=1))
         grid.fit(X, y)
         scores = [x[1] for x in grid.grid_scores_]

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -738,15 +738,13 @@ class LeavePLabelOut(_PartitionIterator):
 class BaseShuffleSplit(with_metaclass(ABCMeta)):
     """Base class for ShuffleSplit and StratifiedShuffleSplit"""
 
-    def __init__(self, n, n_iter=10, test_size=0.1, train_size=None,
+    def __init__(self, n, n_iter=10, test_size=0.1,
                  random_state=None):
         self.n = n
         self.n_iter = n_iter
         self.test_size = test_size
-        self.train_size = train_size
         self.random_state = random_state
-        self.n_train, self.n_test = _validate_shuffle_split(n, test_size,
-                                                            train_size)
+        self.n_train, self.n_test = _validate_shuffle_split(n, test_size)
 
     def __iter__(self):
         for train, test in self._iter_indices():
@@ -780,14 +778,7 @@ class ShuffleSplit(BaseShuffleSplit):
     test_size : float (default 0.1), int, or None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
-
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
+        int, represents the absolute number of test samples.
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -808,15 +799,6 @@ class ShuffleSplit(BaseShuffleSplit):
     TRAIN: [3 1 0] TEST: [2]
     TRAIN: [2 1 3] TEST: [0]
     TRAIN: [0 2 1] TEST: [3]
-
-    >>> rs = cross_validation.ShuffleSplit(4, n_iter=3,
-    ...     train_size=0.5, test_size=.25, random_state=0)
-    >>> for train_index, test_index in rs:
-    ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...
-    TRAIN: [3 1] TEST: [2]
-    TRAIN: [2 1] TEST: [0]
-    TRAIN: [0 2] TEST: [3]
 
     """
 
@@ -843,10 +825,10 @@ class ShuffleSplit(BaseShuffleSplit):
         return self.n_iter
 
 
-def _validate_shuffle_split(n, test_size, train_size):
-    if test_size is None and train_size is None:
+def _validate_shuffle_split(n, test_size):
+    if test_size is None:
         raise ValueError(
-            'test_size and train_size can not both be None')
+            'test_size cannot be None')
 
     if test_size is not None:
         if np.asarray(test_size).dtype.kind == 'f':
@@ -862,46 +844,12 @@ def _validate_shuffle_split(n, test_size, train_size):
         else:
             raise ValueError("Invalid value for test_size: %r" % test_size)
 
-    if train_size is not None:
-        if np.asarray(train_size).dtype.kind == 'f':
-            if train_size >= 1.:
-                raise ValueError("train_size=%f should be smaller "
-                                 "than 1.0 or be an integer" % train_size)
-            elif np.asarray(test_size).dtype.kind == 'f' and \
-                    train_size + test_size > 1.:
-                raise ValueError('The sum of test_size and train_size = %f, '
-                                 'should be smaller than 1.0. Reduce '
-                                 'test_size and/or train_size.' %
-                                 (train_size + test_size))
-        elif np.asarray(train_size).dtype.kind == 'i':
-            if train_size >= n:
-                raise ValueError("train_size=%d should be smaller "
-                                 "than the number of samples %d" %
-                                 (train_size, n))
-        else:
-            raise ValueError("Invalid value for train_size: %r" % train_size)
-
     if np.asarray(test_size).dtype.kind == 'f':
         n_test = ceil(test_size * n)
     elif np.asarray(test_size).dtype.kind == 'i':
         n_test = float(test_size)
 
-    if train_size is None:
-        n_train = n - n_test
-    else:
-        if np.asarray(train_size).dtype.kind == 'f':
-            n_train = floor(train_size * n)
-        else:
-            n_train = float(train_size)
-
-    if test_size is None:
-        n_test = n - n_train
-
-    if n_train + n_test > n:
-        raise ValueError('The sum of train_size and test_size = %d, '
-                         'should be smaller than the number of '
-                         'samples %d. Reduce test_size and/or '
-                         'train_size.' % (n_train + n_test, n))
+    n_train = n - n_test
 
     return int(n_train), int(n_test)
 
@@ -932,14 +880,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     test_size : float (default 0.1), int, or None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
-
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
+        int, represents the absolute number of test samples.
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -963,11 +904,10 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     TRAIN: [0 2] TEST: [3 1]
     """
 
-    def __init__(self, y, n_iter=10, test_size=0.1, train_size=None,
-                 random_state=None):
+    def __init__(self, y, n_iter=10, test_size=0.1, random_state=None):
 
         super(StratifiedShuffleSplit, self).__init__(
-            len(y), n_iter, test_size, train_size, random_state)
+            len(y), n_iter, test_size, random_state)
 
         self.y = np.array(y)
         self.classes, self.y_indices = np.unique(y, return_inverse=True)
@@ -980,8 +920,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
                              " be less than 2.")
 
         if self.n_train < n_cls:
-            raise ValueError('The train_size = %d should be greater or '
-                             'equal to the number of classes = %d' %
+            raise ValueError('The complement of test_size = %d should be greater '
+                             'or equal to the number of classes = %d' %
                              (self.n_train, n_cls))
         if self.n_test < n_cls:
             raise ValueError('The test_size = %d should be greater or '
@@ -1112,7 +1052,7 @@ class LabelShuffleSplit(ShuffleSplit):
     ``LeavePLabelOut(labels, p=10)`` would be
     ``LabelShuffleSplit(labels, test_size=10, n_iter=100)``.
 
-    Note: The parameters ``test_size`` and ``train_size`` refer to labels, and
+    Note: The parameter ``test_size`` refers to labels, and
     not to samples, as in ShuffleSplit.
 
     .. versionadded:: 0.17
@@ -1128,21 +1068,13 @@ class LabelShuffleSplit(ShuffleSplit):
     test_size : float (default 0.2), int, or None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the labels to include in the test split. If
-        int, represents the absolute number of test labels. If None,
-        the value is automatically set to the complement of the train size.
-
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the labels to include in the train split. If
-        int, represents the absolute number of train labels. If None,
-        the value is automatically set to the complement of the test size.
+        int, represents the absolute number of test labels.
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
     """
-    def __init__(self, labels, n_iter=5, test_size=0.2, train_size=None,
-                 random_state=None):
+    def __init__(self, labels, n_iter=5, test_size=0.2, random_state=None):
 
         classes, label_indices = np.unique(labels, return_inverse=True)
 
@@ -1150,7 +1082,6 @@ class LabelShuffleSplit(ShuffleSplit):
             len(classes),
             n_iter=n_iter,
             test_size=test_size,
-            train_size=train_size,
             random_state=random_state)
 
         self.labels = labels
@@ -1822,18 +1753,10 @@ def train_test_split(*arrays, **options):
             preserves input type instead of always casting to numpy array.
 
 
-    test_size : float, int, or None (default is None)
+    test_size : float, int, or None (default is 0.25)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
-        If train size is also None, test size is set to 0.25.
-
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
+        int, represents the absolute number of test samples.
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -1888,24 +1811,21 @@ def train_test_split(*arrays, **options):
         raise ValueError("At least one array required as input")
 
     test_size = options.pop('test_size', None)
-    train_size = options.pop('train_size', None)
     random_state = options.pop('random_state', None)
     stratify = options.pop('stratify', None)
 
     if options:
         raise TypeError("Invalid parameters passed: %s" % str(options))
 
-    if test_size is None and train_size is None:
+    if test_size is None:
         test_size = 0.25
     arrays = indexable(*arrays)
     if stratify is not None:
         cv = StratifiedShuffleSplit(stratify, test_size=test_size,
-                                    train_size=train_size,
                                     random_state=random_state)
     else:
         n_samples = _num_samples(arrays[0])
         cv = ShuffleSplit(n_samples, test_size=test_size,
-                          train_size=train_size,
                           random_state=random_state)
 
     train, test = next(iter(cv))

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -5,7 +5,7 @@ functions to split the data based on a preset strategy.
 
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>,
 #         Gael Varoquaux <gael.varoquaux@normalesup.org>,
-#         Olivier Girsel <olivier.grisel@ensta.org>
+#         Olivier Grisel <olivier.grisel@ensta.org>
 #         Raghav R V <rvraghav93@gmail.com>
 # License: BSD 3 clause
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -806,12 +806,10 @@ class LeavePLabelOut(BaseCrossValidator):
 class BaseShuffleSplit(with_metaclass(ABCMeta)):
     """Base class for ShuffleSplit and StratifiedShuffleSplit"""
 
-    def __init__(self, n_iter=10, test_size=0.1, train_size=None,
-                 random_state=None):
-        _validate_shuffle_split_init(test_size, train_size)
+    def __init__(self, n_iter=10, test_size=0.1, random_state=None):
+        _validate_shuffle_split_init(test_size)
         self.n_iter = n_iter
         self.test_size = test_size
-        self.train_size = train_size
         self.random_state = random_state
 
     def split(self, X, y=None, labels=None):
@@ -890,14 +888,7 @@ class ShuffleSplit(BaseShuffleSplit):
     test_size : float, int, or None, default 0.1
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If
-        int, represents the absolute number of test samples. If None,
-        the value is automatically set to the complement of the train size.
-
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
+        int, represents the absolute number of test samples.
 
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
@@ -911,27 +902,18 @@ class ShuffleSplit(BaseShuffleSplit):
     >>> rs.get_n_splits(X)
     3
     >>> print(rs)
-    ShuffleSplit(n_iter=3, random_state=0, test_size=0.25, train_size=None)
+    ShuffleSplit(n_iter=3, random_state=0, test_size=0.25)
     >>> for train_index, test_index in rs.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...  # doctest: +ELLIPSIS
     TRAIN: [3 1 0] TEST: [2]
     TRAIN: [2 1 3] TEST: [0]
     TRAIN: [0 2 1] TEST: [3]
-    >>> rs = ShuffleSplit(n_iter=3, train_size=0.5, test_size=.25,
-    ...                   random_state=0)
-    >>> for train_index, test_index in rs.split(X):
-    ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...  # doctest: +ELLIPSIS
-    TRAIN: [3 1] TEST: [2]
-    TRAIN: [2 1] TEST: [0]
-    TRAIN: [0 2] TEST: [3]
     """
 
     def _iter_indices(self, X, y=None, labels=None):
         n_samples = _num_samples(X)
-        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size)
+        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size)
         rng = check_random_state(self.random_state)
         for i in range(self.n_iter):
             # random partition
@@ -960,7 +942,7 @@ class LabelShuffleSplit(ShuffleSplit):
     ``LeavePLabelOut(p=10)`` would be
     ``LabelShuffleSplit(test_size=10, n_iter=100)``.
 
-    Note: The parameters ``test_size`` and ``train_size`` refer to labels, and
+    Note: The parameter ``test_size`` refers to labels, and
     not to samples, as in ShuffleSplit.
 
 
@@ -975,22 +957,14 @@ class LabelShuffleSplit(ShuffleSplit):
         int, represents the absolute number of test labels. If None,
         the value is automatically set to the complement of the train size.
 
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the labels to include in the train split. If
-        int, represents the absolute number of train labels. If None,
-        the value is automatically set to the complement of the test size.
-
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
     '''
 
-    def __init__(self, n_iter=5, test_size=0.2, train_size=None,
-                 random_state=None):
+    def __init__(self, n_iter=5, test_size=0.2, random_state=None):
         super(LabelShuffleSplit, self).__init__(
             n_iter=n_iter,
             test_size=test_size,
-            train_size=train_size,
             random_state=random_state)
 
     def _iter_indices(self, X, y, labels):
@@ -1034,12 +1008,6 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         int, represents the absolute number of test samples. If None,
         the value is automatically set to the complement of the train size.
 
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
-
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
@@ -1062,27 +1030,25 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     TRAIN: [0 2] TEST: [3 1]
     """
 
-    def __init__(self, n_iter=10, test_size=0.1, train_size=None,
-                 random_state=None):
+    def __init__(self, n_iter=10, test_size=0.1, random_state=None):
         super(StratifiedShuffleSplit, self).__init__(
-            n_iter, test_size, train_size, random_state)
+            n_iter, test_size, random_state)
 
     def _iter_indices(self, X, y, labels=None):
         n_samples = _num_samples(X)
-        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
-                                                  self.train_size)
+        n_train, n_test = _validate_shuffle_split(n_samples, self.test_size)
         classes, y_indices = np.unique(y, return_inverse=True)
         n_classes = classes.shape[0]
 
         class_counts = bincount(y_indices)
         if np.min(class_counts) < 2:
-            raise ValueError("The least populated class in y has only 1"
-                             " member, which is too few. The minimum"
-                             " number of labels for any class cannot"
-                             " be less than 2.")
+            raise ValueError('The least populated class in y has only 1'
+                             ' member, which is too few. The minimum'
+                             ' number of labels for any class cannot'
+                             ' be less than 2.')
 
         if n_train < n_classes:
-            raise ValueError('The train_size = %d should be greater or '
+            raise ValueError('The complement of test_size  = %d should be greater or '
                              'equal to the number of classes = %d' %
                              (n_train, n_classes))
         if n_test < n_classes:
@@ -1150,14 +1116,14 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         return super(StratifiedShuffleSplit, self).split(X, y, labels)
 
 
-def _validate_shuffle_split_init(test_size, train_size):
-    """Validation helper to check the test_size and train_size at init
+def _validate_shuffle_split_init(test_size):
+    """Validation helper to check the test_size at init
 
     NOTE This does not take into account the number of samples which is known
     only at split
     """
-    if test_size is None and train_size is None:
-        raise ValueError('test_size and train_size can not both be None')
+    if test_size is None:
+        raise ValueError('test_size cannot be None.')
 
     if test_size is not None:
         if np.asarray(test_size).dtype.kind == 'f':
@@ -1169,23 +1135,8 @@ def _validate_shuffle_split_init(test_size, train_size):
             # int values are checked during split based on the input
             raise ValueError("Invalid value for test_size: %r" % test_size)
 
-    if train_size is not None:
-        if np.asarray(train_size).dtype.kind == 'f':
-            if train_size >= 1.:
-                raise ValueError("train_size=%f should be smaller "
-                                 "than 1.0 or be an integer" % train_size)
-            elif (np.asarray(test_size).dtype.kind == 'f' and
-                    (train_size + test_size) > 1.):
-                raise ValueError('The sum of test_size and train_size = %f, '
-                                 'should be smaller than 1.0. Reduce '
-                                 'test_size and/or train_size.' %
-                                 (train_size + test_size))
-        elif np.asarray(train_size).dtype.kind != 'i':
-            # int values are checked during split based on the input
-            raise ValueError("Invalid value for train_size: %r" % train_size)
 
-
-def _validate_shuffle_split(n_samples, test_size, train_size):
+def _validate_shuffle_split(n_samples, test_size):
     """
     Validation helper to check if the test/test sizes are meaningful wrt to the
     size of the data (n_samples)
@@ -1195,32 +1146,13 @@ def _validate_shuffle_split(n_samples, test_size, train_size):
         raise ValueError('test_size=%d should be smaller than the number of '
                          'samples %d' % (test_size, n_samples))
 
-    if (train_size is not None and np.asarray(train_size).dtype.kind == 'i'
-            and train_size >= n_samples):
-        raise ValueError("train_size=%d should be smaller than the number of"
-                         " samples %d" % (train_size, n_samples))
-
     if np.asarray(test_size).dtype.kind == 'f':
         n_test = ceil(test_size * n_samples)
     elif np.asarray(test_size).dtype.kind == 'i':
         n_test = float(test_size)
 
-    if train_size is None:
-        n_train = n_samples - n_test
-    elif np.asarray(train_size).dtype.kind == 'f':
-        n_train = floor(train_size * n_samples)
-    else:
-        n_train = float(train_size)
-
-    if test_size is None:
-        n_test = n_samples - n_train
-
-    if n_train + n_test > n_samples:
-        raise ValueError('The sum of train_size and test_size = %d, '
-                         'should be smaller than the number of '
-                         'samples %d. Reduce test_size and/or '
-                         'train_size.' % (n_train + n_test, n_samples))
-
+    n_train = n_samples - n_test
+    
     return int(n_train), int(n_test)
 
 
@@ -1448,12 +1380,6 @@ def train_test_split(*arrays, **options):
         the value is automatically set to the complement of the train size.
         If train size is also None, test size is set to 0.25.
 
-    train_size : float, int, or None (default is None)
-        If float, should be between 0.0 and 1.0 and represent the
-        proportion of the dataset to include in the train split. If
-        int, represents the absolute number of train samples. If None,
-        the value is automatically set to the complement of the test size.
-
     random_state : int or RandomState
         Pseudo-random number generator state used for random sampling.
 
@@ -1503,14 +1429,13 @@ def train_test_split(*arrays, **options):
     if n_arrays == 0:
         raise ValueError("At least one array required as input")
     test_size = options.pop('test_size', None)
-    train_size = options.pop('train_size', None)
     random_state = options.pop('random_state', None)
     stratify = options.pop('stratify', None)
 
     if options:
         raise TypeError("Invalid parameters passed: %s" % str(options))
 
-    if test_size is None and train_size is None:
+    if test_size is None:
         test_size = 0.25
 
     arrays = indexable(*arrays)
@@ -1521,7 +1446,6 @@ def train_test_split(*arrays, **options):
         CVClass = ShuffleSplit
 
     cv = CVClass(test_size=test_size,
-                 train_size=train_size,
                  random_state=random_state)
 
     train, test = next(cv.split(X=arrays[0], y=stratify))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -771,7 +771,7 @@ def test_shufflesplit_errors():
     assert_raises(ValueError, ShuffleSplit, test_size=1.0)
     assert_raises(ValueError, ShuffleSplit, test_size=1j)
 
-    # When the {test|train}_size is an int, validation is based on the input X
+    # When the test_size is an int, validation is based on the input X
     # and happens at split(...)
     assert_raises(ValueError, next, ShuffleSplit(test_size=11).split(X))
     assert_raises(ValueError, next, ShuffleSplit(test_size=10).split(X))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -155,8 +155,7 @@ def test_cross_validator_with_default_params():
     skf_repr = "StratifiedKFold(n_folds=2, random_state=None, shuffle=False)"
     lolo_repr = "LeaveOneLabelOut()"
     lopo_repr = "LeavePLabelOut(n_labels=2)"
-    ss_repr = ("ShuffleSplit(n_iter=10, random_state=0, test_size=0.1, "
-               "train_size=None)")
+    ss_repr = ("ShuffleSplit(n_iter=10, random_state=0, test_size=0.1)")
     ps_repr = "PredefinedSplit(test_fold=array([1, 1, 2, 2]))"
 
     n_splits = [n_samples, comb(n_samples, p), n_folds, n_folds,
@@ -520,15 +519,10 @@ def test_stratified_shuffle_split_init():
     X = np.arange(9)
     y = np.asarray([0, 0, 0, 1, 1, 1, 2, 2, 2])
     # Check that errors are raised if there is not enough samples
-    assert_raises(ValueError, StratifiedShuffleSplit, 3, 0.5, 0.6)
     assert_raises(ValueError, next,
                   StratifiedShuffleSplit(3, 8, 0.6).split(X, y))
-    assert_raises(ValueError, next,
-                  StratifiedShuffleSplit(3, 0.6, 8).split(X, y))
 
     # Train size or test size too small
-    assert_raises(ValueError, next,
-                  StratifiedShuffleSplit(train_size=2).split(X, y))
     assert_raises(ValueError, next,
                   StratifiedShuffleSplit(test_size=2).split(X, y))
 
@@ -592,8 +586,7 @@ def test_stratified_shuffle_split_even():
         assert_equal(n_splits, n_iter)
 
         n_train, n_test = _validate_shuffle_split(n_samples,
-                                                  test_size=1./n_folds,
-                                                  train_size=1.-(1./n_folds))
+                                                  test_size=1./n_folds)
 
         assert_equal(len(train), n_train)
         assert_equal(len(test), n_test)
@@ -696,15 +689,9 @@ def test_leave_label_out_changing_labels():
 
 def test_train_test_split_errors():
     assert_raises(ValueError, train_test_split)
-    assert_raises(ValueError, train_test_split, range(3), train_size=1.1)
-    assert_raises(ValueError, train_test_split, range(3), test_size=0.6,
-                  train_size=0.6)
-    assert_raises(ValueError, train_test_split, range(3),
-                  test_size=np.float32(0.6), train_size=np.float32(0.6))
     assert_raises(ValueError, train_test_split, range(3),
                   test_size="wrong_type")
-    assert_raises(ValueError, train_test_split, range(3), test_size=2,
-                  train_size=4)
+    assert_raises(ValueError, train_test_split, range(3), test_size=4)
     assert_raises(TypeError, train_test_split, range(3),
                   some_argument=1.1)
     assert_raises(ValueError, train_test_split, range(3), range(42))
@@ -716,7 +703,7 @@ def test_train_test_split():
     y = np.arange(10)
 
     # simple test
-    split = train_test_split(X, y, test_size=None, train_size=.5)
+    split = train_test_split(X, y, test_size=.5)
     X_train, X_test, y_train, y_test = split
     assert_equal(len(y_test), len(y_train))
     # test correspondence of X and y
@@ -778,21 +765,18 @@ def train_test_split_mock_pandas():
 
 
 def test_shufflesplit_errors():
-    # When the {test|train}_size is a float/invalid, error is raised at init
-    assert_raises(ValueError, ShuffleSplit, test_size=None, train_size=None)
+    # When the test_size is a float/invalid, error is raised at init
+    assert_raises(ValueError, ShuffleSplit, test_size=None)
     assert_raises(ValueError, ShuffleSplit, test_size=2.0)
     assert_raises(ValueError, ShuffleSplit, test_size=1.0)
-    assert_raises(ValueError, ShuffleSplit, test_size=0.1, train_size=0.95)
-    assert_raises(ValueError, ShuffleSplit, train_size=1j)
+    assert_raises(ValueError, ShuffleSplit, test_size=1j)
 
     # When the {test|train}_size is an int, validation is based on the input X
     # and happens at split(...)
     assert_raises(ValueError, next, ShuffleSplit(test_size=11).split(X))
     assert_raises(ValueError, next, ShuffleSplit(test_size=10).split(X))
-    assert_raises(ValueError, next, ShuffleSplit(test_size=8,
-                                                 train_size=3).split(X))
 
-
+    
 def test_shufflesplit_reproducible():
     # Check that iterating twice on the ShuffleSplit gives the same
     # sequence of train-test when the random_state is given

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -466,12 +466,9 @@ def test_stratified_shuffle_split_init():
 
     y = np.asarray([0, 0, 0, 1, 1, 1, 2, 2, 2])
     # Check that errors are raised if there is not enough samples
-    assert_raises(ValueError, cval.StratifiedShuffleSplit, y, 3, 0.5, 0.6)
-    assert_raises(ValueError, cval.StratifiedShuffleSplit, y, 3, 8, 0.6)
-    assert_raises(ValueError, cval.StratifiedShuffleSplit, y, 3, 0.6, 8)
+    assert_raises(ValueError, cval.StratifiedShuffleSplit, y, 3, 8)
 
-    # Train size or test size too small
-    assert_raises(ValueError, cval.StratifiedShuffleSplit, y, train_size=2)
+    # Test size too small
     assert_raises(ValueError, cval.StratifiedShuffleSplit, y, test_size=2)
 
 
@@ -771,15 +768,9 @@ def test_cross_val_score_errors():
 
 def test_train_test_split_errors():
     assert_raises(ValueError, cval.train_test_split)
-    assert_raises(ValueError, cval.train_test_split, range(3), train_size=1.1)
-    assert_raises(ValueError, cval.train_test_split, range(3), test_size=0.6,
-                  train_size=0.6)
-    assert_raises(ValueError, cval.train_test_split, range(3),
-                  test_size=np.float32(0.6), train_size=np.float32(0.6))
     assert_raises(ValueError, cval.train_test_split, range(3),
                   test_size="wrong_type")
-    assert_raises(ValueError, cval.train_test_split, range(3), test_size=2,
-                  train_size=4)
+    assert_raises(ValueError, cval.train_test_split, range(3), test_size=4)
     assert_raises(TypeError, cval.train_test_split, range(3),
                   some_argument=1.1)
     assert_raises(ValueError, cval.train_test_split, range(3), range(42))
@@ -791,7 +782,7 @@ def test_train_test_split():
     y = np.arange(10)
 
     # simple test
-    split = cval.train_test_split(X, y, test_size=None, train_size=.5)
+    split = cval.train_test_split(X, y, test_size=.5)
     X_train, X_test, y_train, y_test = split
     assert_equal(len(y_test), len(y_train))
     # test correspondence of X and y
@@ -999,14 +990,9 @@ def test_cross_val_generator_with_default_indices():
 def test_shufflesplit_errors():
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=2.0)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=1.0)
-    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=0.1,
-                  train_size=0.95)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=11)
     assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=10)
-    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=8, train_size=3)
-    assert_raises(ValueError, cval.ShuffleSplit, 10, train_size=1j)
-    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=None,
-                  train_size=None)
+    assert_raises(ValueError, cval.ShuffleSplit, 10, test_size=1j)
 
 
 def test_shufflesplit_reproducible():


### PR DESCRIPTION
Finally got around to this, sorry for the delay! This PR addresses issue https://github.com/scikit-learn/scikit-learn/issues/5948. I've removed `train_size` from the CV and splitting functions. Some tests that dealt with `train_size` behavior and edge cases were removed, so coverage may decrease a bit. Let me know if this is an issue, and what sort of tests I should supplement this PR with.
Lastly, I noticed that there are differing defaults among CV and splitting functions. Is this intended? Or should we make these uniform as well?

Please let me know if there are any changes I should make, thanks in advance for reviewing!
