### PR TITLE
[MRG + 1] Make `raw_values` an estimator parameter in EllipticEnvelope

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -233,6 +233,11 @@ API changes summary
       :func:`sklearn.model_selection.cross_val_predict`.
       :issue:`2879` by :user:`Stephen Hoover <stephen-hoover>`.
 
+    - Deprecate the ``raw_values`` argument of the ``decision_function``
+      method in :class:`sklearn.covariance.EllipticEnvelope` in favor of the
+      estimator parameter ``raw_decision``. ``raw_decision`` now makes
+      ``decision_function`` return the negated Mahalanobis distances.
+
 .. _changes_0_18_1:
 
 Version 0.18.1

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -32,8 +32,8 @@ class OutlierDetectionMixin(object):
     raw_decision : bool
         Whether or not to consider raw negated Mahalanobis distances as the
         decision function. Otherwise returns `[-dist**(1/3) + thres**(1/3)]`.
-        Must be False` (default) for compatibility with the others outlier
-        detection tools.
+        Must be False (default) for compatibility with the others outlier
+        detection tools (which use a threshold of 0 for outliers).
 
         .. versionadded:: 0.19
 
@@ -58,7 +58,8 @@ class OutlierDetectionMixin(object):
         raw_values : bool
             Whether or not to consider raw positive Mahalanobis
             distances as the decision function. Must be False (default) for
-            compatibility with the others outlier detection tools.
+            compatibility with the others outlier detection tools, which use a
+            threshold of 0 for being an outlier.
 
             .. depricated:: 0.19
                 set self.raw_decision to return the negated distance values
@@ -69,7 +70,7 @@ class OutlierDetectionMixin(object):
         decision : array-like, shape (n_samples, )
             The values of the decision function for each observations.
             It is equal to the Mahalanobis distances if `raw_values`
-            is True. By default (``raw_values=True``), it is equal
+            is True. By default (``raw_values=False``), it is equal
             to the cubic root of the shifted Mahalanobis distances.
             In that case, the threshold for being an outlier is 0, which
             ensures a compatibility with other outlier detection tools

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -84,11 +84,11 @@ class OutlierDetectionMixin(object):
         mahal_dist = self.mahalanobis(X)
         if self.raw_decision:
             decision = -mahal_dist
-        elif raw_values is not None:
+        elif raw_values:
             # For compatibility with legacy argument
             decision = mahal_dist
-        else:
             check_is_fitted(self, 'threshold_')
+        else:
             transformed_mahal_dist = mahal_dist ** 0.33
             decision = self.threshold_ ** 0.33 - transformed_mahal_dist
 

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -31,9 +31,9 @@ class OutlierDetectionMixin(object):
 
     raw_decision : bool
         Whether or not to consider raw negated Mahalanobis distances as the
-        decision function. Otherwise returns `[-dist**(1/3) + thres**(1/3)]`.
+        decision function. Otherwise returns ``-dist**(1/3) + thres**(1/3)``.
         Must be False (default) for compatibility with the others outlier
-        detection tools (which use a threshold of 0 for outliers).
+        detection tools, which use a threshold of 0 for outliers.
 
         .. versionadded:: 0.19
 
@@ -61,7 +61,7 @@ class OutlierDetectionMixin(object):
             compatibility with the others outlier detection tools, which use a
             threshold of 0 for being an outlier.
 
-            .. depricated:: 0.19
+            .. deprecated:: 0.19
                 set self.raw_decision to return the negated distance values
                 instead
 
@@ -80,7 +80,8 @@ class OutlierDetectionMixin(object):
 
         if raw_values is not None:
             warnings.warn(
-                'raw_values keyword has been moved to class initialization',
+                'raw_values keyword has been moved to class initialization '
+                'as raw_decision. raw_values will be removed in version 0.21',
                 DeprecationWarning)
 
         check_is_fitted(self, 'threshold_')

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -30,20 +30,18 @@ class OutlierDetectionMixin(object):
         of outliers in the data set.
 
     raw_decision : bool
-        Whether or not to consider raw (negative) Mahalanobis distances as the
-        decision function. Otherwise returns `[-(dist)**(1/3) + thres**(1/3)]`.
+        Whether or not to consider raw negated Mahalanobis distances as the
+        decision function. Otherwise returns `[-dist**(1/3) + thres**(1/3)]`.
         Must be False` (default) for compatibility with the others outlier
         detection tools.
+
+        .. versionadded:: 0.19
 
     Notes
     -----
     Outlier detection from covariance estimation may break or not
     perform well in high-dimensional settings. In particular, one will
     always take care to work with ``n_samples > n_features ** 2``.
