### PR TITLE
[MRG + 1] Fix repr on isotropic kernels when a 1-D length scale is given

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 # caution: testing won't work on windows, see README
 
-PYTHON ?= python3
-CYTHON ?= cython3
-NOSETESTS ?= nosetests-3.4
+PYTHON ?= python
+CYTHON ?= cython
+NOSETESTS ?= nosetests
 CTAGS ?= ctags
 
 # skip doctests on 32bit python

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 # caution: testing won't work on windows, see README
 
-PYTHON ?= python
-CYTHON ?= cython
-NOSETESTS ?= nosetests
+PYTHON ?= python3
+CYTHON ?= cython3
+NOSETESTS ?= nosetests-3.4
 CTAGS ?= ctags
 
 # skip doctests on 32bit python

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -33,6 +33,15 @@ from ..base import clone
 from sklearn.externals.funcsigs import signature
 
 
+def _squeeze(length_scale):
+    """
+    np.squeeze that returns a scalar instead of a 0-D array.
+    """
+    length_scale = np.squeeze(length_scale).astype(float)
+    if length_scale.ndim == 0:
+        length_scale = np.asscalar(length_scale)
+    return length_scale
+
 def _check_length_scale(X, length_scale):
     length_scale = np.squeeze(length_scale).astype(float)
     if np.ndim(length_scale) > 1:
@@ -1204,7 +1213,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
                                                    self.length_scale)))
         else:  # isotropic
             return "{0}(length_scale={1:.3g})".format(
-                self.__class__.__name__, self.length_scale)
+                self.__class__.__name__, _squeeze(self.length_scale))
 
 
 class Matern(RBF):
@@ -1348,9 +1357,9 @@ class Matern(RBF):
                 self.__class__.__name__,
                 ", ".join(map("{0:.3g}".format, self.length_scale)),
                 self.nu)
-        else:  # isotropic
+        else:
             return "{0}(length_scale={1:.3g}, nu={2:.3g})".format(
-                self.__class__.__name__, self.length_scale, self.nu)
+                self.__class__.__name__, _squeeze(self.length_scale), self.nu)
 
 
 class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -33,15 +33,6 @@ from ..base import clone
 from sklearn.externals.funcsigs import signature
 
 
-def _squeeze(length_scale):
-    """
-    np.squeeze that returns a scalar instead of a 0-D array.
-    """
-    length_scale = np.squeeze(length_scale).astype(float)
-    if length_scale.ndim == 0:
-        length_scale = np.asscalar(length_scale)
-    return length_scale
-
 def _check_length_scale(X, length_scale):
     length_scale = np.squeeze(length_scale).astype(float)
     if np.ndim(length_scale) > 1:
@@ -1213,7 +1204,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
                                                    self.length_scale)))
         else:  # isotropic
             return "{0}(length_scale={1:.3g})".format(
-                self.__class__.__name__, _squeeze(self.length_scale))
+                self.__class__.__name__, np.ravel(self.length_scale)[0])
 
 
 class Matern(RBF):
@@ -1359,7 +1350,8 @@ class Matern(RBF):
                 self.nu)
         else:
             return "{0}(length_scale={1:.3g}, nu={2:.3g})".format(
-                self.__class__.__name__, _squeeze(self.length_scale), self.nu)
+                self.__class__.__name__, np.ravel(self.length_scale)[0],
+                self.nu)
 
 
 class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -311,4 +311,4 @@ def test_repr_kernels():
     """Smoke-test for repr in kernels."""
 
     for kernel in kernels:
-        kernel_repr = repr(kernel)
+        repr(kernel)

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -304,3 +304,12 @@ def test_set_get_params():
                 kernel.set_params(**{hyperparameter.name: value})
                 assert_almost_equal(np.exp(kernel.theta[index]), value)
                 index += 1
+
+
+def test_repr_kernels_isotropic_1D_length_scale():
+    """Test that repr works on isotropic kernels with a 1-D length_scale"""
+    matern = Matern(length_scale=[1.2])
+    assert_equal(repr(matern), "Matern(length_scale=1.2, nu=1.5)")
+
+    rbf = RBF(length_scale=[1.2])
+    assert_equal(repr(rbf), "RBF(length_scale=1.2)")

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,7 +20,7 @@ from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
                                    assert_not_equal, assert_array_equal,
-                                   assert_array_almost_equal, assert_true)
+                                   assert_array_almost_equal)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,7 +20,7 @@ from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
                                    assert_not_equal, assert_array_equal,
-                                   assert_array_almost_equal)
+                                   assert_array_almost_equal, assert_true)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -41,7 +41,8 @@ kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            4.0 * Matern(length_scale=[0.5, 0.5], nu=2.5),
            RationalQuadratic(length_scale=0.5, alpha=1.5),
            ExpSineSquared(length_scale=0.5, periodicity=1.5),
-           DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2]
+           DotProduct(sigma_0=2.0), DotProduct(sigma_0=2.0) ** 2,
+           RBF(length_scale=[2.0]), Matern(length_scale=[2.0])]
 for metric in PAIRWISE_KERNEL_FUNCTIONS:
     if metric in ["additive_chi2", "chi2"]:
         continue
@@ -306,10 +307,8 @@ def test_set_get_params():
                 index += 1
 
 
-def test_repr_kernels_isotropic_1D_length_scale():
-    """Test that repr works on isotropic kernels with a 1-D length_scale"""
-    matern = Matern(length_scale=[1.2])
-    assert_equal(repr(matern), "Matern(length_scale=1.2, nu=1.5)")
+def test_repr_kernels():
+    """Smoke-test for repr in kernels."""
 
-    rbf = RBF(length_scale=[1.2])
-    assert_equal(repr(rbf), "RBF(length_scale=1.2)")
+    for kernel in kernels:
+        kernel_repr = repr(kernel)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Moving setting the `length_scale` logic from the constructor to the methods broke `__repr__`  on a 1-D length_scale isotropic kernel.

``` python
 matern = Matern(length_scale=np.ones(1))
matern
TypeError: non-empty format string passed to object.__format__
```

This was because the formatting expected `self.length_scale` to be a scalar while the `self.length_scale` to be an array. To fix this, I squeeze the 1-D length_scale by squeezing it when `__repr__` is called.
