### PR TITLE
[MRG] MKL is always enabled for latest numpy in conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
       CACHED_BUILD_DIR="$HOME/sklearn_build_oldest"
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-      NUMPY_VERSION="1.10.2" SCIPY_VERSION="0.16.1" CYTHON_VERSION="0.23.4"
+      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.23.4"
       CACHED_BUILD_DIR="$HOME/sklearn_build_latest"
 
 matrix:


### PR DESCRIPTION
The master branch is currently failing on travis probably caused by the recent changes in the way conda is shipping MKL enabled builds of numpy / scipy.

This is an attempt to fix the issue by bumping up to the latest versions of those packages. I will merge as soon as travis is green.
