### PR TITLE
[WIP] Adding version of deprecation to warning messages

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -36,7 +36,7 @@ from .gaussian_process.kernels import Kernel as GPKernel
 from .exceptions import FitFailedWarning
 
 
-warnings.warn("This module has been deprecated in favor of the "
+warnings.warn("This module was deprecated in version 0.18 in favor of the "
               "model_selection module into which all the refactored classes "
               "and functions are moved. Also note that the interface of the "
               "new CV iterators are different from that of this module. "

--- a/sklearn/decomposition/pca.py
+++ b/sklearn/decomposition/pca.py
@@ -512,7 +512,7 @@ class PCA(_BasePCA):
         return np.mean(self.score_samples(X))
 
 
-@deprecated("RandomizedPCA will be removed in 0.20. "
+@deprecated("RandomizedPCA was deprecated in 0.18 and will be removed in 0.20. "
             "Use PCA(svd_solver='randomized') instead. The new implementation "
             "DOES NOT store whiten components_. Apply transform to get them.")
 class RandomizedPCA(BaseEstimator, TransformerMixin):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -494,7 +494,8 @@ def test_deprecation_randomized_pca():
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
 
-    depr_message = ("Class RandomizedPCA is deprecated; RandomizedPCA will be "
+    depr_message = ("Class RandomizedPCA is deprecated; RandomizedPCA was "
+                    "deprecated in 0.18 and will be "
                     "removed in 0.20. Use PCA(svd_solver='randomized') "
                     "instead. The new implementation DOES NOT store "
                     "whiten components_. Apply transform to get them.")

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -20,7 +20,8 @@ from ..utils import deprecated
 MACHINE_EPSILON = np.finfo(np.double).eps
 
 
-@deprecated("l1_cross_distances is deprecated and will be removed in 0.20.")
+@deprecated("l1_cross_distances was deprecated in version 0.18 "
+            "and will be removed in 0.20.")
 def l1_cross_distances(X):
     """
     Computes the nonzero componentwise L1 cross-distances between the vectors
@@ -58,13 +59,13 @@ def l1_cross_distances(X):
     return D, ij
 
 
-@deprecated("GaussianProcess is deprecated and will be removed in 0.20. "
-            "Use the GaussianProcessRegressor instead.")
+@deprecated("GaussianProcess was deprecated in version 0.18 and will be "
+            "removed in 0.20. Use the GaussianProcessRegressor instead.")
 class GaussianProcess(BaseEstimator, RegressorMixin):
     """The legacy Gaussian Process model class.
 
-    Note that this class is deprecated and will be removed in 0.20.
-    Use the GaussianProcessRegressor instead.
+    Note that this class was deprecated in version 0.18 and will be
+    removed in 0.20. Use the GaussianProcessRegressor instead.
 
     Read more in the :ref:`User Guide <gaussian_process>`.
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -37,7 +37,7 @@ __all__ = ['GridSearchCV', 'ParameterGrid', 'fit_grid_point',
            'ParameterSampler', 'RandomizedSearchCV']
 
 
-warnings.warn("This module has been deprecated in favor of the "
+warnings.warn("This module was deprecated in version 0.18 in favor of the "
               "model_selection module into which all the refactored classes "
               "and functions are moved. This module will be removed in 0.20.",
               DeprecationWarning)

--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -17,7 +17,7 @@ from .utils import indexable
 from .utils.fixes import astype
 
 
-warnings.warn("This module has been deprecated in favor of the "
+warnings.warn("This module was deprecated in version 0.18 in favor of the "
               "model_selection module into which all the functions are moved."
               " This module will be removed in 0.20",
               DeprecationWarning)

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -67,8 +67,8 @@ def make_dataset(X, y, sample_weight, random_state=None):
     return dataset, intercept_decay
 
 
-@deprecated("sparse_center_data will be removed in "
-            "0.20. Use utilities in preprocessing.data instead")
+@deprecated("sparse_center_data was deprecated in version 0.18 and will be "
+            "removed in 0.20. Use utilities in preprocessing.data instead")
 def sparse_center_data(X, y, fit_intercept, normalize=False):
     """
     Compute information needed to center data to have mean zero along
@@ -105,7 +105,7 @@ def sparse_center_data(X, y, fit_intercept, normalize=False):
     return X, y, X_offset, y_offset, X_std
 
 
-@deprecated("center_data will be removed in "
+@deprecated("center_data was deprecated in version 0.18 and will be removed in "
             "0.20. Use utilities in preprocessing.data instead")
 def center_data(X, y, fit_intercept, normalize=False, copy=True,
                 sample_weight=None):

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -256,8 +256,9 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
 
         if self.residual_metric is not None:
             warnings.warn(
-                "'residual_metric' will be removed in version 0.20. Use "
-                "'loss' instead.", DeprecationWarning)
+                "'residual_metric' was deprecated in version 0.18 and "
+                "will be removed in version 0.20. Use 'loss' instead.",
+                DeprecationWarning)
 
         if self.loss == "absolute_loss":
             if y.ndim == 1:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -614,8 +614,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     @property
     def grid_scores_(self):
         warnings.warn(
-            "The grid_scores_ attribute is deprecated in favor of the"
-            " more elaborate results_ attribute."
+            "The grid_scores_ attribute was deprecated in version 0.18"
+            " in favor of the more elaborate results_ attribute."
             " The grid_scores_ attribute will not be available from 0.20",
             DeprecationWarning)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In`DeprecationWarning` messages, added the version in which the deprecation was introduced, as suggested here: http://scikit-learn.org/dev/developers/contributing.html#deprecation.

A couple of questions:
1. Is this worth doing? Or should it be avoided because it messes up "git blame"?
2. _If_ this is worth doing, what should be done with deprecation messages from v0.17? Ignore? Fix in both v0.17 and v0.18? Fix in just v0.18?
   - For example, [this one](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/decomposition/nmf.py#L771-L772) doesn't say when it was deprecated.
   - [This docstring](https://github.com/scikit-learn/scikit-learn/blob/06bf797c0deabe2a2f166d19abbd0c305da4d123/sklearn/preprocessing/data.py#L236) says `data_max` was deprecated in v0.17, but it actually didn't exist before v0.17.
