### PR TITLE
[MRG+1] Some changes to let Scikit-learn work in Pyston

### DIFF
--- a/sklearn/externals/funcsigs.py
+++ b/sklearn/externals/funcsigs.py
@@ -20,8 +20,8 @@ __version__ = "0.4"
 __all__ = ['BoundArguments', 'Parameter', 'Signature', 'signature']
 
 
-_WrapperDescriptor = type(type.__call__)
-_MethodWrapper = type(all.__call__)
+_WrapperDescriptor = type(bytearray.__add__)
+_MethodWrapper = type(u'str'.__add__)
 
 _NonUserDefinedCallables = (_WrapperDescriptor,
                             _MethodWrapper,

--- a/sklearn/src/cblas/atlas_reflevel1.h
+++ b/sklearn/src/cblas/atlas_reflevel1.h
@@ -251,6 +251,15 @@ void       ATL_crefrotg
    float *
 );
 
+void ATL_srefcopy
+(
+   const int                  N,
+   const float                * X,
+   const int                  INCX,
+   float                      * Y,
+   const int                  INCY
+);
+
 float      ATL_screfnrm2
 (
    const int,
@@ -328,6 +337,15 @@ void       ATL_crefdotu_sub
    const float *,          const int,
    const float *,          const int,
    float *
+);
+
+void ATL_drefcopy
+(
+   const int                  N,
+   const double               * X,
+   const int                  INCX,
+   double                     * Y,
+   const int                  INCY
 );
 
 void       ATL_zrefrotg

--- a/sklearn/src/cblas/cblas.h
+++ b/sklearn/src/cblas/cblas.h
@@ -591,6 +591,7 @@ void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
                   void *C, const int ldc);
 
 int cblas_errprn(int ierr, int info, char *form, ...);
+void cblas_xerbla(int p, char *rout, char *form, ...);
 
 #endif  /* end #ifdef CBLAS_ENUM_ONLY */
 #endif

--- a/sklearn/src/cblas/cblas_dcopy.c
+++ b/sklearn/src/cblas/cblas_dcopy.c
@@ -34,6 +34,7 @@
    #include "atlas_ptalias1.h"
 #endif
 #include "atlas_level1.h"
+#include "atlas_reflevel1.h"
 #include "cblas.h"
 
 void cblas_dcopy(const int N, const double *X, const int incX,

--- a/sklearn/src/cblas/cblas_scopy.c
+++ b/sklearn/src/cblas/cblas_scopy.c
@@ -34,6 +34,7 @@
    #include "atlas_ptalias1.h"
 #endif
 #include "atlas_level1.h"
+#include "atlas_reflevel1.h"
 #include "cblas.h"
 
 void cblas_scopy(const int N, const float *X, const int incX,

--- a/sklearn/src/cblas/cblas_xerbla.c
+++ b/sklearn/src/cblas/cblas_xerbla.c
@@ -35,6 +35,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 void cblas_xerbla(int p, char *rout, char *form, ...)
 {
    va_list argptr;


### PR DESCRIPTION
This are some changes to let Scikit-learn could work in Pyston.

Unlike CPython, Pyston treat implicit declaration as error. So I added some structs and function declarations in related head files. And also includes proper head files. Please correct me if I did something wrong.

The second change is: In Pyston, the `type(type.__call__)` is different than CPython. This was found by @undingen Thank you! He use `type(unicode.__getitem__)`, but I change it to `type(arraybyte.__add__)` for compatibility reason. More details please see the second commit. 
