### PR TITLE
[MRG] Fix TSNE init as NumPy array

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -13,6 +13,7 @@ from scipy import linalg
 import scipy.sparse as sp
 from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
+from six import string_types
 from ..neighbors import BallTree
 from ..base import BaseEstimator
 from ..utils import check_array
@@ -644,7 +645,7 @@ class TSNE(BaseEstimator):
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
-        if not ((isinstance(init, basestring) and
+        if not ((isinstance(init, string_types) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
             msg = "'init' must be 'pca', 'random', or a NumPy array"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -13,7 +13,6 @@ from scipy import linalg
 import scipy.sparse as sp
 from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
-from six import string_types
 from ..neighbors import BallTree
 from ..base import BaseEstimator
 from ..utils import check_array
@@ -645,7 +644,7 @@ class TSNE(BaseEstimator):
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
-        if not ((isinstance(init, string_types) and
+        if not (((isinstance(init, str) or isinstance(init, unicode)) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
             msg = "'init' must be 'pca', 'random', or a NumPy array"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -569,7 +569,7 @@ class TSNE(BaseEstimator):
 
     init : string or numpy array, optional (default: "random")
         Initialization of embedding. Possible options are 'random', 'pca',
-        and a numpy array of shape [n_samples, n_components].
+        and a numpy array of shape (n_samples, n_components).
         PCA initialization cannot be used with precomputed distances and is
         usually more globally stable than random initialization.
 

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -23,6 +23,7 @@ from ..metrics.pairwise import pairwise_distances
 from . import _utils
 from . import _barnes_hut_tsne
 from ..utils.fixes import astype
+from ..externals.six import string_types
 
 
 MACHINE_EPSILON = np.finfo(np.double).eps
@@ -644,7 +645,7 @@ class TSNE(BaseEstimator):
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
-        if not ((not isinstance(init, np.ndarray) and
+        if not ((isinstance(init, string_types) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
             msg = "'init' must be 'pca', 'random', or a numpy array"
@@ -710,7 +711,7 @@ class TSNE(BaseEstimator):
             raise ValueError("n_iter should be at least 200")
 
         if self.metric == "precomputed":
-            if not isinstance(self.init, np.ndarray) and self.init == 'pca':
+            if isinstance(self.init, string_types) and self.init == 'pca':
                 raise ValueError("The parameter init=\"pca\" cannot be used "
                                  "with metric=\"precomputed\".")
             if X.shape[0] != X.shape[1]:

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -567,11 +567,11 @@ class TSNE(BaseEstimator):
         the distance between them. The default is "euclidean" which is
         interpreted as squared euclidean distance.
 
-    init : string or NumPy array, optional (default: "random")
+    init : string or numpy array, optional (default: "random")
         Initialization of embedding. Possible options are 'random', 'pca',
-        and a NumPy array. PCA initialization cannot be used with precomputed
-        distances and is usually more globally stable than random
-        initialization.
+        and a numpy array of shape [n_samples, n_components].
+        PCA initialization cannot be used with precomputed distances and is
+        usually more globally stable than random initialization.
 
     verbose : int, optional (default: 0)
         Verbosity level.
@@ -647,7 +647,7 @@ class TSNE(BaseEstimator):
         if not (((isinstance(init, str) or isinstance(init, unicode)) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
-            msg = "'init' must be 'pca', 'random', or a NumPy array"
+            msg = "'init' must be 'pca', 'random', or a numpy array"
             raise ValueError(msg)
         self.n_components = n_components
         self.perplexity = perplexity

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -644,7 +644,7 @@ class TSNE(BaseEstimator):
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
-        if not (((isinstance(init, str) or isinstance(init, unicode)) and
+        if not ((not isinstance(init, np.ndarray) and
                 init in ["pca", "random"]) or
                 isinstance(init, np.ndarray)):
             msg = "'init' must be 'pca', 'random', or a numpy array"

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -770,10 +770,10 @@ class TSNE(BaseEstimator):
             pca = PCA(n_components=self.n_components, svd_solver='randomized',
                       random_state=random_state)
             X_embedded = pca.fit_transform(X)
-        elif isinstance(self.init, np.ndarray):
-            X_embedded = self.init
         elif self.init == 'random':
             X_embedded = None
+        elif isinstance(self.init, np.ndarray):
+            X_embedded = self.init
         else:
             raise ValueError("Unsupported initialization scheme: %s"
                              % self.init)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -710,7 +710,7 @@ class TSNE(BaseEstimator):
             raise ValueError("n_iter should be at least 200")
 
         if self.metric == "precomputed":
-            if self.init == 'pca':
+            if not isinstance(self.init, np.ndarray) and self.init == 'pca':
                 raise ValueError("The parameter init=\"pca\" cannot be used "
                                  "with metric=\"precomputed\".")
             if X.shape[0] != X.shape[1]:
@@ -766,14 +766,14 @@ class TSNE(BaseEstimator):
         assert np.all(P <= 1), ("All probabilities should be less "
                                 "or then equal to one")
 
-        if self.init == 'pca':
+        if isinstance(self.init, np.ndarray):
+            X_embedded = self.init
+        elif self.init == 'pca':
             pca = PCA(n_components=self.n_components, svd_solver='randomized',
                       random_state=random_state)
             X_embedded = pca.fit_transform(X)
         elif self.init == 'random':
             X_embedded = None
-        elif isinstance(self.init, np.ndarray):
-            X_embedded = self.init
         else:
             raise ValueError("Unsupported initialization scheme: %s"
                              % self.init)

--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -567,10 +567,11 @@ class TSNE(BaseEstimator):
         the distance between them. The default is "euclidean" which is
         interpreted as squared euclidean distance.
 
-    init : string, optional (default: "random")
-        Initialization of embedding. Possible options are 'random' and 'pca'.
-        PCA initialization cannot be used with precomputed distances and is
-        usually more globally stable than random initialization.
+    init : string or NumPy array, optional (default: "random")
+        Initialization of embedding. Possible options are 'random', 'pca',
+        and a NumPy array. PCA initialization cannot be used with precomputed
+        distances and is usually more globally stable than random
+        initialization.
 
     verbose : int, optional (default: 0)
         Verbosity level.
@@ -643,8 +644,10 @@ class TSNE(BaseEstimator):
                  n_iter_without_progress=30, min_grad_norm=1e-7,
                  metric="euclidean", init="random", verbose=0,
                  random_state=None, method='barnes_hut', angle=0.5):
-        if init not in ["pca", "random"] or isinstance(init, np.ndarray):
-            msg = "'init' must be 'pca', 'random' or a NumPy array"
+        if not ((isinstance(init, basestring) and
+                init in ["pca", "random"]) or
+                isinstance(init, np.ndarray)):
+            msg = "'init' must be 'pca', 'random', or a NumPy array"
             raise ValueError(msg)
         self.n_components = n_components
         self.perplexity = perplexity

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -305,8 +305,8 @@ def test_non_square_precomputed_distances():
 
 
 def test_init_not_available():
-    # 'init' must be 'pca', 'random', or NumPy array.
-    m = "'init' must be 'pca', 'random', or a NumPy array"
+    # 'init' must be 'pca', 'random', or numpy array.
+    m = "'init' must be 'pca', 'random', or a numpy array"
     assert_raises_regexp(ValueError, m, TSNE, init="not available")
 
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -305,8 +305,7 @@ def test_non_square_precomputed_distances():
 
 
 def test_init_not_available():
-    # 'init' must be 'pca' or 'random'.
-    m = "'init' must be 'pca', 'random' or a NumPy array"
+    m = "'init' must be 'pca', 'random', or a NumPy array"
     assert_raises_regexp(ValueError, m, TSNE, init="not available")
 
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -305,6 +305,7 @@ def test_non_square_precomputed_distances():
 
 
 def test_init_not_available():
+    # 'init' must be 'pca', 'random', or NumPy array.
     m = "'init' must be 'pca', 'random', or a NumPy array"
     assert_raises_regexp(ValueError, m, TSNE, init="not available")
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -309,6 +309,10 @@ def test_init_not_available():
     assert_raises_regexp(ValueError, m, TSNE, init="not available")
 
 
+def test_init_ndarray():
+    tsne = TSNE(init=np.zeros((100, 2)))
+
+
 def test_distance_not_available():
     # 'metric' must be valid.
     tsne = TSNE(metric="not available")

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -318,6 +318,13 @@ def test_init_ndarray():
     assert_array_equal(np.zeros((100, 2)), X_embedded)
 
 
+def test_init_ndarray_precomputed():
+    # Initialize TSNE with ndarray and metric 'precomputed'
+    # Make sure no FutureWarning is thrown from _fit
+    tsne = TSNE(init=np.zeros((100, 2)), metric="precomputed")
+    tsne.fit(np.zeros((100, 100)))
+
+
 def test_distance_not_available():
     # 'metric' must be valid.
     tsne = TSNE(metric="not available")

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -7,6 +7,7 @@ from sklearn.neighbors import BallTree
 from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises_regexp
@@ -311,7 +312,10 @@ def test_init_not_available():
 
 
 def test_init_ndarray():
+    # Initialize TSNE with ndarray and test fit
     tsne = TSNE(init=np.zeros((100, 2)))
+    X_embedded = tsne.fit_transform(np.ones((100, 5)))
+    assert_array_equal(np.zeros((100, 2)), X_embedded)
 
 
 def test_distance_not_available():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #7204 
#### What does this implement/fix? Explain your changes.

Fixes discrepancy between doc and type checking for the 'init' parameter in TSNE. NumPy array is now a possible value for 'init'. Type check and docstring are updated to reflect this change.

Updates existing test to reflect change in error msg.

Adds new test to validate NumPy array as a possible 'init' value.
#### Any other comments?

Made one other small readability change by reordering elif options to show string options before NumPy array check.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
