### PR TITLE
[MRG] fix references to examples

### DIFF
--- a/sklearn/cluster/mean_shift_.py
+++ b/sklearn/cluster/mean_shift_.py
@@ -167,7 +167,7 @@ def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
 
     Notes
     -----
-    See examples/cluster/plot_meanshift.py for an example.
+    See examples/cluster/plot_mean_shift.py for an example.
 
     """
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -363,7 +363,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     Notes
     -----
-    See examples/plot_lasso_coordinate_descent_path.py for an example.
+    See examples/linear_model/plot_lasso_coordinate_descent_path.py for an example.
 
     See also
     --------
@@ -1324,7 +1324,7 @@ class LassoCV(LinearModelCV, RegressorMixin):
 
     Notes
     -----
-    See examples/linear_model/lasso_path_with_crossvalidation.py
+    See examples/linear_model/plot_lasso_model_selection.py
     for an example.
 
     To avoid unnecessary memory duplication the X argument of the fit method
@@ -1479,7 +1479,7 @@ class ElasticNetCV(LinearModelCV, RegressorMixin):
 
     Notes
     -----
-    See examples/linear_model/lasso_path_with_crossvalidation.py
+    See examples/linear_model/plot_lasso_model_selection.py
     for an example.
 
     To avoid unnecessary memory duplication the X argument of the fit method


### PR DESCRIPTION
As in #1980 and #1986, some examples were misreferenced. Now they should point to the right examples.

```
$ ls `grep -hRo 'examples/[^ ]*.py' sklearn | sort -u` >/dev/null
ls: examples/cluster/plot_meanshift.py: No such file or directory
ls: examples/linear_model/lasso_path_with_crossvalidation.py: No such file or directory
ls: examples/plot_lasso_coordinate_descent_path.py: No such file or directory
```
