### PR TITLE
[MRG+1] Fix bug in SquaredEpsilonInsensitive loss function #6728

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4180,3 +4180,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Ori Ziv: https://github.com/zivori
 
 .. _Sears Merritt: https://github.com/merritts
+
+.. _Wenhua Yang: https://github.com/geekoala

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -196,6 +196,10 @@ Bug fixes
       :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
       correct results. By `JPFrancoia`_
 
+    - Fixed bug in :class:`linear_model.SquaredEpsilonInsensitive`
+      where condition of if statement is incorrect when p - y > epsilon.
+      (`#6764 <https://github.com/scikit-learn/scikit-learn/pull/6764>`_). By `Wenhua Yang`_.
+
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -196,8 +196,9 @@ Bug fixes
       :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
       correct results. By `JPFrancoia`_
 
-    - Fixed bug in :class:`linear_model.SquaredEpsilonInsensitive`
+    - Fixed bug in :class:`linear_model.sgd_fast.SquaredEpsilonInsensitive`
       where condition of if statement is incorrect when p - y > epsilon.
+      Affects :class:`linear_model.SGDClassifier` and :class:`linear_model.SGDRegressor`.
       (`#6764 <https://github.com/scikit-learn/scikit-learn/pull/6764>`_). By `Wenhua Yang`_.
 
 

--- a/sklearn/linear_model/sgd_fast.pyx
+++ b/sklearn/linear_model/sgd_fast.pyx
@@ -319,7 +319,7 @@ cdef class SquaredEpsilonInsensitive(Regression):
         z = y - p
         if z > self.epsilon:
             return -2 * (z - self.epsilon)
-        elif z < self.epsilon:
+        elif z < -self.epsilon:
             return 2 * (-z - self.epsilon)
         else:
             return 0

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1172,6 +1172,17 @@ def _test_gradient_common(loss_function, cases):
 
 def test_gradient_hinge():
     # Test Hinge (hinge / perceptron)
