### PR TITLE
Modified BaseDecisionTree so that min_weight_fraction_leaf works when…

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -797,7 +797,8 @@ class RandomForestClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -991,7 +992,8 @@ class RandomForestRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1150,7 +1152,8 @@ class ExtraTreesClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1343,7 +1346,8 @@ class ExtraTreesRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1488,7 +1492,8 @@ class RandomTreesEmbedding(BaseForest):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1315,7 +1315,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
@@ -1661,7 +1662,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by `sample_weight` in the fit
+        method.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -297,9 +297,13 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                 sample_weight = expanded_class_weight
 
         # Set min_weight_leaf from min_weight_fraction_leaf
-        if self.min_weight_fraction_leaf != 0. and sample_weight is not None:
+        if self.min_weight_fraction_leaf != 0.:
+            if sample_weight is None:
+                sample_weight = np.repeat(1., n_samples)
+
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))
+
         else:
             min_weight_leaf = 0.
 
@@ -577,7 +581,7 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by sample_weight in the fit method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -831,7 +835,7 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by sample_weight in the fit method.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.


### PR DESCRIPTION
#### Reference Issue

Addresses #6945
#### Changes

min_weight_fraction_leaf should work even when sample_weight is not given (in which case samples are assumed to have equal weight).  I also tweaked the description of min_weight_fraction_leaf to make its purpose a bit more clear.
#### Other comments

I'm fairly new to open-source collaboration as well as scikit-learn.  I think my changes have room for improvement.  For example, if sample_weight is given as None by the user, I reset it to an array of all 1s.  I'm guessing this is a bad solution.  However, I could use help figuring out where and how to implement the correct solution.  I'm also slightly unsure the best way to test my changes.  Would really appreciate someone offering 5 or 10 minutes of their time via Skype or Google Hangout so I can become a contributor and hopefully add more contributions in the future.

… sample_weight is None and improved parameter description
