### PR TITLE
[MRG+1] TST ensure tests are importable

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -10,11 +10,13 @@ from __future__ import print_function
 import os
 import warnings
 import sys
+import re
 import pkgutil
 
 from sklearn.externals.six import PY3
 from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import ignore_warnings
@@ -140,6 +142,29 @@ def test_root_import_all_completeness():
         if '.' in modname or modname.startswith('_') or modname in EXCEPTIONS:
             continue
         assert_in(modname, sklearn.__all__)
+
+
+def test_all_tests_are_importable():
+    # Ensure that for each contentful subpackage, there is a test directory
+    # within it that is also a subpackage (i.e. a directory with __init__.py)
+
+    HAS_TESTS_EXCEPTIONS = re.compile(r'''(?x)
+                                      \.externals(\.|$)|
+                                      \.tests(\.|$)|
+                                      \._
+                                      ''')
+    lookup = dict((name, ispkg)
+                  for _, name, ispkg
+                  in pkgutil.walk_packages(sklearn.__path__,
+                                           prefix='sklearn.'))
+    missing_tests = [name for name, ispkg in lookup.items()
+                     if ispkg
+                     and not HAS_TESTS_EXCEPTIONS.search(name)
+                     and name + '.tests' not in lookup]
+    assert_equal(missing_tests, [],
+                 '{0} do not have `tests` subpackages. Perhaps they require '
+                 '__init__.py or an add_subpackage directive in the parent '
+                 'setup.py'.format(missing_tests))
 
 
 def test_non_transformer_estimators_n_iter():

--- a/sklearn/utils/sparsetools/setup.py
+++ b/sklearn/utils/sparsetools/setup.py
@@ -17,6 +17,8 @@ def configuration(parent_package='', top_path=None):
                          #libraries=libraries
                          )
 
+    config.add_subpackage('tests')
+
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a test to make sure that any useful subpackages have tests, and can be imported. Despite the fixes to this problem in #6274, one `.../tests/__init__.py` was still absent, and is added in this PR.

Related to #6274, supersedes #6849 and #6861.
