### PR TITLE
avoid creating a diagonal matrix

### DIFF
--- a/sklearn/decomposition/truncated_svd.py
+++ b/sklearn/decomposition/truncated_svd.py
@@ -176,7 +176,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         self.components_ = VT
 
         # Calculate explained variance & explained variance ratio
-        X_transformed = np.dot(U, np.diag(Sigma))
+        X_transformed = U * Sigma
         self.explained_variance_ = exp_var = np.var(X_transformed, axis=0)
         if sp.issparse(X):
             _, full_var = mean_variance_axis(X, axis=0)


### PR DESCRIPTION
Broadcasted elementwise multiplication with a vector is equivalent to matrix multiplication against a diagonal matrix, but is more efficient.
