### PR TITLE
[MRG + 1] __array__ should take an optional dtype

### DIFF
--- a/sklearn/utils/mocking.py
+++ b/sklearn/utils/mocking.py
@@ -26,7 +26,7 @@ class MockDataFrame(object):
     def __len__(self):
         return len(self.array)
 
-    def __array__(self):
+    def __array__(self, dtype=None):
         # Pandas data frames also are array-like: we want to make sure that
         # input validation in cross-validation does not try to call that
         # method.

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -36,7 +36,7 @@ class NotAnArray(object):
     def __init__(self, data):
         self.data = data
 
-    def __array__(self):
+    def __array__(self, dtype=None):
         return self.data
 
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -236,6 +236,16 @@ def test_check_array_pandas_dtype_object_conversion():
     assert_equal(check_array(X_df, ensure_2d=False).dtype.kind, "f")
 
 
+def test_check_array_on_mock_dataframe():
+    arr = np.array([[0.2, 0.7], [0.6, 0.5], [0.4, 0.1], [0.7, 0.2]])
+    mock_df = MockDataFrame(arr)
+    checked_arr = check_array(mock_df)
+    assert_equal(checked_arr.dtype,
+                 arr.dtype)
+    checked_arr = check_array(mock_df, dtype=np.float32)
+    assert_equal(checked_arr.dtype, np.dtype(np.float32))
+
+
 def test_check_array_dtype_stability():
     # test that lists with ints don't get converted to floats
     X = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]


### PR DESCRIPTION
#### Reference Issue

Fixes #7241.
#### What does this implement/fix? Explain your changes.

`__array__` takes an optional dtype as documented  [here](http://docs.scipy.org/doc/numpy-1.10.0/reference/arrays.classes.html#numpy.class.__array__).