+    # hinge
+    loss = sgd_fast.Hinge(1.0)
+    cases = [
+        # (p, y, expected)
+        (1.1, 1.0, 0.0), (-2.0, -1.0, 0.0),
+        (1.0, 1.0, -1.0), (-1.0, -1.0, 1.0), (0.5, 1.0, -1.0),
+        (2.0, -1.0, 1.0), (-0.5, -1.0, 1.0), (0.0, 1.0, -1.0)
+    ]
+    _test_gradient_common(loss, cases)
+
+    # perceptron
     loss = sgd_fast.Hinge(0.0)
     cases = [
         # (p, y, expected)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -21,6 +21,8 @@ from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.preprocessing import LabelEncoder, scale, MinMaxScaler
 
+from sklearn.linear_model import sgd_fast
+
 
 class SparseSGDClassifier(SGDClassifier):
 
@@ -1159,3 +1161,106 @@ def test_large_regularization():
         with np.errstate(all='raise'):
             model.fit(iris.data, iris.target)
         assert_array_almost_equal(model.coef_, np.zeros_like(model.coef_))
+
+
+def _test_gradient_common(loss_function, cases):
+    # Test gradient of different loss functions
+    # cases is a list of (p, y, expected)
+    for p, y, expected in cases:
+        assert_almost_equal(loss_function.dloss(p, y), expected)
+
+
+def test_gradient_hinge():
+    # Test Hinge (hinge / perceptron)
+    loss = sgd_fast.Hinge(0.0)
+    cases = [
+        # (p, y, expected)
+        (1.0, 1.0, 0.0), (-0.1, -1.0, 0.0),
+        (0.0, 1.0, -1.0), (0.0, -1.0, 1.0), (0.5, -1.0, 1.0),
+        (2.0, -1.0, 1.0), (-0.5, 1.0, -1.0), (-1.0, 1.0, -1.0),
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_squared_hinge():
+    # Test SquaredHinge
+    loss = sgd_fast.SquaredHinge(1.0)
+    cases = [
+        # (p, y, expected)
+        (1.0, 1.0, 0.0), (-2.0, -1.0, 0.0), (1.0, -1.0, 4.0),
+        (-1.0, 1.0, -4.0), (0.5, 1.0, -1.0), (0.5, -1.0, 3.0)
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_log():
+    # Test Log (logistic loss)
+    loss = sgd_fast.Log()
+    cases = [
+        # (p, y, expected)
+        (1.0, 1.0, -1.0 / (np.exp(1.0) + 1.0)),
+        (1.0, -1.0, 1.0 / (np.exp(-1.0) + 1.0)),
+        (-1.0, -1.0, 1.0 / (np.exp(1.0) + 1.0)),
+        (-1.0, 1.0, -1.0 / (np.exp(-1.0) + 1.0)),
+        (0.0, 1.0, -0.5), (0.0, -1.0, 0.5),
+        (17.9, -1.0, 1.0), (-17.9, 1.0, -1.0),
+    ]
+    _test_gradient_common(loss, cases)
+    assert_almost_equal(loss.dloss(18.1, 1.0), np.exp(-18.1) * -1.0, 16)
+    assert_almost_equal(loss.dloss(-18.1, -1.0), np.exp(-18.1) * 1.0, 16)
+
+
+def test_gradient_squared_loss():
+    # Test SquaredLoss
+    loss = sgd_fast.SquaredLoss()
+    cases = [
+        # (p, y, expected)
+        (0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (1.0, 0.0, 1.0),
+        (0.5, -1.0, 1.5), (-2.5, 2.0, -4.5)
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_huber():
+    # Test Huber
+    loss = sgd_fast.Huber(0.1)
+    cases = [
+        # (p, y, expected)
+        (0.0, 0.0, 0.0), (0.1, 0.0, 0.1), (0.0, 0.1, -0.1),
+        (3.95, 4.0, -0.05), (5.0, 2.0, 0.1), (-1.0, 5.0, -0.1)
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_modified_huber():
+    # Test ModifiedHuber
+    loss = sgd_fast.ModifiedHuber()
+    cases = [
+        # (p, y, expected)
+        (1.0, 1.0, 0.0), (-1.0, -1.0, 0.0), (2.0, 1.0, 0.0),
+        (0.0, 1.0, -2.0), (-1.0, 1.0, -4.0), (0.5, -1.0, 3.0),
+        (0.5, -1.0, 3.0), (-2.0, 1.0, -4.0), (-3.0, 1.0, -4.0)
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_epsilon_insensitive():
+    # Test EpsilonInsensitive
+    loss = sgd_fast.EpsilonInsensitive(0.1)
+    cases = [
+        (0.0, 0.0, 0.0), (0.1, 0.0, 0.0), (-2.05, -2.0, 0.0),
+        (3.05, 3.0, 0.0), (2.2, 2.0, 1.0), (2.0, -1.0, 1.0),
+        (2.0, 2.2, -1.0), (-2.0, 1.0, -1.0)
+    ]
+    _test_gradient_common(loss, cases)
+
+
+def test_gradient_squared_epsilon_insensitive():
+    # Test SquaredEpsilonInsensitive
+    loss = sgd_fast.SquaredEpsilonInsensitive(0.1)
+    cases = [
+        (0.0, 0.0, 0.0), (0.1, 0.0, 0.0), (-2.05, -2.0, 0.0),
+        (3.05, 3.0, 0.0), (2.2, 2.0, 0.2), (2.0, -1.0, 5.8),
+        (2.0, 2.2, -0.2), (-2.0, 1.0, -5.8)
+    ]
+    _test_gradient_common(loss, cases)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

This PR comes to fix #6728 .
#### What does this implement/fix? Explain your changes.
- Condition of if statement is incorrect in linear_model.SquaredEpsilonInsensitive(loss function) when p - y > epsilon. It should be z < -epsilon where z = y - p.
- Added tests for each Cython class on the gradient values in SGD.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
