### PR TITLE
#6652: Removed redundant Classification metrics entry: metrics.brier_score_l…

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -818,7 +818,6 @@ details.
    metrics.roc_auc_score
    metrics.roc_curve
    metrics.zero_one_loss
-   metrics.brier_score_loss
 
 Regression metrics
 ------------------


### PR DESCRIPTION
https://github.com/scikit-learn/scikit-learn/issues/6652
