### PR TITLE
[MRG] load_breast_cancer dataset: added return_X_y option

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -231,7 +231,7 @@ Enhancements
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
    - Added new return type ``(data, target)`` : tuple option to
-     :func:`load_iris` dataset, :func: `load_breast_cancer` dataset
+     :func:`load_iris` dataset, :func:`load_breast_cancer` dataset
      (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) by
      `Manvendra Singh`_.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -231,7 +231,7 @@ Enhancements
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
    - Added new return type ``(data, target)`` : tuple option to
-     :func:`load_iris` dataset.
+     :func:`load_iris` dataset, :func: `load_breast_cancer` dataset
      (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) by
      `Manvendra Singh`_.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -231,8 +231,10 @@ Enhancements
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
    - Added new return type ``(data, target)`` : tuple option to
-     :func:`load_iris` dataset, :func:`load_breast_cancer` dataset
-     (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_) by
+     :func:`load_iris` dataset, 
+     (`#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_)
+     :func:`load_breast_cancer` dataset
+     (`#7152 <https://github.com/scikit-learn/scikit-learn/pull/7152>`_) by
      `Manvendra Singh`_.
 
 Bug fixes

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -318,7 +318,7 @@ def load_iris(return_X_y=False):
                                 'petal length (cm)', 'petal width (cm)'])
 
 
-def load_breast_cancer():
+def load_breast_cancer(return_X_y=False):
     """Load and return the breast cancer wisconsin dataset (classification).
 
     The breast cancer dataset is a classic and very easy binary classification
@@ -332,6 +332,14 @@ def load_breast_cancer():
     Features            real, positive
     =================   ==============
 
+    Parameters
+    ----------
+    return_X_y : boolean, deafult=True
+        If True, returns ``(data, target)`` instead of a Bunch object.
+        See below for more information about the `data` and `target` object.
+
+    .. versionadded:: 0.18
+
     Returns
     -------
     data : Bunch
@@ -340,6 +348,10 @@ def load_breast_cancer():
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
         full description of the dataset.
+
+    (data, target) : tuple if ``return_X_y`` is True
+
+    .. versionadded:: 0.18
 
     The copy of UCI ML Breast Cancer Wisconsin (Diagnostic) dataset is
     downloaded from:
@@ -389,6 +401,9 @@ def load_breast_cancer():
                               'worst smoothness', 'worst compactness',
                               'worst concavity', 'worst concave points',
                               'worst symmetry', 'worst fractal dimension'])
+
+    if return_X_y:
+        return data, target
 
     return Bunch(data=data, target=target,
                  target_names=target_names,

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -334,7 +334,7 @@ def load_breast_cancer(return_X_y=False):
 
     Parameters
     ----------
-    return_X_y : boolean, deafult=True
+    return_X_y : boolean, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
         See below for more information about the `data` and `target` object.
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -196,6 +196,13 @@ def test_load_breast_cancer():
     assert_equal(res.target_names.size, 2)
     assert_true(res.DESCR)
 
+    # test return_X_y option
+    X_y_tuple = load_breast_cancer(return_X_y=True)
+    bunch = load_breast_cancer()
+    assert_true(isinstance(X_y_tuple, tuple))
+    assert_array_equal(X_y_tuple[0], bunch.data)
+    assert_array_equal(X_y_tuple[1], bunch.target)
+
 
 def test_load_boston():
     res = load_boston()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Partially Fixes https://github.com/scikit-learn/scikit-learn/issues/6670
#### What does this implement/fix? Explain your changes.
1. added return_X_y option for `load_breast_cancer` dataset
2. Wrote tests for the same
#### Any other comments?

Very similar to https://github.com/scikit-learn/scikit-learn/pull/7049

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
