### PR TITLE
[MRG] fix line length in whats_new and fix indent in datasets/base.py

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -230,8 +230,10 @@ Enhancements
      (`#6846 <https://github.com/scikit-learn/scikit-learn/pull/6846>`_)
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
-   - Added new return type ``(data, target)`` : tuple option to :func:`load_iris` dataset. (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) 
-     By `Manvendra Singh`_ and `Nelson Liu`_.   
+   - Added new return type ``(data, target)`` : tuple option to
+     :func:`load_iris` dataset.
+     (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) by
+     `Manvendra Singh`_.
 
 Bug fixes
 .........

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -260,12 +260,11 @@ def load_iris(return_X_y=False):
 
     Parameters
     ----------
-    
-        .. versionadded:: 0.18
-     
     return_X_y : boolean, default=False.
         If True, returns ``(data, target)`` instead of a Bunch object.
         See below for more information about the `data` and `target` object.
+
+    .. versionadded:: 0.18
 
     Returns
     -------
@@ -277,6 +276,8 @@ def load_iris(return_X_y=False):
         full description of the dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
+
+    .. versionadded:: 0.18
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issue

Fixes some last comments in https://github.com/scikit-learn/scikit-learn/pull/7049
#### What does this implement/fix? Explain your changes.
- Adjusts the line length for the new return type entry in whats_new.rst
- move `versionadded` tags below the things added
