### PR TITLE
ENH Isomap: adding choice option for neighborhood function (plus some code cleaning)

### DIFF
--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from ..base import BaseEstimator, TransformerMixin
-from ..neighbors import NearestNeighbors, kneighbors_graph
+from ..neighbors import NearestNeighbors
 from ..utils import check_array
 from ..utils.graph import graph_shortest_path
 from ..decomposition import KernelPCA
@@ -22,7 +22,17 @@ class Isomap(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     n_neighbors : integer
-        number of neighbors to consider for each point.
+        number of neighbors to consider for each point (if mode='k').
+
+    radius : float
+        radius to consider for each point (case mode='radius').
+
+    mode : string ['k'|'radius']
+        neighborhood function.
+
+        'k' : k nearest neighbors.
+
+        'radius' : neighbors into radius range.
 
     n_components : integer
         number of coordinates for the manifold
@@ -87,10 +97,12 @@ class Isomap(BaseEstimator, TransformerMixin):
            framework for nonlinear dimensionality reduction. Science 290 (5500)
     """
 
-    def __init__(self, n_neighbors=5, n_components=2, eigen_solver='auto',
-                 tol=0, max_iter=None, path_method='auto',
+    def __init__(self, n_neighbors=5, radius=1., mode='k', n_components=2,
+                 eigen_solver='auto', tol=0, max_iter=None, path_method='auto',
                  neighbors_algorithm='auto', n_jobs=1):
         self.n_neighbors = n_neighbors
+        self.radius = radius
+        self.mode = mode
         self.n_components = n_components
         self.eigen_solver = eigen_solver
         self.tol = tol
@@ -106,18 +118,25 @@ class Isomap(BaseEstimator, TransformerMixin):
                                       n_jobs=self.n_jobs)
         self.nbrs_.fit(X)
         self.training_data_ = self.nbrs_._fit_X
+
+        # Get the neighbor graph of distances
+        if self.mode == 'k':
+            kng = self.nbrs_.kneighbors_graph(mode='distance')
+        elif self.mode == 'radius':
+            kng = self.nbrs_.radius_neighbors_graph(mode='distance')
+        
+        # Build the full geodesic distance matrix from graph of distances kng
+        self.dist_matrix_ = graph_shortest_path(kng,
+                                                method=self.path_method,
+                                                directed=False)
+
+        # Do classic MDS on geodesic distance matrix
         self.kernel_pca_ = KernelPCA(n_components=self.n_components,
                                      kernel="precomputed",
                                      eigen_solver=self.eigen_solver,
                                      tol=self.tol, max_iter=self.max_iter,
                                      n_jobs=self.n_jobs)
 
-        kng = kneighbors_graph(self.nbrs_, self.n_neighbors,
-                               mode='distance', n_jobs=self.n_jobs)
-
-        self.dist_matrix_ = graph_shortest_path(kng,
-                                                method=self.path_method,
-                                                directed=False)
         G = self.dist_matrix_ ** 2
         G *= -0.5
 

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from ..base import BaseEstimator, TransformerMixin
-from ..neighbors import NearestNeighbors
+from ..neighbors import NearestNeighbors, kneighbors_graph
 from ..utils import check_array
 from ..utils.graph import graph_shortest_path
 from ..decomposition import KernelPCA
@@ -25,7 +25,7 @@ class Isomap(BaseEstimator, TransformerMixin):
         number of neighbors to consider for each point (if mode='k').
 
     radius : float
-        radius to consider for each point (case mode='radius').
+        radius to consider for each point (if mode='radius').
 
     mode : string ['k'|'radius']
         neighborhood function.
@@ -114,6 +114,7 @@ class Isomap(BaseEstimator, TransformerMixin):
     def _fit_transform(self, X):
         X = check_array(X)
         self.nbrs_ = NearestNeighbors(n_neighbors=self.n_neighbors,
+                                      radius=self.radius,
                                       algorithm=self.neighbors_algorithm,
                                       n_jobs=self.n_jobs)
         self.nbrs_.fit(X)
@@ -124,7 +125,7 @@ class Isomap(BaseEstimator, TransformerMixin):
             kng = self.nbrs_.kneighbors_graph(mode='distance')
         elif self.mode == 'radius':
             kng = self.nbrs_.radius_neighbors_graph(mode='distance')
-        
+
         # Build the full geodesic distance matrix from graph of distances kng
         self.dist_matrix_ = graph_shortest_path(kng,
                                                 method=self.path_method,

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -205,11 +205,11 @@ class Isomap(BaseEstimator, TransformerMixin):
 
         This is implemented by linking the points X into the graph of geodesic
         distances of the training data. First the `n_neighbors` nearest
-        neighbors of X are found in the training data, and from these the
-        shortest geodesic distances from each point in X to each point in
-        the training data are computed in order to construct the kernel.
-        The embedding of X is the projection of this kernel onto the
-        embedding vectors of the training set.
+        neighbors of X (or nearest neighbors within `radius`) are found in the
+        training data, and from these the shortest geodesic distances from each
+        point in X to each point in the training data are computed in order to
+        construct the kernel. The embedding of X is the projection of this
+        kernel onto the embedding vectors of the training set.
 
         Parameters
         ----------
@@ -220,7 +220,11 @@ class Isomap(BaseEstimator, TransformerMixin):
         X_new : array-like, shape (n_samples, n_components)
         """
         X = check_array(X)
-        distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
+        if self.mode == 'k':
+            distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
+        elif self.mode == 'radius':
+            distances, indices = self.nbrs_.radius_neighbors(
+                                                       X, return_distance=True)
 
         # Create the graph of shortest distances from X to self.training_data_
         # via the nearest neighbors of X.

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -22,13 +22,13 @@ class Isomap(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     n_neighbors : integer
-        number of neighbors to consider for each point (if mode='k').
+        Number of neighbors to consider for each point (if mode='k').
 
     radius : float
-        radius to consider for each point (if mode='radius').
+        Radius to consider for each point (if mode='radius').
 
     mode : string ['k'|'radius']
-        neighborhood function.
+        Neighborhood function.
 
         'k' : k nearest neighbors.
 

--- a/sklearn/manifold/isomap.py
+++ b/sklearn/manifold/isomap.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from ..base import BaseEstimator, TransformerMixin
-from ..neighbors import NearestNeighbors, kneighbors_graph
+from ..neighbors import NearestNeighbors
 from ..utils import check_array
 from ..utils.graph import graph_shortest_path
 from ..decomposition import KernelPCA

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -89,17 +89,18 @@ def test_transform():
     # Create S-curve dataset
     X, y = datasets.samples_generator.make_s_curve(n_samples, random_state=0)
 
-    # Compute isomap embedding
-    iso = manifold.Isomap(n_components, 2)
-    X_iso = iso.fit_transform(X)
+    for isomap_mode in ['k', 'radius']:
+        # Compute isomap embedding
+        iso = manifold.Isomap(mode=isomap_mode, n_components=n_components)
+        X_iso = iso.fit_transform(X)
 
-    # Re-embed a noisy version of the points
-    rng = np.random.RandomState(0)
-    noise = noise_scale * rng.randn(*X.shape)
-    X_iso2 = iso.transform(X + noise)
+        # Re-embed a noisy version of the points
+        rng = np.random.RandomState(0)
+        noise = noise_scale * rng.randn(*X.shape)
+        X_iso2 = iso.transform(X + noise)
 
-    # Make sure the rms error on re-embedding is comparable to noise_scale
-    assert_less(np.sqrt(np.mean((X_iso - X_iso2) ** 2)), 2 * noise_scale)
+        # Make sure the rms error on re-embedding is comparable to noise_scale
+        assert_less(np.sqrt(np.mean((X_iso - X_iso2) ** 2)), 2 * noise_scale)
 
 
 def test_pipeline():

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -129,8 +129,7 @@ def test_isomap_simple_grid_radius():
     # Similar to test_isomap_simple_grid, tests the radius mode
     # Isomap should preserve distances when all neighbors are used
     N_per_side = 5
-    Npts = N_per_side ** 2
-    radius = N_per_side**2 + 0.1 # radius containing all neighbors
+    radius = N_per_side**2 + 0.1  # radius containing all neighbors
 
     # grid of equidistant points in 2D, n_components = n_dim
     X = np.array(list(product(range(N_per_side), repeat=2)))
@@ -151,4 +150,3 @@ def test_isomap_simple_grid_radius():
                                                      radius,
                                                      mode='distance').toarray()
             assert_array_almost_equal(G, G_iso)
-

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_less
 eigen_solvers = ['auto', 'dense', 'arpack']
 path_methods = ['auto', 'FW', 'D']
 
+
 def test_isomap_simple_grid():
     # Isomap should preserve distances when all neighbors are used
     N_per_side = 5
@@ -122,6 +123,7 @@ def test_isomap_clone_bug():
         assert_equal(model.nbrs_.n_neighbors,
                      n_neighbors)
 
+
 def test_isomap_simple_grid_radius():
     # Similar to test_isomap_simple_grid, tests the radius mode
     # Isomap should preserve distances when all neighbors are used
@@ -148,3 +150,4 @@ def test_isomap_simple_grid_radius():
                                                      radius,
                                                      mode='distance').toarray()
             assert_array_almost_equal(G, G_iso)
+


### PR DESCRIPTION
This pull request proposes 3 changes:
1. In the same way as the [original Tenenbaum's implementation and paper of isomap](http://isomap.stanford.edu/), I added the option to choose the type of neighborhood graph (kneighbor or radius), which can be really useful.
2. Removing the redundant use of NearestNeighbors object and function kneighbors_graph, the latter already existing as a method in NearestNeighbors
3. Structuring+commenting the code to easily get the main steps of isomap
