### PR TITLE
[MRG] user guide keep apostrophes in CountVectorizer, fixes #6892

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -321,6 +321,19 @@ requested explicitly::
   ...     ['this', 'is', 'text', 'document', 'to', 'analyze'])
   True
 
+You can customize the way sentences are tokenzied by modifying the
+``token_pattern`` keyword argument with a customized regular expression.
+For example, if you want to include words with apostrophes, you can try:
+
+  >>> vectorizer2 = CountVectorizer(
+  ...     token_pattern=r"(?u)\b[a-zA-Z0-9_'][a-zA-Z0-9_']+\b"
+  ... )
+  >>> analyze2 = vectorizer2.build_analyzer()
+  >>> analyze2("I couldn't find my wallet. I'll be back with cash.") == (
+  ...     ["couldn't", 'find', 'my', 'wallet', "i'll", 'be', 'back', 
+  ...      'with', 'cash'])
+  True
+
 Each term found by the analyzer during the fit is assigned a unique
 integer index corresponding to a column in the resulting matrix. This
 interpretation of the columns can be retrieved as follows::


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #6892
#### What does this implement/fix? Explain your changes.

It makes a change to the user docs explaining how to use `CountVectorizer(token_pattern=<regex>)` to include words with apostrophes.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
