### PR TITLE
MAINT: better error when Cython not installed (fixes #6434)

### DIFF
--- a/build_tools/cythonize.py
+++ b/build_tools/cythonize.py
@@ -68,23 +68,21 @@ def cythonize(cython_file, gen_file):
         flags += ['--cplus']
 
     try:
-        try:
-            rc = subprocess.call(['cython'] +
-                                 flags + ["-o", gen_file, cython_file])
-            if rc != 0:
-                raise Exception('Cythonizing %s failed' % cython_file)
-        except OSError:
-            # There are ways of installing Cython that don't result in a cython
-            # executable on the path, see scipy issue gh-2397.
-            rc = subprocess.call([sys.executable, '-c',
-                                  'import sys; from Cython.Compiler.Main '
-                                  'import setuptools_main as main;'
-                                  ' sys.exit(main())'] + flags +
-                                 ["-o", gen_file, cython_file])
-            if rc != 0:
-                raise Exception('Cythonizing %s failed' % cython_file)
+        rc = subprocess.call(['cython'] +
+                             flags + ["-o", gen_file, cython_file])
+        if rc != 0:
+            raise Exception('Cythonizing %s failed' % cython_file)
     except OSError:
-        raise OSError('Cython needs to be installed')
+        # There are ways of installing Cython that don't result in a cython
+        # executable on the path, see scipy issue gh-2397.
+        rc = subprocess.call([sys.executable, '-c',
+                              'import sys; from Cython.Compiler.Main '
+                              'import setuptools_main as main;'
+                              ' sys.exit(main())'] + flags +
+                             ["-o", gen_file, cython_file])
+
+        if rc != 0:
+            raise Exception('Cythonizing %s failed' % cython_file)
 
 
 def load_hashes(filename):

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ def generate_cython():
                          'sklearn'],
                         cwd=cwd)
     if p != 0:
-        raise RuntimeError("Running cythonize failed!")
+        raise RuntimeError("Cython either isn't installed or it failed.")
 
 
 def setup_package():


### PR DESCRIPTION
I removed a `try...except` block that is no longer needed after #6354, and changed the error to be more informative.
