### PR TITLE
[MRG+1] Speed issues in sample_without_replacement - bugfix

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -630,10 +630,10 @@ def test_logistic_regression_sample_weights():
     # since the patched liblinear code is different.
     clf_cw = LogisticRegression(
         solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
-        penalty="l1")
+        penalty="l1", tol=1e-5)
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, penalty="l1")
+        solver="liblinear", fit_intercept=False, penalty="l1", tol=1e-5)
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -1,4 +1,3 @@
-# cython: cdivision=True
 # cython: boundscheck=False
 # cython: wraparound=False
 #


### PR DESCRIPTION
Note: `sampling_without_replacement()` will still be slower in many cases than the numpy version (or a more highly optimized Cython implemenation). This fix addresses only a bug that was leading to incorrect integer division, and in turn massively slowed down execution times when the number of samples to be drawn was close to the total number of available values to draw from.
