### PR TITLE
[WIP] Make neighbor tree module supports fused types

### DIFF
--- a/sklearn/neighbors/typedefs.pxd
+++ b/sklearn/neighbors/typedefs.pxd
@@ -16,3 +16,8 @@ ctypedef np.intp_t ITYPE_t  # WARNING: should match ITYPE in typedefs.pyx
 ctypedef fused DITYPE_t:
     ITYPE_t
     DTYPE_t
+
+ctypedef fused floating_ITYPE_t:
+    ITYPE_t
+    DTYPE_t
+    np.float32_t


### PR DESCRIPTION
Ball Tree and KD Tree currently only support `np.float64`, which is a waste of memory as same quality results should be obtainable with `np.float32`.

**Note**: `self.new_data` and `self.new_data_arr` are just for development usage, I try to first use them to repeat what `self.data` and `self.data_arr` do. With this manner, I can still build scikit-learn successfully and I'll change `self.data` and `self.data_arr` in the end.
