### PR TITLE
[MRG + 1] update test_common.py deprecation warning

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -222,7 +222,6 @@ def test_transformer_n_iter():
             else:
                 yield check_transformer_n_iter, name, estimator
 
-@ignore_warnings(category=DeprecationWarning)
 def test_get_params_invariance():
     # Test for estimators that support get_params, that
     # get_params(deep=False) is a subset of get_params(deep=True)
@@ -232,8 +231,8 @@ def test_get_params_invariance():
                                 include_other=True)
     for name, Estimator in estimators:
         if hasattr(Estimator, 'get_params'):
-            # The ProjectedGradientNMF class is deprecated
-            if issubclass(Estimator, ProjectedGradientNMF):
+            # If class is deprecated, ignore deprecated warnings
+            if hasattr(Estimator.__init__, "deprecated_original"):
                 with ignore_warnings():
                     yield check_get_params_invariance, name, Estimator
             else:

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -222,7 +222,7 @@ def test_transformer_n_iter():
             else:
                 yield check_transformer_n_iter, name, estimator
 
-
+@ignore_warnings(category=DeprecationWarning)
 def test_get_params_invariance():
     # Test for estimators that support get_params, that
     # get_params(deep=False) is a subset of get_params(deep=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Too much warnings during the testing process #7006
#### What does this implement/fix? Explain your changes.

sklearn.tests.test_common.test_get_params_invariance('RandomizedPCA', <class 'sklearn.d
ecomposition.pca.RandomizedPCA'>) ... /Users/bf/Desktop/Scipy2016/Sprints/scikit-learn/
scikit-learn/sklearn/utils/deprecation.py:52: DeprecationWarning: Class RandomizedPCA i
s deprecated; RandomizedPCA will be removed in 0.20. Use PCA(svd_solver='randomized') i
nstead. The new implementation DOES NOT store whiten components_. Apply transform to ge
t them.
  warnings.warn(msg, category=DeprecationWarning)
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
