### PR TITLE
NMF Bug fix when init='custom'

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -760,7 +760,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
                          "positive; got (tol=%r)" % tol)
 
     # check W and H, or initialize them
-    if init == 'custom':
+    if init == 'custom' and update_H:
         _check_init(H, (n_components, n_features), "NMF (input H)")
         _check_init(W, (n_samples, n_components), "NMF (input W)")
     elif not update_H:

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -121,6 +121,22 @@ def test_nmf_transform():
 
 
 @ignore_warnings
+def test_nmf_transform_custom_init():
+    # Smoke test that checks if NMF.transform works with custom initialization
+    A = np.abs(random_state.randn(6, 5))
+    n_components = 4
+    avg = np.sqrt(A.mean() / n_components)
+    H_init = np.abs(avg * random_state.randn(n_components, 5))
+    W_init = np.abs(avg * random_state.randn(6, n_components))
+
+    for solver in ('pg', 'cd'):
+        m = NMF(solver=solver, n_components=n_components, init='custom', random_state=0)
+        ft = m.fit_transform(A, W=W_init, H=H_init)
+        t = m.transform(A)
+
+
+
+@ignore_warnings
 def test_nmf_inverse_transform():
     # Test that NMF.inverse_transform returns close values
     random_state = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -120,7 +120,6 @@ def test_nmf_transform():
         assert_array_almost_equal(ft, t, decimal=2)
 
 
-@ignore_warnings
 def test_nmf_transform_custom_init():
     # Smoke test that checks if NMF.transform works with custom initialization
     A = np.abs(random_state.randn(6, 5))
@@ -129,10 +128,9 @@ def test_nmf_transform_custom_init():
     H_init = np.abs(avg * random_state.randn(n_components, 5))
     W_init = np.abs(avg * random_state.randn(6, n_components))
 
-    for solver in ('pg', 'cd'):
-        m = NMF(solver=solver, n_components=n_components, init='custom', random_state=0)
-        ft = m.fit_transform(A, W=W_init, H=H_init)
-        t = m.transform(A)
+    m = NMF(solver='cd', n_components=n_components, init='custom', random_state=0)
+    ft = m.fit_transform(A, W=W_init, H=H_init)
+    t = m.transform(A)
 
 
 


### PR DESCRIPTION
When init='custom' and transform is used, W should not be checked for initialisation.
Previous version gives the following error for following code:

``` python
import numpy as np
X = np.array([[1,1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
from sklearn.decomposition import NMF
model = NMF(n_components=2, init='custom', random_state=0)


n_samples, n_features = X.shape
n_components = 2
avg = np.sqrt(X.mean() / n_components)
H_init = avg * np.random.rand(n_components, n_features)
W_init = avg *np.random.rand(n_samples, n_components)

X_tranformed = model.fit_transform(X, W=W_init, H=H_init)

#test fitted model
X_transformed_2 = model.transform(X+2)
```

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    X_transformed_2 = model.transform(X+2)
  File "/home/sasank/anaconda3/lib/python3.5/site-packages/sklearn/decompositio
n/nmf.py", line 1106, in transform
    beta=self.beta, eta=self.eta)
  File "/home/sasank/anaconda3/lib/python3.5/site-packages/sklearn/decompositio
n/nmf.py", line 765, in non_negative_factorization
    _check_init(W, (n_samples, n_components), "NMF (input W)")
  File "/home/sasank/anaconda3/lib/python3.5/site-packages/sklearn/decompositio
n/nmf.py", line 60, in _check_init
    A = check_array(A)
  File "/home/sasank/anaconda3/lib/python3.5/site-packages/sklearn/utils/valida
tion.py", line 398, in check_array
    _assert_all_finite(array)
  File "/home/sasank/anaconda3/lib/python3.5/site-packages/sklearn/utils/valida
tion.py", line 54, in _assert_all_finite
    " or a value too large for %r." % X.dtype)
ValueError: Input contains NaN, infinity or a value too large for dtype('float6
4').
```

This is fixed now.
