### PR TITLE
[MRG] Fix the negative sign of the initial lower bound

### DIFF
--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -201,7 +201,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
 
             if do_init:
                 self._initialize_parameters(X)
-                self.lower_bound_ = np.infty
+                self.lower_bound_ = -np.infty
 
             for n_iter in range(self.max_iter):
                 prev_lower_bound = self.lower_bound_


### PR DESCRIPTION
This PR fixes the negative value of the lower bound (`-np.infty`) of the GaussianMixture to ensure the lower bound differences between each iterations is always positive. 

In practice, it doesn't change the results of the Gaussian Mixture.

The only way to add a test for that is to store the useless difference of lower bound between two iterations. As the sign of the initial lower bound value does not change the result, I think it's not add a test for that.
