### PR TITLE
[MRG+1] fixed log_loss bug

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1595,6 +1595,10 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True,
     """
     lb = LabelBinarizer()
     lb.fit(labels) if labels is not None else lb.fit(y_true)
+    if labels is None and len(lb.classes_) == 1:
+        raise ValueError('y_true has only one label,'
+        'maybe get error log loss, should use labels option')
+
     T = lb.transform(y_true)
 
     if T.shape[1] == 1:

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1558,9 +1558,8 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weig
         Predicted probabilities, as returned by a classifier's
         predict_proba method.
 
-    labels : array-like 
-        When len(np.unique(y_true)) < len(np.unique(y_pred)), you must use labels option then
-        len(np.unique(labels)) eques len(np.unique(y_pred))
+    labels : array-like, optional (default=None)
+        If not None , LabelBinarizer will fit labels instead of y_true
 
 
     eps : float

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1536,7 +1536,8 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
         raise ValueError("{0} is not supported".format(y_type))
 
 
-def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weight=None):
+def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True,
+             sample_weight=None):
     """Log loss, aka logistic loss or cross-entropy loss.
 
     This is the loss function used in (multinomial) logistic regression
@@ -1558,9 +1559,9 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weig
         Predicted probabilities, as returned by a classifier's
         predict_proba method.
 
-    labels : array-like, optional (default=None)
-        If not None , LabelBinarizer will fit labels instead of y_true
 
+    labels : array-like, optional (default=None)
+        If not provided, labels will be inferred from y_true
 
     eps : float
         Log loss is undefined for p=0 or p=1, so probabilities are
@@ -1594,9 +1595,8 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weig
     """
     lb = LabelBinarizer()
     lb.fit(labels) if labels is not None else lb.fit(y_true)
-
     T = lb.transform(y_true)
-    
+
     if T.shape[1] == 1:
         T = np.append(1 - T, T, axis=1)
     y_pred = check_array(y_pred, ensure_2d=False)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1559,8 +1559,8 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weig
         predict_proba method.
 
     labels : array-like 
-        When len(unique(y_true)) < len(unique(y_pred)), you must use labels option and
-        len(unique(labels)) eques len(unique(y_pred))
+        When len(np.unique(y_true)) < len(np.unique(y_pred)), you must use labels option then
+        len(np.unique(labels)) eques len(np.unique(y_pred))
 
 
     eps : float
@@ -1594,17 +1594,14 @@ def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weig
     The logarithm used is the natural logarithm (base-e).
     """
     lb = LabelBinarizer()
-
-    
-
-    lb.fit(labels) if labels else lb.fit(y_true)
+    lb.fit(labels) if labels is not None else lb.fit(y_true)
 
     T = lb.transform(y_true)
     
     if T.shape[1] == 1:
         T = np.append(1 - T, T, axis=1)
-
     y_pred = check_array(y_pred, ensure_2d=False)
+
     # Clipping
     Y = np.clip(y_pred, eps, 1 - eps)
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1536,7 +1536,7 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
         raise ValueError("{0} is not supported".format(y_type))
 
 
-def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
+def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True, sample_weight=None):
     """Log loss, aka logistic loss or cross-entropy loss.
 
     This is the loss function used in (multinomial) logistic regression
@@ -1557,6 +1557,11 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     y_pred : array-like of float, shape = (n_samples, n_classes)
         Predicted probabilities, as returned by a classifier's
         predict_proba method.
+
+    labels : array-like 
+        When len(unique(y_true)) < len(unique(y_pred)), you must use labels option and
+        len(unique(labels)) eques len(unique(y_pred))
+
 
     eps : float
         Log loss is undefined for p=0 or p=1, so probabilities are
@@ -1589,7 +1594,13 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     The logarithm used is the natural logarithm (base-e).
     """
     lb = LabelBinarizer()
