### PR TITLE
[WIP] new feature: sparse dot row apply

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1359,6 +1359,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         func = partial(_pairwise_callable, metric=metric, **kwds)
     else:
         raise ValueError("Unknown kernel %r" % metric)
+    
     return _parallel_pairwise(X, Y, func, n_jobs, **kwds)
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -15,10 +15,11 @@ import numpy as np
 from scipy.spatial import distance
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
+from scipy.sparse import vstack
 
 from ..utils import check_array
 from ..utils import gen_even_slices
-from ..utils import gen_batches
+from ..utils import gen_batches, _get_n_jobs
 from ..utils.fixes import partial
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..preprocessing import normalize
@@ -1358,5 +1359,137 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
         func = partial(_pairwise_callable, metric=metric, **kwds)
     else:
         raise ValueError("Unknown kernel %r" % metric)
-
     return _parallel_pairwise(X, Y, func, n_jobs, **kwds)
+
+
+def sparse_dot_row_apply(X, Y=None, func=np.sum, batch_size=None,
+                         n_jobs=1, auto_fmt=True, verbose=0, *args, **kwds):
+    """Compute dot of X and Y.
+
+    This method takes either one or two sparse matrices and calculates
+    in batches their dot product. On each batch the callable `func` is
+    then applied. Afterwards a proper output fmt is detected, the results
+    combined and returned.
+
+    The function allows for huge sparse matrix dot calculations, where
+    only a (or some) property(ies) of each row is/are needed.
+
+    For example, passing 'np.sum' as func and 'axis=1' as kwds returns
+    a vector in which element i is the sum of the dot products ith row.
+
+    Another example might be to find only elements in the dot product large
+    than 0.2. In the case of tf-idf cosine similarity of a huge set of
+    documents this can be especially helpful, since holding the whole dot
+    result in memory might not be possible. In that case func should be set
+    to:
+        def my_func(X):
+            X.data[X.data < .2] = 0
+            X.eliminate_zeros()
+            return X
+
+    Another function can be used to find highest ten elements per row in
+    the dot product. For instance a text-based recommender system might
+    want to find the 10 most similar documents for each document. A proper
+    function might look like the following:
+        def my_func(X):
+            res = list()
+            for i in range(X.shape[0]):
+                r = np.array(X[i, :].todense()).ravel()
+                limit = np.sort(r)[-10]
+                r[r < limit] = 0.
+                res.append(csr_matrix(r, shape=(1, len(r))))
+            return vstack(res)
+
+    Naturally, the higher batch_sizes and n_jobs, the more memory is needed.
+
+    Parameters
+    ----------
+    X : sparse matrix
+        X of X dot Y
+
+    Y : sparse or None, default=None
+        Y for X dot Y, if None Y is set to X
+
+    func : callable
+        Function which should be applied to each batch.
+
+    batch_size : int, or None
+        Defines the number of rows processed in each batch. If None the
+        calculation will be split up in n_jobs evenly sized batches.
+
+    n_jobs : int
+        The number of jobs to use for the computation. This works by breaking
+        down the pairwise matrix into slices and computing them in
+        parallel.
+
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging. For n_jobs below -1,
+        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
+        are used.
+
+    auto_fmt : bool
+        Whether to autodetect the return format or not. If False a list
+        containing the result of each batch is returned.
+
+    verbose : int
+        verbose parameter passed to Parallel of joblib.
+
+    `*args` : optional arguments
+        Any further parameters are passed directly to the callable
+
+    `**kwds` : optional keyword parameters
+        Any further keyword parameters are passed directly to the callable
+
+    Returns
+    -------
+    Z : array, sparse matrix, list, ...
+        The type of the result is heavily dependent on the passed `func`.
+        If, for example, `func` returns a sparse matrix, the result will
+        a sparse matrix consisting of all vstacked results. If `func`
+        returns one value per sample, the result will be a vector. If
+        the function cannot automatically detect how to compose the output
+        or auto_fmt is set to False, a list containing the results of
+        each batch is returned.
+
+    """
+
+    if batch_size is None:
+        # no batch size defined. split into n_jobs batches
+
+        # acount for n_jobs < 0
+        n_jobs = _get_n_jobs(n_jobs)
+
+        # create batch size to fit n_jobs
+        batch_size = int(X.shape[0] / n_jobs) + 1
+
+    # worker function for delayed
+    def _sparse_row_apply_worker(X_batch, Y, func, *args, **kwds):
+        return func(X_batch.dot(Y), *args, **kwds)
+
+    if Y is None:
+        Y = X
+
+    # start computation
+    res = list(Parallel(n_jobs=n_jobs, backend='threading', verbose=verbose)
+               (delayed(_sparse_row_apply_worker)
+                (X[chunk, :], Y, func, *args, **kwds)
+                for chunk in gen_batches(X.shape[0], batch_size)))
+
+    if auto_fmt:
+        # auto detect output format using first batch result
+        f_elem = res[0]
+        if isinstance(f_elem, csr_matrix):
+            # csr_matrices per batch -> stack them
+            return vstack(res)
+        elif isinstance(f_elem, (int, float)):
+            # single value -> create array
+            return np.array(res)
+        elif isinstance(f_elem, np.matrix):
+            # matrix per batch
+            if f_elem.shape[0] == batch_size and f_elem.shape[1] == 1:
+                # one value per X row -> create array
+                return np.array(map(np.array, res)).ravel()
+            else:
+                # more values per X row -> stack them
+                return np.vstack(res)
+    return res

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -37,6 +37,7 @@ from sklearn.metrics.pairwise import check_paired_arrays
 from sklearn.metrics.pairwise import paired_distances
 from sklearn.metrics.pairwise import paired_euclidean_distances
 from sklearn.metrics.pairwise import paired_manhattan_distances
