### PR TITLE
[MRG] Allow sample weights and other fit_params for RFE

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -120,7 +120,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
     def _estimator_type(self):
         return self.estimator._estimator_type
 
-    def fit(self, X, y):
+    def fit(self, X, y, **fit_params):
         """Fit the RFE model and then the underlying estimator on the selected
            features.
 
@@ -131,10 +131,13 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
 
         y : array-like, shape = [n_samples]
             The target values.
-        """
-        return self._fit(X, y)
 
-    def _fit(self, X, y, step_score=None):
+        **fit_params : kwargs
+            Additional parameter passed to the fit function of the estimator.
+        """
+        return self._fit(X, y, **fit_params)
+
+    def _fit(self, X, y, step_score=None, **fit_params):
         X, y = check_X_y(X, y, "csc")
         # Initialization
         n_features = X.shape[1]
@@ -166,7 +169,7 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             if self.verbose > 0:
                 print("Fitting estimator with %d features." % np.sum(support_))
 
-            estimator.fit(X[:, features], y)
+            estimator.fit(X[:, features], y, **fit_params)
 
             # Get coefs
             if hasattr(estimator, 'coef_'):

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -109,8 +109,8 @@ def test_rfe_sample_weights():
     rfe.fit(X_duplicate, y_duplicate)
     ranking_duplicate = rfe.ranking_.copy()
 
-    with assert_raises(AssertionError):
-        assert_array_equal(ranking_original, ranking_weights)
+    assert_raises(AssertionError, assert_array_equal, ranking_original,
+                  ranking_weights)
     assert_array_equal(ranking_weights, ranking_duplicate)
 
 

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -75,6 +75,36 @@ def test_rfe_features_importance():
     assert_array_equal(rfe.get_support(), rfe_svc.get_support())
 
 
+def test_rfe_sample_weights():
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+
+    clf = SVC(kernel="linear")
+    rfe = RFE(estimator=clf, n_features_to_select=1)
+
+    sample_weight_test = 2
+
+    # Case 1 - double the weight of the class's features
+    w = np.ones(y.shape[0])
+    w[y == 2] = sample_weight_test
+
+    rfe.fit(X, y, sample_weight=w)
+    ranking_1 = rfe.ranking_.copy()
+
+    # Case 2 - duplicate the features of one class
+    extra_X = np.tile(X[y == 2], (sample_weight_test - 1, 1))
+    X2 = np.concatenate((X, extra_X), axis=0)
+
+    n_extra = (y == 2).sum() * (sample_weight_test - 1)
+    extra_Y = np.full(n_extra, 2, dtype=int)
+    y2 = np.concatenate((y, extra_Y), axis=0)
+
+    rfe.fit(X2, y2)
+    ranking_2 = rfe.ranking_.copy()
+
+    assert_array_equal(ranking_1, ranking_2)
+
 def test_rfe():
     generator = check_random_state(0)
     iris = load_iris()

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -84,20 +84,21 @@ def test_rfe_sample_weights():
     rfe = RFE(estimator=clf, n_features_to_select=1)
 
     sample_weight_test = 2
+    class_test = 2
 
     # Case 1 - double the weight of the class's features
     w = np.ones(y.shape[0])
-    w[y == 2] = sample_weight_test
+    w[y == class_test] = sample_weight_test
 
     rfe.fit(X, y, sample_weight=w)
     ranking_1 = rfe.ranking_.copy()
 
     # Case 2 - duplicate the features of one class
-    extra_X = np.tile(X[y == 2], (sample_weight_test - 1, 1))
+    extra_X = np.tile(X[y == class_test], (sample_weight_test - 1, 1))
     X2 = np.concatenate((X, extra_X), axis=0)
 
-    n_extra = (y == 2).sum() * (sample_weight_test - 1)
-    extra_Y = np.full(n_extra, 2, dtype=int)
+    n_extra = (y == class_test).sum() * (sample_weight_test - 1)
+    extra_Y = np.ones(n_extra, dtype=int) * class_test
     y2 = np.concatenate((y, extra_Y), axis=0)
 
     rfe.fit(X2, y2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes  #7308
#### What does this implement/fix? Explain your changes.

Adds support for passing sample weights into `RFE.fit()` and having them used by the estimator's `fit` method.

Adds a test for this with the iris dataset, where sample weights are used to give one class double its normal weight and compare that to doubling the samples in that class. The test passes if both these approaches produce the same feature ranking. This feature ranking is different from the one which arises when all samples have the same weight.
#### Any other comments?

I will look in to adding the same support for `RFECV`, and to `RFE.score()`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
