### PR TITLE
[MRG+1] Fix for test_neighbors_metrics() check kd-tree algorithm when possible

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -944,7 +944,7 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     for metric, metric_params in metrics:
         results = {}
         p = metric_params.pop('p', 2)
-        for i, algorithm in enumerate(algorithms):
+        for algorithm in algorithms:
             # KD tree doesn't support all metrics
             if (algorithm == 'kd_tree' and
                     metric not in neighbors.KDTree.valid_metrics):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -944,25 +944,28 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     for metric, metric_params in metrics:
         results = []
         p = metric_params.pop('p', 2)
-        for algorithm in algorithms:
+        kd = True
+        for i, algorithm in enumerate(algorithms):
             # KD tree doesn't support all metrics
             if (algorithm == 'kd_tree' and
                     metric not in neighbors.KDTree.valid_metrics):
+                kd = False
                 assert_raises(ValueError,
                               neighbors.NearestNeighbors,
                               algorithm=algorithm,
                               metric=metric, metric_params=metric_params)
                 continue
-
             neigh = neighbors.NearestNeighbors(n_neighbors=n_neighbors,
                                                algorithm=algorithm,
                                                metric=metric, p=p,
                                                metric_params=metric_params)
             neigh.fit(X)
             results.append(neigh.kneighbors(test, return_distance=True))
-
         assert_array_almost_equal(results[0][0], results[1][0])
         assert_array_almost_equal(results[0][1], results[1][1])
+        if kd:
+            assert_array_almost_equal(results[0][0], results[2][0])
+            assert_array_almost_equal(results[0][1], results[2][1])
 
 
 def test_callable_metric():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -962,8 +962,10 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
         assert_array_almost_equal(results['brute'][0], results['ball_tree'][0])
         assert_array_almost_equal(results['brute'][1], results['ball_tree'][1])
         if 'kd_tree' in results:
-            assert_array_almost_equal(results['brute'][0], results['kd_tree'][0])
-            assert_array_almost_equal(results['brute'][1], results['kd_tree'][1])
+            assert_array_almost_equal(results['brute'][0],
+                                      results['kd_tree'][0])
+            assert_array_almost_equal(results['brute'][1],
+                                      results['kd_tree'][1])
 
 
 def test_callable_metric():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -942,14 +942,12 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     test = rng.rand(n_query_pts, n_features)
 
     for metric, metric_params in metrics:
-        results = []
+        results = {}
         p = metric_params.pop('p', 2)
-        kd = True
         for i, algorithm in enumerate(algorithms):
             # KD tree doesn't support all metrics
             if (algorithm == 'kd_tree' and
                     metric not in neighbors.KDTree.valid_metrics):
-                kd = False
                 assert_raises(ValueError,
                               neighbors.NearestNeighbors,
                               algorithm=algorithm,
@@ -960,12 +958,12 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
                                                metric=metric, p=p,
                                                metric_params=metric_params)
             neigh.fit(X)
-            results.append(neigh.kneighbors(test, return_distance=True))
-        assert_array_almost_equal(results[0][0], results[1][0])
-        assert_array_almost_equal(results[0][1], results[1][1])
-        if kd:
-            assert_array_almost_equal(results[0][0], results[2][0])
-            assert_array_almost_equal(results[0][1], results[2][1])
+            results[algorithm] = neigh.kneighbors(test, return_distance=True)
+        assert_array_almost_equal(results['brute'][0], results['ball_tree'][0])
+        assert_array_almost_equal(results['brute'][1], results['ball_tree'][1])
+        if 'kd_tree' in results:
+            assert_array_almost_equal(results['brute'][0], results['kd_tree'][0])
+            assert_array_almost_equal(results['brute'][1], results['kd_tree'][1])
 
 
 def test_callable_metric():


### PR DESCRIPTION
Addresses Issue #7336
jnothman suggested to submit a pull request .

As indicated in the issue, this should improve test coverage as now the kd-tree algorithm is tested when it is available for a given metric.
