### PR TITLE
Fix feature importances computation error in RandomForest, ExtraTrees…

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -775,7 +775,7 @@ accessed via the ``feature_importances_`` property::
     >>> clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0,
     ...     max_depth=1, random_state=0).fit(X, y)
     >>> clf.feature_importances_  # doctest: +ELLIPSIS
-    array([ 0.11,  0.1 ,  0.11,  ...
+    array([ 0.10684213,  0.10461707,  0.11265447,  ...
 
 .. topic:: Examples:
 

--- a/sklearn/ensemble/forest.py
+++ b/sklearn/ensemble/forest.py
@@ -363,10 +363,12 @@ class BaseForest(six.with_metaclass(ABCMeta, BaseEnsemble,
 
         all_importances = Parallel(n_jobs=self.n_jobs,
                                    backend="threading")(
-            delayed(getattr)(tree, 'feature_importances_')
+            delayed(parallel_helper)(tree, '_compute_feature_importances',
+                                     normalize=False)
             for tree in self.estimators_)
 
-        return sum(all_importances) / len(self.estimators_)
+        all_importances_sum = sum(all_importances)
+        return all_importances_sum / sum(all_importances_sum)
 
 
 class ForestClassifier(six.with_metaclass(ABCMeta, BaseForest,

--- a/sklearn/ensemble/gradient_boosting.py
+++ b/sklearn/ensemble/gradient_boosting.py
@@ -1212,11 +1212,11 @@ class BaseGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble,
 
         total_sum = np.zeros((self.n_features, ), dtype=np.float64)
         for stage in self.estimators_:
-            stage_sum = sum(tree.feature_importances_
+            stage_sum = sum(tree._compute_feature_importances(normalize=False)
                             for tree in stage) / len(stage)
             total_sum += stage_sum
 
-        importances = total_sum / len(self.estimators_)
+        importances = total_sum / sum(total_sum)
         return importances
 
     def _validate_y(self, y):

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -507,11 +507,10 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         X = self._validate_X_predict(X, check_input)
         return self.tree_.decision_path(X)
 
-    @property
-    def feature_importances_(self):
+    def _compute_feature_importances(self, normalize=True):
         """Return the feature importances.
 
-        The importance of a feature is computed as the (normalized) total
+        The importance of a feature is computed as the total
         reduction of the criterion brought by that feature.
         It is also known as the Gini importance.
 
@@ -523,7 +522,9 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             raise NotFittedError("Estimator not fitted, call `fit` before"
                                  " `feature_importances_`.")
 
-        return self.tree_.compute_feature_importances()
+        return self.tree_.compute_feature_importances(normalize)
+
+    feature_importances_ = property(_compute_feature_importances)
 
 
 # =============================================================================


### PR DESCRIPTION
… and GradientBoosting

This fixes an error in feature importances computation of forests (i.e. RandomForest, ExtraTrees and GradientBoosting). As it is now, the feature importances are computed as the mean over the trees of the _normalized_ feature importances of each tree.

This is wrong especially for GradientBoosting as it means that the feature importances of the lastest trees will be weighted the same as the ones of the first trees although the lastest splits contribute much less to the global reduction of impurity. This is why the normalization must be done at the end.
(although it is not exactly the same computation, this is what is done in J. Friedman, “Greedy Function Approximation: A Gradient Boosting Machine”, The Annals of Statistics, Vol. 29, No. 5, 2001. in equation 44 and 45)

Thus, I have added a method to `BaseDecisionTree` called `_compute_feature_importances` that does the same as the attribute `feature_importances_` except that it accepts a facultative `normalize` argument (`feature_importances_` has been kept). `BaseForest` and `BaseGradientBoosting` now use that method to compute the non-normalized feature importances of each tree, sum them and normalize them before returning them.
