### PR TITLE
Install doc fixed Linux numpy warning about pip

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -28,13 +28,10 @@ or ``conda``::
 
     conda install scikit-learn
 
-**We don't recommend installing scipy or numpy using pip on linux**,
-as this will involve a lengthy build-process with many dependencies.
-Without careful configuration, building numpy yourself can lead to an installation
-that is much slower than it should be. 
-If you are using Linux, consider using your package manager to install
-scikit-learn. It is usually the easiest way, but might not provide the newest
-version.
+
+If you are using Linux, ``pip`` should work for installing numpy and scipy, but
+consider using your package manager to install scikit-learn. It is usually the 
+easiest way, but might not provide the newestversion. 
 If you haven't already installed numpy and scipy and can't install them via
 your operation system, it is recommended to use a third party distribution.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #7019
#### What does this implement/fix? Explain your changes.

This changes the install doc to say that you can use pip for numpy/Scipy in Linux but that the package manager scikit-learn is still recommended, even if it's old.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
