### PR TITLE
[MRG] FIX SquaredHinge is a classification loss

### DIFF
--- a/sklearn/linear_model/sgd_fast.pyx
+++ b/sklearn/linear_model/sgd_fast.pyx
@@ -167,7 +167,7 @@ cdef class Hinge(Classification):
         return Hinge, (self.threshold,)
 
 
-cdef class SquaredHinge(LossFunction):
+cdef class SquaredHinge(Classification):
     """Squared Hinge loss for binary classification tasks with y in {-1,1}
 
     Parameters


### PR DESCRIPTION
Quick fix: SquaredHinge is a classification loss as it is only defined for `y` in `{-1, 1}`. I don't think this has any user-visible impact though.

@mblondel I am not sure why the Classification and Regression subclasses were introduced in the first place, can you please enlighten me? How could I add a test for this fix?
