### PR TITLE
[MRG + 1] User guide cleanup, mainly in LaTeX.

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -134,7 +134,7 @@ although they live in the same space.
 The K-means algorithm aims to choose centroids
 that minimise the *inertia*, or within-cluster sum of squared criterion:
 
-.. math:: \sum_{i=0}^{n}\min_{\mu_j \in C}(||x_j - \mu_i||^2)
+.. math:: \sum_{i=0}^{n}\min_{\mu_j \in C}\left(||x_j - \mu_i||^2\right)
 
 Inertia, or the within-cluster sum of squares criterion,
 can be recognized as a measure of how internally coherent clusters are.
@@ -338,7 +338,8 @@ to be the exemplar of sample :math:`i` is given by:
 
 .. math::
 
-    r(i, k) \leftarrow s(i, k) - max [ a(i, \acute{k}) + s(i, \acute{k}) \forall \acute{k} \neq k ]
+    r(i, k) \leftarrow s(i, k) - \max_{\overline k \ne k} \left( a(i, \overline
+    k) + s(i, \overline k) \right)
 
 Where :math:`s(i, k)` is the similarity between samples :math:`i` and :math:`k`.
 The availability of sample :math:`k`
@@ -346,7 +347,8 @@ to be the exemplar of sample :math:`i` is given by:
 
 .. math::
 
-    a(i, k) \leftarrow min [0, r(k, k) + \sum_{\acute{i}~s.t.~\acute{i} \notin \{i, k\}}{r(\acute{i}, k)}]
+    a(i, k) \leftarrow min \{ 0, r(k, k) + \sum_{\overline i \notin
+    \{i,k\}}{r(\overline i, k)} \}
 
 To begin with, all values for :math:`r` and :math:`a` are set to zero,
 and the calculation of each iterates until convergence.
@@ -991,10 +993,10 @@ define :math:`a` and :math:`b` as:
 
 The raw (unadjusted) Rand index is then given by:
 
-.. math:: \text{RI} = \frac{a + b}{C_2^{n_{samples}}}
+.. math:: \text{RI} = \frac{a + b}{C_2^{n_\textrm{samples}}}
 
