### PR TITLE
[MRG+3] Fix min_weight_fraction_leaf to work when sample_weights are not provided

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,14 +19,17 @@ New features
 
 Enhancements
 ............
-   - The ``min_weight_fraction_leaf`` parameter of tree-based classifiers and
-     regressors now assumes uniform sample weights by default if the
-     ``sample_weight`` parameter is not passed to the ``fit`` function. (`#7301
-     <https://github.com/scikit-learn/scikit-learn/pull/7301>`_) by `Nelson
-     Liu`_.
+
 
 Bug fixes
 .........
+
+   - The ``min_weight_fraction_leaf`` parameter of tree-based classifiers and
+     regressors now assumes uniform sample weights by default if the
+     ``sample_weight`` argument is not passed to the ``fit`` function.
+     Previously, the parameter was silently ignored. (`#7301
+     <https://github.com/scikit-learn/scikit-learn/pull/7301>`_) by `Nelson
+     Liu`_.
 
 .. _changes_0_18:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,11 @@ New features
 
 Enhancements
 ............
-
+   - The ``min_weight_fraction_leaf`` parameter of tree-based classifiers and
+     regressors now assumes uniform sample weights by default if the
+     ``sample_weight`` parameter is not passed to the ``fit`` function. (`#7301
+     <https://github.com/scikit-learn/scikit-learn/pull/7301>`_) by `Nelson
+     Liu`_.
 
 Bug fixes
 .........

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -808,7 +808,9 @@ class RandomForestClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided, but
+        min_samples_leaf is more efficient.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1019,7 +1021,9 @@ class RandomForestRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided, but
+        min_samples_leaf is more efficient.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1190,7 +1194,9 @@ class ExtraTreesClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided, but
+        min_samples_leaf is more efficient.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1400,7 +1406,9 @@ class ExtraTreesRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided, but
+        min_samples_leaf is more efficient.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1557,7 +1565,9 @@ class RandomTreesEmbedding(BaseForest):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided, but
+        min_samples_leaf is more efficient.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -808,7 +808,8 @@ class RandomForestClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1019,7 +1020,8 @@ class RandomForestRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1190,7 +1192,8 @@ class ExtraTreesClassifier(ForestClassifier):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1400,7 +1403,8 @@ class ExtraTreesRegressor(ForestRegressor):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1557,7 +1561,8 @@ class RandomTreesEmbedding(BaseForest):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -807,9 +807,8 @@ class RandomForestClassifier(ForestClassifier):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1019,9 +1018,8 @@ class RandomForestRegressor(ForestRegressor):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1191,9 +1189,8 @@ class ExtraTreesClassifier(ForestClassifier):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1402,9 +1399,8 @@ class ExtraTreesRegressor(ForestRegressor):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1560,9 +1556,8 @@ class RandomTreesEmbedding(BaseForest):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -809,8 +809,7 @@ class RandomForestClassifier(ForestClassifier):
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided, but
-        min_samples_leaf is more efficient.
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1022,8 +1021,7 @@ class RandomForestRegressor(ForestRegressor):
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided, but
-        min_samples_leaf is more efficient.
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1195,8 +1193,7 @@ class ExtraTreesClassifier(ForestClassifier):
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided, but
-        min_samples_leaf is more efficient.
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1407,8 +1404,7 @@ class ExtraTreesRegressor(ForestRegressor):
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided, but
-        min_samples_leaf is more efficient.
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -1566,8 +1562,7 @@ class RandomTreesEmbedding(BaseForest):
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided, but
-        min_samples_leaf is more efficient.
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow trees with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1330,9 +1330,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
@@ -1699,9 +1698,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1331,7 +1331,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
@@ -1699,7 +1700,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1331,7 +1331,8 @@ class GradientBoostingClassifier(BaseGradientBoosting, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base
@@ -1699,7 +1700,8 @@ class GradientBoostingRegressor(BaseGradientBoosting, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided.
 
     subsample : float, optional (default=1.0)
         The fraction of samples to be used for fitting the individual base

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -705,7 +705,8 @@ def test_min_weight_fraction_leaf():
         yield check_min_weight_fraction_leaf, name, "multilabel", True
 
 
-def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets, sparse=False):
+def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets,
+                                                         sparse=False):
     """Test the interaction between min_weight_fraction_leaf and min_samples_leaf
     when sample_weights is not provided in fit."""
     if sparse:
@@ -766,6 +767,24 @@ def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets, sparse=
             "min_samples_leaf={2}".format(name,
                                           est.min_weight_fraction_leaf,
                                           est.min_samples_leaf))
