### PR TITLE
Fixing doc of `check_array`

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -297,6 +297,10 @@ def check_array(array, accept_sparse=None, dtype="numeric", order=None,
 
     order : 'F', 'C' or None (default=None)
         Whether an array will be forced to be fortran or c-style.
+        When order is None (default), then if copy=False, nothing is ensured
+        about the memory layout of the output array; otherwise (copy=True)
+        the memory layout of the returned array is kept as close as possible
+        to the original array.
 
     copy : boolean (default=False)
         Whether a forced copy will be triggered. If copy=False, a copy might


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

This PR comes to fix #6721.
#### What does this implement/fix? Explain your changes.

According to the description of issue #6721, the documentation for `sklearn.utils.validation.check_array` lacks description for the parameter `order=None`. When `order` is set to `None`, the `check_array` function actually invokes `np.array` with the default order "K", which may behaves differently when `copy` is `True` or not:
When `copy` is `False`, nothing is guaranteed. If `copy` is `True`, the order of the copied array is kept as close as possible to the original array.
#### Any other comments?

None.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
