### PR TITLE
BUG fixed a typo in ``sklearn.gmm``

### DIFF
--- a/sklearn/mixture/gmm.py
+++ b/sklearn/mixture/gmm.py
@@ -682,7 +682,7 @@ def _log_multivariate_normal_density_spherical(X, means, covars):
     cv = covars.copy()
     if covars.ndim == 1:
         cv = cv[:, np.newaxis]
-    if covars.shape[1] == 1:
+    if cv.shape[1] == 1:
         cv = np.tile(cv, (1, X.shape[-1]))
     return _log_multivariate_normal_density_diag(X, means, cv)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes an `IndexError` in `_log_multivariate_normal_density_spherical` when called with a scalar `covar`.
#### Any other comments?

`GMM` isn't affected by the bug because it distributes spherical covariance using `np.tile` in line 789.
