### PR TITLE
[MRG+1] TST: estimator_checks: skip transform test when not implemented

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -536,7 +536,8 @@ def check_transformers_unfitted(name, Transformer):
     with warnings.catch_warnings(record=True):
         transformer = Transformer()
 
-    assert_raises((AttributeError, ValueError), transformer.transform, X)
+    if hasattr(transformer, "transform"):
+        assert_raises((AttributeError, ValueError), transformer.transform, X)
 
 
 def _check_transformer(name, Transformer, X, y):


### PR DESCRIPTION
Estimator checks fail when a transformer only implements `fit_transform`.
