### PR TITLE
Avoid deprecation from inspect.getargspec()

### DIFF
--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -435,7 +435,7 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
-                argspec = inspect.getargspec(func)
+                argspec = inspect.signature(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -7,6 +7,7 @@ import textwrap
 import re
 import pydoc
 from warnings import warn
+import sys
 # Try Python 2 first, otherwise load from Python 3
 try:
     from StringIO import StringIO
@@ -435,7 +436,11 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
-                argspec = inspect.signature(func)
+                if 3 > sys.version_info[0]:
+                   argspec = inspect.getargspec(func)
+                else:
+                   # getargspec deprecated in python3
+                   argspec = inspect.signature(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -171,10 +171,10 @@ def getfullargspec(func):
         return inspect.getfullargspec(func)
     except AttributeError:
         if 3 > sys.version_info[0]:
-           argspec = inspect.getargspec(func)
+           arg_spec = inspect.getargspec(func)
         else:
            # getargspec deprecated in python3
-           argspec = inspect.signature(func)
+           arg_spec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -169,7 +169,7 @@ def getfullargspec(func):
     try:
         return inspect.getfullargspec(func)
     except AttributeError:
-        arg_spec = inspect.getargspec(func)
+        arg_spec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -11,6 +11,7 @@ import inspect
 import warnings
 import re
 import os
+import sys
 
 from ._compat import _basestring
 from .logger import pformat

--- a/sklearn/externals/joblib/func_inspect.py
+++ b/sklearn/externals/joblib/func_inspect.py
@@ -169,7 +169,11 @@ def getfullargspec(func):
     try:
         return inspect.getfullargspec(func)
     except AttributeError:
-        arg_spec = inspect.signature(func)
+        if 3 > sys.version_info[0]:
+           argspec = inspect.getargspec(func)
+        else:
+           # getargspec deprecated in python3
+           argspec = inspect.signature(func)
         import collections
         tuple_fields = ('args varargs varkw defaults kwonlyargs '
                         'kwonlydefaults annotations')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

None
#### What does this implement/fix? Explain your changes.

Changed /sphinxext/numpy_ext/docscrape.py and sklearn/externals/joblib/func_inspect.py to avoid DepricationWarning and use latest function.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

However, there are several test warnings (currently 7 after nosetest --verbose) that occur from nose\util.py similar to
C:\Anaconda3\envs\my_scikit-learn\lib\site-packages\nose\util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
This can be duplicated with
$ nosetests --verbose 'C:\Users\fthomassy\Documents\GitHub\scikit-learn\sklearn\metrics\tests\test_score_objects.py'

@tguillemot
