### PR TITLE
[MRG] Remove redundant assignment of variable in test_locally_linear.py

### DIFF
--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -39,7 +39,6 @@ def test_lle_simple_grid():
     # note: ARPACK is numerically unstable, so this test will fail for
     #       some random seeds.  We choose 2 because the tests pass.
     rng = np.random.RandomState(2)
-    tol = 0.1
 
     # grid of equidistant points in 2D, n_components = n_dim
     X = np.array(list(product(range(5), repeat=2)))


### PR DESCRIPTION
This line is redundant since variable `tol` is then assigned to 0.1 again in line 51:
https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/manifold/tests/test_locally_linear.py#L51
