### PR TITLE
Fix minor typo in grid_search.py

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -965,7 +965,7 @@ class RandomizedSearchCV(BaseSearchCV):
         Does exhaustive search over a grid of parameters.
 
     :class:`ParameterSampler`:
-        A generator over parameter settins, constructed from
+        A generator over parameter settings, constructed from
         param_distributions.
 
     """


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fix minor typo in `grid_search.py`: "settins" -> "settings"
