### PR TITLE
Add TPOT to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -24,6 +24,12 @@ enhance the functionality of scikit-learn's estimators.
   An automated machine learning toolkit and a drop-in replacement for a
   scikit-learn estimator
 
+- `TPOT <https://github.com/rhiever/tpot>`_
+  An automated machine learning toolkit that optimizes a series of scikit-learn
+  operators to design a machine learning pipeline, including data and feature
+  preprocessors as well as the estimators. Works as a drop-in replacement for a
+  scikit-learn estimator.
+
 - `sklearn-pmml <https://github.com/alex-pirozhenko/sklearn-pmml>`_
   Serialization of (some) scikit-learn estimators into PMML.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR only changes part of the documentation to list [TPOT](https://github.com/rhiever/tpot) as a related project. TPOT is a tool similar to auto-sklearn and similarly works as a wrapper around scikit-learn to optimize the entire machine learning pipeline.
