### PR TITLE
[MRG] fix MultiOutputEstimator fit return docstring

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -60,9 +60,11 @@ class MultiOutputEstimator(six.with_metaclass(ABCMeta, BaseEstimator)):
             Sample weights. If None, then samples are equally weighted.
             Only supported if the underlying regressor supports sample
             weights.
+
         Returns
         -------
-        self
+        self : object
+            Returns self.
         """
 
         if not hasattr(self.estimator, "fit"):


### PR DESCRIPTION
#### Reference Issue

None
#### What does this implement/fix? Explain your changes.

`MultiOutputEstimator` docs for the return type of the `fit` method were incomplete.
