### PR TITLE
fixed error message for invalid class_weight values

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -71,7 +71,7 @@ def compute_class_weight(class_weight, classes, y):
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order='C')
         if not isinstance(class_weight, dict):
-            raise ValueError("class_weight must be dict, 'auto', or None,"
+            raise ValueError("class_weight must be dict, 'balanced', or None,"
                              " got: %r" % class_weight)
         for c in class_weight:
             i = np.searchsorted(classes, c)


### PR DESCRIPTION
'auto' class_weight is deprecated, but it is still suggested for users (like me) who pass incorrect `class_weight` argument to a classifier.
