### PR TITLE
[MRG] Improve the error message raised by check_consistent_length

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1394,8 +1394,8 @@ def test_log_loss():
     assert_raise_message(ValueError, error_str, log_loss, y_true, y_pred)
 
     y_pred = [[0.2, 0.7], [0.6, 0.5], [0.2, 0.3]]
-    error_str = ('Found arrays with inconsistent numbers of '
-                 'samples: [2 3]')
+    error_str = ('Found input variables with inconsistent numbers of samples: '
+                 '[3, 2]')
     assert_raise_message(ValueError, error_str, log_loss, y_true, y_pred)
 
     # works when the labels argument is used

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -174,10 +174,11 @@ def check_consistent_length(*arrays):
         Objects that will be checked for consistent length.
     """
 
-    uniques = np.unique([_num_samples(X) for X in arrays if X is not None])
+    lengths = [_num_samples(X) for X in arrays if X is not None]
+    uniques = np.unique(lengths)
     if len(uniques) > 1:
-        raise ValueError("Found arrays with inconsistent numbers of samples: "
-                         "%s" % str(uniques))
+        raise ValueError("Found input variables with inconsistent numbers of"
+                         " samples: %r" % [int(l) for l in lengths])
 
 
 def indexable(*iterables):


### PR DESCRIPTION
I find that displaying only the unique values is confusing as the order of the values might differ from the order of the input variables.
