### PR TITLE
[WIP] Change boolean array to 0-1 array (fixes #6416)

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -542,7 +542,8 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
                           "the shape of the decision function returned by "
                           "SVC.", ChangedBehaviorWarning)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:
-            return _ovr_decision_function(dec < 0, dec, len(self.classes_))
+            pred = map(lambda x: 1 if x else 0, dec < 0)
+            return _ovr_decision_function(pred, dec, len(self.classes_))
         return dec
 
     def predict(self, X):


### PR DESCRIPTION
I've changed the first argument passed to `_ovr_decision_function` from boolean array to array contains 0 and 1 in sklearn/svn/base.py, which will be treated correctly in sklearn/multiclass.py.
This should fix #6416 .
