### PR TITLE
[WIP] score function computing balanced accuracy

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -801,6 +801,7 @@ details.
    metrics.accuracy_score
    metrics.auc
    metrics.average_precision_score
+   metrics.balanced_accuracy_score
    metrics.brier_score_loss
    metrics.classification_report
    metrics.confusion_matrix

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -59,6 +59,7 @@ Scoring                      Function                                    Comment
 ========================     =======================================     ==================================
 **Classification**
 'accuracy'                   :func:`metrics.accuracy_score`
+'balanced_accuracy'          :func:`metrics.balanced_accuracy_score`     for binary targets
 'average_precision'          :func:`metrics.average_precision_score`
 'f1'                         :func:`metrics.f1_score`                    for binary targets
 'f1_micro'                   :func:`metrics.f1_score`                    micro-averaged
@@ -224,6 +225,7 @@ Some of these are restricted to the binary classification case:
    matthews_corrcoef
    precision_recall_curve
    roc_curve
+   balanced_accuracy_score
 
 
 Others also work in the multiclass case:
@@ -353,6 +355,49 @@ In the multilabel case with binary label indicators: ::
   * See :ref:`example_feature_selection_plot_permutation_test_for_classification.py`
     for an example of accuracy score usage using permutations of
     the dataset.
+
+.. _balanced_accuracy_score:
+
+Balanced accuracy score
+-----------------------
+
+The :func:`balanced_accuracy_score` function computes the
+`balanced accuracy <https://en.wikipedia.org/wiki/Accuracy_and_precision>`_, which
+avoids inflated performance estimates on imbalanced datasets. It is defined as the
+arithmetic mean of `sensitivity <https://en.wikipedia.org/wiki/Sensitivity_and_specificity>`_
+(true positive rate) and `specificity <https://en.wikipedia.org/wiki/Sensitivity_and_specificity>`_
+(true negative rate), or the average accuracy obtained on either class. It can also
+be seen as the average of `recall scores <https://en.wikipedia.org/wiki/Precision_and_recall>`_
+on both classes.
+
+If the classifier performs equally well on either class, this term reduces to the
+conventional accuracy (i.e., the number of correct predictions divided by the total
+number of predictions). In contrast, if the conventional accuracy is above chance only
+because the classifier takes advantage of an imbalanced test set, then the balanced
+accuracy, as appropriate, will drop to chance.
+
+If :math:`\hat{y}_i\in\{0,1\}` is the predicted value of
+the :math:`i`-th sample and :math:`y_i\in\{0,1\}` is the corresponding true value,
+then the balanced accuracy is defined as
+
+.. math::
+
+   \texttt{balanced-accuracy}(y, \hat{y}) = \frac{1}{2} \left(\frac{\sum_i 1(\hat{y}_i = 1 \land y_i = 1)}{\sum_i 1(y_i = 1)} + \frac{\sum_i 1(\hat{y}_i = 0 \land y_i = 0)}{\sum_i 1(y_i = 0)}\right)
+
+where :math:`1(x)` is the `indicator function
+<https://en.wikipedia.org/wiki/Indicator_function>`_.
+
+  >>> import numpy as np
+  >>> from sklearn.metrics import balanced_accuracy_score
+  >>> y_true = [0, 1, 0, 0, 1, 0]
+  >>> y_pred = [0, 1, 0, 0, 0, 1]
+  >>> balanced_accuracy_score(y_true, y_pred)
+  0.625
+
+.. note::
+
+    Currently this score function is only defined for binary classification problems, you
+    may need to wrap it by yourself if you want to use it for multilabel problems.
 
 .. _cohen_kappa:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -366,9 +366,8 @@ The :func:`balanced_accuracy_score` function computes the
 avoids inflated performance estimates on imbalanced datasets. It is defined as the
 arithmetic mean of `sensitivity <https://en.wikipedia.org/wiki/Sensitivity_and_specificity>`_
 (true positive rate) and `specificity <https://en.wikipedia.org/wiki/Sensitivity_and_specificity>`_
