### PR TITLE
[MRG] Add Deprecation Warning to address making "batch" the default learning method in LDA in 0.19 release

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -802,8 +802,7 @@ between :math:`q(z,\theta,\beta)` and the true posterior
 :class:`LatentDirichletAllocation` implements online variational Bayes algorithm and supports
 both online and batch update method.
 While batch method updates variational variables after each full pass through the data,
-online method updates variational variables from mini-batch data points. Therefore,
-online method usually converges faster than batch method.
+online method updates variational variables from mini-batch data points.
 
 .. note::
 

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -160,7 +160,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         Method used to update `_component`. Only used in `fit` method.
         In general, if the data size is large, the online update will be much
         faster than the batch update.
-        The default learning method will be changed to 'batch' in the 0.19 release.
+        The default learning method is going to be changed to 'batch' in the 0.20 release.
         Valid options::
 
             'batch': Batch variational Bayes method. Use all training data in
@@ -502,8 +502,9 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         evaluate_every = self.evaluate_every
         learning_method = self.learning_method
         if learning_method == None:
-            warnings.warn("The default value for 'learning_method' will be"
-                          "changed from 'online' to 'batch' in 0.19.",
+            warnings.warn("The default value for 'learning_method' will be "
+                          "changed from 'online' to 'batch' in the release 0.20. "
+                          "This warning was introduced in 0.18.",
                           DeprecationWarning)          
             learning_method = 'online'
 

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -14,6 +14,7 @@ Link: http://www.cs.princeton.edu/~mdhoffma/code/onlineldavb.tar
 import numpy as np
 import scipy.sparse as sp
 from scipy.special import gammaln
+import warnings
 
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import (check_random_state, check_array,
@@ -155,10 +156,11 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         to `1 / n_topics`.
         In the literature, this is called `eta`.
 
-    learning_method : 'batch' | 'online', default='batch'
+    learning_method : 'batch' | 'online', default='online'
         Method used to update `_component`. Only used in `fit` method.
         In general, if the data size is large, the online update will be much
         faster than the batch update.
+        The default learning method will be changed to 'batch' in the 0.19 release.
         Valid options::
 
             'batch': Batch variational Bayes method. Use all training data in
@@ -246,7 +248,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_topics=10, doc_topic_prior=None,
-                 topic_word_prior=None, learning_method='batch',
+                 topic_word_prior=None, learning_method=None,
                  learning_decay=.7, learning_offset=10., max_iter=10,
                  batch_size=128, evaluate_every=-1, total_samples=1e6,
                  perp_tol=1e-1, mean_change_tol=1e-3, max_doc_update_iter=100,
@@ -283,7 +285,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
             raise ValueError("Invalid 'learning_offset' parameter: %r"
                              % self.learning_offset)
 
-        if self.learning_method not in ("batch", "online"):
+        if self.learning_method not in ("batch", "online", None):
             raise ValueError("Invalid 'learning_method' parameter: %r"
                              % self.learning_method)
 
@@ -499,6 +501,12 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         max_iter = self.max_iter
         evaluate_every = self.evaluate_every
         learning_method = self.learning_method
+        if learning_method == None:
+            warnings.warn("The default value for 'learning_method' will be"
+                          "changed from 'online' to 'batch' in 0.19.",
+                          DeprecationWarning)          
+            learning_method = 'online'
+
         batch_size = self.batch_size
 
         # initialize parameters

--- a/sklearn/decomposition/online_lda.py
+++ b/sklearn/decomposition/online_lda.py
@@ -155,7 +155,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
         to `1 / n_topics`.
         In the literature, this is called `eta`.
 
-    learning_method : 'batch' | 'online', default='online'
+    learning_method : 'batch' | 'online', default='batch'
         Method used to update `_component`. Only used in `fit` method.
         In general, if the data size is large, the online update will be much
         faster than the batch update.
@@ -246,7 +246,7 @@ class LatentDirichletAllocation(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_topics=10, doc_topic_prior=None,
-                 topic_word_prior=None, learning_method='online',
+                 topic_word_prior=None, learning_method='batch',
                  learning_decay=.7, learning_offset=10., max_iter=10,
                  batch_size=128, evaluate_every=-1, total_samples=1e6,
                  perp_tol=1e-1, mean_change_tol=1e-3, max_doc_update_iter=100,

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -80,7 +80,8 @@ def test_lda_partial_fit():
     # (same as test_lda_batch)
     rng = np.random.RandomState(0)
     n_topics, X = _build_sparse_mtx()
-    lda = LatentDirichletAllocation(n_topics=n_topics, learning_offset=10.,
+    lda = LatentDirichletAllocation(n_topics=n_topics, 
+                                    learning_method='online', learning_offset=10.,
                                     total_samples=100, random_state=rng)
     for i in xrange(3):
         lda.partial_fit(X)
@@ -216,6 +217,7 @@ def test_lda_partial_fit_multi_jobs():
     rng = np.random.RandomState(0)
     n_topics, X = _build_sparse_mtx()
     lda = LatentDirichletAllocation(n_topics=n_topics, n_jobs=2,
+                                    learning_method='online',
                                     learning_offset=5., total_samples=30,
                                     random_state=rng)
     for i in range(2):

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -80,8 +80,7 @@ def test_lda_partial_fit():
     # (same as test_lda_batch)
     rng = np.random.RandomState(0)
     n_topics, X = _build_sparse_mtx()
-    lda = LatentDirichletAllocation(n_topics=n_topics, 
-                                    learning_method='online', learning_offset=10.,
+    lda = LatentDirichletAllocation(n_topics=n_topics, learning_offset=10.,
                                     total_samples=100, random_state=rng)
     for i in xrange(3):
         lda.partial_fit(X)
@@ -217,7 +216,6 @@ def test_lda_partial_fit_multi_jobs():
     rng = np.random.RandomState(0)
     n_topics, X = _build_sparse_mtx()
     lda = LatentDirichletAllocation(n_topics=n_topics, n_jobs=2,
-                                    learning_method='online',
                                     learning_offset=5., total_samples=30,
                                     random_state=rng)
     for i in range(2):


### PR DESCRIPTION
#### Reference Issue

Fixes: #6997 
#### What does this implement/fix? Explain your changes.

This fix sets "batch" as the default "learning_method" in Latent Dirichlet Allocation.
Also, it fixes a few tests which used the default method and were explicitly said to perform over "online" learning method of LDA. 
Finally, the line stating that "online" is faster than "batch" was removed from the documentation.
#### Any other comments?

What could be better update for the DOC? Do we have a reasoning why "batch" performs better?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
