### PR TITLE
[MRG] ENH support multiclass column vector array-like in metrics

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -493,10 +493,10 @@ def test_format_invariance_with_1d_vectors():
                                 err_msg=MSG % (name, 'list'))
 
             assert_almost_equal(metric(y1_1d, y2_1d), measure,
-                                err_msg=MSG % (name, np-array 1d))
+                                err_msg=MSG % (name, 'np-array-1d'))
 
             assert_almost_equal(metric(y1_column, y2_column), measure,
-                                err_msg=MSG % (name, "np-array-column")
+                                err_msg=MSG % (name, "np-array-column"))
 
             assert_almost_equal(metric(y1_column_list, y2_column_list),
                                 measure,

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -25,7 +25,7 @@ from ..utils.fixes import array_equal
 
 
 def _unique_multiclass(y):
-    if hasattr(y, '__array__'):
+    if hasattr(y, '__array__') or isinstance(y, Sequence):
         return np.unique(np.asarray(y))
     else:
         return set(y)


### PR DESCRIPTION
For non-thresholded classification metrics, this adds tests for:
- column vectors as lists of lists
- multiclass input

and ensures their support. This effectively fixes #7081.

Column vectors are analogous to multioutput classification targets with a single target.

We did not previously support nested lists (unlike arrays) as a target format because these were confusable with the now-unsupported-for-some-time list of lists multilabel format. I'm not _entirely_ sure they should be supported now, but it seems consistent with our support of "array-likes" elsewhere.
