### PR TITLE
[MRG+1] DOC: refactor issue and PR template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,37 @@ review. This will send an email to the committers.
 (If any of the above seems like magic to you, then look up the 
 [Git documentation](http://git-scm.com/documentation) on the web.)
 
+Contributing Pull Requests
+--------------------------
+
 It is recommended to check that your contribution complies with the
 following rules before submitting a pull request:
 
+-  Follow the
+   [coding-guidelines](http://scikit-learn.org/dev/developers/contributing.html#coding-guidelines).
+
+-  When applicable, use the validation tools and other code in the
+   `sklearn.utils` submodule.  A list of utility routines available
+   for developers can be found in the
+   [Utilities for Developers](http://scikit-learn.org/dev/developers/utilities.html#developers-utils)
+   page.
+
+-  If your pull request addresses an issue, please use the title to describe
+   the issue and mention the issue number in the pull request description to
+   ensure a link is created to the original issue.
+
 -  All public methods should have informative docstrings with sample
    usage presented as doctests when appropriate.
+
+-  Please prefix the title of your pull request with `[MRG]` if the
+   contribution is complete and should be subjected to a detailed review.
+   Incomplete contributions should be prefixed `[WIP]` to indicate a work
+   in progress (and changed to `[MRG]` when it matures). WIPs may be useful
+   to: indicate you are working on something to avoid duplicated work,
+   request broad review of functionality or API, or seek collaborators.
+   WIPs often benefit from the inclusion of a
+   [task list](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
+   in the PR description.
 
 -  All other tests pass when everything is rebuilt from scratch. On
    Unix-like systems, check with (from the toplevel source folder):
@@ -63,6 +89,9 @@ following rules before submitting a pull request:
    examples for reference. Examples should demonstrate why the new
    functionality is useful in practice and, if possible, compare it
    to other methods available in scikit-learn.
+
+-  Documentation and high-coverage tests are necessary for enhancements
+   to be accepted.
 
 -  At least one paragraph of narrative documentation with links to
    references in the literature (with PDF links when possible) and
@@ -100,6 +129,44 @@ tools:
 Bonus points for contributions that include a performance analysis with
 a benchmark script and profiling output (please report on the mailing
 list or on the GitHub issue).
+
+Filing bugs
+-----------
+We use Github issues to track all bugs and feature requests; feel free to
+open an issue if you have found a bug or wish to see a feature implemented.
+
+It is recommended to check that your issue complies with the
+following rules before submitting:
+
+-  Verify that your issue is not being currently addressed by other
+   [issues](https://github.com/scikit-learn/scikit-learn/issues?q=)
+   or [pull requests](https://github.com/scikit-learn/scikit-learn/pulls?q=).
+
+-  If you are submitting an algorithm or feature request, please verify that
+   the algorithm fulfills our
+   [new algorithm requirements](http://scikit-learn.org/stable/faq.html#can-i-add-this-new-algorithm-that-i-or-someone-else-just-published).
+
+-  Please ensure all code snippets and error messages are formatted in
+   appropriate code blocks.
+   See [Creating and highlighting code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks).
+
+-  Please include your operating system type and version number, as well
+   as your Python, scikit-learn, numpy, and scipy versions. This information
+   can be found by runnning the following code snippet:
+
+   ```python
+   import platform; print(platform.platform())
+   import sys; print("Python", sys.version)
+   import numpy; print("NumPy", numpy.__version__)
+   import scipy; print("SciPy", scipy.__version__)
+   import sklearn; print("Scikit-Learn", sklearn.__version__)
+   ```
+   
+-  Please be specific about what estimators and/or functions are involved
+   and the shape of the data, as appropriate; please include a
+   [reproducible](http://stackoverflow.com/help/mcve) code snippet
+   or link to a [gist](https://gist.github.com). If an exception is raised,
+   please provide the traceback.
 
 Easy Issues
 -----------

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,39 +1,59 @@
-Please try to adhere to the guidelines below as much as possible when
-submitting your issue.
-- Verify that your issue is not being currently addressed by other
-[issues](https://github.com/scikit-learn/scikit-learn/issues?q=)
-or [pull requests](https://github.com/scikit-learn/scikit-learn/pulls?q=).
-- If your issue is a usage question or does not potentially require
-changes to the codebase to be solved, then
-[StackOverflow](http://stackoverflow.com/questions/tagged/scikit-learn)
-(using the`[scikit-learn]` tag) or our
-[mailing list](https://lists.sourceforge.net/lists/listinfo/scikit-learn-general)
-may be a better place to bring it up. For more information, see
-[User Questions](http://scikit-learn.org/stable/support.html#user-questions).
+<!--
+If your issue is a usage question, submit it here instead:
+- StackOverflow with the scikit-learn tag: http://stackoverflow.com/questions/tagged/scikit-learn
+- Mailing List: https://lists.sourceforge.net/lists/listinfo/scikit-learn-general
+For more information, see User Questions: http://scikit-learn.org/stable/support.html#user-questions
+-->
 
-If you are submitting a bug issue:
-- Please include your operating system type and version number, as well
-as your Python, scikit-learn, numpy, and scipy versions. This information
-can be found by runnning the following code snippet:
+<!-- Instructions For Filing a Bug: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#filing-bugs -->
+
+Description
+-----------
+<!-- Example: Joblib Error thrown when calling fit on LatentDirichletAllocation with evaluate_every > 0-->
+
+Steps/Code to Reproduce
+-----------------------
+<!--
+Example:
 ```
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.decomposition import LatentDirichletAllocation
+
+docs = ["Help I have a bug" for i in range(1000)]
+
+vectorizer = CountVectorizer(input=docs, analyzer='word')
+lda_features = vectorizer.fit_transform(docs)
+
+lda_model = LatentDirichletAllocation(
+    n_topics=10,
+    learning_method='online',
+    evaluate_every=10,
+    n_jobs=4,
+)
+model = lda_model.fit(lda_features)
+```
+If the code is too long, feel free to put it in a public gist and link
+it in the issue: https://gist.github.com
+-->
+
+Expected Results
+----------------
+<!-- Example: No error is throw. Please paste or describe the expected results.-->
+
+Actual Results
+--------------
+<!-- Please paste or specifically describe the actual output or traceback. -->
+
+Versions
+--------
+<!--
+Please run the following snippet and paste the output below.
 import platform; print(platform.platform())
 import sys; print("Python", sys.version)
 import numpy; print("NumPy", numpy.__version__)
 import scipy; print("SciPy", scipy.__version__)
 import sklearn; print("Scikit-Learn", sklearn.__version__)
-```
-- Please be specific about what estimators and/or functions are involved
-and the shape of the data, as appropriate; please include a
-[reproducible](http://stackoverflow.com/help/mcve) code snippet
-or link to a [gist](https://gist.github.com). If an exception is raised,
-please provide the traceback.
-- Please ensure all code snippets and error messages are formatted in
-appropriate code blocks.
-See ["Creating and highlighting code blocks"](https://help.github.com/articles/creating-and-highlighting-code-blocks).
+-->
 
-If you are submitting an algorithm or feature request:
-- Please verify that the algorithm fulfills our
-[new algorithm requirements](http://scikit-learn.org/stable/faq.html#can-i-add-this-new-algorithm-that-i-or-someone-else-just-published).
 
-Thanks for contributing! Please delete these guidelines before submitting
-your issue.
+<!-- Thanks for contributing! -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,29 @@
-Please try to adhere to the guidelines below as much as possible when submitting your pull request.
+<!--
+Thanks for contributing a pull request! Please ensure you have taken a look at
+the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
+-->
+Reference Issue
+---------------
+<!-- Example: Fixes #1234 -->
 
-- Please verify that your code satisfies the
-[code/documentation quality guidelines](http://scikit-learn.org/stable/developers/contributing.html#coding-guidelines).
-- Please prefix the title of your pull request with `[MRG]` if the
-contribution is complete and should be subjected to a detailed review.
 
-- Incomplete contributions should be prefixed `[WIP]` to indicate a work
-in progress (and changed to `[MRG]` when it matures). WIPs may be useful
-to: indicate you are working on something to avoid duplicated work,
-request broad review of functionality or API, or seek collaborators.
-WIPs often benefit from the inclusion of a
-[task list](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-in the PR description.
-- Documentation and high-coverage tests are necessary for enhancements to
-be accepted.
-- If you are adding an enhancement, you may wish to provide evidence for
-its benefit with distinguishing examples in the code and benchmarks
-in the PR discussion.
-- If your pull request addresses an issue, please use the title to describe
-the issue and mention the issue number in the pull request description to
-ensure a link is created to the original issue.
+What does this implement/fix? Explain your changes.
+---------------------------------------------------
 
+
+Any other comments?
+-------------------
+
+
+<!--
 Please be aware that we are a loose team of volunteers so patience is
 necessary; assistance handling other issues is very welcome. We value
 all user contributions, no matter how minor they are. If we are slow to
 review, either the pull request needs some benchmarking, tinkering,
 convincing, etc. or more likely the reviewers are simply busy. In either
 case, we ask for your understanding during the review process.
-For more information, see
-[Why is my PR not getting any attention?](http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention)
+For more information, see our FAQ on this topic:
+http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
 
-Thanks for contributing! Please delete these guidelines before submitting your pull request.
+Thanks for contributing!
+-->

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -131,17 +131,35 @@ visibility.
 (If any of the above seems like magic to you, then look up the
 `Git documentation <http://git-scm.com/documentation>`_ on the web.)
 
+Contributing pull requests
+--------------------------
+
 It is recommended to check that your contribution complies with the following
 rules before submitting a pull request:
 
     * Follow the `coding-guidelines`_ (see below).
 
-    * When applicable, use the Validation tools and other code in the
+    * When applicable, use the validation tools and other code in the
       ``sklearn.utils`` submodule.  A list of utility routines available
       for developers can be found in the :ref:`developers-utils` page.
 
+    * If your pull request addresses an issue, please use the title to describe
+      the issue and mention the issue number in the pull request description to
+      ensure a link is created to the original issue.
+      
     * All public methods should have informative docstrings with sample
       usage presented as doctests when appropriate.
+
+    * Please prefix the title of your pull request with ``[MRG]`` if the
+      contribution is complete and should be subjected to a detailed review.
+      Incomplete contributions should be prefixed ``[WIP]`` to indicate a work
+      in progress (and changed to ``[MRG]`` when it matures). WIPs may be useful
+      to: indicate you are working on something to avoid duplicated work,
+      request broad review of functionality or API, or seek collaborators.
+      WIPs often benefit from the inclusion of a
+      `task list
+      <https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments>`_
+      in the PR description.
 
     * All other tests pass when everything is rebuilt from scratch. On
       Unix-like systems, check with (from the toplevel source folder)::
@@ -153,6 +171,9 @@ rules before submitting a pull request:
       Examples should demonstrate why the new functionality is useful in
       practice and, if possible, compare it to other methods available in
       scikit-learn.
+
+    * Documentation and high-coverage tests are necessary for enhancements
+      to be accepted.
 
     * At least one paragraph of narrative documentation with links to
       references in the literature (with PDF links when possible) and
@@ -206,6 +227,47 @@ and Cython optimizations.
    and the `Astropy Workflow for Developers
    <http://astropy.readthedocs.org/en/latest/development/workflow/development_workflow.html>`_
    sections.
+
+.. _filing_bugs:
+
+Filing Bugs
+-----------
+
+We use Github issues to track all bugs and feature requests; feel free to
+open an issue if you have found a bug or wish to see a feature implemented.
+
+It is recommended to check that your issue complies with the
+following rules before submitting:
+
+-  Verify that your issue is not being currently addressed by other
+   `issues <https://github.com/scikit-learn/scikit-learn/issues?q=>`_
+   or `pull requests <https://github.com/scikit-learn/scikit-learn/pulls?q=>`_.
+
+-  If you are submitting an algorithm or feature request, please verify that
+   the algorithm fulfills our
+   `new algorithm requirements
+   <http://scikit-learn.org/stable/faq.html#can-i-add-this-new-algorithm-that-i-or-someone-else-just-published>`_.
+
+-  Please ensure all code snippets and error messages are formatted in
+   appropriate code blocks.
+   See `Creating and highlighting code blocks
+   <https://help.github.com/articles/creating-and-highlighting-code-blocks>`_.
+
+-  Please include your operating system type and version number, as well
+   as your Python, scikit-learn, numpy, and scipy versions. This information
+   can be found by runnning the following code snippet::
+
+     import platform; print(platform.platform())
+     import sys; print("Python", sys.version)
+     import numpy; print("NumPy", numpy.__version__)
+     import scipy; print("SciPy", scipy.__version__)
+     import sklearn; print("Scikit-Learn", sklearn.__version__)
+   
+-  Please be specific about what estimators and/or functions are involved
+   and the shape of the data, as appropriate; please include a
+   `reproducible <http://stackoverflow.com/help/mcve>`_ code snippet
+   or link to a `gist <https://gist.github.com>`_. If an exception is raised,
+   please provide the traceback.
 
 .. _easy_issues:
 


### PR DESCRIPTION
I've refactored the issue and PR template by moving some of the guidelines we had in there to CONTRIBUTING.md and adding headers to guide users toward supplying the needed information. I feel like this is less verbose and more functional, but I'm not sure whether putting everything into CONTRIBUTING.md was proper. 
Thoughts on this new format? Remember that when users submit a PR or an issue, they see this raw output and unfortunately not the pretty preview. HTML comments do not render in the markdown of issues or PRs, which makes them ideal for inline examples and such.

There's some related discussion at https://github.com/scikit-learn/scikit-learn/issues/6394 about issue / pr templates in general, so try to save PR comments for suggestions specific to this pull request. General suggestions should go in the issue if at all possible.
Here are direct links to the raw and rendered versions:
[raw PR template](https://raw.githubusercontent.com/nelson-liu/scikit-learn/refactor_templates/PULL_REQUEST_TEMPLATE.md)
[rendered PR template](https://github.com/nelson-liu/scikit-learn/blob/refactor_templates/PULL_REQUEST_TEMPLATE.md)

[raw issue template](https://raw.githubusercontent.com/nelson-liu/scikit-learn/refactor_templates/ISSUE_TEMPLATE.md)
[rendered issue template](https://github.com/nelson-liu/scikit-learn/blob/refactor_templates/ISSUE_TEMPLATE.md)