-Where :math:`C_2^{n_{samples}}` is the total number of possible pairs
-in the dataset (without ordering).
+Where :math:`C_2^{n_\textrm{samples}}` is the total number of possible pairs in
+the dataset (without ordering).
 
 However the RI score does not guarantee that random label assignments
 will get a value close to zero (esp. if the number of clusters is in
@@ -1148,10 +1150,12 @@ following equation, from Vinh, Epps, and Bailey, (2009). In this equation,
 :math:`b_j = |V_j|` (the number of elements in :math:`V_j`).
 
 
-.. math:: E[\text{MI}(U,V)]=\sum_{i=1}^|U| \sum_{j=1}^|V| \sum_{n_{ij}=(a_i+b_j-N)^+
-   }^{\min(a_i, b_j)} \frac{n_{ij}}{N}\log \left( \frac{ N.n_{ij}}{a_i b_j}\right)
-   \frac{a_i!b_j!(N-a_i)!(N-b_j)!}{N!n_{ij}!(a_i-n_{ij})!(b_j-n_{ij})!
-   (N-a_i-b_j+n_{ij})!}
+.. math::
+  E[\text{MI}(U,V)]=\sum_{i=1}^{|U|} \sum_{j=1}^{|V|}
+  \sum_{n_{ij}=(a_i+b_j-N)^+ }^{\min(a_i, b_j)} \frac{n_{ij}}{N}\log \left(
+  \frac{ N.n_{ij}}{a_i b_j}\right)
+  \frac{a_i!b_j!(N-a_i)!(N-b_j)!}{N!n_{ij}!(a_i-n_{ij})!(b_j-n_{ij})!
+  (N-a_i-b_j+n_{ij})!}
 
 Using the expected value, the adjusted mutual information can then be
 calculated using a similar form to that of the adjusted Rand index:
@@ -1445,7 +1449,7 @@ of two scores:
 
 The Silhouette Coefficient *s* for a single sample is then given as:
 
-.. math:: s = \frac{b - a}{max(a, b)}
+.. math:: s = \frac{b - a}{\max(a, b)}
 
 The Silhouette Coefficient for a set of samples is given as the mean of the
 Silhouette Coefficient for each sample.

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -338,8 +338,7 @@ to be the exemplar of sample :math:`i` is given by:
 
 .. math::
 
-    r(i, k) \leftarrow s(i, k) - \max_{\overline k \ne k} \left( a(i, \overline
-    k) + s(i, \overline k) \right)
+    r(i, k) \leftarrow s(i, k) - \max_{k' \ne k} \{ a(i, k') + s(i, k') \}
 
 Where :math:`s(i, k)` is the similarity between samples :math:`i` and :math:`k`.
 The availability of sample :math:`k`
@@ -347,8 +346,8 @@ to be the exemplar of sample :math:`i` is given by:
 
 .. math::
 
-    a(i, k) \leftarrow min \{ 0, r(k, k) + \sum_{\overline i \notin
-    \{i,k\}}{r(\overline i, k)} \}
+    a(i, k) \leftarrow \min \{ 0, r(k, k) + \sum_{i' \notin \{i,k\}}{r(i', k)}
+    \}
 
 To begin with, all values for :math:`r` and :math:`a` are set to zero,
 and the calculation of each iterates until convergence.

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -808,7 +808,7 @@ the need to hold the entire input data in memory. This information includes:
 
 - Number of samples in a subcluster.
 - Linear Sum - A n-dimensional vector holding the sum of all samples
-- Squared Sum - Sum of the squared L2 norm of all samples.
+- Squared Sum - Sum of the squared :math:`\ell_2` norm of all samples.
 - Centroids - To avoid recalculation linear sum / n_samples.
 - Squared norm of the centroids.
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -221,10 +221,9 @@ The mathematical formulation is the following:
 
 .. math::
 
-    \hat{K} = \mathrm{argmin}_K \big(
-                \mathrm{tr} S K - \mathrm{log} \mathrm{det} K
-                + \alpha \|K\|_1
-                \big)
+    \hat{K} = \underset{K}{\operatorname{arg\,min\,}} \left(
+                \operatorname{tr} \left( S K \right) - \log \det K
+                + \alpha \|K\|_1 \right)
 
 Where :math:`K` is the precision matrix to be estimated, and :math:`S` is the
 sample covariance matrix. :math:`\|K\|_1` is the sum of the absolute values of

--- a/doc/modules/cross_decomposition.rst
+++ b/doc/modules/cross_decomposition.rst
@@ -20,7 +20,7 @@ are 2D arrays.
 
 
 Cross decomposition algorithms find the fundamental relations between two
-matrices (X and Y). They are latent variable approaches to modeling the
+matrices X and Y. They are latent variable approaches to modeling the
 covariance structures in these two spaces. They will try to find the
 multidimensional direction in the X space that explains the maximum
 multidimensional variance direction in the Y space. PLS-regression is

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -703,11 +703,12 @@ matrices by setting :attr:`init="random"`. An integer seed or a
 ``RandomState`` can also be passed to :attr:`random_state` to control
 reproducibility.
 
-In :class:`NMF`, L1 and L2 priors can be added to the loss function in order
-to regularize the model. The L2 prior uses the Frobenius norm, while the L1
-prior uses an elementwise L1 norm. As in :class:`ElasticNet`, we control the
-combination of L1 and L2 with the :attr:`l1_ratio` (:math:`\rho`) parameter,
-and the intensity of the regularization with the :attr:`alpha`
+In :class:`NMF`, :math:`\ell_1` and :math:`\ell_2` priors can be added to the
+loss function in order to regularize the model. The :math:`\ell_2` prior uses
+the Frobenius norm, while the :math:`\ell_1` prior uses an elementwise
+:math:`\ell_1` norm. As in :class:`ElasticNet`, we control the combination of
+:math:`\ell_1` and :math:`\ell_2` with the :attr:`l1_ratio` (:math:`\rho`)
+parameter, and the intensity of the regularization with the :attr:`alpha`
 (:math:`\alpha`) parameter. Then the priors terms are
 
 .. math::

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -122,12 +122,12 @@ to drop most of the singular vectors it is much more efficient to limit the
 computation to an approximated estimate of the singular vectors we will keep
 to actually perform the transform.
 
-For instance, the following shows 16 sample portraits (centered around
-0.0) from the Olivetti dataset. On the right hand side are the first 16
-singular vectors reshaped as portraits. Since we only require the top
-16 singular vectors of a dataset with size :math:`n_{samples} = 400`
-and :math:`n_{features} = 64 \times 64 = 4096`, the computation time is
-less than 1s:
+For instance, the following shows 16 sample portraits (centered around 0.0)
+from the Olivetti dataset. On the right hand side are the first 16 singular
+vectors reshaped as portraits. Since we only require the top 16 singular
+vectors of a dataset with size :math:`n_\textrm{samples} = 400` and
+:math:`n_\textrm{features} = 64 \times 64 = 4096`, the computation time is less
+than 1s:
 
 .. |orig_img| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_001.png
    :target: ../auto_examples/decomposition/plot_faces_decomposition.html
@@ -143,15 +143,16 @@ Note: with the optional parameter ``svd_solver='randomized'``, we also
 need to give :class:`PCA` the size of the lower-dimensional space
 ``n_components`` as a mandatory input parameter.
 
-If we note :math:`n_{max} = max(n_{samples}, n_{features})` and
-:math:`n_{min} = min(n_{samples}, n_{features})`, the time complexity
-of the randomized :class:`PCA` is :math:`O(n_{max}^2 \cdot n_{components})`
-instead of :math:`O(n_{max}^2 \cdot n_{min})` for the exact method
+If we note :math:`n_\textrm{max} = \max(n_\textrm{samples},
+n_\textrm{features})` and :math:`n_\textrm{min} = \min(n_\textrm{samples},
+n_\textrm{features})`, the time complexity of the randomized :class:`PCA` is
+:math:`O(n_\textrm{max}^2 \cdot n_\textrm{components})` instead of
+:math:`O(n_\textrm{max}^2 \cdot n_\textrm{min})` for the exact method
 implemented in :class:`PCA`.
 
-The memory footprint of randomized :class:`PCA` is also proportional to
-:math:`2 \cdot n_{max} \cdot n_{components}` instead of :math:`n_{max}
-\cdot n_{min}` for the exact method.
+The memory footprint of the randomized :class:`PCA` is also proportional to
+:math:`2 \cdot n_\textrm{max} \cdot n_\textrm{components}` instead of
+:math:`n_\textrm{max} \cdot n_\textrm{min}` for the exact method.
 
 Note: the implementation of ``inverse_transform`` in :class:`PCA` with
 ``svd_solver='randomized'`` is not the exact inverse transform of
@@ -222,14 +223,14 @@ The following example illustrates 16 components extracted using sparse PCA from
 the Olivetti faces dataset.  It can be seen how the regularization term induces
 many zeros. Furthermore, the natural structure of the data causes the non-zero
 coefficients to be vertically adjacent. The model does not enforce this
-mathematically: each component is a vector :math:`h \in \mathbf{R}^{4096}`, and
+mathematically: each component is a vector :math:`h \in \mathbb R^{4096}`, and
 there is no notion of vertical adjacency except during the human-friendly
 visualization as 64x64 pixel images. The fact that the components shown below
 appear local is the effect of the inherent structure of the data, which makes
-such local patterns minimize reconstruction error. There exist sparsity-inducing
-norms that take into account adjacency and different kinds of structure; see
-[Jen09]_ for a review of such methods.
-For more details on how to use Sparse PCA, see the Examples section, below.
+such local patterns minimize reconstruction error. There exist
+sparsity-inducing norms that take into account adjacency and different kinds of
+structure; see [Jen09]_ for a review of such methods. For more details on how
+to use Sparse PCA, see the Examples section, below.
 
 
 .. |spca_img| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_005.png
@@ -245,9 +246,9 @@ problem solved is a PCA problem (dictionary learning) with an
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_2^2+\alpha||V||_1 \\
-                \text{subject to\,} & ||U_k||_2 = 1 \text{ for all }
-                0 \leq k < n_{components}
+                \|X-UV\|_2^2+\alpha\|V\|_1 \\
+                \text{subject to\,} & \|U_k\|_2 = 1 \text{ for all }
+                0 \leq k < n_\textrm{components}
 
 
 The sparsity-inducing :math:`\ell_1` norm also prevents learning
@@ -431,9 +432,9 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_2^2+\alpha||U||_1 \\
-                \text{subject to\,} & ||V_k||_2 = 1 \text{ for all }
-                0 \leq k < n_{atoms}
+                \|X-UV\|_2^2+\alpha\|U\|_1 \\
+                \text{subject to\,} & \|V_k\|_2 = 1 \text{ for all }
+                0 \leq k < n_\textrm{atoms}
 
 
 .. |pca_img2| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_002.png
@@ -555,9 +556,9 @@ structure of the error covariance :math:`\Psi`:
 * :math:`\Psi = \sigma^2 \mathbf{I}`: This assumption leads to
   the probabilistic model of :class:`PCA`.
 
-* :math:`\Psi = diag(\psi_1, \psi_2, \dots, \psi_n)`: This model is called
-  :class:`FactorAnalysis`, a classical statistical model. The matrix W is
-  sometimes called the "factor loading matrix".
+* :math:`\Psi = \operatorname{diag}(\psi_1, \psi_2, \dots, \psi_n)`: This model
+  is called :class:`FactorAnalysis`, a classical statistical model. The matrix
+  W is sometimes called the "factor loading matrix".
 
 Both models essentially estimate a Gaussian with a low-rank covariance matrix.
 Because both models are probabilistic they can be integrated in more complex
@@ -657,7 +658,8 @@ into two matrices :math:`W` and :math:`H` of non-negative elements,
 by optimizing for the squared Frobenius norm:
 
 .. math::
-    \arg\min_{W,H} \frac{1}{2} ||X - WH||_{Fro}^2 = \frac{1}{2} \sum_{i,j} (X_{ij} - {WH}_{ij})^2
+    \arg\min_{W,H} \frac{1}{2} \|X - WH\|_\textrm{Fro}^2 = \frac{1}{2}
+    \sum_{i,j} (X_{ij} - {WH}_{ij})^2
 
 This norm is an obvious extension of the Euclidean norm to matrices. (Other
 optimization objectives have been suggested in the NMF literature, in
@@ -706,20 +708,20 @@ to regularize the model. The L2 prior uses the Frobenius norm, while the L1
 prior uses an elementwise L1 norm. As in :class:`ElasticNet`, we control the
 combination of L1 and L2 with the :attr:`l1_ratio` (:math:`\rho`) parameter,
 and the intensity of the regularization with the :attr:`alpha`
-(:math:`\alpha`) parameter. Then the priors terms are:
+(:math:`\alpha`) parameter. Then the priors terms are
 
 .. math::
-    \alpha \rho ||W||_1 + \alpha \rho ||H||_1
-    + \frac{\alpha(1-\rho)}{2} ||W||_{Fro} ^ 2
-    + \frac{\alpha(1-\rho)}{2} ||H||_{Fro} ^ 2
+    \alpha \rho \|W||_1 + \alpha \rho \|H\|_1
+    + \frac{\alpha(1-\rho)}{2} \|W\|_\textrm{Fro} ^ 2
+    + \frac{\alpha(1-\rho)}{2} \|H\|_\textrm{Fro} ^ 2
 
-and the regularized objective function is:
+and the regularized objective function is
 
 .. math::
-    \frac{1}{2}||X - WH||_{Fro}^2
+    \frac{1}{2}\|X - WH\|_\textrm{Fro}^2
     + \alpha \rho ||W||_1 + \alpha \rho ||H||_1
-    + \frac{\alpha(1-\rho)}{2} ||W||_{Fro} ^ 2
-    + \frac{\alpha(1-\rho)}{2} ||H||_{Fro} ^ 2
+    + \frac{\alpha(1-\rho)}{2} \|W\|_\textrm{Fro} ^ 2
+    + \frac{\alpha(1-\rho)}{2} \|H\|_\textrm{Fro} ^ 2 .
 
 :class:`NMF` regularizes both W and H. The public function
 :func:`non_negative_factorization` allows a finer control through the
@@ -772,20 +774,23 @@ The graphical model of LDA is a three-level Bayesian model:
 When modeling text corpora, the model assumes the following generative process for
 a corpus with :math:`D` documents and :math:`K` topics:
 
-  1. For each topic :math:`k`, draw :math:`\beta_k \sim Dirichlet(\eta),\: k =1...K`
+  1. For each topic :math:`k=1, \ldots, K`, draw :math:`\beta_k \sim \operatorname{Dirichlet}(\eta)`;
 
-  2. For each document :math:`d`, draw :math:`\theta_d \sim Dirichlet(\alpha), \: d=1...D`
+  2. For each document :math:`d=1,\ldots,D`, draw :math:`\theta_d \sim \operatorname{Dirichlet}(\alpha)`;
 
   3. For each word :math:`i` in document :math:`d`:
 
-    a. Draw a topic index :math:`z_{di} \sim Multinomial(\theta_d)`
-    b. Draw the observed word :math:`w_{ij} \sim Multinomial(beta_{z_{di}}.)`
+    a. Draw a topic index :math:`z_{di} \sim
+    \operatorname{Multinomial}(\theta_d)`;
+
+    b. Draw the observed word :math:`w_{ij} \sim
+    \operatorname{Multinomial}(\beta_{z_{di}})`.
 
 For parameter estimation, the posterior distribution is:
 
 .. math::
   p(z, \theta, \beta |w, \alpha, \eta) =
-    \frac{p(z, \theta, \beta|\alpha, \eta)}{p(w|\alpha, \eta)}
+    \frac{p(z, \theta, \beta|\alpha, \eta)}{p(w|\alpha, \eta)} .
 
 Since the posterior is intractable, variational Bayesian method
 uses a simpler distribution :math:`q(z,\theta,\beta | \lambda, \phi, \gamma)`
@@ -793,8 +798,9 @@ to approximate it, and those variational parameters :math:`\lambda`, :math:`\phi
 :math:`\gamma` are optimized to maximize the Evidence Lower Bound (ELBO):
 
 .. math::
-  log\: P(w | \alpha, \eta) \geq L(w,\phi,\gamma,\lambda) \overset{\triangle}{=}
-    E_{q}[log\:p(w,z,\theta,\beta|\alpha,\eta)] - E_{q}[log\:q(z, \theta, \beta)]
+  \log\: P(w | \alpha, \eta) \geq L(w,\phi,\gamma,\lambda)
+  \overset{\triangle}{=} E_{q}[\log\:p(w,z,\theta,\beta|\alpha,\eta)] -
+  E_{q}[\log\:q(z, \theta, \beta)] .
 
 Maximizing ELBO is equivalent to minimizing the Kullback-Leibler(KL) divergence
 between :math:`q(z,\theta,\beta)` and the true posterior

--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -113,7 +113,7 @@ The form of these kernels is as follows:
 
 * Gaussian kernel (``kernel = 'gaussian'``)
 
-  :math:`K(x; h) \propto \exp(- \frac{x^2}{2h^2} )`
+  :math:`K(x; h) \propto \exp\left(- \frac{x^2}{2h^2} \right)`
 
 * Tophat kernel (``kernel = 'tophat'``)
 
@@ -125,7 +125,7 @@ The form of these kernels is as follows:
 
 * Exponential kernel (``kernel = 'exponential'``)
 
-  :math:`K(x; h) \propto \exp(-x/h)`
+  :math:`K(x; h) \propto \exp\left(-\frac x h \right)`
 
 * Linear kernel (``kernel = 'linear'``)
 
@@ -133,7 +133,7 @@ The form of these kernels is as follows:
 
 * Cosine kernel (``kernel = 'cosine'``)
 
-  :math:`K(x; h) \propto \cos(\frac{\pi x}{2h})` if :math:`x < h`
+  :math:`K(x; h) \propto \cos\left(\frac{\pi x}{2h}\right)` if :math:`x < h`
 
 The kernel density estimator can be used with any of the valid distance
 metrics (see :class:`sklearn.neighbors.DistanceMetric` for a list of available metrics), though

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -110,8 +110,8 @@ construction.  The prediction of the ensemble is given as the averaged
 prediction of the individual classifiers.
 
 As other classifiers, forest classifiers have to be fitted with two
-arrays: a sparse or dense array X of size ``[n_samples, n_features]`` holding the
-training samples, and an array Y of size ``[n_samples]`` holding the
+arrays: a sparse or dense array X of shape ``(n_samples, n_features)`` holding the
+training samples, and an array Y of shape ``(n_samples,)`` holding the
 target values (class labels) for the training samples::
 
     >>> from sklearn.ensemble import RandomForestClassifier
@@ -121,8 +121,8 @@ target values (class labels) for the training samples::
     >>> clf = clf.fit(X, Y)
 
 Like :ref:`decision trees <tree>`, forests of trees also extend
-to :ref:`multi-output problems <tree_multioutput>`  (if Y is an array of size
-``[n_samples, n_outputs]``).
+to :ref:`multi-output problems <tree_multioutput>` if Y is an array of shape
+``(n_samples, n_outputs)``.
 
 Random Forests
 --------------

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -197,10 +197,7 @@ alpha parameter, the fewer features selected.
 
 .. topic:: Examples:
 
-    *
-    :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`:
-    Comparison of different algorithms for document classification including
-    :math:`\ell_1`-based feature selection.
+    * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`: Comparison of different algorithms for document classification including :math:`\ell_1`-based feature selection.
 
 .. _compressive_sensing:
 

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -147,7 +147,7 @@ Feature selection using SelectFromModel
 
 :class:`SelectFromModel` is a meta-transformer that can be used along with any
 estimator that has a ``coef_`` or ``feature_importances_`` attribute after fitting.
-The features are considered unimportant and removed, if the corresponding
+The features are considered unimportant and removed if the corresponding
 ``coef_`` or ``feature_importances_`` values are below the provided
 ``threshold`` parameter. Apart from specifying the threshold numerically,
 there are built-in heuristics for finding a threshold using a string argument.

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -164,12 +164,12 @@ For examples on how it is to be used refer to the sections below.
 
 .. _l1_feature_selection:
 
-L1-based feature selection
---------------------------
+:math:`\ell_1`-based feature selection
+--------------------------------------
 
 .. currentmodule:: sklearn
 
-:ref:`Linear models <linear_model>` penalized with the L1 norm have
+:ref:`Linear models <linear_model>` penalized with the :math:`\ell_1` norm have
 sparse solutions: many of their estimated coefficients are zero. When the goal
 is to reduce the dimensionality of the data to use with another classifier,
 they can be used along with :class:`feature_selection.SelectFromModel`
@@ -197,23 +197,24 @@ alpha parameter, the fewer features selected.
 
 .. topic:: Examples:
 
-    * :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`: Comparison
-      of different algorithms for document classification including L1-based
-      feature selection.
+    *
+    :ref:`sphx_glr_auto_examples_text_document_classification_20newsgroups.py`:
+    Comparison of different algorithms for document classification including
+    :math:`\ell_1`-based feature selection.
 
 .. _compressive_sensing:
 
-.. topic:: **L1-recovery and compressive sensing**
+.. topic:: **l1-recovery and compressive sensing**
 
-   For a good choice of alpha, the :ref:`lasso` can fully recover the
-   exact set of non-zero variables using only few observations, provided
-   certain specific conditions are met. In particular, the number of
-   samples should be "sufficiently large", or L1 models will perform at
-   random, where "sufficiently large" depends on the number of non-zero
-   coefficients, the logarithm of the number of features, the amount of
-   noise, the smallest absolute value of non-zero coefficients, and the
-   structure of the design matrix X. In addition, the design matrix must
-   display certain specific properties, such as not being too correlated.
+   For a good choice of alpha, the :ref:`lasso` can fully recover the exact set
+   of non-zero variables using only few observations, provided certain specific
+   conditions are met. In particular, the number of samples should be
+   "sufficiently large", or :math:`\ell_1` models will perform at random, where
+   "sufficiently large" depends on the number of non-zero coefficients, the
+   logarithm of the number of features, the amount of noise, the smallest
+   absolute value of non-zero coefficients, and the structure of the design
+   matrix X. In addition, the design matrix must display certain specific
+   properties, such as not being too correlated.
 
    There is no general rule to select an alpha parameter for recovery of
    non-zero coefficients. It can by set by cross-validation
@@ -235,21 +236,22 @@ Randomized sparse models
 .. currentmodule:: sklearn.linear_model
 
 In terms of feature selection, there are some well-known limitations of
-L1-penalized models for regression and classification. For example, it is
-known that the Lasso will tend to select an individual variable out of a group
-of highly correlated features. Furthermore, even when the correlation between
-features is not too high, the conditions under which L1-penalized methods
-consistently select "good" features can be restrictive in general.
+:math:`\ell_1`-penalized models for regression and classification. For example,
+it is known that the Lasso will tend to select an individual variable out of a
+group of highly correlated features. Furthermore, even when the correlation
+between features is not too high, the conditions under which
+:math:`\ell_1`-penalized methods consistently select "good" features can be
+restrictive in general.
 
 To mitigate this problem, it is possible to use randomization techniques such
 as those presented in [B2009]_ and [M2010]_. The latter technique, known as
 stability selection, is implemented in the module :mod:`sklearn.linear_model`.
 In the stability selection method, a subsample of the data is fit to a
-L1-penalized model where the penalty of a random subset of coefficients has
-been scaled. Specifically, given a subsample of the data
+:math:`\ell_1`-penalized model where the penalty of a random subset of
+coefficients has been scaled. Specifically, given a subsample of the data
 :math:`(x_i, y_i), i \in I`, where :math:`I \subset \{1, 2, \ldots, n\}` is a
-random subset of the data of size :math:`n_I`, the following modified Lasso
-fit is obtained:
+random subset of the data of size :math:`n_I`, the following modified Lasso fit
+is obtained:
 
 .. math::   \hat{w_I} = \mathrm{arg}\min_{w} \frac{1}{2n_I} \sum_{i \in I} (y_i - x_i^T w)^2 + \alpha \sum_{j=1}^p \frac{ \vert w_j \vert}{s_j},
 

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -452,30 +452,32 @@ Basic kernels
 The :class:`ConstantKernel` kernel can be used as part of a :class:`Product`
 kernel where it scales the magnitude of the other factor (kernel) or as part
 of a :class:`Sum` kernel, where it modifies the mean of the Gaussian process.
-It depends on a parameter :math:`constant\_value`. It is defined as:
+It depends on a parameter ``constant_value``. It is defined as:
 
 .. math::
-   k(x_i, x_j) = constant\_value \;\forall\; x_1, x_2
+   k(x_i, x_j) = \textrm{constant\_value}
 
 The main use-case of the :class:`WhiteKernel` kernel is as part of a
 sum-kernel where it explains the noise-component of the signal. Tuning its
-parameter :math:`noise\_level` corresponds to estimating the noise-level.
-It is defined as:e
+parameter ``noise_level`` corresponds to estimating the noise-level.
+It is defined as:
 
 .. math::
-    k(x_i, x_j) = noise\_level \text{ if } x_i == x_j \text{ else } 0
-
+  k(x_i, x_j) = \begin{cases}
+    \textrm{noise\_level}, & \textrm{if } x_i=x_j, \\
+    0, & \textrm{otherwise}
+  \end{cases}
 
 Kernel operators
 ----------------
 Kernel operators take one or two base kernels and combine them into a new
-kernel. The :class:`Sum` kernel takes two kernels :math:`k1` and :math:`k2`
-and combines them via :math:`k_{sum}(X, Y) = k1(X, Y) + k2(X, Y)`.
-The  :class:`Product` kernel takes two kernels :math:`k1` and :math:`k2`
-and combines them via :math:`k_{product}(X, Y) = k1(X, Y) * k2(X, Y)`.
-The :class:`Exponentiation` kernel takes one base kernel and a scalar parameter
-:math:`exponent` and combines them via
-:math:`k_{exp}(X, Y) = k(X, Y)^\text{exponent}`.
+kernel. The :class:`Sum` kernel takes two kernels ``k1`` and ``k2`` and
+combines them via :math:`k_\textrm{sum}(X, Y) = k_1(X, Y) + k_2(X, Y)`. The
+:class:`Product` kernel takes two kernels ``k1`` and ``k2`` and combines them
+via :math:`k_\textrm{product}(X, Y) = k_1(X, Y) k_2(X, Y)`. The
+:class:`Exponentiation` kernel takes one base kernel and a scalar parameter
+``exponent`` and combines them via :math:`k_\textrm{exp}(X, Y) = k(X,
+Y)^\textrm{exponent}`.
 
 Radial-basis function (RBF) kernel
 ----------------------------------
@@ -870,12 +872,12 @@ models, see the book by Rasmussen & Williams in references.
 Regression Models
 -----------------
 
-Common linear regression models involve zero- (constant), first- and
-second-order polynomials. But one may specify its own in the form of a Python
-function that takes the features X as input and that returns a vector
-containing the values of the functional set. The only constraint is that the
-number of functions must not exceed the number of available observations so
-that the underlying regression problem is not *underdetermined*.
+Common linear regression models involve polynomials of order zero (constant),
+one, or two. But one may specify its own in the form of a Python function that
+takes the features X as input and that returns a vector containing the values
+of the functional set. The only constraint is that the number of functions must
+not exceed the number of available observations so that the underlying
+regression problem is not *underdetermined*.
 
 
 Implementation details

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -77,7 +77,7 @@ evaluated and the best combination is retained.
       of Grid Search coupling parameters from a text documents feature
       extractor (n-gram count vectorizer and TF-IDF transformer) with a
       classifier (here a linear SVM trained with SGD with either elastic
-      net or L2 penalty) using a :class:`pipeline.Pipeline` instance.
+      net or :math:`\ell_2`) using a :class:`pipeline.Pipeline` instance.
 
     - See :ref:`sphx_glr_auto_examples_model_selection_plot_nested_cross_validation_iris.py`
       for an example of Grid Search within a cross validation loop on the iris

--- a/doc/modules/learning_curve.rst
+++ b/doc/modules/learning_curve.rst
@@ -12,14 +12,15 @@ estimator is its average error for different training sets. The **variance**
 of an estimator indicates how sensitive it is to varying training sets. Noise
 is a property of the data.
 
-In the following plot, we see a function :math:`f(x) = \cos (\frac{3}{2} \pi x)`
-and some noisy samples from that function. We use three different estimators
-to fit the function: linear regression with polynomial features of degree 1,
-4 and 15. We see that the first estimator can at best provide only a poor fit
-to the samples and the true function because it is too simple (high bias),
-the second estimator approximates it almost perfectly and the last estimator
-approximates the training data perfectly but does not fit the true function
-very well, i.e. it is very sensitive to varying training data (high variance).
+In the following plot, we see a function :math:`f(x) = \cos \left(\frac{3}{2}
+\pi x\right)` and some noisy samples from that function. We use three different
+estimators to fit the function: linear regression with polynomial features of
+degree 1, 4 and 15. We see that the first estimator can at best provide only a
+poor fit to the samples and the true function because it is too simple (high
+bias), the second estimator approximates it almost perfectly and the last
+estimator approximates the training data perfectly but does not fit the true
+function very well, i.e. it is very sensitive to varying training data (high
+variance).
 
 .. figure:: ../auto_examples/model_selection/images/sphx_glr_plot_underfitting_overfitting_001.png
    :target: ../auto_examples/model_selection/plot_underfitting_overfitting.html

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -31,7 +31,7 @@ of squares between the observed responses in the dataset, and the
 responses predicted by the linear approximation. Mathematically it
 solves a problem of the form:
 
-.. math:: \underset{w}{min\,} {|| X w - y||_2}^2
+.. math:: \min_w {\| X w - y\|_2}^2
 
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ols_001.png
    :target: ../auto_examples/linear_model/plot_ols.html
@@ -83,7 +83,7 @@ of squares,
 
 .. math::
 
-   \underset{w}{min\,} {{|| X w - y||_2}^2 + \alpha {||w||_2}^2}
+   \min_w {{\| X w - y\|_2}^2 + \alpha {\|w\|_2}^2}
 
 
 Here, :math:`\alpha \geq 0` is a complexity parameter that controls the amount
@@ -170,11 +170,12 @@ weights (see
 Mathematically, it consists of a linear model trained with :math:`\ell_1` prior
 as regularizer. The objective function to minimize is:
 
-.. math::  \underset{w}{min\,} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha ||w||_1}
+.. math::
+  \min_w { \frac{1}{2n_\textrm{samples}} \|X w - y\|_2 ^ 2 + \alpha \|w\|_1}
 
 The lasso estimate thus solves the minimization of the
-least-squares penalty with :math:`\alpha ||w||_1` added, where
-:math:`\alpha` is a constant and :math:`||w||_1` is the :math:`\ell_1`-norm of
+least-squares penalty with :math:`\alpha \|w\|_1` added, where
+:math:`\alpha` is a constant and :math:`\|w\|_1` is the :math:`\ell_1`-norm of
 the parameter vector.
 
 The implementation in the class :class:`Lasso` uses coordinate descent as
@@ -303,15 +304,18 @@ Mathematically, it consists of a linear model trained with a mixed
 :math:`\ell_1` :math:`\ell_2` prior as regularizer.
 The objective function to minimize is:
 
-.. math::  \underset{w}{min\,} { \frac{1}{2n_{samples}} ||X W - Y||_{Fro} ^ 2 + \alpha ||W||_{21}}
+.. math::
 
-where :math:`Fro` indicates the Frobenius norm:
+  \min_W { \frac{1}{2n_\textrm{samples}} \|X W - Y\|_\textrm{Fro} ^ 2 + \alpha
+  \|W\|_{21}}
 
-.. math:: ||A||_{Fro} = \sqrt{\sum_{ij} a_{ij}^2}
+where :math:`\textrm{Fro}` indicates the Frobenius norm:
+
+.. math:: \|A\|_\textrm{Fro} = \sqrt{\sum_{ij} a_{ij}^2}
 
 and :math:`\ell_1` :math:`\ell_2` reads:
 
-.. math:: ||A||_{2 1} = \sum_i \sqrt{\sum_j a_{ij}^2}
+.. math:: \|A\|_{2 1} = \sum_i \sqrt{\sum_j a_{ij}^2}
 
 
 The implementation in the class :class:`MultiTaskLasso` uses coordinate descent as
@@ -322,11 +326,12 @@ the algorithm to fit the coefficients.
 
 Elastic Net
 ===========
-:class:`ElasticNet` is a linear regression model trained with L1 and L2 prior
-as regularizer. This combination allows for learning a sparse model where
-few of the weights are non-zero like :class:`Lasso`, while still maintaining
-the regularization properties of :class:`Ridge`. We control the convex
-combination of L1 and L2 using the ``l1_ratio`` parameter.
+:class:`ElasticNet` is a linear regression model trained with :math:`\ell_1`
+and :math:`\ell_2` prior as regularizer. This combination allows for learning a
+sparse model where few of the weights are non-zero like :class:`Lasso`, while
+still maintaining the regularization properties of :class:`Ridge`. We control
+the convex combination of :math:`\ell_1` and :math:`\ell_2` using the
+``l1_ratio`` parameter.
 
 Elastic-net is useful when there are multiple features which are
 correlated with one another. Lasso is likely to pick one of these
@@ -339,8 +344,8 @@ The objective function to minimize is in this case
 
 .. math::
 
-    \underset{w}{min\,} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha \rho ||w||_1 +
-    \frac{\alpha(1-\rho)}{2} ||w||_2 ^ 2}
+    \min_w { \frac{1}{2n_\textrm{samples}} \|X w - y\|_2 ^ 2 + \alpha \rho
+    \|w\|_1 + \frac{\alpha(1-\rho)}{2} \|w\|_2 ^ 2}
 
 
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_lasso_coordinate_descent_path_001.png
@@ -364,9 +369,9 @@ Multi-task Elastic Net
 ======================
 
 The :class:`MultiTaskElasticNet` is an elastic-net model that estimates sparse
