### PR TITLE
[MRG] Fixed issue #6635, updated incorrect docstring. 

### DIFF
--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -345,7 +345,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
         split and if the number of subclusters in the parent is greater than
         the branching factor, then it has to be split recursively.
 
-    n_clusters : int, instance of sklearn.cluster model, default None
+    n_clusters : int, instance of sklearn.cluster model, default 3
         Number of clusters after the final clustering step, which treats the
         subclusters from the leaves as new samples. By default, this final
         clustering step is not performed and the subclusters are returned

--- a/sklearn/cluster/birch.py
+++ b/sklearn/cluster/birch.py
@@ -347,7 +347,7 @@ class Birch(BaseEstimator, TransformerMixin, ClusterMixin):
 
     n_clusters : int, instance of sklearn.cluster model, default 3
         Number of clusters after the final clustering step, which treats the
-        subclusters from the leaves as new samples. By default, this final
+        subclusters from the leaves as new samples. If None, this final
         clustering step is not performed and the subclusters are returned
         as they are. If a model is provided, the model is fit treating
         the subclusters as new samples and the initial data is mapped to the


### PR DESCRIPTION
 Fixed issue #6635 - the docstring for sklearn.cluster.Birch init function said that n_clusters defaults to None but were actually 3.

I were not sure if i was supposed to recompile the documentation when making this pull request, which is why i didn't do it.
