### PR TITLE
[MRG+1] Make KernelCenterer a _pairwise operation

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1584,7 +1584,7 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         K += self.K_fit_all_
 
         return K
-        
+
     @property
     def _pairwise(self):
         return True

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1584,6 +1584,10 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         K += self.K_fit_all_
 
         return K
+        
+    @property
+    def _pairwise(self):
+        return True
 
 
 def add_dummy_feature(X, value=1.0):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1373,11 +1373,12 @@ def test_center_kernel():
     K_pred_centered2 = centerer.transform(K_pred)
     assert_array_almost_equal(K_pred_centered, K_pred_centered2)
 
+
 def test_cv_pipeline_precomputed():
-    """Cross-validate a regression on four coplanar points with the same 
+    """Cross-validate a regression on four coplanar points with the same
     value. Use precomputed kernel to ensure Pipeline with KernelCenterer
     is treated as a _pairwise operation."""
-    X = np.array([[3,0,0],[0,3,0],[0,0,3],[1,1,1]])
+    X = np.array([[3, 0, 0], [0, 3, 0], [0, 0, 3], [1, 1, 1]])
     y_true = np.ones((4,))
     K = X.dot(X.T)
     kcent = KernelCenterer()
@@ -1389,7 +1390,7 @@ def test_cv_pipeline_precomputed():
     # test cross-validation, score should be almost perfect
     # NB: this test is pretty vacuous -- it's mainly to test integration
     #     of Pipeline and KernelCenterer
-    y_pred = cross_val_predict(pipeline,K,y_true,cv=4)
+    y_pred = cross_val_predict(pipeline, K, y_true, cv=4)
     assert_array_almost_equal(y_true, y_pred)
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -53,8 +53,7 @@ from sklearn.preprocessing.data import PolynomialFeatures
 from sklearn.exceptions import DataConversionWarning
 
 from sklearn.pipeline import Pipeline
-from sklearn.cross_validation import cross_val_score
-from sklearn.cross_validation import LeaveOneOut
+from sklearn.cross_validation import cross_val_predict
 from sklearn.svm import SVR
 
 from sklearn import datasets
@@ -1379,7 +1378,7 @@ def test_cv_pipeline_precomputed():
     value. Use precomputed kernel to ensure Pipeline with KernelCenterer
     is treated as a _pairwise operation."""
     X = np.array([[3,0,0],[0,3,0],[0,0,3],[1,1,1]])
-    y = np.ones((4,))
+    y_true = np.ones((4,))
     K = X.dot(X.T)
     kcent = KernelCenterer()
     pipeline = Pipeline([("kernel_centerer", kcent), ("svr", SVR())])
@@ -1388,8 +1387,10 @@ def test_cv_pipeline_precomputed():
     assert_true(pipeline._pairwise)
 
     # test cross-validation, score should be almost perfect
-    score = cross_val_score(pipeline,K,y,cv=LeaveOneOut(4))
-    assert_array_almost_equal(score, np.ones_like(score))
+    # NB: this test is pretty vacuous -- it's mainly to test integration
+    #     of Pipeline and KernelCenterer
+    y_pred = cross_val_predict(pipeline,K,y_true,cv=4)
+    assert_array_almost_equal(y_true, y_pred)
 
 
 def test_fit_transform():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

https://github.com/scikit-learn/scikit-learn/pull/803 is the relevant PR for fixing `KernelPCA` in `Pipeline`s
#### What does this implement/fix? Explain your changes.

Allows for using `KernelCenterer` in `Pipeline`s. EDIT: More specifically, in `Pipeline`s that you want to run CV on.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Replicate solution to https://github.com/scikit-learn/scikit-learn/commit/9a520779c233dfeff466870c0b7cb04b705e61af except that `_pairwise` should always be `True` for `KernelCenterer` because it's supposed to receive a Gram matrix. This should make `KernelCenterer` usable in `Pipeline`s.

Happy to add tests, just tell me what should be covered.
