### PR TITLE
[MRG+1] Allows KMeans/MiniBatchKMeans to use float32 internally by using cython fused types

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -121,6 +121,12 @@ Enhancements
    - Added ``inverse_transform`` function to :class:`decomposition.nmf` to compute
      data matrix of original shape. By `Anish Shah`_.
 
+   - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
+     with ``np.float32`` and ``np.float64`` input data without converting it.
+     This allows to reduce the memory consumption by using ``np.float32``.
+     (`#6430 <https://github.com/scikit-learn/scikit-learn/pull/6430>`_)
+     By `Sebastian Säger`_.
+
 Bug fixes
 .........
 
@@ -1647,7 +1653,7 @@ List of contributors for release 0.15 by number of commits.
 *   4	Alexis Metaireau
 *   4	Ignacio Rossi
 *   4	Virgile Fritsch
-*   4	Sebastian Saeger
+*   4	Sebastian Säger
 *   4	Ilambharathi Kanniah
 *   4	sdenton4
 *   4	Robert Layton
@@ -4127,3 +4133,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Anish Shah: https://github.com/AnishShah
 
 .. _Ryad Zenine: https://github.com/ryadzenine
+
+.. _Sebastian Säger: https://github.com/ssaeger

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -16,7 +16,6 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import if_safe_multiprocessing_with_blas
-from sklearn.utils.testing import if_not_mac_os
 from sklearn.utils.testing import assert_raise_message
 
 
@@ -272,14 +271,18 @@ def test_k_means_explicit_init_shape():
         msg = "does not match the number of features of the data"
         assert_raises_regex(ValueError, msg, km.fit, X)
         # for callable init
-        km = Class(n_init=1, init=lambda X_, k, random_state: X_[:, :2], n_clusters=len(X))
+        km = Class(n_init=1,
+                   init=lambda X_, k, random_state: X_[:, :2],
+                   n_clusters=len(X))
         assert_raises_regex(ValueError, msg, km.fit, X)
         # mismatch of number of clusters
         msg = "does not match the number of clusters"
         km = Class(n_init=1, init=X[:2, :], n_clusters=3)
         assert_raises_regex(ValueError, msg, km.fit, X)
         # for callable init
-        km = Class(n_init=1, init=lambda X_, k, random_state: X_[:2, :], n_clusters=3)
+        km = Class(n_init=1,
+                   init=lambda X_, k, random_state: X_[:2, :],
+                   n_clusters=3)
         assert_raises_regex(ValueError, msg, km.fit, X)
 
 
@@ -730,4 +733,122 @@ def test_x_squared_norms_init_centroids():
 def test_max_iter_error():
 
     km = KMeans(max_iter=-1)
