### PR TITLE
update setup.py PyPI trove classifier section

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,8 +210,7 @@ def setup_package():
                                  'Programming Language :: Python :: 2.6',
                                  'Programming Language :: Python :: 2.7',
                                  'Programming Language :: Python :: 3',
-                                 'Programming Language :: Python :: 3.3',
-                                 'Programming Language :: Python :: 3.4',
+                                 'Programming Language :: Python :: 3.5',
                                  ],
                     cmdclass=cmdclass,
                     **extra_setuptools_args)

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ def setup_package():
                                  'Programming Language :: Python :: 2.6',
                                  'Programming Language :: Python :: 2.7',
                                  'Programming Language :: Python :: 3',
+                                 'Programming Language :: Python :: 3.4',
                                  'Programming Language :: Python :: 3.5',
                                  ],
                     cmdclass=cmdclass,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Updates the PyPI trove classifier section -- removes Python 3.3 from the list and adds Python 3.5
#### Any other comments?

When I see it correctly Python 3.3 is not part of the test matrix anymore so I thought removing it from the setup.py specs may be a good idea.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
