### PR TITLE
log_loss bug fixed 

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1543,7 +1543,8 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
         raise ValueError("{0} is not supported".format(y_type))
 
 
-def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
+def log_loss(y_true, y_pred, labels=None, eps=1e-15, normalize=True,
+             sample_weight=None):
     """Log loss, aka logistic loss or cross-entropy loss.
 
     This is the loss function used in (multinomial) logistic regression
@@ -1564,6 +1565,9 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     y_pred : array-like of float, shape = (n_samples, n_classes)
         Predicted probabilities, as returned by a classifier's
         predict_proba method.
+
+    labels : array-like, optional (default=None) 
+        If not provided, labels will be inferred from y_true
 
     eps : float
         Log loss is undefined for p=0 or p=1, so probabilities are
@@ -1596,11 +1600,17 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     The logarithm used is the natural logarithm (base-e).
     """
     lb = LabelBinarizer()
-    T = lb.fit_transform(y_true)
+    lb.fit(labels) if labels is not None else lb.fit(y_true)
+    if labels is None and len(lb.classes_) == 1:
+        raise ValueError('y_true has only one label. Please provide '
+        'the true labels explicitly through the labels argument.')
+
+    T = lb.transform(y_true)
+
     if T.shape[1] == 1:
         T = np.append(1 - T, T, axis=1)
-
     y_pred = check_array(y_pred, ensure_2d=False)
+
     # Clipping
     Y = np.clip(y_pred, eps, 1 - eps)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -45,7 +45,6 @@ from sklearn.metrics import recall_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
 
-
 from sklearn.metrics.classification import _check_targets
 from sklearn.exceptions import UndefinedMetricWarning
 
@@ -1383,6 +1382,29 @@ def test_log_loss():
     y_pred = [[0.2, 0.7], [0.6, 0.5], [0.4, 0.1], [0.7, 0.2]]
     loss = log_loss(y_true, y_pred)
     assert_almost_equal(loss, 1.0383217, decimal=6)
+
+    # test labels option
+
+    y_true = [2, 2]
+    y_score = np.array([[0.1, 0.9], [0.1, 0.9]])
+
+    # because y_true label are the same, there should be an error if the
+    # labels option has not been used
+
+    # error_logloss = log_loss(y_true, y_score)
+    # label_not_of_2_loss = -np.mean(np.log(y_score[:,0]))
+    # assert_almost_equal(error_logloss, label_not_of_2_loss)
+    # assert_raises(log_loss(y_true, y_score))
+
+    error_str = ('y_true has only one label. Please provide '
+                 'the true labels explicitly through the labels argument.')
+
+    assert_raise_message(ValueError, error_str, log_loss, y_true, y_pred)
+
+    # when the labels argument is used, it works
+    true_log_loss = -np.mean(np.log(y_score[:, 1]))
+    calculated_log_loss = log_loss(y_true, y_score, labels=[1, 2])
+    assert_almost_equal(calculated_log_loss, true_log_loss)
 
 
 def test_log_loss_pandas_input():


### PR DESCRIPTION
all credit for this goes to @hongguangguo
**Reference Issue**
metrics.log_loss fails when any classes are missing in y_true #4033
Fix a bug, the result is wrong when use sklearn.metrics.log_loss with one class, #4546
Log_loss is calculated incorrectly when only 1 class present #6703

**What does this implement/fix? Explain your changes.**
added labels option. when length of unique y_true < number of columns for y_score/y_pred, should use labels so as to len(unique(labels)) eques y_pred.shap[1].
