### PR TITLE
[MRG] Fix IsotonicRegression __setstate__

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -429,4 +429,5 @@ class IsotonicRegression(BaseEstimator, TransformerMixin, RegressorMixin):
         We need to rebuild the interpolation function.
         """
         self.__dict__.update(state)
-        self._build_f(self._necessary_X_, self._necessary_y_)
+        if hasattr(self, '_necessary_X_') and hasattr(self, '_necessary_y_'):
+            self._build_f(self._necessary_X_, self._necessary_y_)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 import pickle
+import copy
 
 from sklearn.isotonic import (check_increasing, isotonic_regression,
                               IsotonicRegression)
@@ -395,3 +396,9 @@ def test_fast_predict():
     y_pred_fast = fast_model.predict(X_test)
 
     assert_array_equal(y_pred_slow, y_pred_fast)
+
+
+def test_isotonic_copy_before_fit():
+    # https://github.com/scikit-learn/scikit-learn/issues/6628
+    ir = IsotonicRegression()
+    copy.copy(ir)


### PR DESCRIPTION
Fixes #6628.

An instance of IsotonicRegression can not been copied if it has not been fitted yet.
