### PR TITLE
[MRG] Adding pos_label parameter to roc_auc_score (#6873)

### DIFF
--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -183,7 +183,8 @@ def average_precision_score(y_true, y_score, average="macro",
                                  average, sample_weight=sample_weight)
 
 
-def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
+def roc_auc_score(y_true, y_score, average="macro", sample_weight=None,
+                  pos_label=None):
     """Compute Area Under the Curve (AUC) from prediction scores
 
     Note: this implementation is restricted to the binary classification task
@@ -220,6 +221,9 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
 
+    pos_label : int, optional (default=None)
+        The label of the positive class
+
     Returns
     -------
     auc : float
@@ -250,7 +254,8 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
             raise ValueError("Only one class present in y_true. ROC AUC score "
                              "is not defined in that case.")
 
-        fpr, tpr, tresholds = roc_curve(y_true, y_score,
+        # use closure for pos_label parameter
+        fpr, tpr, tresholds = roc_curve(y_true, y_score, pos_label=pos_label,
                                         sample_weight=sample_weight)
         return auc(fpr, tpr, reorder=True)
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -21,6 +21,7 @@ from __future__ import division
 
 import warnings
 import numpy as np
+from functools import partial
 from scipy.sparse import csr_matrix
 
 from ..utils import check_consistent_length
@@ -249,19 +250,21 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None,
     0.75
 
     """
-    def _binary_roc_auc_score(y_true, y_score, sample_weight=None):
+    def _binary_roc_auc_score(y_true, y_score, sample_weight=None,
+                              pos_label=None):
         if len(np.unique(y_true)) != 2:
             raise ValueError("Only one class present in y_true. ROC AUC score "
                              "is not defined in that case.")
 
-        # use closure for pos_label parameter
         fpr, tpr, tresholds = roc_curve(y_true, y_score, pos_label=pos_label,
                                         sample_weight=sample_weight)
         return auc(fpr, tpr, reorder=True)
 
-    return _average_binary_score(
-        _binary_roc_auc_score, y_true, y_score, average,
-        sample_weight=sample_weight)
+    _partial_binary_roc_auc_score = partial(_binary_roc_auc_score,
+                                            pos_label=pos_label)
+    return _average_binary_score(_partial_binary_roc_auc_score,
+                                 y_true, y_score, average,
+                                 sample_weight=sample_weight)
 
 
 def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -134,6 +134,10 @@ def test_roc_curve():
         roc_auc = auc(fpr, tpr)
         assert_array_almost_equal(roc_auc, expected_auc, decimal=2)
         assert_almost_equal(roc_auc, roc_auc_score(y_true, probas_pred))
+        assert_almost_equal(roc_auc,
+                            roc_auc_score(y_true, probas_pred, pos_label=1))
+        assert_almost_equal(1 - roc_auc,
+                            roc_auc_score(y_true, probas_pred, pos_label=0))
         assert_equal(fpr.shape, tpr.shape)
         assert_equal(fpr.shape, thresholds.shape)
 
@@ -272,6 +276,18 @@ def test_roc_curve_toydata():
     assert_array_almost_equal(fpr, [1, 1])
     assert_almost_equal(roc_auc, 1.)
 
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=1)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=1)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [1, 1])
+    assert_almost_equal(roc_auc, 1.)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=0)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=0)
+    assert_array_almost_equal(tpr, [0, 1, 1])
+    assert_array_almost_equal(fpr, [0, 0, 1])
+    assert_almost_equal(roc_auc, 0.)
+
     y_true = [0, 1]
     y_score = [1, 0]
     tpr, fpr, _ = roc_curve(y_true, y_score)
@@ -280,10 +296,34 @@ def test_roc_curve_toydata():
     assert_array_almost_equal(fpr, [0, 0, 1])
     assert_almost_equal(roc_auc, 0.)
 
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=1)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=1)
+    assert_array_almost_equal(tpr, [0, 1, 1])
+    assert_array_almost_equal(fpr, [0, 0, 1])
+    assert_almost_equal(roc_auc, 0.)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=0)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=0)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [1, 1])
+    assert_almost_equal(roc_auc, 1.)
+
     y_true = [1, 0]
     y_score = [1, 1]
     tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [0, 1])
+    assert_almost_equal(roc_auc, 0.5)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=1)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=1)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [0, 1])
+    assert_almost_equal(roc_auc, 0.5)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=0)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=0)
     assert_array_almost_equal(tpr, [0, 1])
     assert_array_almost_equal(fpr, [0, 1])
     assert_almost_equal(roc_auc, 0.5)
