### PR TITLE
[MRG+1] Deprecated GMM functions

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -24,7 +24,7 @@ from sklearn.externals.six.moves import zip
 
 EPS = np.finfo(float).eps
 
-
+@deprecated("The class GMM is deprecated and will be removed in 0.20.")
 def log_multivariate_normal_density(X, means, covars, covariance_type='diag'):
     """Compute the log probability under a multivariate Gaussian distribution.
 
@@ -757,6 +757,7 @@ def _validate_covars(covars, covariance_type, n_components):
                          "'spherical', 'tied', 'diag', 'full'")
 
 
+@deprecated("The class GMM is deprecated and will be removed in 0.20.")
 def distribute_covar_matrix_to_match_covariance_type(
         tied_cv, covariance_type, n_components):
     """Create all the covariance matrices from a given template."""

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -24,7 +24,8 @@ from sklearn.externals.six.moves import zip
 
 EPS = np.finfo(float).eps
 
-@deprecated("The function log_multivariate_normal_density is deprecated and will be removed in 0.18.")
+@deprecated("The function log_multivariate_normal_density is deprecated in 0.18"
+            " and will be removed in 0.20.")
 def log_multivariate_normal_density(X, means, covars, covariance_type='diag'):
     """Compute the log probability under a multivariate Gaussian distribution.
 
@@ -649,8 +650,8 @@ class _GMMBase(BaseEstimator):
         return - 2 * self.score(X).sum() + 2 * self._n_parameters()
 
 
-@deprecated("The class GMM is deprecated and "
-            "will be removed in 0.18. Use class GaussianMixture instead.")
+@deprecated("The class GMM is deprecated in 0.18 and will be "
+            " removed in 0.20. Use class GaussianMixture instead.")
 class GMM(_GMMBase):
     def __init__(self, n_components=1, covariance_type='diag',
                  random_state=None, tol=1e-3, min_covar=1e-3,
@@ -758,7 +759,7 @@ def _validate_covars(covars, covariance_type, n_components):
 
 
 @deprecated("The functon distribute_covar_matrix_to_match_covariance_type"
-            "is deprecated and will be removed in 0.18.")
+            "is deprecated in 0.18 and will be removed in 0.20.")
 def distribute_covar_matrix_to_match_covariance_type(
         tied_cv, covariance_type, n_components):
     """Create all the covariance matrices from a given template."""

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -24,7 +24,7 @@ from sklearn.externals.six.moves import zip
 
 EPS = np.finfo(float).eps
 
-@deprecated("The function log_multivariate_normal_density is deprecated and will be removed in 0.20.")
+@deprecated("The function log_multivariate_normal_density is deprecated and will be removed in 0.18.")
 def log_multivariate_normal_density(X, means, covars, covariance_type='diag'):
     """Compute the log probability under a multivariate Gaussian distribution.
 
@@ -650,7 +650,7 @@ class _GMMBase(BaseEstimator):
 
 
 @deprecated("The class GMM is deprecated and "
-            "will be removed in 0.20. Use class GaussianMixture instead.")
+            "will be removed in 0.18. Use class GaussianMixture instead.")
 class GMM(_GMMBase):
     def __init__(self, n_components=1, covariance_type='diag',
                  random_state=None, tol=1e-3, min_covar=1e-3,
@@ -758,7 +758,7 @@ def _validate_covars(covars, covariance_type, n_components):
 
 
 @deprecated("The functon distribute_covar_matrix_to_match_covariance_type"
-            "is deprecated and will be removed in 0.20.")
+            "is deprecated and will be removed in 0.18.")
 def distribute_covar_matrix_to_match_covariance_type(
         tied_cv, covariance_type, n_components):
     """Create all the covariance matrices from a given template."""

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -24,7 +24,7 @@ from sklearn.externals.six.moves import zip
 
 EPS = np.finfo(float).eps
 
-@deprecated("The class GMM is deprecated and will be removed in 0.20.")
+@deprecated("The function log_multivariate_normal_density is deprecated and will be removed in 0.20.")
 def log_multivariate_normal_density(X, means, covars, covariance_type='diag'):
     """Compute the log probability under a multivariate Gaussian distribution.
 
@@ -757,7 +757,8 @@ def _validate_covars(covars, covariance_type, n_components):
                          "'spherical', 'tied', 'diag', 'full'")
 
 
-@deprecated("The class GMM is deprecated and will be removed in 0.20.")
+@deprecated("The functon distribute_covar_matrix_to_match_covariance_type"
+            "is deprecated and will be removed in 0.20.")
 def distribute_covar_matrix_to_match_covariance_type(
         tied_cv, covariance_type, n_components):
     """Create all the covariance matrices from a given template."""

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -84,7 +84,7 @@ def test_lmvnpdf_diag():
     assert_array_almost_equal(lpr, ref)
     r = assert_warns_message(DeprecationWarning, exp_msg,"The function"
                              " log_multivariate_normal_daensity is "
-                             "deprecated and will be removed in 0.20.",
+                             "deprecated and will be removed in 0.18.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'diag')
 
@@ -104,7 +104,7 @@ def test_lmvnpdf_spherical():
     assert_array_almost_equal(lpr, reference)
     r = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.20.",
+                             "deprecated and will be removed in 0.18.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'spherical')
 
@@ -123,7 +123,7 @@ def test_lmvnpdf_full():
     assert_array_almost_equal(lpr, reference)
     r = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.20.",
+                             "deprecated and will be removed in 0.18.",
                              mixture.log_multivariate_normal_density,
                              X, mu, fullcv, 'full')
 
