### PR TITLE
[MRG] Block-wise silhouette calculation to avoid memory consumption

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -78,6 +78,49 @@ def test_no_nan():
     assert_false(np.isnan(ss).any())
 
 
+def test_silhouette_paper_example():
+    # Explicitly check per-sample results against Rousseeuw (1987)
+    lower = [5.58,
+             7.00, 6.50,
+             7.08, 7.00, 3.83,
+             4.83, 5.08, 8.17, 5.83,
+             2.17, 5.75, 6.67, 6.92, 4.92,
+             6.42, 5.00, 5.58, 6.00, 4.67, 6.42,
+             3.42, 5.50, 6.42, 6.42, 5.00, 3.92, 6.17,
+             2.50, 4.92, 6.25, 7.33, 4.50, 2.25, 6.33, 2.75,
+             6.08, 6.67, 4.25, 2.67, 6.00, 6.17, 6.17, 6.92, 6.17,
+             5.25, 6.83, 4.50, 3.75, 5.75, 5.42, 6.08, 5.83, 6.67, 3.67,
+             4.75, 3.00, 6.08, 6.67, 5.00, 5.58, 4.83, 6.17, 5.67, 6.50, 6.92]
+    D = np.zeros((12, 12))
+    D[np.tril_indices(12, -1)] = lower
+    D += D.T
+
+    names = ['BEL', 'BRA', 'CHI', 'CUB', 'EGY', 'FRA', 'IND', 'ISR', 'USA',
+             'USS', 'YUG', 'ZAI']
+
+    labels1 = [1, 1, 2, 2, 1, 1, 2, 1, 1, 2, 2, 1]
+    labels2 = [1, 2, 3, 3, 1, 1, 2, 1, 1, 3, 3, 2]
+
+    expected1 = {'USA': .43, 'BEL': .39, 'FRA': .35, 'ISR': .30, 'BRA': .22,
+                 'EGY': .20, 'ZAI': .19, 'CUB': .40, 'USS': .34, 'CHI': .33,
+                 'YUG': .26, 'IND': -.04}
+    score1 = .28
+    expected2 = {'USA': .47, 'FRA': .44, 'BEL': .42, 'ISR': .37, 'EGY': .02,
+                 'ZAI': .28, 'BRA': .25, 'IND': .17, 'CUB': .48, 'USS': .44,
+                 'YUG': .31, 'CHI': .31}
+    score2 = .33
+
+    for labels, expected, score in [(labels1, expected1, score1),
+                                    (labels2, expected2, score2)]:
+        expected = [expected[name] for name in names]
+        assert_almost_equal(expected, silhouette_samples(D, np.array(labels),
+                                                         metric='precomputed'),
+                            decimal=2)
+        assert_almost_equal(score, silhouette_score(D, np.array(labels),
+                                                    metric='precomputed'),
+                            decimal=2)
+
+
 def test_correct_labelsize():
     # Assert 1 < n_labels < n_samples
     dataset = datasets.load_iris()

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -35,21 +35,22 @@ def test_silhouette():
         assert_almost_equal(score_precomputed, score_euclidean)
 
         # test block_size
