### PR TITLE
[MRG]Minor change for elegancy and performance

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -88,9 +88,9 @@ def softmax(X):
     X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
         The transformed data.
     """
-    tmp = X - X.max(axis=1)[:, np.newaxis]
+    tmp = X - X.max(axis=1, keepdims=True)
     np.exp(tmp, out=X)
-    X /= X.sum(axis=1)[:, np.newaxis]
+    X /= X.sum(axis=1, keepdims=True)
 
     return X
 


### PR DESCRIPTION
When doing dimension reducing operations in numpy(such as sum, max), 
I think it would be more elegant and also more efficient to use the builtin option '**keepdims**' rather than manually add a new dimension.
