### PR TITLE
[MRG] Update manifold tests to PEP 8

### DIFF
--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -14,7 +14,7 @@ from sklearn.utils.testing import assert_raise_message
 eigen_solvers = ['dense', 'arpack']
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Test utility routines
 def test_barycenter_kneighbors_graph():
     X = np.array([[0, 1], [1.01, 1.], [2, 0]])
@@ -33,7 +33,7 @@ def test_barycenter_kneighbors_graph():
     assert_less(linalg.norm(pred - X) / X.shape[0], 1)
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Test LLE by computing the reconstruction error on some manifolds.
 
 def test_lle_simple_grid():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -196,10 +196,13 @@ def test_gradient():
 
     P = _joint_probabilities(distances, desired_perplexity=25.0,
                              verbose=0)
-    fun = lambda params: _kl_divergence(params, P, alpha, n_samples,
-                                        n_components)[0]
-    grad = lambda params: _kl_divergence(params, P, alpha, n_samples,
-                                         n_components)[1]
+
+    def fun(params):
+        return _kl_divergence(params, P, alpha, n_samples, n_components)[0]
+
+    def grad(params):
+        return _kl_divergence(params, P, alpha, n_samples, n_components)[1]
+
     assert_almost_equal(check_grad(fun, grad, X_embedded.ravel()), 0.0,
                         decimal=5)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

N/A
#### What does this implement/fix? Explain your changes.

Makes a couple changes in manifold tests to fix PEP 8 issues. The manifold/test directory is now clean when running pep8 checker.
#### Any other comments?

N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
