### PR TITLE
Improved error message for nan in metrics

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -36,11 +36,11 @@ from ..utils import check_consistent_length
 from ..utils import column_or_1d
 from ..utils.multiclass import unique_labels
 from ..utils.multiclass import type_of_target
-from ..utils.validation import _num_samples
+from ..utils.validation import _assert_all_finite, _num_samples
 from ..utils.sparsefuncs import count_nonzero
 from ..utils.fixes import bincount
 from ..exceptions import UndefinedMetricWarning
-from ..utils.validation import _assert_all_finite
+
 
 def _check_targets(y_true, y_pred):
     """Check that y_true and y_pred belong to the same classification task

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -40,7 +40,7 @@ from ..utils.validation import _num_samples
 from ..utils.sparsefuncs import count_nonzero
 from ..utils.fixes import bincount
 from ..exceptions import UndefinedMetricWarning
-
+from ..utils.validation import _assert_all_finite
 
 def _check_targets(y_true, y_pred):
     """Check that y_true and y_pred belong to the same classification task
@@ -70,6 +70,8 @@ def _check_targets(y_true, y_pred):
     y_pred : array or indicator matrix
     """
     check_consistent_length(y_true, y_pred)
+    _assert_all_finite(y_true)
+    _assert_all_finite(y_pred)
     type_true = type_of_target(y_true)
     type_pred = type_of_target(y_pred)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -102,16 +102,6 @@ def make_prediction(dataset=None, binary=False):
 # Tests
 
 
-def test_metrics_no_nan():
-    y_test = [np.nan, 1, 2]
-    y_pred = [1, 2, 3]
-
-    err_message = "Input contains NaN, infinity or a value too large for " \
-                  "dtype('float64')."
-
-    for metric in [accuracy_score]:
-        assert_raise_message(ValueError, err_message, metric, y_test, y_pred)
-
 def test_multilabel_accuracy_score_subset_accuracy():
     # Dense label indicator matrix format
     y1 = np.array([[0, 1, 1], [1, 0, 1]])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -102,6 +102,16 @@ def make_prediction(dataset=None, binary=False):
 # Tests
 
 
+def test_metrics_no_nan():
+    y_test = [np.nan, 1, 2]
+    y_pred = [1, 2, 3]
+
+    err_message = "Input contains NaN, infinity or a value too large for " \
+                  "dtype('float64')."
+
+    for metric in [accuracy_score]:
+        assert_raise_message(ValueError, err_message, metric, y_test, y_pred)
+
 def test_multilabel_accuracy_score_subset_accuracy():
     # Dense label indicator matrix format
     y1 = np.array([[0, 1, 1], [1, 0, 1]])

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -638,7 +638,8 @@ def test_inf_nan_input():
     for metric in CLASSIFICATION_METRICS.values():
         for y_true, y_score in invalids:
             assert_raise_message(ValueError,
-                                 "Can't handle mix of binary and continuous",
+                                 "Input contains NaN, infinity or a value " \
+                                 "too large for dtype('float64').",
                                  metric, y_true, y_score)
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -638,7 +638,7 @@ def test_inf_nan_input():
     for metric in CLASSIFICATION_METRICS.values():
         for y_true, y_score in invalids:
             assert_raise_message(ValueError,
-                                 "Input contains NaN, infinity or a value " \
+                                 "Input contains NaN, infinity or a value "
                                  "too large for dtype('float64').",
                                  metric, y_true, y_score)
 


### PR DESCRIPTION
Addresses #6809.

If we move forward with this PR, I'll be adding the appropriate for-loop to make sure none of the metrics have `nan` as input.

Off the top of my head, I can't think of a metric which would accept `nan` as input. Please let me know if you know of the exceptions.
