### PR TITLE
[MRG + 1] doc: specifically address reinforcement learning in faq

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -254,9 +254,9 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
 --------------------------------------------------------------------------------------------------------------------------------------
 Deep learning and reinforcement learning both require a rich vocabulary to
-define an architecture, and deep learning also requires
+define an architecture, with deep learning additionally requiring
 GPUs for efficient computing. However, neither of these fit within
-the design constraints of scikit-learn. As a result, deep learning
+the design constraints of scikit-learn; as a result, deep learning
 and reinforcement learning are currently out of scope for what
 scikit-learn seeks to achieve.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -251,12 +251,13 @@ You can find more default on the new start methods in the `multiprocessing
 documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
 
 
-Why is there no support for deep learning / Will there be support for deep learning in scikit-learn?
-----------------------------------------------------------------------------------------------------
-Deep learning requires a rich vocabulary to define an architecture and the
-use of GPUs for efficient computing. However, neither of these fit within
-the design constraints of scikit-learn. As a result, deep learning is
-currently out of scope for what scikit-learn seeks to achieve.
+Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
+--------------------------------------------------------------------------------------------------------------------------------------
+Deep learning and reinforcement learning requiresa rich vocabulary to define an
+architecture and the use of GPUs for efficient computing.
+However, neither of these fit within the design constraints of
+scikit-learn. As a result, deep learning and reinforcement learning
+are currently out of scope for what scikit-learn seeks to achieve.
 
 
 Why is my pull request not getting any attention?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -253,7 +253,7 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 
 Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
 --------------------------------------------------------------------------------------------------------------------------------------
-Deep learning and reinforcement learning requiresa rich vocabulary to define an
+Deep learning and reinforcement learning require a rich vocabulary to define an
 architecture and the use of GPUs for efficient computing.
 However, neither of these fit within the design constraints of
 scikit-learn. As a result, deep learning and reinforcement learning

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -253,11 +253,12 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 
 Why is there no support for deep or reinforcement learning / Will there be support for deep or reinforcement learning in scikit-learn?
 --------------------------------------------------------------------------------------------------------------------------------------
-Deep learning and reinforcement learning require a rich vocabulary to define an
-architecture and the use of GPUs for efficient computing.
-However, neither of these fit within the design constraints of
-scikit-learn. As a result, deep learning and reinforcement learning
-are currently out of scope for what scikit-learn seeks to achieve.
+Deep learning and reinforcement learning both require a rich vocabulary to
+define an architecture, and deep learning also requires
+GPUs for efficient computing. However, neither of these fit within
+the design constraints of scikit-learn. As a result, deep learning
+and reinforcement learning are currently out of scope for what
+scikit-learn seeks to achieve.
 
 
 Why is my pull request not getting any attention?


### PR DESCRIPTION
From the mailing list:

> > On 03/02/2016 02:21 PM, Michał Koziarski wrote:
> > As far as I can tell, except PyBrain (which doesn't seem to be
> > actively developed) there are no reinforcement learning libraries in
> > Python. I was wondering if community would be interested in using one
> > and making it a part of scikit-learn. Does it lie within the scope of
> > the project?
> 
> It's not (and we should maybe make that more explicit in the FAQ). ~ @amueller 

Edited the FAQ entry about deep learning to address reinforcement learning as well, since they're not included for similar reasons.
