### PR TITLE
[MRG+2] fix #5269:  Overflow error with sklearn.datasets.load_svmlight

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -312,6 +312,10 @@ Bug fixes
       (`#5460 https://github.com/scikit-learn/scikit-learn/pull/5460>`_)
       By `Tom Dupre la Tour`_.
 
+    - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
+      (`#7101 <https://github.com/scikit-learn/scikit-learn/pull/7101>`_)
+      By `Ibraim Ganiev`_.
+
 API changes summary
 -------------------
 
@@ -4312,3 +4316,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Nelson Liu: https://github.com/nelson-liu
 
 .. _Manvendra Singh: https://github.com/manu-chroma
+
+.. _Ibraim Ganiev: https://github.com/olologin

--- a/sklearn/datasets/_svmlight_format.pyx
+++ b/sklearn/datasets/_svmlight_format.pyx
@@ -27,7 +27,7 @@ cdef bytes COLON = u':'.encode('ascii')
 @cython.wraparound(False)
 def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
                         bint query_id):
-    cdef array.array data, indices, indptr, query
+    cdef array.array data, indices, indptr
     cdef bytes line
     cdef char *hash_ptr
     cdef char *line_cstr
@@ -45,7 +45,7 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         data = array.array("d")
     indices = array.array("i")
     indptr = array.array("i", [0])
-    query = array.array("i")
+    query = np.arange(0, dtype=np.int64)
 
     if multilabel:
         labels = []
@@ -80,8 +80,8 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         if n_features and features[0].startswith(qid_prefix):
             _, value = features[0].split(COLON, 1)
             if query_id:
-                array.resize_smart(query, len(query) + 1)
-                query[len(query) - 1] = int(value)
+                query.resize(len(query) + 1)
+                query[len(query) - 1] = np.int64(value)
             features.pop(0)
             n_features -= 1
 

--- a/sklearn/datasets/svmlight_format.py
+++ b/sklearn/datasets/svmlight_format.py
@@ -166,7 +166,7 @@ def _open_and_load(f, dtype, multilabel, zero_based, query_id):
     data = frombuffer_empty(data, actual_dtype)
     indices = frombuffer_empty(ind, np.intc)
     indptr = np.frombuffer(indptr, dtype=np.intc)   # never empty
-    query = frombuffer_empty(query, np.intc)
+    query = frombuffer_empty(query, np.int64)
 
     data = np.asarray(data, dtype=dtype)    # no-op for float{32,64}
     return data, indices, indptr, labels, query


### PR DESCRIPTION
Looks like previous branch is somehow corrupted, created new branch and applied patches. Previous review https://github.com/scikit-learn/scikit-learn/pull/5580.

Fix #5269.

svmlight implementation uses long data type to read and store qid, so i think it makes sense to do same in scikit-learn implementation.
