### PR TITLE
Minor doc fixes in pairwise metrics

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -893,7 +893,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
         ``False``, the output is sparse if both input arrays are sparse.
 
         .. versionadded:: 0.17
-           parameter *dense_output* for dense output.
+           parameter ``dense_output`` for dense output.
 
     Returns
     -------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -893,7 +893,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
         ``False``, the output is sparse if both input arrays are sparse.
 
         .. versionadded:: 0.17
-           parameter *dense_output* for sparse output.
+           parameter *dense_output* for dense output.
 
     Returns
     -------

--- a/sklearn/metrics/pairwise_fast.pyx
+++ b/sklearn/metrics/pairwise_fast.pyx
@@ -14,8 +14,8 @@ cimport numpy as np
 cdef extern from "cblas.h":
     double cblas_dasum(int, const double *, int) nogil
 
-ctypedef float [:, :] float_array_2d_t 
-ctypedef double [:, :] double_array_2d_t 
+ctypedef float [:, :] float_array_2d_t
+ctypedef double [:, :] double_array_2d_t
 
 cdef fused floating1d:
     float[::1]


### PR DESCRIPTION
#### Reference Issue

None
#### What does this implement/fix? Explain your changes.

Was looking at the code for cosine similarity and noticed some things that should be changed in the docs.
#### Any other comments?

On another note, `metrics.pairwise.cosine_similarity` is extremely slow; much more so than implementing a function in numpy or using `1 - scipy.spatial.distance.cosine`. I think it's a result of the `safe_sparse_dot`, and I'm wondering if there are ways to make it faster...
