### PR TITLE
Fixes the 'make cython' by adjusting the path to cythonize.py #6413

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ trailing-spaces:
 	find sklearn -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 
 cython:
-	python sklearn/_build_utils/cythonize.py sklearn
+	python build_tools/cythonize.py sklearn
 
 ctags:
 	# make tags for symbol based navigation in emacs and vim


### PR DESCRIPTION
Fixes #6413 by adjusting the path of `cythonize.py`, which was previously moved from `sklearn/_build_utils/cythonize.py` to `build_tools/cythonize.py`.