-
-    The `raw_decision` kwarg now returns the negative Mahalanobis distance as a
-    more appropriate penalty function. The depricated `decision_function` kwarg
-    `raw_values` still returns a postive distance.
 
     """
     def __init__(self, contamination=0.1, raw_decision=False):
@@ -58,9 +56,13 @@ class OutlierDetectionMixin(object):
         X : array-like, shape (n_samples, n_features)
 
         raw_values : bool
-            (Deprecated) Whether or not to consider raw (positive) Mahalanobis
+            Whether or not to consider raw positive Mahalanobis
             distances as the decision function. Must be False (default) for
             compatibility with the others outlier detection tools.
+
+            .. depricated:: 0.19
+                set self.raw_decision to return the negated distance values
+                instead
 
         Returns
         -------

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -29,7 +29,7 @@ class OutlierDetectionMixin(object):
         The amount of contamination of the data set, i.e. the proportion
         of outliers in the data set.
 
-    raw_values : bool
+    raw_decision : bool
         Whether or not to consider raw Mahalanobis distances as the
         decision function. Must be False (default) for compatibility
         with the others outlier detection tools.
@@ -41,9 +41,9 @@ class OutlierDetectionMixin(object):
     always take care to work with ``n_samples > n_features ** 2``.
 
     """
-    def __init__(self, contamination=0.1, raw_values=False):
+    def __init__(self, contamination=0.1, raw_decision=False):
         self.contamination = contamination
-        self.raw_values = raw_values
+        self.raw_decision = raw_decision
 
     def decision_function(self, X, raw_values=None):
         """Compute the decision function of the given observations.
@@ -70,15 +70,17 @@ class OutlierDetectionMixin(object):
 
         """
 
+        use_raw_decision = self.raw_decision
+
         if raw_values is not None:
             warnings.warn(
                 'raw_values keyword has been moved to class initialization',
                 DeprecationWarning)
-            self.raw_values = raw_values
+            use_raw_decision = raw_values
 
         check_is_fitted(self, 'threshold_')
         mahal_dist = self.mahalanobis(X)
-        if self.raw_values:
+        if use_raw_decision:
             decision = mahal_dist
         else:
             check_is_fitted(self, 'threshold_')

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -112,13 +112,13 @@ def test_outlier_detection():
     clf.raw_decision = True
     new_decision = clf.decision_function(X)
 
-    assert_array_almost_equal(previous_decision, new_decision)
+    assert_array_almost_equal(-previous_decision, new_decision)
 
     clf.raw_decision = False
     decision_transformed = clf.decision_function(X)
 
     assert_array_almost_equal(
-        new_decision, clf.mahalanobis(X))
+        new_decision, -clf.mahalanobis(X))
     assert_array_almost_equal(clf.mahalanobis(X), clf.dist_)
     assert_almost_equal(clf.score(X, np.ones(100)),
                         (100 - y_pred[y_pred == -1].size) / 100.)

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -10,6 +10,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_warns
 from sklearn.exceptions import NotFittedError
 
 from sklearn import datasets
@@ -100,11 +101,20 @@ def test_outlier_detection():
     assert_raises(NotFittedError, clf.decision_function, X)
     clf.fit(X)
     y_pred = clf.predict(X)
-    decision = clf.decision_function(X, raw_values=True)
-    decision_transformed = clf.decision_function(X, raw_values=False)
+
+    previous_decision = assert_warns(
+        DeprecationWarning, clf.decision_function, X, raw_values=True)
+
+    clf.raw_values = True
+    new_decision = clf.decision_function(X)
+
+    assert_array_almost_equal(previous_decision, new_decision)
+
+    clf.raw_values = False
+    decision_transformed = clf.decision_function(X)
 
     assert_array_almost_equal(
-        decision, clf.mahalanobis(X))
+        new_decision, clf.mahalanobis(X))
     assert_array_almost_equal(clf.mahalanobis(X), clf.dist_)
     assert_almost_equal(clf.score(X, np.ones(100)),
                         (100 - y_pred[y_pred == -1].size) / 100.)

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -7,6 +7,7 @@
 import numpy as np
 
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
@@ -105,12 +106,15 @@ def test_outlier_detection():
     previous_decision = assert_warns(
         DeprecationWarning, clf.decision_function, X, raw_values=True)
 
-    clf.raw_values = True
+    # Make sure passing raw_values does not change attribute
+    assert_equal(clf.raw_decision, False)
+
+    clf.raw_decision = True
     new_decision = clf.decision_function(X)
 
     assert_array_almost_equal(previous_decision, new_decision)
 
-    clf.raw_values = False
+    clf.raw_decision = False
     decision_transformed = clf.decision_function(X)
 
     assert_array_almost_equal(


### PR DESCRIPTION
This PR allows kwargs to be passed from pipeline's decision_function
to the final estimator. Currently only useful for returning
raw_values from `EllipticEnvelope` (which is pretty hard to do any other
way from a pipeline). But should be generalizable in case any other
decision functions implement kwargs in the future.

Also includes a test
