### PR TITLE
[MRG] Docs: Link MinMaxScaler to minmax_scale, and StandardScaler to scaler

### DIFF
--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -590,7 +590,7 @@ class Ridge(_BaseRidge, RegressorMixin):
 
     See also
     --------
-    RidgeClassifier, RidgeCV, :func:`sklearn.kernel_ridge.KernelRidge`
+    RidgeClassifier, RidgeCV, :class:`sklearn.kernel_ridge.KernelRidge`
 
     Examples
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -121,9 +121,8 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
     See also
     --------
-    :class:`sklearn.preprocessing.StandardScaler` to perform centering and
-    scaling using the ``Transformer`` API (e.g. as part of a preprocessing
-    :class:`sklearn.pipeline.Pipeline`)
+    StandardScaler: Performs scaling to unit variance using the``Transformer`` API
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
                     warn_on_dtype=True, estimator='the scale function',
@@ -240,6 +239,10 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
         .. versionadded:: 0.17
            *data_range_* instead of deprecated *data_range*.
+
+    See also
+    --------
+    minmax_scale: Equivalent function without the object oriented API
     """
 
     def __init__(self, feature_range=(0, 1), copy=True):
@@ -409,6 +412,11 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
     copy : boolean, optional, default is True
         Set to False to perform inplace scaling and avoid a copy (if the input
         is already a numpy array).
+
+    See also
+    --------
+    MinMaxScaler: Performs scaling to a given range using the``Transformer`` API
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     # To allow retro-compatibility, we handle here the case of 1D-input
     # From 0.17, 1D-input are deprecated in scaler objects
@@ -503,11 +511,10 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    :func:`sklearn.preprocessing.scale` to perform centering and
-    scaling without using the ``Transformer`` object oriented API
+    scale: Equivalent function without the object oriented API
 
-    :class:`sklearn.decomposition.RandomizedPCA` with `whiten=True`
-    to further remove the linear correlation across features.
+    :class:`sklearn.decomposition.PCA`
+        Further removes the linear correlation across features with 'whiten=True'.
     """
 
     def __init__(self, copy=True, with_mean=True, with_std=True):
@@ -719,6 +726,10 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
     n_samples_seen_ : int
         The number of samples processed by the estimator. Will be reset on
         new calls to fit, but increments across ``partial_fit`` calls.
+
+    See also
+    --------
+    maxabs_scale: Equivalent function without the object oriented API
     """
 
     def __init__(self, copy=True):
@@ -849,6 +860,11 @@ def maxabs_scale(X, axis=0, copy=True):
     copy : boolean, optional, default is True
         Set to False to perform inplace scaling and avoid a copy (if the input
         is already a numpy array).
+
+    See also
+    --------
+    MaxAbsScaler: Performs scaling to the [-1, 1] range using the``Transformer`` API
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     # To allow retro-compatibility, we handle here the case of 1D-input
     # From 0.17, 1D-input are deprecated in scaler objects
@@ -931,11 +947,10 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    :class:`sklearn.preprocessing.StandardScaler` to perform centering
-    and scaling using mean and variance.
+    robust_scale: Equivalent function without the object oriented API
 
-    :class:`sklearn.decomposition.RandomizedPCA` with `whiten=True`
-    to further remove the linear correlation across features.
+    :class:`sklearn.decomposition.PCA`
+        Further removes the linear correlation across features with 'whiten=True'.
 
     Notes
     -----
@@ -1086,9 +1101,8 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True, copy=True):
 
     See also
     --------
-    :class:`sklearn.preprocessing.RobustScaler` to perform centering and
-    scaling using the ``Transformer`` API (e.g. as part of a preprocessing
-    :class:`sklearn.pipeline.Pipeline`)
+    RobustScaler: Performs centering and scaling using the ``Transformer`` API
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     s = RobustScaler(with_centering=with_centering, with_scaling=with_scaling,
                      copy=copy)
@@ -1289,9 +1303,8 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     See also
     --------
-    :class:`sklearn.preprocessing.Normalizer` to perform normalization
-    using the ``Transformer`` API (e.g. as part of a preprocessing
-    :class:`sklearn.pipeline.Pipeline`)
+    Normalizer: Performs normalization using the ``Transformer`` API
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     if norm not in ('l1', 'l2', 'max'):
         raise ValueError("'%s' is not a supported norm" % norm)
@@ -1373,8 +1386,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    :func:`sklearn.preprocessing.normalize` equivalent function
-    without the object oriented API
+    normalize: Equivalent function without the object oriented API
     """
 
     def __init__(self, norm='l2', copy=True):
@@ -1427,9 +1439,8 @@ def binarize(X, threshold=0.0, copy=True):
 
     See also
     --------
