### PR TITLE
[MRG+1] Add weighting option to cohen_kappa_score

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -327,17 +327,11 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     if weights == None:
         w_mat = np.ones([n, n]) - np.diag(np.ones([n, ]))
     elif weights == "linear":
-        w_mat = np.zeros([n, n])
-        for i in range(n):
-            for j in range(i, n):
-                w = abs(i - j)
-                w_mat[i, j] = w_mat[j, i] = w
+        w_mat = np.tile(np.arange(n), [n, 1])
+        w_mat = abs(w_mat - w_mat.T)
     elif weights == "quadratic":
-        w_mat = np.zeros([n, n])
-        for i in range(n):
-            for j in range(i, n):
-                w = (i - j) ** 2
-                w_mat[i, j] = w_mat[j, i] = w
+        w_mat = np.tile(np.arange(n), [n, 1])
+        w_mat = (w_mat - w_mat.T) ** 2
     else:
         raise ValueError("Unknown kappa weighting type.")
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -317,7 +317,7 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
            computational linguistics". Computational Linguistic 34(4):555-596.
     """
     confusion = confusion_matrix(y1, y2, labels=labels)
-    n = confusion.shape[0]
+    n_classes = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)
     expected = np.outer(sum0, sum1) / np.sum(sum0)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -320,9 +320,7 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     n = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)
-    sum = np.sum(sum0)
-
-    expected = np.outer(sum0, sum1) / sum
+    expected = np.outer(sum0, sum1) / np.sum(sum0)
 
     if weights == None:
         w_mat = np.ones([n, n]) - np.diag(np.ones([n, ]))

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -322,14 +322,17 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     sum1 = np.sum(confusion, axis=1)
     expected = np.outer(sum0, sum1) / np.sum(sum0)
 
-    if weights == None:
-        w_mat = np.ones([n, n]) - np.diag(np.ones([n, ]))
-    elif weights == "linear":
-        w_mat = np.tile(np.arange(n), [n, 1])
-        w_mat = abs(w_mat - w_mat.T)
-    elif weights == "quadratic":
-        w_mat = np.tile(np.arange(n), [n, 1])
-        w_mat = (w_mat - w_mat.T) ** 2
+    if weights is None:
+        w_mat = np.ones([n_classes, n_classes], dtype=np.int)
+        for i in range(n_classes):
+            w_mat[i, i] = 0
+    elif weights == "linear" or weights == "quadratic":
+        w_mat = np.zeros([n_classes, n_classes], dtype=np.int)
+        w_mat += np.arange(n_classes)
+        if weights == "linear":
+            w_mat = abs(w_mat - w_mat.T)
+        else:
+            w_mat = (w_mat - w_mat.T) ** 2
     else:
         raise ValueError("Unknown kappa weighting type.")
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -324,13 +324,12 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
 
     if weights is None:
         w_mat = np.ones([n_classes, n_classes], dtype=np.int)
-        for i in range(n_classes):
-            w_mat[i, i] = 0
+        w_mat.flat[:: n_classes + 1] = 0
     elif weights == "linear" or weights == "quadratic":
         w_mat = np.zeros([n_classes, n_classes], dtype=np.int)
         w_mat += np.arange(n_classes)
         if weights == "linear":
-            w_mat = abs(w_mat - w_mat.T)
+            w_mat = np.abs(w_mat - w_mat.T)
         else:
             w_mat = (w_mat - w_mat.T) ** 2
     else:

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -331,15 +331,13 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
         for i in range(n):
             for j in range(i, n):
                 w = abs(i - j)
-                w_mat[i, j] = w
-                w_mat[j, i] = w
+                w_mat[i, j] = w_mat[j, i] = w
     elif weights == "quadratic":
         w_mat = np.zeros([n, n])
         for i in range(n):
             for j in range(i, n):
                 w = (i - j) ** 2
-                w_mat[i, j] = w
-                w_mat[j, i] = w
+                w_mat[i, j] = w_mat[j, i] = w
     else:
         raise ValueError("Unknown kappa weighting type.")
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -324,6 +324,13 @@ def test_cohen_kappa():
     y2 = np.array([0] * 52 + [1] * 32 + [2] * 16)
     assert_almost_equal(cohen_kappa_score(y1, y2), .8013, decimal=4)
 
+    # Weighting example: none, linear, quadratic.
+    y1 = np.array([0] * 46 + [1] * 44 + [2] * 10)
+    y2 = np.array([0] * 50 + [1] * 40 + [2] * 10)
+    assert_almost_equal(cohen_kappa_score(y1, y2), .9315, decimal=4)
+    assert_almost_equal(cohen_kappa_score(y1, y2, weights="linear"), .9412, decimal=4)
+    assert_almost_equal(cohen_kappa_score(y1, y2, weights="quadratic"), .9541, decimal=4)
+
 
 @ignore_warnings
 def test_matthews_corrcoef_nan():


### PR DESCRIPTION
Add two common weighting types to cohen_kappa_score : linear weighted and quadratic weighted.

cohen_kappa_score(y1, y2) -> standard kappa value,
cohen_kappa_score(y1, y2, weights="linear") -> linear weighted kappa value,
cohen_kappa_score(y1, y2, weights="quadratic") -> quadratic weighted kappa value
