### PR TITLE
[MRG] LabelPropagation and LabelSpreading enhancements

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -81,9 +81,10 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', None}
         String identifier for kernel function to use.
-        Only 'rbf' and 'knn' kernels are currently supported..
+        Only 'rbf' and 'knn' kernels are currently supported.
+        If None is specified no kernel function is used and X is assumed to be an affinity/adjacent matrix of a Graph
 
     gamma : float
         Parameter for rbf kernel
@@ -139,6 +140,8 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
                                                     mode='connectivity')
             else:
                 return self.nn_fit.kneighbors(y, return_distance=False)
+        elif self.kernel is None:
+            return X
         else:
             raise ValueError("%s is not a valid kernel. Only rbf and knn"
                              " are supported at this time" % self.kernel)

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -66,6 +66,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils.graph import graph_laplacian
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_X_y, check_is_fitted, check_array
+from ..preprocessing import normalize
 
 
 # Helper functions
@@ -221,7 +222,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y)
+        X, y = check_X_y(X, y, accept_sparse='csr')
         self.X_ = X
         check_classification_targets(y)
 
@@ -354,11 +355,7 @@ class LabelPropagation(BaseLabelPropagation):
         if self.kernel == 'knn':
             self.nn_fit = None
         affinity_matrix = self._get_kernel(self.X_)
-        normalizer = affinity_matrix.sum(axis=0)
-        if sparse.isspmatrix(affinity_matrix):
-            affinity_matrix.data /= np.diag(np.array(normalizer))
-        else:
-            affinity_matrix /= normalizer[:, np.newaxis]
+        affinity_matrix = normalize(affinity_matrix, norm='l1', axis=1)
         return affinity_matrix
 
 

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -82,10 +82,10 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf', None}
+    kernel : {'knn', 'rbf', 'precomputed'}
         String identifier for kernel function to use.
         Only 'rbf' and 'knn' kernels are currently supported.
-        If None is specified no kernel function is used and X is assumed to be an affinity/adjacent matrix of a Graph
+        If 'precomputed' is specified no kernel function is used and X is assumed to be an affinity/adjacent matrix of a Graph
 
     gamma : float
         Parameter for rbf kernel
@@ -141,7 +141,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
                                                     mode='connectivity')
             else:
                 return self.nn_fit.kneighbors(y, return_distance=False)
