### PR TITLE
[MRG+1] DOC: fix spellings of 'license'

### DIFF
--- a/examples/gaussian_process/plot_gpc_isoprobability.py
+++ b/examples/gaussian_process/plot_gpc_isoprobability.py
@@ -14,7 +14,7 @@ print(__doc__)
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 # Adapted to GaussianProcessClassifier:
 #         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/examples/gaussian_process/plot_gpr_noisy_targets.py
+++ b/examples/gaussian_process/plot_gpr_noisy_targets.py
@@ -23,7 +23,7 @@ print(__doc__)
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 #         Jake Vanderplas <vanderplas@astro.washington.edu>
 #         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>s
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 from matplotlib import pyplot as pl

--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -9,7 +9,7 @@ are represented by the dashed lines.
 """
 print(__doc__)
 # Authors: Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -10,7 +10,7 @@ shifted to avoid overlapping.
 """
 
 # Author: Nelle Varoquaux <nelle.varoquaux@gmail.com>
-# Licence: BSD
+# License: BSD
 
 print(__doc__)
 import numpy as np

--- a/examples/plot_isotonic_regression.py
+++ b/examples/plot_isotonic_regression.py
@@ -15,7 +15,7 @@ print(__doc__)
 
 # Author: Nelle Varoquaux <nelle.varoquaux@gmail.com>
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/semi_supervised/plot_label_propagation_digits.py
+++ b/examples/semi_supervised/plot_label_propagation_digits.py
@@ -17,7 +17,7 @@ At the end, the top 10 most uncertain predictions will be shown.
 print(__doc__)
 
 # Authors: Clay Woolam <clay@woolam.org>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
+++ b/examples/semi_supervised/plot_label_propagation_digits_active_learning.py
@@ -18,7 +18,7 @@ model with their true labels.
 print(__doc__)
 
 # Authors: Clay Woolam <clay@woolam.org>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/semi_supervised/plot_label_propagation_structure.py
+++ b/examples/semi_supervised/plot_label_propagation_structure.py
@@ -13,7 +13,7 @@ print(__doc__)
 
 # Authors: Clay Woolam <clay@woolam.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/semi_supervised/plot_label_propagation_versus_svm_iris.py
+++ b/examples/semi_supervised/plot_label_propagation_versus_svm_iris.py
@@ -13,7 +13,7 @@ even with a small amount of labeled data.
 print(__doc__)
 
 # Authors: Clay Woolam <clay@woolam.org>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -6,7 +6,7 @@
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Lars Buitinck
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.math cimport sqrt
 import numpy as np

--- a/sklearn/decomposition/factor_analysis.py
+++ b/sklearn/decomposition/factor_analysis.py
@@ -17,7 +17,7 @@ Algorithm 21.1
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #         Denis A. Engemann <d.engemann@fz-juelich.de>
 
-# Licence: BSD3
+# License: BSD3
 
 import warnings
 from math import sqrt, log

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -1,6 +1,6 @@
 # Author: Christian Osendorfer <osendorf@gmail.com>
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
-# Licence: BSD3
+# License: BSD3
 
 import numpy as np
 

--- a/sklearn/ensemble/_gradient_boosting.pyx
+++ b/sklearn/ensemble/_gradient_boosting.pyx
@@ -4,7 +4,7 @@
 #
 # Author: Peter Prettenhofer
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 cimport cython
 

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -9,7 +9,7 @@ classification estimators.
 # Authors: Sebastian Raschka <se.raschka@gmail.com>,
 #          Gilles Louppe <g.louppe@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -21,7 +21,7 @@ The module structure is the following:
 #          Hamzeh Alsalhi <ha258@cornell.edu>
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from abc import ABCMeta, abstractmethod
 

