### PR TITLE
[MRG] identity activation function for MLPs

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -99,64 +99,78 @@ ACTIVATIONS = {'identity': identity, 'tanh': tanh, 'logistic': logistic,
                'relu': relu, 'softmax': softmax}
 
 
-def inplace_logistic_derivative(Z):
-    """Compute the derivative of the logistic function given output value
-    from logistic function
+def inplace_identity_derivative(Z, delta):
+    """Apply the derivative of the identity function: do nothing.
+
+    Parameters
+    ----------
+    Z : {array-like, sparse matrix}, shape (n_samples, n_features)
+        The data which was output from the identity activation function during
+        the forward pass.
+
+    delta : {array-like}, shape (n_samples, n_features)
+         The backpropagated error signal to be modified inplace.
+    """
+    # Nothing to do
+
+
+def inplace_logistic_derivative(Z, delta):
+    """Apply the derivative of the logistic sigmoid function.
 
     It exploits the fact that the derivative is a simple function of the output
-    value from logistic function
+    value from logistic function.
 
     Parameters
     ----------
     Z : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The input data which is output from logistic function
+        The data which was output from the logistic activation function during
+        the forward pass.
 
-    Returns
-    -------
-    Z_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
+    delta : {array-like}, shape (n_samples, n_features)
+         The backpropagated error signal to be modified inplace.
     """
-    return Z * (1 - Z)
+    delta *= Z
+    delta *= (1 - Z)
 
 
-def inplace_tanh_derivative(Z):
-    """Compute the derivative of the hyperbolic tan function given output value
-    from hyperbolic tan
+def inplace_tanh_derivative(Z, delta):
+    """Apply the derivative of the hyperbolic tanh function.
 
     It exploits the fact that the derivative is a simple function of the output
-    value from hyperbolic tan
+    value from hyperbolic tangent.
 
     Parameters
     ----------
     Z : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The input data which is output from hyperbolic tan function
+        The data which was output from the hyperbolic tangent activation
+        function during the forward pass.
 
-    Returns
-    -------
-    Z_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
+    delta : {array-like}, shape (n_samples, n_features)
+         The backpropagated error signal to be modified inplace.
     """
-    return 1 - (Z ** 2)
+    delta *= (1 - Z ** 2)
 
 
-def inplace_relu_derivative(Z):
-    """Compute the derivative of the rectified linear unit function given output
-    value from relu
+def inplace_relu_derivative(Z, delta):
+    """Apply the derivative of the relu function.
+
+    It exploits the fact that the derivative is a simple function of the output
+    value from rectified linear units activation function.
 
     Parameters
     ----------
     Z : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The input data which is output from some relu
+        The data which was output from the rectified linear units activation
+        function during the forward pass.
 
-    Returns
-    -------
-    Z_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
+    delta : {array-like}, shape (n_samples, n_features)
+         The backpropagated error signal to be modified inplace.
     """
-    return (Z > 0).astype(Z.dtype)
+    delta[Z == 0] = 0
 
 
-DERIVATIVES = {'tanh': inplace_tanh_derivative,
+DERIVATIVES = {'identity': inplace_identity_derivative,
+               'tanh': inplace_tanh_derivative,
                'logistic': inplace_logistic_derivative,
                'relu': inplace_relu_derivative}
 

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -235,8 +235,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         # combinations of output activation and loss function:
         # sigmoid and binary cross entropy, softmax and categorical cross
         # entropy, and identity with squared loss
-        diff = y - activations[-1]
-        deltas[last] = -diff
+        deltas[last] = activations[-1] - y
 
         # Compute gradient for the last layer
         coef_grads, intercept_grads = self._compute_loss_grad(

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -27,7 +27,7 @@ from sklearn.utils.testing import (assert_raises, assert_greater, assert_equal,
 
 np.seterr(all='warn')
 
-ACTIVATION_TYPES = ["logistic", "tanh", "relu"]
+ACTIVATION_TYPES = ["identity", "logistic", "tanh", "relu"]
 
 digits_dataset_multi = load_digits(n_class=3)
 
@@ -254,7 +254,11 @@ def test_lbfgs_regression():
                            max_iter=150, shuffle=True, random_state=1,
                            activation=activation)
         mlp.fit(X, y)
-        assert_greater(mlp.score(X, y), 0.95)
+        if activation == 'identity':
+            assert_greater(mlp.score(X, y), 0.84)
+        else:
+            # Non linear models perform much better than linear bottleneck:
+            assert_greater(mlp.score(X, y), 0.95)
 
 
 def test_learning_rate_warmstart():


### PR DESCRIPTION
Here is an implementation of the identity function for MLPs. It might be useful to implement linear bottleneck layers, linear autoencoders and fastText-style text classification models (when combined with a bi-gram hashing vectorizer with l1-normalization).

I also change the way the inplace derivative function work to let them do the inplace-multiplication into the delta signal: this makes it possible to remove intermediate memory allocations and do-nothing in case of the identity activation function.