-coefficients for multiple regression problems jointly: ``Y`` is a 2D array,
-of shape ``(n_samples, n_tasks)``. The constraint is that the selected
-features are the same for all the regression problems, also called tasks.
+coefficients for multiple regression problems jointly: ``Y`` is a 2D array of
+shape ``(n_samples, n_tasks)``. The constraint is that the selected features
+are the same for all the regression problems, also called tasks.
 
 Mathematically, it consists of a linear model trained with a mixed
 :math:`\ell_1` :math:`\ell_2` prior and :math:`\ell_2` prior as regularizer.
@@ -374,8 +379,8 @@ The objective function to minimize is:
 
 .. math::
 
-    \underset{W}{min\,} { \frac{1}{2n_{samples}} ||X W - Y||_{Fro}^2 + \alpha \rho ||W||_{2 1} +
-    \frac{\alpha(1-\rho)}{2} ||W||_{Fro}^2}
+    \min_W { \frac{1}{2n_\textrm{samples}} \|X W - Y\|_\textrm{Fro}^2 + \alpha
+    \rho \|W\|_{2 1} + \frac{\alpha(1-\rho)}{2} \|W\|_\textrm{Fro}^2}
 
 The implementation in the class :class:`MultiTaskElasticNet` uses coordinate descent as
 the algorithm to fit the coefficients.
