### PR TITLE
Fix roc

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -329,7 +329,8 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # We need to use isclose to avoid spurious repeated thresholds
     # stemming from floating point roundoff errors.
     distinct_value_indices = np.where(np.logical_not(isclose(
-        np.diff(y_score), 0)))[0]
+        np.diff(y_score), 0, atol=0.0, rtol=0.0)))[0]
+
     threshold_idxs = np.r_[distinct_value_indices, y_true.size - 1]
 
     # accumulate the true positives with decreasing threshold

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -15,6 +15,7 @@ the lower the better
 #          Lars Buitinck
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Noel Dawe <noel@dawe.me>
+#          Maximilian Soelch <m.soelch@tum.de>
 # License: BSD 3 clause
 
 from __future__ import division
@@ -328,6 +329,8 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     # concatenate a value for the end of the curve.
     # We need to use isclose to avoid spurious repeated thresholds
     # stemming from floating point roundoff errors.
+    # Setting the tolerances to higher values than 0.0 will cause unexpected
+    # behavior for low variance y_score arrays.
     distinct_value_indices = np.where(np.logical_not(isclose(
         np.diff(y_score), 0, atol=0.0, rtol=0.0)))[0]
 


### PR DESCRIPTION
#### Reference Issue

https://github.com/scikit-learn/scikit-learn/issues/6688
#### What does this implement/fix? Explain your changes.

It sets the tolerance threshold to 0.0 so that only identical thresholds are ignored.
#### Any other comments?

This is a quick fix at the cost of time efficiency. One can think of several fixes, all of which have different drawbacks:
- affine rescaling of the scores to [0, 1]
- scale the tolerance w.r.t. the std in y_score
- add aditional arguments to `roc_curve` for the user to set `a_tol` and `r_tol`
