### PR TITLE
[MRG + 1] [MAINT] Make sure set_params does not break clone on kernels

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -92,6 +92,13 @@ class Hyperparameter(namedtuple('Hyperparameter',
         return super(Hyperparameter, cls).__new__(
             cls, name, value_type, bounds, n_elements, fixed)
 
+    def __eq__(self, other):
+        return (self.name == other.name and
+                self.value_type == other.value_type and
+                np.all(self.bounds == other.bounds) and
+                self.n_elements == other.n_elements and
+                self.fixed == other.fixed)
+
 
 class Kernel(six.with_metaclass(ABCMeta)):
     """Base class for all kernels."""

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -92,6 +92,8 @@ class Hyperparameter(namedtuple('Hyperparameter',
         return super(Hyperparameter, cls).__new__(
             cls, name, value_type, bounds, n_elements, fixed)
 
+    # This is mainly a testing utility to check that two hyperparameters
+    # are equal.
     def __eq__(self, other):
         return (self.name == other.name and
                 self.value_type == other.value_type and

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -189,7 +189,8 @@ def test_kernel_clone():
     for kernel in kernels:
         kernel_cloned = clone(kernel)
 
-        # XXX: Should thie be fixed?
+        # XXX: Should this be fixed?
+        # This differs from the sklearn's estimators equality check.
         assert_equal(kernel, kernel_cloned)
         assert_not_equal(id(kernel), id(kernel_cloned))
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -189,31 +189,19 @@ def test_kernel_clone():
     for kernel in kernels:
         kernel_cloned = clone(kernel)
 
+        # XXX: Should thie be fixed?
         assert_equal(kernel, kernel_cloned)
         assert_not_equal(id(kernel), id(kernel_cloned))
-        for attr in kernel.__dict__.keys():
-            attr_value = getattr(kernel, attr)
-            attr_value_cloned = getattr(kernel_cloned, attr)
+
+        # Check that all constructor parameters are equal.
+        assert_equal(kernel.get_params(), kernel_cloned.get_params())
+
+        for attr in dir(kernel):
+
             if attr.startswith("hyperparameter_"):
-                assert_equal(attr_value.name, attr_value_cloned.name)
-                assert_equal(attr_value.value_type,
-                             attr_value_cloned.value_type)
-                assert_array_equal(attr_value.bounds,
-                                   attr_value_cloned.bounds)
-                assert_equal(attr_value.n_elements,
-                             attr_value_cloned.n_elements)
-            elif np.iterable(attr_value):
-                for i in range(len(attr_value)):
-                    if np.iterable(attr_value[i]):
-                        assert_array_equal(attr_value[i],
-                                           attr_value_cloned[i])
-                    else:
-                        assert_equal(attr_value[i], attr_value_cloned[i])
-            else:
+                attr_value = getattr(kernel, attr)
+                attr_value_cloned = getattr(kernel_cloned, attr)
                 assert_equal(attr_value, attr_value_cloned)
-            if not isinstance(attr_value, Hashable):
-                # modifiable attributes must not be identical
-                assert_not_equal(id(attr_value), id(attr_value_cloned))
 
         # This test is to verify that using set_params does not
         # break clone on kernels.
@@ -232,7 +220,8 @@ def test_kernel_clone():
                 params['length_scale_bounds'] = bounds * 2
         kernel_cloned.set_params(**params)
         kernel_cloned_clone = clone(kernel_cloned)
-        assert_equal(kernel_cloned_clone, kernel_cloned)
+        assert_equal(kernel_cloned_clone.get_params(),
+                     kernel_cloned.get_params())
         assert_not_equal(id(kernel_cloned_clone), id(kernel_cloned))
 
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -183,6 +183,15 @@ def test_kernel_stationary():
         assert_almost_equal(K[0, 0], np.diag(K))
 
 
+def check_hyperparameters_equal(kernel1, kernel2):
+    """Check that hyperparameters of two kernels are equal"""
+    for attr in set(dir(kernel1) + dir(kernel2)):
+        if attr.startswith("hyperparameter_"):
+            attr_value1 = getattr(kernel1, attr)
+            attr_value2 = getattr(kernel2, attr)
+            assert_equal(attr_value1, attr_value2)
+
+
 def test_kernel_clone():
     """ Test that sklearn's clone works correctly on kernels. """
     bounds = (1e-5, 1e5)
@@ -197,12 +206,8 @@ def test_kernel_clone():
         # Check that all constructor parameters are equal.
         assert_equal(kernel.get_params(), kernel_cloned.get_params())
 
-        for attr in dir(kernel):
-
-            if attr.startswith("hyperparameter_"):
-                attr_value = getattr(kernel, attr)
-                attr_value_cloned = getattr(kernel_cloned, attr)
-                assert_equal(attr_value, attr_value_cloned)
+        # Check that all hyperparameters are equal.
+        yield check_hyperparameters_equal, kernel, kernel_cloned
 
         # This test is to verify that using set_params does not
         # break clone on kernels.
@@ -211,7 +216,9 @@ def test_kernel_clone():
         # See https://github.com/scikit-learn/scikit-learn/issues/6961
         # for more details.
         params = kernel.get_params()
-        if 'length_scale' in params:
+        # RationalQuadratic kernel is isotropic.
+        isotropic_kernels = (ExpSineSquared, RationalQuadratic)
+        if 'length_scale' in params and not isinstance(kernel, isotropic_kernels):
             length_scale = params['length_scale']
             if np.iterable(length_scale):
                 params['length_scale'] = length_scale[0]
@@ -219,11 +226,12 @@ def test_kernel_clone():
             else:
                 params['length_scale'] = [length_scale] * 2
                 params['length_scale_bounds'] = bounds * 2
-        kernel_cloned.set_params(**params)
-        kernel_cloned_clone = clone(kernel_cloned)
-        assert_equal(kernel_cloned_clone.get_params(),
-                     kernel_cloned.get_params())
-        assert_not_equal(id(kernel_cloned_clone), id(kernel_cloned))
+            kernel_cloned.set_params(**params)
+            kernel_cloned_clone = clone(kernel_cloned)
+            assert_equal(kernel_cloned_clone.get_params(),
+                         kernel_cloned.get_params())
+            assert_not_equal(id(kernel_cloned_clone), id(kernel_cloned))
+            yield check_hyperparameters_equal, kernel_cloned, kernel_cloned_clone
 
 
 def test_matern_kernel():


### PR DESCRIPTION
#### Reference Issue

Fixes #6961 
#### What does this implement/fix? Explain your changes.

For example, in kernels such as RBF, using set_params with a
length_scale of different length, used to break clone because of
the non-trivial modification of length_scale in the constructor.

This PR resolves this by moving this logic to **call** and
making hyperparameter attributes properties.
