### PR TITLE
[MRG+1] FIX support memmap scalars as CV scores

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1648,6 +1648,13 @@ def _score(estimator, X_test, y_test, scorer):
         score = scorer(estimator, X_test)
     else:
         score = scorer(estimator, X_test, y_test)
+    if hasattr(score, 'item'):
+        try:
+            # e.g. unwrap memmapped scalars
+            score = score.item()
+        except ValueError:
+            # non-scalar?
+            pass
     if not isinstance(score, numbers.Number):
         raise ValueError("scoring must return a number, got %s (%s) instead."
                          % (str(score), type(score)))

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -301,6 +301,13 @@ def _score(estimator, X_test, y_test, scorer):
         score = scorer(estimator, X_test)
     else:
         score = scorer(estimator, X_test, y_test)
+    if hasattr(score, 'item'):
+        try:
+            # e.g. unwrap memmapped scalars
+            score = score.item()
+        except ValueError:
+            # non-scalar?
+            pass
     if not isinstance(score, numbers.Number):
         raise ValueError("scoring must return a number, got %s (%s) instead."
                          % (str(score), type(score)))

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -779,10 +779,10 @@ def test_score_memmap():
     X, y = iris.data, iris.target
     clf = MockClassifier()
     tf = tempfile.NamedTemporaryFile(mode='wb', delete=False)
-    tf.write('Hello world!!!!!')
+    tf.write(b'Hello world!!!!!')
     tf.close()
     scores = np.memmap(tf.name, dtype=float)
-    score = scores.sum()
+    score = np.memmap(tf.name, shape=(), mode='w+', dtype=float)
     try:
         cross_val_score(clf, X, y, scoring=lambda est, X, y: score)
         # non-scalar should still fail


### PR DESCRIPTION
#### Reference Issue

Fixes #6783
#### What does this implement/fix? Explain your changes.

The test - which introduces a cross-validation score of type np.memmap - fails without the patch.
