### PR TITLE
[MRG+1] Check for bad labels in confusion_matrix.

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -240,10 +240,8 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
         labels = unique_labels(y_true, y_pred)
     else:
         labels = np.asarray(labels)
-        # check for labels not contained in y_true
-        bad_labels = np.setdiff1d(labels, y_true)
-        if bad_labels.size:
-            raise ValueError("Unknown label(s) {}".format(bad_labels))
+        if np.all([l not in y_true for l in labels]):
+            raise ValueError("At least one label specified must be in y_true")
 
     if sample_weight is None:
         sample_weight = np.ones(y_true.shape[0], dtype=np.int)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -240,6 +240,10 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
         labels = unique_labels(y_true, y_pred)
     else:
         labels = np.asarray(labels)
+        # check for labels not contained in y_true
+        bad_labels = np.setdiff1d(labels, y_true)
+        if bad_labels.size:
+            raise ValueError("Unknown label(s) {}".format(bad_labels))
 
     if sample_weight is None:
         sample_weight = np.ones(y_true.shape[0], dtype=np.int)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -240,7 +240,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
         labels = unique_labels(y_true, y_pred)
     else:
         labels = np.asarray(labels)
-        if np.intersect1d(labels, y_true).size == 0:
+        if np.all([l not in y_true for l in labels]):
             raise ValueError("At least one label specified must be in y_true")
 
     if sample_weight is None:

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -240,7 +240,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
         labels = unique_labels(y_true, y_pred)
     else:
         labels = np.asarray(labels)
-        if np.all([l not in y_true for l in labels]):
+        if np.intersect1d(labels, y_true).size == 0:
             raise ValueError("At least one label specified must be in y_true")
 
     if sample_weight is None:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -551,9 +551,15 @@ def test_confusion_matrix_multiclass_subset_labels():
     assert_array_equal(cm, [[18, 2],
                             [24, 3]])
 
-    bad_label = np.max(y_true) + 1
+    # a label not in y_true should result in zeros for that row/column
+    extra_label = np.max(y_true) + 1
+    cm = confusion_matrix(y_true, y_pred, labels=[2, extra_label])
+    assert_array_equal(cm, [[18, 0],
+                            [0, 0]])
+
+    # check for exception when none of the specified labels are in y_true
     assert_raises(ValueError, confusion_matrix, y_true, y_pred,
-                  labels=bad_label)
+                  labels=[extra_label, extra_label + 1])
 
 
 def test_classification_report_multiclass():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -551,6 +551,10 @@ def test_confusion_matrix_multiclass_subset_labels():
     assert_array_equal(cm, [[18, 2],
                             [24, 3]])
 
+    bad_label = np.max(y_true) + 1
+    assert_raises(ValueError, confusion_matrix, y_true, y_pred,
+                  labels=bad_label)
+
 
 def test_classification_report_multiclass():
     # Test performance report


### PR DESCRIPTION
#### Reference Issue

Fixes #6952.
#### What does this implement/fix? Explain your changes.

When explicitly specifying a subset/re-ordering of labels in `confusion_matrix()`, labels not contained in `y_true`/`y_pred` silently result in zero rows/columns in the resulting confusion matrix. This PR checks if none of the labels in `y_true` are in the specified `labels` and raises an exception if so.
#### Any other comments?

There are several places in `sklearn.metrics.classification` which take an optional `labels` argument. I was thinking there should be a `_check_labels(y_true, y_pred, labels=None)` function that would check for this condition and return properly formatted labels, but they seem to use labels somewhat differently. I opted to go with the minimal approach first.
