### PR TITLE
fixing ElasticNet sparse decision function to match output with dense

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -766,8 +766,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         """
         check_is_fitted(self, 'n_iter_')
         if sparse.isspmatrix(X):
-            return safe_sparse_dot(X, self.coef_.T, dense_output=True) \
-                    + self.intercept_
+            return safe_sparse_dot(X, self.coef_.T,
+                                   dense_output=True) + self.intercept_
         else:
             return super(ElasticNet, self)._decision_function(X)
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -766,7 +766,8 @@ class ElasticNet(LinearModel, RegressorMixin):
         """
         check_is_fitted(self, 'n_iter_')
         if sparse.isspmatrix(X):
-            return safe_sparse_dot(self.coef_, X.T, dense_output=True).T + self.intercept_
+            return safe_sparse_dot(X, self.coef_.T, dense_output=True) \
+                    + self.intercept_
         else:
             return super(ElasticNet, self)._decision_function(X)
 

--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -766,9 +766,7 @@ class ElasticNet(LinearModel, RegressorMixin):
         """
         check_is_fitted(self, 'n_iter_')
         if sparse.isspmatrix(X):
-            return np.ravel(safe_sparse_dot(self.coef_, X.T,
-                                            dense_output=True) +
-                            self.intercept_)
+            return safe_sparse_dot(self.coef_, X.T, dense_output=True).T + self.intercept_
         else:
             return super(ElasticNet, self)._decision_function(X)
 

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -267,3 +267,36 @@ def test_same_output_sparse_dense_lasso_and_enet_cv():
         assert_almost_equal(clfs.intercept_, clfd.intercept_, 7)
         assert_array_almost_equal(clfs.mse_path_, clfd.mse_path_)
         assert_array_almost_equal(clfs.alphas_, clfd.alphas_)
+
+
+def test_same_multiple_output_sparse_dense():
+    X, y = make_sparse_data(n_samples=40, n_features=10)
+    for normalize in [True, False]:
+        l = ElasticNet(normalize=normalize)
+        X = [[0, 1, 2, 3, 4],
+             [0, 2, 5, 8, 11],
+             [9, 10, 11, 12, 13],
+             [10, 11, 12, 13, 14]]
+        y = [[1, 2, 3, 4, 5],
+             [1, 3, 6, 9, 12],
+             [10, 11, 12, 13, 14],
+             [11, 12, 13, 14, 15]]
+        l.fit(X, y)
+        ignore_warnings(l.fit)(X, y)
+        sample = np.array([1, 2, 3, 4, 5]).reshape(1, -1)
+        predict_dense = l.predict(sample)
+
+        l_sp = ElasticNet(normalize=normalize)
+        X_sp = sp.coo_matrix([[0, 1, 2, 3, 4],
+                              [0, 2, 5, 8, 11],
+                              [9, 10, 11, 12, 13],
+                              [10, 11, 12, 13, 14]])
+        y_sp = [[1, 2, 3, 4, 5],
+                [1, 3, 6, 9, 12],
+                [10, 11, 12, 13, 14],
+                [11, 12, 13, 14, 15]]
+        ignore_warnings(l_sp.fit)(X_sp, y_sp)
+
+        sample_sparse = sp.coo_matrix(sample)
+        predict_sparse = l_sp.predict(sample_sparse)
+        assert_array_almost_equal(predict_sparse, predict_dense)

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -270,7 +270,6 @@ def test_same_output_sparse_dense_lasso_and_enet_cv():
 
 
 def test_same_multiple_output_sparse_dense():
-    X, y = make_sparse_data(n_samples=40, n_features=10)
     for normalize in [True, False]:
         l = ElasticNet(normalize=normalize)
         X = [[0, 1, 2, 3, 4],

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -289,11 +289,7 @@ def test_same_multiple_output_sparse_dense():
                               [0, 2, 5, 8, 11],
                               [9, 10, 11, 12, 13],
                               [10, 11, 12, 13, 14]])
-        y_sp = [[1, 2, 3, 4, 5],
-                [1, 3, 6, 9, 12],
-                [10, 11, 12, 13, 14],
-                [11, 12, 13, 14, 15]]
-        ignore_warnings(l_sp.fit)(X_sp, y_sp)
+        ignore_warnings(l_sp.fit)(X_sp, y)
         sample_sparse = sp.coo_matrix(sample)
         predict_sparse = l_sp.predict(sample_sparse)
 

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -280,7 +280,6 @@ def test_same_multiple_output_sparse_dense():
              [1, 3, 6, 9, 12],
              [10, 11, 12, 13, 14],
              [11, 12, 13, 14, 15]]
-        l.fit(X, y)
         ignore_warnings(l.fit)(X, y)
         sample = np.array([1, 2, 3, 4, 5]).reshape(1, -1)
         predict_dense = l.predict(sample)
@@ -295,7 +294,7 @@ def test_same_multiple_output_sparse_dense():
                 [10, 11, 12, 13, 14],
                 [11, 12, 13, 14, 15]]
         ignore_warnings(l_sp.fit)(X_sp, y_sp)
-
         sample_sparse = sp.coo_matrix(sample)
         predict_sparse = l_sp.predict(sample_sparse)
+
         assert_array_almost_equal(predict_sparse, predict_dense)


### PR DESCRIPTION
#### Reference Issue

Issue #7130 
#### What does this implement/fix? Explain your changes.

Fixes ElasticNet decision function for sparse matrices and multiple outputs.
#### Any other comments?

There should probably be a test case for multiple outputs with sparse matrices.
