### PR TITLE
[MRG] DOC: add "versionadded" tags to criterion docstrings for MAE

### DIFF
--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -959,6 +959,9 @@ class RandomForestRegressor(ForestRegressor):
         reduction as feature selection criterion, and "mae" for the mean
         absolute error.
 
+    .. versionadded:: 0.18
+           Mean Absolute Error (MAE) criterion.
+
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:
 
@@ -1324,6 +1327,9 @@ class ExtraTreesRegressor(ForestRegressor):
         are "mse" for the mean squared error, which is equal to variance
         reduction as feature selection criterion, and "mae" for the mean
         absolute error.
+
+        .. versionadded:: 0.18
+           Mean Absolute Error (MAE) criterion.
 
     max_features : int, float, string or None, optional (default="auto")
         The number of features to consider when looking for the best split:

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1306,6 +1306,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
         generally the best as it can provide a better approximation in
         some cases.
 
+        .. versionadded:: 0.18
+
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:
 
@@ -1666,6 +1668,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
         the mean absolute error. The default value of "friedman_mse" is
         generally the best as it can provide a better approximation in
         some cases.
+
+        .. versionadded:: 0.18
 
     min_samples_split : int, float, optional (default=2)
         The minimum number of samples required to split an internal node:

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -802,6 +802,9 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
         reduction as feature selection criterion, and "mae" for the mean
         absolute error.
 
+        .. versionadded:: 0.18
+           Mean Absolute Error (MAE) criterion.
+
     splitter : string, optional (default="best")
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Add `versionadded` tags to `criterion` docstrings for `mae` criterion
