### PR TITLE
[MRG] Remove redundant logic in Decision Tree

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -441,6 +441,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                    (n_node_samples < self.min_samples_leaf) or
                    (weighted_n_node_samples < self.min_weight_leaf) or
                    (impurity <= min_impurity_split))
+
         if not is_leaf:
             splitter.node_split(impurity, &split, &n_constant_features)
             is_leaf = is_leaf or (split.pos >= end)

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -218,7 +218,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
 
                 is_leaf = ((depth >= max_depth) or
                            (n_node_samples < min_samples_split) or
-                           (n_node_samples < 2 * min_samples_leaf) or
+                           (n_node_samples < min_samples_leaf) or
                            (weighted_n_node_samples < min_weight_leaf))
 
                 if first:
@@ -438,10 +438,9 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         n_node_samples = end - start
         is_leaf = ((depth > self.max_depth) or
                    (n_node_samples < self.min_samples_split) or
-                   (n_node_samples < 2 * self.min_samples_leaf) or
+                   (n_node_samples < self.min_samples_leaf) or
                    (weighted_n_node_samples < self.min_weight_leaf) or
                    (impurity <= min_impurity_split))
-
         if not is_leaf:
             splitter.node_split(impurity, &split, &n_constant_features)
             is_leaf = is_leaf or (split.pos >= end)

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -226,7 +226,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)
 
-        min_samples_split = max(min_samples_split, 2 * min_samples_leaf)
+        # min_samples_split = max(min_samples_split, 2 * min_samples_leaf)
 
         if isinstance(self.max_features, six.string_types):
             if self.max_features == "auto":

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -226,8 +226,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)
 
-        # min_samples_split = max(min_samples_split, 2 * min_samples_leaf)
-
         if isinstance(self.max_features, six.string_types):
             if self.max_features == "auto":
                 if is_classification:
@@ -308,8 +306,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
             min_weight_leaf = 0.
 
         if self.min_impurity_split < 0.:
-            raise ValueError("min_impurity_split must be greater than or equal "
-                             "to 0")
+            raise ValueError("min_impurity_split must be greater than "
+                             "or equal to 0")
 
         presort = self.presort
         # Allow presort to be 'auto', which means True if the dataset is dense,
@@ -372,7 +370,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                                            min_samples_leaf,
                                            min_weight_leaf,
                                            max_depth,
-                                           max_leaf_nodes, self.min_impurity_split)
+                                           max_leaf_nodes,
+                                           self.min_impurity_split)
 
         builder.build(self.tree_, X, y, sample_weight, X_idx_sorted)
 
@@ -592,7 +591,8 @@ class DecisionTreeClassifier(BaseDecisionTree, ClassifierMixin):
         Best nodes are defined as relative reduction in impurity.
         If None then unlimited number of leaf nodes.
 
-    class_weight : dict, list of dicts, "balanced" or None, optional (default=None)
+    class_weight : dict, list of dicts, "balanced" or None, \
+                   optional (default=None)
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one. For
         multi-output problems, a list of dicts can be provided in the same


### PR DESCRIPTION
#### Reference Issue

Fixes #7338 
#### What does this implement/fix? Explain your changes.

Removes duplicate logic in tree building and edits `min_samples_leaf` to behave similarly to `min_fraction_weight_leaf`. Also removes automatic setting of `min_samples_split` from `min_samples_split`.
#### Any other comments?

A PR with the concrete changes proposed in #7338 
