### PR TITLE
[MRG + 1] BLD: Add 'pip' extra for installing with pip

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -28,15 +28,22 @@ or ``conda``::
 
     conda install scikit-learn
 
-**We don't recommend installing scipy or numpy using pip on linux**,
-as this will involve a lengthy build-process with many dependencies.
-Without careful configuration, building numpy yourself can lead to an installation
-that is much slower than it should be. 
+**We don't recommend installing scipy or numpy using pip on Linux**,
+as this will involve a lengthy build process with many dependencies.
+Without careful configuration, building numpy yourself is likely to lead to an
+installation that is much slower than it should be.
 If you are using Linux, consider using your package manager to install
 scikit-learn. It is usually the easiest way, but might not provide the newest
 version.
 If you haven't already installed numpy and scipy and can't install them via
-your operation system, it is recommended to use a third party distribution.
+your operating system, we recommended using a third-party distribution.
+
+If you must install scikit-learn and its dependencies with pip, you can install
+it as ``scikit-learn[alldeps]``. We strongly recommend against doing this
+unless you are familiar with how to correctly build numpy and scipy. The most
+common use case for this is in a ``requirements.txt`` file used as part of an
+automated build process for a PaaS application or a Docker image. This option
+is not intended for manual installation from the command line.
 
 Third-party Distributions
 ==========================

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ import sklearn
 
 VERSION = sklearn.__version__
 
+SCIPY_MIN_VERSION = '0.9'
+NUMPY_MIN_VERSION = '1.6.1'
+
+
 # Optional setuptools features
 # We need to import setuptools early, if we want setuptools features,
 # as it monkey-patches the 'setup' function
@@ -58,6 +62,12 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
     extra_setuptools_args = dict(
         zip_safe=False,  # the package can run out of an .egg file
         include_package_data=True,
+        extras_require={
+            'alldeps': (
+                'numpy >= {0}'.format(NUMPY_MIN_VERSION),
+                'scipy >= {0}'.format(SCIPY_MIN_VERSION),
+            ),
+        },
     )
 else:
     extra_setuptools_args = dict()
@@ -131,10 +141,6 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
-scipy_min_version = '0.9'
-numpy_min_version = '1.6.1'
-
-
 def get_scipy_status():
     """
     Returns a dictionary containing a boolean specifying whether SciPy
@@ -146,7 +152,7 @@ def get_scipy_status():
         import scipy
         scipy_version = scipy.__version__
         scipy_status['up_to_date'] = parse_version(
-            scipy_version) >= parse_version(scipy_min_version)
+            scipy_version) >= parse_version(SCIPY_MIN_VERSION)
         scipy_status['version'] = scipy_version
     except ImportError:
         scipy_status['up_to_date'] = False
@@ -165,7 +171,7 @@ def get_numpy_status():
         import numpy
         numpy_version = numpy.__version__
         numpy_status['up_to_date'] = parse_version(
-            numpy_version) >= parse_version(numpy_min_version)
+            numpy_version) >= parse_version(NUMPY_MIN_VERSION)
         numpy_status['version'] = numpy_version
     except ImportError:
         numpy_status['up_to_date'] = False
@@ -236,10 +242,10 @@ def setup_package():
     else:
         numpy_status = get_numpy_status()
         numpy_req_str = "scikit-learn requires NumPy >= {0}.\n".format(
-            numpy_min_version)
+            NUMPY_MIN_VERSION)
         scipy_status = get_scipy_status()
         scipy_req_str = "scikit-learn requires SciPy >= {0}.\n".format(
-            scipy_min_version)
+            SCIPY_MIN_VERSION)
 
         instructions = ("Installation instructions are available on the "
                         "scikit-learn website: "


### PR DESCRIPTION
#### Reference Issue

Fixes https://github.com/scikit-learn/scikit-learn/issues/4164
#### What does this implement/fix? Explain your changes.

This allows advanced users who are using standard Python management tools to install `scikit-learn[pip]`, which includes the appropriate `numpy` and `scipy` dependencies.
