### PR TITLE
[MRG + 1] Add best way ask questions; Fixes #6815

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -65,7 +65,7 @@ The following people have been core contributors to scikit-learn's development a
   * `Gael Varoquaux <http://gael-varoquaux.info/blog/>`_
   * Ron Weissz
 
-Please do not contact the authors directly with bug reports or feature requests.
+Please do not email the authors directly with bug reports or feature requests.
 To address those concerns, please make use of the
 <issue tracker on Github 'https://github.com/scikit-learn/scikit-learn/issues'>
 or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
@@ -74,4 +74,4 @@ or you have a more general question about
 machine learning, please consult 'Stack Overflow <http://stackoverflow.com>'
 or 'Cross Validated <stats.stackexchange.com>' before contacting the mailing
 list. Those sites may already have an answer to your question. They provide
-convenient search and access to many users that may not be on the mailing list.
+convenient search, and access to many users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,11 +67,11 @@ The following people have been core contributors to scikit-learn's development a
 
 Please do not email the authors directly with bug reports or feature requests.
 To address those concerns, please make use of the
-`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`
-or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`.
+`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
+or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
 If you are not sure whether you have a found a bug,
 or you have a more general question about
-machine learning, please consult `Stack Overflow <http://stackoverflow.com>'
-or 'Cross Validated <http://stats.stackexchange.com>' before contacting the mailing
+machine learning, please consult `Stack Overflow <http://stackoverflow.com>`_
+or `Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
 list. Those sites may already have an answer to your question. They provide
 convenient search, and access to many users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,6 @@ or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
 If you are not sure whether you have a found a bug,
 or you have a more general question about
 machine learning, please consult 'Stack Overflow <http://stackoverflow.com>'
-or 'Cross Validated <stats.stackexchange.com>' before contacting the mailing
+or 'Cross Validated <http://stats.stackexchange.com>' before contacting the mailing
 list. Those sites may already have an answer to your question. They provide
 convenient search, and access to many users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,8 +70,8 @@ To address those concerns, please make use of the
 `issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
 or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
 If you are not sure whether you have a found a bug,
-or you have a more general question about
+or if you have a more general question about
 machine learning, please consult `Stack Overflow <http://stackoverflow.com>`_
 or `Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
 list. Those sites may already have an answer to your question. They provide
-convenient search, and access to many users that may not be on the mailing list.
+convenient search, and access to a community of users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,4 +63,15 @@ The following people have been core contributors to scikit-learn's development a
   * `Jake VanderPlas <http://www.astro.washington.edu/users/vanderplas/>`_
   * Nelle Varoquaux
   * `Gael Varoquaux <http://gael-varoquaux.info/blog/>`_
-  * Ron Weiss
+  * Ron Weissz
+
+Please do not contact the authors directly with bug reports or feature requests.
+To address those concerns, please make use of the
+<issue tracker on Github 'https://github.com/scikit-learn/scikit-learn/issues'>
+or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
+If you are not sure whether you have a found a bug,
+or you have a more general question about
+machine learning, please consult 'Stack Overflow <http://stackoverflow.com>'
+or 'Cross Validated <stats.stackexchange.com>' before contacting the mailing
+list. Those sites may already have an answer to your question. They provide
+convenient search and access to many users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,11 +67,11 @@ The following people have been core contributors to scikit-learn's development a
 
 Please do not email the authors directly with bug reports or feature requests.
 To address those concerns, please make use of the
-<issue tracker on Github 'https://github.com/scikit-learn/scikit-learn/issues'>
-or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
+`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`
+or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`.
 If you are not sure whether you have a found a bug,
 or you have a more general question about
-machine learning, please consult 'Stack Overflow <http://stackoverflow.com>'
+machine learning, please consult `Stack Overflow <http://stackoverflow.com>'
 or 'Cross Validated <http://stats.stackexchange.com>' before contacting the mailing
 list. Those sites may already have an answer to your question. They provide
 convenient search, and access to many users that may not be on the mailing list.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,7 +63,7 @@ The following people have been core contributors to scikit-learn's development a
   * `Jake VanderPlas <http://www.astro.washington.edu/users/vanderplas/>`_
   * Nelle Varoquaux
   * `Gael Varoquaux <http://gael-varoquaux.info/blog/>`_
