### PR TITLE
[MRG + 1] Fixes #7237 classes renamed to labels in hamming_loss

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -380,11 +380,6 @@ Bug fixes
     - Fix :class:`linear_model.ElasticNet` sparse decision function to match
     output with dense in the multioutput case.
 
-    - ``classes`` parameter was renamed to ``labels`` in
-      :func:`metrics.classification.hamming_loss`.
-      (`#7237 <https://github.com/scikit-learn/scikit-learn/issues/7237>`_) by
-      `Sebastian Vanrell`_.
-
 API changes summary
 -------------------
 
@@ -418,6 +413,11 @@ API changes summary
      and unambiguous interface to represent the number of train-test splits.
      (`#7187 <https://github.com/scikit-learn/scikit-learn/pull/7187>`_)
      by `YenChen Lin`_.
+
+    - ``classes`` parameter was renamed to ``labels`` in
+      :func:`metrics.classification.hamming_loss`.
+      (`#7237 <https://github.com/scikit-learn/scikit-learn/issues/7237>`_) by
+      `Sebastian Vanrell`_.
 
 
 .. currentmodule:: sklearn

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -380,6 +380,11 @@ Bug fixes
     - Fix :class:`linear_model.ElasticNet` sparse decision function to match
     output with dense in the multioutput case.
 
+    - `classes` parameter was renamed to `labels` in
+      :func:`metrics.classification.hamming_loss`.
+      (`#7237 <https://github.com/scikit-learn/scikit-learn/issues/7237>`_) by
+      `Sebastian Vanrell`_.
+
 API changes summary
 -------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -416,7 +416,7 @@ API changes summary
 
     - ``classes`` parameter was renamed to ``labels`` in
       :func:`metrics.classification.hamming_loss`.
-      (`#7237 <https://github.com/scikit-learn/scikit-learn/issues/7237>`_) by
+      (`#7260 <https://github.com/scikit-learn/scikit-learn/pull/7260>`_) by
       `Sebastian Vanrell`_.
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -417,7 +417,7 @@ API changes summary
     - ``classes`` parameter was renamed to ``labels`` in
       :func:`metrics.classification.hamming_loss`.
       (`#7260 <https://github.com/scikit-learn/scikit-learn/pull/7260>`_) by
-      `Sebastian Vanrell`_.
+      `Sebastián Vanrell`_.
 
 
 .. currentmodule:: sklearn
@@ -4401,3 +4401,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Hong Guangguo: https://github.com/hongguangguo
 
 .. _Mads Jensen: https://github.com/indianajensen
+
+.. _Sebastián Vanrell: https://github.com/srvanrell

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -380,7 +380,7 @@ Bug fixes
     - Fix :class:`linear_model.ElasticNet` sparse decision function to match
     output with dense in the multioutput case.
 
-    - `classes` parameter was renamed to `labels` in
+    - ``classes`` parameter was renamed to ``labels`` in
       :func:`metrics.classification.hamming_loss`.
       (`#7237 <https://github.com/scikit-learn/scikit-learn/issues/7237>`_) by
       `Sebastian Vanrell`_.

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1472,6 +1472,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
     labels : array, shape = [n_labels], optional (default=None)
         Integer array of labels. If not provided, labels will be inferred
         from y_true and y_pred.
+        .. versionadded:: 0.18
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1505,9 +1505,6 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
     The Hamming loss is upperbounded by the subset zero-one loss. When
     normalized over samples, the Hamming loss is always between 0 and 1.
 
-    'classes' was renamed to 'labels' in version 0.18 and will be removed in
-    0.20.
-
     References
     ----------
     .. [1] Grigorios Tsoumakas, Ioannis Katakis. Multi-Label Classification:

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -667,7 +667,8 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
 
     References
     ----------
-    .. [1] `Wikipedia entry for the F1-score <https://en.wikipedia.org/wiki/F1_score>`_
+    .. [1] `Wikipedia entry for the F1-score
+       <https://en.wikipedia.org/wiki/F1_score>`_
 
     Examples
     --------