-    T = lb.fit_transform(y_true)
+
+    
+
+    lb.fit(labels) if labels else lb.fit(y_true)
+
+    T = lb.transform(y_true)
+    
     if T.shape[1] == 1:
         T = np.append(1 - T, T, axis=1)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1375,29 +1375,26 @@ def test_log_loss():
     assert_almost_equal(loss, 1.0383217, decimal=6)
 
     #test labels option
-    X = [[1,1], [1,1], [2, 2], [2, 2]]
 
-    y = [1, 1, 2, 2]
-    clf = DecisionTreeClassifier()
-    clf.fit(X, y)
+    X = [[1,1], [1,1], [2,2], [2,2]]
+    y_label = [1,1,2,2]
 
-
-    y_score = clf.predict_proba([[2,2], [2,2]])
+    X_test = [[2,2], [2,2]]
     y_true = [2,2]
-    expected_loss = -np.log(1)*2
-
-
-    # because y_true label are the same, if not use labels option , will get error
+    y_score = np.array([[0.1,0.9], [0.1, 0.9]])
+    
+    # because y_true label are the same, if not use labels option, will get error
     error_logloss = log_loss(y_true, y_score)
-    label_not_of_2_loss = -np.mean( np.log( np.clip(y_score[:,0],1e-15, 1-1e-15)))
+    label_not_of_2_loss = -np.mean(np.log(y_score[:,0]))
     assert_almost_equal(error_logloss, label_not_of_2_loss)
     
 
     # use labels, it works
-    label_of_2_loss = -np.mean(np.log(y_score[:,1]))
+    label_of_2_loss = -np.mean(np.log(y_score[:, 1]))
     expected_logloss = log_loss(y_true, y_score, labels=[1, 2])
-    assert_almost_equal(expected_loss, label_of_2_loss)
+    assert_almost_equal(expected_logloss, label_of_2_loss)
 
+test_log_loss()
 def test_log_loss_pandas_input():
     # case when input is a pandas series and dataframe gh-5715
     y_tr = np.array(["ham", "spam", "spam", "ham"])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1398,6 +1398,7 @@ def test_log_loss():
     calculated_log_loss = log_loss(y_true, y_score, labels=[1, 2])
     assert_almost_equal(calculated_log_loss, ture_log_loss)
 
+    
 
 
 def test_log_loss_pandas_input():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -44,7 +44,6 @@ from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
-from sklearn.tree import DecisionTreeClassifier
 
 from sklearn.metrics.classification import _check_targets
 from sklearn.exceptions import UndefinedMetricWarning
@@ -1384,17 +1383,23 @@ def test_log_loss():
     y_score = np.array([[0.1,0.9], [0.1, 0.9]])
     
     # because y_true label are the same, if not use labels option, will get error
-    error_logloss = log_loss(y_true, y_score)
-    label_not_of_2_loss = -np.mean(np.log(y_score[:,0]))
-    assert_almost_equal(error_logloss, label_not_of_2_loss)
-    
+    #error_logloss = log_loss(y_true, y_score)
+    #label_not_of_2_loss = -np.mean(np.log(y_score[:,0]))
+    #assert_almost_equal(error_logloss, label_not_of_2_loss)
+    #assert_raises(log_loss(y_true, y_score))
+
+    error_str  = ('y_true has only one label,'
+        'maybe get error log loss, should use labels option')
+
+    assert_raise_message(ValueError, error_str, log_loss, y_true, y_pred)
 
     # use labels, it works
-    label_of_2_loss = -np.mean(np.log(y_score[:, 1]))
-    expected_logloss = log_loss(y_true, y_score, labels=[1, 2])
-    assert_almost_equal(expected_logloss, label_of_2_loss)
+    ture_log_loss = -np.mean(np.log(y_score[:, 1]))
+    calculated_log_loss = log_loss(y_true, y_score, labels=[1, 2])
+    assert_almost_equal(calculated_log_loss, ture_log_loss)
 
-test_log_loss()
+
+
 def test_log_loss_pandas_input():
     # case when input is a pandas series and dataframe gh-5715
     y_tr = np.array(["ham", "spam", "spam", "ham"])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -44,7 +44,7 @@ from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
