### PR TITLE
[MRG] Allow bagging models to accept NaN values

### DIFF
--- a/sklearn/ensemble/bagging.py
+++ b/sklearn/ensemble/bagging.py
@@ -285,7 +285,7 @@ class BaseBagging(with_metaclass(ABCMeta, BaseEnsemble)):
         random_state = check_random_state(self.random_state)
 
         # Convert data
-        X, y = check_X_y(X, y, ['csr', 'csc'])
+        X, y = check_X_y(X, y, ['csr', 'csc'], force_all_finite=False)
 
         # Remap output
         n_samples, self.n_features_ = X.shape

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -410,6 +410,9 @@ def test_error():
     # Test support of decision_function
     assert_false(hasattr(BaggingClassifier(base).fit(X, y), 'decision_function'))
 
+    bad_X = X.copy()
+    bad_X[0, 2] = np.nan
+    assert_raises(ValueError, BaggingClassifier(base).fit, bad_X, y)
 
 def test_parallel_classification():
     # Check parallel classification.


### PR DESCRIPTION
If a bagging model's underlying model allows for nonfinite values in the
features, there's seemingly no reason to enforce finite values for the bagging
model. Those errors, if they occur, should probably be raised elsewhere.

As a specific use case, this allows you to bag pipelines that include their own imputation methods.
