### PR TITLE
Use sparse contingency matrix for supervised cluster metrics

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -48,7 +48,8 @@ def check_clusterings(labels_true, labels_pred):
     return labels_true, labels_pred
 
 
-def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, sparse=False):
+def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000,
+                       sparse=False):
     """Build a contingency matrix describing the relationship between labels.
 
     Parameters
@@ -67,7 +68,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     max_n_classes : int, optional (default=5000)
         Maximal number of classeses handled for contingency_matrix.
         This help to avoid Memory error with regression target
-        for mutual_information. If `sparse`, `max_n_classes` is ignored.
+        for mutual_information. If ``sparse is True``,
+        `max_n_classes` is ignored.
 
     sparse: boolean, optional.
         If True, return a sparse continency matrix. If ``eps is not None``,
@@ -75,11 +77,11 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
 
     Returns
     -------
-    contingency: {array-like, sparse matrix}, shape=[n_classes_true, n_classes_pred]
+    contingency: {array-like, sparse}, shape=[n_classes_true, n_classes_pred]
         Matrix :math:`C` such that :math:`C_{i, j}` is the number of samples in
         true class :math:`i` and in predicted class :math:`j`. If
         ``eps is None``, the dtype of this array will be integer. If ``eps`` is
-        given, the dtype will be float.
+        given, the dtype will be float. Will be sparse if ``sparse is True``
     """
 
     if eps is not None and sparse:
@@ -100,7 +102,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     # Using coo_matrix to accelerate simple histogram calculation,
     # i.e. bins are consecutive integers
     # Currently, coo_matrix is faster than histogram2d for simple cases
-    contingency = coo_matrix((np.ones(class_idx.shape[0]), (class_idx, cluster_idx)),
+    contingency = coo_matrix((np.ones(class_idx.shape[0]),
+                              (class_idx, cluster_idx)),
                              shape=(n_classes, n_clusters),
                              dtype=np.int)
     if not sparse:
@@ -113,7 +116,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
 
 # clustering measures
 
-def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingency=None):
+def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
+                        contingency=None):
     """Rand index adjusted for chance.
 
     The Rand Index computes a similarity measure between two clusterings
@@ -209,7 +213,7 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
         n_samples = labels_true.shape[0]
         n_classes = np.unique(labels_true).shape[0]
         n_clusters = np.unique(labels_pred).shape[0]
-    elif isinstance(contingency, _data_matrix):  # scipy.sparse.data._data_matrix
+    elif isinstance(contingency, _data_matrix):
         n_samples = contingency.nnz
         n_classes, n_clusters = contingency.shape
     else:
@@ -225,7 +229,8 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
 
     # Compute contingency matrix if we weren't given it
     if contingency is None:
-        contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+        contingency = contingency_matrix(labels_true, labels_pred,
+                                         max_n_classes=max_n_classes)
 
     # Compute the ARI using the contingency data
     if isinstance(contingency, np.ndarray):
@@ -235,18 +240,22 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
         sum_comb = sum(comb2(n_ij) for n_ij in contingency.flatten())
     elif isinstance(contingency, _data_matrix):
         # For a sparse matrix
-        sum_comb_c = sum(comb2(n_c) for n_c in np.array(contingency.sum(axis=1)))
-        sum_comb_k = sum(comb2(n_k) for n_k in np.array(contingency.sum(axis=0)).T)
+        sum_comb_c = sum(
+            comb2(n_c) for n_c in np.array(contingency.sum(axis=1)))
+        sum_comb_k = sum(
+            comb2(n_k) for n_k in np.array(contingency.sum(axis=0)).T)
         sum_comb = sum(comb2(n_ij) for n_ij in find(contingency)[2])
     else:
-        raise ValueError("Unsupported type for 'contingency': " + str(type(contingency)))
+        raise ValueError(
+            "Unsupported type for 'contingency': " + str(type(contingency)))
 
     prod_comb = (sum_comb_c * sum_comb_k) / float(comb(n_samples, 2))
     mean_comb = (sum_comb_k + sum_comb_c) / 2.
     return float((sum_comb - prod_comb) / (mean_comb - prod_comb))
 
 
-def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                       max_n_classes=5000, sparse=False):
     """Compute the homogeneity and completeness and V-Measure scores at once.
 
     Those metrics are based on normalized conditional entropy measures of
@@ -318,7 +327,8 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5
         contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
         MI = mutual_info_score(None, None, contingency=contingency)
     else:
-        MI = mutual_info_score(labels_true, labels_pred, max_n_classes=max_n_classes)
+        MI = mutual_info_score(labels_true, labels_pred,
+                               max_n_classes=max_n_classes)
 
     homogeneity = MI / (entropy_C) if entropy_C else 1.0
     completeness = MI / (entropy_K) if entropy_K else 1.0
