### PR TITLE
Replace Google search by Algolia docsearch

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -89,7 +89,7 @@
             </ul>
 
             <div class="search_form">
-                <div id="cse" style="width: 100%;"></div>
+              <input type="text" id='docsearch-input' placeholder="Search docs...">
             </div>
         </div> <!-- end navbar -->
 
@@ -336,14 +336,13 @@
     </script>
     {% endif %}
 
-    <script src="http://www.google.com/jsapi" type="text/javascript"></script>
-    <script type="text/javascript"> google.load('search', '1',
-        {language : 'en'}); google.setOnLoadCallback(function() {
-            var customSearchControl = new
-            google.search.CustomSearchControl('016639176250731907682:tjtqbvtvij0');
-            customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-            var options = new google.search.DrawOptions();
-            options.setAutoComplete(true);
-            customSearchControl.draw('cse', options); }, true);
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
+    <script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
+    <script type="text/javascript">
+      docsearch({
+        apiKey: 'd1eea247ba648e6a42e72a961a615ab2',
+        indexName: 'sklearn',
+        inputSelector: '#docsearch-input'
+      });
     </script>
 {%- endblock %}

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -72,6 +72,7 @@ div.navbar ul {
     border-radius: 5px;
     -moz-border-radius: 5px;
     list-style: none;
+    float: left;
 }
 
 div.navbar ul, div.navbar li {
@@ -95,29 +96,64 @@ div.navbar ul li a:hover {
 }
 
 /*-------------------------------------------------------------*/
-/* The next few elements have to do with the gsc (referring to */
-/* Google's custom search bar */
-
-.gsc-input {
-    width: 180px;
-    float: right;
-}
+/* The next elements have to do with the Algolia docsearch input */
 
 .search_form {
-    margin-top: -23px;
-    /*The min-height is added here, to prevent the element from shrinking
-    too much, while the scripts are still loading the search-bar.
-    Without it, layout glitches occur, as the element keeps dynamically
-    changing its size while its loading-contents adjusts into position.*/
-    min-height: 42px;
+    margin-left: 10px;
+    float: left;
+    width: 180px;
 }
 
-#cse .gsc-clear-button {
-    width: 50px;
+/* Make the dropdown menu aligned on its right side */
+.aa-dropdown-menu {
+    right: 0px !important;
+    left: auto !important;
 }
 
-.gsc-branding {
-    display: none;
+/* Bottom border of each suggestion */
+.algolia-docsearch-suggestion {
+    border-bottom-color: #3A3DD1 !important;
+}
+
+/* Main category headers */
+.algolia-docsearch-suggestion--category-header {
+    background-color: #3499CD !important;
+    font-weight: normal !important;
+}
+
+/* Highlighted search terms in the main category headers */
+.algolia-docsearch-suggestion--highlight  {
+    color: inherit !important;
+    background: rgba(187, 223, 241, 0.6) !important;
+}
+
+.algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight {
+    color: inherit !important;
+    border-bottom: 2px solid rgba(187, 223, 241, 0.6);
+    background: none !important;
+}
+
+/* Currently selected suggestion */
+.aa-cursor .algolia-docsearch-suggestion--content {
+    color: #3499CD !important;
+}
+
+.aa-cursor .algolia-docsearch-suggestion {
+    background: #EBEBFB;
+}
+
+/* For bigger screens, when displaying results in two columns */
+@media (min-width: 768px) {
+    /* Bottom border of each suggestion */
+    .algolia-docsearch-suggestion {
+        border-bottom-color: #7671df;
+    }
+    /* Left column, with secondary category header */
+    .algolia-docsearch-suggestion--subcategory-column {
+        border-right-color: #7671df;
+        background-color: #F2F2FF;
+        color: #4E4726;
+    }
 }
 
 /*---------------------------------------------------------------*/


### PR DESCRIPTION
Hello scikit-learn team!

I have been using scikit-learn lately and I struggled sometimes finding efficiently what I was looking for; this is what I try to improve with this pull request.

![scikit4](https://cloud.githubusercontent.com/assets/5895601/14784027/b4819274-0af3-11e6-854f-dec3dca5c1db.gif)

You can test it live [here](https://demo.algolia.com/docsearch/scikit-learn). Note that each search will redirect to [scikit-learn.org](http://scikit-learn.org/stable/).
#### Benefits for the end user
- Search in the whole documentation with typo tolerance
- Instant access to the documentation at the first keystroke, in a few milliseconds
#### How it works
1. We periodically crawl your documentation pages so you are always up to date.
2. You don’t need to configure any settings or even have an Algolia account.
   We take care of all of this automatically to ensure the best documentation search experience.
3. It's free: no commitment, no subscription, and it won't change.
#### Relevant links
- [Algolia](https://www.algolia.com/)
- [Docsearch](https://community.algolia.com/docsearch/)
#### About Algolia

At Algolia we provide a hosted search API and support community websites via initiatives like Docsearch or community plans.

I'm available for any question you may have or any more information you would need.
