### PR TITLE
[WIP] Test determinism of estimators

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -13,13 +13,9 @@ import sys
 import re
 import pkgutil
 
-import numpy as np
-
 from sklearn.externals.six import PY3
-from sklearn.utils.fixes import signature
 from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
-from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
@@ -28,8 +24,6 @@ from sklearn.utils.testing import ignore_warnings
 import sklearn
 from sklearn.cluster.bicluster import BiclusterMixin
 from sklearn.decomposition import ProjectedGradientNMF
-from sklearn.datasets import make_classification
-from sklearn.model_selection import train_test_split
 
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
@@ -79,45 +73,6 @@ def test_non_meta_estimators():
                     yield check, name, Estimator
             else:
                 yield check, name, Estimator
-
-
-def test_estimator_is_deterministic():
-    # all estimators should be deterministic with a fixed random_state
-    X, y = make_classification(n_classes=3, n_informative=3, random_state=3)
-    # We need to make sure that we have non negative data, for some estimators
-    X -= X.min() - .1
-
-    for name, Estimator in all_estimators(type_filter=['classifier',
-                                                       'regressor']):
-        # XXX skipping bad estimators for the moment
-        if name in ('HuberRegressor', 'LogisticRegressionCV',
-                    'LinearRegression', 'RANSACRegressor',
-                    'RadiusNeighborsClassifier'):
-            continue
-
-        if name.startswith("_"):
-            continue
-
-        X_train, X_test, y_train, y_test = train_test_split(X, y,
-                                                            train_size=0.5,
-                                                            random_state=3)
-        if "MultiTask" in name:
-            y_train = np.reshape(y_train, (-1, 1))
-            y_test = np.reshape(y_test, (-1, 1))
-
-        needs_state = 'random_state' in signature(Estimator.__init__).parameters
-        if needs_state:
-            est1 = Estimator(random_state=1)
-            est2 = Estimator(random_state=1)
-        else:
-            est1 = Estimator()
-            est2 = Estimator()
-
-        est1.fit(X_train, y_train)
-        est2.fit(X_train, y_train)
-
-        assert_array_almost_equal(est1.predict(X_test),
-                                  est2.predict(X_test))
 
 
 def test_configure():

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -12,10 +12,14 @@ import warnings
 import sys
 import re
 import pkgutil
+from inspect import signature
+
+import numpy as np
 
 from sklearn.externals.six import PY3
 from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
@@ -24,6 +28,8 @@ from sklearn.utils.testing import ignore_warnings
 import sklearn
 from sklearn.cluster.bicluster import BiclusterMixin
 from sklearn.decomposition import ProjectedGradientNMF
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
 
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
@@ -73,6 +79,48 @@ def test_non_meta_estimators():
                     yield check, name, Estimator
             else:
                 yield check, name, Estimator
+
+
+def test_estimator_is_deterministic():
+    # all estimators should be deterministic with a fixed random_state
+    X, y = make_classification(n_classes=3, n_informative=3, random_state=3)
+    # We need to make sure that we have non negative data, for some estimators
+    X -= X.min() - .1
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.5)
+
+    for name, Estimator in all_estimators(type_filter=['classifier',
+                                                       'regressor']):
+        # XXX skipping bad estimators for the moment
+        if name in ('HuberRegressor', 'LogisticRegressionCV',
+                    'LinearRegression', 'RANSACRegressor',
+                    'RadiusNeighborsClassifier'):
+            continue
+
+        if name.startswith("_"):
+            continue
+
+        X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                            train_size=0.5,
+                                                            random_state=3)
+        if "MultiTask" in name:
+            y_train = np.reshape(y_train, (-1, 1))
+            y_test = np.reshape(y_test, (-1, 1))
+
+        needs_state = 'random_state' in signature(Estimator.__init__).parameters
+        if needs_state:
+            est1 = Estimator(random_state=1)
+            est2 = Estimator(random_state=1)
+        else:
+            est1 = Estimator()
+            est2 = Estimator()
+
+        est1.fit(X_train, y_train)
+        est2.fit(X_train, y_train)
+
+        print(name)
+        assert_array_almost_equal(est1.predict(X_test),
+                                  est2.predict(X_test))
 
 
 def test_configure():

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -12,11 +12,11 @@ import warnings
 import sys
 import re
 import pkgutil