@@ -332,7 +342,8 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5
     return homogeneity, completeness, v_measure_score
 
 
-def homogeneity_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def homogeneity_score(labels_true, labels_pred, max_n_classes=5000,
+                      sparse=False):
     """Homogeneity metric of a cluster labeling given a ground truth.
 
     A clustering result satisfies homogeneity if all of its clusters
@@ -412,11 +423,13 @@ def homogeneity_score(labels_true, labels_pred, max_n_classes=5000, sparse=False
       0.0...
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                              max_n_classes=max_n_classes)[0]
+    return \
+    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
+                                       max_n_classes=max_n_classes)[0]
 
 
-def completeness_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def completeness_score(labels_true, labels_pred, max_n_classes=5000,
+                       sparse=False):
     """Completeness metric of a cluster labeling given a ground truth.
 
     A clustering result satisfies completeness if all the data points
@@ -492,8 +505,9 @@ def completeness_score(labels_true, labels_pred, max_n_classes=5000, sparse=Fals
       0.0
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                              max_n_classes=max_n_classes)[1]
+    return \
+    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
+                                       max_n_classes=max_n_classes)[1]
 
 
 def v_measure_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
@@ -597,11 +611,13 @@ def v_measure_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
       0.0...
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=max_n_classes,
+    return homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                              max_n_classes=max_n_classes,
                                               sparse=sparse)[2]
 
 
-def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=5000):
+def mutual_info_score(labels_true, labels_pred, contingency=None,
+                      max_n_classes=5000):
     """Mutual Information between two clusterings.
 
     The Mutual Information is a measure of the similarity between two labels of
@@ -636,7 +652,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
     labels_pred : array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    contingency: {None, array, sparse matrix}, shape = [n_classes_true, n_classes_pred]
+    contingency: {None, array, sparse matrix},
+                shape = [n_classes_true, n_classes_pred]
         A contingency matrix given by the :func:`contingency_matrix` function.
         If value is ``None``, it will be computed, otherwise the given value is
         used, with ``labels_true`` and ``labels_pred`` ignored.
@@ -658,7 +675,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
     """
     if contingency is None:
         labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
-        contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+        contingency = contingency_matrix(labels_true, labels_pred,
+                                         max_n_classes=max_n_classes)
     if isinstance(contingency, np.ndarray):
         # For an array
         contingency = np.array(contingency, dtype='float')
@@ -684,14 +702,16 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
         pj = np.array(contingency.sum(axis=0)).T
         nnzx, nnzy, nnz_val = find(contingency)
         log_contingency_nm = np.log(nnz_val)
-        contingency_nm = nnz_val * 1.0 / contingency_sum  # python2 integer division...
+        contingency_nm = nnz_val * 1.0 / contingency_sum
         # Don't need to calculate the full outer product. Just for the non-zero values
         outer = np.array([pi[x] * pj[y] for x, y in zip(nnzx, nnzy)]).T
         log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
-        mi = contingency_nm * (log_contingency_nm - log(contingency_sum)) + contingency_nm * log_outer
+        mi = contingency_nm * (log_contingency_nm - log(contingency_sum)) + \
+             contingency_nm * log_outer
         return mi.sum()
     else:
-        raise ValueError("Unsupported type for 'contingency': " + str(type(contingency)))
+        raise ValueError(
+            "Unsupported type for 'contingency': " + str(type(contingency)))
 
 
 def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
@@ -780,9 +800,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     # Special limit cases: no clustering since the data is not split.
     # This is a perfect match hence return 1.0.
     if (classes.shape[0] == clusters.shape[0] == 1 or
-                    classes.shape[0] == clusters.shape[0] == 0):
+                classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
-    contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    contingency = contingency_matrix(labels_true, labels_pred,
+                                     max_n_classes=max_n_classes)
     contingency = np.array(contingency, dtype='float')
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
@@ -868,7 +889,8 @@ def normalized_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     if (classes.shape[0] == clusters.shape[0] == 1 or
                     classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
-    contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    contingency = contingency_matrix(labels_true, labels_pred,
+                                     max_n_classes=max_n_classes)
     contingency = np.array(contingency, dtype='float')
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
@@ -950,7 +972,8 @@ def fowlkes_mallows_score(labels_true, labels_pred, max_n_classes=5000):
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred, )
     n_samples, = labels_true.shape
 
