### PR TITLE
[MRG+1] Disabled randomized_svd warning when number of iterations is no…

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -267,7 +267,7 @@ def randomized_range_finder(A, size, n_iter,
     return Q
 
 
-def randomized_svd(M, n_components, n_oversamples=10, n_iter=4,
+def randomized_svd(M, n_components, n_oversamples=10, n_iter=None,
                    power_iteration_normalizer='auto', transpose='auto',
                    flip_sign=True, random_state=0):
     """Computes a truncated randomized SVD
@@ -349,6 +349,13 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=4,
     n_random = n_components + n_oversamples
     n_samples, n_features = M.shape
 
+    if n_iter == None:
+        # Checks if the number of iterations is explicitely specified
+        n_iter = 4
+        n_iter_specified = False
+    else:
+        n_iter_specified = True
+
     if transpose == 'auto':
         transpose = n_samples < n_features
     if transpose:
@@ -357,8 +364,9 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=4,
 
     # Adjust n_iter. 7 was found a good compromise for PCA. See #5299
     if n_components < .1 * min(M.shape) and n_iter < 7:
-        warnings.warn("The number of power iterations is increased to 7 to "
-                      "achieve higher precision.")
+        if n_iter_specified:
+            warnings.warn("The number of power iterations is increased to "
+                      "7 to achieve higher precision.")
         n_iter = 7
 
     Q = randomized_range_finder(M, n_random, n_iter,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->

<!-- Example: Fixes #1234 -->

Disabled randomized_svd warning when number of iterations is not specified (#6746)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