@@ -1452,7 +1453,8 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     return report
 
 
-def hamming_loss(y_true, y_pred, labels=None, sample_weight=None, classes=None):
+def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
+                 classes=None):
     """Compute the average Hamming loss.
 
     The Hamming loss is the fraction of labels that are incorrectly predicted.
@@ -1503,7 +1505,8 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None, classes=None):
     The Hamming loss is upperbounded by the subset zero-one loss. When
     normalized over samples, the Hamming loss is always between 0 and 1.
 
-    'classes' was renamed to 'labels' in version 0.18 and will be removed in 0.20.
+    'classes' was renamed to 'labels' in version 0.18 and will be removed in
+    0.20.
 
     References
     ----------
@@ -1632,12 +1635,13 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
 
     if len(lb.classes_) == 1:
         if labels is None:
-            raise ValueError('y_true contains only one label ({0}). Please provide '
-                             'the true labels explicitly through the labels '
-                             'argument.'.format(lb.classes_[0]))
+            raise ValueError('y_true contains only one label ({0}). Please '
+                             'provide the true labels explicitly through the '
+                             'labels argument.'.format(lb.classes_[0]))
         else:
-            raise ValueError('The labels array needs to contain at least two labels'
-                             'for log_loss, got {0}.'.format(lb.classes_))
+            raise ValueError('The labels array needs to contain at least two '
+                             'labels for log_loss, '
+                             'got {0}.'.format(lb.classes_))
 
     transformed_labels = lb.transform(y_true)
 
@@ -1659,11 +1663,13 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
     transformed_labels = check_array(transformed_labels)
     if len(lb.classes_) != y_pred.shape[1]:
         if labels is None:
-            raise ValueError("y_true and y_pred contain different number of classes "
-                             "{0}, {1}. Please provide the true labels explicitly "
-                             "through the labels argument. Classes found in"
+            raise ValueError("y_true and y_pred contain different number of "
+                             "classes {0}, {1}. Please provide the true "
+                             "labels explicitly through the labels argument. "
+                             "Classes found in "
                              "y_true: {2}".format(transformed_labels.shape[1],
-                                               y_pred.shape[1], lb.classes_))
+                                                  y_pred.shape[1],
+                                                  lb.classes_))
         else:
             raise ValueError('The number of classes in labels is different '
                              'from that in y_pred. Classes found in '

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -668,7 +668,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
     References
     ----------
     .. [1] `Wikipedia entry for the F1-score
-       <https://en.wikipedia.org/wiki/F1_score>`_
+           <https://en.wikipedia.org/wiki/F1_score>`_
 
     Examples
     --------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1479,7 +1479,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
 
     classes : array, shape = [n_labels], optional
         (deprecated) Integer array of labels. This parameter has been
-         renamed to ``labels`` in version 0.18 an will be removed in 0.20.
+         renamed to ``labels`` in version 0.18 and will be removed in 0.20.
 
     Returns
     -------

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1452,7 +1452,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
     return report
 
 
-def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
+def hamming_loss(y_true, y_pred, labels=None, sample_weight=None, classes=None):
     """Compute the average Hamming loss.
 
     The Hamming loss is the fraction of labels that are incorrectly predicted.
@@ -1467,11 +1467,16 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
     y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
-    classes : array, shape = [n_labels], optional
-        Integer array of labels.
+    labels : array, shape = [n_labels], optional (default=None)
+        Integer array of labels. If not provided, labels will be inferred
+        from y_true and y_pred.
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.
+
+    classes : array, shape = [n_labels], optional
+        (deprecated) Integer array of labels. This parameter has been
+         renamed to ``labels`` in version 0.18 an will be removed in 0.20.
 
     Returns
     -------
@@ -1498,6 +1503,8 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
     The Hamming loss is upperbounded by the subset zero-one loss. When
     normalized over samples, the Hamming loss is always between 0 and 1.
 
