### PR TITLE
remove redundant NotFittedError import from VotingClassifier

### DIFF
--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -19,7 +19,6 @@ from ..base import TransformerMixin
 from ..base import clone
 from ..preprocessing import LabelEncoder
 from ..externals import six
-from ..exceptions import NotFittedError
 from ..utils.validation import check_is_fitted
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Looking for something else, I found a redundant report in the VotingClassifier. This pull request just removes a `from ..exceptions import NotFittedError`, since `NotFittedError` was imported but never used.
