### PR TITLE
TfidfTransformer.transform() performance bug fix

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -993,8 +993,8 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
             # log+1 instead of log makes sure terms with zero idf don't get
             # suppressed entirely.
             idf = np.log(float(n_samples) / df) + 1.0
-            self._idf_diag = sp.spdiags(idf,
-                                        diags=0, m=n_features, n=n_features, format='csr')
+            self._idf_diag = sp.spdiags(idf, diags=0, m=n_features, 
+                                        n=n_features, format='csr')
 
         return self
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -994,7 +994,7 @@ class TfidfTransformer(BaseEstimator, TransformerMixin):
             # suppressed entirely.
             idf = np.log(float(n_samples) / df) + 1.0
             self._idf_diag = sp.spdiags(idf,
-                                        diags=0, m=n_features, n=n_features)
+                                        diags=0, m=n_features, n=n_features, format='csr')
 
         return self
 


### PR DESCRIPTION
Changing fit() to save self._idf_diag as csr_matrix to avoid transforming self._idf_diag to csr_matrix each transform() call.
It happens when self.use_idf==True in: X = X \* self._idf_diag in __mul__ operator.
