### PR TITLE
[WIP] Add examples to samples_generator

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -144,6 +144,16 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     --------
     make_blobs: simplified variant
     make_multilabel_classification: unrelated generator for multilabel tasks
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_classification
+    >>> import matplotlib.pyplot as plt
+    >>> X, y = make_classification(n_features=2, n_redundant=0,
+    ...                            random_state=0, n_clusters_per_class=1)
+    >>> plt.gray()
+    >>> _ = plt.scatter(X[:, 0], X[:, 1], c=y)
+    >>> plt.show()
     """
     generator = check_random_state(random_state)
 
@@ -600,6 +610,15 @@ def make_circles(n_samples=100, shuffle=True, noise=None, random_state=None,
 
     y : array of shape [n_samples]
         The integer labels (0 or 1) for class membership of each sample.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_circles
+    >>> import matplotlib.pyplot as plt
+    >>> X, y = make_circles(noise=0.1, random_state=0)
+    >>> plt.gray()
+    >>> _ = plt.scatter(X[:, 0], X[:, 1], c=y)
+    >>> plt.show()
     """
 
     if factor > 1 or factor < 0:
@@ -653,6 +672,15 @@ def make_moons(n_samples=100, shuffle=True, noise=None, random_state=None):
 
     y : array of shape [n_samples]
         The integer labels (0 or 1) for class membership of each sample.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_moons
+    >>> import matplotlib.pyplot as plt
+    >>> X, y = make_moons(noise=0.1, random_state=0)
+    >>> plt.gray()
+    >>> _ = plt.scatter(X[:, 0], X[:, 1], c=y)
+    >>> plt.show()
     """
 
     n_samples_out = n_samples // 2


### PR DESCRIPTION
#### What does this implement/fix?

It adds graphical examples directly to some of the data generators
#### Comments

Currently, `make` does not work. But it seems not to be related to my changes:

```
Doctest: unsupervised_learning.rst ... ok
Doctest: working_with_text_data.rst ... /home/moose/GitHub/scikit-learn/doc/tutorial/text_analytics/working_with_text_data.rst:1: VisibleDeprecationWarning: converting an array with ndim > 0 to an index will result in an error in the future
  .. _text_data_tutorial:
FAIL

======================================================================
FAIL: Doctest: working_with_text_data.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for working_with_text_data.rst
  File "/home/moose/GitHub/scikit-learn/doc/tutorial/text_analytics/working_with_text_data.rst", line 0

----------------------------------------------------------------------
File "/home/moose/GitHub/scikit-learn/doc/tutorial/text_analytics/working_with_text_data.rst", line 99, in working_with_text_data.rst
Failed example:
    twenty_train = fetch_20newsgroups(subset='train',
        categories=categories, shuffle=True, random_state=42)
Expected nothing
Got:
    Downloading 20news dataset. This may take a few minutes.
----------------------------------------------------------------------
File "/home/moose/GitHub/scikit-learn/doc/tutorial/text_analytics/working_with_text_data.rst", line 452, in working_with_text_data.rst
Failed example:
    gs_clf.best_score_
Expected:
    0.900...
Got:
    0.90000000000000002

>>  raise self.failureException(self.format_failure(<StringIO.StringIO instance at 0x7fb149ea1d88>.getvalue()))

-------------------- >> begin captured logging << --------------------
sklearn.datasets.twenty_newsgroups: WARNING: Downloading dataset from http://people.csail.mit.edu/jrennie/20Newsgroups/20news-bydate.tar.gz (14 MB)
sklearn.datasets.twenty_newsgroups: INFO: Decompressing /home/moose/scikit_learn_data/20news_home/20news-bydate.tar.gz
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 38 tests in 43.950s

FAILED (SKIP=3, failures=1)
Makefile:40: recipe for target 'test-doc' failed

```

Also, the printed plots open during the test. I'm not sure if this might be a problem.
