### PR TITLE
[MRG+1] DOC: Clarify splitting sparse data always outputs csr matrix

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1890,7 +1890,9 @@ def train_test_split(*arrays, **options):
         List containing train-test split of inputs.
 
         .. versionadded:: 0.16
-            Output type is the same as the input type.
+            If the input is sparse, the output will be a
+            ``scipy.sparse.csr_matrix``. Else, output type is the same as the
+            input type.
 
     Examples
     --------

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1858,7 +1858,9 @@ def train_test_split(*arrays, **options):
         matrices or pandas dataframes.
 
         .. versionadded:: 0.16
-            preserves input type instead of always casting to numpy array.
+            If the input is sparse will be converted to a
+            ``scipy.sparse.csr_matrix``. Else, the input type
+            will not be changed instead of always casting to numpy array.
 
 
     test_size : float, int, or None (default is None)

--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1853,15 +1853,8 @@ def train_test_split(*arrays, **options):
     Parameters
     ----------
     *arrays : sequence of indexables with same length / shape[0]
-
-        allowed inputs are lists, numpy arrays, scipy-sparse
+        Allowed inputs are lists, numpy arrays, scipy-sparse
         matrices or pandas dataframes.
-
-        .. versionadded:: 0.16
-            If the input is sparse will be converted to a
-            ``scipy.sparse.csr_matrix``. Else, the input type
-            will not be changed instead of always casting to numpy array.
-
 
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1442,7 +1442,10 @@ def train_test_split(*arrays, **options):
         matrices or pandas dataframes.
 
         .. versionadded:: 0.16
-            preserves input type instead of always casting to numpy array.
+            If the input is sparse will be converted to a
+            ``scipy.sparse.csr_matrix``. Else, the input type
+            will not be changed instead of always casting to numpy array.
+
 
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1437,14 +1437,8 @@ def train_test_split(*arrays, **options):
     Parameters
     ----------
     *arrays : sequence of indexables with same length / shape[0]
-
-        allowed inputs are lists, numpy arrays, scipy-sparse
+        Allowed inputs are lists, numpy arrays, scipy-sparse
         matrices or pandas dataframes.
-
-        .. versionadded:: 0.16
-            If the input is sparse will be converted to a
-            ``scipy.sparse.csr_matrix``. Else, the input type
-            will not be changed instead of always casting to numpy array.
 
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1470,7 +1470,9 @@ def train_test_split(*arrays, **options):
         List containing train-test split of inputs.
 
         .. versionadded:: 0.16
-            Output type is the same as the input type.
+            If the input is sparse, the output will be a
+            ``scipy.sparse.csr_matrix``. Else, output type is the same as the
+            input type.
 
     Examples
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1446,7 +1446,6 @@ def train_test_split(*arrays, **options):
             ``scipy.sparse.csr_matrix``. Else, the input type
             will not be changed instead of always casting to numpy array.
 
-
     test_size : float, int, or None (default is None)
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the test split. If

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -3,7 +3,7 @@ from __future__ import division
 import warnings
 
 import numpy as np
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
 from scipy import stats
 from scipy.misc import comb
 from itertools import combinations
@@ -781,6 +781,16 @@ def train_test_split_pandas():
         X_train, X_test = train_test_split(X_df)
         assert_true(isinstance(X_train, InputFeatureType))
         assert_true(isinstance(X_test, InputFeatureType))
+
+
+def train_test_split_sparse():
+    # check that train_test_split converts scipy sparse matrices to csr
+    sparse_types = [csr_matrix, csc_matrix, coo_matrix]
+    for InputFeatureType in sparse_types:
+        X_sparse_matrix = InputFeatureType(X)
+        X_train, X_test = train_test_split(X_sparse_matrix)
+        assert_true(isinstance(X_train, csr_matrix))
+        assert_true(isinstance(X_test, csr_matrix))
 
 
 def train_test_split_mock_pandas():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -784,7 +784,8 @@ def train_test_split_pandas():
 
 
 def train_test_split_sparse():
-    # check that train_test_split converts scipy sparse matrices to csr
+    # check that train_test_split converts scipy sparse matrices
+    # to csr, as stated in the documentation
     X = np.arange(100).reshape((10, 10))
     sparse_types = [csr_matrix, csc_matrix, coo_matrix]
     for InputFeatureType in sparse_types:

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -785,10 +785,11 @@ def train_test_split_pandas():
 
 def train_test_split_sparse():
     # check that train_test_split converts scipy sparse matrices to csr
+    X = np.arange(100).reshape((10, 10))
     sparse_types = [csr_matrix, csc_matrix, coo_matrix]
     for InputFeatureType in sparse_types:
-        X_sparse_matrix = InputFeatureType(X)
-        X_train, X_test = train_test_split(X_sparse_matrix)
+        X_s = InputFeatureType(X)
+        X_train, X_test = train_test_split(X_s)
         assert_true(isinstance(X_train, csr_matrix))
         assert_true(isinstance(X_test, csr_matrix))
 


### PR DESCRIPTION
#### Reference Issue
#7198
#### What does this implement/fix? Explain your changes.

Edit docs to clarify that passing in sparse data to `train_test_split` always returns a `scipy.sparse.csr_matrix`, which was ambiguous before because it was only stated that "output type is the same as input type"
