### PR TITLE
Add Bold Titles for the User Guide Sidebar boxes #7021

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -262,9 +262,9 @@
     {% endif %}
 
     {%- if pagename != "install" %}
-      <p class="doc-version">This documentation is for {{project}} <strong>version {{ release|e }}</strong> &mdash; <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
+      <p class="doc-version"><b><strong>VERSION:</strong></b>This documentation is for {{project}} <strong>version {{ release|e }}</strong> &mdash; <a href="http://scikit-learn.org/stable/support.html#documentation-resources">Other versions</a></p>
     {%- endif %}
-    <p class="citing">If you use the software, please consider <a href="{{pathto('about')}}#citing-scikit-learn">citing scikit-learn</a>.</p>
+    <p class="citing"><strong><b>CITE US:</b></strong>If you use the software, please consider <a href="{{pathto('about')}}#citing-scikit-learn">citing scikit-learn</a>.</p>
     {{ toc }}
     </div>
 </div>


### PR DESCRIPTION
#7021

Reformatted the User Guide side boxes by adding bold titles CITE US and VERSION so that people notice them!
