### PR TITLE
[MRG] doc: fix capitalization in svm.rst citation to match paper.

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -702,10 +702,10 @@ computations. These libraries are wrapped using C and Cython.
   For a description of the implementation and details of the algorithms
   used, please refer to
 
-    - `LIBSVM: a library for Support Vector Machines
+    - `LIBSVM: A Library for Support Vector Machines
       <http://www.csie.ntu.edu.tw/~cjlin/papers/libsvm.pdf>`_.
 
-    - `LIBLINEAR -- a library for Large Linear Classification
+    - `LIBLINEAR -- A Library for Large Linear Classification
       <http://www.csie.ntu.edu.tw/~cjlin/liblinear/>`_.
 
 


### PR DESCRIPTION
Seems like the citation was inadvertently modified in https://github.com/scikit-learn/scikit-learn/pull/6412 and not reverted back to match the capitalization in the paper. It's not exactly proper capitalization (in a grammatical sense), but citations should generally stay true to the papers they correspond to.