-    c = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    c = contingency_matrix(labels_true, labels_pred,
+                           max_n_classes=max_n_classes)
     tk = np.dot(c.ravel(), c.ravel()) - n_samples
     pk = np.sum(np.sum(c, axis=0) ** 2) - n_samples
     qk = np.sum(np.sum(c, axis=1) ** 2) - n_samples

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -67,7 +67,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     max_n_classes : int, optional (default=5000)
         Maximal number of classeses handled for contingency_matrix.
         This help to avoid Memory error with regression target
-        for mutual_information.
+        for mutual_information. If `sparse`, `max_n_classes` is ignored.
 
     sparse: boolean, optional.
         If True, return a sparse continency matrix. If ``eps is not None``,

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,23 +1,21 @@
 import numpy as np
-
-from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.cluster import homogeneity_score
-from sklearn.metrics.cluster import completeness_score
-from sklearn.metrics.cluster import v_measure_score
-from sklearn.metrics.cluster import homogeneity_completeness_v_measure
-from sklearn.metrics.cluster import adjusted_mutual_info_score
-from sklearn.metrics.cluster import normalized_mutual_info_score
-from sklearn.metrics.cluster import mutual_info_score
-from sklearn.metrics.cluster import expected_mutual_information
-from sklearn.metrics.cluster import contingency_matrix
-from sklearn.metrics.cluster import fowlkes_mallows_score
-from sklearn.metrics.cluster import entropy
-
-from sklearn.utils.testing import assert_raise_message
 from nose.tools import assert_almost_equal
 from nose.tools import assert_equal
 from numpy.testing import assert_array_almost_equal
 
+from sklearn.metrics.cluster import adjusted_mutual_info_score
+from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.metrics.cluster import completeness_score
+from sklearn.metrics.cluster import contingency_matrix
+from sklearn.metrics.cluster import entropy
+from sklearn.metrics.cluster import expected_mutual_information
+from sklearn.metrics.cluster import fowlkes_mallows_score
+from sklearn.metrics.cluster import homogeneity_completeness_v_measure
+from sklearn.metrics.cluster import homogeneity_score
+from sklearn.metrics.cluster import mutual_info_score
+from sklearn.metrics.cluster import normalized_mutual_info_score
+from sklearn.metrics.cluster import v_measure_score
+from sklearn.utils.testing import assert_raise_message
 
 score_funcs = [
     adjusted_rand_score,
@@ -55,12 +53,14 @@ def test_perfect_matches():
         assert_equal(score_func([0., 1., 2.], [42., 7., 2.]), 1.0)
         assert_equal(score_func([0, 1, 2], [42, 7, 2]), 1.0)
 
+
 def test_homogeneity_completeness_v_measure_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
     h, c, v = homogeneity_completeness_v_measure(labels_a, labels_b)
-    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)
-    assert_array_almost_equal([h, c, v],[h_s, c_s, v_s])
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse=True)
+    assert_array_almost_equal([h, c, v], [h_s, c_s, v_s])
+
 
 """ Takes too long...
 def test_homogeneity_completeness_v_measure_large():
@@ -71,6 +71,7 @@ def test_homogeneity_completeness_v_measure_large():
     h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)    
     assert_raises(MemoryError, homogeneity_completeness_v_measure, labels_a, labels_b)
 """
+
 
 def test_homogeneous_but_not_complete_labeling():
     # homogeneous but not complete clustering
@@ -203,37 +204,60 @@ def test_contingency_matrix_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
     C = contingency_matrix(labels_a, labels_b)
-    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True).toarray()
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse=True).toarray()
     assert_array_almost_equal(C, C_sparse)
-    
+
 
 def test_adjusted_rand_score_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
-    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True)
-    assert_almost_equal(adjusted_rand_score(labels_a,labels_b), adjusted_rand_score(None, None, C_sparse))
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse=True)
+    assert_almost_equal(adjusted_rand_score(labels_a, labels_b), adjusted_rand_score(None, None, contingency=C_sparse))
 
 
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(np.int):
-        labels_a, labels_b = np.ones(i, dtype=np.int),\
-            np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
-        assert_equal(v_measure_score(labels_a, labels_b), 0.0)
-        assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+        labels_a, labels_b = np.ones(i, dtype=np.int), \
+                             np.arange(i, dtype=np.int)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(v_measure_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
 
 
 def test_v_measure_and_mutual_information(seed=36):
     # Check relation between v_measure, entropy and mutual information
     for i in np.logspace(1, 4, 4).astype(np.int):
         random_state = np.random.RandomState(seed)
-        labels_a, labels_b = random_state.randint(0, 10, i),\
-            random_state.randint(0, 10, i)
+        labels_a, labels_b = random_state.randint(0, 10, i), \
+                             random_state.randint(0, 10, i)
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)
+
+
+def test_max_n_classes():
+    rng = np.random.RandomState(seed=0)
+    labels_true = rng.rand(53)
+    labels_pred = rng.rand(53)
+    labels_zero = np.zeros(53)
+    labels_true[:2] = 0
+    labels_zero[:3] = 1
+    labels_pred[:2] = 0
+    for score_func in score_funcs:
+        expected = ("Too many classes for a clustering metric. If you "
+                    "want to increase the limit, pass parameter "
+                    "max_n_classes to the scoring function")
+        assert_raise_message(ValueError, expected, score_func,
+                             labels_true, labels_pred,
+                             max_n_classes=50)
+        expected = ("Too many clusters for a clustering metric. If you "
+                    "want to increase the limit, pass parameter "
+                    "max_n_classes to the scoring function")
+        assert_raise_message(ValueError, expected, score_func,
+                             labels_zero, labels_pred,
+                             max_n_classes=50)
 
 
 def test_fowlkes_mallows_score():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -55,6 +55,22 @@ def test_perfect_matches():
         assert_equal(score_func([0., 1., 2.], [42., 7., 2.]), 1.0)
         assert_equal(score_func([0, 1, 2], [42, 7, 2]), 1.0)
 
