### PR TITLE
[MRG] Docs: add description about default score_func

### DIFF
--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -355,6 +355,8 @@ class SelectPercentile(_BaseFilter):
     score_func : callable
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues) or a single array with scores.
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     percentile : int, optional, default=10
         Percent of features to keep.
@@ -426,6 +428,8 @@ class SelectKBest(_BaseFilter):
     score_func : callable
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues) or a single array with scores.
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     k : int or "all", optional, default=10
         Number of top features to select.
@@ -498,6 +502,8 @@ class SelectFpr(_BaseFilter):
     score_func : callable
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues).
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     alpha : float, optional
         The highest p-value for features to be kept.
@@ -547,6 +553,8 @@ class SelectFdr(_BaseFilter):
     score_func : callable
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues).
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     alpha : float, optional
         The highest uncorrected p-value for features to keep.
@@ -604,6 +612,8 @@ class SelectFwe(_BaseFilter):
     score_func : callable
         Function taking two arrays X and y, and returning a pair of arrays
         (scores, pvalues).
+        Default is f_classif (see below "See also"). The default function only
+        works with classification tasks.
 
     alpha : float, optional
         The highest uncorrected p-value for features to keep.


### PR DESCRIPTION
Addresses Issue #6744 : SelectPercentile doesn't document default value for score_func
