### PR TITLE
[MRG] add error in the return function of tsne library

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -855,7 +855,7 @@ class TSNE(BaseEstimator):
         X_embedded = params.reshape(n_samples, self.n_components)
         self.kl_divergence_ = kl_divergence
 
-        return X_embedded
+        return X_embedded, error
 
     def fit_transform(self, X, y=None):
         """Fit X into an embedded space and return that transformed


### PR DESCRIPTION
It's important to have access to the error when calling model.fit_transform(X).
An example is to use Bayesian optimisation to minimise the error of the resulting TSNE transformation.

```
from sklearn.manifold.t_sne import TSNE
[...]
model = TSNE(n_components=n_components,
                 perplexity=perplexity,
                 early_exaggeration=early_exaggeration,
                 learning_rate=learning_rate,
                 n_iter=n_iter,
                 random_state=random_state,
                 angle=angle,
                 verbose=1)
    _, error = model.fit_transform(X)
    return error
```
