### PR TITLE
[MRG] Fix CircleCI build failure

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -45,8 +45,8 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes --quiet python numpy scipy \
-  cython nose coverage matplotlib sphinx pillow psutil
-source /home/ubuntu/miniconda/envs/testenv/bin/activate testenv
+  cython nose coverage matplotlib sphinx pillow
+source activate testenv
 
 # Build and install scikit-learn in dev mode
 python setup.py develop


### PR DESCRIPTION
The way the environment was activated was a la virtualenv. Maybe it used
to work for some time but not anymore.

Actually the psutil was a red herring. It is just a warning.

I used [doc build] in the commit message to force the doc building in the PR.