@@ -395,8 +400,8 @@ Johnstone and Robert Tibshirani.
 
 The advantages of LARS are:
 
-  - It is numerically efficient in contexts where p >> n (i.e., when the
-    number of dimensions is significantly greater than the number of
+  - It is numerically efficient in contexts where :math:`p >> n` (i.e., when
+    the number of dimensions is significantly greater than the number of
     points)
 
   - It is computationally just as fast as forward selection and has
@@ -465,10 +470,10 @@ of including variables at each step, the estimated parameters are
 increased in a direction equiangular to each one's correlations with
 the residual.
 
-Instead of giving a vector result, the LARS solution consists of a
-curve denoting the solution for each value of the L1 norm of the
+Instead of giving a vector result, the LARS solution consists of a curve
+denoting the solution for each value of the :math:`\ell_1` norm of the
 parameter vector. The full coefficients path is stored in the array
-``coef_path_``, which has size (n_features, max_features+1). The first
+``coef_path_``, which has shape ``(n_features, max_features+1)``. The first
 column is always zero.
 
 .. topic:: References:
@@ -490,13 +495,13 @@ Being a forward feature selection method like :ref:`least_angle_regression`,
 orthogonal matching pursuit can approximate the optimum solution vector with a
 fixed number of non-zero elements:
 
-.. math:: \text{arg\,min\,} ||y - X\gamma||_2^2 \text{ subject to } \
-    ||\gamma||_0 \leq n_{nonzero\_coefs}
+.. math:: \text{arg\,min\,} \|y - X\gamma\|_2^2 \text{ subject to } \
+    \|\gamma\|_0 \leq n_\textrm{nonzero\_coefs}
 
 Alternatively, orthogonal matching pursuit can target a specific error instead
 of a specific number of non-zero coefficients. This can be expressed as:
 
-.. math:: \text{arg\,min\,} ||\gamma||_0 \text{ subject to } ||y-X\gamma||_2^2 \
+.. math:: \text{arg\,min\,} \|\gamma\|_0 \text{ subject to } \|y-X\gamma\|_2^2 \
     \leq \text{tol}
 
 
@@ -531,12 +536,11 @@ not set in a hard sense but tuned to the data at hand.
 
 This can be done by introducing `uninformative priors
 <https://en.wikipedia.org/wiki/Non-informative_prior#Uninformative_priors>`__
-over the hyper parameters of the model.
-The :math:`\ell_{2}` regularization used in `Ridge Regression`_ is equivalent
-to finding a maximum a-postiori solution under a Gaussian prior over the
-parameters :math:`w` with precision :math:`\lambda^-1`.  Instead of setting
-`\lambda` manually, it is possible to treat it as a random variable to be
-estimated from the data.
+over the hyper parameters of the model. The :math:`\ell_{2}` regularization
+used in `Ridge Regression`_ is equivalent to finding a maximum a-postiori
+solution under a Gaussian prior over the parameters :math:`w` with precision
+:math:`\lambda^{-1}`.  Instead of setting `\lambda` manually, it is possible to
+treat it as a random variable to be estimated from the data.
 
 To obtain a fully probabilistic model, the output :math:`y` is assumed
 to be Gaussian distributed around :math:`X w`:
@@ -590,7 +594,7 @@ remaining hyperparameters are the parameters of the gamma priors over
 *non-informative*.  The parameters are estimated by maximizing the *marginal
 log likelihood*.
 
-By default :math:`\alpha_1 = \alpha_2 =  \lambda_1 = \lambda_2 = 1.e^{-6}`.
+By default :math:`\alpha_1 = \alpha_2 =  \lambda_1 = \lambda_2 = 10^{-6}`.
 
 
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_bayesian_ridge_001.png
@@ -653,7 +657,8 @@ centered on zero and with a precision :math:`\lambda_{i}`:
 
 .. math:: p(w|\lambda) = \mathcal{N}(w|0,A^{-1})
 
-with :math:`diag \; (A) = \lambda = \{\lambda_{1},...,\lambda_{p}\}`.
+with :math:`\operatorname{diag} \; (A) = \lambda =
+\{\lambda_{1},...,\lambda_{p}\}`.
 
 In contrast to `Bayesian Ridge Regression`_, each coordinate of :math:`w_{i}`
 has its own standard deviation :math:`\lambda_i`. The prior over all
@@ -702,12 +707,17 @@ regularization.
 As an optimization problem, binary class L2 penalized logistic regression
 minimizes the following cost function:
 
-.. math:: \underset{w, c}{min\,} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
+.. math::
+
+  \min_{w,c} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) +
+  1) .
 
 Similarly, L1 regularized logistic regression solves the following
 optimization problem
 
-.. math:: \underset{w, c}{min\,} \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
+.. math::
+
+  \min_{w,c} \|w\|_1 + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) + 1) .
 
 The solvers implemented in the class :class:`LogisticRegression`
 are "liblinear", "newton-cg", "lbfgs" and "sag":
