### PR TITLE
[MRG + 1] Check for NaN or Inf in roc_curve input

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -30,6 +30,7 @@ from scipy.sparse import csr_matrix
 
 from ..preprocessing import LabelBinarizer, label_binarize
 from ..preprocessing import LabelEncoder
+from ..utils import assert_all_finite
 from ..utils import check_array
 from ..utils import check_consistent_length
 from ..utils import column_or_1d
@@ -1841,6 +1842,9 @@ def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
     """
     y_true = column_or_1d(y_true)
     y_prob = column_or_1d(y_prob)
+    assert_all_finite(y_true)
+    assert_all_finite(y_prob)
+
     if pos_label is None:
         pos_label = y_true.max()
     y_true = np.array(y_true == pos_label, int)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -23,6 +23,7 @@ import warnings
 import numpy as np
 from scipy.sparse import csr_matrix
 
+from ..utils import assert_all_finite
 from ..utils import check_consistent_length
 from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
@@ -296,6 +297,9 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     check_consistent_length(y_true, y_score)
     y_true = column_or_1d(y_true)
     y_score = column_or_1d(y_score)
+    assert_all_finite(y_true)
+    assert_all_finite(y_score)
+
     if sample_weight is not None:
         sample_weight = column_or_1d(sample_weight)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -19,6 +19,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 
@@ -606,6 +607,29 @@ def test_invariance_string_vs_numbers_labels():
             # TODO those metrics doesn't support string label yet
             assert_raises(ValueError, metric, y1_str, y2)
             assert_raises(ValueError, metric, y1_str.astype('O'), y2)
+
+
+def test_inf_nan_input():
+    invalids =[([0, 1], [np.inf, np.inf]),
+               ([0, 1], [np.nan, np.nan]),
+               ([0, 1], [np.nan, np.inf])]
+
+    METRICS = dict()
+    METRICS.update(THRESHOLDED_METRICS)
+    METRICS.update(REGRESSION_METRICS)
+
+    for metric in METRICS.values():
+        for y_true, y_score in invalids:
+            assert_raise_message(ValueError,
+                                 "contains NaN, infinity",
+                                 metric, y_true, y_score)
+
+    # Classification metrics all raise a mixed input exception
+    for metric in CLASSIFICATION_METRICS.values():
+        for y_true, y_score in invalids:
+            assert_raise_message(ValueError,
+                                 "Can't handle mix of binary and continuous",
+                                 metric, y_true, y_score)
 
 
 @ignore_warnings

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -200,6 +200,16 @@ def test_roc_curve_multi():
     assert_raises(ValueError, roc_curve, y_true, probas_pred)
 
 
+def test_roc_curve_nan_inf():
+    invalids =[([0, 1], [np.inf, np.inf]),
+               ([0, 1], [np.nan, np.nan]),
+               ([0, 1], [np.nan, np.inf])]
+
+    for y_true, y_score in invalids:
+        assert_raise_message(ValueError, "contains NaN, infinity",
+                             roc_curve, y_true, y_score)
+
+
 def test_roc_curve_confidence():
     # roc_curve for confidence scores
     y_true, _, probas_pred = make_prediction(binary=True)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -200,16 +200,6 @@ def test_roc_curve_multi():
     assert_raises(ValueError, roc_curve, y_true, probas_pred)
 
 
-def test_roc_curve_nan_inf():
-    invalids =[([0, 1], [np.inf, np.inf]),
-               ([0, 1], [np.nan, np.nan]),
-               ([0, 1], [np.nan, np.inf])]
-
-    for y_true, y_score in invalids:
-        assert_raise_message(ValueError, "contains NaN, infinity",
-                             roc_curve, y_true, y_score)
-
-
 def test_roc_curve_confidence():
     # roc_curve for confidence scores
     y_true, _, probas_pred = make_prediction(binary=True)


### PR DESCRIPTION
#### Reference Issue

Fixes #5735 
#### What does this implement/fix? Explain your changes.

`roc_auc_score([1,1,0,0], [np.nan, np.nan, np.nan, np.nan])` now raises `ValueError`. Previously it
would return a score of 0
#### Any other comments?

In the test I added I swapped in all the other functions in `ranking.py` and for all of them the right
kind of `ValueError` is raised. Should we capture that in a test to make sure it doesn't stop in the future? Related to this, does it make sense for all of them to raise an error on `nan` or `inf` (not that familiar with most of those metrics but it seems reasonable)?

For my education: what is the difference between `assert_something` and `check_something` in `validation.py`?