@@ -139,7 +139,7 @@ def test_lvmpdf_full_cv_non_positive_definite():
                          X, mu, cv, 'full')
     r = assert_warns_message(DeprecationWarning,"The function" 
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.20.",     
+                             "deprecated and will be removed in 0.18.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'full')
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -134,6 +134,7 @@ def test_lvmpdf_full_cv_non_positive_definite():
     assert_raise_message(ValueError, expected_message,
                          mixture.log_multivariate_normal_density,
                          X, mu, cv, 'full')
+    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
     r = assert_warns_message(DeprecationWarning, exp_msg,
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'full')

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -12,11 +12,10 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import (assert_greater, assert_raise_message,
+                                   assert_warns_message, ignore_warnings)
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.externals.six.moves import cStringIO as StringIO
-from sklearn.utils.testing import ignore_warnings
 
 
 rng = np.random.RandomState(0)
@@ -83,6 +82,11 @@ def test_lmvnpdf_diag():
     ref = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, cv, 'diag')
     assert_array_almost_equal(lpr, ref)
+    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
+    r = assert_warns_message(DeprecationWarning, exp_msg,
+                             mixture.log_multivariate_normal_density,
+                             X, mu, cv, 'diag')
+
 
 
 def test_lmvnpdf_spherical():
@@ -97,6 +101,10 @@ def test_lmvnpdf_spherical():
     lpr = mixture.log_multivariate_normal_density(X, mu, spherecv,
                                                   'spherical')
     assert_array_almost_equal(lpr, reference)
+    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
+    r = assert_warns_message(DeprecationWarning, exp_msg,
+                             mixture.log_multivariate_normal_density,
+                             X, mu, cv, 'spherical')
 
 
 def test_lmvnpdf_full():
@@ -111,7 +119,10 @@ def test_lmvnpdf_full():
     reference = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, fullcv, 'full')
     assert_array_almost_equal(lpr, reference)
-
+    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
+    r = assert_warns_message(DeprecationWarning, exp_msg,
+                             mixture.log_multivariate_normal_density,
+                             X, mu, fullcv, 'full')
 
 def test_lvmpdf_full_cv_non_positive_definite():
     n_features, n_samples = 2, 10
@@ -123,7 +134,9 @@ def test_lvmpdf_full_cv_non_positive_definite():
     assert_raise_message(ValueError, expected_message,
                          mixture.log_multivariate_normal_density,
                          X, mu, cv, 'full')
-
+    r = assert_warns_message(DeprecationWarning, exp_msg,
+                             mixture.log_multivariate_normal_density,
+                             X, mu, cv, 'full')
 
 # This function tests the deprecated old GMM class
 @ignore_warnings(category=DeprecationWarning)

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -82,7 +82,7 @@ def test_lmvnpdf_diag():
     ref = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, cv, 'diag')
     assert_array_almost_equal(lpr, ref)
-    r = assert_warns_message(DeprecationWarning, exp_msg,"The function"
+    r = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
                              "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
@@ -106,7 +106,7 @@ def test_lmvnpdf_spherical():
                              " log_multivariate_normal_density is "
                              "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
-                             X, mu, cv, 'spherical')
+                             X, mu, spherecv, 'spherical')
 
 
 def test_lmvnpdf_full():

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -80,14 +80,12 @@ def test_lmvnpdf_diag():
     X = rng.randint(10) * rng.rand(n_samples, n_features)
 
     ref = _naive_lmvnpdf_diag(X, mu, cv)
