### PR TITLE
[MRG+1] Do not ignore files starting with _ and . in nose

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ with-doctest = 1
 doctest-tests = 1
 doctest-extension = rst
 doctest-fixtures = _fixture
+ignore-files=^setup\.py$
 #doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE
 
 [wheelhouse_uploader]


### PR DESCRIPTION
By default, files starting with `.` or `_` and `setup.py` are ignored by nose (from this [SO answer](http://stackoverflow.com/a/23616492)). This causes doctests to be skipped in `_*.py` modules as noticed in https://github.com/scikit-learn/scikit-learn/pull/6379#discussion_r54098250.

Not sure exactly why, but setup.py in sub-packages confuses nose so we can not use `ignore-files=regex_that_is_unlikely_to_match_any_file`. I am guessing nose sees sklearn.datasets.setup and thinks it's a package-level fixture that it can call as a function. Here is the full traceback for completeness:

```
======================================================================
ERROR: test suite for <module 'sklearn.datasets' from '/home/le243287/dev/scikit-learn/sklearn/datasets/__init__.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/volatile/le243287/miniconda3/lib/python3.5/inspect.py", line 1089, in getfullargspec
    sigcls=Signature)
  File "/volatile/le243287/miniconda3/lib/python3.5/inspect.py", line 2156, in _signature_from_callable
    raise TypeError('{!r} is not a callable object'.format(obj))
TypeError: <module 'sklearn.datasets.setup' from '/home/le243287/dev/scikit-learn/sklearn/datasets/setup.py'> is not a callable object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/volatile/le243287/miniconda3/lib/python3.5/site-packages/nose/util.py", line 460, in try_run
    inspect.getargspec(func)
  File "/volatile/le243287/miniconda3/lib/python3.5/inspect.py", line 1043, in getargspec
    getfullargspec(func)
  File "/volatile/le243287/miniconda3/lib/python3.5/inspect.py", line 1095, in getfullargspec
    raise TypeError('unsupported callable') from ex
TypeError: unsupported callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/volatile/le243287/miniconda3/lib/python3.5/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/volatile/le243287/miniconda3/lib/python3.5/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "/volatile/le243287/miniconda3/lib/python3.5/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/volatile/le243287/miniconda3/lib/python3.5/site-packages/nose/util.py", line 466, in try_run
    (name, obj))
TypeError: Attribute setup of <module 'sklearn.datasets' from '/home/le243287/dev/scikit-learn/sklearn/datasets/__init__.py'> is not a python function. Only functions or callables may be used as fixtures.
```
