### PR TITLE
[MRG] Removed unused imports

### DIFF
--- a/sklearn/cluster/dbscan_.py
+++ b/sklearn/cluster/dbscan_.py
@@ -13,7 +13,6 @@ import numpy as np
 from scipy import sparse
 
 from ..base import BaseEstimator, ClusterMixin
-from ..metrics import pairwise_distances
 from ..utils import check_array, check_consistent_length
 from ..utils.fixes import astype
 from ..neighbors import NearestNeighbors

--- a/sklearn/cluster/hierarchical.py
+++ b/sklearn/cluster/hierarchical.py
@@ -9,7 +9,6 @@ License: BSD 3 clause
 """
 from heapq import heapify, heappop, heappush, heappushpop
 import warnings
-import sys
 
 import numpy as np
 from scipy import sparse

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -12,7 +12,6 @@ covariance estimator (the Minimum Covariance Determinant).
 #
 # License: BSD 3 clause
 
-import warnings
 import numpy as np
 import scipy as sp
 from . import MinCovDet

--- a/sklearn/datasets/california_housing.py
+++ b/sklearn/datasets/california_housing.py
@@ -22,7 +22,6 @@ Statistics and Probability Letters, 33 (1997) 291-297.
 # License: BSD 3 clause
 
 from io import BytesIO
-import os
 from os.path import exists
 from os import makedirs
 import tarfile

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -1,7 +1,6 @@
 """
 Testing Recursive feature elimination
 """
-import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from nose.tools import assert_equal, assert_true
@@ -16,7 +15,6 @@ from sklearn.model_selection import cross_val_score
 
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_greater
 
 from sklearn.metrics import make_scorer

--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -9,7 +9,6 @@ of Gaussian Mixture Models.
 #         Fabian Pedregosa <fabian.pedregosa@inria.fr>
 #         Bertrand Thirion <bertrand.thirion@inria.fr>
 
-import warnings
 import numpy as np
 from scipy import linalg
 from time import time

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -3,7 +3,6 @@
 import unittest
 import copy
 import sys
-import warnings
 
 from nose.tools import assert_true
 import numpy as np

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 from __future__ import division
 
 import warnings
-import inspect
 from itertools import chain, combinations
 from collections import Iterable
 from math import ceil, floor

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -44,7 +44,6 @@ from .preprocessing import LabelBinarizer
 from .metrics.pairwise import euclidean_distances
 from .utils import check_random_state
 from .utils.validation import _num_samples
-from .utils.validation import check_consistent_length
 from .utils.validation import check_is_fitted
 from .utils.validation import check_X_y
 from .utils.multiclass import (_check_partial_fit_first_call,
@@ -246,7 +245,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
                                  "method".format(self.estimator))
             self.estimators_ = [clone(self.estimator) for _ in range
                                 (self.n_classes_)]
-        
+
         # A sparse LabelBinarizer, with sparse_output=True, has been shown to
         # outperform or match a dense label binarizer in all cases and has also
         # resulted in less or equal memory consumption in the fit_ovr function
@@ -517,7 +516,7 @@ class OneVsOneClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
             delayed(_partial_fit_ovo_binary)(
                 estimator, X, y, self.classes_[i], self.classes_[j])
-            for estimator, (i, j) in izip(self.estimators_, ((i, j) for i 
+            for estimator, (i, j) in izip(self.estimators_, ((i, j) for i
                                 in range(self.n_classes_) for j in range
                                             (i + 1, self.n_classes_))))
         return self

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -16,10 +16,10 @@ extends single output estimators to multioutput estimators.
 
 import numpy as np
 
-from abc import ABCMeta, abstractmethod
-from .base import BaseEstimator, clone, MetaEstimatorMixin
+from abc import ABCMeta
+from .base import BaseEstimator, clone
 from .base import RegressorMixin, ClassifierMixin
-from .utils import check_array, check_random_state, check_X_y
+from .utils import check_array, check_X_y
 from .utils.fixes import parallel_helper
 from .utils.validation import check_is_fitted, has_fit_parameter
 from .externals.joblib import Parallel, delayed

--- a/sklearn/neighbors/graph.py
+++ b/sklearn/neighbors/graph.py
@@ -4,8 +4,6 @@
 #
 # License: BSD 3 clause (C) INRIA, University of Amsterdam
 
-import warnings
-
 from .base import KNeighborsMixin, RadiusNeighborsMixin
 from .unsupervised import NearestNeighbors
 

--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -6,7 +6,7 @@ from ..base import BaseEstimator, RegressorMixin
 from ..linear_model.base import LinearClassifierMixin, SparseCoefMixin, \
     LinearModel
 from ..feature_selection.from_model import _LearntSelectorMixin
-from ..utils import check_X_y, column_or_1d
+from ..utils import check_X_y
 from ..utils.validation import _num_samples
 from ..utils.multiclass import check_classification_targets
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -9,8 +9,7 @@ from sklearn.utils.testing import (assert_array_almost_equal, assert_equal,
                                    assert_greater_equal,
                                    assert_array_equal,
                                    assert_raises,
-                                   ignore_warnings,
-                                   assert_warns_message)
+                                   ignore_warnings)
 from sklearn.datasets import make_classification, make_blobs
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -22,8 +22,7 @@ from sklearn.metrics import recall_score
 from sklearn.svm import LinearSVC, SVC
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import (LinearRegression, Lasso, ElasticNet, Ridge,
-                                  Perceptron, LogisticRegression,
-                                  SGDClassifier)
+                                  Perceptron, LogisticRegression)
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
@@ -96,7 +95,7 @@ def test_ovr_partial_fit():
     pred = ovr.predict(iris.data)
     ovr2 = OneVsRestClassifier(MultinomialNB())
     pred2 = ovr2.fit(iris.data, iris.target).predict(iris.data)
-    
+
     assert_almost_equal(pred, pred2)
     assert_equal(len(ovr.estimators_), len(np.unique(iris.target)))
     assert_greater(np.mean(iris.target == pred), 0.65)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -41,7 +41,6 @@ from sklearn.tree import ExtraTreeClassifier
 from sklearn.tree import ExtraTreeRegressor
 
 from sklearn import tree
-from sklearn.tree.tree import SPARSE_SPLITTERS
 from sklearn.tree._tree import TREE_LEAF
 from sklearn import datasets
 

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -1,5 +1,3 @@
-import numpy as np
-from numpy.testing import TestCase
 from sklearn.utils.testing import assert_array_equal
 
 from sklearn.utils.stats import rankdata

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import pinv2
-from scipy.linalg import eigh
 from itertools import chain
 
 from sklearn.utils.testing import (assert_equal, assert_raises, assert_true,
@@ -132,7 +131,7 @@ def test_pinvh_simple_complex():
 
 
 def test_arpack_eigsh_initialization():
-    # Non-regression test that shows null-space computation is better with 
+    # Non-regression test that shows null-space computation is better with
     # initialization of eigsh from [-1,1] instead of [0,1]
     random_state = check_random_state(42)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I removed unused imports, primarily to reduce the output from `pyflakes`. There are "unused" imports remaining, but in most cases those seem intentional. One case I'm not sure about, [here](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/ensemble/tests/test_weight_boosting.py#L290). I'm not sure whether a) the import should be removed, or b) there was supposed be another test, but it didn't get written. 
