### PR TITLE
Timing and training score in *SearchCV.results_

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -541,7 +541,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
           for parameters in parameter_iterable
           for train, test in cv.split(X, y, labels))
 
-        # if one choose to see train score, out will have train score info.
+        # if one choose to see train score, "out" will contain train score info
         if self.return_train_score:
             train_scores, test_scores, test_sample_counts, _, parameters =\
                 zip(*out)
@@ -761,6 +761,9 @@ class GridSearchCV(BaseSearchCV):
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error.
 
+    return_train_score: boolean, default=False
+        If "True", the results_ attribute will include training scores.
+
 
     Examples
     --------
@@ -779,13 +782,13 @@ class GridSearchCV(BaseSearchCV):
                          random_state=None, shrinking=True, tol=...,
                          verbose=False),
            fit_params={}, iid=..., n_jobs=1,
-           param_grid=..., pre_dispatch=..., refit=...,
+           param_grid=..., pre_dispatch=..., refit=..., return_train_score=...,
            scoring=..., verbose=...)
     >>> sorted(clf.results_.keys())
     ...                             # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ['param_C', 'param_kernel', 'params', 'test_mean_score',...
-     'test_rank_score', 'test_split0_score', 'test_split1_score',...
-     'test_split2_score', 'test_std_score']
+    ['param_C', 'param_kernel', 'params', 'test_mean_score', 'test_mean_time',
+     'test_rank_score', 'test_split0_score', 'test_split1_score',
+     'test_split2_score', 'test_std_score', 'test_std_time']
 
     Attributes
     ----------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -822,13 +822,17 @@ class GridSearchCV(BaseSearchCV):
             'test_split0_score' : [0.8, 0.7, 0.8, 0.9],
             'test_split1_score' : [0.82, 0.5, 0.7, 0.78],
             'test_mean_score'   : [0.81, 0.60, 0.75, 0.82],
+            'test_mean_time'    : [ 0.00073,  0.00063,  0.00043,  0.00049]
+            'test_std_time'     : [ 1.62e-4,   3.37e-5,   1.42e-5, 1.1e-5]
             'test_std_score'    : [0.02, 0.01, 0.03, 0.03],
             'test_rank_score'   : [2, 4, 3, 1],
             'params'            : [{'kernel': 'poly', 'degree': 2}, ...],
             }
 
         NOTE that the key ``'params'`` is used to store a list of parameter
-        settings dict for all the parameter candidates.
+        settings dict for all the parameter candidates.  Besides,
+        'train_mean_score', 'train_split*_score', ... will be present when
+        return_train_score is set to True.
 
     best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
@@ -1026,6 +1030,9 @@ class RandomizedSearchCV(BaseSearchCV):
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error.
 
+    return_train_score: boolean, default=False
+        If "True", the results_ attribute will include training scores.
+
     Attributes
     ----------
     results_ : dict of numpy (masked) ndarrays
@@ -1053,13 +1060,17 @@ class RandomizedSearchCV(BaseSearchCV):
             'test_split0_score' : [0.8, 0.9, 0.7],
             'test_split1_score' : [0.82, 0.5, 0.7],
             'test_mean_score'   : [0.81, 0.7, 0.7],
+            'test_mean_time'    : [0.00073, 0.00063, 0.00043]
+            'test_std_time'     : [1.62e-4, 3.37e-5, 1.1e-5]
             'test_std_score'    : [0.02, 0.2, 0.],
             'test_rank_score'   : [3, 1, 1],
             'params' : [{'kernel' : 'rbf', 'gamma' : 0.1}, ...],
             }
 
         NOTE that the key ``'params'`` is used to store a list of parameter
