### PR TITLE
Refactored Count Vectorizer to be more memory efficient on N-grams

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -803,16 +803,9 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         for n in xrange(min_n, max_n + 1):
 
             analyze_count = self.build_analyzer_count(n)
-            tick = time.time()
             print n
-            j = 0
             for doc in raw_documents:
                 analyze_count(doc)
-                j += 1
-                if j % 100000 == 0:
-                    print ('Instance Processed', j)
-            tock = time.time()
-            print (tock - tick) / 60
 
             self.top = [pair[0] for pair in sorted(self.count.items(), key=lambda item: item[1])]
             self.top = self.top[-self.max_features:]
@@ -822,7 +815,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             self.count = count_new
             self.top = set(self.top)
             print len(self.top)
-        print 'finish count '
 
         analyze = self.build_analyzer()
         j_indices = _make_int_array()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

When max_features are specified, CountVectorizer will first count the word occurrence. It will take the the top occurring words up to max_features.  It will only make a 2-gram when its 1 gram count is apart of max_features, make a 3-gram when its 2-gram is apart of the max features and so on. This faster and more memory efficient on n-grams when the data sets are large.
