### PR TITLE
[MRG+1] Add and print a total_n_estimators information

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -34,7 +34,7 @@ MAX_INT = np.iinfo(np.int32).max
 
 
 def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
-                               max_samples, seeds, verbose, total_n_estimators):
+                               max_samples, seeds, total_n_estimators, verbose):
     """Private function used to build a batch of estimators within a job."""
     # Retrieve settings
     n_samples, n_features = X.shape
@@ -344,7 +344,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         # Parallel loop
         n_jobs, n_estimators, starts = _partition_estimators(n_more_estimators,
                                                              self.n_jobs)
-        total_n_estimators = len(n_estimators)
+        total_n_estimators = sum(n_estimators)
 
         # Advance random state to state after training
         # the first n_estimators
@@ -362,8 +362,8 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
                 sample_weight,
                 max_samples,
                 seeds[starts[i]:starts[i + 1]],
-                verbose=self.verbose,
-                total_n_estimators)
+                total_n_estimators,
+                verbose=self.verbose)
             for i in range(n_jobs))
 
         # Reduce

--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -34,7 +34,7 @@ MAX_INT = np.iinfo(np.int32).max
 
 
 def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
-                               max_samples, seeds, verbose):
+                               max_samples, seeds, verbose, total_n_estimators):
     """Private function used to build a batch of estimators within a job."""
     # Retrieve settings
     n_samples, n_features = X.shape
@@ -62,7 +62,8 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
 
     for i in range(n_estimators):
         if verbose > 1:
-            print("building estimator %d of %d" % (i + 1, n_estimators))
+            print("Building estimator %d of %d for this parallel run (total %d)..." %
+                  (i + 1, n_estimators, total_n_estimators))
 
         random_state = check_random_state(seeds[i])
         seed = random_state.randint(MAX_INT)
@@ -343,6 +344,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         # Parallel loop
         n_jobs, n_estimators, starts = _partition_estimators(n_more_estimators,
                                                              self.n_jobs)
+        total_n_estimators = len(n_estimators)
 
         # Advance random state to state after training
         # the first n_estimators
@@ -360,7 +362,8 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
                 sample_weight,
                 max_samples,
                 seeds[starts[i]:starts[i + 1]],
-                verbose=self.verbose)
+                verbose=self.verbose,
+                total_n_estimators)
             for i in range(n_jobs))
 
         # Reduce


### PR DESCRIPTION
Add to bagging.Bagging._parallel_build_estimators a total_n_estimators parameter, to improve the (optional) information printed if verbose > 1.

It felt weird to see 6 times in a row "building estimator 1 of 1" without any idea of total number of estimators to build, now it will be printed more nicely:
![typo__building_estimator_1_out_of_1](https://cloud.githubusercontent.com/assets/11994719/13762485/9559060e-ea3f-11e5-8ffd-0016f5805609.png)