-    lpr = mixture.log_multivariate_normal_density(X, mu, cv, 'diag')
-    assert_array_almost_equal(lpr, ref)
-    r = assert_warns_message(DeprecationWarning, "The function"
+    lpr = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
                              "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'diag')
-
+    assert_array_almost_equal(lpr, ref)
 
 
 def test_lmvnpdf_spherical():
@@ -99,15 +97,12 @@ def test_lmvnpdf_spherical():
 
     cv = np.tile(spherecv, (n_features, 1))
     reference = _naive_lmvnpdf_diag(X, mu, cv)
-    lpr = mixture.log_multivariate_normal_density(X, mu, spherecv,
-                                                  'spherical')
-    assert_array_almost_equal(lpr, reference)
-    r = assert_warns_message(DeprecationWarning, "The function"
+    lpr = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
                              "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, spherecv, 'spherical')
-
+    assert_array_almost_equal(lpr, reference)
 
 def test_lmvnpdf_full():
     n_features, n_components, n_samples = 2, 3, 10
@@ -119,13 +114,13 @@ def test_lmvnpdf_full():
     fullcv = np.array([np.diag(x) for x in cv])
 
     reference = _naive_lmvnpdf_diag(X, mu, cv)
-    lpr = mixture.log_multivariate_normal_density(X, mu, fullcv, 'full')
-    assert_array_almost_equal(lpr, reference)
-    r = assert_warns_message(DeprecationWarning, "The function"
+    lpr = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
                              "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, fullcv, 'full')
+    assert_array_almost_equal(lpr, reference)
+
 
 def test_lvmpdf_full_cv_non_positive_definite():
     n_features, n_samples = 2, 10
@@ -137,11 +132,7 @@ def test_lvmpdf_full_cv_non_positive_definite():
     assert_raise_message(ValueError, expected_message,
                          mixture.log_multivariate_normal_density,
                          X, mu, cv, 'full')
-    r = assert_warns_message(DeprecationWarning,"The function" 
-                             " log_multivariate_normal_density is "
-                             "deprecated in 0.18 and will be removed in 0.20.",
-                             mixture.log_multivariate_normal_density,
-                             X, mu, cv, 'full')
+
 
 # This function tests the deprecated old GMM class
 @ignore_warnings(category=DeprecationWarning)

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -84,7 +84,7 @@ def test_lmvnpdf_diag():
     assert_array_almost_equal(lpr, ref)
     r = assert_warns_message(DeprecationWarning, exp_msg,"The function"
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.18.",
+                             "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'diag')
 
@@ -104,7 +104,7 @@ def test_lmvnpdf_spherical():
     assert_array_almost_equal(lpr, reference)
     r = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.18.",
+                             "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'spherical')
 
@@ -123,7 +123,7 @@ def test_lmvnpdf_full():
     assert_array_almost_equal(lpr, reference)
     r = assert_warns_message(DeprecationWarning, "The function"
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.18.",
+                             "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, fullcv, 'full')
 
@@ -139,7 +139,7 @@ def test_lvmpdf_full_cv_non_positive_definite():
                          X, mu, cv, 'full')
     r = assert_warns_message(DeprecationWarning,"The function" 
                              " log_multivariate_normal_density is "
-                             "deprecated and will be removed in 0.18.",
+                             "deprecated in 0.18 and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'full')
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -82,8 +82,9 @@ def test_lmvnpdf_diag():
     ref = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, cv, 'diag')
     assert_array_almost_equal(lpr, ref)
-    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
-    r = assert_warns_message(DeprecationWarning, exp_msg,
+    r = assert_warns_message(DeprecationWarning, exp_msg,"The function"
+                             " log_multivariate_normal_daensity is "
+                             "deprecated and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'diag')
 
@@ -101,8 +102,9 @@ def test_lmvnpdf_spherical():
     lpr = mixture.log_multivariate_normal_density(X, mu, spherecv,
                                                   'spherical')
     assert_array_almost_equal(lpr, reference)
-    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
-    r = assert_warns_message(DeprecationWarning, exp_msg,
+    r = assert_warns_message(DeprecationWarning, "The function"
+                             " log_multivariate_normal_density is "
+                             "deprecated and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'spherical')
 
@@ -119,8 +121,9 @@ def test_lmvnpdf_full():
     reference = _naive_lmvnpdf_diag(X, mu, cv)
     lpr = mixture.log_multivariate_normal_density(X, mu, fullcv, 'full')
     assert_array_almost_equal(lpr, reference)
-    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
-    r = assert_warns_message(DeprecationWarning, exp_msg,
+    r = assert_warns_message(DeprecationWarning, "The function"
+                             " log_multivariate_normal_density is "
+                             "deprecated and will be removed in 0.20.",
                              mixture.log_multivariate_normal_density,
                              X, mu, fullcv, 'full')
 
@@ -134,8 +137,9 @@ def test_lvmpdf_full_cv_non_positive_definite():
     assert_raise_message(ValueError, expected_message,
                          mixture.log_multivariate_normal_density,
                          X, mu, cv, 'full')
-    exp_msg = "The class GMM is deprecated and will be removed in 0.20."
-    r = assert_warns_message(DeprecationWarning, exp_msg,
+    r = assert_warns_message(DeprecationWarning,"The function" 
+                             " log_multivariate_normal_density is "
+                             "deprecated and will be removed in 0.20.",     
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'full')
 

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -83,7 +83,7 @@ def test_lmvnpdf_diag():
     lpr = mixture.log_multivariate_normal_density(X, mu, cv, 'diag')
     assert_array_almost_equal(lpr, ref)
     r = assert_warns_message(DeprecationWarning, exp_msg,"The function"
-                             " log_multivariate_normal_daensity is "
+                             " log_multivariate_normal_density is "
                              "deprecated and will be removed in 0.18.",
                              mixture.log_multivariate_normal_density,
                              X, mu, cv, 'diag')


### PR DESCRIPTION
I deprecated two functions in mixture/gmm.py as directed by @tguillemot. 
#### Reference Issue

<!-- None-->
#### What does this implement/fix? Explain your changes.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