+    'classes' was renamed to 'labels' in version 0.18 and will be removed in 0.20.
+
     References
     ----------
     .. [1] Grigorios Tsoumakas, Ioannis Katakis. Multi-Label Classification:
@@ -1520,12 +1527,17 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
     >>> hamming_loss(np.array([[0, 1], [1, 1]]), np.zeros((2, 2)))
     0.75
     """
+    if classes is not None:
+        warnings.warn("'classes' was renamed to 'labels' in version 0.18 and "
+                      "will be removed in 0.20.", DeprecationWarning)
+        labels = classes
+
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
-    if classes is None:
-        classes = unique_labels(y_true, y_pred)
+    if labels is None:
+        labels = unique_labels(y_true, y_pred)
     else:
-        classes = np.asarray(classes)
+        labels = np.asarray(labels)
 
     if sample_weight is None:
         weight_average = 1.
@@ -1536,7 +1548,7 @@ def hamming_loss(y_true, y_pred, classes=None, sample_weight=None):
         n_differences = count_nonzero(y_true - y_pred,
                                       sample_weight=sample_weight)
         return (n_differences /
-                (y_true.shape[0] * len(classes) * weight_average))
+                (y_true.shape[0] * len(labels) * weight_average))
 
     elif y_type in ["binary", "multiclass"]:
         return _weighted_sum(y_true != y_pred, sample_weight, normalize=True)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -1472,6 +1472,7 @@ def hamming_loss(y_true, y_pred, labels=None, sample_weight=None,
     labels : array, shape = [n_labels], optional (default=None)
         Integer array of labels. If not provided, labels will be inferred
         from y_true and y_pred.
+
         .. versionadded:: 0.18
 
     sample_weight : array-like of shape = [n_samples], optional

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -767,6 +767,7 @@ def test_multilabel_hamming_loss():
     assert_equal(hamming_loss(y1, np.zeros_like(y1), sample_weight=w), 2. / 3)
     # sp_hamming only works with 1-D arrays
     assert_equal(hamming_loss(y1[0], y2[0]), sp_hamming(y1[0], y2[0]))
+    assert_warns(DeprecationWarning, hamming_loss, y1, y2, classes=np.array([0, 1]))
 
 
 def test_multilabel_jaccard_similarity_score():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -754,6 +754,7 @@ def test_multilabel_hamming_loss():
     y1 = np.array([[0, 1, 1], [1, 0, 1]])
     y2 = np.array([[0, 0, 1], [1, 0, 1]])
     w = np.array([1, 3])
+    l = np.array([0, 1])
 
     assert_equal(hamming_loss(y1, y2), 1 / 6)
     assert_equal(hamming_loss(y1, y1), 0)
@@ -767,7 +768,7 @@ def test_multilabel_hamming_loss():
     assert_equal(hamming_loss(y1, np.zeros_like(y1), sample_weight=w), 2. / 3)
     # sp_hamming only works with 1-D arrays
     assert_equal(hamming_loss(y1[0], y2[0]), sp_hamming(y1[0], y2[0]))
-    assert_warns(DeprecationWarning, hamming_loss, y1, y2, classes=np.array([0, 1]))
+    assert_warns(DeprecationWarning, hamming_loss, y1, y2, classes=l)
 
 
 def test_multilabel_jaccard_similarity_score():

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -258,6 +258,8 @@ METRICS_WITH_POS_LABEL = [
 METRICS_WITH_LABELS = [
     "confusion_matrix",
 
+    "hamming_loss",
+
     "precision_score", "recall_score", "f1_score", "f2_score", "f0.5_score",
 
     "weighted_f0.5_score", "weighted_f1_score", "weighted_f2_score",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #7237 
#### What does this implement/fix? Explain your changes.

`classes` is renamed to `labels` in `hamming_loss()`.
A deprecation warning was added (to be removed in 0.20).
#### Any other comments?

PEP8 warnings in sklearn/metrics/classification.py were fixed 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
