### PR TITLE
[WIP/RFC] ENH identify when user has passed scoring=metric and raise error

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -515,10 +515,11 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
         estimator = self.estimator
         cv = check_cv(self.cv, y, classifier=is_classifier(estimator))
-        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
-
         X, y, labels = indexable(X, y, labels)
         n_splits = cv.get_n_splits(X, y, labels)
+        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring,
+                                     metric_check_y=y)
+
         if self.verbose > 0 and isinstance(parameter_iterable, Sized):
             n_candidates = len(parameter_iterable)
             print("Fitting {0} folds for each of {1} candidates, totalling"

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -15,6 +15,7 @@ from sklearn.utils.fixes import sp_version
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_false, assert_true
@@ -982,3 +983,11 @@ def test_parameters_sampler_replacement():
     sampler = ParameterSampler(params_distribution, n_iter=7)
     samples = list(sampler)
     assert_equal(len(samples), 7)
+
+
+def test_scoring_is_not_metric():
+    clf = MockClassifier()
+    grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, verbose=3,
+                               scoring=f1_score)
+    assert_raises_regexp(ValueError, 'make_scorer', grid_search.fit, X, y)
+    grid_search.fit(X, y)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -990,4 +990,3 @@ def test_scoring_is_not_metric():
     grid_search = GridSearchCV(clf, {'foo_param': [1, 2, 3]}, verbose=3,
                                scoring=f1_score)
     assert_raises_regexp(ValueError, 'make_scorer', grid_search.fit, X, y)
-    grid_search.fit(X, y)


### PR DESCRIPTION
?Fixes #6775.

I can hardly blame users for putting a metric where a scoring function belongs. But perhaps we can help them by raising an error when the passed function does not have the signature of a scorer. This (only roughly implemented and tested for grid search) PR takes a similar approach: raise an error when the passed function behaves like a metric.

Regarding the broader problem of helping users understand the distinction between metrics and scorers: we may alleviate this a bit if we put the entire scoring abstraction under `model_selection`...? Conceptually this might be good, but I have my doubts as I reconsider the kinds of errors users are making now.
