### PR TITLE
[MRG+1] Make Silhouette_score support sparse X

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -15,31 +15,29 @@ from sklearn.metrics import pairwise_distances
 def test_silhouette():
     # Tests the Silhouette Coefficient.
     dataset = datasets.load_iris()
-    X = dataset.data
+    X_dense = dataset.data
+    X_sparse = csr_matrix(X_dense)
     y = dataset.target
-    D = pairwise_distances(X, metric='euclidean')
-    # Given that the actual labels are used, we can assume that S would be
-    # positive.
-    silhouette = silhouette_score(D, y, metric='precomputed')
-    assert(silhouette > 0)
-    # Test without calculating D
-    silhouette_metric = silhouette_score(X, y, metric='euclidean')
-    assert_almost_equal(silhouette, silhouette_metric)
-    # Test with sampling
-    silhouette = silhouette_score(D, y, metric='precomputed',
-                                  sample_size=int(X.shape[0] / 2),
-                                  random_state=0)
-    silhouette_metric = silhouette_score(X, y, metric='euclidean',
-                                         sample_size=int(X.shape[0] / 2),
-                                         random_state=0)
-    assert(silhouette > 0)
-    assert(silhouette_metric > 0)
-    assert_almost_equal(silhouette_metric, silhouette)
-    # Test with sparse X
-    X_sparse = csr_matrix(X)
-    D = pairwise_distances(X_sparse, metric='euclidean')
-    silhouette = silhouette_score(D, y, metric='precomputed')
-    assert(silhouette > 0)
+
+    for X in [X_dense, X_sparse]:
+        D = pairwise_distances(X, metric='euclidean')
+        # Given that the actual labels are used, we can assume that S would be
+        # positive.
+        silhouette = silhouette_score(D, y, metric='precomputed')
+        assert(silhouette > 0)
+        # Test without calculating D
+        silhouette_metric = silhouette_score(X, y, metric='euclidean')
+        assert_almost_equal(silhouette, silhouette_metric)
+        # Test with sampling
+        silhouette = silhouette_score(D, y, metric='precomputed',
+                                    sample_size=int(X.shape[0] / 2),
+                                    random_state=0)
+        silhouette_metric = silhouette_score(X, y, metric='euclidean',
+                                            sample_size=int(X.shape[0] / 2),
+                                            random_state=0)
+        assert(silhouette > 0)
+        assert(silhouette_metric > 0)
+        assert_almost_equal(silhouette_metric, silhouette)
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -22,7 +22,6 @@ def test_silhouette():
     X_lil = sp.lil_matrix(X_dense)
     y = dataset.target
 
-    X_dense_score = {}
     for X in [X_dense, X_csr, X_dok, X_lil]:
         D = pairwise_distances(X, metric='euclidean')
         # Given that the actual labels are used, we can assume that S would be
@@ -42,14 +41,11 @@ def test_silhouette():
         assert(silhouette > 0)
         assert(silhouette_metric > 0)
         assert_almost_equal(score_euclidean, score_precomputed)
+
         if X is X_dense:
-            X_dense_score['precomputed'] = score_precomputed
-            X_dense_score['euclidean'] = score_euclidean
+            X_dense_score = score_precomputed
         else:
-            assert_almost_equal(X_dense_score['precomputed'],
-                                score_precomputed)
-            assert_almost_equal(X_dense_score['euclidean'],
-                                score_euclidean)
+            assert_almost_equal(X_dense_score, score_euclidean)
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -22,7 +22,6 @@ def test_silhouette():
     X_lil = sp.lil_matrix(X_dense)
     y = dataset.target
 
-    X_dense_score = {}
     for X in [X_dense, X_csr, X_dok, X_lil]:
         D = pairwise_distances(X, metric='euclidean')
         # Given that the actual labels are used, we can assume that S would be
@@ -34,10 +33,10 @@ def test_silhouette():
         assert_almost_equal(score_precomputed, score_euclidean)
 
         if X is X_dense:
-            X_dense_score['without_sampling'] = score_precomputed
+            score_dense_without_sampling = score_precomputed
         else:
             assert_almost_equal(score_euclidean,
-                                X_dense_score['without_sampling'])
+                                score_dense_without_sampling)
 
         # Test with sampling
         score_precomputed = silhouette_score(D, y, metric='precomputed',
@@ -51,9 +50,9 @@ def test_silhouette():
         assert_almost_equal(score_euclidean, score_precomputed)
 
         if X is X_dense:
-            X_dense_score['with_sampling'] = score_precomputed
+            score_dense_with_sampling = score_precomputed
         else:
-            assert_almost_equal(score_euclidean, X_dense_score['with_sampling'])
+            assert_almost_equal(score_euclidean, score_dense_with_sampling)
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -8,6 +8,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_greater
 from sklearn.metrics.cluster import silhouette_score
 from sklearn.metrics.cluster import calinski_harabaz_score
 from sklearn.metrics import pairwise_distances
@@ -27,7 +28,7 @@ def test_silhouette():
         # Given that the actual labels are used, we can assume that S would be
         # positive.
         score_precomputed = silhouette_score(D, y, metric='precomputed')
-        assert(score_precomputed > 0)
+        assert_greater(score_precomputed, 0)
         # Test without calculating D
         score_euclidean = silhouette_score(X, y, metric='euclidean')
         assert_almost_equal(score_precomputed, score_euclidean)
@@ -45,8 +46,8 @@ def test_silhouette():
         score_euclidean = silhouette_score(X, y, metric='euclidean',
                                            sample_size=int(X.shape[0] / 2),
                                            random_state=0)
-        assert(score_precomputed > 0)
-        assert(score_euclidean > 0)
+        assert_greater(score_precomputed, 0)
+        assert_greater(score_euclidean, 0)
         assert_almost_equal(score_euclidean, score_precomputed)
 
         if X is X_dense:

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -22,15 +22,23 @@ def test_silhouette():
     X_lil = sp.lil_matrix(X_dense)
     y = dataset.target
 
+    X_dense_score = {}
     for X in [X_dense, X_csr, X_dok, X_lil]:
         D = pairwise_distances(X, metric='euclidean')
         # Given that the actual labels are used, we can assume that S would be
         # positive.
-        silhouette = silhouette_score(D, y, metric='precomputed')
-        assert(silhouette > 0)
+        score_precomputed = silhouette_score(D, y, metric='precomputed')
+        assert(score_precomputed > 0)
         # Test without calculating D
-        silhouette_metric = silhouette_score(X, y, metric='euclidean')
-        assert_almost_equal(silhouette, silhouette_metric)
+        score_euclidean = silhouette_score(X, y, metric='euclidean')
+        assert_almost_equal(score_precomputed, score_euclidean)
+
+        if X is X_dense:
+            X_dense_score['without_sampling'] = score_precomputed
+        else:
+            assert_almost_equal(score_euclidean,
+                                X_dense_score['without_sampling'])
+
         # Test with sampling
         score_precomputed = silhouette_score(D, y, metric='precomputed',
                                              sample_size=int(X.shape[0] / 2),
@@ -38,14 +46,14 @@ def test_silhouette():
         score_euclidean = silhouette_score(X, y, metric='euclidean',
                                            sample_size=int(X.shape[0] / 2),
                                            random_state=0)
-        assert(silhouette > 0)
-        assert(silhouette_metric > 0)
+        assert(score_precomputed > 0)
+        assert(score_euclidean > 0)
         assert_almost_equal(score_euclidean, score_precomputed)
 
         if X is X_dense:
-            X_dense_score = score_precomputed
+            X_dense_score['with_sampling'] = score_precomputed
         else:
-            assert_almost_equal(X_dense_score, score_euclidean)
+            assert_almost_equal(score_euclidean, X_dense_score['with_sampling'])
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -88,7 +88,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
-    X, labels = check_X_y(X, labels)
+    X, labels = check_X_y(X, labels, accept_sparse=True)
     le = LabelEncoder()
     labels = le.fit_transform(labels)
     n_labels = len(le.classes_)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -88,7 +88,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
-    X, labels = check_X_y(X, labels, accept_sparse=True)
+    X, labels = check_X_y(X, labels, accept_sparse=['csc', 'csr'])
     le = LabelEncoder()
     labels = le.fit_transform(labels)
     n_labels = len(le.classes_)


### PR DESCRIPTION
Currently `silhouette_score` only support dense data, this PR would make it support sparse input.
Also, this PR fix #6317.
