### PR TITLE
[MRG+1] test against single-class y_true values for #6980

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1760,7 +1760,7 @@ def _check_binary_probabilistic_predictions(y_true, y_prob):
 
     labels = np.unique(y_true)
 
-    if len(labels) != 2:
+    if len(labels) > 2:
         raise ValueError("Only binary classification is supported. "
                          "Provided labels %s." % labels)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1407,3 +1407,6 @@ def test_brier_score_loss():
     assert_raises(ValueError, brier_score_loss, y_true, y_pred[1:])
     assert_raises(ValueError, brier_score_loss, y_true, y_pred + 1.)
     assert_raises(ValueError, brier_score_loss, y_true, y_pred - 1.)
+    # calculate even if only single class in y_true (#6980)
+    assert_almost_equal(brier_score_loss([0], [0.5]), 0.25)
+    assert_almost_equal(brier_score_loss([1], [0.5]), 0.25)


### PR DESCRIPTION
Test(s) for #6980. 

`calibration.calibration_curve()` may have similar issue and need a test (not yet in this branch) too. 
