### PR TITLE
[MRG] Allow requesting std or cov when predicting from the prior

### DIFF
--- a/sklearn/gaussian_process/gpr.py
+++ b/sklearn/gaussian_process/gpr.py
@@ -128,7 +128,11 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
     def __init__(self, kernel=None, alpha=1e-10,
                  optimizer="fmin_l_bfgs_b", n_restarts_optimizer=0,
                  normalize_y=False, copy_X_train=True, random_state=None):
-        self.kernel = kernel
+        if kernel is None:  # Use an RBF kernel as default
+            self.kernel = C(1.0, constant_value_bounds="fixed") \
+                * RBF(1.0, length_scale_bounds="fixed")
+        else:
+            self.kernel = kernel
         self.alpha = alpha
         self.optimizer = optimizer
         self.n_restarts_optimizer = n_restarts_optimizer
@@ -151,11 +155,7 @@ class GaussianProcessRegressor(BaseEstimator, RegressorMixin):
         -------
         self : returns an instance of self.
         """
-        if self.kernel is None:  # Use an RBF kernel as default
-            self.kernel_ = C(1.0, constant_value_bounds="fixed") \
-                * RBF(1.0, length_scale_bounds="fixed")
-        else:
-            self.kernel_ = clone(self.kernel)
+        self.kernel_ = clone(self.kernel)
 
         self.rng = check_random_state(self.random_state)
 


### PR DESCRIPTION
#### Reference Issue

Fixes #6573 - When you call `predict()` on a `GaussianProcessRegressor` object that was not supplied with a kernel argument, while setting either of `return_std=True` or `return_cov=True`, you get a NoneType error. We claim in the documentation of predict that we support calling it to generate predictions from the prior.

I believe this pull request is preferable to the previous one in that issue though as this is more maintainable. That PR has the default kernel we use hard coded in two locations, both the fit and the predict method, while this PR has the default kernel hard coded only in the single location of the `__init__()` method. This PR also does not alter the code in `predict()` like that PR. I think how the code is there now better indicates we are pulling from the prior anyways, because it uses the `kernel` attribute and not `kernel_` to compute the prior std or cov.
#### What does this implement/fix?

Here is a minimal example of the bad behavior before this fix:

```
>>> from sklearn.gaussian_process.gpr import GaussianProcessRegressor
>>> import numpy as np
>>> a = np.arange(3).reshape(-1, 1)
>>> gpr = GaussianProcessRegressor()
>>> preds = gpr.predict(a)  # Returns prior prediction, no error
>>> preds, sigma = gpr.predict(a, return_std=True)  # Raises NoneType error
>>> preds, cov = gpr.predict(a, return_cov=True) # Raises NoneType error
```

Here is the behavior now:

```
>>> preds = gpr.predict(a)  # Same as before
>>> preds, sigma = gpr.predict(a, return_std=True)  # No error, returns correct prior mean and sigma
>>> preds, cov = gpr.predict(a, return_cov=True)  # No error, returns correct prior mean and cov
```
#### Potential concern

A negative of this PR is that a user could see a change if they do the following:
1. Instantiate a `GaussianProcessRegressor` without supplying any kernel of their own
2. Check whether the `kernel` attribute is None, expecting it to be since they didn't supply any kernel and that's the default parameter value.

Someone might do that to differentiate between instances of `GaussianProcessRegressor` objects that were instantiated with a specific kernel from those who started with the default kernel. Not sure if this is deal breaking on this PR, someone more knowledgeable should say.

Below examples that behavior before this PR:

```
>>> gpr = GaussianProcessRegressor()
>>> gpr.kernel is None
True
```

Here is the behavior after this PR:

```
>>> gpr = GaussianProcessRegressor()
>>> gpr.kernel is None
False
```

However, if the user provided their own kernel the behavior is the same for both before and after. It would return `False` every time if the user gave their own kernel.
