### PR TITLE
Fixed python2 libsvm call with unicode kernel

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -232,6 +232,15 @@ class BaseLibSVM(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         libsvm.set_verbosity_wrap(self.verbose)
 
+        if six.PY2:
+            # In python2 ensure kernel is ascii bytes to prevent a TypeError
+            if isinstance(kernel, six.types.UnicodeType):
+                kernel = str(kernel)
+        if six.PY3:
+            # In python2 ensure kernel is utf8 unicode to prevent a TypeError
+            if isinstance(kernel, bytes):
+                kernel = str(kernel, 'utf8')
+
         # we don't pass **self.get_params() to allow subclasses to
         # add other parameters to __init__
         self.support_, self.support_vectors_, self.n_support_, \

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -3,7 +3,6 @@ Testing for Support Vector Machine module (sklearn.svm)
 
 TODO: remove hard coded numerical results when possible
 """
-
 import numpy as np
 import itertools
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -25,6 +24,7 @@ from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.multiclass import OneVsRestClassifier
+from sklearn.externals import six
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
@@ -519,6 +519,30 @@ def test_bad_input():
     clf = svm.SVC()
     clf.fit(X, Y)
     assert_raises(ValueError, clf.predict, Xt)
+
+
+def test_unicode_kernel():
+    # Test that a unicode kernel name does not cause a TypeError on clf.fit
+    if six.PY2:
+        # Test unicode (same as str on python3)
+        clf = svm.SVC(kernel=unicode('linear'))
+        clf.fit(X, Y)
+
+        # Test ascii bytes (str is bytes in python2)
+        clf = svm.SVC(kernel=str('linear'))
+        clf.fit(X, Y)
+    else:
+        # Test unicode (str is unicode in python3)
+        clf = svm.SVC(kernel=str('linear'))
+        clf.fit(X, Y)
+
+        # Test ascii bytes (same as str on python2)
+        clf = svm.SVC(kernel=bytes('linear', 'ascii'))
+        clf.fit(X, Y)
+
+    # Test default behavior on both versions
+    clf = svm.SVC(kernel='linear')
+    clf.fit(X, Y)
 
 
 def test_sparse_precomputed():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### What does this implement/fix? Explain your changes.

In python2 with from **future** import absolute_import, division, print_function, unicode_literals I ran across an error when running the line: 
 When running the line 

```
    from sklearn import svm
    clf = svm.SVC(kernel='linear', C=1)
```

I received the error: 

```
   TypeError: Argument 'kernel' has incorrect type (expected str, got unicode)
```

I simply added a check for this case before the offending call, which should prevent it from occurring again. 
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
