### PR TITLE
[MRG] Replace all the deprecated random_integers by randint.

### DIFF
--- a/benchmarks/bench_plot_fastkmeans.py
+++ b/benchmarks/bench_plot_fastkmeans.py
@@ -23,7 +23,7 @@ def compute_bench(samples_range, features_range):
             print('Iteration %03d of %03d' % (it, max_it))
             print('==============================')
             print()
-            data = nr.random_integers(-50, 50, (n_samples, n_features))
+            data = nr.randint(-50, 51, (n_samples, n_features))
 
             print('K-Means')
             tstart = time()

--- a/examples/cluster/plot_adjusted_for_chance_measures.py
+++ b/examples/cluster/plot_adjusted_for_chance_measures.py
@@ -41,18 +41,17 @@ def uniform_labelings_scores(score_func, n_samples, n_clusters_range,
     When fixed_n_classes is not None the first labeling is considered a ground
     truth class assignment with fixed number of classes.
     """
-    random_labels = np.random.RandomState(seed).random_integers
+    random_labels = np.random.RandomState(seed).randint
     scores = np.zeros((len(n_clusters_range), n_runs))
 
     if fixed_n_classes is not None:
-        labels_a = random_labels(low=0, high=fixed_n_classes - 1,
-                                 size=n_samples)
+        labels_a = random_labels(low=0, high=fixed_n_classes, size=n_samples)
 
     for i, k in enumerate(n_clusters_range):
         for j in range(n_runs):
             if fixed_n_classes is None:
-                labels_a = random_labels(low=0, high=k - 1, size=n_samples)
-            labels_b = random_labels(low=0, high=k - 1, size=n_samples)
+                labels_a = random_labels(low=0, high=k, size=n_samples)
+            labels_b = random_labels(low=0, high=k, size=n_samples)
             scores[i, j] = score_func(labels_a, labels_b)
     return scores
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -626,8 +626,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
                 "Setting it to 3*k" % (init_size, k),
                 RuntimeWarning, stacklevel=2)
             init_size = 3 * k
-        init_indices = random_state.random_integers(
-            0, n_samples - 1, init_size)
+        init_indices = random_state.randint(0, n_samples, init_size)
         X = X[init_indices]
         x_squared_norms = x_squared_norms[init_indices]
         n_samples = X.shape[0]
@@ -1275,8 +1274,7 @@ class MiniBatchKMeans(KMeans):
             init_size = n_samples
         self.init_size_ = init_size
 
-        validation_indices = random_state.random_integers(
-            0, n_samples - 1, init_size)
+        validation_indices = random_state.randint(0, n_samples, init_size)
         X_valid = X[validation_indices]
         x_squared_norms_valid = x_squared_norms[validation_indices]
 
@@ -1324,8 +1322,8 @@ class MiniBatchKMeans(KMeans):
         # criterion
         for iteration_idx in range(n_iter):
             # Sample a minibatch from the full dataset
-            minibatch_indices = random_state.random_integers(
-                0, n_samples - 1, self.batch_size)
+            minibatch_indices = random_state.randint(
+                0, n_samples, self.batch_size)
 
             # Perform the actual update step on the minibatch data
             batch_inertia, centers_squared_diff = _mini_batch_step(

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -181,7 +181,7 @@ def test_discretize(seed=8):
     for n_samples in [50, 100, 150, 500]:
         for n_class in range(2, 10):
             # random class labels
-            y_true = random_state.random_integers(0, n_class, n_samples)
+            y_true = random_state.randint(0, n_class + 1, n_samples)
             y_true = np.array(y_true, np.float)
             # noise class assignment matrix
             y_indicator = sparse.coo_matrix((np.ones(n_samples),

--- a/sklearn/linear_model/randomized_l1.py
+++ b/sklearn/linear_model/randomized_l1.py
@@ -46,8 +46,8 @@ def _resample_model(estimator_func, X, y, scaling=.5, n_resampling=200,
     for active_set in Parallel(n_jobs=n_jobs, verbose=verbose,
                                pre_dispatch=pre_dispatch)(
             delayed(estimator_func)(
-                X, y, weights=scaling * random_state.random_integers(
-                    0, 1, size=(n_features,)),
+                X, y, weights=scaling * random_state.randint(
+                    0, 2, size=(n_features,)),
                 mask=(random_state.rand(n_samples) < sample_fraction),
                 verbose=max(0, verbose - 1),
                 **params)
@@ -627,8 +627,7 @@ def lasso_stability_path(X, y, scaling=0.5, random_state=None,
     paths = Parallel(n_jobs=n_jobs, verbose=verbose)(
         delayed(_lasso_stability_path)(
             X, y, mask=rng.rand(n_samples) < sample_fraction,
-            weights=1. - scaling * rng.random_integers(0, 1,
-                                                       size=(n_features,)),
+            weights=1. - scaling * rng.randint(0, 2, size=(n_features,)),
             eps=eps)
         for k in range(n_resampling))
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -110,12 +110,12 @@ def test_non_consicutive_labels():
 def uniform_labelings_scores(score_func, n_samples, k_range, n_runs=10,
                              seed=42):
     # Compute score for random uniform cluster labelings
-    random_labels = np.random.RandomState(seed).random_integers
+    random_labels = np.random.RandomState(seed).randint
     scores = np.zeros((len(k_range), n_runs))
     for i, k in enumerate(k_range):
         for j in range(n_runs):
-            labels_a = random_labels(low=0, high=k - 1, size=n_samples)
-            labels_b = random_labels(low=0, high=k - 1, size=n_samples)
+            labels_a = random_labels(low=0, high=k, size=n_samples)
+            labels_b = random_labels(low=0, high=k, size=n_samples)
             scores[i, j] = score_func(labels_a, labels_b)
     return scores
 
@@ -195,8 +195,8 @@ def test_v_measure_and_mutual_information(seed=36):
     # Check relation between v_measure, entropy and mutual information
     for i in np.logspace(1, 4, 4).astype(np.int):
         random_state = np.random.RandomState(seed)
-        labels_a, labels_b = random_state.random_integers(0, 10, i),\
-            random_state.random_integers(0, 10, i)
+        labels_a, labels_b = random_state.randint(0, 10, i),\
+            random_state.randint(0, 10, i)
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -420,7 +420,7 @@ def test_standard_scaler_partial_fit_numerical_stability():
     # Sparse input
     size = (100, 3)
     scale = 1e20
-    X = rng.random_integers(0, 1, size).astype(np.float64) * scale
+    X = rng.randint(0, 2, size).astype(np.float64) * scale
     X_csr = sparse.csr_matrix(X)
     X_csc = sparse.csc_matrix(X)
 

--- a/sklearn/semi_supervised/label_propagation.py
+++ b/sklearn/semi_supervised/label_propagation.py
@@ -33,7 +33,7 @@ Examples
 >>> from sklearn.semi_supervised import LabelPropagation
 >>> label_prop_model = LabelPropagation()
 >>> iris = datasets.load_iris()
->>> random_unlabeled_points = np.where(np.random.random_integers(0, 1,
+>>> random_unlabeled_points = np.where(np.random.randint(0, 2,
 ...        size=len(iris.target)))
 >>> labels = np.copy(iris.target)
 >>> labels[random_unlabeled_points] = -1
@@ -323,7 +323,7 @@ class LabelPropagation(BaseLabelPropagation):
     >>> from sklearn.semi_supervised import LabelPropagation
     >>> label_prop_model = LabelPropagation()
     >>> iris = datasets.load_iris()
-    >>> random_unlabeled_points = np.where(np.random.random_integers(0, 1,
+    >>> random_unlabeled_points = np.where(np.random.randint(0, 2,
     ...    size=len(iris.target)))
     >>> labels = np.copy(iris.target)
     >>> labels[random_unlabeled_points] = -1
@@ -417,7 +417,7 @@ class LabelSpreading(BaseLabelPropagation):
     >>> from sklearn.semi_supervised import LabelSpreading
     >>> label_prop_model = LabelSpreading()
     >>> iris = datasets.load_iris()
-    >>> random_unlabeled_points = np.where(np.random.random_integers(0, 1,
+    >>> random_unlabeled_points = np.where(np.random.randint(0, 2,
     ...    size=len(iris.target)))
     >>> labels = np.copy(iris.target)
     >>> labels[random_unlabeled_points] = -1

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -88,7 +88,7 @@ def test_incr_mean_variance_axis():
         rng = np.random.RandomState(0)
         n_features = 50
         n_samples = 10
-        data_chunks = [rng.random_integers(0, 1, size=n_features)
+        data_chunks = [rng.randint(0, 2, size=n_features)
                        for i in range(n_samples)]
 
         # default params for incr_mean_variance


### PR DESCRIPTION
The function random_integers was recently deprecated in numpy resulting a lot of warnings during the test. This PR is done to correct that.
