### PR TITLE
[MRG+1] Improve strip_accents_unicode performance when strings do not need stripping

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -55,8 +55,11 @@ def strip_accents_unicode(s):
         Remove accentuated char for any unicode symbol that has a direct
         ASCII equivalent.
     """
-    return ''.join([c for c in unicodedata.normalize('NFKD', s)
-                    if not unicodedata.combining(c)])
+    normalized = unicodedata.normalize('NFKD', s)
+    if normalized == s:
+        return s
+    else:
+        return ''.join([c for c in normalized if not unicodedata.combining(c)])
 
 
 def strip_accents_ascii(s):


### PR DESCRIPTION
This PR addresses the speed issue when the majority of the strings do not need normalization (but you might still use the function on them). There is a slightly performance decrease when all the strings need normalization. I leave it up to the contributors to judge whether the regression is acceptable

``` python
from itertools import combinations_with_replacement
import string
import unicodedata

def strip_accents_unicode_improved(s):
    normalized = unicodedata.normalize('NFKD', s)
    if normalized == s:
        return s
    else:
        return ''.join([c for c in normalized if not unicodedata.combining(c)])

def strip_accents_unicode(s):
    return ''.join([c for c in unicodedata.normalize('NFKD', s)
                    if not unicodedata.combining(c)])


lots_of_strings_none_in_need = ['n'.join(r) for r in combinations_with_replacement(string.ascii_lowercase, 5)]
strings = lots_of_strings_none_in_need + ['normal', 'strings', 'are', 'these', 'or', 'ñøt really', 'bé it a short or long version of a single string']

%timeit list(map(strip_accents_unicode, strings))  # 340ms
%timeit list(map(strip_accents_unicode_improved, strings))  # 50ms

# where performance suffer is the following case

lots_of_strings_all_in_need = ['ñ'.join(r) for r in combinations_with_replacement(string.ascii_lowercase, 5)]
strings = lots_of_strings_all_in_need + ['normal', 'strings', 'are', 'these', 'or', 'ñøt really', 'bé it a short or long version of a single string']

%timeit list(map(strip_accents_unicode, strings))  # 472ms
%timeit list(map(strip_accents_unicode_improved, strings))  # 479ms
```