-from inspect import signature
 
 import numpy as np
 
 from sklearn.externals.six import PY3
+from sklearn.utils.fixes import signature
 from sklearn.utils.testing import assert_false, clean_warning_registry
 from sklearn.utils.testing import all_estimators
 from sklearn.utils.testing import assert_array_almost_equal
@@ -87,8 +87,6 @@ def test_estimator_is_deterministic():
     # We need to make sure that we have non negative data, for some estimators
     X -= X.min() - .1
 
-    X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.5)
-
     for name, Estimator in all_estimators(type_filter=['classifier',
                                                        'regressor']):
         # XXX skipping bad estimators for the moment
@@ -118,7 +116,6 @@ def test_estimator_is_deterministic():
         est1.fit(X_train, y_train)
         est2.fit(X_train, y_train)
 
-        print(name)
         assert_array_almost_equal(est1.predict(X_test),
                                   est2.predict(X_test))
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -334,7 +334,7 @@ def _is_32bit():
 
 def check_estimators_are_deterministic(name, Estimator):
     # all estimators should be deterministic with a fixed random_state
-    X, y = make_classification(n_classes=3, n_informative=5, n_samples=4000,
+    X, y = make_classification(n_classes=3, n_informative=5, n_samples=100,
                                random_state=2)
     # make sure there is nothing to be learnt
     rng = np.random.RandomState(0)
@@ -370,6 +370,7 @@ def check_estimators_are_deterministic(name, Estimator):
     # XXX statistical equivalence
     assert_array_almost_equal(est1.predict(X_test),
                               est2.predict(X_test))
+    assert_equal(pickle.dumps(est1), pickle.dumps(est2))
 
 
 def check_estimator_sparse_data(name, Estimator):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -334,8 +334,12 @@ def _is_32bit():
 
 def check_estimators_are_deterministic(name, Estimator):
     # all estimators should be deterministic with a fixed random_state
-    X, y = make_classification(n_classes=3, n_informative=3, random_state=3)
-    # We need to make sure that we have non negative data, for some estimators
+    X, y = make_classification(n_classes=3, n_informative=5, n_samples=4000,
+                               random_state=2)
+    # make sure there is nothing to be learnt
+    rng = np.random.RandomState(0)
+    rng.shuffle(y)
+    # For some estimators we need to make sure that we have non negative data
     X -= X.min() - .1
 
     # XXX skipping bad estimators for the moment
@@ -346,7 +350,7 @@ def check_estimators_are_deterministic(name, Estimator):
 
     X_train, X_test, y_train, y_test = train_test_split(X, y,
                                                         train_size=0.5,
-                                                        random_state=3)
+                                                        random_state=4)
     if "MultiTask" in name:
         y_train = np.reshape(y_train, (-1, 1))
         y_test = np.reshape(y_test, (-1, 1))
@@ -362,7 +366,10 @@ def check_estimators_are_deterministic(name, Estimator):
     est1.fit(X_train, y_train)
     est2.fit(X_train, y_train)
 
-    assert_array_almost_equal(est1.predict(X_test), est2.predict(X_test))
+    # XXX replace me by a better identity test, want identity not just
+    # XXX statistical equivalence
+    assert_array_almost_equal(est1.predict(X_test),
+                              est2.predict(X_test))
 
 
 def check_estimator_sparse_data(name, Estimator):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #7139 
#### What does this implement/fix? Explain your changes.

Fit two instances of the same estimator on a toy problem. Use both to predict on an unseen subset of data and compare predictions. If an estimator has a `random_state` argument provide it, if not then not.
#### Any other comments?

There are a few estimators that I am skipping at the moment because they fail the test. Most blatantly are not deterministic but two or so have a different error.

Unsure about the location, should this be a check in `utils/estimator_checks.py` instead?
- [x] move to `check_deterministic` in`utils/estimator_checks.py`
- [ ] transformers
- [ ] unsupervised algorithms
- [ ] why do `HuberRegressor`, `LogisticRegressionCV`, `LinearRegression`, `RANSACRegressor` fail?
- [ ] why does `RadiusNeighborsClassifier` fail? Failure mode is different to the above
