### PR TITLE
[MRG] DOC: add gitter information to readme / support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Travis|_ |AppVeyor|_ |Coveralls|_ |CircleCI|_
+|Travis|_ |AppVeyor|_ |Coveralls|_ |CircleCI|_ |Gitter|_ 
 
 .. |Travis| image:: https://api.travis-ci.org/scikit-learn/scikit-learn.svg?branch=master
 .. _Travis: https://travis-ci.org/scikit-learn/scikit-learn
@@ -14,7 +14,9 @@
 .. |CircleCI| image:: https://circleci.com/gh/scikit-learn/scikit-learn/tree/master.svg?style=shield&circle-token=:circle-token
 .. _CircleCI: https://circleci.com/gh/scikit-learn/scikit-learn
 
-
+.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
+.. _Gitter: https://gitter.im/scikit-learn/scikit-learn?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+	    
 scikit-learn
 ============
 
@@ -39,6 +41,7 @@ Important links
 - Download releases: http://sourceforge.net/projects/scikit-learn/files/
 - Issue tracker: https://github.com/scikit-learn/scikit-learn/issues
 - Mailing list: https://lists.sourceforge.net/lists/listinfo/scikit-learn-general
+- Gitter chat room: https://gitter.im/scikit-learn/scikit-learn
 - IRC channel: ``#scikit-learn`` at ``irc.freenode.net``
 
 Dependencies

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -79,7 +79,8 @@ IRC
 ===
 
 Some developers like to hang out on channel ``#scikit-learn`` on
-``irc.freenode.net``.
+``irc.freenode.net`` and in our
+`Gitter room  <https://gitter.im/scikit-learn/scikit-learn>`_.
 
 If you do not have an IRC client or are behind a firewall this web
 client works fine: http://webchat.freenode.net


### PR DESCRIPTION
Gitter seems to be far more active than IRC, but is mentioned nowhere in the documentation as a place to ask questions / discuss. This PR adds a gitter badge to the readme and links to the gitter room in the readme and the support pages (http://scikit-learn.org/stable/support.html). Addresses https://github.com/scikit-learn/scikit-learn/issues/6390
