### PR TITLE
[MRG] DOC make confusion_matrix_plot.py example more copy-pastable

### DIFF
--- a/examples/model_selection/plot_confusion_matrix.py
+++ b/examples/model_selection/plot_confusion_matrix.py
@@ -26,6 +26,7 @@ using :ref:`grid_search`.
 
 print(__doc__)
 
+import itertools
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -37,6 +38,7 @@ from sklearn.metrics import confusion_matrix
 iris = datasets.load_iris()
 X = iris.data
 y = iris.target
+class_names = iris.target_names
 
 # Split the data into a training set and a test set
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
@@ -47,32 +49,51 @@ classifier = svm.SVC(kernel='linear', C=0.01)
 y_pred = classifier.fit(X_train, y_train).predict(X_test)
 
 
-def plot_confusion_matrix(cm, title='Confusion matrix', cmap=plt.cm.Blues):
+def plot_confusion_matrix(cm, classes,
+                          normalize=False,
+                          title='Confusion matrix',
+                          cmap=plt.cm.Blues):
+    """
+    This function prints and plots the confusion matrix.
+    Normalization can be applied by setting `normalize=True`.
+    """
     plt.imshow(cm, interpolation='nearest', cmap=cmap)
     plt.title(title)
     plt.colorbar()
-    tick_marks = np.arange(len(iris.target_names))
-    plt.xticks(tick_marks, iris.target_names, rotation=45)
-    plt.yticks(tick_marks, iris.target_names)
+    tick_marks = np.arange(len(classes))
+    plt.xticks(tick_marks, classes, rotation=45)
+    plt.yticks(tick_marks, classes)
+
+    if normalize:
+        cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
+        print("Normalized confusion matrix")
+    else:
+        print('Confusion matrix, without normalization')
+
+    print(cm)
+
+    thresh = cm.max() / 2.
+    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
+        plt.text(j, i, cm[i, j],
+                 horizontalalignment="center",
+                 color="white" if cm[i, j] > thresh else "black")
+
     plt.tight_layout()
     plt.ylabel('True label')
     plt.xlabel('Predicted label')
 
-
 # Compute confusion matrix
-cm = confusion_matrix(y_test, y_pred)
+cnf_matrix = confusion_matrix(y_test, y_pred)
 np.set_printoptions(precision=2)
-print('Confusion matrix, without normalization')
-print(cm)
-plt.figure()
-plot_confusion_matrix(cm)
 
-# Normalize the confusion matrix by row (i.e by the number of samples
-# in each class)
-cm_normalized = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
-print('Normalized confusion matrix')
-print(cm_normalized)
+# Plot non-normalized confusion matrix
 plt.figure()
-plot_confusion_matrix(cm_normalized, title='Normalized confusion matrix')
+plot_confusion_matrix(cnf_matrix, classes=class_names,
+                      title='Confusion matrix, without normalization')
+
+# Plot normalized confusion matrix
+plt.figure()
+plot_confusion_matrix(cnf_matrix, classes=class_names, normalize=True,
+                      title='Normalized confusion matrix')
 
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Addressed: #6796
#### What does this implement/fix? Explain your changes.
- Make plot_confusion_matrix.py example more copy-pastable by putting the calculated numbers into the middle of each square on the plot
- Use the list of class names as a parameter of the plotting function

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
