### PR TITLE
Vary step size

### DIFF
--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -101,7 +101,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         self.C = C
         self.loss = loss
 
-    def partial_fit(self, X, y, classes=None):
+    def partial_fit(self, X, y, C_=self.C, classes=None):
         """Fit linear model with Passive Aggressive algorithm.
 
         Parameters
@@ -135,7 +135,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
                              "resulting weights as the class_weight "
                              "parameter.")
         lr = "pa1" if self.loss == "hinge" else "pa2"
-        return self._partial_fit(X, y, alpha=1.0, C=self.C,
+        return self._partial_fit(X, y, alpha=1.0, C=C_,
                                  loss="hinge", learning_rate=lr, n_iter=1,
                                  classes=classes, sample_weight=None,
                                  coef_init=None, intercept_init=None)

--- a/sklearn/linear_model/passive_aggressive.py
+++ b/sklearn/linear_model/passive_aggressive.py
@@ -140,7 +140,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
                                  classes=classes, sample_weight=None,
                                  coef_init=None, intercept_init=None)
 
-    def fit(self, X, y, coef_init=None, intercept_init=None):
+    def fit(self, X, y, C_= self.C, coef_init=None, intercept_init=None):
         """Fit linear model with Passive Aggressive algorithm.
 
         Parameters
@@ -162,7 +162,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         self : returns an instance of self.
         """
         lr = "pa1" if self.loss == "hinge" else "pa2"
-        return self._fit(X, y, alpha=1.0, C=self.C,
+        return self._fit(X, y, alpha=1.0, C=C_,
                          loss="hinge", learning_rate=lr,
                          coef_init=coef_init, intercept_init=intercept_init)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Current implementation of PA requires the step size (C) to be same across all fit()/partial_fit()
The changes allow to vary the value of C per call of fit()/partial_fit(). 

Use case : Google's priority inbox paper uses this to incorporate user feedback. 
[Google_Prioroty_Inbox.pdf](https://github.com/scikit-learn/scikit-learn/files/456577/Google_Prioroty_Inbox.pdf)

"In practice, we abuse C by adjusting it per mail to represent our confidence in the label, e.g. a manual correction by a user is given a higher value of C. User models also have higher C than the global model, and new user models have higher values still to promote initial learning."
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
