### PR TITLE
[MRG] Added load_iris return_X_y option

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -239,7 +239,7 @@ def load_files(container_path, description=None, categories=None,
                  DESCR=description)
 
 
-def load_iris():
+def load_iris(return_X_y=False):
     """Load and return the iris dataset (classification).
 
     The iris dataset is a classic and very easy multi-class classification
@@ -254,6 +254,12 @@ def load_iris():
     =================   ==============
 
     Read more in the :ref:`User Guide <datasets>`.
+
+    Parameters
+    ----------
+    return_X_y : boolean, default=False.
+        If true, you will get (X, y), else you will get Bunch.
+
 
     Returns
     -------
@@ -292,6 +298,11 @@ def load_iris():
 
     with open(join(module_path, 'descr', 'iris.rst')) as rst_file:
         fdescr = rst_file.read()
+
+
+
+    if return_X_y:
+        return data, target
 
     return Bunch(data=data, target=target,
                  target_names=target_names,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -258,8 +258,8 @@ def load_iris(return_X_y=False):
     Parameters
     ----------
     return_X_y : boolean, default=False.
-        If true, you will get (X, y), else you will get Bunch.
-
+        If True, returns (data, target) instead of a Bunch object. See below for more
+        information about the `data` and `target` object
 
     Returns
     -------

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -183,11 +183,14 @@ def test_load_iris():
 
     # test return_X_y option
     X_y_tuple = load_iris(return_X_y=True)
+    bunch = load_iris()
     assert_true(isinstance(X_y_tuple, tuple))
+    assert_equal(X_y_tuple[0].shape, bunch.data.shape)
+    assert_equal(X_y_tuple[0].size, bunch.data.size)
     assert_equal(X_y_tuple[0].shape, (150, 4))
     assert_equal(X_y_tuple[1].size, 150)
 
-
+    
 
 def test_load_breast_cancer():
     res = load_breast_cancer()
@@ -232,6 +235,3 @@ def test_bunch_pickle_generated_with_0_16_and_read_with_0_17():
     assert_equal(bunch_from_pkl.key, 'changed')
     assert_equal(bunch_from_pkl['key'], 'changed')
 
-
-
-test_load_iris()

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -187,6 +187,7 @@ def test_load_iris():
     assert_true(isinstance(X_y_tuple, tuple))
     assert_equal(X_y_tuple[0].shape, bunch.data.shape)
     assert_equal(X_y_tuple[0].size, bunch.data.size)
+    
     assert_equal(X_y_tuple[0].shape, (150, 4))
     assert_equal(X_y_tuple[1].size, 150)
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -1,5 +1,4 @@
 import os
-import sklearn
 import shutil
 import tempfile
 import warnings
@@ -187,11 +186,10 @@ def test_load_iris():
     assert_true(isinstance(X_y_tuple, tuple))
     assert_equal(X_y_tuple[0].shape, bunch.data.shape)
     assert_equal(X_y_tuple[0].size, bunch.data.size)
-    
+
     assert_equal(X_y_tuple[0].shape, (150, 4))
     assert_equal(X_y_tuple[1].size, 150)
 
-    
 
 def test_load_breast_cancer():
     res = load_breast_cancer()
@@ -235,4 +233,3 @@ def test_bunch_pickle_generated_with_0_16_and_read_with_0_17():
     bunch_from_pkl.key = 'changed'
     assert_equal(bunch_from_pkl.key, 'changed')
     assert_equal(bunch_from_pkl['key'], 'changed')
-

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -1,4 +1,5 @@
 import os
+import sklearn
 import shutil
 import tempfile
 import warnings
@@ -180,6 +181,13 @@ def test_load_iris():
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
 
+    # test return_X_y option
+    X_y_tuple = load_iris(return_X_y=True)
+    assert_true(isinstance(X_y_tuple, tuple))
+    assert_equal(X_y_tuple[0].shape, (150, 4))
+    assert_equal(X_y_tuple[1].size, 150)
+
+
 
 def test_load_breast_cancer():
     res = load_breast_cancer()
@@ -223,3 +231,7 @@ def test_bunch_pickle_generated_with_0_16_and_read_with_0_17():
     bunch_from_pkl.key = 'changed'
     assert_equal(bunch_from_pkl.key, 'changed')
     assert_equal(bunch_from_pkl['key'], 'changed')
+
+
+
+test_load_iris()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Add return_tuple option to data loaders that return a Bunch #6670
#### What does this implement/fix? Explain your changes.

added return_X_y option in load_iris
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
