### PR TITLE
[MRG] type checking before comparison, to avoid warning messages, in preprocessing.OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1796,7 +1796,8 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         if np.any(X < 0):
             raise ValueError("X needs to contain only non-negative integers.")
         n_samples, n_features = X.shape
-        if self.n_values == 'auto':
+        if (isinstance(self.n_values, six.string_types) and
+            self.n_values == 'auto'):
             n_values = np.max(X, axis=0) + 1
         elif isinstance(self.n_values, numbers.Integral):
             if (np.max(X, axis=0) >= self.n_values).any():


### PR DESCRIPTION
# preprocessing.OneHotEncoder
- type checking before comparison, to avoid warning messages
- If np.array is pssed as a parameter 'n_values', warning of multiple comparison is printed. This patch avoid this problem.
