### PR TITLE
minor wording fix

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -16,7 +16,7 @@ Standardization, or mean removal and variance scaling
 =====================================================
 
 **Standardization** of datasets is a **common requirement for many
-machine learning estimators** implemented in the scikit; they might behave
+machine learning estimators** implemented in scikit-learn; they might behave
 badly if the individual features do not more or less look like standard
 normally distributed data: Gaussian with **zero mean and unit variance**.
 


### PR DESCRIPTION
Changes "the scikit" to "scikit-learn". While both might be technically accurate, explicitly calling the package "scikit-learn" helps with naming consistency.
