### PR TITLE
[MRG+1] use inspect in _set_test_name to get the calling test.

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import numpy as np
 from scipy import sparse
 import struct
+import inspect
 
 from sklearn.externals.six.moves import zip
 from sklearn.externals.joblib import hash, Memory
@@ -76,8 +77,8 @@ DEPRECATED_TRANSFORM = [
 
 
 def _set_test_name(function, name):
-    function.description = ("sklearn.tests.test_common.{0}({1})".format(
-        function.__name__, name))
+    function.description = ("sklearn.tests.test_common.{0}.{1}({2})".format(
+        inspect.stack()[1][3], function.__name__, name))
     return function
 
 


### PR DESCRIPTION
Follow up on the comments in #7317.
Now it looks like

```
sklearn.tests.test_common.test_non_meta_estimators.check_pipeline_consistency(MultiTaskElasticNetCV) ... ok
```

That was the goal, right?
