### PR TITLE
[MRG] Fix the conf.py of sphinx for doctest

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ except:
 extensions = ['gen_rst',
               'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
               'sphinx.ext.pngmath', 'numpy_ext.numpydoc',
-              'sphinx.ext.linkcode',
+              'sphinx.ext.linkcode', 'sphinx.ext.doctest',
               ]
 
 autosummary_generate = True


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #6763 
#### What does this implement/fix? Explain your changes.

The `doc/conf.py` didn't load `doctest` extension for sphinx, while in the `doc/Makefile` there exists a `doctest` target. Thus when you execute `make doctest` in `doc/` sphinx will throw a "module unregistered" error.

So I just load the `sphinx.ext.doctest` in `conf.py`.
#### Any other comments?

None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