--- a/sklearn/gaussian_process/__init__.py
+++ b/sklearn/gaussian_process/__init__.py
@@ -3,7 +3,7 @@
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
 #         Vincent Dubourg <vincent.dubourg@gmail.com>
 #         (mostly translation, see implementation details)
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 """
 The :mod:`sklearn.gaussian_process` module implements Gaussian Process

--- a/sklearn/gaussian_process/correlation_models.py
+++ b/sklearn/gaussian_process/correlation_models.py
@@ -2,7 +2,7 @@
 
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 #         (mostly translation, see implementation details)
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 """
 The built-in correlation models submodule for the gaussian_process module.

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -2,7 +2,7 @@
 
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 #         (mostly translation, see implementation details)
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from __future__ import print_function
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -14,7 +14,7 @@ optimization.
 """
 
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 # Note: this module is strongly inspired by the kernel module of the george
 #       package.

--- a/sklearn/gaussian_process/regression_models.py
+++ b/sklearn/gaussian_process/regression_models.py
@@ -2,7 +2,7 @@
 
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 #         (mostly translation, see implementation details)
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 """
 The built-in regression models submodule for the gaussian_process module.

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -3,7 +3,7 @@ Testing for Gaussian Process module (sklearn.gaussian_process)
 """
 
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from nose.tools import raises
 from nose.tools import assert_true

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -1,7 +1,7 @@
 """Testing for Gaussian process classification """
 
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -1,7 +1,7 @@
 """Testing for Gaussian process regression """
 
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -1,7 +1,7 @@
 """Testing for kernels for Gaussian processes."""
 
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from collections import Hashable
 from sklearn.externals.funcsigs import signature

--- a/sklearn/linear_model/cd_fast.pyx
+++ b/sklearn/linear_model/cd_fast.pyx
@@ -4,7 +4,7 @@
 #         Alexis Mignon <alexis.mignon@gmail.com>
 #         Manoj Kumar <manojkumarsivaraj334@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.math cimport fabs
 cimport numpy as np

--- a/sklearn/linear_model/sag.py
+++ b/sklearn/linear_model/sag.py
@@ -2,7 +2,7 @@
 
 # Authors: Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 import warnings

--- a/sklearn/linear_model/sag_fast.pyx
+++ b/sklearn/linear_model/sag_fast.pyx
@@ -5,7 +5,7 @@
 # Authors: Danny Sullivan <dbsullivan23@gmail.com>
 #          Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 import numpy as np
 cimport numpy as np
 import scipy.sparse as sp

--- a/sklearn/linear_model/sgd_fast.pxd
+++ b/sklearn/linear_model/sgd_fast.pxd
@@ -1,5 +1,5 @@
 """Helper to load LossFunction from sgd_fast.pyx to sag_fast.pyx"""
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 cdef class LossFunction:
     cdef double loss(self, double p, double y) nogil

--- a/sklearn/linear_model/sgd_fast.pyx
+++ b/sklearn/linear_model/sgd_fast.pyx
@@ -7,7 +7,7 @@
 #         Rob Zinkov (passive-aggressive)
 #         Lars Buitinck
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 
 import numpy as np

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -1,5 +1,5 @@
 # Author: Vlad Niculae
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -1,7 +1,7 @@
 # Authors: Danny Sullivan <dbsullivan23@gmail.com>
 #          Tom Dupre la Tour <tom.dupre-la-tour@m4x.org>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import math
 import numpy as np

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -3,7 +3,7 @@ Multi-dimensional Scaling (MDS)
 """
 
 # author: Nelle Varoquaux <nelle.varoquaux@gmail.com>
-# Licence: BSD
+# License: BSD
 
 import numpy as np
 

--- a/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 # cython: wraparound=False
 # Authors: Robert Layton <robertlayton@gmail.com>
 #           Corey Lynch <coreylynch9@gmail.com>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.math cimport exp
 from scipy.special import gammaln

--- a/sklearn/metrics/pairwise_fast.pyx
+++ b/sklearn/metrics/pairwise_fast.pyx
@@ -5,7 +5,7 @@
 # Author: Andreas Mueller <amueller@ais.uni-bonn.de>
 #         Lars Buitinck
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.string cimport memset
 import numpy as np

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -4,7 +4,7 @@
 #cython: cdivision=True
 
 # Author: Jake Vanderplas <vanderplas@astro.washington.edu>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 __all__ = ['BallTree']
 

--- a/sklearn/neural_network/__init__.py
+++ b/sklearn/neural_network/__init__.py
@@ -3,7 +3,7 @@ The :mod:`sklearn.neural_network` module includes models based on neural
 networks.
 """
 
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from .rbm import BernoulliRBM
 

--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -2,7 +2,7 @@
 """
 
 # Author: Issam H. Laradji <issam.laradji@gmail.com>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/neural_network/_stochastic_optimizers.py