+
+    for max_leaf_nodes, frac in product((None, 1000), np.linspace(0.1, 0.5, 3)):
+        # test that min_samples_leaf and min_weight_fraction_leaf
+        # yield the same results when sample_weight is None.
+        est_weight = TreeEstimator(max_leaf_nodes=max_leaf_nodes,
+                                   min_weight_fraction_leaf=frac,
+                                   random_state=0)
+        est_sample = TreeEstimator(max_leaf_nodes=max_leaf_nodes,
+                                   min_samples_leaf=frac,
+                                   random_state=0)
+        est_weight.fit(X, y)
+        est_sample.fit(X, y)
+
+        assert_tree_equal(est_weight.tree_, est_sample.tree_,
+                          "{0} with equal values of min_samples_leaf "
+                          "and min_weight_fraction_leaf "
+                          "are unequal with parameter value "
+                          "{1}".format(name, frac))
 
 
 def test_min_weight_fraction_leaf_with_min_samples_leaf():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -656,6 +656,7 @@ def check_min_weight_fraction_leaf(name, datasets, sparse=False):
 
         if sparse:
             out = est.tree_.apply(X.tocsr())
+
         else:
             out = est.tree_.apply(X)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -768,24 +768,6 @@ def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets,
                                           est.min_weight_fraction_leaf,
                                           est.min_samples_leaf))
 
-    for max_leaf_nodes, frac in product((None, 1000), np.linspace(0.1, 0.5, 3)):
-        # test that min_samples_leaf and min_weight_fraction_leaf
-        # yield the same results when sample_weight is None.
-        est_weight = TreeEstimator(max_leaf_nodes=max_leaf_nodes,
-                                   min_weight_fraction_leaf=frac,
-                                   random_state=0)
-        est_sample = TreeEstimator(max_leaf_nodes=max_leaf_nodes,
-                                   min_samples_leaf=frac,
-                                   random_state=0)
-        est_weight.fit(X, y)
-        est_sample.fit(X, y)
-
-        assert_tree_equal(est_weight.tree_, est_sample.tree_,
-                          "{0} with equal values of min_samples_leaf "
-                          "and min_weight_fraction_leaf "
-                          "are unequal with parameter value "
-                          "{1}".format(name, frac))
-
 
 def test_min_weight_fraction_leaf_with_min_samples_leaf():
     # Check on dense input

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -302,8 +302,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         # Set min_weight_leaf from min_weight_fraction_leaf
         if sample_weight is None:
-            min_weight_leaf = int(ceil(self.min_weight_fraction_leaf *
-                                       n_samples))
+            min_weight_leaf = (self.min_weight_fraction_leaf *
+                               n_samples)
         else:
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -302,7 +302,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         # Set min_weight_leaf from min_weight_fraction_leaf
         if sample_weight is None:
-            min_weight_leaf = int(ceil(self.min_weight_fraction_leaf * n_samples))
+            min_weight_leaf = int(ceil(self.min_weight_fraction_leaf *
+                                       n_samples))
             min_samples_leaf = max(min_samples_leaf, min_weight_leaf)
             min_weight_leaf = 0.
         else:

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -593,9 +593,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -864,9 +863,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
            Added float values for percentages.
 
     min_weight_fraction_leaf : float, optional (default=0.)
-        The minimum weighted fraction of the input samples required to be at a
-        leaf node where weights are determined by ``sample_weight`` provided
-        to ``fit``.
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -594,7 +594,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -864,7 +865,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the sum total of weights (of all
-        the input samples) required to be at a leaf node.
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -304,7 +304,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         if sample_weight is None:
             min_weight_leaf = int(ceil(self.min_weight_fraction_leaf *
                                        n_samples))
-            min_samples_leaf = max(min_samples_leaf, min_weight_leaf)
         else:
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -301,11 +301,13 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                 sample_weight = expanded_class_weight
 
         # Set min_weight_leaf from min_weight_fraction_leaf
-        if self.min_weight_fraction_leaf != 0. and sample_weight is not None:
+        if sample_weight is None:
+            min_weight_leaf = int(ceil(self.min_weight_fraction_leaf * n_samples))
+            min_samples_leaf = max(min_samples_leaf, min_weight_leaf)
+            min_weight_leaf = 0.
+        else:
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))
-        else:
-            min_weight_leaf = 0.
 
         if self.min_impurity_split < 0.:
             raise ValueError("min_impurity_split must be greater than or equal "
@@ -593,7 +595,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -863,7 +866,8 @@ class DecisionTreeRegressor(BaseDecisionTree, RegressorMixin):
 
     min_weight_fraction_leaf : float, optional (default=0.)
         The minimum weighted fraction of the input samples required to be at a
-        leaf node.
+        leaf node where weights are determined by ``sample_weight`` provided
+        to ``fit``.
 
     max_leaf_nodes : int or None, optional (default=None)
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -305,7 +305,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             min_weight_leaf = int(ceil(self.min_weight_fraction_leaf *
                                        n_samples))
             min_samples_leaf = max(min_samples_leaf, min_weight_leaf)
-            min_weight_leaf = 0.
         else:
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))


### PR DESCRIPTION
#### Reference Issue

Fixes #6945, previous PR at #6947
#### What does this implement/fix? Explain your changes.

> min_weight_fraction_leaf should work even when sample_weight is not given (in which case samples are assumed to have equal weight). I also tweaked the description of min_weight_fraction_leaf to make its purpose a bit more clear.
#### Any other comments?
