### PR TITLE
[MRG+2] Make `enet_coordinate_descent_gram` support fused types

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -682,9 +682,11 @@ def test_enet_float_precision():
         for fit_intercept in [True, False]:
             coef = {}
             intercept = {}
-            clf = ElasticNet(alpha=0.5, max_iter=100, precompute=False,
-                            fit_intercept=fit_intercept, normalize=normalize)
             for dtype in [np.float64, np.float32]:
+                clf = ElasticNet(alpha=0.5, max_iter=100, precompute=False,
+                                 fit_intercept=fit_intercept,
+                                 normalize=normalize)
+
                 X = dtype(X)
                 y = dtype(y)
                 ignore_warnings(clf.fit)(X, y)
@@ -694,8 +696,19 @@ def test_enet_float_precision():
 
                 assert_equal(clf.coef_.dtype, dtype)
 
+                # test precompute Gram array
+                Gram = X.T.dot(X)
+                clf_precompute = ElasticNet(alpha=0.5, max_iter=100,
+                                            precompute=Gram,
+                                            fit_intercept=fit_intercept,
+                                            normalize=normalize)
+                ignore_warnings(clf_precompute.fit)(X, y)
+                assert_array_almost_equal(clf.coef_, clf_precompute.coef_)
+                assert_array_almost_equal(clf.intercept_,
+                                          clf_precompute.intercept_)
+
             assert_array_almost_equal(coef[np.float32], coef[np.float64],
-                                    decimal=4)
+                                      decimal=4)
             assert_array_almost_equal(intercept[np.float32],
-                                    intercept[np.float64],
-                                    decimal=4)
+                                      intercept[np.float64],
+                                      decimal=4)


### PR DESCRIPTION
For the ElasticNetCV (and related classes), the precompute is set by default to "auto", which means for benefits in memory when `n_samples > n_features`, we need to make `enet_coordinate_descent_gram` handle float32 dtypes as well.

This PR makes `enet_coordinate_descent_gram` support cython fused types.

****EDIT 8/26**
Here is the profiling results when fitting **float32** data:
- This branch
  ![32](https://cloud.githubusercontent.com/assets/7057863/17992531/c6134e50-6b7a-11e6-862c-ff4010add61a.png)
- Master
  ![64](https://cloud.githubusercontent.com/assets/7057863/17992530/c5fe6d14-6b7a-11e6-9ad9-fe5e38166e8e.png)
