### PR TITLE
[MRG] (issue #6639) added counter-example to multi-label binarizer

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -661,6 +661,17 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
     >>> list(mlb.classes_)
     ['comedy', 'sci-fi', 'thriller']
 
+    The following counter-example should be a reminder to new users to pass in
+    an iterable of iterables.
+    >>> mlb.fit(['sci-fi', 'thriller', 'comedy'])
+    >>> mlb.classes_
+    array(['-', 'c', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'o', 'r', 's', 't',
+        'y'], dtype=object)
+
+    To correct this, the list of labels should be passed in as:
+    >>> mlb.fit([['sci-fi', 'thriller', 'comedy']])
+    >>> mlb.classes_
+    array(['comedy', 'sci-fi', 'thriller'], dtype=object)
     """
     def __init__(self, classes=None, sparse_output=False):
         self.classes = classes


### PR DESCRIPTION
This is a small PR to improve documentation for the `MultiLabelBinarizer` class.

References issue #6639, in which @jnothman helped address the issue I was facing (many thanks!). Short summary is that new users of scikit-learn, and moderate users (like myself) may accidentally use `mlb.fit(['my', 'favourite', 'labels'])`, when the correct usage is `mlb.fit([['my', 'favourite', 'labels']])` (i.e. iterable of iterables). 

My personal experience is that after a few tries of not being able to figure out where I went wrong, I gave up on the `MultiLabelBinarizer` and did my own hack instead. I would like to help other users avoid this right from the outset.

This PR adds a single counter-example to the MultiLabelBinarizer, so that users like myself do not fall into the trap that I did. Hopefully it comes in handy for other users. I am happy to modify the PR if it isn't good enough in the current state.
