### PR TITLE
typo fix "func" to "function" in testing.py

### DIFF
--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -406,12 +406,12 @@ def assert_raise_message(exceptions, message, function, *args, **kwargs):
     exceptions : exception or tuple of exception
         Name of the estimator
 
-    func : callable
+    function : callable
         Calable object to raise error
 
-    *args : the positional arguments to `func`.
+    *args : the positional arguments to `function`.
 
-    **kw : the keyword arguments to `func`
+    **kw : the keyword arguments to `function`
     """
     try:
         function(*args, **kwargs)


### PR DESCRIPTION
Hi,
I adjusted the docstring of the `assert_raise_message` function from "func" to "function" to match the function parameter (`def assert_raise_message(exceptions, message, function, *args, **kwargs)`).

However, I am wondering if we shouldn't change it to `func` instead:

`def assert_raise_message(exceptions, message, func, *args, **kwargs)`

to be consistent with the other functions in testing.py. I could take care of the current tests and adjust them where appropriate. What do you think?
