### PR TITLE
[MRG + 1] ENH use n_jobs in brute-force radius_neighbors

### DIFF
--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -583,11 +583,12 @@ class RadiusNeighborsMixin(object):
             # for efficiency, use squared euclidean distances
             if self.effective_metric_ == 'euclidean':
                 dist = pairwise_distances(X, self._fit_X, 'euclidean',
-                                          squared=True)
+                                          n_jobs=self.n_jobs, squared=True)
                 radius *= radius
             else:
                 dist = pairwise_distances(X, self._fit_X,
                                           self.effective_metric_,
+                                          n_jobs=self.n_jobs,
                                           **self.effective_metric_params_)
 
             neigh_ind_list = [np.where(d <= radius)[0] for d in dist]


### PR DESCRIPTION
It seems this was forgotten when the distance tree parallelism didn't work out in `radius_neighbors`
