### PR TITLE
[MRG + 1] Fix GaussianProcess batch predict  #7329

### DIFF
--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -527,7 +527,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             else:
 
                 y = np.zeros(n_eval)
-                for k in range(max(1, n_eval / batch_size)):
+                for k in range(max(1, int(n_eval / batch_size))):
                     batch_from = k * batch_size
                     batch_to = min([(k + 1) * batch_size + 1, n_eval + 1])
                     y[batch_from:batch_to] = \

--- a/sklearn/gaussian_process/gaussian_process.py
+++ b/sklearn/gaussian_process/gaussian_process.py
@@ -515,7 +515,7 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
             if eval_MSE:
 
                 y, MSE = np.zeros(n_eval), np.zeros(n_eval)
-                for k in range(max(1, n_eval / batch_size)):
+                for k in range(max(1, int(n_eval / batch_size))):
                     batch_from = k * batch_size
                     batch_to = min([(k + 1) * batch_size + 1, n_eval + 1])
                     y[batch_from:batch_to], MSE[batch_from:batch_to] = \

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -129,7 +129,7 @@ def test_ordinary_kriging():
 
 def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
-    y_pred = gp.predict(X)
+    y_pred = gp.predict(X, batch_size=1)
     assert_true(np.allclose(y_pred, y))
 
 

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -132,6 +132,7 @@ def test_no_normalize():
     y_pred = gp.predict(X)
     assert_true(np.allclose(y_pred, y))
 
+
 def test_batch_size():
     # TypeError when using batch_size on Python 3, see
     # https://github.com/scikit-learn/scikit-learn/issues/7329 for more
@@ -140,6 +141,7 @@ def test_batch_size():
     gp.fit(X, y)
     gp.predict(X, batch_size=1)
     gp.predict(X, batch_size=1, eval_MSE=True)
+
 
 def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -131,6 +131,8 @@ def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
     y_pred = gp.predict(X, batch_size=1)
     assert_true(np.allclose(y_pred, y))
+    y_pred = gp.predict(X, batch_size=1, eval_MSE=True)
+    assert_true(np.allclose(y_pred, y))
 
 
 def test_random_starts():

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -132,14 +132,14 @@ def test_no_normalize():
     y_pred = gp.predict(X)
     assert_true(np.allclose(y_pred, y))
 
-def test_batch_size():                                                                                                                
-    # TypeError when using batch_size on Python 3, see                                                                                
-    # https://github.com/scikit-learn/scikit-learn/issues/7329 for more            
-    # details                                                                                                                         
-    gp = GaussianProcess()                                                                                                            
-    gp.fit(X, y)                                                                                                                      
-    gp.predict(X, batch_size=1)                                                                                                       
-    gp.predict(X, batch_size=1, eval_MSE=True) 
+def test_batch_size():
+    # TypeError when using batch_size on Python 3, see
+    # https://github.com/scikit-learn/scikit-learn/issues/7329 for more
+    # details
+    gp = GaussianProcess()
+    gp.fit(X, y)
+    gp.predict(X, batch_size=1)
+    gp.predict(X, batch_size=1, eval_MSE=True)
 
 def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -131,8 +131,9 @@ def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
     y_pred = gp.predict(X, batch_size=1)
     assert_true(np.allclose(y_pred, y))
-    y_pred = gp.predict(X, batch_size=1, eval_MSE=True)
-    assert_true(np.allclose(y_pred, y))
+    y_pred = gp.predict(X, eval_MSE=True)
+    y_pred2 = gp.predict(X, batch_size=1, eval_MSE=True)
+    assert_true(np.allclose(y_pred, y_pred2))
 
 
 def test_random_starts():

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -129,12 +129,17 @@ def test_ordinary_kriging():
 
 def test_no_normalize():
     gp = GaussianProcess(normalize=False).fit(X, y)
-    y_pred = gp.predict(X, batch_size=1)
+    y_pred = gp.predict(X)
     assert_true(np.allclose(y_pred, y))
-    y_pred = gp.predict(X, eval_MSE=True)
-    y_pred2 = gp.predict(X, batch_size=1, eval_MSE=True)
-    assert_true(np.allclose(y_pred, y_pred2))
 
+def test_batch_size():                                                                                                                
+    # TypeError when using batch_size on Python 3, see                                                                                
+    # https://github.com/scikit-learn/scikit-learn/issues/7329 for more            
+    # details                                                                                                                         
+    gp = GaussianProcess()                                                                                                            
+    gp.fit(X, y)                                                                                                                      
+    gp.predict(X, batch_size=1)                                                                                                       
+    gp.predict(X, batch_size=1, eval_MSE=True) 
 
 def test_random_starts():
     # Test that an increasing number of random-starts of GP fitting only


### PR DESCRIPTION
#### Reference Issue

Fix #7329
GaussianProcess batch predict fail on py3 due to range(float)
#### What does this implement/fix? Explain your changes.

1,add a int() to convert float to int for py3
2,add a test for 'batch_size'
