### PR TITLE
[MRG+1] ENH Raise a meaningful error message when refit=False in GridSearchCV

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -24,6 +24,7 @@ from ..base import BaseEstimator, is_classifier, clone
 from ..base import MetaEstimatorMixin
 from ._split import check_cv
 from ._validation import _fit_and_score
+from ..exceptions import NotFittedError
 from ..externals.joblib import Parallel, delayed
 from ..externals import six
 from ..utils import check_random_state
@@ -414,6 +415,15 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                              % self.best_estimator_)
         return self.scorer_(self.best_estimator_, X, y)
 
+    def _check_is_fitted(self, method_name):
+        if not self.refit:
+            raise NotFittedError(('This GridSearchCV instance was initialized '
+                                  'with refit=False. %s is '
+                                  'available only after refitting on the best '
+                                  'parameters. ') % method_name)
+        else:
+            check_is_fitted(self, 'best_estimator_')
+
     @if_delegate_has_method(delegate='estimator')
     def predict(self, X):
         """Call predict on the estimator with the best found parameters.
@@ -428,6 +438,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('predict')
         return self.best_estimator_.predict(X)
 
     @if_delegate_has_method(delegate='estimator')
@@ -444,6 +455,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('predict_proba')
         return self.best_estimator_.predict_proba(X)
 
     @if_delegate_has_method(delegate='estimator')
@@ -460,6 +472,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('predict_log_proba')
         return self.best_estimator_.predict_log_proba(X)
 
     @if_delegate_has_method(delegate='estimator')
@@ -476,6 +489,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('decision_function')
         return self.best_estimator_.decision_function(X)
 
     @if_delegate_has_method(delegate='estimator')
@@ -492,11 +506,12 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('transform')
         return self.best_estimator_.transform(X)
 
     @if_delegate_has_method(delegate='estimator')
     def inverse_transform(self, Xt):
-        """Call inverse_transform on the estimator with the best found parameters.
+        """Call inverse_transform on the estimator with the best found params.
 
         Only available if the underlying estimator implements
         ``inverse_transform`` and ``refit=True``.
@@ -508,6 +523,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
             underlying estimator.
 
         """
+        self._check_is_fitted('inverse_transform')
         return self.best_estimator_.transform(Xt)
 
     def _fit(self, X, y, labels, parameter_iterable):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -28,6 +28,7 @@ from scipy.stats import bernoulli, expon, uniform
 
 from sklearn.externals.six.moves import zip
 from sklearn.base import BaseEstimator
+from sklearn.exceptions import NotFittedError
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_blobs
 from sklearn.datasets import make_multilabel_classification
@@ -73,8 +74,10 @@ class MockClassifier(object):
         return T.shape[0]
 
     predict_proba = predict
+    predict_log_proba = predict
     decision_function = predict
     transform = predict
+    inverse_transform = predict
 
     def score(self, X=None, Y=None):
         if self.foo_param > 1:
@@ -267,6 +270,14 @@ def test_no_refit():
     assert_true(not hasattr(grid_search, "best_estimator_") and
                 hasattr(grid_search, "best_index_") and
                 hasattr(grid_search, "best_params_"))
+
+    # Make sure the predict/transform etc fns raise meaningfull error msg
+    for fn_name in ('predict', 'predict_proba', 'predict_log_proba',
+                    'transform', 'inverse_transform'):
+        assert_raise_message(NotFittedError,
+                             ('refit=False. %s is available only after '
+                              'refitting on the best parameters' % fn_name),
+                             getattr(grid_search, fn_name), X)
 
 
 def test_grid_search_error():


### PR DESCRIPTION
Setup

``` python
>>> from sklearn.svm import LinearSVC
>>> from sklearn.model_selection import GridSearchCV
>>> from sklearn.datasets import make_classification

>>> X, y = make_classification()
```

In master - After calling `fit`

``` python
>>> grid_search = GridSearchCV(LinearSVC(), {'C': [1, 2]},
...                            refit=False)
>>> grid_search.fit(X, y)
>>> grid_search.predict(X)

AttributeError: 'GridSearchCV' object has no attribute 'best_estimator_'
```

In master - without calling `fit`

``` python
>>> grid_search = GridSearchCV(LinearSVC(), {'C': [1, 2]},
...                            refit=False)
>>> # grid_search.fit(X, y)
>>> grid_search.predict(X)

AttributeError: 'GridSearchCV' object has no attribute 'best_estimator_'
```

This branch - when `refit=False`, with/without calling `fit` 

``` python
>>> grid_search = GridSearchCV(LinearSVC(), {'C': [1, 2]},
...                            refit=False)
>>> # grid_search.fit(X, y)
>>> grid_search.predict(X)

NotFittedError: This GridSearchCV instance was initialized with refit=False. predict is available only after refitting on the best parameters. 
```

This branch - when `refit=True`, before calling fit

``` python
>>> grid_search = GridSearchCV(LinearSVC(), {'C': [1, 2]},
...                            refit=True)
>>> # grid_search.fit(X, y)
>>> grid_search.predict(X)

NotFittedError: This GridSearchCV instance is not fitted yet. Call 'fit' with appropriate arguments before using this method.
```

@amueller @jnothman @vene @MechCoder @agramfort 
