### PR TITLE
[MRG+1] Parameter check in NMF

### DIFF
--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -19,7 +19,6 @@ import numbers
 import numpy as np
 import scipy.sparse as sp
 
-from ..externals import six
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_random_state, check_array
 from ..utils.extmath import randomized_svd, safe_sparse_dot, squared_norm
@@ -747,11 +746,11 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
     if n_components is None:
         n_components = n_features
 
-    if not isinstance(n_components, six.integer_types) or n_components <= 0:
-        raise ValueError("Number of components must be positive;"
+    if not isinstance(n_components, numbers.Integral) or n_components <= 0:
+        raise ValueError("Number of components must be a positive integer;"
                          " got (n_components=%r)" % n_components)
-    if not isinstance(max_iter, numbers.Number) or max_iter < 0:
-        raise ValueError("Maximum number of iteration must be positive;"
+    if not isinstance(max_iter, numbers.Integral) or max_iter < 0:
+        raise ValueError("Maximum number of iterations must be a positive integer;"
                          " got (max_iter=%r)" % max_iter)
     if not isinstance(tol, numbers.Number) or tol < 0:
         raise ValueError("Tolerance for stopping criteria must be "

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -235,7 +235,7 @@ def test_non_negative_factorization_checking():
     A = np.ones((2, 2))
     # Test parameters checking is public function
     nnmf = non_negative_factorization
-    msg = "Number of components must be positive; got (n_components='2')"
+    msg = "Number of components must be a positive integer; got (n_components='2')"
     assert_raise_message(ValueError, msg, nnmf, A, A, A, '2')
     msg = "Negative values in data passed to NMF (input H)"
     assert_raise_message(ValueError, msg, nnmf, A, A, -A, 2, 'custom')

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -133,7 +133,6 @@ def test_nmf_transform_custom_init():
     t = m.transform(A)
 
 
-
 @ignore_warnings
 def test_nmf_inverse_transform():
     # Test that NMF.inverse_transform returns close values

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -7,7 +7,7 @@ from scipy.sparse import csc_matrix
 
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_raise_message, assert_no_warnings
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_greater
@@ -235,6 +235,9 @@ def test_non_negative_factorization_checking():
     A = np.ones((2, 2))
     # Test parameters checking is public function
     nnmf = non_negative_factorization
+    assert_no_warnings(nnmf, A, A, A, np.int64(1))
+    msg = "Number of components must be a positive integer; got (n_components=1.5)"
+    assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5)
     msg = "Number of components must be a positive integer; got (n_components='2')"
     assert_raise_message(ValueError, msg, nnmf, A, A, A, '2')
     msg = "Negative values in data passed to NMF (input H)"

--- a/sklearn/ensemble/iforest.py
+++ b/sklearn/ensemble/iforest.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 from scipy.sparse import issparse
 
+import numbers
 from ..externals import six
 from ..tree import ExtraTreeRegressor
 from ..utils import check_random_state, check_array
@@ -167,7 +168,7 @@ class IsolationForest(BaseBagging):
                                  'Valid choices are: "auto", int or'
                                  'float' % self.max_samples)
 
-        elif isinstance(self.max_samples, six.integer_types):
+        elif isinstance(self.max_samples, numbers.Integral):
             if self.max_samples > n_samples:
                 warn("max_samples (%s) is greater than the "
                      "total number of samples (%s). max_samples "
@@ -277,7 +278,7 @@ def _average_path_length(n_samples_leaf):
     average_path_length : array, same shape as n_samples_leaf
 
     """
-    if isinstance(n_samples_leaf, six.integer_types):
+    if isinstance(n_samples_leaf, numbers.Integral):
         if n_samples_leaf <= 1:
             return 1.
         else:

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -104,8 +104,9 @@ def test_iforest_error():
                          "max_samples will be set to n_samples for estimation",
                          IsolationForest(max_samples=1000).fit, X)
     assert_no_warnings(IsolationForest(max_samples='auto').fit, X)
-    assert_raises(ValueError,
-                  IsolationForest(max_samples='foobar').fit, X)
+    assert_no_warnings(IsolationForest(max_samples=np.int64(2)).fit, X)
+    assert_raises(ValueError, IsolationForest(max_samples='foobar').fit, X)
+    assert_raises(ValueError, IsolationForest(max_samples=1.5).fit, X)
 
 
 def test_recalculate_max_depth():


### PR DESCRIPTION
Fixes #6793
Also, I've improved the error messages a little bit. I've replaced six.integer_types with numbers.Integral in iforest.py as well.
The tests pass on my configuration (win64, python3.5.1), the test case submitted in the issue report works as well.
