### PR TITLE
[MRG] Add link to AUTHORS.rst in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ SciPy and distributed under the 3-Clause BSD license.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the AUTHORS.rst file for a complete list of contributors.
+the [AUTHORS.rst](https://github.com/scikit-learn/scikit-learn/blob/master/AUTHORS.rst) file for a complete list of contributors.
 
 It is currently maintained by a team of volunteers.
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ SciPy and distributed under the 3-Clause BSD license.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the [AUTHORS.rst](https://github.com/scikit-learn/scikit-learn/blob/master/AUTHORS.rst) file for a complete list of contributors.
+the [AUTHORS.rst](https://github.com/scikit-learn/scikit-learn/blob/master/AUTHORS.rst)
+file for a complete list of contributors.
 
 It is currently maintained by a team of volunteers.
 

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,7 @@ SciPy and distributed under the 3-Clause BSD license.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the [AUTHORS.rst](https://github.com/scikit-learn/scikit-learn/blob/master/AUTHORS.rst)
-file for a complete list of contributors.
+the `AUTHORS.rst <AUTHORS.rst>`_ file for a complete list of contributors.
 
 It is currently maintained by a team of volunteers.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Adds a link to AUTHORS.rst in the readme file.
