### PR TITLE
Fix for #6931: isotonic y_min/y_max bounds

### DIFF
--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -338,6 +338,17 @@ def test_isotonic_duplicate_min_entry():
     assert_true(all_predictions_finite)
 
 
+def test_isotonic_ymin_ymax():
+    # Test case as reported in Issue #6921
+    x = np.array([1.26336413, 1.31853693, -0.57200917, 0.3072928, -0.70686507,
+                            -0.17614937, -1.59943059, 1.05908504, 1.3958263, 1.90580318,
+                            0.20992272, 0.02836316, -0.08092235, 0.44438247, 0.01791253,
+                            -0.3771914, -0.89577538, -0.37726249, -1.32687569, 0.18013201])
+    y = isotonic_regression(x, y_min=0, y_max=0.1)
+
+    assert(np.all(y > 0))
+    assert(np.all(y < 0.1))
+
 def test_isotonic_zero_weight_loop():
     # Test from @ogrisel's issue:
     # https://github.com/scikit-learn/scikit-learn/issues/4297

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -349,6 +349,7 @@ def test_isotonic_ymin_ymax():
     assert(np.all(y >= 0))
     assert(np.all(y <= 0.1))
 
+    
 def test_isotonic_zero_weight_loop():
     # Test from @ogrisel's issue:
     # https://github.com/scikit-learn/scikit-learn/issues/4297

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -346,8 +346,8 @@ def test_isotonic_ymin_ymax():
                             -0.3771914, -0.89577538, -0.37726249, -1.32687569, 0.18013201])
     y = isotonic_regression(x, y_min=0, y_max=0.1)
 
-    assert(np.all(y > 0))
-    assert(np.all(y < 0.1))
+    assert(np.all(y >= 0))
+    assert(np.all(y <= 0.1))
 
 def test_isotonic_zero_weight_loop():
     # Test from @ogrisel's issue:


### PR DESCRIPTION
As noted on #6921, the `isotonic_regression` method:
- assumed pre-sorted data
- relied on a heuristic reweighting to achieve the desired `y_min`/`y_max` outcome (that does not work w.p.1)

This PR fixes both issues by:
- adding a test case for the reported data
- adding a `pre_sorted` bool parameter to `isotonic_regression` with default `True`, which should allow for no change in performance for the primary class callers
- replaced the `C` reweighting approach with a data censoring pass s.t. all input values are within `[y_min, y_max`].

That said, as mentioned on the mailing list, I think we are still mixing use cases for the isotonic methods, and would recommend that we investigate docking and documenting against the R `isotone` package behavior:
https://github.com/scikit-learn/scikit-learn/pull/4185#issuecomment-72875303
