### PR TITLE
Rename `TimeSeriesCV` to `TimeSeriesSplit`

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -174,6 +174,7 @@ Splitter Classes
    model_selection.LabelShuffleSplit
    model_selection.StratifiedShuffleSplit
    model_selection.PredefinedSplit
+   model_selection.TimeSeriesSplit
 
 Splitter Functions
 ------------------

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -533,13 +533,13 @@ between training and testing instances (yielding poor estimates of
 generalisation error) on time series data. Therefore, it is very important 
 to evaluate our model for time series data on the "future" observations 
 least like those that are used to train the model. To achieve this, one 
-solution is provided by :class:`TimeSeriesCV`.
+solution is provided by :class:`TimeSeriesSplit`.
 
 
-TimeSeriesCV
+TimeSeriesSplit
 -----------------------
 
-:class:`TimeSeriesCV` is a variation of *k-fold* which 
+:class:`TimeSeriesSplit` is a variation of *k-fold* which 
 returns first :math:`k` folds as train set and the :math:`(k+1)` th 
 fold as test set. Note that unlike standard cross-validation methods, 
 successive training sets are supersets of those that come before them.
@@ -551,13 +551,13 @@ that are observed at fixed time intervals.
 
 Example of 3-split time series cross-validation on a dataset with 6 samples::
 
-  >>> from sklearn.model_selection import TimeSeriesCV
+  >>> from sklearn.model_selection import TimeSeriesSplit
 
   >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4], [1, 2], [3, 4]])
   >>> y = np.array([1, 2, 3, 4, 5, 6])
-  >>> tscv = TimeSeriesCV(n_splits=3)
+  >>> tscv = TimeSeriesSplit(n_splits=3)
   >>> print(tscv)  # doctest: +NORMALIZE_WHITESPACE
-  TimeSeriesCV(n_splits=3)
+  TimeSeriesSplit(n_splits=3)
   >>> for train, test in tscv.split(X):
   ...     print("%s %s" % (train, test))
   [0 1 2] [3]

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -141,6 +141,12 @@ New features
      <https://github.com/scikit-learn/scikit-learn/pull/6954>`_) by `Nelson
      Liu`_
 
+   - Added new cross-validation splitter 
+     :class:`model_selection.TimeSeriesSplit` to handle time series data. 
+     (`#6586
+     <https://github.com/scikit-learn/scikit-learn/pull/6586>`_) by `YenChen
+     Lin`_
+
 Enhancements
 ............
 

--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -2,7 +2,7 @@ from ._split import BaseCrossValidator
 from ._split import KFold
 from ._split import LabelKFold
 from ._split import StratifiedKFold
-from ._split import TimeSeriesCV
+from ._split import TimeSeriesSplit
 from ._split import LeaveOneLabelOut
 from ._split import LeaveOneOut
 from ._split import LeavePLabelOut
@@ -28,7 +28,7 @@ from ._search import fit_grid_point
 
 __all__ = ('BaseCrossValidator',
            'GridSearchCV',
-           'TimeSeriesCV',
+           'TimeSeriesSplit',
            'KFold',
            'LabelKFold',
            'LabelShuffleSplit',

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -635,7 +635,7 @@ class StratifiedKFold(_BaseKFold):
         return super(StratifiedKFold, self).split(X, y, labels)
 
 
-class TimeSeriesCV(_BaseKFold):
+class TimeSeriesSplit(_BaseKFold):
     """Time Series cross-validator
 
     Provides train/test indices to split time series data samples
@@ -659,12 +659,12 @@ class TimeSeriesCV(_BaseKFold):
 
     Examples
     --------
-    >>> from sklearn.model_selection import TimeSeriesCV
+    >>> from sklearn.model_selection import TimeSeriesSplit
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4])
-    >>> tscv = TimeSeriesCV(n_splits=3)
+    >>> tscv = TimeSeriesSplit(n_splits=3)
     >>> print(tscv)  # doctest: +NORMALIZE_WHITESPACE
-    TimeSeriesCV(n_splits=3)
+    TimeSeriesSplit(n_splits=3)
     >>> for train_index, test_index in tscv.split(X):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]
@@ -681,9 +681,9 @@ class TimeSeriesCV(_BaseKFold):
     where ``n_samples`` is the number of samples.
     """
     def __init__(self, n_splits=3):
-        super(TimeSeriesCV, self).__init__(n_splits,
-                                           shuffle=False,
-                                           random_state=None)
+        super(TimeSeriesSplit, self).__init__(n_splits,
+                                              shuffle=False,
+                                              random_state=None)
 
     def split(self, X, y=None, labels=None):
         """Generate indices to split data into training and test set.

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -30,7 +30,7 @@ from sklearn.model_selection import cross_val_score
 from sklearn.model_selection import KFold
 from sklearn.model_selection import StratifiedKFold
 from sklearn.model_selection import LabelKFold
-from sklearn.model_selection import TimeSeriesCV
+from sklearn.model_selection import TimeSeriesSplit
 from sklearn.model_selection import LeaveOneOut
 from sklearn.model_selection import LeaveOneLabelOut
 from sklearn.model_selection import LeavePOut
@@ -1004,9 +1004,9 @@ def test_time_series_cv():
     # Should fail if there are more folds than samples
     assert_raises_regexp(ValueError, "Cannot have number of folds.*greater",
                          next,
-                         TimeSeriesCV(n_splits=7).split(X))
+                         TimeSeriesSplit(n_splits=7).split(X))
 
-    tscv = TimeSeriesCV(2)
+    tscv = TimeSeriesSplit(2)
 
     # Manually check that Time Series CV preserves the data
     # ordering on toy datasets
@@ -1019,7 +1019,7 @@ def test_time_series_cv():
     assert_array_equal(train, [0, 1, 2, 3])
     assert_array_equal(test, [4, 5])
 
-    splits = TimeSeriesCV(2).split(X)
+    splits = TimeSeriesSplit(2).split(X)
 
     train, test = next(splits)
     assert_array_equal(train, [0, 1, 2])
@@ -1030,7 +1030,7 @@ def test_time_series_cv():
     assert_array_equal(test, [5, 6])
 
     # Check get_n_splits returns the correct number of splits
-    splits = TimeSeriesCV(2).split(X)
+    splits = TimeSeriesSplit(2).split(X)
     n_splits_actual = len(list(splits))
     assert_equal(n_splits_actual, tscv.get_n_splits())
     assert_equal(n_splits_actual, 2)


### PR DESCRIPTION
According to discussion in #6586, this PR rename `TimeSeriesCV` to `TimeSeriesSplit` and add it to the `classes.rst`.