+from sklearn.metrics.pairwise import sparse_dot_row_apply
 from sklearn.preprocessing import normalize
 
 
@@ -661,3 +662,25 @@ def test_check_preserve_type():
                                                    XB.astype(np.float))
     assert_equal(XA_checked.dtype, np.float)
     assert_equal(XB_checked.dtype, np.float)
+
+
+def test_sparse_dot_row_apply():
+    X = csr_matrix(np.random.random((10, 10)))
+    Y = csr_matrix(np.random.random((10, 10)))
+
+    XY = X.dot(Y)
+
+    def my_func(x):
+        return x
+
+    XYSD = sparse_dot_row_apply(X, Y, my_func, n_jobs=2)
+    assert_array_equal(np.array(XY.todense()).ravel(),
+                       np.array(XYSD.todense()).ravel())
+
+    def my_func(x, axis):
+        return x.sum(axis=axis)
+
+    XY_rsum = np.array(XY.sum(axis=1)).ravel()
+    XYSD_rsum = sparse_dot_row_apply(X, Y, my_func, axis=1, n_jobs=2)
+    assert_array_equal(XY_rsum, XYSD_rsum)
+

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -665,15 +665,12 @@ def test_check_preserve_type():
 
 
 def test_sparse_dot_row_apply():
-    X = csr_matrix(np.random.random((10, 10)))
-    Y = csr_matrix(np.random.random((10, 10)))
+    X = csr_matrix(np.random.random((7, 7)))
+    Y = csr_matrix(np.random.random((7, 7)))
 
     XY = X.dot(Y)
 
-    def my_func(x):
-        return x
-
-    XYSD = sparse_dot_row_apply(X, Y, my_func, n_jobs=2)
+    XYSD = sparse_dot_row_apply(X, Y, lambda x: x, n_jobs=2)
     assert_array_equal(np.array(XY.todense()).ravel(),
                        np.array(XYSD.todense()).ravel())
 


### PR DESCRIPTION
Hi all,

I created a function which calculates the dot product of two sparse matrices in parallel (batches), applies a function onto each batch and combines the results. I noticed that it is somehow similar to metrices.pairwise._parallel_pairwise. However, _parallel_pairwise aims to increase speed, whereas this function tries to tackle limitations of memory. I wrote down some examples in the comments how this function might be used (please read them). I found it especially useful in the case of calculating the cosine similarity of huge sparse matrices X[n_samples, n_features] in which each row represents the tf-idf vector of a document (e.g., the output produced by the tfidf vectorizer). In such cases often only values larger than ~0.2 are valuable or one might only need the 10 most similar documents. However, simple doing X.dot(X.T) mostly results in a dense matrix which often exceeds the available memory. This function can be used to calculate the dot product in batches and filter out unwanted values before stacking all batch results together.

I already created some test cases to validate the code. However, I'm open to any suggestions to make the function more generic, increase its usability, improve performance or what ever :) I'm also not sure if it should be a public or private function, where it should be located and how it should be called. 

Looking forward to your comments and a fruitful discussion,
Florian