+++ b/sklearn/neural_network/_stochastic_optimizers.py
@@ -2,7 +2,7 @@
 """
 
 # Authors:  Jiyuan Qian <jq401@nyu.edu>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -4,7 +4,7 @@
 # Authors: Issam H. Laradji <issam.laradji@gmail.com>
 #          Andreas Mueller
 #          Jiyuan Qian
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -3,7 +3,7 @@ Testing for Multi-layer Perceptron module (sklearn.neural_network)
 """
 
 # Author: Issam H. Laradji
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import sys
 import warnings

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -7,7 +7,7 @@ estimator, as a chain of transforms and estimators.
 #         Virgile Fritsch
 #         Alexandre Gramfort
 #         Lars Buitinck
-# Licence: BSD
+# License: BSD
 
 from collections import defaultdict
 from warnings import warn

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -52,7 +52,7 @@ Non-Parametric Function Induction in Semi-Supervised Learning. AISTAT 2005
 """
 
 # Authors: Clay Woolam <clay@woolam.org>
-# Licence: BSD
+# License: BSD
 from abc import ABCMeta, abstractmethod
 
 import numpy as np

--- a/sklearn/tests/test_check_build.py
+++ b/sklearn/tests/test_check_build.py
@@ -3,7 +3,7 @@ Smoke Test the check_build module
 """
 
 # Author: G Varoquaux
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from sklearn.__check_build import raise_build_error
 

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -5,7 +5,7 @@
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 # See _criterion.pyx for implementation details.
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -13,7 +13,7 @@
 #          Fares Hedayati <fares.hedayati@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -5,7 +5,7 @@
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 # See _splitter.pyx for details.
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -13,7 +13,7 @@
 #          Fares Hedayati <fares.hedayati@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from ._criterion cimport Criterion
 

--- a/sklearn/tree/_tree.pxd
+++ b/sklearn/tree/_tree.pxd
@@ -5,7 +5,7 @@
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 # See _tree.pyx for details.
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -13,7 +13,7 @@
 #          Fares Hedayati <fares.hedayati@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from cpython cimport Py_INCREF, PyObject
 

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -3,7 +3,7 @@
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 # See _utils.pyx for details.
 

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -8,7 +8,7 @@
 #          Jacob Schreiber <jmschreiber91@gmail.com>
 #
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.stdlib cimport free
 from libc.stdlib cimport malloc

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -8,7 +8,7 @@ This module defines export functions for decision trees.
 #          Noel Dawe <noel@dawe.me>
 #          Satrajit Gosh <satrajit.ghosh@gmail.com>
 #          Trevor Stephens <trev.stephens@gmail.com>
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 import numpy as np
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -11,7 +11,7 @@ randomized trees. Single and multi-output problems are both handled.
 #          Joly Arnaud <arnaud.v.joly@gmail.com>
 #          Fares Hedayati <fares.hedayati@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from __future__ import division
 

--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -1,6 +1,6 @@
 # Authors: Arnaud Joly
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 
 import numpy as np

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -4,7 +4,7 @@
 #
 # Author: Arnaud Joly
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 """
 Random utility function
 =======================

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -1,7 +1,7 @@
 """Utilities for meta-estimators"""
 # Author: Joel Nothman
 #         Andreas Mueller
-# Licence: BSD
+# License: BSD
 
 from operator import attrgetter
 from functools import update_wrapper

--- a/sklearn/utils/murmurhash.pyx
+++ b/sklearn/utils/murmurhash.pyx
@@ -12,7 +12,7 @@ and can be found here:
 """
 # Author: Olivier Grisel <olivier.grisel@ensta.org>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 cimport cython
 cimport numpy as np

--- a/sklearn/utils/seq_dataset.pyx
+++ b/sklearn/utils/seq_dataset.pyx
@@ -4,7 +4,7 @@
 #
 # Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 cimport cython
 from libc.limits cimport INT_MAX

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -4,7 +4,7 @@
 #          Lars Buitinck
 #          Giorgio Patrini
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 from libc.math cimport fabs, sqrt, pow
 cimport numpy as np

--- a/sklearn/utils/weight_vector.pyx
+++ b/sklearn/utils/weight_vector.pyx
@@ -6,7 +6,7 @@
 #         Lars Buitinck
 #         Danny Sullivan <dsullivan7@hotmail.com>
 #
-# Licence: BSD 3 clause
+# License: BSD 3 clause
 
 cimport cython
 from libc.limits cimport INT_MAX


### PR DESCRIPTION
Trivial PR. Was reading through the tree code, when I noticed that "License" was misspelled. Ran a quick grep/sed to fix this across the codebase. Most of the files are spelled "License", so i figured it's best to homogenize with the majority.
