### PR TITLE
[MRG] workaround bug in numpy 1.9

### DIFF
--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 import tempfile
 import os
+from time import sleep
 
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
@@ -60,6 +61,12 @@ from sklearn.datasets import make_classification
 from sklearn.datasets import make_multilabel_classification
 
 from sklearn.model_selection.tests.test_split import MockClassifier
+
+
+try:
+    WindowsError
+except NameError:
+    WindowsError = None
 
 
 class MockImprovingEstimator(BaseEstimator):
@@ -781,12 +788,20 @@ def test_score_memmap():
     tf = tempfile.NamedTemporaryFile(mode='wb', delete=False)
     tf.write(b'Hello world!!!!!')
     tf.close()
-    scores = np.memmap(tf.name, dtype=float)
-    score = np.memmap(tf.name, shape=(), mode='w+', dtype=float)
+    scores = np.memmap(tf.name, dtype=np.float64)
+    score = np.memmap(tf.name, shape=(), mode='r', dtype=np.float64)
     try:
         cross_val_score(clf, X, y, scoring=lambda est, X, y: score)
         # non-scalar should still fail
         assert_raises(ValueError, cross_val_score, clf, X, y,
                       scoring=lambda est, X, y: scores)
     finally:
-        os.unlink(tf.name)
+        # Best effort to release the mmap file handles before deleting the
+        # backing file under Windows
+        scores, score = None, None
+        for _ in range(3):
+            try:
+                os.unlink(tf.name)
+                break
+            except WindowsError:
+                sleep(1.)


### PR DESCRIPTION
Recent appveyor tests revealed a test failure with numpy 1.9:

https://ci.appveyor.com/project/sklearn-ci/scikit-learn/build/1.0.6688/job/hmx1ii0khg0uwd5f

This is actually a bug in how numpy handles the mmap mode kwarg.

I believe this failure was caused by @jnothman  #6789  although appveyor tests did pass at the time and we have not changed the version of numpy in the mean time. Maybe something else has changed in the appveyor setup.

I plan to merge this quickfix as soon as CI is green to limit CI noise in other's people PRs.
