### PR TITLE
Fixed minor typo in multitasklasso docs

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1742,7 +1742,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
         ||W||_21 = \sum_i \sqrt{\sum_j w_{ij}^2}
 
-    i.e. the sum of norm of earch row.
+    i.e. the sum of norm of each row.
 
     Read more in the :ref:`User Guide <multi_task_lasso>`.
 


### PR DESCRIPTION
As title. Just a one character change in the docstring.