-(true negative rate), or the average accuracy obtained on either class. It can also
-be seen as the average of `recall scores <https://en.wikipedia.org/wiki/Precision_and_recall>`_
-on both classes.
+(true negative rate), or the average of `recall scores <https://en.wikipedia.org/wiki/Precision_and_recall>`_
+obtained on either class.
 
 If the classifier performs equally well on either class, this term reduces to the
 conventional accuracy (i.e., the number of correct predictions divided by the total
@@ -384,15 +383,21 @@ then the balanced accuracy is defined as
 
    \texttt{balanced-accuracy}(y, \hat{y}) = \frac{1}{2} \left(\frac{\sum_i 1(\hat{y}_i = 1 \land y_i = 1)}{\sum_i 1(y_i = 1)} + \frac{\sum_i 1(\hat{y}_i = 0 \land y_i = 0)}{\sum_i 1(y_i = 0)}\right)
 
-where :math:`1(x)` is the `indicator function
-<https://en.wikipedia.org/wiki/Indicator_function>`_.
+where :math:`1(x)` is the `indicator function <https://en.wikipedia.org/wiki/Indicator_function>`_.
+
+Under this definition, the balanced accuracy coincides with `AUC score <https://en.wikipedia.org/wiki/AUC>`_
+given binary ``y_true`` and ``y_pred``:
 
   >>> import numpy as np
-  >>> from sklearn.metrics import balanced_accuracy_score
+  >>> from sklearn.metrics import balanced_accuracy_score, roc_auc_score
   >>> y_true = [0, 1, 0, 0, 1, 0]
   >>> y_pred = [0, 1, 0, 0, 0, 1]
   >>> balanced_accuracy_score(y_true, y_pred)
   0.625
+  >>> roc_auc_score(y_true, y_pred)
+  0.625
+
+(but in general, :func:`roc_auc_score` takes as its second argument non-binary scores).
 
 .. note::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -93,7 +93,7 @@ Usage examples:
     >>> model = svm.SVC()
     >>> cross_val_score(model, X, y, scoring='wrong_choice')
     Traceback (most recent call last):
-    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'f1', 'f1_macro', 'f1_micro', 'f1_samples', 'f1_weighted', 'log_loss', 'mean_absolute_error', 'mean_squared_error', 'median_absolute_error', 'precision', 'precision_macro', 'precision_micro', 'precision_samples', 'precision_weighted', 'r2', 'recall', 'recall_macro', 'recall_micro', 'recall_samples', 'recall_weighted', 'roc_auc']
+    ValueError: 'wrong_choice' is not a valid scoring value. Valid options are ['accuracy', 'adjusted_rand_score', 'average_precision', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_samples', 'f1_weighted', 'log_loss', 'mean_absolute_error', 'mean_squared_error', 'median_absolute_error', 'precision', 'precision_macro', 'precision_micro', 'precision_samples', 'precision_weighted', 'r2', 'recall', 'recall_macro', 'recall_micro', 'recall_samples', 'recall_weighted', 'roc_auc']
 
 .. note::
 

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -27,6 +27,7 @@ from .classification import matthews_corrcoef
 from .classification import precision_recall_fscore_support
 from .classification import precision_score
 from .classification import recall_score
+from .classification import balanced_accuracy_score
 from .classification import zero_one_loss
 from .classification import brier_score_loss
 
@@ -101,6 +102,7 @@ __all__ = [
     'precision_score',
     'r2_score',
     'recall_score',
+    'balanced_accuracy_score',
     'roc_auc_score',
     'roc_curve',
     'SCORERS',

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -14,6 +14,7 @@ from .ranking import roc_auc_score
 from .ranking import roc_curve
 
 from .classification import accuracy_score
+from .classification import balanced_accuracy_score
 from .classification import classification_report
 from .classification import cohen_kappa_score
 from .classification import confusion_matrix
@@ -27,7 +28,6 @@ from .classification import matthews_corrcoef
 from .classification import precision_recall_fscore_support
 from .classification import precision_score
 from .classification import recall_score
-from .classification import balanced_accuracy_score
 from .classification import zero_one_loss
 from .classification import brier_score_loss
 
@@ -66,6 +66,7 @@ __all__ = [
     'adjusted_rand_score',
     'auc',
     'average_precision_score',
+    'balanced_accuracy_score',
     'classification_report',
     'cluster',
     'completeness_score',
@@ -102,7 +103,6 @@ __all__ = [
     'precision_score',
     'r2_score',
     'recall_score',
-    'balanced_accuracy_score',
     'roc_auc_score',
     'roc_curve',
     'SCORERS',

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1354,7 +1354,8 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
     The balanced accuracy is used in binary classification problems to deal
     with imbalanced datasets. It is defined as the arithmetic mean of sensitivity
     (true positive rate) and specificity (true negative rate), or the average
-    accuracy obtained on either class.
+    recall obtained on either class. It is also equal to the AUC score
+    given binary inputs.
 
     The best value is 1 and the worst value is 0.
 
@@ -1378,7 +1379,7 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
 
     See also
     --------
-    recall_score
+    recall_score, roc_auc_score
 
     References
     ----------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1385,7 +1385,7 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
     .. [1] Brodersen, K.H.; Ong, C.S.; Stephan, K.E.; Buhmann, J.M. (2010).
            The balanced accuracy and its posterior distribution.
            Proceedings of the 20th International Conference on Pattern Recognition,
-           3121–24.
+           3121-24.
 
     Examples
     --------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1348,6 +1348,52 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     return r
 
 
+def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
+    """Compute the balanced accuracy
+
+    The balanced accuracy is basically an unweighted average of recall score
+    for each class: ``1/C * \sum_{i=1}^C rc_i``, where ``rc_i`` is the recall
+    score for class ``i`` and ``C`` is the total number of unique classes.
+
+    The best value is 1 and the worst value is 0.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
+    Returns
+    -------
+    balanced_accuracy : float
+        Unweighted average of the recall of each class.
+
+    See also
+    --------
+    recall_score: Compute the recall
+
+    Examples
+    --------
+    >>> from sklearn.metrics import balanced_accuracy_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> balanced_accuracy_score(y_true, y_pred)  # doctest: +ELLIPSIS
+    0.33
+
+    """
+    # simply wrap the ``recall_score`` function
+    return recall_score(y_true, y_pred,
+                        labels=None,
+                        pos_label=None,
+                        average='macro',
+                        sample_weight=sample_weight)
+
+
 def classification_report(y_true, y_pred, labels=None, target_names=None,
                           sample_weight=None, digits=2):
     """Build a text report showing the main classification metrics

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1386,7 +1386,7 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
            The balanced accuracy and its posterior distribution.
            Proceedings of the 20th International Conference on Pattern Recognition,
            3121–24.
-
+           
     Examples
     --------
     >>> from sklearn.metrics import balanced_accuracy_score

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1351,18 +1351,21 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
     """Compute the balanced accuracy
 
-    The balanced accuracy is basically an unweighted average of recall score
-    for each class: ``1/C * \sum_{i=1}^C rc_i``, where ``rc_i`` is the recall
-    score for class ``i`` and ``C`` is the total number of unique classes.
+    The balanced accuracy is used in binary classification problems to deal
+    with imbalanced datasets. It is defined as the arithmetic mean of sensitivity
+    (true positive rate) and specificity (true negative rate), or the average
+    accuracy obtained on either class.
 
     The best value is 1 and the worst value is 0.
 
+    Read more in the :ref:`User Guide <balanced_accuracy_score>`.
+
     Parameters
     ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
+    y_true : 1d array-like
         Ground truth (correct) target values.
 
-    y_pred : 1d array-like, or label indicator array / sparse matrix
+    y_pred : 1d array-like
         Estimated targets as returned by a classifier.
 
     sample_weight : array-like of shape = [n_samples], optional
@@ -1370,25 +1373,36 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
 
     Returns
     -------
-    balanced_accuracy : float
-        Unweighted average of the recall of each class.
+    balanced_accuracy : float.
+        The average of sensitivity and specificity
 
     See also
     --------
-    recall_score: Compute the recall
+    recall_score
+
+    References
+    ----------
+    .. [1] Brodersen, K.H.; Ong, C.S.; Stephan, K.E.; Buhmann, J.M. (2010).
+           The balanced accuracy and its posterior distribution.
+           Proceedings of the 20th International Conference on Pattern Recognition,
+           3121–24.
 
     Examples
     --------
     >>> from sklearn.metrics import balanced_accuracy_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> balanced_accuracy_score(y_true, y_pred)  # doctest: +ELLIPSIS
-    0.33
+    >>> y_true = [0, 1, 0, 0, 1, 0]
+    >>> y_pred = [0, 1, 0, 0, 0, 1]
+    >>> balanced_accuracy_score(y_true, y_pred)
+    0.625
 
     """
+    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
+
+    if y_type != 'binary':
+        raise ValueError('Balanced accuracy is only meaningful '
+                         'for binary classification problems.')
     # simply wrap the ``recall_score`` function
     return recall_score(y_true, y_pred,
-                        labels=None,
                         pos_label=None,
                         average='macro',
                         sample_weight=sample_weight)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1386,7 +1386,7 @@ def balanced_accuracy_score(y_true, y_pred, sample_weight=None):
            The balanced accuracy and its posterior distribution.
            Proceedings of the 20th International Conference on Pattern Recognition,
            3121–24.
-           
+
     Examples
     --------
     >>> from sklearn.metrics import balanced_accuracy_score

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -25,6 +25,7 @@ import numpy as np
 from . import (r2_score, median_absolute_error, mean_absolute_error,
                mean_squared_error, accuracy_score, f1_score,
                roc_auc_score, average_precision_score,
+               balanced_accuracy_score,
                precision_score, recall_score, log_loss)
 from .cluster import adjusted_rand_score
 from ..utils.multiclass import type_of_target
@@ -323,6 +324,7 @@ median_absolute_error_scorer = make_scorer(median_absolute_error,
 # Standard Classification Scores
 accuracy_scorer = make_scorer(accuracy_score)
 f1_scorer = make_scorer(f1_score)
+balanced_accuracy_scorer = make_scorer(balanced_accuracy_score)
 
 # Score functions that need decision values
 roc_auc_scorer = make_scorer(roc_auc_score, greater_is_better=True,
@@ -344,6 +346,7 @@ SCORERS = dict(r2=r2_scorer,
                mean_absolute_error=mean_absolute_error_scorer,
                mean_squared_error=mean_squared_error_scorer,
                accuracy=accuracy_scorer, roc_auc=roc_auc_scorer,
+               balanced_accuracy=balanced_accuracy_scorer,
                average_precision=average_precision_scorer,
                log_loss=log_loss_scorer,
                adjusted_rand_score=adjusted_rand_scorer)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -258,8 +258,6 @@ METRICS_WITH_POS_LABEL = [
 # TODO: Handle multi_class metrics that has a labels argument as well as a
 # decision function argument. e.g hinge_loss
 METRICS_WITH_LABELS = [
-    "balanced_accuracy_score",
-
     "confusion_matrix",
 
     "precision_score", "recall_score", "f1_score", "f2_score", "f0.5_score",

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -23,6 +23,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 
 from sklearn.metrics import accuracy_score
+from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import cohen_kappa_score
@@ -98,6 +99,7 @@ REGRESSION_METRICS = {
 
 CLASSIFICATION_METRICS = {
     "accuracy_score": accuracy_score,
+    "balanced_accuracy_score": balanced_accuracy_score,
     "unnormalized_accuracy_score": partial(accuracy_score, normalize=False),
     "confusion_matrix": confusion_matrix,
     "hamming_loss": hamming_loss,
@@ -216,6 +218,7 @@ METRIC_UNDEFINED_BINARY = [
 METRIC_UNDEFINED_MULTICLASS = [
     "brier_score_loss",
     "matthews_corrcoef_score",
+    "balanced_accuracy_score"
 ]
 
 # Metric undefined with "binary" or "multiclass" input
@@ -255,6 +258,8 @@ METRICS_WITH_POS_LABEL = [
 # TODO: Handle multi_class metrics that has a labels argument as well as a
 # decision function argument. e.g hinge_loss
 METRICS_WITH_LABELS = [
+    "balanced_accuracy_score",
+
     "confusion_matrix",
 
     "precision_score", "recall_score", "f1_score", "f2_score", "f0.5_score",
@@ -340,6 +345,7 @@ SYMMETRIC_METRICS = [
 # Asymmetric with respect to their input arguments y_true and y_pred
 # metric(y_true, y_pred) != metric(y_pred, y_true).
 NOT_SYMMETRIC_METRICS = [
+    "balanced_accuracy_score",
     "explained_variance_score",
     "r2_score",
     "confusion_matrix",

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -40,7 +40,8 @@ from sklearn.externals import joblib
 REGRESSION_SCORERS = ['r2', 'mean_absolute_error', 'mean_squared_error',
                       'median_absolute_error']
 
-CLF_SCORERS = ['accuracy', 'f1', 'f1_weighted', 'f1_macro', 'f1_micro',
+CLF_SCORERS = ['accuracy', 'balanced_accuracy',
+               'f1', 'f1_weighted', 'f1_macro', 'f1_micro',
                'roc_auc', 'average_precision', 'precision',
                'precision_weighted', 'precision_macro', 'precision_micro',
                'recall', 'recall_weighted', 'recall_macro', 'recall_micro',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

This PR comes to address issue #6747, which suggests to implement an score function calculating the balanced accuracy.
#### What does this implement/fix? Explain your changes.

The balanced accuracy is actually an unweighted average of recall scores for each class. And the functionality is already provided by the `sklearn.metrics.recall_score` -- just pass the argument `average='macro'` (and `pos_label=None` for version before 0.18).

So the `balanced_accuracy_score` in this PR is a simple wrapper of the `recall_score`.
#### Any other comments?

I'm not sure if there should be an test case for this function since the corresponding scenario already tested for `recall_score`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
