### PR TITLE
[MRG+2] Fix ConvergenceWarning's in tests

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -1,4 +1,7 @@
 import numpy as np
+
+from sklearn.exceptions import ConvergenceWarning
+
 from sklearn.utils import check_array
 
 from sklearn.utils.testing import assert_array_almost_equal
@@ -66,9 +69,12 @@ def test_dict_learning_lassocd_readonly_data():
     n_components = 12
     with TempMemmap(X) as X_read_only:
         dico = DictionaryLearning(n_components, transform_algorithm='lasso_cd',
-                                  transform_alpha=0.001, random_state=0, n_jobs=-1)
-        code = dico.fit(X_read_only).transform(X_read_only)
-        assert_array_almost_equal(np.dot(code, dico.components_), X_read_only, decimal=2)
+                                  transform_alpha=0.001, random_state=0,
+                                  n_jobs=-1)
+        with ignore_warnings(category=ConvergenceWarning):
+            code = dico.fit(X_read_only).transform(X_read_only)
+        assert_array_almost_equal(np.dot(code, dico.components_), X_read_only,
+                                  decimal=2)
 
 
 def test_dict_learning_nonzero_coefs():

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -10,7 +10,8 @@ from sklearn.datasets import make_classification, load_digits, make_blobs
 from sklearn.svm.tests import test_svm
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils.testing import assert_warns, assert_raise_message
+from sklearn.utils.testing import (assert_warns, assert_raise_message,
+                                   ignore_warnings)
 
 # test sample 1
 X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]])
@@ -334,7 +335,9 @@ def test_timeout():
 
 def test_consistent_proba():
     a = svm.SVC(probability=True, max_iter=1, random_state=0)
-    proba_1 = a.fit(X, Y).predict_proba(X)
+    with ignore_warnings(category=ConvergenceWarning):
+        proba_1 = a.fit(X, Y).predict_proba(X)
     a = svm.SVC(probability=True, max_iter=1, random_state=0)
-    proba_2 = a.fit(X, Y).predict_proba(X)
+    with ignore_warnings(category=ConvergenceWarning):
+        proba_2 = a.fit(X, Y).predict_proba(X)
     assert_array_almost_equal(proba_1, proba_2)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -7,6 +7,7 @@ from scipy.sparse import coo_matrix
 from scipy.sparse import csr_matrix
 from scipy import stats
 
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_equal
@@ -1167,14 +1168,16 @@ def test_cross_val_predict_input_types():
     assert_equal(predictions.shape, (10,))
 
     # test with multioutput y
-    predictions = cval.cross_val_predict(clf, X_sparse, X)
+    with ignore_warnings(category=ConvergenceWarning):
+        predictions = cval.cross_val_predict(clf, X_sparse, X)
     assert_equal(predictions.shape, (10, 2))
 
     predictions = cval.cross_val_predict(clf, X_sparse, y)
     assert_array_equal(predictions.shape, (10,))
 
     # test with multioutput y
-    predictions = cval.cross_val_predict(clf, X_sparse, X)
+    with ignore_warnings(category=ConvergenceWarning):
+        predictions = cval.cross_val_predict(clf, X_sparse, X)
     assert_array_equal(predictions.shape, (10, 2))
 
     # test with X and y as list


### PR DESCRIPTION
This PR tries to fix some `ConvergenceWarning`s raised in the tests.

Where it seemed sensible I modified the parameters of the classifier used (e.g., increased `max_iter` until the warning disappears without the test taking noticeably more time to run). Otherwise, the warnings are explicitly ignored.

Any advice is welcome if you think there might be a better way to do it.

Note:
- This might address #4780 (it seems quite old, though).
- And part of #7006.