+def test_homogeneity_completeness_v_measure_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    h, c, v = homogeneity_completeness_v_measure(labels_a, labels_b)
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)
+    assert_array_almost_equal([h, c, v],[h_s, c_s, v_s])
+
+""" Takes too long...
+def test_homogeneity_completeness_v_measure_large():
+    # This will fail without sparse matrices with any reasonable amount of RAM (<~1TB)
+    from random import randrange
+    labels_a = [randrange(100000) for x in range(1000000)]
+    labels_b = [randrange(100000) for x in range(1000000)]
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)    
+    assert_raises(MemoryError, homogeneity_completeness_v_measure, labels_a, labels_b)
+"""
 
 def test_homogeneous_but_not_complete_labeling():
     # homogeneous but not complete clustering
@@ -183,19 +199,30 @@ def test_contingency_matrix():
     assert_array_almost_equal(C, C2 + .1)
 
 
+def test_contingency_matrix_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    C = contingency_matrix(labels_a, labels_b)
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True).toarray()
+    assert_array_almost_equal(C, C_sparse)
+    
+
+def test_adjusted_rand_score_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True)
+    assert_almost_equal(adjusted_rand_score(labels_a,labels_b), adjusted_rand_score(None, None, C_sparse))
+
+
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(np.int):
         labels_a, labels_b = np.ones(i, dtype=np.int),\
             np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b,
-                                                  max_n_classes=1e4), 0.0)
-        assert_equal(v_measure_score(labels_a, labels_b,
-                                     max_n_classes=1e4), 0.0)
-        assert_equal(adjusted_mutual_info_score(labels_a, labels_b,
-                                                max_n_classes=1e4), 0.0)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b,
-                                                  max_n_classes=1e4), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(v_measure_score(labels_a, labels_b), 0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
 
 
 def test_v_measure_and_mutual_information(seed=36):
@@ -207,29 +234,6 @@ def test_v_measure_and_mutual_information(seed=36):
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)
-
-
-def test_max_n_classes():
-    rng = np.random.RandomState(seed=0)
-    labels_true = rng.rand(53)
-    labels_pred = rng.rand(53)
-    labels_zero = np.zeros(53)
-    labels_true[:2] = 0
-    labels_zero[:3] = 1
-    labels_pred[:2] = 0
-    for score_func in score_funcs:
-        expected = ("Too many classes for a clustering metric. If you "
-                    "want to increase the limit, pass parameter "
-                    "max_n_classes to the scoring function")
-        assert_raise_message(ValueError, expected, score_func,
-                             labels_true, labels_pred,
-                             max_n_classes=50)
-        expected = ("Too many clusters for a clustering metric. If you "
-                    "want to increase the limit, pass parameter "
-                    "max_n_classes to the scoring function")
-        assert_raise_message(ValueError, expected, score_func,
-                             labels_zero, labels_pred,
-                             max_n_classes=50)
 
 
 def test_fowlkes_mallows_score():


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/pull/4788

Replaces `max_n_classes`

In sklearn.metrics.cluster.supervised
With large numbers of clusters (approx. >100k), construction of the contingency matrix runs out of memory (throws MemoryError).

```
>>> from random import randrange
>>> labels_true = [randrange(100000) for x in range(100000)]
>>> labels_pred = [randrange(100000) for x in range(100000)]
>>> contingency = contingency_matrix(labels_true, labels_pred)
... MemoryError
>>> contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
... No error
```

Using a sparse matrix instead allows construction of the contingency matrix.

Modified adjusted_rand_score
homogeneity_completeness_v_measure
mutual_info_score
to accept a sparse matrix.
