### PR TITLE
[MRG+1] documentation: fixing typo

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -253,7 +253,7 @@ class BaseEstimator(object):
         """Set the parameters of this estimator.
 
         The method works on simple estimators as well as on nested objects
-        (such as pipelines). The former have parameters of the form
+        (such as pipelines). The latter have parameters of the form
         ``<component>__<parameter>`` so that it's possible to update each
         component of a nested object.
 


### PR DESCRIPTION
Documentation of set_params is corrected:

The form of regular parameters in set_param is just `<parameter>`,
for nested objects it is `<component>__<parameter>`,
so the order in the documentation needs to be reversed

Thanks for considering the PR.
