### PR TITLE
[MRG] Use pgtol parameter in fmin_l_bfgs call in HuberRegressor

### DIFF
--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -258,7 +258,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
             parameters, f, dict_ = optimize.fmin_l_bfgs_b(
                 _huber_loss_and_gradient, parameters,
                 args=(X, y, self.epsilon, self.alpha, sample_weight),
-                maxiter=self.max_iter, tol=self.tol, bounds=bounds,
+                maxiter=self.max_iter, pgtol=self.tol, bounds=bounds,
                 iprint=0)
         except TypeError:
             parameters, f, dict_ = optimize.fmin_l_bfgs_b(

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -155,9 +155,8 @@ def test_huber_warm_start():
     assert_array_almost_equal(huber_warm.coef_, huber_warm_coef, 1)
 
     # No n_iter_ in old SciPy (<=0.9)
-    # And as said above, the first iteration seems to be run anyway.
     if huber_warm.n_iter_ is not None:
-        assert_equal(1, huber_warm.n_iter_)
+        assert_equal(0, huber_warm.n_iter_)
 
 
 def test_huber_better_r2_score():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`tol` is not a parameter of `scipy.optimize.fmin_l_bfgs_b` (see http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html). This resulted in the scipy < 0.9 branch always being called, which means both `self.maxiter` and `self.tol` were not used.
