### PR TITLE
[MRG] Fixes the accessible kl_divergence value #6507

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -847,7 +847,8 @@ class TSNE(BaseEstimator):
         P /= self.early_exaggeration
         opt_args['n_iter'] = self.n_iter
         opt_args['it'] = it + 1
-        params, error, it = _gradient_descent(obj_func, params, **opt_args)
+        params, kl_divergence, it = _gradient_descent(obj_func, params,
+                                                      **opt_args)
 
         if self.verbose:
             print("[t-SNE] Error after %d iterations: %f"


### PR DESCRIPTION
As described in #6507 the accessible kl_divergence value was wrong. This PR fixes this and adds a test to ensure that the accessible value corresponds to the value that is printed if a verbosity level is set.