-        elif self.kernel is None:
+        elif self.kernel == 'precomputed':
             return X
         else:
             raise ValueError("%s is not a valid kernel. Only rbf and knn"
@@ -198,8 +198,8 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
         elif self.kernel == 'rbf':
             weight_matrices = weight_matrices.T
             probabilities = np.dot(weight_matrices, self.label_distributions_)
-        elif self.kernel is None:
-            raise NotImplementedError("Currently not implemented for Kernel=None scheme")
+        elif self.kernel == 'precomputed':
+            raise NotImplementedError("Currently not implemented for kernel='precomputed' scheme")
         normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
         probabilities /= normalizer
         return probabilities
@@ -293,9 +293,10 @@ class LabelPropagation(BaseLabelPropagation):
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', 'precomputed'}
         String identifier for kernel function to use.
-        Only 'rbf' and 'knn' kernels are currently supported..
+        Only 'rbf' and 'knn' kernels are currently supported.
+        If 'precomputed' is specified no kernel function is used and X is assumed to be an affinity/adjacent matrix of a Graph
 
     gamma : float
         Parameter for rbf kernel
@@ -382,9 +383,10 @@ class LabelSpreading(BaseLabelPropagation):
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', 'precomputed'}
         String identifier for kernel function to use.
         Only 'rbf' and 'knn' kernels are currently supported.
+        If 'precomputed' is specified no kernel function is used and X is assumed to be an affinity/adjacent matrix of a Graph
 
     gamma : float
       parameter for rbf kernel

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -420,6 +420,9 @@ class LabelSpreading(BaseLabelPropagation):
     transduction_ : array, shape = [n_samples]
         Label assigned to each item via the transduction.
 
+    transduction_prob_ : array, shape = [n_samples]
+        Probability of label assigned to each item via the transduction.
+
     n_iter_ : int
         Number of iterations run.
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -11,8 +11,10 @@ from numpy.testing import assert_array_equal
 ESTIMATORS = [
     (label_propagation.LabelPropagation, {'kernel': 'rbf'}),
     (label_propagation.LabelPropagation, {'kernel': 'knn', 'n_neighbors': 2}),
+    (label_propagation.LabelPropagation, {'kernel': None}),
     (label_propagation.LabelSpreading, {'kernel': 'rbf'}),
-    (label_propagation.LabelSpreading, {'kernel': 'knn', 'n_neighbors': 2})
+    (label_propagation.LabelSpreading, {'kernel': 'knn', 'n_neighbors': 2}),
+    (label_propagation.LabelPropagation, {'kernel': None}),
 ]
 
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -4,6 +4,7 @@ import nose
 import numpy as np
 
 from sklearn.semi_supervised import label_propagation
+from scipy.sparse import dok_matrix
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
@@ -11,15 +12,20 @@ from numpy.testing import assert_array_equal
 ESTIMATORS = [
     (label_propagation.LabelPropagation, {'kernel': 'rbf'}),
     (label_propagation.LabelPropagation, {'kernel': 'knn', 'n_neighbors': 2}),
-    (label_propagation.LabelPropagation, {'kernel': None}),
     (label_propagation.LabelSpreading, {'kernel': 'rbf'}),
-    (label_propagation.LabelSpreading, {'kernel': 'knn', 'n_neighbors': 2}),
-    (label_propagation.LabelPropagation, {'kernel': None}),
+    (label_propagation.LabelSpreading, {'kernel': 'knn', 'n_neighbors': 2})
 ]
 
 
 def test_fit_transduction():
     samples = [[1., 0.], [0., 2.], [1., 3.]]
+    labels = [0, 1, -1]
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(samples, labels)
+        nose.tools.assert_equal(clf.transduction_[2], 1)
+
+def test_fit_transduction_sparse():
+    samples = dok_matrix([[1., 0.], [0., 2.], [1., 3.]])
     labels = [0, 1, -1]
     for estimator, parameters in ESTIMATORS:
         clf = estimator(**parameters).fit(samples, labels)

--- a/sklearn/semi_supervised/tests/test_label_propagation_graph.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation_graph.py
@@ -1,0 +1,48 @@
+""" test the label propagation module """
+
+import nose
+import numpy as np
+
+from sklearn.semi_supervised import label_propagation
+from scipy.sparse import dok_matrix
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_equal
+
+
+ESTIMATORS = [
+    (label_propagation.LabelPropagation, {'kernel': None}),
+    (label_propagation.LabelSpreading, {'kernel': None}),
+]
+
+graph = [[0, 1, 0], [1, 0, 0], [0, 0, 1]]
+labels = [0, -1, 1]
+
+def test_fit_transduction():
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(graph, labels)
+        nose.tools.assert_equal(clf.transduction_[2], 1)
+
+def test_fit_transduction_sparse():
+    graph_sparse = dok_matrix(graph)
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(graph_sparse, labels)
+        nose.tools.assert_equal(clf.transduction_[2], 1)
+
+def test_distribution():
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(graph, labels)
+        assert_array_almost_equal(np.asarray(clf.label_distributions_[1]),
+                                      np.array([1, 0]), 2)
+
+
+def test_predict():
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(graph, labels)
+        assert_array_equal(clf.predict([[1, 0, 0]]), np.array([0, 0, 0]))
+
+
+def test_predict_proba():
+    for estimator, parameters in ESTIMATORS:
+        clf = estimator(**parameters).fit(graph, labels)
+        assert_array_almost_equal(clf.predict_proba([[1, 0, 0]]),
+                                  np.array([[0.5, 0.5]]))

--- a/sklearn/semi_supervised/tests/test_label_propagation_graph.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation_graph.py
@@ -34,15 +34,3 @@ def test_distribution():
         assert_array_almost_equal(np.asarray(clf.label_distributions_[1]),
                                       np.array([1, 0]), 2)
 
-
-def test_predict():
-    for estimator, parameters in ESTIMATORS:
-        clf = estimator(**parameters).fit(graph, labels)
-        assert_array_equal(clf.predict([[1, 0, 0]]), np.array([0, 0, 0]))
-
-
-def test_predict_proba():
-    for estimator, parameters in ESTIMATORS:
-        clf = estimator(**parameters).fit(graph, labels)
-        assert_array_almost_equal(clf.predict_proba([[1, 0, 0]]),
-                                  np.array([[0.5, 0.5]]))

--- a/sklearn/semi_supervised/tests/test_label_propagation_precomputed.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation_precomputed.py
@@ -10,8 +10,8 @@ from numpy.testing import assert_array_equal
 
 
 ESTIMATORS = [
-    (label_propagation.LabelPropagation, {'kernel': None}),
-    (label_propagation.LabelSpreading, {'kernel': None}),
+    (label_propagation.LabelPropagation, {'kernel': 'precomputed'}),
+    (label_propagation.LabelSpreading, {'kernel': 'precomputed'}),
 ]
 
 graph = [[0, 1, 0], [1, 0, 0], [0, 0, 1]]


### PR DESCRIPTION
The following enhancements have been made:
- `X` accepts sparse matrixes
- `X` can now directly represent an adjacency matrix. This is useful when X represents a graph and therefore no kernel is required (`kernel=None`)
- Currently if a sample has been predicted with 0 or NaN probability the argmax will select the first column and therefore classify the sample with the class with an index of 0. e.g. `argmax([0,0,0]) = 0` This is obviously undesirable. Therefore now such samples will remain unclassified with a class of -1
- A `transduction_prob_` attribute has been added after fitting which contains the probability of label assigned to each sample via the transduction

Note:
- I don't know how to implement `predict_proba` and `predict` when `kernel=None`. Currently a `NotImplementedError` is raised. Any suggestions on how to do it is much welcomed
