### PR TITLE
[MRG + 1] load_iris dataset: added return_X_y option

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -230,6 +230,9 @@ Enhancements
      (`#6846 <https://github.com/scikit-learn/scikit-learn/pull/6846>`_)
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
+   - Added new return type ``(data, target)`` : tuple option to :func:`load_iris` dataset. (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) 
+     By `Manvendra Singh`_ and `Nelson Liu`_.   
+
 Bug fixes
 .........
 
@@ -4307,3 +4310,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _YenChen Lin: https://github.com/yenchenlin
 
 .. _Nelson Liu: https://github.com/nelson-liu
+
+.. _Manvendra Singh: https://github.com/manu-chroma

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -261,7 +261,7 @@ def load_iris(return_X_y=False):
     Parameters
      ----------
     return_X_y : boolean, default=False.
-        If True, returns (data, target) instead of a Bunch object.
+        If True, returns ``(data, target)`` instead of a Bunch object.
         See below for more information about the `data` and `target` object.
 
     Returns
@@ -273,7 +273,7 @@ def load_iris(return_X_y=False):
         meaning of the features, and 'DESCR', the
         full description of the dataset.
 
-    (data,target) : tuple if return_X_y == True
+    (data,target) : tuple if ``return_X_y`` is True
 
     Examples
     --------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -262,16 +262,21 @@ def load_iris(return_X_y=False):
      ----------
     return_X_y : boolean, default=False.
         If True, returns (data, target) instead of a Bunch object.
-        See below for more information about the `data` and `target` object
+        See below for more information about the `data` and `target` object.
 
     Returns
     -------
+    if return_X_y == false
     data : Bunch
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
         full description of the dataset.
+    
+    if return_X_y == true
+    (data,target) : tuple
+
 
     Examples
     --------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -272,6 +272,7 @@ def load_iris(return_X_y=False):
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
         full description of the dataset.
+
     (data,target) : tuple if return_X_y == True
 
     Examples

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -266,7 +266,6 @@ def load_iris(return_X_y=False):
 
     Returns
     -------
-    if return_X_y == false
     data : Bunch
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the classification labels,
@@ -274,8 +273,7 @@ def load_iris(return_X_y=False):
         meaning of the features, and 'DESCR', the
         full description of the dataset.
     
-    if return_X_y == true
-    (data,target) : tuple
+    (data,target) : tuple if return_X_y == true
 
 
     Examples

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -272,9 +272,7 @@ def load_iris(return_X_y=False):
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
         full description of the dataset.
-    
-    (data,target) : tuple if return_X_y == true
-
+    (data,target) : tuple if return_X_y == True
 
     Examples
     --------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -271,7 +271,7 @@ def load_iris(return_X_y=False):
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
-        full description of the dataset. This is test text.
+        full description of the dataset.
 
     (data,target) : tuple if return_X_y == True
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -273,7 +273,7 @@ def load_iris(return_X_y=False):
         meaning of the features, and 'DESCR', the
         full description of the dataset.
 
-    (data,target) : tuple if ``return_X_y`` is True
+    (data, target) : tuple if ``return_X_y`` is True
 
     Examples
     --------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -271,7 +271,7 @@ def load_iris(return_X_y=False):
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
-        full description of the dataset.
+        full description of the dataset. This is test text.
 
     (data,target) : tuple if return_X_y == True
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -242,7 +242,7 @@ def load_files(container_path, description=None, categories=None,
                  DESCR=description)
 
 
-def load_iris():
+def load_iris(return_X_y=False):
     """Load and return the iris dataset (classification).
 
     The iris dataset is a classic and very easy multi-class classification
@@ -257,6 +257,12 @@ def load_iris():
     =================   ==============
 
     Read more in the :ref:`User Guide <datasets>`.
+
+    Parameters
+     ----------
+    return_X_y : boolean, default=False.
+        If True, returns (data, target) instead of a Bunch object.
+        See below for more information about the `data` and `target` object
 
     Returns
     -------
@@ -295,6 +301,9 @@ def load_iris():
 
     with open(join(module_path, 'descr', 'iris.rst')) as rst_file:
         fdescr = rst_file.read()
+
+    if return_X_y:
+        return data, target
 
     return Bunch(data=data, target=target,
                  target_names=target_names,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -259,7 +259,7 @@ def load_iris(return_X_y=False):
     Read more in the :ref:`User Guide <datasets>`.
 
     Parameters
-     ----------
+    ----------
     
         .. versionadded:: 0.18
      

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -260,6 +260,9 @@ def load_iris(return_X_y=False):
 
     Parameters
      ----------
+    
+        .. versionadded:: 0.18
+     
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
         See below for more information about the `data` and `target` object.

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -184,7 +184,7 @@ def test_load_iris():
     #test return_X_y option
     X_y_tuple = load_iris(return_X_y=True)
     bunch = load_iris()
-    assert_true(isinstance(X_y_tuple,tuple))
+    assert_true(isinstance(X_y_tuple, tuple))
     assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -26,6 +26,7 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_array_equal
 
 
 DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
@@ -179,6 +180,13 @@ def test_load_iris():
     assert_equal(res.target.size, 150)
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
+
+    #test return_X_y option
+    X_y_tuple = load_iris(return_X_y=True)
+    bunch = load_iris()
+    assert_true(isinstance(X_y_tuple,tuple))
+    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[1], bunch.target)
 
 
 def test_load_breast_cancer():

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -181,7 +181,7 @@ def test_load_iris():
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
 
-    #test return_X_y option
+    # test return_X_y option
     X_y_tuple = load_iris(return_X_y=True)
     bunch = load_iris()
     assert_true(isinstance(X_y_tuple, tuple))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Add return_tuple option to data loaders that return a Bunch https://github.com/scikit-learn/scikit-learn/issues/6670
#### What does this implement/fix? Explain your changes.
1. added return_X_y option in load_iris
2. Wrote tests for the same 
#### Any other comments?
1. Majority of the code is taken from https://github.com/scikit-learn/scikit-learn/pull/6704
2. Some improvements based on the discussion on the same PR 
3. First contribution to scikit-learn 

<!--Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