@@ -1051,7 +1061,7 @@ dimensions [#f2]_.
 In terms of time and space complexity, Theil-Sen scales according to
 
 .. math::
-    \binom{n_{samples}}{n_{subsamples}}
+    \binom{n_\textrm{samples}}{n_\textrm{subsamples}}
 
 which makes it infeasible to be applied exhaustively to problems with a
 large number of samples and features. Therefore, the magnitude of a
@@ -1089,7 +1099,7 @@ The loss function that :class:`HuberRegressor` minimizes is given by
 
 .. math::
 
-  \underset{w, \sigma}{min\,} {\sum_{i=1}^n\left(\sigma + H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
+  \min_{w,\sigma} {\sum_{i=1}^n\left(\sigma + H_m\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \alpha {||w||_2}^2}
 
 where
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -173,10 +173,9 @@ as regularizer. The objective function to minimize is:
 .. math::
   \min_w { \frac{1}{2n_\textrm{samples}} \|X w - y\|_2 ^ 2 + \alpha \|w\|_1}
 
-The lasso estimate thus solves the minimization of the
-least-squares penalty with :math:`\alpha \|w\|_1` added, where
-:math:`\alpha` is a constant and :math:`\|w\|_1` is the :math:`\ell_1`-norm of
-the parameter vector.
+The lasso estimate thus solves the minimization of the least-squares penalty
+with :math:`\alpha \|w\|_1` added, where :math:`\alpha` is a constant and
+:math:`\|w\|_1` is the :math:`\ell_1`-norm of the parameter vector.
 
 The implementation in the class :class:`Lasso` uses coordinate descent as
 the algorithm to fit the coefficients. See :ref:`least_angle_regression`
@@ -301,8 +300,8 @@ columns.
 
 
 Mathematically, it consists of a linear model trained with a mixed
-:math:`\ell_1` :math:`\ell_2` prior as regularizer.
-The objective function to minimize is:
+:math:`\ell_1\ell_2` prior as regularizer. The objective function to
+minimize is:
 
 .. math::
 
@@ -313,7 +312,7 @@ where :math:`\textrm{Fro}` indicates the Frobenius norm:
 
 .. math:: \|A\|_\textrm{Fro} = \sqrt{\sum_{ij} a_{ij}^2}
 
-and :math:`\ell_1` :math:`\ell_2` reads:
+and :math:`\ell_1\ell_2` reads:
 
 .. math:: \|A\|_{2 1} = \sum_i \sqrt{\sum_j a_{ij}^2}
 
@@ -701,18 +700,18 @@ or the log-linear classifier. In this model, the probabilities describing the po
 
 The implementation of logistic regression in scikit-learn can be accessed from
 class :class:`LogisticRegression`. This implementation can fit binary, One-vs-
-Rest, or multinomial logistic regression with optional L2 or L1
-regularization.
+Rest, or multinomial logistic regression with optional :math:`\ell_2` or
+:math:`\ell_1` regularization.
 
-As an optimization problem, binary class L2 penalized logistic regression
-minimizes the following cost function:
+As an optimization problem, binary class :math:`\ell_2` penalized logistic
+regression minimizes the following cost function:
 
 .. math::
 
   \min_{w,c} \frac{1}{2}w^T w + C \sum_{i=1}^n \log(\exp(- y_i (X_i^T w + c)) +
   1) .
 
-Similarly, L1 regularized logistic regression solves the following
+Similarly, :math:`\ell_1` regularized logistic regression solves the following
 optimization problem
 
 .. math::
@@ -722,25 +721,26 @@ optimization problem
 The solvers implemented in the class :class:`LogisticRegression`
 are "liblinear", "newton-cg", "lbfgs" and "sag":
 
-The solver "liblinear" uses a coordinate descent (CD) algorithm, and relies
-on the excellent C++ `LIBLINEAR library
+The solver "liblinear" uses a coordinate descent (CD) algorithm, and relies on
+the excellent C++ `LIBLINEAR library
 <http://www.csie.ntu.edu.tw/~cjlin/liblinear/>`_, which is shipped with
-scikit-learn. However, the CD algorithm implemented in liblinear cannot learn
-a true multinomial (multiclass) model; instead, the optimization problem is
+scikit-learn. However, the CD algorithm implemented in liblinear cannot learn a
+true multinomial (multiclass) model; instead, the optimization problem is
 decomposed in a "one-vs-rest" fashion so separate binary classifiers are
 trained for all classes. This happens under the hood, so
 :class:`LogisticRegression` instances using this solver behave as multiclass
-classifiers. For L1 penalization :func:`sklearn.svm.l1_min_c` allows to
-calculate the lower bound for C in order to get a non "null" (all feature
-weights to zero) model.
+classifiers. For :math:`\ell_1` penalization :func:`sklearn.svm.l1_min_c`
+allows to calculate the lower bound for C in order to get a non "null" (all
+feature weights to zero) model.
 
-The "lbfgs", "sag" and "newton-cg" solvers only support L2 penalization and
-are found to converge faster for some high dimensional data. Setting
-`multi_class` to "multinomial" with these solvers learns a true multinomial
-logistic regression model [5]_, which means that its probability estimates
-should be better calibrated than the default "one-vs-rest" setting. The
-"lbfgs", "sag" and "newton-cg"" solvers cannot optimize L1-penalized models,
-therefore the "multinomial" setting does not learn sparse models.
+The "lbfgs", "sag" and "newton-cg" solvers only support :math:`\ell_2`
+penalization and are found to converge faster for some high dimensional data.
+Setting `multi_class` to "multinomial" with these solvers learns a true
+multinomial logistic regression model [5]_, which means that its probability
+estimates should be better calibrated than the default "one-vs-rest" setting.
+The "lbfgs", "sag" and "newton-cg"" solvers cannot optimize
+:math:`\ell_1`-penalized models, therefore the "multinomial" setting does not
+learn sparse models.
 
 The solver "sag" uses a Stochastic Average Gradient descent [6]_. It is faster
 than other solvers for large datasets, when both the number of samples and the
@@ -748,15 +748,15 @@ number of features are large.
 
 In a nutshell, one may choose the solver with the following rules:
 
-=================================  =============================
-Case                               Solver
-=================================  =============================
-Small dataset or L1 penalty        "liblinear"
-Multinomial loss or large dataset  "lbfgs", "sag" or "newton-cg"
-Very Large dataset                 "sag"
-=================================  =============================
-
-For large dataset, you may also consider using :class:`SGDClassifier` with 'log' loss.
+=================================         =============================
+Case                                      Solver
+=================================         =============================
+Small dataset or :math:`\ell_1` penalty   "liblinear"
+Multinomial loss or large dataset         "lbfgs", "sag" or "newton-cg"
+Very Large dataset                        "sag"
+=================================         =============================
+For a large dataset, you may also consider using :class:`SGDClassifier` with
+'log' loss.
 
 .. topic:: Examples:
 
@@ -783,8 +783,8 @@ For large dataset, you may also consider using :class:`SGDClassifier` with 'log'
 
 .. note:: **Feature selection with sparse logistic regression**
 
-   A logistic regression with L1 penalty yields sparse models, and can
-   thus be used to perform feature selection, as detailed in
+   A logistic regression with :math:`\ell_1` penalty yields sparse models, and
+   can thus be used to perform feature selection, as detailed in
    :ref:`l1_feature_selection`.
 
 :class:`LogisticRegressionCV` implements Logistic Regression with builtin

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -426,7 +426,7 @@ space and the similarities/dissimilarities.
 Let :math:`S` be the similarity matrix, and :math:`X` the coordinates of the
 :math:`n` input points. Disparities :math:`\hat{d}_{ij}` are transformation of
 the similarities chosen in some optimal ways. The objective, called the
-stress, is then defined by :math:`sum_{i < j} d_{ij}(X) - \hat{d}_{ij}(X)`
+stress, is then defined by :math:`\sum_{i < j} d_{ij}(X) - \hat{d}_{ij}(X)`
 
 
 Metric MDS
@@ -533,7 +533,7 @@ the quality of the resulting embedding:
 * maximum number of iterations
 * angle (not used in the exact method)
 
-The perplexity is defined as :math:`k=2^(S)` where :math:`S` is the Shannon
+The perplexity is defined as :math:`k=2^S` where :math:`S` is the Shannon
 entropy of the conditional probability distribution. The perplexity of a
 :math:`k`-sided die is :math:`k`, so that :math:`k` is effectively the number of
 nearest neighbors t-SNE considers when generating the conditional probabilities.

--- a/doc/modules/metrics.rst
+++ b/doc/modules/metrics.rst
@@ -39,18 +39,17 @@ the kernel:
 
 Cosine similarity
 -----------------
-:func:`cosine_similarity` computes the L2-normalized dot product of vectors.
-That is, if :math:`x` and :math:`y` are row vectors,
-their cosine similarity :math:`k` is defined as:
+:func:`cosine_similarity` computes the :math:`\ell_2`-normalized dot product of
+vectors. That is, if :math:`x` and :math:`y` are row vectors, their cosine
+similarity :math:`k` is defined as:
 
 .. math::
 
     k(x, y) = \frac{x y^\top}{\|x\| \|y\|}
 
-This is called cosine similarity, because Euclidean (L2) normalization
-projects the vectors onto the unit sphere,
-and their dot product is then the cosine of the angle between the points
-denoted by the vectors.
+This is called cosine similarity, because Euclidean (:math:`\ell_2`)
+normalization projects the vectors onto the unit sphere, and their dot product
+is then the cosine of the angle between the points denoted by the vectors.
 
 This kernel is a popular choice for computing the similarity of documents
 represented as tf-idf vectors.
@@ -188,9 +187,10 @@ The chi squared kernel is given by
 
         k(x, y) = \exp \left (-\gamma \sum_i \frac{(x[i] - y[i]) ^ 2}{x[i] + y[i]} \right )
 
-The data is assumed to be non-negative, and is often normalized to have an L1-norm of one.
-The normalization is rationalized with the connection to the chi squared distance,
-which is a distance between discrete probability distributions.
+The data is assumed to be non-negative, and is often normalized to have an
+:math:`\ell_1` norm of one. The normalization is rationalized with the
+connection to the chi squared distance, which is a distance between discrete
+probability distributions.
 
 The chi squared kernel is most commonly used on histograms (bags) of visual words.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1140,7 +1140,7 @@ score associated with each label
 the coverage is defined as
 
 .. math::
-  coverage(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
+  \operatorname{coverage}(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
     \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij}
 
 with :math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`.
@@ -1279,13 +1279,14 @@ The :func:`explained_variance_score` computes the `explained variance
 regression score <https://en.wikipedia.org/wiki/Explained_variation>`_.
 
 If :math:`\hat{y}` is the estimated target output, :math:`y` the corresponding
-(correct) target output, and :math:`Var` is `Variance
+(correct) target output, and :math:`\operatorname{Var}` is `Variance
 <https://en.wikipedia.org/wiki/Variance>`_, the square of the standard deviation,
 then the explained variance is estimated as follow:
 
 .. math::
 
-  \texttt{explained\_{}variance}(y, \hat{y}) = 1 - \frac{Var\{ y - \hat{y}\}}{Var\{y\}}
+  \textrm{explained\_variance}(y, \hat{y}) = 1 - \frac{\operatorname{Var}[ y -
+  \hat{y}]}{\operatorname{Var}[y]}
 
 The best possible score is 1.0, lower values are worse.
 

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -172,12 +172,12 @@ selects the class with the highest aggregate classification confidence by
 summing over the pair-wise classification confidence levels computed by the
 underlying binary classifiers.
 
-Since it requires to fit ``n_classes * (n_classes - 1) / 2`` classifiers,
-this method is usually slower than one-vs-the-rest, due to its
-O(n_classes^2) complexity. However, this method may be advantageous for
-algorithms such as kernel algorithms which don't scale well with
-``n_samples``. This is because each individual learning problem only involves
-a small subset of the data whereas, with one-vs-the-rest, the complete
+Since it requires to fit ``n_classes * (n_classes - 1) / 2`` classifiers, this
+method is usually slower than one-vs-the-rest, due to its
+:math:`O(n_\textrm{classes}^2)` complexity. However, this method may be
+advantageous for algorithms such as kernel algorithms which don't scale well
+with ``n_samples``. This is because each individual learning problem only
+involves a small subset of the data whereas, with one-vs-the-rest, the complete
 dataset is used ``n_classes`` times.
 
 Multiclass learning
@@ -314,11 +314,11 @@ Multioutput classification
 
 Multioutput classification support can be added to any classifier with
 :class:`MultiOutputClassifier`. This strategy consists of fitting one
-classifier per target.  This allows multiple target variable
-classifications. The purpose of this class is to extend estimators
-to be able to estimate a series of target functions (f1,f2,f3...,fn)
-that are trained on a single X predictor matrix to predict a series
-of reponses (y1,y2,y3...,yn).
+classifier per target.  This allows multiple target variable classifications.
+The purpose of this class is to extend estimators to be able to estimate a
+series of target functions :math:`(f_1,f_2,f_3,\ldots,f_n)` that are trained on
+a single X predictor matrix to predict a series oy reponses
+:math:`(y_1,y_2,y_3,\ldots,y_n)`.
 
 Below is an example of multioutput classification:
     

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -419,13 +419,14 @@ depends on a number of factors:
   a significant fraction of the total cost.  If very few query points
   will be required, brute force is better than a tree-based method.
 
-Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2` 
-and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the 
-``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the 
-same order as the number of training points, and that ``leaf_size`` is 
-close to its default value of ``30``.
+Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2` and
+the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
+``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the
+``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of
+``'kd_tree'``. It selects ``'brute'`` if :math:`k \ge N/2`. This choice is
+based on the assumption that the number of query points is at least the same
+order as the number of training points, and that ``leaf_size`` is close to its
+default value of ``30``.
 
 Effect of ``leaf_size``
 -----------------------
@@ -665,7 +666,7 @@ There are two phases of tree traversals used in order to answer a query to find
 the :math:`m` nearest neighbors of a point :math:`q`. First, a top-down
 traversal is performed using a binary search to identify the leaf having the
 longest prefix match (maximum depth) with :math:`q`'s label after subjecting
-:math:`q` to the same hash functions. :math:`M >> m` points (total candidates)
+:math:`q` to the same hash functions. :math:`M \gg m` points (total candidates)
 are extracted from the forest, moving up from the previously found maximum 
 depth towards the root synchronously across all trees in the bottom-up
 traversal. `M` is set to  :math:`cl` where :math:`c`, the number of candidates
@@ -674,7 +675,7 @@ these :math:`M` points against point :math:`q` is calculated and the top
 :math:`m` points are returned as the nearest neighbors of :math:`q`. Since
 most of the time in these queries is spent calculating the distances to
 candidates, the speedup compared to brute force search is approximately
-:math:`N/M`, where :math:`N` is the number of points in database.
+:math:`N/M`, where :math:`N` is the number of points in the database.
 
 .. topic:: References:
 

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -174,9 +174,9 @@ Regularization
 ==============
 
 Both :class:`MLPRegressor` and class:`MLPClassifier` use parameter ``alpha``
-for regularization (L2 regularization) term which helps in avoiding overfitting
-by penalizing weights with large magnitudes. Following plot displays varying
-decision function with value of alpha.
+for regularization (:math:`\ell_2` regularization) term which helps in avoiding
+overfitting by penalizing weights with large magnitudes. Following plot
+displays varying decision function with value of alpha.
 
 .. figure:: ../auto_examples/neural_networks/images/sphx_glr_plot_mlp_alpha_001.png
    :target: ../auto_examples/neural_networks/plot_mlp_alpha.html
@@ -283,9 +283,9 @@ function for classification is Cross-Entropy, which in binary case is given as,
     \textrm{Loss}(\hat{y},y,W) = -y \ln {\hat{y}} - (1-y) \ln{(1-\hat{y})} +
     \alpha \|W\|_2^2
 
-where :math:`\alpha ||W||_2^2` is an L2-regularization term (aka penalty)
-that penalizes complex models; and :math:`\alpha > 0` is a non-negative
-hyperparameter that controls the magnitude of the penalty.
+where :math:`\alpha \|W\|_2^2` is an :math:`\ell_2`-regularization term (aka
+penalty) that penalizes complex models; and :math:`\alpha > 0` is a
+non-negative hyperparameter that controls the magnitude of the penalty.
 
 For regression, MLP uses the Square Error loss function; written as,
 

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -20,14 +20,14 @@ Multi-layer Perceptron
 ======================
 
 **Multi-layer Perceptron (MLP)** is a supervised learning algorithm that learns
-a function :math:`f(\cdot): R^m \rightarrow R^o` by training on a dataset,
-where :math:`m` is the number of dimensions for input and :math:`o` is the
-number of dimensions for output. Given a set of features :math:`X = {x_1, x_2, ..., x_m}`
-and a target :math:`y`, it can learn a non-linear function approximator for either
-classification or regression. It is different from logistic regression, in that
-between the input and the output layer, there can be one or more non-linear
-layers, called hidden layers. Figure 1 shows a one hidden layer MLP with scalar
-output.
+a function :math:`f: \mathbb R^m \rightarrow \mathbb R^o` by training on a
+dataset, where :math:`m` is the number of dimensions for input and :math:`o` is
+the number of dimensions for output. Given a set of features :math:`X = {x_1,
+x_2, \ldots, x_m}` and a target :math:`y`, it can learn a non-linear function
+approximator for either classification or regression. It is different from
+logistic regression, in that between the input and the output layer, there can
+be one or more non-linear layers, called hidden layers. Figure 1 shows a one
+hidden layer MLP with scalar output.
 
 .. figure:: ../images/multilayerperceptron_network.png
    :align: center
@@ -37,11 +37,11 @@ output.
 
 The leftmost layer, known as the input layer, consists of a set of neurons
 :math:`\{x_i | x_1, x_2, ..., x_m\}` representing the input features. Each
-neuron in the hidden layer transforms the values from the previous layer with
-a weighted linear summation :math:`w_1x_1 + w_2x_2 + ... + w_mx_m`, followed
-by a non-linear activation function :math:`g(\cdot):R \rightarrow R` - like
-the hyperbolic tan function. The output layer receives the values from the
-last hidden layer and transforms them into output values.
+neuron in the hidden layer transforms the values from the previous layer with a
+weighted linear summation :math:`w_1x_1 + w_2x_2 + ... + w_mx_m`, followed by a
+non-linear activation function :math:`g:\mathbb R \rightarrow \mathbb R` - like
+the hyperbolic tan function. The output layer receives the values from the last
+hidden layer and transforms them into output values.
 
 The module contains the public attributes ``coefs_`` and ``intercepts_``.
 ``coefs_`` is a list of weight matrices, where weight matrix at index
@@ -78,10 +78,10 @@ Classification
 Class :class:`MLPClassifier` implements a multi-layer perceptron (MLP) algorithm
 that trains using `Backpropagation <http://ufldl.stanford.edu/wiki/index.php/Backpropagation_Algorithm>`_.
 
-MLP trains on two arrays: array X of size (n_samples, n_features), which holds
-the training samples represented as floating point feature vectors; and array
-y of size (n_samples,), which holds the target values (class labels) for the
-training samples::
+MLP trains on two arrays: array X of shape ``(n_samples, n_features)``, which
+holds the training samples represented as floating point feature vectors; and
+array y of shape ``(n_samples,)``, which holds the target values (class labels)
+for the training samples::
 
     >>> from sklearn.neural_network import MLPClassifier
     >>> X = [[0., 0.], [1., 1.]]
@@ -201,12 +201,12 @@ loss function with respect to a parameter that needs adaptation, i.e.
 
 .. math::
 
-    w \leftarrow w - \eta (\alpha \frac{\partial R(w)}{\partial w}
-    + \frac{\partial Loss}{\partial w})
+    w \leftarrow w - \eta \left(\alpha \frac{\partial R(w)}{\partial w}
+    + \frac{\partial \textrm{Loss}}{\partial w}\right)
 
-where :math:`\eta` is the learning rate which controls the step-size in
-the parameter space search.  :math:`Loss` is the loss function used
-for the network.
+where :math:`\eta` is the learning rate which controls the step-size in the
+parameter space search. :math:`\textrm{Loss}` is the loss function used for
+the network.
 
 More details can be found in the documentation of
 `SGD <http://scikit-learn.org/stable/modules/sgd.html>`_
@@ -233,7 +233,7 @@ Complexity
 Suppose there are :math:`n` training samples, :math:`m` features, :math:`k`
 hidden layers, each containing :math:`h` neurons - for simplicity, and :math:`o`
 output neurons.  The time complexity of backpropagation is
-:math:`O(n\cdot m \cdot h^k \cdot o \cdot i)`, where :math:`i` is the number
+:math:`O(nmh^koi)`, where :math:`i` is the number
 of iterations. Since backpropagation has a high time complexity, it is advisable
 to start with smaller number of hidden neurons and few hidden layers for
 training.
@@ -242,18 +242,18 @@ training.
 Mathematical formulation
 ========================
 
-Given a set of training examples :math:`(x_1, y_1), (x_2, y_2), \ldots, (x_n, y_n)`
-where :math:`x_i \in \mathbf{R}^n` and :math:`y_i \in \{0, 1\}`, a one hidden
-layer one hidden neuron MLP learns the function :math:`f(x) = W_2 g(W_1^T x + b_1) + b_2`
-where :math:`W_1 \in \mathbf{R}^m` and :math:`W_2, b_1, b_2 \in \mathbf{R}` are
-model parameters. :math:`W_1, W_2` represent the weights of the input layer and
-hidden layer, resepctively; and :math:`b_1, b_2` represent the bias added to
-the hidden layer and the output layer, respectively.
-:math:`g(\cdot) : R \rightarrow R` is the activation function, set by default as
-the hyperbolic tan. It is given as,
+Given a set of training examples :math:`(x_1, y_1), (x_2, y_2), \ldots, (x_n,
+y_n)` where :math:`x_i \in \mathbb R^n` and :math:`y_i \in \{0, 1\}`, a one
+hidden layer one hidden neuron MLP learns the function :math:`f(x) = W_2
+g(W_1^T x + b_1) + b_2` where :math:`W_1 \in \mathbb R^m` and :math:`W_2, b_1,
+b_2 \in \mathbb R` are model parameters. :math:`W_1, W_2` represent the weights
+of the input layer and hidden layer, resepctively; and :math:`b_1, b_2`
+represent the bias added to the hidden layer and the output layer,
+respectively. :math:`g: \mathbb R \rightarrow \mathbb R` is the activation
+function, set by default as the hyperbolic tan. It is given as
 
 .. math::
-      g(z)= \frac{e^z-e^{-z}}{e^z+e^{-z}}
+      g(z)= \frac{e^z-e^{-z}}{e^z+e^{-z}} .
 
 For binary classification, :math:`f(x)` passes through the logistic function
 :math:`g(z)=1/(1+e^{-z})` to obtain output values between zero and one. A
@@ -280,7 +280,8 @@ function for classification is Cross-Entropy, which in binary case is given as,
 
 .. math::
 
-    Loss(\hat{y},y,W) = -y \ln {\hat{y}} - (1-y) \ln{(1-\hat{y})} + \alpha ||W||_2^2
+    \textrm{Loss}(\hat{y},y,W) = -y \ln {\hat{y}} - (1-y) \ln{(1-\hat{y})} +
+    \alpha \|W\|_2^2
 
 where :math:`\alpha ||W||_2^2` is an L2-regularization term (aka penalty)
 that penalizes complex models; and :math:`\alpha > 0` is a non-negative
@@ -290,7 +291,8 @@ For regression, MLP uses the Square Error loss function; written as,
 
 .. math::
 
-    Loss(\hat{y},y,W) = \frac{1}{2}||\hat{y} - y ||_2^2 + \alpha ||W||_2^2
+    \textrm{Loss}(\hat{y},y,W) = \frac{1}{2}\|\hat{y} - y \|_2^2 + \alpha
+    \|W\|_2^2
 
 
 Starting from initial random weights, multi-layer perceptron (MLP) minimizes
@@ -299,12 +301,12 @@ loss, a backward pass propagates it from the output layer to the previous
 layers, providing each weight parameter with an update value meant to decrease
 the loss.
 
-In gradient descent, the gradient :math:`\nabla Loss_{W}` of the loss with respect
-to the weights is computed and deducted from :math:`W`.
-More formally, this is expressed as,
+In gradient descent, the gradient :math:`\nabla \textrm{Loss}_{W}` of the loss
+with respect to the weights is computed and deducted from :math:`W`. More
+formally, this is expressed as,
 
 .. math::
-    W^{i+1} = W^i - \epsilon \nabla {Loss}_{W}^{i}
+    W^{i+1} = W^i - \epsilon \nabla \textrm{Loss}_{W}^{i}
 
 
 where :math:`i` is the iteration step, and :math:`\epsilon` is the learning rate

--- a/doc/modules/neural_networks_unsupervised.rst
+++ b/doc/modules/neural_networks_unsupervised.rst
@@ -99,8 +99,8 @@ logistic sigmoid activation function of the input it receives:
 
 .. math::
 
-   P(v_i=1|\mathbf{h}) = \sigma(\sum_j w_{ij}h_j + b_i) \\
-   P(h_i=1|\mathbf{v}) = \sigma(\sum_i w_{ij}v_i + c_j)
+   P(v_i=1|\mathbf{h}) = \sigma\left(\sum_j w_{ij}h_j + b_i\right) \\
+   P(h_i=1|\mathbf{v}) = \sigma\left(\sum_i w_{ij}v_i + c_j\right)
 
 where :math:`\sigma` is the logistic sigmoid function:
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -243,10 +243,10 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by function :math:`phi`,
+in a feature space defined by function :math:`\phi`,
 a :class:`KernelCenterer` can transform the kernel matrix
 so that it contains inner products in the feature space
-defined by :math:`phi` followed by removal of the mean in that space.
+defined by :math:`\phi` followed by removal of the mean in that space.
 
 .. _preprocessing_normalization:
 

--- a/doc/modules/preprocessing_targets.rst
+++ b/doc/modules/preprocessing_targets.rst
@@ -36,9 +36,9 @@ Label encoding
 --------------
 
 :class:`LabelEncoder` is a utility class to help normalize labels such that
-they contain only values between 0 and n_classes-1. This is sometimes useful
-for writing efficient Cython routines. :class:`LabelEncoder` can be used as
-follows::
+they contain only values between ``0`` and ``n_classes-1``. This is sometimes
+useful for writing efficient Cython routines. :class:`LabelEncoder` can be used
+as follows::
 
     >>> from sklearn import preprocessing
     >>> le = preprocessing.LabelEncoder()

--- a/doc/modules/random_projection.rst
+++ b/doc/modules/random_projection.rst
@@ -93,7 +93,7 @@ Gaussian random projection
 The :class:`sklearn.random_projection.GaussianRandomProjection` reduces the
 dimensionality by projecting the original input space on a randomly generated
 matrix where components are drawn from the following distribution
-:math:`N(0, \frac{1}{n_{components}})`.
+:math:`N(0, \frac{1}{n_\textrm{components}})`.
 
 Here a small excerpt which illustrates how to use the Gaussian random
 projection transformer::

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -15,11 +15,11 @@ Even though SGD has been around in the machine learning community for
 a long time, it has received a considerable amount of attention just
 recently in the context of large-scale learning.
 
-SGD has been successfully applied to large-scale and sparse machine
-learning problems often encountered in text classification and natural
-language processing.  Given that the data is sparse, the classifiers
-in this module easily scale to problems with more than 10^5 training
-examples and more than 10^5 features.
+SGD has been successfully applied to large-scale and sparse machine learning
+problems often encountered in text classification and natural language
+processing.  Given that the data is sparse, the classifiers in this module
+easily scale to problems with more than :math:`10^5` training examples and more
+than :math:`10^5` features.
 
 The advantages of Stochastic Gradient Descent are:
 
@@ -51,10 +51,10 @@ penalties for classification.
    :align: center
    :scale: 75
 
-As other classifiers, SGD has to be fitted with two arrays: an array X
-of size [n_samples, n_features] holding the training samples, and an
-array Y of size [n_samples] holding the target values (class labels)
-for the training samples::
+As other classifiers, SGD has to be fitted with two arrays: an array ``X`` of
+shape ``(n_samples, n_features)`` holding the training samples, and an array
+``Y`` of shape ``(n_samples,)`` holding the target values (class labels) for
+the training samples::
 
     >>> from sklearn.linear_model import SGDClassifier
     >>> X = [[0., 0.], [1., 1.]]
@@ -116,23 +116,23 @@ Using ``loss="log"`` or ``loss="modified_huber"`` enables the
 The concrete penalty can be set via the ``penalty`` parameter.
 SGD supports the following penalties:
 
-  * ``penalty="l2"``: L2 norm penalty on ``coef_``.
-  * ``penalty="l1"``: L1 norm penalty on ``coef_``.
-  * ``penalty="elasticnet"``: Convex combination of L2 and L1;
-    ``(1 - l1_ratio) * L2 + l1_ratio * L1``.
+  * ``penalty="l2"``: :math:`\ell_2` norm penalty on ``coef_``.
+  * ``penalty="l1"``: :math:`\ell_1` norm penalty on ``coef_``.
+  * ``penalty="elasticnet"``: Convex combination of :math:`\ell_1` and
+    :math:`\ell_2`: ``(1 - l1_ratio) * L2 + l1_ratio * L1``.
 
-The default setting is ``penalty="l2"``. The L1 penalty leads to sparse
-solutions, driving most coefficients to zero. The Elastic Net solves
-some deficiencies of the L1 penalty in the presence of highly correlated
-attributes. The parameter ``l1_ratio`` controls the convex combination
-of L1 and L2 penalty.
+The default setting is ``penalty="l2"``. The :math:`\ell_1` penalty leads to
+sparse solutions, driving most coefficients to zero. The Elastic Net solves
+some deficiencies of the :math:`\ell_1` penalty in the presence of highly
+correlated attributes. The parameter ``l1_ratio`` controls the convex
+combination of :math:`\ell_1` and :math:`\ell_2` penalty.
 
 :class:`SGDClassifier` supports multi-class classification by combining
 multiple binary classifiers in a "one versus all" (OVA) scheme. For each
 of the :math:`K` classes, a binary classifier is learned that discriminates
 between that and all other :math:`K-1` classes. At testing time, we compute the
 confidence score (i.e. the signed distances to the hyperplane) for each
-classifier and choose the class with the highest confidence. The Figure
+classifier and choose the class with the highest confidence. The figure
 below illustrates the OVA approach on the iris dataset.  The dashed
 lines represent the three OVA classifiers; the background colors show
 the decision surface induced by the three classifiers.
@@ -260,12 +260,12 @@ Tips on Practical Use
     for the number of iterations is ``n_iter = np.ceil(10**6 / n)``,
     where ``n`` is the size of the training set.
 
-  * If you apply SGD to features extracted using PCA we found that
-    it is often wise to scale the feature values by some constant `c`
-    such that the average L2 norm of the training data equals one.
+  * If you apply SGD to features extracted using PCA we found that it is often
+    wise to scale the feature values by some constant `c` such that the average
+    :math:`\ell_2` norm of the training data equals one.
 
   * We found that Averaged SGD works best with a larger number of features
-    and a higher eta0
+    and a higher ``eta0``.
 
 .. topic:: References:
 
@@ -279,9 +279,9 @@ Mathematical formulation
 ========================
 
 Given a set of training examples :math:`(x_1, y_1), \ldots, (x_n, y_n)` where
-:math:`x_i \in \mathbf{R}^n` and :math:`y_i \in \{-1,1\}`, our goal is to
+:math:`x_i \in \mathbb R^n` and :math:`y_i \in \{-1,1\}`, our goal is to
 learn a linear scoring function :math:`f(x) = w^T x + b` with model parameters
-:math:`w \in \mathbf{R}^m` and intercept :math:`b \in \mathbf{R}`. In order
+:math:`w \in \mathbb R^m` and intercept :math:`b \in \mathbb R`. In order
 to make predictions, we simply look at the sign of :math:`f(x)`.
 A common choice to find the model parameters is by minimizing the regularized
 training error given by
@@ -338,8 +338,8 @@ example updates the model parameters according to the update rule given by
 
 .. math::
 
-    w \leftarrow w - \eta (\alpha \frac{\partial R(w)}{\partial w}
-    + \frac{\partial L(w^T x_i + b, y_i)}{\partial w})
+    w \leftarrow w - \eta \left(\alpha \frac{\partial R(w)}{\partial w}
+    + \frac{\partial L(w^T x_i + b, y_i)}{\partial w}\right)
 
 where :math:`\eta` is the learning rate which controls the step-size in
 the parameter space.  The intercept :math:`b` is updated similarly but
@@ -353,11 +353,12 @@ is given by
 
     \eta^{(t)} = \frac {1}{\alpha  (t_0 + t)}
 
-where :math:`t` is the time step (there are a total of `n_samples * n_iter`
-time steps), :math:`t_0` is determined based on a heuristic proposed by Léon Bottou
-such that the expected initial updates are comparable with the expected
+where :math:`t` is the time step (there are a total of ``n_samples * n_iter``
+time steps), :math:`t_0` is determined based on a heuristic proposed by Léon
+Bottou such that the expected initial updates are comparable with the expected
 size of the weights (this assuming that the norm of the training samples is
-approx. 1). The exact definition can be found in ``_init_t`` in :class:`BaseSGD`.
+approx. 1). The exact definition can be found in ``_init_t`` in
+:class:`BaseSGD`.
 
 
 For regression the default learning rate schedule is inverse scaling
@@ -365,10 +366,10 @@ For regression the default learning rate schedule is inverse scaling
 
 .. math::
 
-    \eta^{(t)} = \frac{eta_0}{t^{power\_t}}
+    \eta^{(t)} = \frac{\eta_0}{t^p}
 
-where :math:`eta_0` and :math:`power\_t` are hyperparameters chosen by the
-user via ``eta0`` and ``power_t``, resp.
+where :math:`\eta_0` and :math:`p` are hyperparameters chosen by the user via
+``eta0`` and ``power_t``, respectively.
 
 For a constant learning rate use ``learning_rate='constant'`` and use ``eta0``
 to specify the learning rate.
@@ -402,18 +403,17 @@ Implementation details
 ======================
 
 The implementation of SGD is influenced by the `Stochastic Gradient SVM
-<http://leon.bottou.org/projects/sgd>`_  of Léon Bottou. Similar to SvmSGD,
-the weight vector is represented as the product of a scalar and a vector
-which allows an efficient weight update in the case of L2 regularization.
-In the case of sparse feature vectors, the intercept is updated with a
-smaller learning rate (multiplied by 0.01) to account for the fact that
-it is updated more frequently. Training examples are picked up sequentially
-and the learning rate is lowered after each observed example. We adopted the
-learning rate schedule from Shalev-Shwartz et al. 2007.
-For multi-class classification, a "one versus all" approach is used.
-We use the truncated gradient algorithm proposed by Tsuruoka et al. 2009
-for L1 regularization (and the Elastic Net).
-The code is written in Cython.
+<http://leon.bottou.org/projects/sgd>`_  of Léon Bottou. Similar to SvmSGD, the
+weight vector is represented as the product of a scalar and a vector which
+allows an efficient weight update in the case of :math:`\ell_2` regularization.
+In the case of sparse feature vectors, the intercept is updated with a smaller
+learning rate (multiplied by 0.01) to account for the fact that it is updated
+more frequently. Training examples are picked up sequentially and the learning
+rate is lowered after each observed example. We adopted the learning rate
+schedule from Shalev-Shwartz et al. 2007. For multi-class classification, a
+"one versus all" approach is used. We use the truncated gradient algorithm
+proposed by Tsuruoka et al. 2009 for :math:`\ell_1` regularization (and the
+Elastic Net). The code is written in Cython.
 
 .. topic:: References:
 

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -311,10 +311,12 @@ misclassification error (Zero-one loss) as shown in the Figure below.
 
 Popular choices for the regularization term :math:`R` include:
 
-   - L2 norm: :math:`R(w) := \frac{1}{2} \sum_{i=1}^{n} w_i^2`,
-   - L1 norm: :math:`R(w) := \sum_{i=1}^{n} |w_i|`, which leads to sparse
-     solutions.
-   - Elastic Net: :math:`R(w) := \frac{\rho}{2} \sum_{i=1}^{n} w_i^2 + (1-\rho) \sum_{i=1}^{n} |w_i|`, a convex combination of L2 and L1, where :math:`\rho` is given by ``1 - l1_ratio``.
+   - :math:`\ell_2` norm: :math:`R(w) := \frac{1}{2} \sum_{i=1}^{n} w_i^2`,
+   - :math:`\ell_1` norm: :math:`R(w) := \sum_{i=1}^{n} |w_i|`, which leads to
+     sparse solutions.
+   - Elastic Net: :math:`R(w) := \frac{\rho}{2} \sum_{i=1}^{n} w_i^2 + (1-\rho)
+     \sum_{i=1}^{n} |w_i|`, a convex combination of :math:`\ell_2` and
+     :math:`\ell_1`, where :math:`\rho` is given by ``1 - l1_ratio``.
 
 The Figure below shows the contours of the different regularization terms
 in the parameter space when :math:`R(w) = 1`.

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -422,12 +422,12 @@ Tips on Practical Use
     thus not uncommon, to have slightly different results for the same
     input data. If that happens, try with a smaller tol parameter.
 
-  * Using L1 penalization as provided by ``LinearSVC(loss='l2', penalty='l1',
-    dual=False)`` yields a sparse solution, i.e. only a subset of feature
-    weights is different from zero and contribute to the decision function.
-    Increasing ``C`` yields a more complex model (more feature are selected).
-    The ``C`` value that yields a "null" model (all weights equal to zero) can
-    be calculated using :func:`l1_min_c`.
+  * Using :math:`\ell_1` penalization as provided by ``LinearSVC(loss='l2',
+    penalty='l1', dual=False)`` yields a sparse solution, i.e. only a subset of
+    feature weights is different from zero and contribute to the decision
+    function. Increasing ``C`` yields a more complex model (more feature are
+    selected). The ``C`` value that yields a "null" model (all weights equal to
+    zero) can be calculated using :func:`l1_min_c`.
 
 
 .. _svm_kernels:

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -221,18 +221,16 @@ logistic regression on the SVM's scores,
 fit by an additional cross-validation on the training data.
 In the multiclass case, this is extended as per Wu et al. (2004).
 
-Needless to say, the cross-validation involved in Platt scaling
-is an expensive operation for large datasets.
-In addition, the probability estimates may be inconsistent with the scores,
-in the sense that the "argmax" of the scores
-may not be the argmax of the probabilities.
-(E.g., in binary classification,
-a sample may be labeled by ``predict`` as belonging to a class
-that has probability <½ according to ``predict_proba``.)
-Platt's method is also known to have theoretical issues.
-If confidence scores are required, but these do not have to be probabilities,
-then it is advisable to set ``probability=False``
-and use ``decision_function`` instead of ``predict_proba``.
+Needless to say, the cross-validation involved in Platt scaling is an expensive
+operation for large datasets. In addition, the probability estimates may be
+inconsistent with the scores, in the sense that the argmax of the scores may
+not be the argmax of the probabilities. For instance, in binary classification,
+a sample may be labeled by ``predict`` as belonging to a class that has
+probability less than :math`\frac 1 2` according to ``predict_proba``. Platt's
+method is also known to have theoretical issues. If confidence scores are
+required, but these do not have to be probabilities, then it is advisable to
+set ``probability=False`` and use ``decision_function`` instead of
+``predict_proba``.
 
 .. topic:: References:
 
@@ -249,10 +247,11 @@ In problems where it is desired to give more importance to certain
 classes or certain individual samples keywords ``class_weight`` and
 ``sample_weight`` can be used.
 
-:class:`SVC` (but not :class:`NuSVC`) implement a keyword
-``class_weight`` in the ``fit`` method. It's a dictionary of the form
-``{class_label : value}``, where value is a floating point number > 0
-that sets the parameter ``C`` of class ``class_label`` to ``C * value``.
+:class:`SVC` (but not :class:`NuSVC`) has a keyword argument ``class_weight``.
+This should be a dictionry of the form ``{class_label : weight}``, where
+``weight`` is a positive float. This will set the ``C`` parameter of class
+``class_label`` to ``weight*C``. If ``class_weight`` is not given, all classes
+are supposed to have weight one.
 
 .. figure:: ../auto_examples/svm/images/sphx_glr_plot_separating_hyperplane_unbalanced_001.png
    :target: ../auto_examples/svm/plot_separating_hyperplane_unbalanced.html
@@ -261,9 +260,9 @@ that sets the parameter ``C`` of class ``class_label`` to ``C * value``.
 
 
 :class:`SVC`, :class:`NuSVC`, :class:`SVR`, :class:`NuSVR` and
-:class:`OneClassSVM` implement also weights for individual samples in method
-``fit`` through keyword ``sample_weight``. Similar to ``class_weight``, these
-set the parameter ``C`` for the i-th example to ``C * sample_weight[i]``.
+:class:`OneClassSVM` have a keyword argument ``sample_weight`` for their
+``fit`` method. Similar to ``class_weight``, these set the parameter ``C`` for
+the i-th example to ``C * sample_weight[i]``.
 
 
 .. figure:: ../auto_examples/svm/images/sphx_glr_plot_weighted_samples_001.png
@@ -356,16 +355,16 @@ See, section :ref:`outlier_detection` for more details on this usage.
 Complexity
 ==========
 
-Support Vector Machines are powerful tools, but their compute and
-storage requirements increase rapidly with the number of training
-vectors. The core of an SVM is a quadratic programming problem (QP),
-separating support vectors from the rest of the training data. The QP
-solver used by this `libsvm`_-based implementation scales between
-:math:`O(n_{features} \times n_{samples}^2)` and
-:math:`O(n_{features} \times n_{samples}^3)` depending on how efficiently
-the `libsvm`_ cache is used in practice (dataset dependent). If the data
-is very sparse :math:`n_{features}` should be replaced by the average number
-of non-zero features in a sample vector.
+Support Vector Machines are powerful tools, but their compute and storage
+requirements increase rapidly with the number of training vectors. The core of
+an SVM is a quadratic programming problem (QP), separating support vectors from
+the rest of the training data. The QP solver used by this `libsvm`_-based
+implementation scales between :math:`O(n_\textrm{features} \times
+n_\textrm{samples}^2)` and :math:`O(n_\textrm{features} \times
+n_\textrm{samples}^3)` depending on how efficiently the `libsvm`_ cache is used
+in practice (dataset dependent). If the data is very sparse
+:math:`n_\textrm{features}` should be replaced by the average number of
+non-zero features in a sample vector.
 
 Also note that for the linear case, the algorithm used in
 :class:`LinearSVC` by the `liblinear`_ implementation is much more
@@ -595,13 +594,15 @@ is the kernel. Here training vectors are implicitly mapped into a higher
 
 The decision function is:
 
-.. math:: \operatorname{sgn}(\sum_{i=1}^n y_i \alpha_i K(x_i, x) + \rho)
+.. math::
+ 
+  \operatorname{sgn}\left(\sum_{i=1}^n y_i \alpha_i K(x_i, x) + \rho\right)
 
 .. note::
 
     While SVM models derived from `libsvm`_ and `liblinear`_ use ``C`` as
     regularization parameter, most other estimators use ``alpha``. The relation
-    between both is :math:`C = \frac{n\_samples}{alpha}`.
+    between both is :math:`C = \frac{n_\textrm{samples}}{\alpha}`.
 
 .. TODO multiclass case ?/
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -448,7 +448,7 @@ Select the parameters that minimises the impurity
 
     \theta^* = \arg\min_\theta G(Q, \theta)
 
-Recur for subsets :math:`Q_\textrm{left}(\theta^*)` and
+Recurse for subsets :math:`Q_\textrm{left}(\theta^*)` and
 :math:`Q_\textrm{right}(\theta^*)` until either the maximum allowable depth is
 reached, :math:`N_m < \min_\textrm{samples}`, or :math:`N_m = 1`.
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -229,7 +229,7 @@ Multi-output problems
 =====================
 
 A multi-output problem is a supervised learning problem with several outputs
-to predict, that is when Y is a 2d array of size ``[n_samples, n_outputs]``.
+to predict, that is when Y is a 2d array of shape ``(n_samples, n_outputs)``.
 
 When there is no correlation between the outputs, a very simple way to solve
 this kind of problem is to build n independent models, i.e. one for each
@@ -250,7 +250,7 @@ multi-output problems. This requires the following changes:
 This module offers support for multi-output problems by implementing this
 strategy in both :class:`DecisionTreeClassifier` and
 :class:`DecisionTreeRegressor`. If a decision tree is fit on an output array Y
-of size ``[n_samples, n_outputs]`` then the resulting estimator will:
+of shape ``(n_samples, n_outputs)`` then the resulting estimator will:
 
   * Output n_output values upon ``predict``;
 
@@ -295,26 +295,29 @@ Complexity
 ==========
 
 In general, the run time cost to construct a balanced binary tree is
-:math:`O(n_{samples}n_{features}\log(n_{samples}))` and query time
-:math:`O(\log(n_{samples}))`.  Although the tree construction algorithm attempts
-to generate balanced trees, they will not always be balanced.  Assuming that the
-subtrees remain approximately balanced, the cost at each node consists of
-searching through :math:`O(n_{features})` to find the feature that offers the
-largest reduction in entropy.  This has a cost of
-:math:`O(n_{features}n_{samples}\log(n_{samples}))` at each node, leading to a
-total cost over the entire trees (by summing the cost at each node) of
-:math:`O(n_{features}n_{samples}^{2}\log(n_{samples}))`.
+:math:`O(n_\textrm{samples}n_\textrm{features}\log(n_\textrm{samples}))` and
+query time :math:`O(\log(n_\textrm{samples}))`.  Although the tree construction
+algorithm attempts to generate balanced trees, they will not always be
+balanced.  Assuming that the subtrees remain approximately balanced, the cost
+at each node consists of searching through :math:`O(n_\textrm{features})` to
+find the feature that offers the largest reduction in entropy.  This has a cost
+of :math:`O(n_\textrm{features}n_\textrm{samples}\log(n_\textrm{samples}))` at
+each node, leading to a total cost over the entire trees (by summing the cost
+at each node) of
+:math:`O(n_\textrm{features}n_\textrm{samples}^{2}\log(n_\textrm{samples}))`.
 
 Scikit-learn offers a more efficient implementation for the construction of
 decision trees.  A naive implementation (as above) would recompute the class
 label histograms (for classification) or the means (for regression) at for each
-new split point along a given feature. Presorting the feature over all
-relevant samples, and retaining a running label count, will reduce the complexity
-at each node to :math:`O(n_{features}\log(n_{samples}))`, which results in a
-total cost of :math:`O(n_{features}n_{samples}\log(n_{samples}))`. This is an option
-for all tree based algorithms. By default it is turned on for gradient boosting,
-where in general it makes training faster, but turned off for all other algorithms as
-it tends to slow down training when training deep trees.
+new split point along a given feature. Presorting the feature over all relevant
+samples, and retaining a running label count, will reduce the complexity at
+each node to :math:`O(n_\textrm{features}\log(n_\textrm{samples}))`, which
+results in a total cost of
+:math:`O(n_\textrm{features}n_\textrm{samples}\log(n_\textrm{samples}))`. This
+is an option for all tree based algorithms. By default it is turned on for
+gradient boosting, where in general it makes training faster, but turned off
+for all other algorithms as it tends to slow down training when training deep
+trees.
 
 
 Tips on practical use
@@ -415,20 +418,20 @@ scikit-learn uses an optimised version of the CART algorithm.
 Mathematical formulation
 ========================
 
-Given training vectors :math:`x_i \in R^n`, i=1,..., l and a label vector
-:math:`y \in R^l`, a decision tree recursively partitions the space such
-that the samples with the same labels are grouped together.
+Given training vectors :math:`x_i \in \mathbb R^n`, i=1,..., l and a label
+vector :math:`y \in \mathbb R^l`, a decision tree recursively partitions the
+space such that the samples with the same labels are grouped together.
 
 Let the data at node :math:`m` be represented by :math:`Q`. For
 each candidate split :math:`\theta = (j, t_m)` consisting of a
 feature :math:`j` and threshold :math:`t_m`, partition the data into
-:math:`Q_{left}(\theta)` and :math:`Q_{right}(\theta)` subsets
+:math:`Q_\textrm{left}(\theta)` and :math:`Q_\textrm{right}(\theta)` subsets
 
 .. math::
 
-    Q_{left}(\theta) = {(x, y) | x_j <= t_m}
+    Q_\textrm{left}(\theta) = {(x, y) | x_j <= t_m}
 
-    Q_{right}(\theta) = Q \setminus Q_{left}(\theta)
+    Q_\textrm{right}(\theta) = Q \setminus Q_\textrm{left}(\theta)
 
 The impurity at :math:`m` is computed using an impurity function
 :math:`H()`, the choice of which depends on the task being solved
@@ -436,18 +439,18 @@ The impurity at :math:`m` is computed using an impurity function
 
 .. math::
 
-   G(Q, \theta) = \frac{n_{left}}{N_m} H(Q_{left}(\theta))
-   + \frac{n_{right}}{N_m} H(Q_{right}(\theta))
+   G(Q, \theta) = \frac{n_\textrm{left}}{N_m} H(Q_\textrm{left}(\theta))
+   + \frac{n_\textrm{right}}{N_m} H(Q_\textrm{right}(\theta))
 
 Select the parameters that minimises the impurity
 
 .. math::
 
-    \theta^* = \operatorname{argmin}_\theta  G(Q, \theta)
+    \theta^* = \arg\min_\theta G(Q, \theta)
 
-Recurse for subsets :math:`Q_{left}(\theta^*)` and
-:math:`Q_{right}(\theta^*)` until the maximum allowable depth is reached,
-:math:`N_m < \min_{samples}` or :math:`N_m = 1`.
+Recur for subsets :math:`Q_\textrm{left}(\theta^*)` and
+:math:`Q_\textrm{right}(\theta^*)` until either the maximum allowable depth is
+reached, :math:`N_m < \min_\textrm{samples}`, or :math:`N_m = 1`.
 
 Classification criteria
 -----------------------
@@ -458,9 +461,9 @@ observations, let
 
 .. math::
 
-    p_{mk} = 1/ N_m \sum_{x_i \in R_m} I(y_i = k)
+    p_{mk} = \frac{1}{N_m} \sum_{x_i \in R_m} I(y_i = k)
 
-be the proportion of class k observations in node :math:`m`
+be the proportion of class k observations in node :math:`m`.
 
 Common measures of impurity are Gini
 


### PR DESCRIPTION
This is mostly just a lot of LaTeX fixes in the User Guide. A lot of `\textrm` and `\operatorname`s and similar were added. In some places I fixed more substantial LaTeX problems. In a couple places I also fixed other typos or confusing wording.
