### PR TITLE
[MRG] Add whats_new about fixing example

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -326,7 +326,7 @@ Bug fixes
       By `Ibraim Ganiev`_.
 
     - :func:`silhouette_score` now supports sparse input, and this also fixes
-      `example_gaussian_process_plot_gp_regression.py`. 
+      examples/text/document_clustering.py. 
       By `YenChen Lin`_.
 
 API changes summary

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -325,6 +325,10 @@ Bug fixes
       (`#7101 <https://github.com/scikit-learn/scikit-learn/pull/7101>`_)
       By `Ibraim Ganiev`_.
 
+    - :func:`silhouette_score` now supports sparse input, and this also fixes
+      `example_gaussian_process_plot_gp_regression.py`. 
+      By `YenChen Lin`_.
+
 API changes summary
 -------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -325,7 +325,7 @@ Bug fixes
       (`#7101 <https://github.com/scikit-learn/scikit-learn/pull/7101>`_)
       By `Ibraim Ganiev`_.
 
-    - :func:`silhouette_score` now supports sparse input, and this also fixes
+    - :func:`silhouette_score` now again supports sparse input, and this also fixes
       examples/text/document_clustering.py. 
       By `YenChen Lin`_.
 


### PR DESCRIPTION
This PR adds bug fixed in #7170 to `whats_new.rst`.

Sorry for not doing it in the same commit.

pint @jnothman 
