### PR TITLE
MAINT fix coveralls source files lookup

### DIFF
--- a/build_tools/travis/after_success.sh
+++ b/build_tools/travis/after_success.sh
@@ -9,8 +9,8 @@ set -e
 if [[ "$COVERAGE" == "true" ]]; then
     # Need to run coveralls from a git checkout, so we copy .coverage
     # from TEST_DIR where nosetests has been run
-    cp $TEST_DIR/.coverage $TRAVIS_BUILD_DIR
-    cd $TRAVIS_BUILD_DIR
+    cp $TEST_DIR/.coverage $CACHED_BUILD_DIR/scikit-learn
+    cd $CACHED_BUILD_DIR/scikit-learn
     # Ignore coveralls failures as the coveralls server is not
     # very reliable but we don't want travis to report a failure
     # in the github UI just because the coverage report failed to


### PR DESCRIPTION
This is an attempt to fix the currently broken source file lookup in coveralls test coverage reports.
