### PR TITLE
[MRG] ENH Add get_feature_names for various transformers

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -64,11 +64,31 @@ class FunctionTransformer(BaseEstimator, TransformerMixin):
             check_array(X, self.accept_sparse)
         return self
 
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        if input_features is not None:
+            input_features = list(map(lambda input_feature: 'f(' +
+                                 input_feature + ')',
+                                 input_features))
+        return input_features
+
     def transform(self, X, y=None):
         if self.validate:
             X = check_array(X, self.accept_sparse)
         func = self.func if self.func is not None else _identity
-
 
         return func(X, *((y,) if self.pass_y else ()),
                     **(self.kw_args if self.kw_args else {}))

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -273,6 +273,23 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
             del self.data_max_
             del self.data_range_
 
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
+
     def fit(self, X, y=None):
         """Compute the minimum and maximum to be used for later scaling.
 
@@ -533,6 +550,23 @@ class StandardScaler(BaseEstimator, TransformerMixin):
             del self.mean_
             del self.var_
 
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
+
     def fit(self, X, y=None):
         """Compute the mean and std to be used for later scaling.
 
@@ -735,6 +769,23 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
             del self.scale_
             del self.n_samples_seen_
             del self.max_abs_
+
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
 
     def fit(self, X, y=None):
         """Compute the maximum absolute value to be used for later scaling.
@@ -963,6 +1014,23 @@ class RobustScaler(BaseEstimator, TransformerMixin):
                     "Cannot center sparse matrices: use `with_centering=False`"
                     " instead. See docstring for motivation and alternatives.")
         return X
+
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
 
     def fit(self, X, y=None):
         """Compute the median and quantiles to be used for scaling.
@@ -1349,6 +1417,23 @@ class Normalizer(BaseEstimator, TransformerMixin):
     def __init__(self, norm='l2', copy=True):
         self.norm = norm
         self.copy = copy
+
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
 
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1543,6 +1543,23 @@ class Binarizer(BaseEstimator, TransformerMixin):
         self.threshold = threshold
         self.copy = copy
 
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
+
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged
 

--- a/sklearn/preprocessing/imputation.py
+++ b/sklearn/preprocessing/imputation.py
@@ -123,6 +123,23 @@ class Imputer(BaseEstimator, TransformerMixin):
         self.verbose = verbose
         self.copy = copy
 
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features
+
+        Parameters
+        ----------
+        input_features : list of string, length len(input_features), optional
+            String names for input features if available. By default,
+            None is used.
+
+        Returns
+        -------
+        output_feature_names : list of string, length len(input_features)
+
+        """
+        return input_features
+
     def fit(self, X, y=None):
         """Fit the imputer on X.
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -160,6 +160,12 @@ def test_standard_scaler_1d():
     assert_equal(scaler.n_samples_seen_, X.shape[0])
 
 
+def test_standard_scaler_get_feature_names():
+    scaler = StandardScaler()
+    feature_names = scaler.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
+
+
 def test_scale_1d():
     # 1-d inputs
     X_list = [1., 3., 5., 0.]
@@ -577,6 +583,12 @@ def test_min_max_scaler_1d():
                               minmax_scale(X_1d, copy=True))
 
 
+def test_minmax_scaler_get_feature_names():
+    scaler = MinMaxScaler()
+    feature_names = scaler.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
+
+
 def test_scaler_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
@@ -812,6 +824,12 @@ def test_robust_scaler_iris():
     assert_array_almost_equal(iqr, 1)
 
 
+def test_robust_scaler_get_feature_names():
+    scaler = RobustScaler()
+    feature_names = scaler.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
+
+
 def test_scale_function_without_centering():
     rng = np.random.RandomState(42)
     X = rng.randn(4, 5)
@@ -963,6 +981,12 @@ def test_maxabs_scaler_transform_one_row_csr():
     assert_array_almost_equal(X_trans.toarray(), X_expected.toarray())
     X_scaled_back = scaler.inverse_transform(X_trans)
     assert_array_almost_equal(X.toarray(), X_scaled_back.toarray())
+
+
+def test_maxabs_scaler_get_feature_names():
+    scaler = MaxAbsScaler()
+    feature_names = scaler.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
 
 
 @ignore_warnings
@@ -1233,6 +1257,12 @@ def test_normalizer_max():
         for i in range(3):
             assert_almost_equal(row_maxs[i], 1.0)
         assert_almost_equal(la.norm(X_norm[3]), 0.0)
+
+
+def test_normalizer_feature_names():
+    normalizer = Normalizer()
+    feature_names = normalizer.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
 
 
 def test_normalize():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1330,6 +1330,12 @@ def test_binarizer():
     assert_raises(ValueError, binarizer.transform, sparse.csc_matrix(X))
 
 
+def test_binarizer_feature_names():
+    binarizer = Binarizer()
+    feature_names = binarizer.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)
+
+
 def test_center_kernel():
     # Test that KernelCenterer is equivalent to StandardScaler
     # in feature space

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -74,6 +74,14 @@ def test_delegate_to_func():
     )
 
 
+def test_get_feature_names():
+    F = FunctionTransformer()
+    feature_names = F.get_feature_names(["a", "b", "c"])
+    testing.assert_array_equal(['f(a)', 'f(b)', 'f(c)'], feature_names)
+    feature_names_default = F.get_feature_names()
+    testing.assert_array_equal(None, feature_names_default)
+
+
 def test_np_log():
     X = np.arange(10).reshape((5, 2))
 
@@ -91,7 +99,7 @@ def test_kw_arg():
 
     # Test that rounding is correct
     testing.assert_array_equal(F.transform(X),
-                                  np.around(X, decimals=3))
+                               np.around(X, decimals=3))
 
 
 def test_kw_arg_update():
@@ -100,10 +108,9 @@ def test_kw_arg_update():
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 
     F.kw_args['decimals'] = 1
-
     # Test that rounding is correct
     testing.assert_array_equal(F.transform(X),
-                                  np.around(X, decimals=1))
+                               np.around(X, decimals=1))
 
 
 def test_kw_arg_reset():
@@ -115,4 +122,4 @@ def test_kw_arg_reset():
 
     # Test that rounding is correct
     testing.assert_array_equal(F.transform(X),
-                                  np.around(X, decimals=1))
+                               np.around(X, decimals=1))

--- a/sklearn/preprocessing/tests/test_imputation.py
+++ b/sklearn/preprocessing/tests/test_imputation.py
@@ -13,7 +13,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
 from sklearn import tree
 from sklearn.random_projection import sparse_random_matrix
- 
+
 
 def _check_statistics(X, X_true,
                       strategy, statistics, missing_values):
@@ -358,3 +358,9 @@ def test_imputation_copy():
 
     # Note: If X is sparse and if missing_values=0, then a (dense) copy of X is
     # made, even if copy=False.
+
+
+def test_imputation_feature_names():
+    imputer = Imputer()
+    feature_names = imputer.get_feature_names(["a", "b", "c"])
+    assert_array_equal(['a', 'b', 'c'], feature_names)


### PR DESCRIPTION
This is a PR for #6425 .
I've added `get_feature_names` for scalers, normalizers and imputers.

Is the purpose of this function to maintain compatibility when `get_feature_names()` is implemented in Pipeline?

Can @jnothman please have a look?