@@ -296,6 +336,18 @@ def test_roc_curve_toydata():
     assert_array_almost_equal(fpr, [1, 1])
     assert_almost_equal(roc_auc, 1.)
 
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=1)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=1)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [1, 1])
+    assert_almost_equal(roc_auc, 1.)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=0)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=0)
+    assert_array_almost_equal(tpr, [0, 1, 1])
+    assert_array_almost_equal(fpr, [0, 0, 1])
+    assert_almost_equal(roc_auc, 0)
+
     y_true = [1, 0]
     y_score = [0.5, 0.5]
     tpr, fpr, _ = roc_curve(y_true, y_score)
@@ -304,21 +356,59 @@ def test_roc_curve_toydata():
     assert_array_almost_equal(fpr, [0, 1])
     assert_almost_equal(roc_auc, .5)
 
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=1)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=1)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [0, 1])
+    assert_almost_equal(roc_auc, .5)
+
+    tpr, fpr, _ = roc_curve(y_true, y_score, pos_label=0)
+    roc_auc = roc_auc_score(y_true, y_score, pos_label=0)
+    assert_array_almost_equal(tpr, [0, 1])
+    assert_array_almost_equal(fpr, [0, 1])
+    assert_almost_equal(roc_auc, .5)
+
     y_true = [0, 0]
     y_score = [0.25, 0.75]
     # assert UndefinedMetricWarning because of no positive sample in y_true
-    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true, y_score)
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score)
     assert_raises(ValueError, roc_auc_score, y_true, y_score)
     assert_array_almost_equal(tpr, [0., 0.5, 1.])
     assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
 
-    y_true = [1, 1]
-    y_score = [0.25, 0.75]
-    # assert UndefinedMetricWarning because of no negative sample in y_true
-    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true, y_score)
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score, pos_label=1)
+    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    assert_array_almost_equal(tpr, [0., 0.5, 1.])
+    assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
+
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score, pos_label=0)
     assert_raises(ValueError, roc_auc_score, y_true, y_score)
     assert_array_almost_equal(tpr, [np.nan, np.nan])
     assert_array_almost_equal(fpr, [0.5, 1.])
+
+    y_true = [1, 1]
+    y_score = [0.25, 0.75]
+    # assert UndefinedMetricWarning because of no negative sample in y_true
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score)
+    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    assert_array_almost_equal(tpr, [np.nan, np.nan])
+    assert_array_almost_equal(fpr, [0.5, 1.])
+
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score, pos_label=1)
+    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    assert_array_almost_equal(tpr, [np.nan, np.nan])
+    assert_array_almost_equal(fpr, [0.5, 1.])
+
+    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve,
+                               y_true, y_score, pos_label=0)
+    assert_raises(ValueError, roc_auc_score, y_true, y_score)
+    assert_array_almost_equal(tpr, [0., 0.5, 1.])
+    assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
 
     # Multi-label classification task
     y_true = np.array([[0, 1], [0, 1]])
@@ -327,7 +417,15 @@ def test_roc_curve_toydata():
     assert_raises(ValueError, roc_auc_score, y_true, y_score,
                   average="weighted")
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), 1.)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=1), 1.)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=0), 0.)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), 1.)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=1), 1.)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=0), 0.)
 
     y_true = np.array([[0, 1], [0, 1]])
     y_score = np.array([[0, 1], [1, 0]])
@@ -335,21 +433,67 @@ def test_roc_curve_toydata():
     assert_raises(ValueError, roc_auc_score, y_true, y_score,
                   average="weighted")
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), 0.5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=1),
+            0.5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=0),
+            0.5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), 0.5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=1), 0.5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=0), 0.5)
 
     y_true = np.array([[1, 0], [0, 1]])
     y_score = np.array([[0, 1], [1, 0]])
     assert_almost_equal(roc_auc_score(y_true, y_score, average="macro"), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="macro", pos_label=1), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="macro", pos_label=0), 1.)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="weighted"), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="weighted", pos_label=1), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="weighted", pos_label=0),
+            1.)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=1), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=0),
+            1.)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=1), 0)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=0), 1.)
 
     y_true = np.array([[1, 0], [0, 1]])
     y_score = np.array([[0.5, 0.5], [0.5, 0.5]])
     assert_almost_equal(roc_auc_score(y_true, y_score, average="macro"), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="macro", pos_label=1), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="macro", pos_label=0), .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="weighted"), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="weighted", pos_label=1),
+            .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="weighted", pos_label=0),
+            .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=1), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="samples", pos_label=0), .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=1), .5)
+    assert_almost_equal(
+            roc_auc_score(y_true, y_score, average="micro", pos_label=0), .5)
 
 
 def test_roc_curve_drop_intermediate():


### PR DESCRIPTION
#### Reference Issue

Fixes #6873 
#### What does this implement/fix? Explain your changes.

This PR implements the pos_label parameter in roc_auc_score function. Actually all it does is forwarding this parameter to roc_curve function call.
#### Any other comments?

Added tests for pos_label param in roc_curve and roc_auc_score.

Results of make: all tests ok.
