### PR TITLE
Fix a typing issue in expected mutual information

### DIFF
--- a/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
@@ -20,14 +20,14 @@ np.import_array()
 def expected_mutual_information(contingency, int n_samples):
     """Calculate the expected mutual information for two labelings."""
     cdef int R, C
-    cdef float N, gln_N, emi, term2, term3, gln
+    cdef double N, gln_N, emi, term2, term3, gln
     cdef np.ndarray[double] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
     cdef np.ndarray[double] nijs, term1
     cdef np.ndarray[double, ndim=2] log_ab_outer
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
-    N = float(n_samples)
+    N = np.double(n_samples)
     a = np.sum(contingency, axis=1).astype(np.int32)
     b = np.sum(contingency, axis=0).astype(np.int32)
     # There are three major terms to the EMI equation, which are multiplied to

--- a/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
@@ -27,7 +27,7 @@ def expected_mutual_information(contingency, int n_samples):
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
-    N = np.double(n_samples)
+    N = <DOUBLE>n_samples
     a = np.sum(contingency, axis=1).astype(np.int32)
     b = np.sum(contingency, axis=0).astype(np.int32)
     # There are three major terms to the EMI equation, which are multiplied to

--- a/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
@@ -13,17 +13,17 @@ cimport cython
 from sklearn.utils.lgamma cimport lgamma
 
 np.import_array()
-
+ctypedef np.float64_t DOUBLE
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def expected_mutual_information(contingency, int n_samples):
     """Calculate the expected mutual information for two labelings."""
     cdef int R, C
-    cdef double N, gln_N, emi, term2, term3, gln
-    cdef np.ndarray[double] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
-    cdef np.ndarray[double] nijs, term1
-    cdef np.ndarray[double, ndim=2] log_ab_outer
+    cdef DOUBLE N, gln_N, emi, term2, term3, gln
+    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
+    cdef np.ndarray[DOUBLE] nijs, term1
+    cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape


### PR DESCRIPTION
Some variables were typed as float when they should be double in the cythonized version of expected_mutual_information_fast.pyx

_Edited to remove the bug that actually wasn't there..._ but the changes still stand, should probably use double consistently in cython.
