### PR TITLE
[MRG] Remove redundant(?) sorting in ParameterSampler

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -241,11 +241,9 @@ class ParameterSampler(object):
                 yield param_grid[i]
 
         else:
-            # Always sort the keys of a dictionary, for reproducibility
-            items = sorted(self.param_distributions.items())
             for _ in six.moves.range(self.n_iter):
                 params = dict()
-                for k, v in items:
+                for k, v in self.param_distributions.items():
                     if hasattr(v, "rvs"):
                         if sp_version < (0, 16):
                             params[k] = v.rvs()


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

It seems to me that this sorting is redundant in the `ParameterSampler`. I can understand why it is useful in the `ParameterGrid` context, but maybe not here.
#### Any other comments?

No.