-    :class:`sklearn.preprocessing.Binarizer` to perform binarization
-    using the ``Transformer`` API (e.g. as part of a preprocessing
-    :class:`sklearn.pipeline.Pipeline`)
+    Binarizer: Performs binarization using the ``Transformer`` API
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
     """
     X = check_array(X, accept_sparse=['csr', 'csc'], copy=copy)
     if sparse.issparse(X):
@@ -1483,6 +1494,10 @@ class Binarizer(BaseEstimator, TransformerMixin):
 
     This estimator is stateless (besides constructor parameters), the
     fit method does nothing but is useful when used in a pipeline.
+
+    See also
+    --------
+    binarize: Equivalent function without the object oriented API
     """
 
     def __init__(self, threshold=0.0, copy=True):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -122,7 +122,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     See also
     --------
     StandardScaler: Performs scaling to unit variance using the``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
                     warn_on_dtype=True, estimator='the scale function',
@@ -416,7 +416,7 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
     See also
     --------
     MinMaxScaler: Performs scaling to a given range using the``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     # To allow retro-compatibility, we handle here the case of 1D-input
     # From 0.17, 1D-input are deprecated in scaler objects
@@ -1440,7 +1440,7 @@ def binarize(X, threshold=0.0, copy=True):
     See also
     --------
     Binarizer: Performs binarization using the ``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse=['csr', 'csc'], copy=copy)
     if sparse.issparse(X):

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -122,7 +122,7 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     See also
     --------
     StandardScaler: Performs scaling to unit variance using the``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
                     warn_on_dtype=True, estimator='the scale function',
@@ -242,7 +242,7 @@ class MinMaxScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    minmax_scale: Equivalent function without the object oriented API
+    minmax_scale: Equivalent function without the object oriented API.
     """
 
     def __init__(self, feature_range=(0, 1), copy=True):
@@ -416,7 +416,7 @@ def minmax_scale(X, feature_range=(0, 1), axis=0, copy=True):
     See also
     --------
     MinMaxScaler: Performs scaling to a given range using the``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     # To allow retro-compatibility, we handle here the case of 1D-input
     # From 0.17, 1D-input are deprecated in scaler objects
@@ -511,7 +511,7 @@ class StandardScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    scale: Equivalent function without the object oriented API
+    scale: Equivalent function without the object oriented API.
 
     :class:`sklearn.decomposition.PCA`
         Further removes the linear correlation across features with 'whiten=True'.
@@ -729,7 +729,7 @@ class MaxAbsScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    maxabs_scale: Equivalent function without the object oriented API
+    maxabs_scale: Equivalent function without the object oriented API.
     """
 
     def __init__(self, copy=True):
@@ -864,7 +864,7 @@ def maxabs_scale(X, axis=0, copy=True):
     See also
     --------
     MaxAbsScaler: Performs scaling to the [-1, 1] range using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     # To allow retro-compatibility, we handle here the case of 1D-input
     # From 0.17, 1D-input are deprecated in scaler objects
@@ -947,7 +947,7 @@ class RobustScaler(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    robust_scale: Equivalent function without the object oriented API
+    robust_scale: Equivalent function without the object oriented API.
 
     :class:`sklearn.decomposition.PCA`
         Further removes the linear correlation across features with 'whiten=True'.
@@ -1102,7 +1102,7 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True, copy=True):
     See also
     --------
     RobustScaler: Performs centering and scaling using the ``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     s = RobustScaler(with_centering=with_centering, with_scaling=with_scaling,
                      copy=copy)
@@ -1304,7 +1304,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     See also
     --------
     Normalizer: Performs normalization using the ``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     if norm not in ('l1', 'l2', 'max'):
         raise ValueError("'%s' is not a supported norm" % norm)
@@ -1386,7 +1386,7 @@ class Normalizer(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    normalize: Equivalent function without the object oriented API
+    normalize: Equivalent function without the object oriented API.
     """
 
     def __init__(self, norm='l2', copy=True):
@@ -1440,7 +1440,7 @@ def binarize(X, threshold=0.0, copy=True):
     See also
     --------
     Binarizer: Performs binarization using the ``Transformer`` API
-         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`)
+         (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse=['csr', 'csc'], copy=copy)
     if sparse.issparse(X):
@@ -1497,7 +1497,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    binarize: Equivalent function without the object oriented API
+    binarize: Equivalent function without the object oriented API.
     """
 
     def __init__(self, threshold=0.0, copy=True):


### PR DESCRIPTION
Addresses Issue #6514  Docs: Link MinMaxScaler to minmax_scale, and StandardScaler to scale. 

Fixes preprocessing docs and Ridge Doc.  Example images attached.

![robustscaler doc fix](https://cloud.githubusercontent.com/assets/6617297/14964873/4e9cba9e-1078-11e6-8a12-b849dc596580.png)
![binarize doc change](https://cloud.githubusercontent.com/assets/6617297/14964879/53dba09c-1078-11e6-97b3-e369777aa920.png)
![ridge doc change](https://cloud.githubusercontent.com/assets/6617297/14964887/5ea0eba4-1078-11e6-86aa-d38c26b462a5.png)