-  * Ron Weissz
+  * Ron Weiss
 
 Please do not email the authors directly with bug reports or feature requests.
 To address those concerns, please make use of the

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,12 +66,6 @@ The following people have been core contributors to scikit-learn's development a
   * Ron Weiss
 
 Please do not email the authors directly with bug reports or feature requests.
-To address those concerns, please make use of the
-`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
-or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
-If you are not sure whether you have a found a bug,
-or if you have a more general question about
-machine learning, please consult `Stack Overflow <http://stackoverflow.com>`_
-or `Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
-list. Those sites may already have an answer to your question. They provide
-convenient search, and access to a community of users that may not be on the mailing list.
+Instead, please see `What's the best way to ask questions about scikit-learn
+<http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-ask-questions-about-scikit-learn>`_
+in the FAQ.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -37,8 +37,9 @@ The quickest way to get replies to your questions is posting on
  Please don't ask general machine learning questions on the mailing list.
 
 For bug reports or feature requests, please make use of the
-`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
-or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
+`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_,
+the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_, or
+the 'Scikit-learn community on Gitter <https://gitter.im/scikit-learn/scikit-learn>'_.
 Please do not email the authors directly with bug reports or feature requests.
 
 How can I create a bunch object?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -28,16 +28,16 @@ issues <easy_issues>`.
 
 What's the best way to ask questions about scikit-learn?
 --------------------------------------------------------------
-We of course want to help scikit-learn users. But for broader questions about
-using the package or about machine learning, we suggest searching 
-`Stack Overflow <http://stackoverflow.com>`_ or 
-`Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
-list. Those sites may already have an answer to your question. They provide a
-convenient search interface, and access to many users that may not be on the mailing list.
-
 For bug reports or feature requests, please make use of the
 `issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
 or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
+
+We of course want to help scikit-learn users, but we suggest searching 
+`Stack Overflow <http://stackoverflow.com>`_ or 
+`Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
+list. Those sites may already have an answer to your question. They provide a
+convenient search interface, and access to a community of users that may not be on the mailing list.
+Those sites can also provide answers to questions about machine learning in general.
 
 Please do not email the authors directly with bug reports or feature requests.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -31,7 +31,7 @@ What's the best way to ask questions about scikit-learn?
 The quickest way to get replies to your questions is posting on 
 `Stack Overflow <http://stackoverflow.com>`_ or 
 `Cross Validated <http://stats.stackexchange.com>`_ 
- with the "scikit-learn" or "machine learning" tags. These sites may already have an answer
+ with the "scikit-learn" or "machine-learning" tags. These sites may already have an answer
  for your question and provide a convenient search interface. You can also post questions
  on the mailing list, though that often has longer turn-around times.
  Please don't ask general machine learning questions on the mailing list.
@@ -39,7 +39,7 @@ The quickest way to get replies to your questions is posting on
 For bug reports or feature requests, please make use of the
 `issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_,
 the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_, or
-the 'Scikit-learn community on Gitter <https://gitter.im/scikit-learn/scikit-learn>'_.
+the `scikit-learn community on Gitter <https://gitter.im/scikit-learn/scikit-learn>`_.
 Please do not email the authors directly with bug reports or feature requests.
 
 How can I create a bunch object?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -26,6 +26,20 @@ See :ref:`contributing`. Before wanting to add a new algorithm, which is
 usually a major and lengthy undertaking, it is recommended to start with :ref:`known
 issues <easy_issues>`.
 
