### PR TITLE
[MRG] Added cohen kappa score class to API reference

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -803,6 +803,7 @@ details.
    metrics.average_precision_score
    metrics.brier_score_loss
    metrics.classification_report
+   metrics.cohen_kappa_score
    metrics.confusion_matrix
    metrics.f1_score
    metrics.fbeta_score
@@ -928,7 +929,7 @@ See the :ref:`metrics` section of the user guide for further details.
    metrics.pairwise.paired_manhattan_distances
    metrics.pairwise.paired_cosine_distances
    metrics.pairwise.paired_distances
-   
+
 
 .. _mixture_ref:
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1836,7 +1836,8 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Brier_score
+    .. [1] `Wikipedia entry for the Brier score.
+            <https://en.wikipedia.org/wiki/Brier_score>`_
     """
     y_true = column_or_1d(y_true)
     y_prob = column_or_1d(y_prob)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -284,6 +284,8 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     :math:`p_e` is estimated using a per-annotator empirical prior over the
     class labels [2]_.
 
+    Read more in the :ref:`User Guide <cohen_kappa>`.
+
     Parameters
     ----------
     y1 : array, shape = [n_samples]

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -316,7 +316,7 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
            Educational and Psychological Measurement 20(1):37-46.
            doi:10.1177/001316446002000104.
     .. [2] `R. Artstein and M. Poesio (2008). "Inter-coder agreement for
-           computational linguistics". Computational Linguistic 34(4):555-596.
+           computational linguistics". Computational Linguistics 34(4):555-596.
            <http://www.mitpressjournals.org/doi/abs/10.1162/coli.07-034-R2#.V0J1MJMrIWo>`_
     .. [3] `Wikipedia entry for the Cohen's kappa.
             <https://en.wikipedia.org/wiki/Cohen%27s_kappa>`_

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -271,7 +271,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
 def cohen_kappa_score(y1, y2, labels=None, weights=None):
     """Cohen's kappa: a statistic that measures inter-annotator agreement.
 
-    This function computes Cohen's kappa [1], a score that expresses the level
+    This function computes Cohen's kappa [1]_, a score that expresses the level
     of agreement between two annotators on a classification problem. It is
     defined as
 
@@ -282,7 +282,7 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     assigned to any sample (the observed agreement ratio), and :math:`p_e` is
     the expected agreement when both annotators assign labels randomly.
     :math:`p_e` is estimated using a per-annotator empirical prior over the
-    class labels [2].
+    class labels [2]_.
 
     Parameters
     ----------
@@ -313,8 +313,11 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     .. [1] J. Cohen (1960). "A coefficient of agreement for nominal scales".
            Educational and Psychological Measurement 20(1):37-46.
            doi:10.1177/001316446002000104.
-    .. [2] R. Artstein and M. Poesio (2008). "Inter-coder agreement for
+    .. [2] `R. Artstein and M. Poesio (2008). "Inter-coder agreement for
            computational linguistics". Computational Linguistic 34(4):555-596.
+           <http://www.mitpressjournals.org/doi/abs/10.1162/coli.07-034-R2#.V0J1MJMrIWo>`_
+    .. [3] `Wikipedia entry for the Cohen's kappa.
+            <https://en.wikipedia.org/wiki/Cohen%27s_kappa>`_
     """
     confusion = confusion_matrix(y1, y2, labels=labels)
     n_classes = confusion.shape[0]


### PR DESCRIPTION
Addresses issue #6808. @jnothman @larsmans 
# Roadmap
- [x] Cohen Kappa Score is now in API reference.
- [x] Links
  - [x] Fix the References link to `sklearn.metrics.cohen_kappa_score.html` page.
  - [x] Build `User Guide` links.
- [x] Extras
  - [x] Fix reference format for `brier_score_loss` to match the codebase.

Copy of the Sphinx [generated html page](https://www.dropbox.com/s/t6kwx4b9z8ez0b9/sklearn.metrics.cohen_kappa_score.html?dl=0). (To view it correctly with the CSS rendering, put it in the `scikit-learn/doc/_build/html/stable/modules/generated` source directory.)
# Original post

This also creates the `sklearn.metrics.cohen_kappa_score.html` page. (Similar to any other automatically generated function / class reference page like [this one](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.hamming_loss.html#sklearn.metrics.cohen_kappa_score).) However, after opening the html page, I noticed that the "References" links were not working.

I'm not too familiar with Sphinx. Where would be the appropriate place to create the links in the references?

I'd also like to build `See also` links to/from this page. Are there any suggestions to/from which pages we should link this metric? (It doesn't seem like a typical metric for a classifier.)
