### PR TITLE
[MRG+1] Text vectorizers memory usage improvement (v2)

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -688,11 +688,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             vocabulary[term] = new_val
             map_index[old_val] = new_val
 
-        # swap columns in place
-        indices = X.indices
-        for idx, val in enumerate(X.indices):
-            indices[idx] = map_index[val]
-        X.indices = indices
+        X.indices = map_index.take(X.indices, mode='clip')
         return X
 
     def _limit_features(self, X, vocabulary, high=None, low=None,
@@ -766,7 +762,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
             j_indices.extend(feature_counter.keys())
             values.extend(feature_counter.values())
-            del(feature_counter)
             indptr.append(len(j_indices))
 
         if not fixed_vocab:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -676,7 +676,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         self.vocabulary = vocabulary
         self.binary = binary
         self.dtype = dtype
-        self.chunksize = 10000
 
     def _sort_features(self, X, vocabulary):
         """Sort features by name
@@ -706,10 +705,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
         This does not prune samples with zero features.
         """
-        high_not_set = high is None or int(high) == X.shape[0]
-        low_not_set = low is None or int(low) == 1
-        limit_not_set = limit is None or int(limit) == X.shape[1]
-        if high_not_set and low_not_set and limit_not_set:
+        if high is None and low is None and limit is None:
             return X, set()
 
         # Calculate a mask based on document frequencies
@@ -751,7 +747,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             vocabulary.default_factory = vocabulary.__len__
 
         analyze = self.build_analyzer()
-        j_indices = _make_int_array()
+        j_indices = []
         indptr = _make_int_array()
         values = _make_int_array()
         indptr.append(0)
@@ -780,7 +776,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
                 raise ValueError("empty vocabulary; perhaps the documents only"
                                  " contain stop words")
 
-        j_indices = frombuffer_empty(j_indices, dtype=np.intc)
+        j_indices = np.asarray(j_indices, dtype=np.intc)
         indptr = np.frombuffer(indptr, dtype=np.intc)
         values = frombuffer_empty(values, dtype=np.intc)
 


### PR DESCRIPTION
This PR benchmarks and slightly refactors  previously proposed improvements for performance and memory usage of text vectorizers, 
- implements a refactored version of PR https://github.com/scikit-learn/scikit-learn/pull/5122 (excluding the `HashingVectorizer`)
- Benchmarks but **does not include** PR #4968  (as it shows worse performance). Note that PR #5122 is itself is based on PR #4968. 
- Fixes issue #5306

The memory optimisation of the HashingVecotorizer from PR #5122 could be done in a separate PR.

The [benchmark notebook](https://gist.github.com/rth/1fba8e88d2d1f3cd3ef49b0d88a22c57) uses the Enron email collection and considers the performance and memory usage impact of these changes on `CountVectorizer`, `TfidfVectorizer` and `HashingVectorizer` for different number of documents (`Dataset size`),

![tmp1](https://cloud.githubusercontent.com/assets/630936/18035132/4bfaf43e-6d4f-11e6-934f-69994941a352.png)
![tmp2](https://cloud.githubusercontent.com/assets/630936/18035134/55130228-6d4f-11e6-9ba2-515476180d5f.png)
![tmp3](https://cloud.githubusercontent.com/assets/630936/18035135/5a7b619c-6d4f-11e6-8fad-390b92ec5008.png)
![tmp4](https://cloud.githubusercontent.com/assets/630936/18035144/964971e6-6d4f-11e6-9c88-891ada95d5c8.png)

Note that the benchmarks may not be fully reliable  (significant I/O operations for reading the data from disk) and sometimes produce different timing for identical runs.

Memory wise there is indeed a significant improvement,
- **CountVectorizer**: 30-50% less memory used
- **TfidfVecotorizer**: ~25% less memory used
-  **HashingVectorizer**: mostly no impact

~~however there are some performance drawbacks~~, 
- **> 50k document collection**: ~~~10% slower~~ 
- **10k document collection**: ~~up to 2-3 times slower~~

~~I'm not sure if the trade-off is worth it,~~  this is definitely oriented to large scale document collections, but one way or the other this should allow to address those PR & opened issue.   

**Edit**: as of Sept 7, 2016 I'm not able to reproduce the performance deterioration anymore  (cf comments below)
