### PR TITLE
[MRG+1] Allows KMeans/MiniBatchKMeans to use float32 internally by using cython fused types

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -209,6 +209,11 @@ Enhancements
      (`#6697 <https://github.com/scikit-learn/scikit-learn/pull/6697>`_) by
      `Raghav R V`_.
 
+   - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
+     with ``np.float32`` and ``np.float64`` input data without converting it.
+     This allows to reduce the memory consumption by using ``np.float32``.
+     (`#6430 <https://github.com/scikit-learn/scikit-learn/pull/6430>`_)
+     By `Sebastian Säger`_.
 
 Bug fixes
 .........
@@ -1769,7 +1774,7 @@ List of contributors for release 0.15 by number of commits.
 *   4	Alexis Metaireau
 *   4	Ignacio Rossi
 *   4	Virgile Fritsch
-*   4	Sebastian Saeger
+*   4	Sebastian Säger
 *   4	Ilambharathi Kanniah
 *   4	sdenton4
 *   4	Robert Layton
@@ -4266,4 +4271,8 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Wenhua Yang: https://github.com/geekoala
 
+<<<<<<< HEAD
 .. _Arnaud Fouchet: https://github.com/afouchet
+=======
+.. _Sebastian Säger: https://github.com/ssaeger
+>>>>>>> Adds support and tests for KMeans/MiniBatchKMeans to work with float32 to save memory

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -212,8 +212,8 @@ Enhancements
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     (`#6430 <https://github.com/scikit-learn/scikit-learn/pull/6430>`_)
-     By `Sebastian Säger`_.
+     (`#6846 <https://github.com/scikit-learn/scikit-learn/pull/6846>`_)
+     By `Sebastian Säger`_ and `YenChen Lin`_.
 
 Bug fixes
 .........
@@ -4271,8 +4271,8 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Wenhua Yang: https://github.com/geekoala
 
-<<<<<<< HEAD
 .. _Arnaud Fouchet: https://github.com/afouchet
-=======
+
 .. _Sebastian Säger: https://github.com/ssaeger