-    assert_raise_message(ValueError, 'Number of iterations should be', km.fit, X)
+    assert_raise_message(ValueError,
+                         'Number of iterations should be', km.fit, X)
+
+
+def test_kmeans_float32_64():
+    km = KMeans(n_init=1, random_state=11)
+
+    # float64 data
+    km.fit(X)
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia64 = km.inertia_
+    X_new64 = km.transform(km.cluster_centers_)
+    pred64 = km.predict(X[0])
+
+    # float32 data
+    km.fit(np.float32(X))
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float32)
+    inertia32 = km.inertia_
+    X_new32 = km.transform(km.cluster_centers_)
+    pred32 = km.predict(X[0])
+
+    # compare arrays with low precision since the difference between
+    # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
+    assert_array_almost_equal(inertia32, inertia64, decimal=4)
+    assert_array_almost_equal(X_new32, X_new64, decimal=4)
+    # both predictions have to be the same and correspond to the correct label
+    assert_equal(pred32, pred64)
+    assert_equal(pred32, km.labels_[0])
+    assert_equal(pred64, km.labels_[0])
+
+    # float64 sparse data
+    km.fit(X_csr)
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia64 = km.inertia_
+    X_new64 = km.transform(km.cluster_centers_)
+    pred64 = km.predict(X_csr[0])
+
+    # float32 sparse data
+    # Note: at the moment sparse data is always processed as float64 internally
+    km.fit(sp.csr_matrix(X_csr, dtype=np.float32))
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia32 = km.inertia_
+    X_new32 = km.transform(km.cluster_centers_)
+    pred32 = km.predict(X_csr[0])
+
+    assert_array_almost_equal(inertia32, inertia64)
+    assert_array_almost_equal(X_new32, X_new64)
+    # both predictions have to be the same and correspond to the correct label
+    assert_equal(pred32, pred64)
+    assert_equal(pred32, km.labels_[0])
+    assert_equal(pred64, km.labels_[0])
+
+
+def test_mb_k_means_float32_64():
+    km = MiniBatchKMeans(n_init=1, random_state=30)
+
+    # float64 data
+    km.fit(X)
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia64 = km.inertia_
+    X_new64 = km.transform(km.cluster_centers_)
+    pred64 = km.predict(X[0])
+    km.partial_fit(X[0:3])
+    # dtype of cluster centers has to stay the same after partial_fit
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+
+    # float32 data
+    km.fit(np.float32(X))
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float32)
+    inertia32 = km.inertia_
+    X_new32 = km.transform(km.cluster_centers_)
+    pred32 = km.predict(X[0])
+    km.partial_fit(X[0:3])
+    # dtype of cluster centers has to stay the same after partial_fit
+    assert_equal(km.cluster_centers_.dtype, np.float32)
+
+    # compare arrays with low precision since the difference between
+    # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
+    assert_array_almost_equal(inertia32, inertia64, decimal=4)
+    assert_array_almost_equal(X_new32, X_new64, decimal=4)
+    # both predictions have to be the same and correspond to the correct label
+    assert_equal(pred32, pred64)
+    assert_equal(pred32, km.labels_[0])
+    assert_equal(pred64, km.labels_[0])
+
+    # float64 sparse data
+    km.fit(X_csr)
+    # dtype of cluster centers has to be the dtype of the input data
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia64 = km.inertia_
+    X_new64 = km.transform(km.cluster_centers_)
+    pred64 = km.predict(X_csr[0])
+    km.partial_fit(X_csr[0:3])
+    # dtype of cluster centers has to stay the same after partial_fit
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+
+    # float32 sparse data
+    # Note: at the moment sparse data is always processed as float64 internally
+    km.fit(sp.csr_matrix(X_csr, dtype=np.float32))
+    # dtype of cluster centers has to be always float64 (see Note above.)
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+    inertia32 = km.inertia_
+    X_new32 = km.transform(km.cluster_centers_)
+    pred32 = km.predict(X_csr[0])
+    km.partial_fit(X_csr[0:3])
+    # dtype of cluster centers has to stay the same after partial_fit
+    assert_equal(km.cluster_centers_.dtype, np.float64)
+
+    assert_array_almost_equal(inertia32, inertia64)
+    assert_array_almost_equal(X_new32, X_new64)
+    # both predictions have to be the same and correspond to the correct label
+    assert_equal(pred32, pred64)
+    assert_equal(pred32, km.labels_[0])
+    assert_equal(pred64, km.labels_[0])

