### PR TITLE
[MRG+1] Faster isotonic regression.

### DIFF
--- a/benchmarks/bench_isotonic.py
+++ b/benchmarks/bench_isotonic.py
@@ -22,8 +22,8 @@ import argparse
 
 
 def generate_perturbed_logarithm_dataset(size):
-    return np.random.randint(-50, 50, size=n) \
-        + 50. * np.log(1 + np.arange(n))
+    return (np.random.randint(-50, 50, size=size)
+            + 50. * np.log(1 + np.arange(size)))
 
 
 def generate_logistic_dataset(size):
@@ -33,7 +33,9 @@ def generate_logistic_dataset(size):
 
 def generate_pathological_dataset(size):
     # Triggers O(n^2) complexity on the original implementation.
-    return np.r_[np.arange(n), np.arange(-(n - 1), n), np.arange(-(n - 1), 1)]
+    return np.r_[np.arange(size),
+                 np.arange(-(size - 1), size),
+                 np.arange(-(size - 1), 1)]
 
 
 DATASET_GENERATORS = {

--- a/benchmarks/bench_isotonic.py
+++ b/benchmarks/bench_isotonic.py
@@ -31,9 +31,15 @@ def generate_logistic_dataset(size):
     return np.random.random(size=size) < 1.0 / (1.0 + np.exp(-X))
 
 
+def generate_pathological_dataset(size):
+    # Triggers O(n^2) complexity on the original implementation.
+    return np.r_[np.arange(n), np.arange(-(n - 1), n), np.arange(-(n - 1), 1)]
+
+
 DATASET_GENERATORS = {
     'perturbed_logarithm': generate_perturbed_logarithm_dataset,
-    'logistic': generate_logistic_dataset
+    'logistic': generate_logistic_dataset,
+    'pathological': generate_pathological_dataset,
 }
 
 

--- a/benchmarks/bench_isotonic.py
+++ b/benchmarks/bench_isotonic.py
@@ -59,6 +59,8 @@ def bench_isotonic_regression(Y):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Isotonic Regression benchmark tool")
+    parser.add_argument('--seed', type=int,
+                        help="RNG seed")
     parser.add_argument('--iterations', type=int, required=True,
                         help="Number of iterations to average timings over "
                         "for each problem size")
@@ -72,6 +74,8 @@ if __name__ == '__main__':
                         required=True)
 
     args = parser.parse_args()
