### PR TITLE
[MRG+1] New text for the ValueError that is thrown by _check_param_grid method

### DIFF
--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -332,11 +332,11 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter({0}) values should be a list."
+                raise ValueError("Parameter ({0}) value should be a list."
                                  "".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter({0}) values should be a non-empty "
+                raise ValueError("Parameter ({0}) value should be a non-empty "
                                  "list.".format(name))
 
 

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -332,12 +332,12 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter ({0}) value should be a list."
-                                 "".format(name))
+                raise ValueError("Parameter values for parameter ({}) need to "
+                                 "be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter ({0}) value should be a non-empty "
-                                 "list.".format(name))
+                raise ValueError("Parameter values for parameter ({}) need to "
+                                 "be a non-empty sequence.".format(name))
 
 
 class _CVScoreTuple (namedtuple('_CVScoreTuple',

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -332,12 +332,12 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values for parameter ({0}) need to "
-                                 "be a sequence.".format(name))
+                raise ValueError("Parameter values for parameter ({0}) need "
+                                 "to be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values for parameter ({0}) need to "
-                                 "be a non-empty sequence.".format(name))
+                raise ValueError("Parameter values for parameter ({0}) need "
+                                 "to be a non-empty sequence.".format(name))
 
 
 class _CVScoreTuple (namedtuple('_CVScoreTuple',

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -326,17 +326,18 @@ def _check_param_grid(param_grid):
         param_grid = [param_grid]
 
     for p in param_grid:
-        for v in p.values():
+        for name, v in p.items():
             if isinstance(v, np.ndarray) and v.ndim > 1:
                 raise ValueError("Parameter array should be one-dimensional.")
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values should be a list.")
+                raise ValueError("Parameter({0}) values should be a list."
+                                 "".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values should be a non-empty "
-                                 "list.")
+                raise ValueError("Parameter({0}) values should be a non-empty "
+                                 "list.".format(name))
 
 
 class _CVScoreTuple (namedtuple('_CVScoreTuple',

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -332,11 +332,11 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values for parameter ({}) need to "
+                raise ValueError("Parameter values for parameter ({0}) need to "
                                  "be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values for parameter ({}) need to "
+                raise ValueError("Parameter values for parameter ({0}) need to "
                                  "be a non-empty sequence.".format(name))
 
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -333,11 +333,11 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values for parameter ({}) need to "
+                raise ValueError("Parameter values for parameter ({0}) need to "
                                  "be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values for parameter ({}) need to "
+                raise ValueError("Parameter values for parameter ({0}) need to "
                                  "be a non-empty sequence.".format(name))
 
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -333,12 +333,12 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values for parameter ({0}) need to "
-                                 "be a sequence.".format(name))
+                raise ValueError("Parameter values for parameter ({0}) need "
+                                 "to be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values for parameter ({0}) need to "
-                                 "be a non-empty sequence.".format(name))
+                raise ValueError("Parameter values for parameter ({0}) need "
+                                 "to be a non-empty sequence.".format(name))
 
 
 # XXX Remove in 0.20

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -333,12 +333,12 @@ def _check_param_grid(param_grid):
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter({0}) values should be a list."
-                                 "".format(name))
+                raise ValueError("Parameter values for parameter ({}) need to "
+                                 "be a sequence.".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter({0}) values should be a non-empty "
-                                 "list.".format(name))
+                raise ValueError("Parameter values for parameter ({}) need to "
+                                 "be a non-empty sequence.".format(name))
 
 
 # XXX Remove in 0.20

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -327,17 +327,18 @@ def _check_param_grid(param_grid):
         param_grid = [param_grid]
 
     for p in param_grid:
-        for v in p.values():
+        for name, v in p.items():
             if isinstance(v, np.ndarray) and v.ndim > 1:
                 raise ValueError("Parameter array should be one-dimensional.")
 
             check = [isinstance(v, k) for k in (list, tuple, np.ndarray)]
             if True not in check:
-                raise ValueError("Parameter values should be a list.")
+                raise ValueError("Parameter({0}) values should be a list."
+                                 "".format(name))
 
             if len(v) == 0:
-                raise ValueError("Parameter values should be a non-empty "
-                                 "list.")
+                raise ValueError("Parameter({0}) values should be a non-empty "
+                                 "list.".format(name))
 
 
 # XXX Remove in 0.20

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -165,6 +165,24 @@ def test_grid_search():
     assert_raises(ValueError, grid_search.fit, X, y)
 
 
+def test_grid_search_incorrect_param_grid():
+    assert_raise_message(
+        ValueError,
+        "Parameter values for parameter (C) need to be a sequence.",
+        GridSearchCV,
+        None,
+        {'C': 1})
+
+
+def test_grid_search_incorrect_param_grid():
+    assert_raise_message(
+        ValueError,
+        "Parameter values for parameter (C) need to be a non-empty sequence.",
+        GridSearchCV,
+        None,
+        {'C': []})
+
+
 @ignore_warnings
 def test_grid_search_no_score():
     # Test grid-search on classifier that has no score function.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -166,21 +166,19 @@ def test_grid_search():
 
 
 def test_grid_search_incorrect_param_grid():
+    clf = MockClassifier()
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a sequence.",
-        GridSearchCV,
-        None,
-        {'C': 1})
+        GridSearchCV, clf, {'C': 1})
 
 
 def test_grid_search_param_grid_includes_sequence_of_a_zero_length():
+    clf = MockClassifier()
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a non-empty sequence.",
-        GridSearchCV,
-        None,
-        {'C': []})
+        GridSearchCV, clf, {'C': []})
 
 
 @ignore_warnings

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -174,7 +174,7 @@ def test_grid_search_incorrect_param_grid():
         {'C': 1})
 
 
-def test_grid_search_incorrect_param_grid():
+def test_grid_search_param_grid_includes_sequence_of_a_zero_length():
     assert_raise_message(
         ValueError,
         "Parameter values for parameter (C) need to be a non-empty sequence.",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

N/A
#### What does this implement/fix? Explain your changes.

ValueError that is thrown by _check_param_grid method now includes parameters name when values of a parameter have incorrect type.

Old ValueError:
ValueError: Parameter values should be a list.

New ValueError:
ValueError: Parameter(key1) values should be a non-empty list.
#### Any other comments?

p.items() - creates a new list that includes tuples from the original dict on the Python2.x, however amount of a params should not be big, so it should not be a problem. On a Python 3.x items() crates iterator.

2 tests are broken:
sklearn.feature_extraction.tests.test_image.test_connect_regions ... FAIL
sklearn.feature_extraction.tests.test_image.test_connect_regions_with_grid ... FAIL
they have been broken before my commit. No new breakage is introduced by the commit itself.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