-        score_batched = silhouette_score(X, y, block_size=17,
+        score_batched = silhouette_score(X, y, block_size=10000,
                                          metric='euclidean')
         assert_almost_equal(score_batched, score_euclidean)
-        score_batched = silhouette_score(D, y, block_size=17,
+        score_batched = silhouette_score(D, y, block_size=10000,
                                          metric='precomputed')
         assert_almost_equal(score_batched, score_euclidean)
-        score_batched = silhouette_score(D, y, block_size=len(y) + 10,
+        # absurdly large block_size
+        score_batched = silhouette_score(D, y, block_size=1e100,
                                          metric='precomputed')
         assert_almost_equal(score_batched, score_euclidean)
 
-        # smoke test n_jobs with and without block_size
-        score_parallel = silhouette_score(X, y, block_size=None,
+        # smoke test n_jobs with and without explicit block_size
+        score_parallel = silhouette_score(X, y,
                                           n_jobs=2, metric='euclidean')
         assert_almost_equal(score_parallel, score_euclidean)
-        score_parallel = silhouette_score(X, y, block_size=50,
+        score_parallel = silhouette_score(X, y, block_size=5000,
                                           n_jobs=2, metric='euclidean')
         assert_almost_equal(score_parallel, score_euclidean)
 
@@ -74,6 +75,14 @@ def test_silhouette():
             score_dense_with_sampling = score_precomputed
         else:
             assert_almost_equal(score_euclidean, score_dense_with_sampling)
+
+
+def test_silhouette_invalid_block_size():
+    X = [[0], [0], [1]]
+    y = [1, 1, 2]
+    assert_raise_message(ValueError, 'block_size should be at least n_samples '
+                         '* 8 = 24 bytes, got 1',
+                         silhouette_score, X, y, block_size=1)
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -3,6 +3,7 @@ from scipy.sparse import csr_matrix
 
 from sklearn import datasets
 from sklearn.metrics.cluster.unsupervised import silhouette_score
+from sklearn.metrics.cluster.unsupervised import silhouette_samples
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_almost_equal
@@ -50,6 +51,8 @@ def test_no_nan():
     D = np.random.RandomState(0).rand(len(labels), len(labels))
     silhouette = silhouette_score(D, labels, metric='precomputed')
     assert_false(np.isnan(silhouette))
+    ss = silhouette_samples(D, labels, metric='precomputed')
+    assert_false(np.isnan(ss).any())
 
 
 def test_correct_labelsize():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -35,14 +35,14 @@ def test_silhouette():
         assert_almost_equal(score_precomputed, score_euclidean)
 
         # test block_size
-        score_batched = silhouette_score(X, y, block_size=10000,
+        score_batched = silhouette_score(X, y, block_size=10,
                                          metric='euclidean')
         assert_almost_equal(score_batched, score_euclidean)
-        score_batched = silhouette_score(D, y, block_size=10000,
+        score_batched = silhouette_score(D, y, block_size=10,
                                          metric='precomputed')
         assert_almost_equal(score_batched, score_euclidean)
         # absurdly large block_size
-        score_batched = silhouette_score(D, y, block_size=1e100,
+        score_batched = silhouette_score(D, y, block_size=10000,
                                          metric='precomputed')
         assert_almost_equal(score_batched, score_euclidean)
 
@@ -50,7 +50,7 @@ def test_silhouette():
         score_parallel = silhouette_score(X, y,
                                           n_jobs=2, metric='euclidean')
         assert_almost_equal(score_parallel, score_euclidean)
-        score_parallel = silhouette_score(X, y, block_size=5000,
+        score_parallel = silhouette_score(X, y, block_size=10,
                                           n_jobs=2, metric='euclidean')
         assert_almost_equal(score_parallel, score_euclidean)
 
@@ -81,8 +81,8 @@ def test_silhouette_invalid_block_size():
     X = [[0], [0], [1]]
     y = [1, 1, 2]
     assert_raise_message(ValueError, 'block_size should be at least n_samples '
-                         '* 8 = 24 bytes, got 1',
-                         silhouette_score, X, y, block_size=1)
+                         '* 8 bytes = 1 MiB, got 0',
+                         silhouette_score, X, y, block_size=0)
 
 
 def test_no_nan():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -34,12 +34,24 @@ def test_silhouette():
         score_euclidean = silhouette_score(X, y, metric='euclidean')
         assert_almost_equal(score_precomputed, score_euclidean)
 
+        # test block_size
         score_batched = silhouette_score(X, y, block_size=17,
                                          metric='euclidean')
         assert_almost_equal(score_batched, score_euclidean)
         score_batched = silhouette_score(D, y, block_size=17,
                                          metric='precomputed')
         assert_almost_equal(score_batched, score_euclidean)
+        score_batched = silhouette_score(D, y, block_size=len(y) + 10,
+                                         metric='precomputed')
+        assert_almost_equal(score_batched, score_euclidean)
+
+        # smoke test n_jobs with and without block_size
+        score_parallel = silhouette_score(X, y, block_size=None,
+                                          n_jobs=2, metric='euclidean')
+        assert_almost_equal(score_parallel, score_euclidean)
+        score_parallel = silhouette_score(X, y, block_size=50,
+                                          n_jobs=2, metric='euclidean')
+        assert_almost_equal(score_parallel, score_euclidean)
 
         if X is X_dense:
             score_dense_without_sampling = score_precomputed

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -33,6 +33,13 @@ def test_silhouette():
         score_euclidean = silhouette_score(X, y, metric='euclidean')
         assert_almost_equal(score_precomputed, score_euclidean)
 
+        score_batched = silhouette_score(X, y, block_size=17,
+                                         metric='euclidean')
+        assert_almost_equal(score_batched, score_euclidean)
+        score_batched = silhouette_score(D, y, block_size=17,
+                                         metric='precomputed')
+        assert_almost_equal(score_batched, score_euclidean)
+
         if X is X_dense:
             score_dense_without_sampling = score_precomputed
         else:

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -194,10 +194,11 @@ def silhouette_samples(X, labels, metric='euclidean', block_size=None, **kwds):
 
     for start in range(0, n_samples, block_size):
         stop = min(start + block_size, n_samples)
-        # TODO: perhaps ensure pairwise_distances args are identical if
-        # block_size is None
-        block_dists = pairwise_distances(X[start:stop], X,
-                                         metric=metric, **kwds)
+        if stop - start == n_samples:
+            block_dists = pairwise_distances(X, metric=metric, **kwds)
+        else:
+            block_dists = pairwise_distances(X[start:stop], X,
+                                             metric=metric, **kwds)
         clust_dists = np.bincount(add_at[:block_dists.size],
                                   block_dists.ravel())
         clust_dists = clust_dists.reshape((stop - start, n_clusters))

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -20,7 +20,7 @@ def check_number_of_labels(n_labels, n_samples):
 
 
 def silhouette_score(X, labels, metric='euclidean', sample_size=None,
-                     random_state=None, **kwds):
+                     block_size=None, random_state=None, **kwds):
     """Compute the mean Silhouette Coefficient of all samples.
 
     The Silhouette Coefficient is calculated using the mean intra-cluster
@@ -55,6 +55,12 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
         allowed by :func:`metrics.pairwise.pairwise_distances
         <sklearn.metrics.pairwise.pairwise_distances>`. If X is the distance
         array itself, use ``metric="precomputed"``.
+
+    block_size : int, optional
+        The number of rows to process at a time to limit memory usage to
+        O(block_size * n_samples). Default is n_samples.
+
+        .. versionadded:: 0.18
 
     sample_size : int or None
         The size of the sample to use when computing the Silhouette Coefficient
@@ -103,7 +109,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
             X, labels = X[indices].T[indices].T, labels[indices]
         else:
             X, labels = X[indices], labels[indices]
-    return np.mean(silhouette_samples(X, labels, metric=metric, **kwds))
+    return np.mean(silhouette_samples(X, labels, metric=metric,
+                                      block_size=block_size, **kwds))
 
 
 def silhouette_samples(X, labels, metric='euclidean', block_size=None, **kwds):

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -200,4 +200,6 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     sil_samples = inter_clust_dists - intra_clust_dists
     sil_samples /= np.maximum(intra_clust_dists, inter_clust_dists)
-    return sil_samples
+
+    # nan values are for clusters of size 1, and should be 0
+    return np.nan_to_num(sil_samples)

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -125,7 +125,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
         else:
             X, labels = X[indices], labels[indices]
     return np.mean(silhouette_samples(X, labels, metric=metric,
-                                      block_size=block_size, **kwds))
+                                      block_size=block_size, n_jobs=n_jobs,
+                                      **kwds))
 
 
 def _silhouette_block(X, labels, label_freqs, start, block_n_rows,
@@ -276,7 +277,7 @@ def silhouette_samples(X, labels, metric='euclidean',
     add_at = np.ravel_multi_index((np.repeat(block_range, n_samples),
                                    np.tile(labels, block_n_rows)),
                                   dims=(block_n_rows, len(label_freqs)))
-    parallel = Parallel(n_jobs=n_jobs)
+    parallel = Parallel(n_jobs=n_jobs, backend='threading')
 
     kwds['metric'] = metric
     results = parallel(delayed(_silhouette_block)(X, labels, label_freqs,

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -148,6 +148,8 @@ def silhouette_samples(X, labels, metric='euclidean', block_size=None, **kwds):
         The number of rows to process at a time to limit memory usage to
         O(block_size * n_samples). Default is n_samples.
 
+        .. versionadded:: 0.18
+
     `**kwds` : optional keyword parameters
         Any further parameters are passed directly to the distance function.
         If using a ``scipy.spatial.distance`` metric, the parameters are still

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -62,7 +62,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
 
     block_size : int, optional
         The number of rows to process at a time to limit memory usage to
-        O(block_size * n_jobs * n_samples). Default is n_samples / n_jobs.
+        ``O(block_size * n_jobs * n_samples)``.
+        Default is ``n_samples / n_jobs``.
 
         .. versionadded:: 0.18
 
@@ -191,7 +192,8 @@ def silhouette_samples(X, labels, metric='euclidean', block_size=None,
 
     block_size : int, optional
         The number of rows to process at a time to limit memory usage to
-        O(block_size * n_jobs * n_samples). Default is n_samples / n_jobs.
+        ``O(block_size * n_jobs * n_samples)``.
+        Default is ``n_samples / n_jobs``.
 
         .. versionadded:: 0.18
 

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -62,7 +62,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
 
     block_size : int, optional
         The number of rows to process at a time to limit memory usage to
-        O(block_size * n_samples). Default is n_samples.
+        O(block_size * n_jobs * n_samples). Default is n_samples / n_jobs.
 
         .. versionadded:: 0.18
 
@@ -191,7 +191,7 @@ def silhouette_samples(X, labels, metric='euclidean', block_size=None,
 
     block_size : int, optional
         The number of rows to process at a time to limit memory usage to
-        O(block_size * n_samples). Default is n_samples / n_jobs.
+        O(block_size * n_jobs * n_samples). Default is n_samples / n_jobs.
 
         .. versionadded:: 0.18
 


### PR DESCRIPTION
Superseding #1976 which breaks the problem down by cluster, here we simply break the input down by fixed-size blocks of rows. Reports of memory issues when calculating silhouette include #7175 and [mailing list](http://sourceforge.net/mailarchive/message.php?msg_id=30828533). Also incorporates #6089's fix for #5988; and adds a test for `silhouette_samples` self-plagiarised from #4087.

potential enhancements:
- [x] work out what to do to avoid using `np.ufunc.at` in numpy<1.8
- [x] the minor TODOs mentioned in the code
- [x] benchmark to ensure this is not much slower than incumbent implementation. [See  #below](https://github.com/scikit-learn/scikit-learn/pull/7177#issuecomment-239166677).
- [x] a test for `silhouette_samples` (none exists!); could perhaps be a separate PR...
- [x] support parallelised computation over blocks?; could be a separate PR
- [x] allow users to specify `block_size` by target memory usage, e.g. `block_size='1G'`. Probably out of scope of this PR.
- [x] use `block_size=100` or `block_size='1G'` or some other sensible constant as the default to avoid memory errors with default parameters, and to improve default speed.
- [x] add more inline comments
- [ ] add to what's new
- [ ] squash carefully to ensure attribution of #6089