+
+    np.random.seed(args.seed)
 
     timings = []
     for exponent in range(args.log_min_problem_size,

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -293,6 +293,11 @@ Enhancements
      See :ref:`example_plot_compare_reduction.py`. By `Joel Nothman`_ and
      `Robert McGibbon`_.
 
+   - Isotonic regression (:mod:`isotonic`) now uses a better algorithm to avoid
+     `O(n^2)` behavior in pathological cases, and is also generally faster
+     (`#6601 <https://github.com/scikit-learn/scikit-learn/pull/6691>`).
+     By `Antony Lee`_.
+
 Bug fixes
 .........
 

--- a/sklearn/_isotonic.pyx
+++ b/sklearn/_isotonic.pyx
@@ -31,7 +31,9 @@ def _inplace_contiguous_isotonic_regression(DOUBLE[::1] y, DOUBLE[::1] w):
         i = 0
         while i < n:
             k = target[i] + 1
-            if k == n or y[i] < y[k]:
+            if k == n:
+                break
+            if y[i] < y[k]:
                 i = k
                 continue
             sum_wy = w[i] * y[i]
@@ -53,8 +55,7 @@ def _inplace_contiguous_isotonic_regression(DOUBLE[::1] y, DOUBLE[::1] w):
                         # Backtrack if we can.  This makes the algorithm
                         # single-pass and ensures O(n) complexity.
                         i = target[i - 1]
-                    else:
-                        i = k
+                    # Otherwise, restart from the same point.
                     break
         # Reconstruct the solution.
         i = 0

--- a/sklearn/_isotonic.pyx
+++ b/sklearn/_isotonic.pyx
@@ -1,4 +1,4 @@
-# Author: Nelle Varoquaux, Andrew Tulloch
+# Author: Nelle Varoquaux, Andrew Tulloch, Antony Lee
 
 # Uses the pool adjacent violators algorithm (PAVA), with the
 # enhancement of searching for the longest decreasing subsequence to
@@ -10,73 +10,64 @@ cimport cython
 
 ctypedef np.float64_t DOUBLE
 
-np.import_array()
-
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _isotonic_regression(np.ndarray[DOUBLE, ndim=1] y,
-                         np.ndarray[DOUBLE, ndim=1] weight,
-                         np.ndarray[DOUBLE, ndim=1] solution):
+def _inplace_contiguous_isotonic_regression(DOUBLE[::1] y, DOUBLE[::1] w):
     cdef:
-        DOUBLE numerator, denominator, ratio
-        Py_ssize_t i, pooled, n, k
+        Py_ssize_t n = y.shape[0], i, k
+        bint pooled
+        DOUBLE prev_y, sum_wy, sum_w
+        Py_ssize_t[::1] skip_to = np.arange(1, n + 1, dtype=np.intp)
 
-    n = y.shape[0]
-    # The algorithm proceeds by iteratively updating the solution
-    # array.
-
-    # TODO - should we just pass in a pre-copied solution
-    # array and mutate that?
-    for i in range(n):
-        solution[i] = y[i]
-
-    if n <= 1:
-        return solution
-
-    n -= 1
-    while 1:
-        # repeat until there are no more adjacent violators.
+    # skip_to describes a list of "constant" sections, skipping over redundant
+    # indices.
+    # For "active" indices (not skipped over):
+    # w[i] := sum{w_orig[j], j=[i..skip_to[i])}
+    # y[i] := sum{y_orig[j]*w_orig[j], j=[i..skip_to[i])} / w[i]
+    while True:
+        # Repeat until there are no more adjacent violators.
         i = 0
-        pooled = 0
+        pooled = False
         while i < n:
             k = i
-            while k < n and solution[k] >= solution[k + 1]:
-                k += 1
-            if solution[i] != solution[k]:
-                # solution[i:k + 1] is a decreasing subsequence, so
-                # replace each point in the subsequence with the
-                # weighted average of the subsequence.
-
-                # TODO: explore replacing each subsequence with a
-                # _single_ weighted point, and reconstruct the whole
-                # sequence from the sequence of collapsed points.
-                # Theoretically should reduce running time, though
-                # initial experiments weren't promising.
-                numerator = 0.0
-                denominator = 0.0
-                for j in range(i, k + 1):
-                    numerator += solution[j] * weight[j]
-                    denominator += weight[j]
-                ratio = numerator / denominator
-                for j in range(i, k + 1):
-                    solution[j] = ratio
-                pooled = 1
-            i = k + 1
+            prev_y = y[k]
+            sum_wy = w[k] * y[k]
+            sum_w = w[k]
+            while True:
+                k = skip_to[k]
+                if k == n or prev_y < y[k]:
+                    # Decreasing subsequence is finished, update first entry.
+                    if pooled:
+                        y[i] = sum_wy / sum_w
+                        w[i] = sum_w
+                        skip_to[i] = k
+                    break
+                # We are within a decreasing subsequence.
+                prev_y = y[k]
+                sum_wy += w[k] * y[k]
+                sum_w += w[k]
+                pooled = True
+            i = k
         # Check for convergence
-        if pooled == 0:
+        if not pooled:
             break
 
-    return solution
+    # Reconstruct the solution.
+    i = 0
+    while i < n:
+        k = skip_to[i]
+        y[i + 1 : k] = y[i]
+        i = k
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
 def _make_unique(np.ndarray[dtype=np.float64_t] X,
-                  np.ndarray[dtype=np.float64_t] y,
-                  np.ndarray[dtype=np.float64_t] sample_weights):
+                 np.ndarray[dtype=np.float64_t] y,
+                 np.ndarray[dtype=np.float64_t] sample_weights):
     """Average targets for duplicate X, drop duplicates.
 
     Aggregates duplicate X values into a single X value where

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -80,6 +80,10 @@ def test_isotonic_regression():
     y_ = np.array([3, 6, 6, 8, 8, 8, 10])
     assert_array_equal(y_, isotonic_regression(y))
 
+    y = np.array([10, 0, 2])
+    y_ = np.array([4, 4, 4])
+    assert_array_equal(y_, isotonic_regression(y))
+
     x = np.arange(len(y))
     ir = IsotonicRegression(y_min=0., y_max=1.)
     ir.fit(x, y)


### PR DESCRIPTION
Maintain an array of indices to skip over because they have been merged,
and running weighted averages and total weights for the merged sections.

For >10,000 data points, runtime is ~2/3 of the previous implementation on
the logistic dataset and ~1/2 for the perturbed logarithm dataset.  Sometimes
marginally (<10%) slower on very small datasets (<1,000) points.

Add RNG seeding for the benchmark script.
