### PR TITLE
[MRG] Documentation and some input validation for get_scorer

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -187,8 +187,7 @@ class _ThresholdScorer(_BaseScorer):
 
 
 def get_scorer(scoring):
-    """Converts an estimator scoring strategy into a valid callable
-    object.
+    """Converts an scoring strategy into a valid callable object.
 
     For possible string arguments to the function, read more in the
     :ref:`User Guide <scoring>`.
@@ -201,18 +200,19 @@ def get_scorer(scoring):
 
         Some possible string arguments include: "accuracy",
         "average_precision", "f1", "adjusted_rand_score", "r2". Read
-        the User Guide for the full list of possibilities.
+        the :ref:`User Guide <scoring>`. for the full list of options.
 
         If a callable is passed in, the signature of the callable
         should be ``(estimator, X, y)``, where ``estimator`` is the
         model to be evaluated, ``X`` is the test data and ``y`` is the
         ground truth labeling (or ``None`` in the case of unsupervised
-        models).
+        models). The callable returns a float.
 
     Returns
     -------
     scorer : callable scoring object
         Callable scoring object with signature ``(estimator, X, y)``.
+        The callable returns a float.
 
     Example
     -------
@@ -272,14 +272,14 @@ def check_scoring(estimator, scoring=None, allow_none=False):
         ``scorer(estimator, X, y)``.
 
     allow_none : boolean, optional, default: False
-        If no scoring is specified and the estimator has no score function, we
-        can either return None or raise an exception.
+        If no scoring is specified and the estimator has no score
+        function, we can either return None or raise an exception.
 
     Returns
     -------
     scoring : callable
         A scorer callable object / function with signature
-        ``scorer(estimator, X, y)``.
+        ``scorer(estimator, X, y)``. Returns a float.
     """
     has_scoring = scoring is not None
     if not hasattr(estimator, 'fit'):

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -225,13 +225,15 @@ def get_scorer(scoring):
     >>> dummy = DummyClassifier(strategy="constant", constant=1.0)
     >>>
     >>> cross_val_score(dummy, X, y, scoring=get_scorer("accuracy"))
-    array([0.5, 0.5, 0.5])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    array([ 0.5, 0.5, 0.5])
     >>>
     >>> def dummy_scorer(estimator, y_test, y_pred):
-    >>>     return 1.0
+    ...     return 1.0
     >>>
     >>> cross_val_score(dummy, X, y, scoring=get_scorer(dummy_scorer))
-    array([1., 1., 1.])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    array([ 1., 1., 1.])
 
     """
     if isinstance(scoring, six.string_types):

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -243,8 +243,11 @@ def get_scorer(scoring):
             raise ValueError('%r is not a valid scoring value. '
                              'Valid options are %s'
                              % (scoring, sorted(SCORERS.keys())))
-    else:
+    elif six.callable(scoring):
+        # TODO Check that scoring method has three arguments
         scorer = scoring
+    else:
+        raise ValueError("Input must be either callable or string.")
     return scorer
 
 

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -187,6 +187,53 @@ class _ThresholdScorer(_BaseScorer):
 
 
 def get_scorer(scoring):
+    """Converts an estimator scoring strategy into a valid callable
+    object.
+
+    For possible string arguments to the function, read more in the
+    :ref:`User Guide <scoring>`.
+
+    Parameters
+    ----------
+    scoring : str or callable
+        String to specify the scoring metric, or a callable with
+        signature ``scorer(estimator, X, y)``.
+
+        Some possible string arguments include: "accuracy",
+        "average_precision", "f1", "adjusted_rand_score", "r2". Read
+        the User Guide for the full list of possibilities.
+
+        If a callable is passed in, the signature of the callable
+        should be ``(estimator, X, y)``, where ``estimator`` is the
+        model to be evaluated, ``X`` is the test data and ``y`` is the
+        ground truth labeling (or ``None`` in the case of unsupervised
+        models).
+
+    Returns
+    -------
+    scorer : callable scoring object
+        Callable scoring object with signature ``(estimator, X, y)``.
+
+    Example
+    -------
+    >>> from sklearn.datasets import make_classification
+    >>> from sklearn.dummy import DummyClassifier
+    >>> from sklearn.model_selection import cross_val_score
+    >>> from sklearn.metrics import get_scorer
+    >>>
+    >>> X, y = make_classification(random_state=0)
+    >>> dummy = DummyClassifier(strategy="constant", constant=1.0)
+    >>>
+    >>> cross_val_score(dummy, X, y, scoring=get_scorer("accuracy"))
+    array([0.5, 0.5, 0.5])
+    >>>
+    >>> def dummy_scorer(estimator, y_test, y_pred):
+    >>>     return 1.0
+    >>>
+    >>> cross_val_score(dummy, X, y, scoring=get_scorer(dummy_scorer))
+    array([1., 1., 1.])
+
+    """
     if isinstance(scoring, six.string_types):
         try:
             scorer = SCORERS[scoring]

--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -267,9 +267,9 @@ def check_scoring(estimator, scoring=None, allow_none=False):
         The object to use to fit the data.
 
     scoring : string, callable or None, optional, default: None
-        A string (see model evaluation documentation) or
-        a scorer callable object / function with signature
-        ``scorer(estimator, X, y)``.
+        A string (see model scoring `User Guide <scoring>` for full
+        list of options) or a scorer callable object / function with
+        signature ``scorer(estimator, X, y)``.
 
     allow_none : boolean, optional, default: False
         If no scoring is specified and the estimator has no score
@@ -277,9 +277,12 @@ def check_scoring(estimator, scoring=None, allow_none=False):
 
     Returns
     -------
-    scoring : callable
+    scoring : callable or None
         A scorer callable object / function with signature
-        ``scorer(estimator, X, y)``. Returns a float.
+        ``scorer(estimator, X, y)``. The callable returns a float.
+
+        If no scoring is specified and the estimator has no score
+        function, None is returned when allow_none=True
     """
     has_scoring = scoring is not None
     if not hasattr(estimator, 'fit'):

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -9,6 +9,7 @@ import numpy as np
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
@@ -189,6 +190,16 @@ def test_make_scorer():
     f = lambda *args: 0
     assert_raises(ValueError, make_scorer, f, needs_threshold=True,
                   needs_proba=True)
+
+
+def test_get_scorer_inputs():
+
+    msg = "Input must be either callable or string."
+    bad1 = list()
+
+    bad_callables = [bad1]
+    for bad_call in bad_callables:
+        assert_raise_message(ValueError, msg, get_scorer, bad_call)
 
 
 def test_classification_scores():


### PR DESCRIPTION
# Roadmap
- [x] Added documentation for `sklearn.metrics.get_scorer`
- [ ] Input validation check
  - [x] `scoring` parameter should be a callable
  - [ ] `scoring` should only receive 3 parameters
  - [ ] Add test cases for input validation
## Original Post

Added documentation for `sklearn.metrics.get_scorer`, which (until now) seemed blank. (Link [here](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.get_scorer.html#sklearn.metrics.get_scorer).)

To be honest, I can't seem to find a user case where this function would be useful. For example, if we were to use `cross_val_score`, we can state `cross_val_score(..., scoring="accuracy")` instead of `cross_val_score(..., scoring=get_scorer("accuracy")` to evaluate using the accuracy score. On the other hand, if a user generated his or her own evaluation metric, it would make more sense to wrap it with `make_scorer`. 

@GaelVaroquaux, do you have any ideas? (My idea is to deprecate the function altogether.)

If we choose to move forward with documenting this function, we probably want to make sure that if `scoring` is not a string, that it is a callable that takes in three arguments.

Motivation for PR: #6697.