-        settings dict for all the parameter candidates.
+        settings dict for all the parameter candidates.  Besides,
+        'train_mean_score', 'train_split*_score', ... will be present when
+        return_train_score is set to True.
 
     best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -602,16 +602,18 @@ def test_grid_search_results():
     params = [dict(kernel=['rbf', ], C=[1, 10], gamma=[0.1, 1]),
               dict(kernel=['poly', ], degree=[1, 2])]
     grid_search = GridSearchCV(SVC(), cv=n_folds, iid=False,
-                               param_grid=params)
+                               param_grid=params, return_train_score=True)
     grid_search.fit(X, y)
     grid_search_iid = GridSearchCV(SVC(), cv=n_folds, iid=True,
-                                   param_grid=params)
+                                   param_grid=params, return_train_score=True)
     grid_search_iid.fit(X, y)
 
     param_keys = ('param_C', 'param_degree', 'param_gamma', 'param_kernel')
-    score_keys = ('test_mean_score', 'test_rank_score',
-                  'test_split0_score', 'test_split1_score',
-                  'test_split2_score', 'test_std_score')
+    score_keys = ('test_mean_score', 'train_mean_score', 'test_mean_time',
+                  'test_rank_score', 'test_split0_score', 'test_split1_score',
+                  'test_split2_score', 'train_split0_score',
+                  'train_split1_score', 'train_split2_score',
+                  'test_std_score', 'train_std_score', 'test_std_time')
     n_candidates = n_grid_points
 
     for search, iid in zip((grid_search, grid_search_iid), (False, True)):
@@ -649,17 +651,21 @@ def test_random_search_results():
     n_search_iter = 30
     params = dict(C=expon(scale=10), gamma=expon(scale=0.1))
     random_search = RandomizedSearchCV(SVC(), n_iter=n_search_iter, cv=n_folds,
-                                       iid=False, param_distributions=params)
+                                       iid=False, param_distributions=params,
+                                       return_train_score=True)
     random_search.fit(X, y)
     random_search_iid = RandomizedSearchCV(SVC(), n_iter=n_search_iter,
                                            cv=n_folds, iid=True,
-                                           param_distributions=params)
+                                           param_distributions=params,
+                                           return_train_score=True)
     random_search_iid.fit(X, y)
 
     param_keys = ('param_C', 'param_gamma')
-    score_keys = ('test_mean_score', 'test_rank_score',
-                  'test_split0_score', 'test_split1_score',
-                  'test_split2_score', 'test_std_score')
+    score_keys = ('test_mean_score', 'train_mean_score', 'test_mean_time',
+                  'test_rank_score', 'test_split0_score', 'test_split1_score',
+                  'test_split2_score', 'train_split0_score',
+                  'train_split1_score', 'train_split2_score',
+                  'test_std_score', 'train_std_score', 'test_std_time')
     n_cand = n_search_iter
 
     for search, iid in zip((random_search, random_search_iid), (False, True)):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -619,6 +619,13 @@ def test_grid_search_results():
     for search, iid in zip((grid_search, grid_search_iid), (False, True)):
         assert_equal(iid, search.iid)
         results = search.results_
+        # Check if score and timing are reasonable
+        assert_true(all(results['test_rank_score'] >= 1))
+        assert_true(all(results[k] >= 0) for k in score_keys
+                    if k is not 'test_rank_score')
+        assert_true(all(results[k] <= 1) for k in score_keys
+                    if not k.endswith('time') and
+                    k is not 'test_rank_score')
         # Check results structure
         check_results_array_types(results, param_keys, score_keys)
         check_results_keys(results, param_keys, score_keys, n_candidates)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Resolves #6894 Timing in *SearchCV.results_
               #6895 Training Score in *SearchCV.results_
#### What does this implement/fix? Explain your changes.

The _fit method in BaseSearchCV calls the _fit_and_score function from module _validation.
_fit_and_score has the ability to report train_score, but not by default.  On the other hand,
the __init__ of BaseSearchCV does not accept return_train_score as an optional keyword.  As a result, there was no way to have the results_ attribute receving train score.

The fix is to add the keyword return_train_score to the __init__ of BaseSearchCV (which is inherited by both GridSearchCV and RandomizedSearchCV).  Default is still set to False.  When return_train_score is set to True, a set of addition steps is taken to put train_score into results_

The timing information is always available but was not written into "results_".  This patch also writes timing info into results_ by default.
#### Any other comments?

Test is also re-written.  In the test I explicitly choose return_train_score=True for better coverage.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
