### PR TITLE
[MRG+1] Add a set recording pushed elements in DBSCAN

### DIFF
--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -4,7 +4,7 @@
 
 cimport cython
 from libcpp.vector cimport vector
-from libcpp.map cimport map as cmap
+from libcpp.set cimport set as cset
 cimport numpy as np
 import numpy as np
 
@@ -23,7 +23,7 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
     cdef np.npy_intp i, label_num = 0, v
     cdef np.ndarray[np.npy_intp, ndim=1] neighb
     cdef vector[np.npy_intp] stack
-    cdef cmap[np.npy_intp, np.npy_intp] push_map
+    cdef cset[np.npy_intp] seen
 
     for i in range(labels.shape[0]):
         if labels[i] != -1 or not is_core[i]:
@@ -40,8 +40,8 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
                     neighb = neighborhoods[i]
                     for i in range(neighb.shape[0]):
                         v = neighb[i]
-                        if labels[v] == -1 and push_map.count(v) == 0:
-                            push_map[v] = 1
+                        if labels[v] == -1 and seen.count(v) == 0:
+                            seen.insert(v)
                             push(stack, v)
 
             if stack.size() == 0:
@@ -49,6 +49,6 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
             i = stack.back()
             stack.pop_back()
 
-        push_map.clear()
+        seen.clear()
 
         label_num += 1

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -4,6 +4,7 @@
 
 cimport cython
 from libcpp.vector cimport vector
+from libcpp.map cimport map as cmap
 cimport numpy as np
 import numpy as np
 
@@ -22,6 +23,7 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
     cdef np.npy_intp i, label_num = 0, v
     cdef np.ndarray[np.npy_intp, ndim=1] neighb
     cdef vector[np.npy_intp] stack
+    cdef cmap[np.npy_intp, np.npy_intp] push_map
 
     for i in range(labels.shape[0]):
         if labels[i] != -1 or not is_core[i]:
@@ -38,12 +40,15 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
                     neighb = neighborhoods[i]
                     for i in range(neighb.shape[0]):
                         v = neighb[i]
-                        if labels[v] == -1:
+                        if labels[v] == -1 and push_map.count(v) == 0:
+                            push_map[v] = 1
                             push(stack, v)
 
             if stack.size() == 0:
                 break
             i = stack.back()
             stack.pop_back()
+
+        push_map.clear()
 
         label_num += 1

--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -196,6 +196,10 @@ class DBSCAN(BaseEstimator, ClusterMixin):
         to store the tree. The optimal value depends
         on the nature of the problem.
 
+    p : float, optional
+        The power of the Minkowski metric to be used to calculate distance
+        between points.
+
     n_jobs : int, optional (default = 1)
         The number of parallel jobs to run.
         If ``-1``, then the number of jobs is set to the number of CPU cores.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### What does this implement/fix? Explain your changes.

We push the neighbors waiting for visiting into a vector in DBSCAN. When the data is big and eps is large enough, the neighbors could be many and duplicate. In this case, the duplicate elements in this vector cause memory pressure. This patch adds a set to record pushed elements and avoids duplicate elements to be pushed.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
