### PR TITLE
[MRG+1] Fix segmentation fault in libsvm

### DIFF
--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -1009,7 +1009,7 @@ int Solver::select_working_set(int &out_i, int &out_j)
 		}
 	}
 
-	if(Gmax+Gmax2 < eps)
+	if(Gmax+Gmax2 < eps || Gmin_idx == -1)
 		return 1;
 
 	out_i = Gmax_idx;
@@ -1261,7 +1261,7 @@ int Solver_NU::select_working_set(int &out_i, int &out_j)
 		}
 	}
 
-	if(max(Gmaxp+Gmaxp2,Gmaxn+Gmaxn2) < eps)
+	if(max(Gmaxp+Gmaxp2,Gmaxn+Gmaxn2) < eps || Gmin_idx == -1)
 		return 1;
 
 	if (y[Gmin_idx] == +1)


### PR DESCRIPTION
Fix #6687.

The fix was taken from libsvm: 
https://github.com/cjlin1/libsvm/commit/745fdb02bf392b28a033921984901d24038472f7

I haven't really understood how to trigger this edge case in the libsvm code with some toy data, should I spend more time on this and try to write a test?
