### PR TITLE
[MRG] Expose mean_time in results_ for *SearchCV

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -538,11 +538,14 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
           for parameters in parameter_iterable
           for train, test in cv.split(X, y, labels))
 
-        test_scores, test_sample_counts, _, parameters = zip(*out)
+        test_scores, test_sample_counts, scoring_time, parameters = zip(*out)
 
         candidate_params = parameters[::n_splits]
         n_candidates = len(candidate_params)
 
+        scoring_time = np.array(scoring_time,
+                                dtype=np.float64).reshape(n_candidates,
+                                                          n_splits)
         test_scores = np.array(test_scores,
                                dtype=np.float64).reshape(n_candidates,
                                                          n_splits)
@@ -556,11 +559,14 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         stds = np.sqrt(np.average((test_scores - means[:, np.newaxis]) ** 2,
                                   axis=1, weights=weights))
 
+        mean_time = np.average(scoring_time, axis=1)
+
         results = dict()
         for split_i in range(n_splits):
             results["test_split%d_score" % split_i] = test_scores[:, split_i]
         results["test_mean_score"] = means
         results["test_std_score"] = stds
+        results["test_mean_time"] = mean_time
 
         ranks = np.asarray(rankdata(-means, method='min'), dtype=np.int32)
 
@@ -786,6 +792,7 @@ class GridSearchCV(BaseSearchCV):
             'test_mean_score'   : [0.81, 0.60, 0.75, 0.82],
             'test_std_score'    : [0.02, 0.01, 0.03, 0.03],
             'test_rank_score'   : [2, 4, 3, 1],
+            'test_mean_time'    : [--, -- ,-- ,--],
             'params'            : [{'kernel': 'poly', 'degree': 2}, ...],
             }
 
@@ -1015,6 +1022,7 @@ class RandomizedSearchCV(BaseSearchCV):
             'test_mean_score'   : [0.81, 0.7, 0.7],
             'test_std_score'    : [0.02, 0.2, 0.],
             'test_rank_score'   : [3, 1, 1],
+            'test_mean_time'    : [--, -- ,-- ,--],
             'params' : [{'kernel' : 'rbf', 'gamma' : 0.1}, ...],
             }
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -611,7 +611,7 @@ def test_grid_search_results():
     param_keys = ('param_C', 'param_degree', 'param_gamma', 'param_kernel')
     score_keys = ('test_mean_score', 'test_rank_score',
                   'test_split0_score', 'test_split1_score',
-                  'test_split2_score', 'test_std_score')
+                  'test_split2_score', 'test_std_score', 'test_mean_time')
     n_candidates = n_grid_points
 
     for search, iid in zip((grid_search, grid_search_iid), (False, True)):
@@ -659,7 +659,7 @@ def test_random_search_results():
     param_keys = ('param_C', 'param_gamma')
     score_keys = ('test_mean_score', 'test_rank_score',
                   'test_split0_score', 'test_split1_score',
-                  'test_split2_score', 'test_std_score')
+                  'test_split2_score', 'test_std_score', 'test_mean_time')
     n_cand = n_search_iter
 
     for search, iid in zip((random_search, random_search_iid), (False, True)):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #6894
#### What does this implement/fix? Explain your changes.

Extract the `scoring_time` from `_fit_and_score`, calculate the mean time and add it to the `results_` dict.
#### Any other comments?

@raghavrv @jnothman

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