--- a/sklearn/src/cblas/cblas_sdot.c
+++ b/sklearn/src/cblas/cblas_sdot.c
@@ -1,0 +1,132 @@
+/* ---------------------------------------------------------------------
+ *
+ * -- Automatically Tuned Linear Algebra Software (ATLAS)
+ *    (C) Copyright 2000 All Rights Reserved
+ *
+ * -- ATLAS routine -- Version 3.2 -- December 25, 2000
+ *
+ * Author         : Antoine P. Petitet
+ * Originally developed at the University of Tennessee,
+ * Innovative Computing Laboratory, Knoxville TN, 37996-1301, USA.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * -- Copyright notice and Licensing terms:
+ *
+ *  Redistribution  and  use in  source and binary forms, with or without
+ *  modification, are  permitted provided  that the following  conditions
+ *  are met:
+ *
+ * 1. Redistributions  of  source  code  must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce  the above copyright
+ *    notice,  this list of conditions, and the  following disclaimer in
+ *    the documentation and/or other materials provided with the distri-
+ *    bution.
+ * 3. The name of the University,  the ATLAS group,  or the names of its
+ *    contributors  may not be used to endorse or promote products deri-
+ *    ved from this software without specific written permission.
+ *
+ * -- Disclaimer:
+ *
+ * THIS  SOFTWARE  IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,  INDIRECT, INCIDENTAL, SPE-
+ * CIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO,  PROCUREMENT  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEO-
+ * RY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT  (IN-
+ * CLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ---------------------------------------------------------------------
+ */
+/*
+ * Include files
+ */
+#include "atlas_refmisc.h"
+
+float cblas_sdot
+(
+   const int                  N,
+   const float                * X,
+   const int                  INCX,
+   const float                * Y,
+   const int                  INCY
+)
+{
+/*
+ * Purpose
+ * =======
+ *
+ * ATL_srefdot returns the dot product x^T * y of two n-vectors x and y.
+ *
+ * Arguments
+ * =========
+ *
+ * N       (input)                       const int
+ *         On entry, N specifies the length of the vector x. N  must  be
+ *         at least zero. Unchanged on exit.
+ *
+ * X       (input)                       const float *
+ *         On entry,  X  points to the  first entry to be accessed of an
+ *         incremented array of size equal to or greater than
+ *            ( 1 + ( n - 1 ) * abs( INCX ) ) * sizeof(   float   ),
+ *         that contains the vector x. Unchanged on exit.
+ *
+ * INCX    (input)                       const int
+ *         On entry, INCX specifies the increment for the elements of X.
+ *         INCX must not be zero. Unchanged on exit.
+ *
+ * Y       (input)                       const float *
+ *         On entry,  Y  points to the  first entry to be accessed of an
+ *         incremented array of size equal to or greater than
+ *            ( 1 + ( n - 1 ) * abs( INCY ) ) * sizeof(   float   ),
+ *         that contains the vector y. Unchanged on exit.
+ *
+ * INCY    (input)                       const int
+ *         On entry, INCY specifies the increment for the elements of Y.
+ *         INCY must not be zero. Unchanged on exit.
+ *
+ * ---------------------------------------------------------------------
+ */
+/*
+ * .. Local Variables ..
+ */
+   register float             dot = ATL_sZERO, x0, x1, x2, x3,
+                              y0, y1, y2, y3;
+   float                      * StX;
+   register int               i;
+   int                        nu;
+   const int                  incX2 = 2 * INCX, incY2 = 2 * INCY,
+                              incX3 = 3 * INCX, incY3 = 3 * INCY,
+                              incX4 = 4 * INCX, incY4 = 4 * INCY;
+/* ..
+ * .. Executable Statements ..
+ *
+ */
+   if( N > 0 )
+   {
+      if( ( nu = ( N >> 2 ) << 2 ) != 0 )
+      {
+         StX = (float *)X + nu * INCX;
+
+         do
+         {
+            x0 = (*X);     y0 = (*Y);     x1 = X[INCX ]; y1 = Y[INCY ];
+            x2 = X[incX2]; y2 = Y[incY2]; x3 = X[incX3]; y3 = Y[incY3];
+            dot += x0 * y0; dot += x1 * y1; dot += x2 * y2; dot += x3 * y3;
+            X  += incX4; Y  += incY4;
+         } while( X != StX );
+      }
+
+      for( i = N - nu; i != 0; i-- )
+      {  x0 = (*X); y0 = (*Y); dot += x0 * y0; X += INCX; Y += INCY; }
+   }
+   return( dot );
+/*
+ * End of ATL_srefdot
+ */
+}


### PR DESCRIPTION
As mentioned in #5973, #5776 or #5464 we could use fused types in Cython to work with float32 inputs without wasting memory by converting them internally to float64.

This PR implements fused types for KMeans/MiniBatchKMeans so that float32 input will result in using only float32 internally. Additionally it adds tests to ensure the desired data types are used.

Memory usage for float32 inputs with dimensions 500k x 20:
**Before** the code changes of this commit:
![mem_prof_500k_20_32_old_2](https://cloud.githubusercontent.com/assets/1192254/13248997/f52ded02-da21-11e5-843c-3699c526a2fc.png)
and **after** the code changes:
![mem_prof_500k_20_32_new_2](https://cloud.githubusercontent.com/assets/1192254/13249055/399a50de-da22-11e5-8730-805982cf6660.png)

Unfortunately I was not able to add support to handle sparse float32 input data as float32 internally, so that this is still converted to float64. This would require many changes in `sparsefuncs_fast.pyx`.
