### PR TITLE
[MRG] doc: add link to user guide in isolation forest docstring

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -129,6 +129,7 @@ This strategy is illustrated below.
     ..  [RD1999] Rousseeuw, P.J., Van Driessen, K. "A fast algorithm for the minimum
         covariance determinant estimator" Technometrics 41(3), 212 (1999)
 
+.. _isolation_forest:
 
 Isolation Forest
 ----------------------------

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -42,6 +42,7 @@ class IsolationForest(BaseBagging):
     Hence, when a forest of random trees collectively produce shorter path
     lengths for particular samples, they are highly likely to be anomalies.
 
+    Read more in the :ref:`User Guide <isolation_forest>`.
 
     Parameters
     ----------


### PR DESCRIPTION
Added a link in the isolation forest docstring to the user guide section about isolation forest in novelty and outlier detection. Addresses https://github.com/scikit-learn/scikit-learn/issues/6485.