-
+from sklearn.tree import DecisionTreeClassifier
 
 from sklearn.metrics.classification import _check_targets
 from sklearn.exceptions import UndefinedMetricWarning
@@ -1374,6 +1374,29 @@ def test_log_loss():
     loss = log_loss(y_true, y_pred)
     assert_almost_equal(loss, 1.0383217, decimal=6)
 
+    #test labels option
+    X = [[1,1], [1,1], [2, 2], [2, 2]]
+
+    y = [1, 1, 2, 2]
+    clf = DecisionTreeClassifier()
+    clf.fit(X, y)
+
+
+    y_score = clf.predict_proba([[2,2], [2,2]])
+    y_true = [2,2]
+    expected_loss = -np.log(1)*2
+
+
+    # because y_true label are the same, if not use labels option , will get error
+    error_logloss = log_loss(y_true, y_score)
+    label_not_of_2_loss = -np.mean( np.log( np.clip(y_score[:,0],1e-15, 1-1e-15)))
+    assert_almost_equal(error_logloss, label_not_of_2_loss)
+    
+
+    # use labels, it works
+    label_of_2_loss = -np.mean(np.log(y_score[:,1]))
+    expected_logloss = log_loss(y_true, y_score, labels=[1, 2])
+    assert_almost_equal(expected_loss, label_of_2_loss)
 
 def test_log_loss_pandas_input():
     # case when input is a pandas series and dataframe gh-5715

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -247,31 +247,6 @@ def test_regression_scorers():
     assert_almost_equal(score1, score2)
 
 
-def test_log_loss():
-   
-
-
-
-    X = [[1,1], [1,1], [2, 2], [2, 2]]
-    y = [1, 1, 2, 2]
-    clf = DecisionTreeClassifier()
-    clf.fit(X, y)
-
-
-
-    y_score = clf.predict_proba([[2,2], [2,2]])
-    y_true = [2,2]
-    expected_value = np.log(1)*2
-
-    # y_true are the same, not use labels arg, you will get error 
-    error_logloss = log_loss(y_true, y_score)
-    assert_not_equal(expected_value, error_logloss)
-
-
-    # use labels, it works
-    expected_logloss = log_loss(y_true, y_score, labels=[1, 2])
-    assert_almost_equal(expected_value, expected_logloss)
-
 def test_thresholded_scorers():
     # Test scorers that take thresholds.
     X, y = make_blobs(random_state=0, centers=2)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -247,6 +247,31 @@ def test_regression_scorers():
     assert_almost_equal(score1, score2)
 
 
+def test_log_loss():
+   
+
+
+
+    X = [[1,1], [1,1], [2, 2], [2, 2]]
+    y = [1, 1, 2, 2]
+    clf = DecisionTreeClassifier()
+    clf.fit(X, y)
+
+
+
+    y_score = clf.predict_proba([[2,2], [2,2]])
+    y_true = [2,2]
+    expected_value = np.log(1)*2
+
+    # y_true are the same, not use labels arg, you will get error 
+    error_logloss = log_loss(y_true, y_score)
+    assert_not_equal(expected_value, error_logloss)
+
+
+    # use labels, it works
+    expected_logloss = log_loss(y_true, y_score, labels=[1, 2])
+    assert_almost_equal(expected_value, expected_logloss)
+
 def test_thresholded_scorers():
     # Test scorers that take thresholds.
     X, y = make_blobs(random_state=0, centers=2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

metrics.log_loss fails when any classes are missing in y_true #4033
Fix a bug, the result is wrong when use sklearn.metrics.log_loss with one class, #4546
Log_loss is calculated incorrectly when only 1 class present #6703
#### What does this implement/fix? Explain your changes.

added labels option. when length of unique y_true <  number of columns for y_score/y_pred, should use labels so as to len(unique(labels)) eques y_pred.shap[1].
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
