### PR TITLE
ENH Isomap: adding choice option for neighborhood function (plus some code cleaning)

### DIFF
--- a/examples/manifold/plot_weighted_mds.py
+++ b/examples/manifold/plot_weighted_mds.py
@@ -1,0 +1,132 @@
+"""
+==================================
+Weighted Multi-dimensional scaling
+==================================
+
+An illustration of the smacof algorithm with weighting. The example considers
+the localization of nodes in a wireless network. Because of range limit,
+internode distances are known below a threshold, and other distances are
+missing. Weighting enables to solve localization, even when data are missing.
+"""
+
+# Author: Charles Vanwynsberghe <charles.vanwynsberghe@outlook.fr>
+# Licence: BSD
+
+print(__doc__)
+import numpy as np
+
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+
+from sklearn.manifold import MDS
+from sklearn.decomposition import PCA
+from sklearn.metrics import euclidean_distances
+
+# %% create input data
+prng = np.random.RandomState(4)  # set random state
+
+n_node = 15  # Number of nodes
+
+# Node Positions are set randomly
+X = np.zeros((n_node, 2))
+X[:, 0] = 1*prng.rand(n_node)
+X[:, 1] = 3*prng.rand(n_node)
+
+X -= X.mean(axis=0)
+
+# Create distance matrix
+D = euclidean_distances(X)
+
+# Add some noise to distance matrix
+noise = 0.01 * D * prng.randn(*D.shape)
+noise = (noise + noise.T) / 2
+Dn = D + noise
+
+# %% Solve node localization problem
+
+# smacof: all pairwise distances are known and used for smacof minimisation
+smacof = MDS(n_components=2, n_init=1,
+             max_iter=100, dissimilarity='precomputed',
+             n_jobs=1, random_state=3)
+smacof.fit(Dn)
+
+# weighted smacof: only local connectivity is used,
+# ie distances below a threshold
+weight = np.ones_like(D)
+weight[D > 2] = 0
+
+smacof_w = MDS(n_components=2, n_init=1,
+               max_iter=100, dissimilarity='precomputed',
+               n_jobs=1, random_state=3)
+smacof_w.fit(Dn, weight=weight)
+
+# Align estimations onto ground truth for plot
+clf = PCA(n_components=2)
+X = clf.fit_transform(X)
+smacof.embedding_ = clf.fit_transform(smacof.embedding_)
+smacof_w.embedding_ = clf.fit_transform(smacof_w.embedding_)
+
+# %% Plot results
+plt.figure(figsize=(15, 10))
+
+# Non-weighted case
+
+# ground truth + internode distances
+ax = plt.subplot(221)
+ax.set_title("Input data \n\n all pairwise nodes (blue) are known")
+ax.axis('equal')
+ax.set_xticks([]), ax.set_yticks([])
+ax.scatter(*X.T, facecolor='none', s=60)
+# Plot the distances
+segments = [[X[i, :], X[j, :]]
+            for i in range(len(X)) for j in range(len(X))]
+lc = LineCollection(segments, colors=([146./255, 197./255, 222./255, 1]))
+lc.set_linewidths(0.5 * np.ones(len(segments)))
+ax.add_collection(lc)
+
+# ground truth + estimated
+plt.subplot(222)
+plt.title("Solving localization \n\n By Smacof")
+plt.axis('equal')
+plt.xticks([]), plt.yticks([])
+plt.scatter(*smacof.embedding_.T, marker='+', s=60,
+            color='black', label='estimated')
+plt.scatter(*X.T, facecolor='none', s=60, label='ground truth')
+plt.legend(scatterpoints=1, loc='best', ncol=2)
+
+# Weighted case
+
+# ground truth + internode distances
+ax2 = plt.subplot(223)
+ax2.set_title("Local distances (blue) are known, \nothers (red) are missing.")
+ax2.axis('equal')
+ax2.set_xticks([]), ax2.set_yticks([])
+ax2.scatter(*X.T, facecolor='none', s=60)
+# Plot the known/unknown distances
+segments_1 = []
+segments_0 = []
+for i in range(len(X)):
+    for j in range(len(X)):
+        if (weight[i, j] == 1):
+            segments_1.append([X[i, :], X[j, :]])
+        elif (weight[i, j] == 0):
+            segments_0.append([X[i, :], X[j, :]])
+
+lc_0 = LineCollection(segments_0, colors=([202./255, 0./255, 32./255, 1]))
+lc_1 = LineCollection(segments_1, colors=([146./255, 197./255, 222./255, 1]))
+lc_1.set_linewidths(0.5 * np.ones(len(segments_1)))
+lc_0.set_linewidths(0.5 * np.ones(len(segments_0)))
+ax2.add_collection(lc_0)
+ax2.add_collection(lc_1)
+
+# ground truth + estimated
+plt.subplot(224)
+plt.title("Weighting Smacof enables to solve localization\n with missing data")
+plt.axis('equal')
+plt.xticks([]), plt.yticks([])
+plt.scatter(*smacof_w.embedding_.T, marker='+', s=60,
+            color='black', label='estimated')
+plt.scatter(*X.T, facecolor='none', s=60, label='ground truth')
+plt.legend(scatterpoints=1, loc='best', ncol=2)
+
+plt.show()

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -25,7 +25,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         number of neighbors to consider for each point (if mode='k').
 
     radius : float
