### PR TITLE
MultiModelSearch: Wrapper around {Grid,Random}SearchCV supporting multiple estimator classes

### DIFF
--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -20,6 +20,7 @@ from ._validation import permutation_test_score
 from ._validation import validation_curve
 
 from ._search import GridSearchCV
+from ._search import MultiModelSearch
 from ._search import RandomizedSearchCV
 from ._search import ParameterGrid
 from ._search import ParameterSampler
@@ -27,6 +28,7 @@ from ._search import fit_grid_point
 
 __all__ = ('BaseCrossValidator',
            'GridSearchCV',
+           'MultiModelSearch',
            'KFold',
            'LabelKFold',
            'LabelShuffleSplit',


### PR DESCRIPTION
Hi everyone,

I'd like the functionality to run hyperparameter optimization over more than one algorithm, e.g. Random Forests + Gradient Boosted Trees. 

So I wrote a wrapper class `MultiModelSearch` (loosely based on [this post](http://www.codiply.com/blog/hyperparameter-grid-search-across-multiple-models-in-scikit-learn/) ) which currently takes a dict of estimators, a dict or their parameter grids (for gridsearch) or -distributions (for random search).

I added a test example [in this notebook](https://gist.github.com/4sig/262b902ae96e469485214de76bab5797).
