### PR TITLE
[MRG] Removed unnecessary element-wise division

### DIFF
--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -671,7 +671,6 @@ class AdaBoostClassifier(BaseWeightBoosting, ClassifierMixin):
                        for estimator, w in zip(self.estimators_,
                                                self.estimator_weights_))
 
-        pred /= self.estimator_weights_.sum()
         if n_classes == 2:
             pred[:, 0] *= -1
             return pred.sum(axis=1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
## Reference Issue

<!-- Example: Fixes #1234 -->
## What does this implement/fix? Explain your changes.
## Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

I removed the line:
        pred /= self.estimator_weights_.sum()

The max pred is picked from this array anyway, no need to divide all elements