+What's the best way to ask questions about scikit-learn?
+--------------------------------------------------------------
+We of course want to help scikit-learn users. But for broader questions about
+using the package or about machine learning, we suggest searching 
+'Stack Overflow <http://stackoverflow.com>' or 
+'Cross Validated <stats.stackexchange.com>' before contacting the mailing
+list. Those sites may already have an answer to your question. They provide a
+convenient search interface, and access to many users that may not be on the mailing list.
+
+For bug reports or feature requests, please make use of the
+<issue tracker on Github 'https://github.com/scikit-learn/scikit-learn/issues'>
+or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
+
+Please do not email the authors directly with bug reports or feature requests.
 
 How can I create a bunch object?
 ------------------------------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -28,17 +28,17 @@ issues <easy_issues>`.
 
 What's the best way to ask questions about scikit-learn?
 --------------------------------------------------------------
+The quickest way to get replies to your questions is posting on 
+`Stack Overflow <http://stackoverflow.com>`_ or 
+`Cross Validated <http://stats.stackexchange.com>`_ 
+ with the "scikit-learn" or "machine learning" tags. These sites may already have an answer
+ for your question and provide a convenient search interface. You can also post questions
+ on the mailing list, though that often has longer turn-around times.
+ Please don't ask general machine learning questions on the mailing list.
+
 For bug reports or feature requests, please make use of the
 `issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
 or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
-
-Helping users is important to us, but we suggest searching 
-`Stack Overflow <http://stackoverflow.com>`_ or 
-`Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
-list. Those sites may already have an answer to your question. They provide a
-convenient search interface, and access to a community of users that may not be on the mailing list.
-Those sites can also provide answers to questions about machine learning in general.
-
 Please do not email the authors directly with bug reports or feature requests.
 
 How can I create a bunch object?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -31,7 +31,7 @@ What's the best way to ask questions about scikit-learn?
 We of course want to help scikit-learn users. But for broader questions about
 using the package or about machine learning, we suggest searching 
 'Stack Overflow <http://stackoverflow.com>' or 
-'Cross Validated <stats.stackexchange.com>' before contacting the mailing
+'Cross Validated <http://stats.stackexchange.com>' before contacting the mailing
 list. Those sites may already have an answer to your question. They provide a
 convenient search interface, and access to many users that may not be on the mailing list.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -36,8 +36,8 @@ list. Those sites may already have an answer to your question. They provide a
 convenient search interface, and access to many users that may not be on the mailing list.
 
 For bug reports or feature requests, please make use of the
-<issue tracker on Github 'https://github.com/scikit-learn/scikit-learn/issues'>
-or the <mailing list 'https://mail.python.org/mailman/listinfo/scikit-learn'>.
+`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`
+or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>.
 
 Please do not email the authors directly with bug reports or feature requests.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -32,7 +32,7 @@ For bug reports or feature requests, please make use of the
 `issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
 or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
 
-We of course want to help scikit-learn users, but we suggest searching 
+Helping users is important to us, but we suggest searching 
 `Stack Overflow <http://stackoverflow.com>`_ or 
 `Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
 list. Those sites may already have an answer to your question. They provide a

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -30,14 +30,14 @@ What's the best way to ask questions about scikit-learn?
 --------------------------------------------------------------
 We of course want to help scikit-learn users. But for broader questions about
 using the package or about machine learning, we suggest searching 
-'Stack Overflow <http://stackoverflow.com>' or 
-'Cross Validated <http://stats.stackexchange.com>' before contacting the mailing
+`Stack Overflow <http://stackoverflow.com>`_ or 
+`Cross Validated <http://stats.stackexchange.com>`_ before contacting the mailing
 list. Those sites may already have an answer to your question. They provide a
 convenient search interface, and access to many users that may not be on the mailing list.
 
 For bug reports or feature requests, please make use of the
-`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`
-or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>.
+`issue tracker on Github <https://github.com/scikit-learn/scikit-learn/issues>`_
+or the `mailing list <https://mail.python.org/mailman/listinfo/scikit-learn>`_.
 
 Please do not email the authors directly with bug reports or feature requests.
 


### PR DESCRIPTION
I added text with links as described in issue #6815.
The formatting checks out on build, see pngs below. In the faq I tried to be helpful and used 'we' in keeping with the tone of the rest of the document.
![screenshot from 2016-07-17 15-49-15](https://cloud.githubusercontent.com/assets/11934090/16903030/87b677ca-4c37-11e6-9b5a-a556ca24faf4.png)
![screenshot from 2016-07-17 15-49-29](https://cloud.githubusercontent.com/assets/11934090/16903031/894a70aa-4c37-11e6-80ec-2d4c43f78e58.png)

Fixes #6815.
