### PR TITLE
fixes #7042, typo in randomized parameter optimization

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -100,8 +100,8 @@ iterations, is specified using the ``n_iter`` parameter.
 For each parameter, either a distribution over possible values or a list of
 discrete choices (which will be sampled uniformly) can be specified::
 
-  [{'C': scipy.stats.expon(scale=100), 'gamma': scipy.stats.expon(scale=.1),
-    'kernel': ['rbf'], 'class_weight':['balanced', None]}]
+  {'C': scipy.stats.expon(scale=100), 'gamma': scipy.stats.expon(scale=.1),
+    'kernel': ['rbf'], 'class_weight':['balanced', None]}
 
 This example uses the ``scipy.stats`` module, which contains many useful
 distributions for sampling parameters, such as ``expon``, ``gamma``,


### PR DESCRIPTION
This works on build as shown in the screenshot.
The example is now a dictionary instead of a list of a dictionary
![screenshot from 2016-07-18 09-20-47](https://cloud.githubusercontent.com/assets/11934090/16918532/64c5162e-4ccb-11e6-84e3-b48f1bf1f212.png)
