### PR TITLE
Update copyright year in the doc footer (2015 → 2016)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u('scikit-learn')
-copyright = u('2010 - 2015, scikit-learn developers (BSD License)')
+copyright = u('2010 - 2016, scikit-learn developers (BSD License)')
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
I just found the old version of conf.py file that updates copyright year in the doc footer. 
