### PR TITLE
K-Means: Subtract X_means from initial centroids iff it's also subtracted from X

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -279,7 +279,6 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
         raise ValueError('Number of iterations should be a positive number,'
                          ' got %d instead' % max_iter)
 
-    best_inertia = np.infty
     X = as_float_array(X, copy=copy_x)
     tol = _tolerance(X, tol)
 
@@ -298,23 +297,22 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
                          precompute_distances)
 
     # subtract of mean of x for more accurate distance computations
-    if not sp.issparse(X) or hasattr(init, '__array__'):
-        X_mean = X.mean(axis=0)
     if not sp.issparse(X):
+        X_mean = X.mean(axis=0)
         # The copy was already done above
         X -= X_mean
 
-    if hasattr(init, '__array__'):
-        init = check_array(init, dtype=np.float64, copy=True)
-        _validate_center_shape(X, n_clusters, init)
+        if hasattr(init, '__array__'):
+            init = check_array(init, dtype=np.float64, copy=True)
+            _validate_center_shape(X, n_clusters, init)
 
-        init -= X_mean
-        if n_init != 1:
-            warnings.warn(
-                'Explicit initial center position passed: '
-                'performing only one init in k-means instead of n_init=%d'
-                % n_init, RuntimeWarning, stacklevel=2)
-            n_init = 1
+            init -= X_mean
+            if n_init != 1:
+                warnings.warn(
+                    'Explicit initial center position passed: '
+                    'performing only one init in k-means instead of n_init=%d'
+                    % n_init, RuntimeWarning, stacklevel=2)
+                n_init = 1
 
     # precompute squared norms of data points
     x_squared_norms = row_norms(X, squared=True)


### PR DESCRIPTION
#### Reference Issue

Fixes #6740
#### What does this implement/fix? Explain your changes.

Subtract X_means from initial centroids iff it's also subtracted from X
#### Any other comments?

The bug happens when X is sparse and initial cluster centroids are given. In this case the means of each of X's columns are computed and subtracted from init for no reason.

To reproduce:

``` py
import numpy as np
import scipy
from sklearn.cluster import KMeans
from sklearn import datasets

iris = datasets.load_iris()
X = iris.data

# Get a local optimum
centers = KMeans(n_clusters=3).fit(X).cluster_centers_

# Fit starting from a local optimum shouldn't change the solution
np.testing.assert_allclose(
    centers,
    KMeans(n_clusters=3, init=centers, n_init=1).fit(X).cluster_centers_
)

# The same should be true when X is sparse, but wasn't before the bug fix
X_sparse = scipy.sparse.csr_matrix(X)
np.testing.assert_allclose(
    centers,
    KMeans(n_clusters=3, init=centers, n_init=1).fit(X_sparse).cluster_centers_
)
```