-        radius to consider for each point (case mode='radius').
+        radius to consider for each point (if mode='radius').
 
     mode : string ['k'|'radius']
         neighborhood function.

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from ..base import BaseEstimator, TransformerMixin
-from ..neighbors import NearestNeighbors, kneighbors_graph
+from ..neighbors import NearestNeighbors
 from ..utils import check_array
 from ..utils.graph import graph_shortest_path
 from ..decomposition import KernelPCA
@@ -22,7 +22,17 @@ class Isomap(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     n_neighbors : integer
-        number of neighbors to consider for each point.
+        number of neighbors to consider for each point (if mode='k').
+
+    radius : float
+        radius to consider for each point (case mode='radius').
+
+    mode : string ['k'|'radius']
+        neighborhood function.
+
+        'k' : k nearest neighbors.
+
+        'radius' : neighbors into radius range.
 
     n_components : integer
         number of coordinates for the manifold
@@ -87,10 +97,12 @@ class Isomap(BaseEstimator, TransformerMixin):
            framework for nonlinear dimensionality reduction. Science 290 (5500)
     """
 
-    def __init__(self, n_neighbors=5, n_components=2, eigen_solver='auto',
-                 tol=0, max_iter=None, path_method='auto',
+    def __init__(self, n_neighbors=5, radius=1., mode='k', n_components=2,
+                 eigen_solver='auto', tol=0, max_iter=None, path_method='auto',
                  neighbors_algorithm='auto', n_jobs=1):
         self.n_neighbors = n_neighbors
+        self.radius = radius
+        self.mode = mode
         self.n_components = n_components
         self.eigen_solver = eigen_solver
         self.tol = tol
@@ -106,18 +118,25 @@ class Isomap(BaseEstimator, TransformerMixin):
                                       n_jobs=self.n_jobs)
         self.nbrs_.fit(X)
         self.training_data_ = self.nbrs_._fit_X
+
+        # Get the neighbor graph of distances
+        if self.mode == 'k':
+            kng = self.nbrs_.kneighbors_graph(mode='distance')
+        elif self.mode == 'radius':
+            kng = self.nbrs_.radius_neighbors_graph(mode='distance')
+        
+        # Build the full geodesic distance matrix from graph of distances kng
+        self.dist_matrix_ = graph_shortest_path(kng,
+                                                method=self.path_method,
+                                                directed=False)
+
+        # Do classic MDS on geodesic distance matrix
         self.kernel_pca_ = KernelPCA(n_components=self.n_components,
                                      kernel="precomputed",
                                      eigen_solver=self.eigen_solver,
                                      tol=self.tol, max_iter=self.max_iter,
                                      n_jobs=self.n_jobs)
 
-        kng = kneighbors_graph(self.nbrs_, self.n_neighbors,
-                               mode='distance', n_jobs=self.n_jobs)
-
-        self.dist_matrix_ = graph_shortest_path(kng,
-                                                method=self.path_method,
-                                                directed=False)
         G = self.dist_matrix_ ** 2
         G *= -0.5
 


### PR DESCRIPTION
This pull request proposes 3 changes:
1. In the same way as the [original Tenenbaum's implementation of isomap](http://isomap.stanford.edu/), I added the option to choose the type of neighborhood graph (kneighbor or radius), which can be really useful.
2. Removing the redundant use of NearestNeighbors object and function kneighbors_graph, the latter already existing as a method in NearestNeighbors
3. Structuring+commenting the code to easily get the main steps of isomap
