### PR TITLE
[MRG] Temporary disable MKL in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,16 @@ env:
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.21"
       CACHED_BUILD_DIR="$HOME/sklearn_build_oldest"
     # This environment tests the newest supported anaconda env
-    - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
+    - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="false"
       NUMPY_VERSION="1.10.2" SCIPY_VERSION="0.16.1" CYTHON_VERSION="0.23.4"
       CACHED_BUILD_DIR="$HOME/sklearn_build_latest"
 
 matrix:
+  allow_failures:
+    # allow_failures seems to be keyed on the python version
+    # We are using this to allow failures for DISTRIB=scipy-dev-wheels
+    - python: 3.5
+
   include:
     # This environment tests scikit-learn against numpy and scipy master
     # installed from their CI wheels in a virtualenv with the Python

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -57,7 +57,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     else
         conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION cython=$CYTHON_VERSION \
-            libgfortran
+            libgfortran nomkl
     fi
     source activate testenv
 


### PR DESCRIPTION
to have master green on Travis until we fix #6279.

The main other change is to install nomkl when INSTALL_MKL is not true.

I got the nomkl tip from this Continuum blog [post](https://www.continuum.io/blog/developer-blog/anaconda-25-release-now-mkl-optimizations).
