### PR TITLE
[MRG+1] add __dir__ to bunch for better autocomplete

### DIFF
--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -51,6 +51,9 @@ class Bunch(dict):
     def __setattr__(self, key, value):
         self[key] = value
 
+    def __dir__(self):
+                return self.keys()
+
     def __getattr__(self, key):
         try:
             return self[key]

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -223,3 +223,9 @@ def test_bunch_pickle_generated_with_0_16_and_read_with_0_17():
     bunch_from_pkl.key = 'changed'
     assert_equal(bunch_from_pkl.key, 'changed')
     assert_equal(bunch_from_pkl['key'], 'changed')
+
+
+def test_bunch_dir():
+    # check that dir (important for autocomplete) shows attributes
+    data = load_iris()
+    assert_true("data" in dir(data))


### PR DESCRIPTION
Fixes #7088.

This removes all the builtin and dict stuff from the dir / autocomplete and only leaves the items in. This should make it easier for newcomers to understand this object (and easier for me to autocomplete on iris).

Any opinions on whether I should also add `items()`?
I'm  somewhat tempted to not allow setattr since this thing should really be immutable.
