### PR TITLE
[MRG+1] MAINT: Remove add_row_csr

### DIFF
--- a/sklearn/utils/sparsefuncs_fast.pxd
+++ b/sklearn/utils/sparsefuncs_fast.pxd
@@ -1,8 +1,0 @@
-cimport numpy as np
-
-
-cdef void add_row_csr(np.ndarray[np.float64_t, ndim=1],
-                      np.ndarray[int, ndim=1],
-                      np.ndarray[int, ndim=1],
-                      int i, np.ndarray[np.float64_t, ndim=1, mode="c"])
-

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -382,21 +382,6 @@ def _inplace_csr_row_normalize_l2(np.ndarray[floating, ndim=1] X_data,
             X_data[j] /= sum_
 
 
-cdef void add_row_csr(np.ndarray[np.float64_t, ndim=1] data,
-                      np.ndarray[int, ndim=1] indices,
-                      np.ndarray[int, ndim=1] indptr,
-                      int i, np.ndarray[np.float64_t, ndim=1, mode="c"] out):
-    """Add row i of CSR matrix (data, indices, indptr) to array out.
-
-    Equivalent to out += X[i].toarray(). Returns None.
-    """
-    cdef int ind, j
-
-    for ind in range(indptr[i], indptr[i + 1]):
-        j = indices[ind]
-        out[j] += data[ind]
-
-
 def assign_rows_csr(X,
                     np.ndarray[np.npy_intp, ndim=1] X_rows,
                     np.ndarray[np.npy_intp, ndim=1] out_rows,
@@ -427,8 +412,6 @@ def assign_rows_csr(X,
 
     out[out_rows] = 0.
     for i in range(X_rows.shape[0]):
-        # XXX we could reuse add_row_csr here, but the array slice
-        # is not optimized away.
         rX = X_rows[i]
         for ind in range(indptr[rX], indptr[rX + 1]):
             j = indices[ind]


### PR DESCRIPTION
**Note:** This PR is created to solve a Travis build cache issue since PR #6676 can't pass CI.

`Add_row_csr` is used only in 2 places.

This pull request removes the usage replacing one loop by assign_rows_csr and the other by just reusing the code.
