### PR TITLE
[MRG+1] Bug fix for OneVsOneClassifier - converted input to numpy array

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -46,6 +46,7 @@ from .utils import check_random_state
 from .utils.validation import _num_samples
 from .utils.validation import check_consistent_length
 from .utils.validation import check_is_fitted
+from .utils.validation import check_X_y
 from .utils.multiclass import (_check_partial_fit_first_call,
                                check_classification_targets)
 from .externals.joblib import Parallel
@@ -468,8 +469,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         -------
         self
         """
-        X = np.asarray(X)
-        y = np.asarray(y)
+        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
         check_consistent_length(X, y)
 
         self.classes_ = np.unique(y)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -468,6 +468,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         -------
         self
         """
+        X = np.asarray(X)
         y = np.asarray(y)
         check_consistent_length(X, y)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -469,8 +469,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         -------
         self
         """
-        X, y = check_X_y(X, y, accept_sparse='csr', dtype=np.float64, order="C")
-        check_consistent_length(X, y)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
 
         self.classes_ = np.unique(y)
         n_classes = self.classes_.shape[0]
@@ -513,8 +512,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
                                 range(self.n_classes_ *
                                 (self.n_classes_-1) // 2)]
 
-        y = np.asarray(y)
-        check_consistent_length(X, y)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc'])
         check_classification_targets(y)
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
             delayed(_partial_fit_ovo_binary)(

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -438,8 +438,9 @@ def test_ovo_fit_on_list():
     # same output as predict from an array
     ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     prediction_from_array = ovo.fit(iris.data, iris.target).predict(iris.data)
-    prediction_from_list = ovo.fit(iris.data,
-                                   list(iris.target)).predict(iris.data)
+    iris_data_list = [list(a) for a in iris.data]
+    prediction_from_list = ovo.fit(iris_data_list,
+                                   list(iris.target)).predict(iris_data_list)
     assert_array_equal(prediction_from_array, prediction_from_list)
 
 


### PR DESCRIPTION
As mentioned in  #6625 `OneVsOneClassifier.fit` function is missing a statement `X = np.asarray(X)` to convert input X to numpy array. This is inconsistent with other classifiers. This also causes unexpected Errors and Exceptions with input type other than numpy array.
