### PR TITLE
cosine as kernel for label propagation

### DIFF
--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -22,7 +22,7 @@ Label clamping:
 
 Kernel:
   A function which projects a vector into some higher dimensional space. This
-  implementation supprots RBF and KNN kernels. Using the RBF kernel generates
+  implementation supprots RBF, KNN, and cosine kernels. Using the RBF and cosine kernel generates
   a dense matrix of size O(N^2). KNN kernel will generate a sparse matrix of
   size O(k*N) which will run much faster. See the documentation for SVMs for
   more info on kernels.
@@ -61,6 +61,7 @@ from scipy import sparse
 from ..base import BaseEstimator, ClassifierMixin
 from ..externals import six
 from ..metrics.pairwise import rbf_kernel
+from ..metrics.pairwise import cosine_similarity
 from ..neighbors.unsupervised import NearestNeighbors
 from ..utils.extmath import safe_sparse_dot
 from ..utils.graph import graph_laplacian
@@ -81,9 +82,9 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', 'cosine'}
         String identifier for kernel function to use.
-        Only 'rbf' and 'knn' kernels are currently supported..
+        Only 'rbf', 'knn', and 'cosine' kernels are currently supported..
 
     gamma : float
         Parameter for rbf kernel
@@ -129,6 +130,11 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
                 return rbf_kernel(X, X, gamma=self.gamma)
             else:
                 return rbf_kernel(X, y, gamma=self.gamma)
+        elif self.kernel == "cosine":
+            if y is None:
+                return cosine_similarity(X)
+            else:
+                return cosine_similarity(X,y)
         elif self.kernel == "knn":
             if self.nn_fit is None:
                 self.nn_fit = NearestNeighbors(self.n_neighbors,
@@ -140,7 +146,7 @@ class BaseLabelPropagation(six.with_metaclass(ABCMeta, BaseEstimator,
             else:
                 return self.nn_fit.kneighbors(y, return_distance=False)
         else:
-            raise ValueError("%s is not a valid kernel. Only rbf and knn"
+            raise ValueError("%s is not a valid kernel. Only rbf, knn, and cosine"
                              " are supported at this time" % self.kernel)
 
     @abstractmethod
@@ -280,9 +286,9 @@ class LabelPropagation(BaseLabelPropagation):
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', 'cosine'}
         String identifier for kernel function to use.
-        Only 'rbf' and 'knn' kernels are currently supported..
+        Only 'rbf', 'knn', and 'cosine'  kernels are currently supported..
 
     gamma : float
         Parameter for rbf kernel
@@ -370,9 +376,9 @@ class LabelSpreading(BaseLabelPropagation):
 
     Parameters
     ----------
-    kernel : {'knn', 'rbf'}
+    kernel : {'knn', 'rbf', 'cosine'}
         String identifier for kernel function to use.
-        Only 'rbf' and 'knn' kernels are currently supported.
+        Only 'rbf', 'knn', and 'cosine' kernels are currently supported.
 
     gamma : float
       parameter for rbf kernel


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fix: #3816
#### What does this implement/fix? Explain your changes.

This update enables semi_supervised to accept cosine similarity as its kernel.
#### Any other comments?

I think semi supervised learning is a good option to classify text documents, which requires cosine similarity as its kernel to achieve better accuracy because the feature vectors from text documents go very sparse.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