->>>>>>> Adds support and tests for KMeans/MiniBatchKMeans to work with float32 to save memory
+
+.. _YenChen Lin: https://github.com/yenchenlin

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -108,7 +108,7 @@ cpdef DOUBLE _assign_labels_array(np.ndarray[floating, ndim=2] X,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef DOUBLE _assign_labels_csr(X, np.ndarray[floating, ndim=1] x_squared_norms,
+cpdef DOUBLE _assign_labels_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
                                 np.ndarray[floating, ndim=2] centers,
                                 np.ndarray[INT, ndim=1] labels,
                                 np.ndarray[floating, ndim=1] distances):
@@ -173,7 +173,7 @@ cpdef DOUBLE _assign_labels_csr(X, np.ndarray[floating, ndim=1] x_squared_norms,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _mini_batch_update_csr(X, np.ndarray[floating, ndim=1] x_squared_norms,
+def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
                            np.ndarray[floating, ndim=2] centers,
                            np.ndarray[INT, ndim=1] counts,
                            np.ndarray[INT, ndim=1] nearest_center,

--- a/sklearn/cluster/_k_means.pyx
+++ b/sklearn/cluster/_k_means.pyx
@@ -13,6 +13,7 @@ import numpy as np
 import scipy.sparse as sp
 cimport numpy as np
 cimport cython
+from cython cimport floating
 
 from ..utils.extmath import norm
 from sklearn.utils.sparsefuncs_fast import assign_rows_csr
@@ -23,6 +24,7 @@ ctypedef np.int32_t INT
 
 cdef extern from "cblas.h":
     double ddot "cblas_ddot"(int N, double *X, int incX, double *Y, int incY)
+    float sdot "cblas_sdot"(int N, float *X, int incX, float *Y, int incY)
 
 np.import_array()
 
@@ -30,11 +32,11 @@ np.import_array()
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef DOUBLE _assign_labels_array(np.ndarray[DOUBLE, ndim=2] X,
-                                  np.ndarray[DOUBLE, ndim=1] x_squared_norms,
-                                  np.ndarray[DOUBLE, ndim=2] centers,
+cpdef DOUBLE _assign_labels_array(np.ndarray[floating, ndim=2] X,
+                                  np.ndarray[floating, ndim=1] x_squared_norms,
+                                  np.ndarray[floating, ndim=2] centers,
                                   np.ndarray[INT, ndim=1] labels,
-                                  np.ndarray[DOUBLE, ndim=1] distances):
+                                  np.ndarray[floating, ndim=1] distances):
     """Compute label assignment and inertia for a dense array
 
     Return the inertia (sum of squared distances to the centers).
@@ -43,24 +45,39 @@ cpdef DOUBLE _assign_labels_array(np.ndarray[DOUBLE, ndim=2] X,
         unsigned int n_clusters = centers.shape[0]
         unsigned int n_features = centers.shape[1]
         unsigned int n_samples = X.shape[0]
-        unsigned int x_stride = X.strides[1] / sizeof(DOUBLE)
-        unsigned int center_stride = centers.strides[1] / sizeof(DOUBLE)
+        unsigned int x_stride
+        unsigned int center_stride
         unsigned int sample_idx, center_idx, feature_idx
         unsigned int store_distances = 0
         unsigned int k
+        np.ndarray[floating, ndim=1] center_squared_norms
+        # the following variables are always double cause make them floating
+        # does not save any memory, but makes the code much bigger
         DOUBLE inertia = 0.0
         DOUBLE min_dist
         DOUBLE dist
-        np.ndarray[DOUBLE, ndim=1] center_squared_norms = np.zeros(
-            n_clusters, dtype=np.float64)
+
+    if floating is float:
+        center_squared_norms = np.zeros(n_clusters, dtype=np.float32)
+        x_stride = X.strides[1] / sizeof(float)
+        center_stride = centers.strides[1] / sizeof(float)
+    else:
+        center_squared_norms = np.zeros(n_clusters, dtype=np.float64)
+        x_stride = X.strides[1] / sizeof(DOUBLE)
+        center_stride = centers.strides[1] / sizeof(DOUBLE)
 
     if n_samples == distances.shape[0]:
         store_distances = 1
 
     for center_idx in range(n_clusters):
-        center_squared_norms[center_idx] = ddot(
-            n_features, &centers[center_idx, 0], center_stride,
-            &centers[center_idx, 0], center_stride)
+        if floating is float:
+            center_squared_norms[center_idx] = sdot(
+                n_features, &centers[center_idx, 0], center_stride,
+                &centers[center_idx, 0], center_stride)
+        else:
+            center_squared_norms[center_idx] = ddot(
+                n_features, &centers[center_idx, 0], center_stride,
+                &centers[center_idx, 0], center_stride)
 
     for sample_idx in range(n_samples):
         min_dist = -1
@@ -68,8 +85,12 @@ cpdef DOUBLE _assign_labels_array(np.ndarray[DOUBLE, ndim=2] X,
             dist = 0.0
             # hardcoded: minimize euclidean distance to cluster center:
             # ||a - b||^2 = ||a||^2 + ||b||^2 -2 <a, b>
-            dist += ddot(n_features, &X[sample_idx, 0], x_stride,
-                         &centers[center_idx, 0], center_stride)
+            if floating is float:
+                dist += sdot(n_features, &X[sample_idx, 0], x_stride,
+                             &centers[center_idx, 0], center_stride)
+            else:
+                dist += ddot(n_features, &X[sample_idx, 0], x_stride,
+                             &centers[center_idx, 0], center_stride)
             dist *= -2
             dist += center_squared_norms[center_idx]
             dist += x_squared_norms[sample_idx]
@@ -87,16 +108,16 @@ cpdef DOUBLE _assign_labels_array(np.ndarray[DOUBLE, ndim=2] X,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef DOUBLE _assign_labels_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
-                                np.ndarray[DOUBLE, ndim=2] centers,
+cpdef DOUBLE _assign_labels_csr(X, np.ndarray[floating, ndim=1] x_squared_norms,
+                                np.ndarray[floating, ndim=2] centers,
                                 np.ndarray[INT, ndim=1] labels,
-                                np.ndarray[DOUBLE, ndim=1] distances):
+                                np.ndarray[floating, ndim=1] distances):
     """Compute label assignment and inertia for a CSR input
 
     Return the inertia (sum of squared distances to the centers).
     """
     cdef:
-        np.ndarray[DOUBLE, ndim=1] X_data = X.data
+        np.ndarray[floating, ndim=1] X_data = X.data
         np.ndarray[INT, ndim=1] X_indices = X.indices
         np.ndarray[INT, ndim=1] X_indptr = X.indptr
         unsigned int n_clusters = centers.shape[0]
@@ -105,18 +126,28 @@ cpdef DOUBLE _assign_labels_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
         unsigned int store_distances = 0
         unsigned int sample_idx, center_idx, feature_idx
         unsigned int k
+        np.ndarray[floating, ndim=1] center_squared_norms
+        # the following variables are always double cause make them floating
+        # does not save any memory, but makes the code much bigger
         DOUBLE inertia = 0.0
         DOUBLE min_dist
         DOUBLE dist
-        np.ndarray[DOUBLE, ndim=1] center_squared_norms = np.zeros(
-            n_clusters, dtype=np.float64)
+
+    if floating is float:
+        center_squared_norms = np.zeros(n_clusters, dtype=np.float32)
+    else:
+        center_squared_norms = np.zeros(n_clusters, dtype=np.float64)
 
     if n_samples == distances.shape[0]:
         store_distances = 1
 
     for center_idx in range(n_clusters):
-        center_squared_norms[center_idx] = ddot(
-            n_features, &centers[center_idx, 0], 1, &centers[center_idx, 0], 1)
+        if floating is float:
+            center_squared_norms[center_idx] = sdot(
+                n_features, &centers[center_idx, 0], 1, &centers[center_idx, 0], 1)
+        else:
+            center_squared_norms[center_idx] = ddot(
+                n_features, &centers[center_idx, 0], 1, &centers[center_idx, 0], 1)
 
     for sample_idx in range(n_samples):
         min_dist = -1
@@ -142,18 +173,18 @@ cpdef DOUBLE _assign_labels_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
-                           np.ndarray[DOUBLE, ndim=2] centers,
+def _mini_batch_update_csr(X, np.ndarray[floating, ndim=1] x_squared_norms,
+                           np.ndarray[floating, ndim=2] centers,
                            np.ndarray[INT, ndim=1] counts,
                            np.ndarray[INT, ndim=1] nearest_center,
-                           np.ndarray[DOUBLE, ndim=1] old_center,
+                           np.ndarray[floating, ndim=1] old_center,
                            int compute_squared_diff):
     """Incremental update of the centers for sparse MiniBatchKMeans.
 
     Parameters
     ----------
 
-    X: CSR matrix, dtype float64
+    X: CSR matrix, dtype float
         The complete (pre allocated) training set as a CSR matrix.
 
     centers: array, shape (n_clusters, n_features)
@@ -179,7 +210,7 @@ def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
     of the algorithm.
     """
     cdef:
-        np.ndarray[DOUBLE, ndim=1] X_data = X.data
+        np.ndarray[floating, ndim=1] X_data = X.data
         np.ndarray[int, ndim=1] X_indices = X.indices
         np.ndarray[int, ndim=1] X_indptr = X.indptr
         unsigned int n_samples = X.shape[0]
@@ -245,9 +276,9 @@ def _mini_batch_update_csr(X, np.ndarray[DOUBLE, ndim=1] x_squared_norms,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def _centers_dense(np.ndarray[DOUBLE, ndim=2] X,
+def _centers_dense(np.ndarray[floating, ndim=2] X,
         np.ndarray[INT, ndim=1] labels, int n_clusters,
-        np.ndarray[DOUBLE, ndim=1] distances):
+        np.ndarray[floating, ndim=1] distances):
     """M step of the K-means EM algorithm
 
     Computation of cluster centers / means.
@@ -275,7 +306,12 @@ def _centers_dense(np.ndarray[DOUBLE, ndim=2] X,
     n_samples = X.shape[0]
     n_features = X.shape[1]
     cdef int i, j, c
-    cdef np.ndarray[DOUBLE, ndim=2] centers = np.zeros((n_clusters, n_features))
+    cdef np.ndarray[floating, ndim=2] centers
+    if floating is float:
+        centers = np.zeros((n_clusters, n_features), dtype=np.float32)
+    else:
+        centers = np.zeros((n_clusters, n_features), dtype=np.float64)
+
     n_samples_in_cluster = bincount(labels, minlength=n_clusters)
     empty_clusters = np.where(n_samples_in_cluster == 0)[0]
     # maybe also relocate small clusters?
@@ -303,7 +339,7 @@ def _centers_dense(np.ndarray[DOUBLE, ndim=2] X,
 @cython.wraparound(False)
 @cython.cdivision(True)
 def _centers_sparse(X, np.ndarray[INT, ndim=1] labels, n_clusters,
-        np.ndarray[DOUBLE, ndim=1] distances):
+        np.ndarray[floating, ndim=1] distances):
     """M step of the K-means EM algorithm
 
     Computation of cluster centers / means.
@@ -329,18 +365,22 @@ def _centers_sparse(X, np.ndarray[INT, ndim=1] labels, n_clusters,
     cdef int n_features = X.shape[1]
     cdef int curr_label
 
-    cdef np.ndarray[DOUBLE, ndim=1] data = X.data
+    cdef np.ndarray[floating, ndim=1] data = X.data
     cdef np.ndarray[int, ndim=1] indices = X.indices
     cdef np.ndarray[int, ndim=1] indptr = X.indptr
 
-    cdef np.ndarray[DOUBLE, ndim=2, mode="c"] centers = \
-        np.zeros((n_clusters, n_features))
+    cdef np.ndarray[floating, ndim=2, mode="c"] centers
     cdef np.ndarray[np.npy_intp, ndim=1] far_from_centers
     cdef np.ndarray[np.npy_intp, ndim=1, mode="c"] n_samples_in_cluster = \
         bincount(labels, minlength=n_clusters)
     cdef np.ndarray[np.npy_intp, ndim=1, mode="c"] empty_clusters = \
         np.where(n_samples_in_cluster == 0)[0]
     cdef int n_empty_clusters = empty_clusters.shape[0]
+
+    if floating is float:
+        centers = np.zeros((n_clusters, n_features), dtype=np.float32)
+    else:
+        centers = np.zeros((n_clusters, n_features), dtype=np.float64)
 
     # maybe also relocate small clusters?
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -397,8 +397,6 @@ def _kmeans_single_elkan(X, n_clusters, max_iter=300, init='k-means++',
     centers, labels, n_iter = k_means_elkan(X, n_clusters, centers, tol=tol,
                                             max_iter=max_iter, verbose=verbose)
     inertia = np.sum((X - centers[labels]) ** 2, dtype=np.float64)
-    if X.dtype is np.float32:
-        inertia = np.float32(inertia)
     return labels, inertia, centers, n_iter
 
 

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -1318,12 +1318,12 @@ class MiniBatchKMeans(KMeans):
             # using tol-based early stopping needs the allocation of a
             # dedicated before which can be expensive for high dim data:
             # hence we allocate it outside of the main loop
-            old_center_buffer = np.zeros(n_features, np.double)
+            old_center_buffer = np.zeros(n_features, dtype=X.dtype)
         else:
             tol = 0.0
             # no need for the center buffer if tol-based early stopping is
             # disabled
-            old_center_buffer = np.zeros(0, np.double)
+            old_center_buffer = np.zeros(0, dtype=X.dtype)
 
         distances = np.zeros(self.batch_size, dtype=X.dtype)
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
@@ -1486,7 +1486,7 @@ class MiniBatchKMeans(KMeans):
             distances = np.zeros(X.shape[0], dtype=X.dtype)
 
         _mini_batch_step(X, x_squared_norms, self.cluster_centers_,
-                         self.counts_, np.zeros(0, np.double), 0,
+                         self.counts_, np.zeros(0, dtype=X.dtype), 0,
                          random_reassign=random_reassign, distances=distances,
                          random_state=self.random_state_,
                          reassignment_ratio=self.reassignment_ratio,

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -867,11 +867,12 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
         self.cluster_centers_, self.labels_, self.inertia_, self.n_iter_ = \
             k_means(
-                X, n_clusters=self.n_clusters, init=self.init, n_init=self.n_init,
-                max_iter=self.max_iter, verbose=self.verbose,
+                X, n_clusters=self.n_clusters, init=self.init,
+                n_init=self.n_init, max_iter=self.max_iter, verbose=self.verbose,
                 precompute_distances=self.precompute_distances,
                 tol=self.tol, random_state=random_state, copy_x=self.copy_x,
-                n_jobs=self.n_jobs, algorithm=self.algorithm, return_n_iter=True)
+                n_jobs=self.n_jobs, algorithm=self.algorithm,
+                return_n_iter=True)
         return self
 
     def fit_predict(self, X, y=None):

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -836,10 +836,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     def _check_fit_data(self, X):
         """Verify that the number of samples given is larger than k"""
-        if sp.issparse(X):
-            X = check_array(X, accept_sparse='csr', dtype=[np.float64, np.float32])
-        else:
-            X = check_array(X, dtype=[np.float64, np.float32])
+        X = check_array(X, accept_sparse='csr', dtype=[np.float64, np.float32])
         if X.shape[0] < self.n_clusters:
             raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
                 X.shape[0], self.n_clusters))
@@ -1289,11 +1286,8 @@ class MiniBatchKMeans(KMeans):
             Coordinates of the data points to cluster
         """
         random_state = check_random_state(self.random_state)
-        if sp.issparse(X):
-            X = check_array(X, accept_sparse="csr", order='C',
-                            dtype=[np.float64, np.float32])
-        else:
-            X = check_array(X, order='C', dtype=[np.float64, np.float32])
+        X = check_array(X, accept_sparse="csr", order='C',
+                        dtype=[np.float64, np.float32])
         n_samples, n_features = X.shape
         if n_samples < self.n_clusters:
             raise ValueError("Number of samples smaller than number "

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -305,7 +305,7 @@ def k_means(X, n_clusters, init='k-means++', precompute_distances='auto',
         X -= X_mean
 
     if hasattr(init, '__array__'):
-        init = check_array(init, dtype=np.float64, copy=True)
+        init = check_array(init, dtype=X.dtype.type, copy=True)
         _validate_center_shape(X, n_clusters, init)
 
         init -= X_mean
@@ -690,6 +690,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
         centers = np.array(init, dtype=X.dtype)
     elif callable(init):
         centers = init(X, k, random_state=random_state)
+        centers = np.asarray(centers, dtype=X.dtype)
     else:
         raise ValueError("the init parameter for the k-means should "
                          "be 'k-means++' or 'random' or an ndarray, "

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -836,7 +836,10 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     def _check_fit_data(self, X):
         """Verify that the number of samples given is larger than k"""
-        X = check_array(X, dtype=[np.float64, np.float32])
+        if sp.issparse(X):
+            X = check_array(X, accept_sparse='csr', dtype=[np.float64, np.float32])
+        else:
+            X = check_array(X, dtype=[np.float64, np.float32])
         if X.shape[0] < self.n_clusters:
             raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
                 X.shape[0], self.n_clusters))
@@ -1286,7 +1289,11 @@ class MiniBatchKMeans(KMeans):
             Coordinates of the data points to cluster
         """
         random_state = check_random_state(self.random_state)
-        X = check_array(X, dtype=[np.float64, np.float32], order='C')
+        if sp.issparse(X):
+            X = check_array(X, accept_sparse="csr", order='C',
+                            dtype=[np.float64, np.float32])
+        else:
+            X = check_array(X, order='C', dtype=[np.float64, np.float32])
         n_samples, n_features = X.shape
         if n_samples < self.n_clusters:
             raise ValueError("Number of samples smaller than number "

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -77,7 +77,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """
     n_samples, n_features = X.shape
 
-    centers = np.empty((n_clusters, n_features))
+    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
 
     assert x_squared_norms is not None, 'x_squared_norms None in _k_init'
 
@@ -396,7 +396,9 @@ def _kmeans_single_elkan(X, n_clusters, max_iter=300, init='k-means++',
         print('Initialization complete')
     centers, labels, n_iter = k_means_elkan(X, n_clusters, centers, tol=tol,
                                             max_iter=max_iter, verbose=verbose)
-    inertia = np.sum((X - centers[labels]) ** 2)
+    inertia = np.sum((X - centers[labels]) ** 2, dtype=np.float64)
+    if X.dtype is np.float32:
+        inertia = np.float32(inertia)
     return labels, inertia, centers, n_iter
 
 
@@ -478,7 +480,7 @@ def _kmeans_single_lloyd(X, n_clusters, max_iter=300, init='k-means++',
 
     # Allocate memory to store the distances for each sample to its
     # closer center for reallocation in case of ties
-    distances = np.zeros(shape=(X.shape[0],), dtype=np.float64)
+    distances = np.zeros(shape=(X.shape[0],), dtype=X.dtype)
 
     # iterations
     for i in range(max_iter):
@@ -586,13 +588,13 @@ def _labels_inertia(X, x_squared_norms, centers,
         Precomputed squared euclidean norm of each data point, to speed up
         computations.
 
-    centers: float64 array, shape (k, n_features)
+    centers: float array, shape (k, n_features)
         The cluster centers.
 
     precompute_distances : boolean, default: True
         Precompute distances (faster but takes more memory).
 
-    distances: float64 array, shape (n_samples,)
+    distances: float array, shape (n_samples,)
         Pre-allocated array to be filled in with each sample's distance
         to the closest center.
 
@@ -609,7 +611,7 @@ def _labels_inertia(X, x_squared_norms, centers,
     # easily
     labels = -np.ones(n_samples, np.int32)
     if distances is None:
-        distances = np.zeros(shape=(0,), dtype=np.float64)
+        distances = np.zeros(shape=(0,), dtype=X.dtype)
     # distances will be changed in-place
     if sp.issparse(X):
         inertia = _k_means._assign_labels_csr(
@@ -685,7 +687,9 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
         seeds = random_state.permutation(n_samples)[:k]
         centers = X[seeds]
     elif hasattr(init, '__array__'):
-        centers = init
+        # ensure that the centers have the same dtype as X
+        # this is a requirement of fused types of cython
+        centers = np.array(init, dtype=X.dtype)
     elif callable(init):
         centers = init(X, k, random_state=random_state)
     else:
@@ -834,7 +838,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     def _check_fit_data(self, X):
         """Verify that the number of samples given is larger than k"""
-        X = check_array(X, accept_sparse='csr', dtype=np.float64)
+        X = check_array(X, dtype=[np.float64, np.float32])
         if X.shape[0] < self.n_clusters:
             raise ValueError("n_samples=%d should be >= n_clusters=%d" % (
                 X.shape[0], self.n_clusters))
@@ -983,7 +987,7 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
          The vector in which we keep track of the numbers of elements in a
          cluster. This array is MODIFIED IN PLACE
 
-    distances : array, dtype float64, shape (n_samples), optional
+    distances : array, dtype float, shape (n_samples), optional
         If not None, should be a pre-allocated array that will be used to store
         the distances of each sample to its closest center.
         May not be None when random_reassign is True.
@@ -1084,7 +1088,9 @@ def _mini_batch_step(X, x_squared_norms, centers, counts,
             counts[center_idx] += count
 
             # inplace rescale to compute mean of all points (old and new)
-            centers[center_idx] /= counts[center_idx]
+            # Note: numpy >= 1.10 does not support '/=' for the following
+            # expression for a mixture of int and float (see numpy issue #6464)
+            centers[center_idx] = centers[center_idx] / counts[center_idx]
 
             # update the squared diff if necessary
             if compute_squared_diff:
@@ -1282,7 +1288,7 @@ class MiniBatchKMeans(KMeans):
             Coordinates of the data points to cluster
         """
         random_state = check_random_state(self.random_state)
-        X = check_array(X, accept_sparse="csr", order='C', dtype=np.float64)
+        X = check_array(X, dtype=[np.float64, np.float32], order='C')
         n_samples, n_features = X.shape
         if n_samples < self.n_clusters:
             raise ValueError("Number of samples smaller than number "
@@ -1290,7 +1296,7 @@ class MiniBatchKMeans(KMeans):
 
         n_init = self.n_init
         if hasattr(self.init, '__array__'):
-            self.init = np.ascontiguousarray(self.init, dtype=np.float64)
+            self.init = np.ascontiguousarray(self.init, dtype=X.dtype)
             if n_init != 1:
                 warnings.warn(
                     'Explicit initial center position passed: '
@@ -1314,7 +1320,7 @@ class MiniBatchKMeans(KMeans):
             # disabled
             old_center_buffer = np.zeros(0, np.double)
 
-        distances = np.zeros(self.batch_size, dtype=np.float64)
+        distances = np.zeros(self.batch_size, dtype=X.dtype)
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
         n_iter = int(self.max_iter * n_batches)
 
@@ -1446,7 +1452,7 @@ class MiniBatchKMeans(KMeans):
         X = check_array(X, accept_sparse="csr")
         n_samples, n_features = X.shape
         if hasattr(self.init, '__array__'):
-            self.init = np.ascontiguousarray(self.init, dtype=np.float64)
+            self.init = np.ascontiguousarray(self.init, dtype=X.dtype)
 
         if n_samples == 0:
             return self
@@ -1472,7 +1478,7 @@ class MiniBatchKMeans(KMeans):
             # reassignment too often, to allow for building up counts
             random_reassign = self.random_state_.randint(
                 10 * (1 + self.counts_.min())) == 0
-            distances = np.zeros(X.shape[0], dtype=np.float64)
+            distances = np.zeros(X.shape[0], dtype=X.dtype)
 
         _mini_batch_step(X, x_squared_norms, self.cluster_centers_,
                          self.counts_, np.zeros(0, np.double), 0,

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -783,6 +783,7 @@ def test_kmeans_float32_64():
 
     inertia = {}
     X_new = {}
+    centers = {}
 
     for dtype in [np.float64, np.float32]:
         X_test = dtype(X)
@@ -791,6 +792,7 @@ def test_kmeans_float32_64():
         assert_equal(km.cluster_centers_.dtype, dtype)
         inertia[dtype] = km.inertia_
         X_new[dtype] = km.transform(km.cluster_centers_)
+        centers[dtype] = km.cluster_centers_
         # make sure predictions correspond to the correct label
         assert_equal(km.predict(X_test[0]), km.labels_[0])
 
@@ -799,6 +801,7 @@ def test_kmeans_float32_64():
     assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
                               decimal=4)
     assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
+    assert_array_almost_equal(centers[np.float32], centers[np.float64])
 
     for dtype in [np.float32, np.float64]:
         X_csr_test = sp.csr_matrix(X_csr, dtype=dtype)
@@ -807,6 +810,7 @@ def test_kmeans_float32_64():
         assert_equal(km.cluster_centers_.dtype, dtype)
         inertia[dtype] = km.inertia_
         X_new[dtype] = km.transform(km.cluster_centers_)
+        centers[dtype] = km.cluster_centers_
         # make sure predictions correspond to the correct label
         assert_equal(km.predict(X_csr_test[0]),
                                 km.labels_[0])
@@ -814,6 +818,7 @@ def test_kmeans_float32_64():
     assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
                               decimal=4)
     assert_array_almost_equal(X_new[np.float32], X_new[np.float64])
+    assert_array_almost_equal(centers[np.float32], centers[np.float64])
 
 
 def test_mb_k_means_float32_64():
@@ -821,6 +826,7 @@ def test_mb_k_means_float32_64():
 
     inertia = {}
     X_new = {}
+    centers = {}
     for dtype in [np.float64, np.float32]:
         X_test = dtype(X)
         km.fit(X_test)
@@ -828,6 +834,7 @@ def test_mb_k_means_float32_64():
         assert_equal(km.cluster_centers_.dtype, dtype)
         inertia[dtype] = km.inertia_
         X_new[dtype] = km.transform(km.cluster_centers_)
+        centers[dtype] = km.cluster_centers_
         # make sure predictions correspond to the correct label
         assert_equal(km.predict(X_test[0]), km.labels_[0])
         km.partial_fit(X_test[0:3])
@@ -838,6 +845,7 @@ def test_mb_k_means_float32_64():
     # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
     assert_array_almost_equal(inertia[np.float32], inertia[np.float64], decimal=4)
     assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
+    assert_array_almost_equal(centers[np.float32], centers[np.float64])
 
     for dtype in [np.float32, np.float64]:
         X_csr_test = sp.csr_matrix(X_csr, dtype=dtype)
@@ -846,6 +854,7 @@ def test_mb_k_means_float32_64():
         assert_equal(km.cluster_centers_.dtype, dtype)
         inertia[dtype] = km.inertia_
         X_new[dtype] = km.transform(km.cluster_centers_)
+        centers[dtype] = km.cluster_centers_
         # make sure predictions correspond to the correct label
         assert_equal(km.predict(X_csr_test[0]), km.labels_[0])
         km.partial_fit(X_csr_test[0:3])
@@ -856,3 +865,4 @@ def test_mb_k_means_float32_64():
                               decimal=4)
     assert_array_almost_equal(X_new[np.float32], X_new[np.float64],
                               decimal=4)
+    assert_array_almost_equal(centers[np.float32], centers[np.float64], 4)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -778,9 +778,9 @@ def test_max_iter_error():
                          km.fit, X)
 
 
-def test_kmeans_float_precision():
-    km = KMeans(n_init=1, random_state=11)
-    mb_km = MiniBatchKMeans(n_init=1, random_state=11)
+def test_float_precision():
+    km = KMeans(n_init=1, random_state=30)
+    mb_km = MiniBatchKMeans(n_init=1, random_state=30)
 
     inertia = {}
     X_new = {}
@@ -797,7 +797,7 @@ def test_kmeans_float_precision():
                 # dtype of cluster centers has to be the dtype of the input data
                 assert_equal(estimator.cluster_centers_.dtype, dtype)
                 inertia[dtype] = estimator.inertia_
-                X_new[dtype] = estimator.transform(estimator.cluster_centers_)
+                X_new[dtype] = estimator.transform(X_test)
                 centers[dtype] = estimator.cluster_centers_
                 # make sure predictions correspond to the correct label
                 assert_equal(estimator.predict(X_test[0]), estimator.labels_[0])

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -817,3 +817,17 @@ def test_float_precision():
                                     decimal=4)
             assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
             assert_array_almost_equal(centers[np.float32], centers[np.float64], decimal=4)
+
+
+def test_KMeans_init_centers():
+    # This test is used to check KMeans won't mutate the user provided input array silently
+    # even if input data and init centers have the same type
+    X_small = np.array([[1.1, 1.1], [-7.5, -7.5], [-1.1, -1.1], [7.5, 7.5]])
+    init_centers = np.array([[0.0, 0.0], [5.0, 5.0], [-5.0, -5.0]])
+    for dtype in [np.int32, np.int64, np.float32, np.float64]:
+        X_test = dtype(X_small)
+        init_centers_test = dtype(init_centers)
+        assert_equal(X_test.dtype, init_centers_test.dtype)
+        km = KMeans(init=init_centers_test, n_clusters=3)
+        km.fit(X_test)
+        assert_equal(False, km.cluster_centers_ is init_centers)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -802,7 +802,7 @@ def test_float_precision():
                 centers[dtype] = estimator.cluster_centers_
                 # make sure predictions correspond to the correct label
                 assert_equal(estimator.predict(X_test[0]), estimator.labels_[0])
-                if estimator == mb_km:
+                if hasattr(estimator, 'partial_fit'):
                     estimator.partial_fit(X_test[0:3])
                     # dtype of cluster centers has to stay the same after partial_fit
                     assert_equal(estimator.cluster_centers_.dtype, dtype)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -651,17 +651,12 @@ def test_int_input():
         init_int = X_int[:2]
 
         fitted_models = [
-            KMeans(n_clusters=2).fit(X_list),
             KMeans(n_clusters=2).fit(X_int),
-            KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_list),
             KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_int),
             # mini batch kmeans is very unstable on such a small dataset hence
             # we use many inits
-            MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_list),
             MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int),
             MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int_csr),
-            MiniBatchKMeans(n_clusters=2, batch_size=2,
-                            init=init_int, n_init=1).fit(X_list),
             MiniBatchKMeans(n_clusters=2, batch_size=2,
                             init=init_int, n_init=1).fit(X_int),
             MiniBatchKMeans(n_clusters=2, batch_size=2,
@@ -827,7 +822,7 @@ def test_KMeans_init_centers():
     for dtype in [np.int32, np.int64, np.float32, np.float64]:
         X_test = dtype(X_small)
         init_centers_test = dtype(init_centers)
-        assert_equal(X_test.dtype, init_centers_test.dtype)
+        assert_array_equal(init_centers, init_centers_test)
         km = KMeans(init=init_centers_test, n_clusters=3)
         km.fit(X_test)
-        assert_equal(False, km.cluster_centers_ is init_centers)
+        assert_equal(False, np.may_share_memory(km.cluster_centers_, init_centers))

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -643,33 +643,38 @@ def test_predict_minibatch_random_init_sparse_input():
     assert_array_equal(mb_k_means.predict(X), mb_k_means.labels_)
 
 
-def test_input_dtypes():
+def test_int_input():
     X_list = [[0, 0], [10, 10], [12, 9], [-1, 1], [2, 0], [8, 10]]
-    X_int = np.array(X_list, dtype=np.int32)
-    X_int_csr = sp.csr_matrix(X_int)
-    init_int = X_int[:2]
+    for dtype in [np.int32, np.int64]:
+        X_int = np.array(X_list, dtype=dtype)
+        X_int_csr = sp.csr_matrix(X_int)
+        init_int = X_int[:2]
 
-    fitted_models = [
-        KMeans(n_clusters=2).fit(X_list),
-        KMeans(n_clusters=2).fit(X_int),
-        KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_list),
-        KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_int),
-        # mini batch kmeans is very unstable on such a small dataset hence
-        # we use many inits
-        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_list),
-        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int),
-        MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int_csr),
-        MiniBatchKMeans(n_clusters=2, batch_size=2,
-                        init=init_int, n_init=1).fit(X_list),
-        MiniBatchKMeans(n_clusters=2, batch_size=2,
-                        init=init_int, n_init=1).fit(X_int),
-        MiniBatchKMeans(n_clusters=2, batch_size=2,
-                        init=init_int, n_init=1).fit(X_int_csr),
-    ]
-    expected_labels = [0, 1, 1, 0, 0, 1]
-    scores = np.array([v_measure_score(expected_labels, km.labels_)
-                       for km in fitted_models])
-    assert_array_equal(scores, np.ones(scores.shape[0]))
+        fitted_models = [
+            KMeans(n_clusters=2).fit(X_list),
+            KMeans(n_clusters=2).fit(X_int),
+            KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_list),
+            KMeans(n_clusters=2, init=init_int, n_init=1).fit(X_int),
+            # mini batch kmeans is very unstable on such a small dataset hence
+            # we use many inits
+            MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_list),
+            MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int),
+            MiniBatchKMeans(n_clusters=2, n_init=10, batch_size=2).fit(X_int_csr),
+            MiniBatchKMeans(n_clusters=2, batch_size=2,
+                            init=init_int, n_init=1).fit(X_list),
+            MiniBatchKMeans(n_clusters=2, batch_size=2,
+                            init=init_int, n_init=1).fit(X_int),
+            MiniBatchKMeans(n_clusters=2, batch_size=2,
+                            init=init_int, n_init=1).fit(X_int_csr),
+        ]
+
+        for km in fitted_models:
+            assert_equal(km.cluster_centers_.dtype, np.float64)
+
+        expected_labels = [0, 1, 1, 0, 0, 1]
+        scores = np.array([v_measure_score(expected_labels, km.labels_)
+                        for km in fitted_models])
+        assert_array_equal(scores, np.ones(scores.shape[0]))
 
 
 def test_transform():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -781,115 +781,78 @@ def test_max_iter_error():
 def test_kmeans_float32_64():
     km = KMeans(n_init=1, random_state=11)
 
-    # float64 data
-    km.fit(X)
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia64 = km.inertia_
-    X_new64 = km.transform(km.cluster_centers_)
-    pred64 = km.predict(X[0])
+    inertia = {}
+    X_new = {}
 
-    # float32 data
-    km.fit(np.float32(X))
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float32)
-    inertia32 = km.inertia_
-    X_new32 = km.transform(km.cluster_centers_)
-    pred32 = km.predict(X[0])
+    for dtype in [np.float64, np.float32]:
+        X_test = dtype(X)
+        km.fit(X_test)
+        # dtype of cluster centers has to be the dtype of the input data
+        assert_equal(km.cluster_centers_.dtype, dtype)
+        inertia[dtype] = km.inertia_
+        X_new[dtype] = km.transform(km.cluster_centers_)
+        # make sure predictions correspond to the correct label
+        assert_equal(km.predict(X_test[0]), km.labels_[0])
 
     # compare arrays with low precision since the difference between
     # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
-    assert_array_almost_equal(inertia32, inertia64, decimal=4)
-    assert_array_almost_equal(X_new32, X_new64, decimal=4)
-    # both predictions have to be the same and correspond to the correct label
-    assert_equal(pred32, pred64)
-    assert_equal(pred32, km.labels_[0])
-    assert_equal(pred64, km.labels_[0])
+    assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
+                              decimal=4)
+    assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
 
-    # float64 sparse data
-    km.fit(X_csr)
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia64 = km.inertia_
-    X_new64 = km.transform(km.cluster_centers_)
-    pred64 = km.predict(X_csr[0])
+    for dtype in [np.float32, np.float64]:
+        X_csr_test = sp.csr_matrix(X_csr, dtype=dtype)
+        km.fit(X_csr_test)
+        # dtype of cluster centers has to be the dtype of the input data
+        assert_equal(km.cluster_centers_.dtype, dtype)
+        inertia[dtype] = km.inertia_
+        X_new[dtype] = km.transform(km.cluster_centers_)
+        # make sure predictions correspond to the correct label
+        assert_equal(km.predict(X_csr_test[0]),
+                                km.labels_[0])
 
-    # float32 sparse data
-    # Note: at the moment sparse data is always processed as float64 internally
-    km.fit(sp.csr_matrix(X_csr, dtype=np.float32))
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia32 = km.inertia_
-    X_new32 = km.transform(km.cluster_centers_)
-    pred32 = km.predict(X_csr[0])
-
-    assert_array_almost_equal(inertia32, inertia64)
-    assert_array_almost_equal(X_new32, X_new64)
-    # both predictions have to be the same and correspond to the correct label
-    assert_equal(pred32, pred64)
-    assert_equal(pred32, km.labels_[0])
-    assert_equal(pred64, km.labels_[0])
+    assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
+                              decimal=4)
+    assert_array_almost_equal(X_new[np.float32], X_new[np.float64])
 
 
 def test_mb_k_means_float32_64():
     km = MiniBatchKMeans(n_init=1, random_state=30)
 
-    # float64 data
-    km.fit(X)
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia64 = km.inertia_
-    X_new64 = km.transform(km.cluster_centers_)
-    pred64 = km.predict(X[0])
-    km.partial_fit(X[0:3])
-    # dtype of cluster centers has to stay the same after partial_fit
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-
-    # float32 data
-    km.fit(np.float32(X))
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float32)
-    inertia32 = km.inertia_
-    X_new32 = km.transform(km.cluster_centers_)
-    pred32 = km.predict(X[0])
-    km.partial_fit(X[0:3])
-    # dtype of cluster centers has to stay the same after partial_fit
-    assert_equal(km.cluster_centers_.dtype, np.float32)
+    inertia = {}
+    X_new = {}
+    for dtype in [np.float64, np.float32]:
+        X_test = dtype(X)
+        km.fit(X_test)
+        # dtype of cluster centers has to be the dtype of the input data
+        assert_equal(km.cluster_centers_.dtype, dtype)
+        inertia[dtype] = km.inertia_
+        X_new[dtype] = km.transform(km.cluster_centers_)
+        # make sure predictions correspond to the correct label
+        assert_equal(km.predict(X_test[0]), km.labels_[0])
+        km.partial_fit(X_test[0:3])
+        # dtype of cluster centers has to stay the same after partial_fit
+        assert_equal(km.cluster_centers_.dtype, dtype)
 
     # compare arrays with low precision since the difference between
     # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
-    assert_array_almost_equal(inertia32, inertia64, decimal=4)
-    assert_array_almost_equal(X_new32, X_new64, decimal=4)
-    # both predictions have to be the same and correspond to the correct label
-    assert_equal(pred32, pred64)
-    assert_equal(pred32, km.labels_[0])
-    assert_equal(pred64, km.labels_[0])
+    assert_array_almost_equal(inertia[np.float32], inertia[np.float64], decimal=4)
+    assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
 
-    # float64 sparse data
-    km.fit(X_csr)
-    # dtype of cluster centers has to be the dtype of the input data
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia64 = km.inertia_
-    X_new64 = km.transform(km.cluster_centers_)
-    pred64 = km.predict(X_csr[0])
-    km.partial_fit(X_csr[0:3])
-    # dtype of cluster centers has to stay the same after partial_fit
-    assert_equal(km.cluster_centers_.dtype, np.float64)
+    for dtype in [np.float32, np.float64]:
+        X_csr_test = sp.csr_matrix(X_csr, dtype=dtype)
+        km.fit(X_csr_test)
+        # dtype of cluster centers has to be the dtype of the input data
+        assert_equal(km.cluster_centers_.dtype, dtype)
+        inertia[dtype] = km.inertia_
+        X_new[dtype] = km.transform(km.cluster_centers_)
+        # make sure predictions correspond to the correct label
+        assert_equal(km.predict(X_csr_test[0]), km.labels_[0])
+        km.partial_fit(X_csr_test[0:3])
+        # dtype of cluster centers has to stay the same after partial_fit
+        assert_equal(km.cluster_centers_.dtype, dtype)
 
-    # float32 sparse data
-    # Note: at the moment sparse data is always processed as float64 internally
-    km.fit(sp.csr_matrix(X_csr, dtype=np.float32))
-    # dtype of cluster centers has to be always float64 (see Note above.)
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-    inertia32 = km.inertia_
-    X_new32 = km.transform(km.cluster_centers_)
-    pred32 = km.predict(X_csr[0])
-    km.partial_fit(X_csr[0:3])
-    # dtype of cluster centers has to stay the same after partial_fit
-    assert_equal(km.cluster_centers_.dtype, np.float64)
-
-    assert_array_almost_equal(inertia32, inertia64)
-    assert_array_almost_equal(X_new32, X_new64)
-    # both predictions have to be the same and correspond to the correct label
-    assert_equal(pred32, pred64)
-    assert_equal(pred32, km.labels_[0])
-    assert_equal(pred64, km.labels_[0])
+    assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
+                              decimal=4)
+    assert_array_almost_equal(X_new[np.float32], X_new[np.float64],
+                              decimal=4)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -63,7 +63,8 @@ def test_elkan_results():
     for X in [X_normal, X_blobs]:
         km_full.fit(X)
         km_elkan.fit(X)
-        assert_array_almost_equal(km_elkan.cluster_centers_, km_full.cluster_centers_)
+        assert_array_almost_equal(km_elkan.cluster_centers_,
+                                  km_full.cluster_centers_)
         assert_array_equal(km_elkan.labels_, km_full.labels_)
 
 
@@ -810,8 +811,10 @@ def test_float_precision():
             # 32 and 64 bit sometimes makes a difference up to the 4th decimal place
             assert_array_almost_equal(inertia[np.float32], inertia[np.float64],
                                     decimal=4)
-            assert_array_almost_equal(X_new[np.float32], X_new[np.float64], decimal=4)
-            assert_array_almost_equal(centers[np.float32], centers[np.float64], decimal=4)
+            assert_array_almost_equal(X_new[np.float32], X_new[np.float64],
+                                      decimal=4)
+            assert_array_almost_equal(centers[np.float32], centers[np.float64],
+                                      decimal=4)
 
 
 def test_KMeans_init_centers():

--- a/sklearn/src/cblas/cblas_sdot.c
+++ b/sklearn/src/cblas/cblas_sdot.c
@@ -1,0 +1,132 @@
+/* ---------------------------------------------------------------------
+ *
+ * -- Automatically Tuned Linear Algebra Software (ATLAS)
+ *    (C) Copyright 2000 All Rights Reserved
+ *
+ * -- ATLAS routine -- Version 3.2 -- December 25, 2000
+ *
+ * Author         : Antoine P. Petitet
+ * Originally developed at the University of Tennessee,
+ * Innovative Computing Laboratory, Knoxville TN, 37996-1301, USA.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * -- Copyright notice and Licensing terms:
+ *
+ *  Redistribution  and  use in  source and binary forms, with or without
+ *  modification, are  permitted provided  that the following  conditions
+ *  are met:
+ *
+ * 1. Redistributions  of  source  code  must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce  the above copyright
+ *    notice,  this list of conditions, and the  following disclaimer in
+ *    the documentation and/or other materials provided with the distri-
+ *    bution.
+ * 3. The name of the University,  the ATLAS group,  or the names of its
+ *    contributors  may not be used to endorse or promote products deri-
+ *    ved from this software without specific written permission.
+ *
+ * -- Disclaimer:
+ *
+ * THIS  SOFTWARE  IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,  INDIRECT, INCIDENTAL, SPE-
+ * CIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO,  PROCUREMENT  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEO-
+ * RY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT  (IN-
+ * CLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ---------------------------------------------------------------------
+ */
+/*
+ * Include files
+ */
+#include "atlas_refmisc.h"
+
+float cblas_sdot
+(
+   const int                  N,
+   const float                * X,
+   const int                  INCX,
+   const float                * Y,
+   const int                  INCY
+)
+{
+/*
+ * Purpose
+ * =======
+ *
+ * ATL_srefdot returns the dot product x^T * y of two n-vectors x and y.
+ *
+ * Arguments
+ * =========
+ *
+ * N       (input)                       const int
+ *         On entry, N specifies the length of the vector x. N  must  be
+ *         at least zero. Unchanged on exit.
+ *
+ * X       (input)                       const float *
+ *         On entry,  X  points to the  first entry to be accessed of an
+ *         incremented array of size equal to or greater than
+ *            ( 1 + ( n - 1 ) * abs( INCX ) ) * sizeof(   float   ),
+ *         that contains the vector x. Unchanged on exit.
+ *
+ * INCX    (input)                       const int
+ *         On entry, INCX specifies the increment for the elements of X.
+ *         INCX must not be zero. Unchanged on exit.
+ *
+ * Y       (input)                       const float *
+ *         On entry,  Y  points to the  first entry to be accessed of an
+ *         incremented array of size equal to or greater than
+ *            ( 1 + ( n - 1 ) * abs( INCY ) ) * sizeof(   float   ),
+ *         that contains the vector y. Unchanged on exit.
+ *
+ * INCY    (input)                       const int
+ *         On entry, INCY specifies the increment for the elements of Y.
+ *         INCY must not be zero. Unchanged on exit.
+ *
+ * ---------------------------------------------------------------------
+ */
+/*
+ * .. Local Variables ..
+ */
+   register float             dot = ATL_sZERO, x0, x1, x2, x3,
+                              y0, y1, y2, y3;
+   float                      * StX;
+   register int               i;
+   int                        nu;
+   const int                  incX2 = 2 * INCX, incY2 = 2 * INCY,
+                              incX3 = 3 * INCX, incY3 = 3 * INCY,
+                              incX4 = 4 * INCX, incY4 = 4 * INCY;
+/* ..
+ * .. Executable Statements ..
+ *
+ */
+   if( N > 0 )
+   {
+      if( ( nu = ( N >> 2 ) << 2 ) != 0 )
+      {
+         StX = (float *)X + nu * INCX;
+
+         do
+         {
+            x0 = (*X);     y0 = (*Y);     x1 = X[INCX ]; y1 = Y[INCY ];
+            x2 = X[incX2]; y2 = Y[incY2]; x3 = X[incX3]; y3 = Y[incY3];
+            dot += x0 * y0; dot += x1 * y1; dot += x2 * y2; dot += x3 * y3;
+            X  += incX4; Y  += incY4;
+         } while( X != StX );
+      }
+
+      for( i = N - nu; i != 0; i-- )
+      {  x0 = (*X); y0 = (*Y); dot += x0 * y0; X += INCX; Y += INCY; }
+   }
+   return( dot );
+/*
+ * End of ATL_srefdot
+ */
+}


### PR DESCRIPTION
This is a follow-up PR for #6430, which use fused types in Cython to work with `np.float32` inputs without wasting memory by converting them internally to `np.float64`.

Since [Sparse Func Utils now supports Cython fused types](http://yclin.me/2016/05/sparse-func-utils), we can avoid zig-zag memory usage which showed in #6430 .

**Updated on 6/19**
- Dense `np.float32` Data
  - Before this PR:

![master](https://cloud.githubusercontent.com/assets/7057863/15679091/35748228-2783-11e6-98ae-596b460c2d1a.png)
- After this PR:

![fused_types](https://cloud.githubusercontent.com/assets/7057863/15679092/374d2794-2783-11e6-8b95-7aac1347581c.png)
- Sparse `np.float32` Data
  - Before this PR:

![master_sparse_32](https://cloud.githubusercontent.com/assets/7057863/16178924/79050080-3688-11e6-9381-1ced28bb5fc0.png)
- After this PR:

![fused_types_sparse_32](https://cloud.githubusercontent.com/assets/7057863/16178743/806a0942-3683-11e6-8764-567762eb0577.png)

Here is the test script used to generate above figures (thanks @ssaeger):

``` python
import numpy as np
from scipy import sparse as sp
from sklearn.cluster import KMeans

@profile
def fit_est():
    estimator.fit(X)

np.random.seed(5)
X = np.random.rand(200000, 20)
X = np.float32(X)

# X = sp.csr_matrix(X)

estimator = KMeans()
fit_est()

```
