### PR TITLE
[MRG] Add get_feature_names to PCA

### DIFF
--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -309,9 +309,9 @@ class PCA(_BasePCA):
         >>> X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
         >>> pca = PCA(n_components=2).fit(X)
         >>> pca.get_feature_names(show_coef=True)
-        ['0.84*x0 + 0.54*x1', '0.54*x0 - 0.84*x1']
+        ['-0.84*x0 - 0.54*x1', '0.54*x0 - 0.84*x1']
         >>> pca.get_feature_names(show_coef=1)
-        ['0.84*x0', '-0.84*x1']
+        ['-0.84*x0', '-0.84*x1']
         >>> pca.get_feature_names()
         ['pc0', 'pc1']
         """

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -11,6 +11,7 @@ from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_less
+from sklearn.utils.testing import assert_array_equal
 
 from sklearn import datasets
 from sklearn.decomposition import PCA
@@ -507,3 +508,18 @@ def test_deprecation_randomized_pca():
     assert_warns_message(DeprecationWarning, depr_message, fit_deprecated, X)
     Y_pca = PCA(svd_solver='randomized', random_state=0).fit_transform(X)
     assert_array_almost_equal(Y, Y_pca)
+
+
+def test_get_feature_names():
+    X1 = np.array([[-1, -1, 3], [-2, -1, 1], [-3, -2, -1], [1, 1, 2]])
+    pca = PCA(n_components=2).fit(X1)
+    assert_array_equal(pca.get_feature_names(), ['pc0', 'pc1'])
+    assert_array_equal(pca.get_feature_names(show_coef=True),
+        ['-0.66*x0 - 0.46*x1 - 0.59*x2', '-0.38*x0 - 0.47*x1 + 0.79*x2'])
+    assert_array_equal(pca.get_feature_names(show_coef=1),
+        ['-0.66*x0', '0.79*x2'])
+    # Raise error when len(input_features) != n_features
+    assert_raises(ValueError, pca.get_feature_names, ['a']);
+    # Raise error when show_coef is greater than n_features
+    assert_raises(ValueError, pca.get_feature_names, None, 4)
+


### PR DESCRIPTION
Attempt to add get_feature_names to PCA as suggested in #6425 .
The present idea is to take the input feature with the most variance along the component. But it doesn't consider the importance of the component. It definitely seems that the present approach can be modified to accommodate the significance of the components.
Please let me know about the best way to move forward here. Thanks!
