### PR TITLE
[DOC] clarify distance mode in graph creation functions.

### DIFF
--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -49,9 +49,9 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity', metric='minkowski',
         Number of neighbors for each sample.
 
     mode : {'connectivity', 'distance'}, optional
-        Type of returned matrix: 'connectivity' will return the
-        connectivity matrix with ones and zeros, in 'distance' the
-        edges are Euclidean distance between points.
+        Type of returned matrix: 'connectivity' will return the connectivity
+        matrix with ones and zeros, and 'distance' will return the distances
+        between neighbors according to the given metric.
 
     metric : string, default 'minkowski'
         The distance metric used to calculate the k-Neighbors for each sample
@@ -124,9 +124,9 @@ def radius_neighbors_graph(X, radius, mode='connectivity', metric='minkowski',
         Radius of neighborhoods.
 
     mode : {'connectivity', 'distance'}, optional
-        Type of returned matrix: 'connectivity' will return the
-        connectivity matrix with ones and zeros, in 'distance' the
-        edges are Euclidean distance between points.
+        Type of returned matrix: 'connectivity' will return the connectivity
+        matrix with ones and zeros, and 'distance' will return the distances
+        between neighbors according to the given metric.
 
     metric : string, default 'minkowski'
         The distance metric used to calculate the neighbors within a


### PR DESCRIPTION
The documentation for the `mode` argument of [`radius_neighbors_graph`](http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.radius_neighbors_graph.html) and [`kneighbors_graph`](http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.kneighbors_graph.html) states that if `'distance'` is specified, the matrix returned contains the Euclidean distances between neighbors, but actually the distances calculated according to `metric` are returned.

Example:

``` python
from sklearn import neighbors

X = [[0, 0], [1, 1], [2, 2]]
w1 = neighbors.radius_neighbors_graph(X, 2, mode='distance', metric='manhattan')
w2 = neighbors.kneighbors_graph(X, 1, mode='distance', metric='manhattan')

print(w1.toarray())
print(w2.toarray())
```

Output:

```
[[ 0.  2.  0.]
 [ 2.  0.  2.]
 [ 0.  2.  0.]]
[[ 0.  2.  0.]
 [ 2.  0.  0.]
 [ 0.  2.  0.]]
```
