### PR TITLE
[MRG] Added flag to disable l2-dist finite check

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -661,10 +661,6 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
         only algorithm is initialized by running a batch KMeans on a
         random subset of the data. This needs to be larger than k.
 
-    check_input : boolean (default=True)
-        Whether to check if inputs are finite and floats
-        if init is `kmeans++`.
-
     Returns
     -------
     centers: array, shape(k, n_features)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -571,9 +571,9 @@ def _labels_inertia_precompute_dense(X, x_squared_norms, centers, distances):
 
     # Breakup nearest neighbor distance computation into batches to prevent
     # memory blowup in the case of a large number of samples and clusters.
-    # TODO: Once PR #7383 is merged use check_inputs=False in metric_kwargs.
     labels, mindist = pairwise_distances_argmin_min(
-        X=X, Y=centers, metric='euclidean', metric_kwargs={'squared': True})
+        X=X, Y=centers, metric='euclidean',
+        metric_kwargs={'squared': True, 'check_inputs': False})
     # cython k-means code assumes int32 inputs
     labels = labels.astype(np.int32)
     if n_samples == distances.shape[0]:

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -41,8 +41,8 @@ from ._k_means_elkan import k_means_elkan
 ###############################################################################
 # Initialization heuristic
 
-
-def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
+def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
+            check_inputs=True):
     """Init n_clusters seeds according to k-means++
 
     Parameters
@@ -66,6 +66,9 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         Set to None to make the number of trials depend logarithmically
         on the number of seeds (2+log(k)); this is the default.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Notes
     -----
     Selects initial cluster centers for k-mean clustering in a smart way
@@ -78,8 +81,6 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """
     n_samples, n_features = X.shape
 
-    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
-
     assert x_squared_norms is not None, 'x_squared_norms None in _k_init'
 
     # Set the number of local seeding trials if none is given
@@ -88,6 +89,18 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         # specific results for other than mentioning in the conclusion
         # that it helped.
         n_local_trials = 2 + int(np.log(n_clusters))
+
+    # Do type checks before the critical loop
+    if check_inputs:
+        X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES,
+                        warn_on_dtype=False, estimator='kmeans++',
+                        force_all_finite=True)
+        x_squared_norms = check_array(x_squared_norms, dtype=FLOAT_DTYPES,
+                                      warn_on_dtype=False,
+                                      estimator='kmeans++',
+                                      force_all_finite=True)
+
+    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
 
     # Pick first center randomly
     center_id = random_state.randint(n_samples)
@@ -99,7 +112,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     # Initialize list of closest distances and calculate current potential
     closest_dist_sq = euclidean_distances(
         centers[0, np.newaxis], X, Y_norm_squared=x_squared_norms,
-        squared=True)
+        squared=True, check_inputs=False)
     current_pot = closest_dist_sq.sum()
 
     # Pick the remaining n_clusters-1 points
@@ -112,7 +125,9 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
 
         # Compute distances to center candidates
         distance_to_candidates = euclidean_distances(
-            X[candidate_ids], X, Y_norm_squared=x_squared_norms, squared=True)
+            X[candidate_ids], X, Y_norm_squared=x_squared_norms, squared=True,
+            check_inputs=False,
+        )
 
         # Decide which candidate is the best
         best_candidate = None
@@ -622,7 +637,7 @@ def _labels_inertia(X, x_squared_norms, centers,
 
 
 def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
-                    init_size=None):
+                    init_size=None, check_inputs=True):
     """Compute the initial centroids
 
     Parameters
@@ -651,6 +666,10 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
         only algorithm is initialized by running a batch KMeans on a
         random subset of the data. This needs to be larger than k.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats
+        if init is `kmeans++`.
+
     Returns
     -------
     centers: array, shape(k, n_features)
@@ -678,7 +697,8 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
 
     if isinstance(init, string_types) and init == 'k-means++':
         centers = _k_init(X, k, random_state=random_state,
-                          x_squared_norms=x_squared_norms)
+                          x_squared_norms=x_squared_norms,
+                          check_inputs=check_inputs)
     elif isinstance(init, string_types) and init == 'random':
         seeds = random_state.permutation(n_samples)[:k]
         centers = X[seeds]
@@ -882,9 +902,10 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         self.cluster_centers_, self.labels_, self.inertia_, self.n_iter_ = \
             k_means(
                 X, n_clusters=self.n_clusters, init=self.init,
-                n_init=self.n_init, max_iter=self.max_iter, verbose=self.verbose,
-                precompute_distances=self.precompute_distances,
-                tol=self.tol, random_state=random_state, copy_x=self.copy_x,
+                n_init=self.n_init, max_iter=self.max_iter,
+                verbose=self.verbose,
+                precompute_distances=self.precompute_distances, tol=self.tol,
+                random_state=random_state, copy_x=self.copy_x,
                 n_jobs=self.n_jobs, algorithm=self.algorithm,
                 return_n_iter=True)
         return self
@@ -1164,8 +1185,8 @@ def _mini_batch_convergence(model, iteration_idx, n_iter, tol,
     else:
         no_improvement += 1
 
-    if (model.max_no_improvement is not None
-            and no_improvement >= model.max_no_improvement):
+    if (model.max_no_improvement is not None and
+            no_improvement >= model.max_no_improvement):
         if verbose:
             print('Converged (lack of improvement in inertia)'
                   ' at iteration %d/%d'
@@ -1378,7 +1399,7 @@ class MiniBatchKMeans(KMeans):
                 X, self.n_clusters, self.init,
                 random_state=random_state,
                 x_squared_norms=x_squared_norms,
-                init_size=init_size)
+                init_size=init_size, check_inputs=False)
 
             # Compute the label assignment on the init dataset
             batch_inertia, centers_squared_diff = _mini_batch_step(
@@ -1486,8 +1507,8 @@ class MiniBatchKMeans(KMeans):
         x_squared_norms = row_norms(X, squared=True)
         self.random_state_ = getattr(self, "random_state_",
                                      check_random_state(self.random_state))
-        if (not hasattr(self, 'counts_')
-                or not hasattr(self, 'cluster_centers_')):
+        if (not hasattr(self, 'counts_') or
+                not hasattr(self, 'cluster_centers_')):
             # this is the first call partial_fit on this object:
             # initialize the cluster centers
             self.cluster_centers_ = _init_centroids(

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -77,6 +77,8 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """
     n_samples, n_features = X.shape
 
+    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
+
     assert x_squared_norms is not None, 'x_squared_norms None in _k_init'
 
     # Set the number of local seeding trials if none is given
@@ -85,17 +87,6 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         # specific results for other than mentioning in the conclusion
         # that it helped.
         n_local_trials = 2 + int(np.log(n_clusters))
-
-    # Do type checks before the critical loop
-    X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES,
-                    warn_on_dtype=False, estimator='kmeans++',
-                    force_all_finite=True)
-    x_squared_norms = check_array(x_squared_norms, dtype=FLOAT_DTYPES,
-                                  warn_on_dtype=False,
-                                  estimator='kmeans++',
-                                  force_all_finite=True)
-
-    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
 
     # Pick first center randomly
     center_id = random_state.randint(n_samples)

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -41,8 +41,7 @@ from ._k_means_elkan import k_means_elkan
 ###############################################################################
 # Initialization heuristic
 
-def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
-            check_inputs=True):
+def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     """Init n_clusters seeds according to k-means++
 
     Parameters
@@ -66,9 +65,6 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
         Set to None to make the number of trials depend logarithmically
         on the number of seeds (2+log(k)); this is the default.
 
-    check_inputs : boolean (default=True)
-        Whether to check if inputs are finite and floats.
-
     Notes
     -----
     Selects initial cluster centers for k-mean clustering in a smart way
@@ -91,14 +87,13 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None,
         n_local_trials = 2 + int(np.log(n_clusters))
 
     # Do type checks before the critical loop
-    if check_inputs:
-        X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES,
-                        warn_on_dtype=False, estimator='kmeans++',
-                        force_all_finite=True)
-        x_squared_norms = check_array(x_squared_norms, dtype=FLOAT_DTYPES,
-                                      warn_on_dtype=False,
-                                      estimator='kmeans++',
-                                      force_all_finite=True)
+    X = check_array(X, accept_sparse='csr', dtype=FLOAT_DTYPES,
+                    warn_on_dtype=False, estimator='kmeans++',
+                    force_all_finite=True)
+    x_squared_norms = check_array(x_squared_norms, dtype=FLOAT_DTYPES,
+                                  warn_on_dtype=False,
+                                  estimator='kmeans++',
+                                  force_all_finite=True)
 
     centers = np.empty((n_clusters, n_features), dtype=X.dtype)
 
@@ -637,7 +632,7 @@ def _labels_inertia(X, x_squared_norms, centers,
 
 
 def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
-                    init_size=None, check_inputs=True):
+                    init_size=None):
     """Compute the initial centroids
 
     Parameters
@@ -697,8 +692,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
 
     if isinstance(init, string_types) and init == 'k-means++':
         centers = _k_init(X, k, random_state=random_state,
-                          x_squared_norms=x_squared_norms,
-                          check_inputs=check_inputs)
+                          x_squared_norms=x_squared_norms)
     elif isinstance(init, string_types) and init == 'random':
         seeds = random_state.permutation(n_samples)[:k]
         centers = X[seeds]
@@ -1399,7 +1393,7 @@ class MiniBatchKMeans(KMeans):
                 X, self.n_clusters, self.init,
                 random_state=random_state,
                 x_squared_norms=x_squared_norms,
-                init_size=init_size, check_inputs=False)
+                init_size=init_size)
 
             # Compute the label assignment on the init dataset
             batch_inertia, centers_squared_diff = _mini_batch_step(

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -107,7 +107,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
     # Initialize list of closest distances and calculate current potential
     closest_dist_sq = euclidean_distances(
         centers[0, np.newaxis], X, Y_norm_squared=x_squared_norms,
-        squared=True, check_inputs=False)
+        squared=True, check_input=False)
     current_pot = closest_dist_sq.sum()
 
     # Pick the remaining n_clusters-1 points
@@ -121,7 +121,7 @@ def _k_init(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
         # Compute distances to center candidates
         distance_to_candidates = euclidean_distances(
             X[candidate_ids], X, Y_norm_squared=x_squared_norms, squared=True,
-            check_inputs=False,
+            check_input=False,
         )
 
         # Decide which candidate is the best
@@ -568,7 +568,7 @@ def _labels_inertia_precompute_dense(X, x_squared_norms, centers, distances):
     # memory blowup in the case of a large number of samples and clusters.
     labels, mindist = pairwise_distances_argmin_min(
         X=X, Y=centers, metric='euclidean',
-        metric_kwargs={'squared': True, 'check_inputs': False})
+        metric_kwargs={'squared': True, 'check_input': False})
     # cython k-means code assumes int32 inputs
     labels = labels.astype(np.int32)
     if n_samples == distances.shape[0]:
@@ -661,7 +661,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
         only algorithm is initialized by running a batch KMeans on a
         random subset of the data. This needs to be larger than k.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats
         if init is `kmeans++`.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -160,7 +160,7 @@ def check_paired_arrays(X, Y):
 
 # Pairwise distances
 def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
-                        X_norm_squared=None, check_inputs=True):
+                        X_norm_squared=None, check_input=True):
     """
     Considering the rows of X (and Y=X) as vectors, compute the
     distance matrix between each pair of vectors.
@@ -198,7 +198,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -222,11 +222,11 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     --------
     paired_distances : distances betweens pairs of elements of X and Y.
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
 
     if X_norm_squared is not None:
-        if check_inputs:
+        if check_input:
             XX = check_array(X_norm_squared)
             if XX.shape == (1, X.shape[0]):
                 XX = XX.T
@@ -265,7 +265,7 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
 def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
                                   batch_size=500, metric_kwargs=None,
-                                  check_inputs=True):
+                                  check_input=True):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -324,7 +324,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     axis : int, optional, default 1
         Axis along which the argmin and distances are to be computed.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -347,7 +347,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     elif not callable(metric) and not isinstance(metric, str):
         raise ValueError("'metric' must be a string or a callable")
 
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
 
     if metric_kwargs is None:
@@ -397,7 +397,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
 
 def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
                               batch_size=500, metric_kwargs=None,
-                              check_inputs=True):
+                              check_input=True):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -460,7 +460,7 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
     axis : int, optional, default 1
         Axis along which the argmin and distances are to be computed.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -477,11 +477,11 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
         metric_kwargs = {}
 
     return pairwise_distances_argmin_min(X, Y, axis, metric, batch_size,
-                                         metric_kwargs, check_inputs)[0]
+                                         metric_kwargs, check_input)[0]
 
 
 def manhattan_distances(X, Y=None, sum_over_features=True,
-                        size_threshold=5e8, check_inputs=True):
+                        size_threshold=5e8, check_input=True):
     """ Compute the L1 distances between the vectors in X and Y.
 
     With sum_over_features equal to False it returns the componentwise
@@ -505,7 +505,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     size_threshold : int, default=5e8
         Unused parameter.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -537,7 +537,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     array([[ 1.,  1.],
            [ 1.,  1.]]...)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
 
     if issparse(X) or issparse(Y):
@@ -561,7 +561,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     return D.reshape((-1, X.shape[1]))
 
 
-def cosine_distances(X, Y=None, check_inputs=True):
+def cosine_distances(X, Y=None, check_input=True):
     """Compute cosine distance between samples in X and Y.
 
     Cosine distance is defined as 1.0 minus the cosine similarity.
@@ -576,7 +576,7 @@ def cosine_distances(X, Y=None, check_inputs=True):
     Y : array_like, sparse matrix (optional)
         with shape (n_samples_Y, n_features).
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -590,7 +590,7 @@ def cosine_distances(X, Y=None, check_inputs=True):
     scipy.spatial.distance.cosine (dense matrices only)
     """
     # 1.0 - cosine_similarity(X, Y) without copy
-    S = cosine_similarity(X, Y, check_inputs)
+    S = cosine_similarity(X, Y, check_input)
     S *= -1
     S += 1
     np.clip(S, 0, 2, out=S)
@@ -602,7 +602,7 @@ def cosine_distances(X, Y=None, check_inputs=True):
 
 
 # Paired distances
-def paired_euclidean_distances(X, Y, check_inputs=True):
+def paired_euclidean_distances(X, Y, check_input=True):
     """
     Computes the paired euclidean distances between X and Y
 
@@ -614,19 +614,19 @@ def paired_euclidean_distances(X, Y, check_inputs=True):
 
     Y : array-like, shape (n_samples, n_features)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     distances : ndarray (n_samples, )
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_paired_arrays(X, Y)
     return row_norms(X - Y)
 
 
-def paired_manhattan_distances(X, Y, check_inputs=True):
+def paired_manhattan_distances(X, Y, check_input=True):
     """Compute the L1 distances between the vectors in X and Y.
 
     Read more in the :ref:`User Guide <metrics>`.
@@ -637,14 +637,14 @@ def paired_manhattan_distances(X, Y, check_inputs=True):
 
     Y : array-like, shape (n_samples, n_features)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     distances : ndarray (n_samples, )
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_paired_arrays(X, Y)
     diff = X - Y
     if issparse(diff):
@@ -654,7 +654,7 @@ def paired_manhattan_distances(X, Y, check_inputs=True):
         return np.abs(diff).sum(axis=-1)
 
 
-def paired_cosine_distances(X, Y, check_inputs=True):
+def paired_cosine_distances(X, Y, check_input=True):
     """
     Computes the paired cosine distances between X and Y
 
@@ -666,7 +666,7 @@ def paired_cosine_distances(X, Y, check_inputs=True):
 
     Y : array-like, shape (n_samples, n_features)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -678,7 +678,7 @@ def paired_cosine_distances(X, Y, check_inputs=True):
     The cosine distance is equivalent to the half the squared
     euclidean distance if each sample is normalized to unit norm
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_paired_arrays(X, Y)
     return .5 * row_norms(normalize(X) - normalize(Y), squared=True)
 
@@ -750,7 +750,7 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
 
 # Kernels
-def linear_kernel(X, Y=None, check_inputs=True):
+def linear_kernel(X, Y=None, check_input=True):
     """
     Compute the linear kernel between X and Y.
 
@@ -762,20 +762,20 @@ def linear_kernel(X, Y=None, check_inputs=True):
 
     Y : array of shape (n_samples_2, n_features)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
     return safe_sparse_dot(X, Y.T, dense_output=True)
 
 
 def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1,
-                      check_inputs=True):
+                      check_input=True):
     """
     Compute the polynomial kernel between X and Y::
 
@@ -796,14 +796,14 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1,
 
     coef0 : int, default 1
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
@@ -815,7 +815,7 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1,
     return K
 
 
-def sigmoid_kernel(X, Y=None, gamma=None, coef0=1, check_inputs=True):
+def sigmoid_kernel(X, Y=None, gamma=None, coef0=1, check_input=True):
     """
     Compute the sigmoid kernel between X and Y::
 
@@ -834,14 +834,14 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1, check_inputs=True):
 
     coef0 : int, default 1
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
@@ -853,7 +853,7 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1, check_inputs=True):
     return K
 
 
-def rbf_kernel(X, Y=None, gamma=None, check_inputs=True):
+def rbf_kernel(X, Y=None, gamma=None, check_input=True):
     """
     Compute the rbf (gaussian) kernel between X and Y::
 
@@ -872,25 +872,25 @@ def rbf_kernel(X, Y=None, gamma=None, check_inputs=True):
     gamma : float, default None
         If None, defaults to 1.0 / n_samples_X
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
-    K = euclidean_distances(X, Y, squared=True, check_inputs=False)
+    K = euclidean_distances(X, Y, squared=True, check_input=False)
     K *= -gamma
     np.exp(K, K)    # exponentiate K in-place
     return K
 
 
-def laplacian_kernel(X, Y=None, gamma=None, check_inputs=True):
+def laplacian_kernel(X, Y=None, gamma=None, check_input=True):
     """Compute the laplacian kernel between X and Y.
 
     The laplacian kernel is defined as::
@@ -911,24 +911,24 @@ def laplacian_kernel(X, Y=None, gamma=None, check_inputs=True):
     gamma : float, default None
         If None, defaults to 1.0 / n_samples_X
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
     """
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
-    K = -gamma * manhattan_distances(X, Y, check_inputs=False)
+    K = -gamma * manhattan_distances(X, Y, check_input=False)
     np.exp(K, K)    # exponentiate K in-place
     return K
 
 
-def cosine_similarity(X, Y=None, dense_output=True, check_inputs=True):
+def cosine_similarity(X, Y=None, dense_output=True, check_input=True):
     """Compute cosine similarity between samples in X and Y.
 
     Cosine similarity, or the cosine kernel, computes similarity as the
@@ -956,7 +956,7 @@ def cosine_similarity(X, Y=None, dense_output=True, check_inputs=True):
         .. versionadded:: 0.17
            parameter ``dense_output`` for dense output.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -966,7 +966,7 @@ def cosine_similarity(X, Y=None, dense_output=True, check_inputs=True):
     """
     # to avoid recursive import
 
-    if check_inputs:
+    if check_input:
         X, Y = check_pairwise_arrays(X, Y)
 
     X_normalized = normalize(X, copy=True)
@@ -980,7 +980,7 @@ def cosine_similarity(X, Y=None, dense_output=True, check_inputs=True):
     return K
 
 
-def additive_chi2_kernel(X, Y=None, check_inputs=True):
+def additive_chi2_kernel(X, Y=None, check_input=True):
     """Computes the additive chi-squared kernel between observations in X and Y
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X
@@ -1007,7 +1007,7 @@ def additive_chi2_kernel(X, Y=None, check_inputs=True):
 
     Y : array of shape (n_samples_Y, n_features)
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -1031,7 +1031,7 @@ def additive_chi2_kernel(X, Y=None, check_inputs=True):
     sklearn.kernel_approximation.AdditiveChi2Sampler : A Fourier approximation
         to this kernel.
     """
-    if check_inputs:
+    if check_input:
         if issparse(X) or issparse(Y):
             raise ValueError("additive_chi2 does not support sparse matrices.")
         X, Y = check_pairwise_arrays(X, Y)
@@ -1045,7 +1045,7 @@ def additive_chi2_kernel(X, Y=None, check_inputs=True):
     return result
 
 
-def chi2_kernel(X, Y=None, gamma=1., check_inputs=True):
+def chi2_kernel(X, Y=None, gamma=1., check_input=True):
     """Computes the exponential chi-squared kernel X and Y.
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X
@@ -1069,7 +1069,7 @@ def chi2_kernel(X, Y=None, gamma=1., check_inputs=True):
     gamma : float, default=1.
         Scaling parameter of the chi2 kernel.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.
 
     Returns
@@ -1091,7 +1091,7 @@ def chi2_kernel(X, Y=None, gamma=1., check_inputs=True):
     sklearn.kernel_approximation.AdditiveChi2Sampler : A Fourier approximation
         to the additive version of this kernel.
     """
-    K = additive_chi2_kernel(X, Y, check_inputs)
+    K = additive_chi2_kernel(X, Y, check_input)
     K *= gamma
     return np.exp(K, K)
 
@@ -1263,7 +1263,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
         (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
         are used.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.  Can only be used
         as a keyword argument with known sklearn.pairwise metrics.
 
@@ -1288,7 +1288,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
                          "callable" % (metric, _VALID_METRICS))
 
     if metric == "precomputed":
-        if kwds.get('check_inputs', True):
+        if kwds.get('check_input', True):
             X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
@@ -1302,7 +1302,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
 
         dtype = bool if metric in PAIRWISE_BOOLEAN_FUNCTIONS else None
 
-        if kwds.get('check_inputs', True):
+        if kwds.get('check_input', True):
             X, Y = check_pairwise_arrays(X, Y, dtype=dtype)
 
         if n_jobs == 1 and X is Y:
@@ -1435,7 +1435,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     filter_params : boolean
         Whether to filter invalid parameters or not.
 
-    check_inputs : boolean (default=True)
+    check_input : boolean (default=True)
         Whether to check if inputs are finite and floats.  Can only be used
         as a keyword argument with known sklearn.pairwise kernels.
 
@@ -1459,7 +1459,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     from ..gaussian_process.kernels import Kernel as GPKernel
 
     if metric == "precomputed":
-        if kwds.get('check_inputs', True):
+        if kwds.get('check_input', True):
             X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif isinstance(metric, GPKernel):

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -160,7 +160,7 @@ def check_paired_arrays(X, Y):
 
 # Pairwise distances
 def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
-                        X_norm_squared=None):
+                        X_norm_squared=None, check_inputs=True):
     """
     Considering the rows of X (and Y=X) as vectors, compute the
     distance matrix between each pair of vectors.
@@ -198,6 +198,9 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     distances : {array, sparse matrix}, shape (n_samples_1, n_samples_2)
@@ -219,10 +222,12 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     --------
     paired_distances : distances betweens pairs of elements of X and Y.
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
 
     if X_norm_squared is not None:
-        XX = check_array(X_norm_squared)
+        if check_inputs:
+            XX = check_array(X_norm_squared)
         if XX.shape == (1, X.shape[0]):
             XX = XX.T
         elif XX.shape != (X.shape[0], 1):

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -774,7 +774,8 @@ def linear_kernel(X, Y=None, check_inputs=True):
     return safe_sparse_dot(X, Y.T, dense_output=True)
 
 
-def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1, check_inputs=True):
+def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1,
+                      check_inputs=True):
     """
     Compute the polynomial kernel between X and Y::
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -187,14 +187,14 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
     Y : {array-like, sparse matrix}, shape (n_samples_2, n_features)
 
-    Y_norm_squared : array-like, shape (n_samples_2, ), optional
+    Y_norm_squared : array-like, shape (1, n_samples_2), optional
         Pre-computed dot-products of vectors in Y (e.g.,
         ``(Y**2).sum(axis=1)``)
 
     squared : boolean, optional
         Return squared Euclidean distances.
 
-    X_norm_squared : array-like, shape = [n_samples_1], optional
+    X_norm_squared : array-like, shape = (n_samples_1, 1), optional
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
 
@@ -228,11 +228,13 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     if X_norm_squared is not None:
         if check_inputs:
             XX = check_array(X_norm_squared)
-        if XX.shape == (1, X.shape[0]):
-            XX = XX.T
-        elif XX.shape != (X.shape[0], 1):
-            raise ValueError(
-                "Incompatible dimensions for X and X_norm_squared")
+            if XX.shape == (1, X.shape[0]):
+                XX = XX.T
+            elif XX.shape != (X.shape[0], 1):
+                raise ValueError(
+                    "Incompatible dimensions for X and X_norm_squared")
+        else:
+            XX = X_norm_squared
     else:
         XX = row_norms(X, squared=True)[:, np.newaxis]
 
@@ -262,7 +264,8 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
 
 def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
-                                  batch_size=500, metric_kwargs=None):
+                                  batch_size=500, metric_kwargs=None,
+                                  check_inputs=True):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -321,6 +324,9 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     axis : int, optional, default 1
         Axis along which the argmin and distances are to be computed.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     argmin : numpy.ndarray
@@ -341,7 +347,8 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     elif not callable(metric) and not isinstance(metric, str):
         raise ValueError("'metric' must be a string or a callable")
 
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
 
     if metric_kwargs is None:
         metric_kwargs = {}
@@ -389,7 +396,8 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
 
 
 def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
-                              batch_size=500, metric_kwargs=None):
+                              batch_size=500, metric_kwargs=None,
+                              check_inputs=True):
     """Compute minimum distances between one point and a set of points.
 
     This function computes for each row in X, the index of the row of Y which
@@ -452,6 +460,9 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
     axis : int, optional, default 1
         Axis along which the argmin and distances are to be computed.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     argmin : numpy.ndarray
@@ -466,11 +477,11 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
         metric_kwargs = {}
 
     return pairwise_distances_argmin_min(X, Y, axis, metric, batch_size,
-                                         metric_kwargs)[0]
+                                         metric_kwargs, check_inputs)[0]
 
 
 def manhattan_distances(X, Y=None, sum_over_features=True,
-                        size_threshold=5e8):
+                        size_threshold=5e8, check_inputs=True):
     """ Compute the L1 distances between the vectors in X and Y.
 
     With sum_over_features equal to False it returns the componentwise
@@ -493,6 +504,9 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
 
     size_threshold : int, default=5e8
         Unused parameter.
+
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
 
     Returns
     -------
@@ -523,7 +537,8 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     array([[ 1.,  1.],
            [ 1.,  1.]]...)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
 
     if issparse(X) or issparse(Y):
         if not sum_over_features:
@@ -546,7 +561,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True,
     return D.reshape((-1, X.shape[1]))
 
 
-def cosine_distances(X, Y=None):
+def cosine_distances(X, Y=None, check_inputs=True):
     """Compute cosine distance between samples in X and Y.
 
     Cosine distance is defined as 1.0 minus the cosine similarity.
@@ -561,6 +576,9 @@ def cosine_distances(X, Y=None):
     Y : array_like, sparse matrix (optional)
         with shape (n_samples_Y, n_features).
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     distance matrix : array
@@ -572,7 +590,7 @@ def cosine_distances(X, Y=None):
     scipy.spatial.distance.cosine (dense matrices only)
     """
     # 1.0 - cosine_similarity(X, Y) without copy
-    S = cosine_similarity(X, Y)
+    S = cosine_similarity(X, Y, check_inputs)
     S *= -1
     S += 1
     np.clip(S, 0, 2, out=S)
@@ -584,7 +602,7 @@ def cosine_distances(X, Y=None):
 
 
 # Paired distances
-def paired_euclidean_distances(X, Y):
+def paired_euclidean_distances(X, Y, check_inputs=True):
     """
     Computes the paired euclidean distances between X and Y
 
@@ -596,15 +614,19 @@ def paired_euclidean_distances(X, Y):
 
     Y : array-like, shape (n_samples, n_features)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     distances : ndarray (n_samples, )
     """
-    X, Y = check_paired_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_paired_arrays(X, Y)
     return row_norms(X - Y)
 
 
-def paired_manhattan_distances(X, Y):
+def paired_manhattan_distances(X, Y, check_inputs=True):
     """Compute the L1 distances between the vectors in X and Y.
 
     Read more in the :ref:`User Guide <metrics>`.
@@ -615,11 +637,15 @@ def paired_manhattan_distances(X, Y):
 
     Y : array-like, shape (n_samples, n_features)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     distances : ndarray (n_samples, )
     """
-    X, Y = check_paired_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_paired_arrays(X, Y)
     diff = X - Y
     if issparse(diff):
         diff.data = np.abs(diff.data)
@@ -628,7 +654,7 @@ def paired_manhattan_distances(X, Y):
         return np.abs(diff).sum(axis=-1)
 
 
-def paired_cosine_distances(X, Y):
+def paired_cosine_distances(X, Y, check_inputs=True):
     """
     Computes the paired cosine distances between X and Y
 
@@ -640,6 +666,9 @@ def paired_cosine_distances(X, Y):
 
     Y : array-like, shape (n_samples, n_features)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     distances : ndarray, shape (n_samples, )
@@ -649,7 +678,8 @@ def paired_cosine_distances(X, Y):
     The cosine distance is equivalent to the half the squared
     euclidean distance if each sample is normalized to unit norm
     """
-    X, Y = check_paired_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_paired_arrays(X, Y)
     return .5 * row_norms(normalize(X) - normalize(Y), squared=True)
 
 
@@ -720,7 +750,7 @@ def paired_distances(X, Y, metric="euclidean", **kwds):
 
 
 # Kernels
-def linear_kernel(X, Y=None):
+def linear_kernel(X, Y=None, check_inputs=True):
     """
     Compute the linear kernel between X and Y.
 
@@ -732,15 +762,19 @@ def linear_kernel(X, Y=None):
 
     Y : array of shape (n_samples_2, n_features)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
     return safe_sparse_dot(X, Y.T, dense_output=True)
 
 
-def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
+def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1, check_inputs=True):
     """
     Compute the polynomial kernel between X and Y::
 
@@ -761,11 +795,15 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     coef0 : int, default 1
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
@@ -776,7 +814,7 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
     return K
 
 
-def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
+def sigmoid_kernel(X, Y=None, gamma=None, coef0=1, check_inputs=True):
     """
     Compute the sigmoid kernel between X and Y::
 
@@ -795,11 +833,15 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
     coef0 : int, default 1
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     Gram matrix : array of shape (n_samples_1, n_samples_2)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
@@ -810,7 +852,7 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
     return K
 
 
-def rbf_kernel(X, Y=None, gamma=None):
+def rbf_kernel(X, Y=None, gamma=None, check_inputs=True):
     """
     Compute the rbf (gaussian) kernel between X and Y::
 
@@ -829,21 +871,25 @@ def rbf_kernel(X, Y=None, gamma=None):
     gamma : float, default None
         If None, defaults to 1.0 / n_samples_X
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
-    K = euclidean_distances(X, Y, squared=True)
+    K = euclidean_distances(X, Y, squared=True, check_inputs=False)
     K *= -gamma
     np.exp(K, K)    # exponentiate K in-place
     return K
 
 
-def laplacian_kernel(X, Y=None, gamma=None):
+def laplacian_kernel(X, Y=None, gamma=None, check_inputs=True):
     """Compute the laplacian kernel between X and Y.
 
     The laplacian kernel is defined as::
@@ -864,20 +910,24 @@ def laplacian_kernel(X, Y=None, gamma=None):
     gamma : float, default None
         If None, defaults to 1.0 / n_samples_X
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:
         gamma = 1.0 / X.shape[1]
 
-    K = -gamma * manhattan_distances(X, Y)
+    K = -gamma * manhattan_distances(X, Y, check_inputs=False)
     np.exp(K, K)    # exponentiate K in-place
     return K
 
 
-def cosine_similarity(X, Y=None, dense_output=True):
+def cosine_similarity(X, Y=None, dense_output=True, check_inputs=True):
     """Compute cosine similarity between samples in X and Y.
 
     Cosine similarity, or the cosine kernel, computes similarity as the
@@ -905,6 +955,9 @@ def cosine_similarity(X, Y=None, dense_output=True):
         .. versionadded:: 0.17
            parameter ``dense_output`` for dense output.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     kernel matrix : array
@@ -912,7 +965,8 @@ def cosine_similarity(X, Y=None, dense_output=True):
     """
     # to avoid recursive import
 
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        X, Y = check_pairwise_arrays(X, Y)
 
     X_normalized = normalize(X, copy=True)
     if X is Y:
@@ -925,7 +979,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
     return K
 
 
-def additive_chi2_kernel(X, Y=None):
+def additive_chi2_kernel(X, Y=None, check_inputs=True):
     """Computes the additive chi-squared kernel between observations in X and Y
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X
@@ -952,6 +1006,9 @@ def additive_chi2_kernel(X, Y=None):
 
     Y : array of shape (n_samples_Y, n_features)
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
@@ -973,9 +1030,10 @@ def additive_chi2_kernel(X, Y=None):
     sklearn.kernel_approximation.AdditiveChi2Sampler : A Fourier approximation
         to this kernel.
     """
-    if issparse(X) or issparse(Y):
-        raise ValueError("additive_chi2 does not support sparse matrices.")
-    X, Y = check_pairwise_arrays(X, Y)
+    if check_inputs:
+        if issparse(X) or issparse(Y):
+            raise ValueError("additive_chi2 does not support sparse matrices.")
+        X, Y = check_pairwise_arrays(X, Y)
     if (X < 0).any():
         raise ValueError("X contains negative values.")
     if Y is not X and (Y < 0).any():
@@ -986,7 +1044,7 @@ def additive_chi2_kernel(X, Y=None):
     return result
 
 
-def chi2_kernel(X, Y=None, gamma=1.):
+def chi2_kernel(X, Y=None, gamma=1., check_inputs=True):
     """Computes the exponential chi-squared kernel X and Y.
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X
@@ -1010,6 +1068,9 @@ def chi2_kernel(X, Y=None, gamma=1.):
     gamma : float, default=1.
         Scaling parameter of the chi2 kernel.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.
+
     Returns
     -------
     kernel_matrix : array of shape (n_samples_X, n_samples_Y)
@@ -1029,7 +1090,7 @@ def chi2_kernel(X, Y=None, gamma=1.):
     sklearn.kernel_approximation.AdditiveChi2Sampler : A Fourier approximation
         to the additive version of this kernel.
     """
-    K = additive_chi2_kernel(X, Y)
+    K = additive_chi2_kernel(X, Y, check_inputs)
     K *= gamma
     return np.exp(K, K)
 
@@ -1201,6 +1262,10 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
         (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
         are used.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.  Can only be used
+        as a keyword argument with known sklearn.pairwise metrics.
+
     `**kwds` : optional keyword parameters
         Any further parameters are passed directly to the distance function.
         If using a scipy.spatial.distance metric, the parameters are still
@@ -1222,7 +1287,8 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
                          "callable" % (metric, _VALID_METRICS))
 
     if metric == "precomputed":
-        X, _ = check_pairwise_arrays(X, Y, precomputed=True)
+        if kwds.get('check_inputs', True):
+            X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif metric in PAIRWISE_DISTANCE_FUNCTIONS:
         func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
@@ -1235,7 +1301,8 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=1, **kwds):
 
         dtype = bool if metric in PAIRWISE_BOOLEAN_FUNCTIONS else None
 
-        X, Y = check_pairwise_arrays(X, Y, dtype=dtype)
+        if kwds.get('check_inputs', True):
+            X, Y = check_pairwise_arrays(X, Y, dtype=dtype)
 
         if n_jobs == 1 and X is Y:
             return distance.squareform(distance.pdist(X, metric=metric,
@@ -1367,6 +1434,10 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     filter_params : boolean
         Whether to filter invalid parameters or not.
 
+    check_inputs : boolean (default=True)
+        Whether to check if inputs are finite and floats.  Can only be used
+        as a keyword argument with known sklearn.pairwise kernels.
+
     `**kwds` : optional keyword parameters
         Any further parameters are passed directly to the kernel function.
 
@@ -1387,7 +1458,8 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     from ..gaussian_process.kernels import Kernel as GPKernel
 
     if metric == "precomputed":
-        X, _ = check_pairwise_arrays(X, Y, precomputed=True)
+        if kwds.get('check_inputs', True):
+            X, _ = check_pairwise_arrays(X, Y, precomputed=True)
         return X
     elif isinstance(metric, GPKernel):
         func = metric.__call__

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -187,14 +187,14 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
     Y : {array-like, sparse matrix}, shape (n_samples_2, n_features)
 
-    Y_norm_squared : array-like, shape (1, n_samples_2), optional
+    Y_norm_squared : array-like, shape (n_samples_2, ), optional
         Pre-computed dot-products of vectors in Y (e.g.,
         ``(Y**2).sum(axis=1)``)
 
     squared : boolean, optional
         Return squared Euclidean distances.
 
-    X_norm_squared : array-like, shape = (n_samples_1, 1), optional
+    X_norm_squared : array-like, shape = [n_samples_1], optional
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
 
@@ -226,15 +226,16 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
         X, Y = check_pairwise_arrays(X, Y)
 
     if X_norm_squared is not None:
+        XX = X_norm_squared
         if check_input:
-            XX = check_array(X_norm_squared)
-            if XX.shape == (1, X.shape[0]):
-                XX = XX.T
-            elif XX.shape != (X.shape[0], 1):
-                raise ValueError(
-                    "Incompatible dimensions for X and X_norm_squared")
-        else:
-            XX = X_norm_squared
+            XX = check_array(XX)
+
+        XX = np.atleast_2d(XX)
+        if XX.shape == (1, X.shape[0]):
+            XX = XX.T
+        elif XX.shape != (X.shape[0], 1):
+            raise ValueError(
+                "Incompatible dimensions for X and X_norm_squared")
     else:
         XX = row_norms(X, squared=True)[:, np.newaxis]
 
@@ -243,7 +244,9 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
     elif Y_norm_squared is not None:
         YY = np.atleast_2d(Y_norm_squared)
 
-        if YY.shape != (1, Y.shape[0]):
+        if YY.shape == (Y.shape[0], 1):
+            YY = YY.T
+        elif YY.shape != (1, Y.shape[0]):
             raise ValueError(
                 "Incompatible dimensions for Y and Y_norm_squared")
     else:
@@ -1031,9 +1034,9 @@ def additive_chi2_kernel(X, Y=None, check_input=True):
     sklearn.kernel_approximation.AdditiveChi2Sampler : A Fourier approximation
         to this kernel.
     """
+    if issparse(X) or issparse(Y):
+        raise ValueError("additive_chi2 does not support sparse matrices.")
     if check_input:
-        if issparse(X) or issparse(Y):
-            raise ValueError("additive_chi2 does not support sparse matrices.")
         X, Y = check_pairwise_arrays(X, Y)
     if (X < 0).any():
         raise ValueError("X contains negative values.")

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -714,12 +714,12 @@ def test_check_preserve_type():
     assert_equal(XB_checked.dtype, np.float)
 
 
-def test_euclidean_no_check_inputs_with_bad_input():
-    # Ensure failure when check_inputs is False and the inputs are bad
+def test_euclidean_no_check_input_with_bad_input():
+    # Ensure failure when check_input is False and the inputs are bad
     X = [[0]]
     Y = [[1], [2]]
     assert_raises(AttributeError, euclidean_distances, X, Y,
-                  check_inputs=False)
+                  check_input=False)
 
     # Unsigned integer types might work if squared is False
     # and numpy casting rule is not 'same_kind'
@@ -727,14 +727,14 @@ def test_euclidean_no_check_inputs_with_bad_input():
     X = np.array([[0]], dtype=np.uint8)
     Y = np.array([[1], [2]], dtype=np.uint8)
     try:
-        euclidean_distances(X, Y, check_inputs=False)
+        euclidean_distances(X, Y, check_input=False)
     except TypeError:
         pass
 
     X = csr_matrix(X)
     Y = csr_matrix(Y)
     try:
-        euclidean_distances(X, Y, check_inputs=False)
+        euclidean_distances(X, Y, check_input=False)
     except TypeError:
         pass
 
@@ -745,24 +745,24 @@ def test_euclidean_no_check_inputs_with_bad_input():
     Y_norm_sq = (Y ** 2).sum(axis=1).reshape(1, -1)
 
     assert_raises(ValueError, euclidean_distances, X, Y,
-                  X_norm_squared=X_norm_sq, check_inputs=False)
+                  X_norm_squared=X_norm_sq, check_input=False)
     assert_raises(ValueError, euclidean_distances, X, Y,
-                  Y_norm_squared=Y_norm_sq.T, check_inputs=False)
+                  Y_norm_squared=Y_norm_sq.T, check_input=False)
     assert_raises(ValueError, euclidean_distances, X, Y,
                   X_norm_squared=X_norm_sq, Y_norm_squared=Y_norm_sq,
-                  check_inputs=False)
+                  check_input=False)
 
 
-def test_euclidean_no_check_inputs_with_good_input():
-    # Ensure success when check_inputs is False and the inputs are good
+def test_euclidean_no_check_input_with_good_input():
+    # Ensure success when check_input is False and the inputs are good
     X = np.array([[0]], dtype=np.float32)
     Y = np.array([[1], [2]], dtype=np.float32)
-    D = euclidean_distances(X, Y, check_inputs=False)
+    D = euclidean_distances(X, Y, check_input=False)
     assert_array_almost_equal(D, [[1., 2.]])
 
     X = csr_matrix(X)
     Y = csr_matrix(Y)
-    D = euclidean_distances(X, Y, check_inputs=False)
+    D = euclidean_distances(X, Y, check_input=False)
     assert_array_almost_equal(D, [[1., 2.]])
 
     rng = np.random.RandomState(0)
@@ -772,36 +772,36 @@ def test_euclidean_no_check_inputs_with_good_input():
     Y_norm_sq = (Y ** 2).sum(axis=1).reshape(1, -1)
 
     # check that we still get the right answers with {X,Y}_norm_squared
-    D1 = euclidean_distances(X, Y, check_inputs=False)
+    D1 = euclidean_distances(X, Y, check_input=False)
     D2 = euclidean_distances(X, Y, X_norm_squared=X_norm_sq,
-                             check_inputs=False)
+                             check_input=False)
     D3 = euclidean_distances(X, Y, Y_norm_squared=Y_norm_sq,
-                             check_inputs=False)
+                             check_input=False)
     D4 = euclidean_distances(X, Y, X_norm_squared=X_norm_sq,
                              Y_norm_squared=Y_norm_sq,
-                             check_inputs=False)
+                             check_input=False)
     assert_array_almost_equal(D2, D1)
     assert_array_almost_equal(D3, D1)
     assert_array_almost_equal(D4, D1)
 
-    # Integer types should work if check_inputs is False and squared is True.
+    # Integer types should work if check_input is False and squared is True.
     X = np.array([[1]], dtype=np.int32)
     Y = np.array([[11], [11]], dtype=np.int32)
-    D = euclidean_distances(X, Y, check_inputs=False, squared=True)
+    D = euclidean_distances(X, Y, check_input=False, squared=True)
     assert_array_equal(D, [[100, 100]])
-    # make sure distance is not converted when check_inputs=False
+    # make sure distance is not converted when check_input=False
     assert_equal(D.dtype, np.int32)
 
     # However, there is a possibility of overflow, but this possibility always
     # exists with numeric datatypes.
     X = np.array([[1]], dtype=np.int8)
     Y = np.array([[101], [101]], dtype=np.int8)
-    D = euclidean_distances(X, Y, check_inputs=False, squared=True)
+    D = euclidean_distances(X, Y, check_input=False, squared=True)
     assert_raises(AssertionError, assert_array_equal, D, [[1000, 1000]])
     assert_array_equal(D, [[16, 16]])
 
 
-def test_pairwise_no_check_inputs_with_good_input():
+def test_pairwise_no_check_input_with_good_input():
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)
     # Euclidean distance should be equivalent to calling the function.
@@ -809,19 +809,19 @@ def test_pairwise_no_check_inputs_with_good_input():
     # Euclidean distance, with Y != X.
     Y = rng.random_sample((5, 4))
     for metric, func in iteritems(PAIRED_DISTANCES):
-        S2 = func(X, Y, check_inputs=False)
-        S3 = func(csr_matrix(X), csr_matrix(Y), check_inputs=False)
+        S2 = func(X, Y, check_input=False)
+        S3 = func(csr_matrix(X), csr_matrix(Y), check_input=False)
         assert_array_almost_equal(S2, S3)
         if metric in PAIRWISE_DISTANCE_FUNCTIONS:
             # Check the pairwise_distances implementation
             # gives the same value
             distances = PAIRWISE_DISTANCE_FUNCTIONS[metric](X, Y,
-                                                            check_inputs=False)
+                                                            check_input=False)
             distances = np.diag(distances)
             assert_array_almost_equal(distances, S2)
 
 
-def test_pairwise_no_check_inputs_with_bad_input():
+def test_pairwise_no_check_input_with_bad_input():
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)
     # Euclidean distance should be equivalent to calling the function.
@@ -829,12 +829,12 @@ def test_pairwise_no_check_inputs_with_bad_input():
     # Euclidean distance, with Y != X.
     Y = rng.random_sample((6, 4)).tolist()
     for metric, func in iteritems(PAIRED_DISTANCES):
-        assert_raises((ValueError, TypeError), func, X, Y, check_inputs=False)
+        assert_raises((ValueError, TypeError), func, X, Y, check_input=False)
         assert_raises(ValueError, func, csr_matrix(X), csr_matrix(Y),
-                      check_inputs=False)
+                      check_input=False)
         if metric in PAIRWISE_DISTANCE_FUNCTIONS:
             # Check the pairwise_distances implementation
             # many different types of errors can happen here
             assert_raises((ValueError, AttributeError),
                           PAIRWISE_DISTANCE_FUNCTIONS[metric], X, Y,
-                          check_inputs=False)
+                          check_input=False)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -718,7 +718,8 @@ def test_euclidean_no_check_inputs_with_bad_input():
     # Ensure failure when check_inputs is False and the inputs are bad
     X = [[0]]
     Y = [[1], [2]]
-    assert_raises(AttributeError, euclidean_distances, X, Y, check_inputs=False)
+    assert_raises(AttributeError, euclidean_distances, X, Y,
+                  check_inputs=False)
 
     # Unsigned integer types might work if squared is False
     # and numpy casting rule is not 'same_kind'
@@ -814,7 +815,8 @@ def test_pairwise_no_check_inputs_with_good_input():
         if metric in PAIRWISE_DISTANCE_FUNCTIONS:
             # Check the pairwise_distances implementation
             # gives the same value
-            distances = PAIRWISE_DISTANCE_FUNCTIONS[metric](X, Y, check_inputs=False)
+            distances = PAIRWISE_DISTANCE_FUNCTIONS[metric](X, Y,
+                                                            check_inputs=False)
             distances = np.diag(distances)
             assert_array_almost_equal(distances, S2)
 
@@ -828,9 +830,11 @@ def test_pairwise_no_check_inputs_with_bad_input():
     Y = rng.random_sample((6, 4)).tolist()
     for metric, func in iteritems(PAIRED_DISTANCES):
         assert_raises((ValueError, TypeError), func, X, Y, check_inputs=False)
-        assert_raises(ValueError, func, csr_matrix(X), csr_matrix(Y), check_inputs=False)
+        assert_raises(ValueError, func, csr_matrix(X), csr_matrix(Y),
+                      check_inputs=False)
         if metric in PAIRWISE_DISTANCE_FUNCTIONS:
             # Check the pairwise_distances implementation
             # many different types of errors can happen here
             assert_raises((ValueError, AttributeError),
-                          PAIRWISE_DISTANCE_FUNCTIONS[metric], X, Y, check_inputs=False)
+                          PAIRWISE_DISTANCE_FUNCTIONS[metric], X, Y,
+                          check_inputs=False)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -720,14 +720,22 @@ def test_euclidean_no_check_inputs_with_bad_input():
     Y = [[1], [2]]
     assert_raises(AttributeError, euclidean_distances, X, Y, check_inputs=False)
 
-    # Integer types should not work if squared is False
+    # Unsigned integer types might work if squared is False
+    # and numpy casting rule is not 'same_kind'
+    # (This was allowed by default with numpy 1.6.1, but failed with 1.11.1)
     X = np.array([[0]], dtype=np.uint8)
     Y = np.array([[1], [2]], dtype=np.uint8)
-    assert_raises(TypeError, euclidean_distances, X, Y, check_inputs=False)
+    try:
+        euclidean_distances(X, Y, check_inputs=False)
+    except TypeError:
+        pass
 
     X = csr_matrix(X)
     Y = csr_matrix(Y)
-    assert_raises(TypeError, euclidean_distances, X, Y, check_inputs=False)
+    try:
+        euclidean_distances(X, Y, check_inputs=False)
+    except TypeError:
+        pass
 
     rng = np.random.RandomState(0)
     X = rng.random_sample((10, 4))

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -714,10 +714,26 @@ def test_check_preserve_type():
     assert_equal(XB_checked.dtype, np.float)
 
 
+def test_euclidean_check_shapes():
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((10, 4))
+    Y = rng.random_sample((20, 4))
+    X_norm_sq = (X ** 2).sum(axis=1).reshape(1, -1)
+    Y_norm_sq = (Y ** 2).sum(axis=1).reshape(1, -1)
+    # Errors in transposed shapes should always be fixed
+    euclidean_distances(X, Y, X_norm_squared=X_norm_sq)
+    euclidean_distances(X, Y, X_norm_squared=X_norm_sq.T)
+    euclidean_distances(X, Y, X_norm_squared=X_norm_sq.ravel())
+    euclidean_distances(X, Y, Y_norm_squared=Y_norm_sq)
+    euclidean_distances(X, Y, Y_norm_squared=Y_norm_sq.T)
+    euclidean_distances(X, Y, Y_norm_squared=Y_norm_sq.ravel())
+
+
 def test_euclidean_no_check_input_with_bad_input():
-    # Ensure failure when check_input is False and the inputs are bad
     X = [[0]]
     Y = [[1], [2]]
+    # Even though check_input is False, taking the dot product should fail
+    # because the inputs have incompatible shapes
     assert_raises(AttributeError, euclidean_distances, X, Y,
                   check_input=False)
 
@@ -737,20 +753,6 @@ def test_euclidean_no_check_input_with_bad_input():
         euclidean_distances(X, Y, check_input=False)
     except TypeError:
         pass
-
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((10, 4))
-    Y = rng.random_sample((20, 4))
-    X_norm_sq = (X ** 2).sum(axis=1).reshape(1, -1)
-    Y_norm_sq = (Y ** 2).sum(axis=1).reshape(1, -1)
-
-    assert_raises(ValueError, euclidean_distances, X, Y,
-                  X_norm_squared=X_norm_sq, check_input=False)
-    assert_raises(ValueError, euclidean_distances, X, Y,
-                  Y_norm_squared=Y_norm_sq.T, check_input=False)
-    assert_raises(ValueError, euclidean_distances, X, Y,
-                  X_norm_squared=X_norm_sq, Y_norm_squared=Y_norm_sq,
-                  check_input=False)
 
 
 def test_euclidean_no_check_input_with_good_input():


### PR DESCRIPTION
The following change significantly speeds up the kmeans++ initialization used
in MiniBatchKmeans.

The Euclidean distance computation is the bottleneck in kmeans++. However, on
every call to Euclidean distance there is also a call to check_pairwise_arrays. 
In in kmeans++, the same Y arrays are being checked every time. One of the checks 
in here turns out to cause a speed issue. Specifically the finite check. This patch adds a flag to disable this check.

I'm not sure if this is the desired way to go about this change, but I do think something needs to be 
done about this functions efficiency. 

Here is some data that shows the speed increase:
For these tests I'm clustering with  n_clusters=1000. The feature dimension is 128 and 
the number of data points is 10*n_clusters. I then profiled different versions of the code.
First here is the slow version where I force it to perform the finite check every time.

``` python
Total time: 5.67384 s
File: /home/joncrall/code/scikit-learn/sklearn/metrics/pairwise.py
Function: euclidean_distances at line 173

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   173                                           @ut.profile
   174                                           def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
   175                                                                   X_norm_squared=None, force_all_finite=True):
   237      1000      1402395   1402.4     24.7      X, Y = check_pairwise_arrays(X, Y, force_all_finite=True)
   239                                           
   240      1000         1000      1.0      0.0      if X_norm_squared is not None:
   241                                                   XX = check_array(X_norm_squared)
   242                                                   if XX.shape == (1, X.shape[0]):
   243                                                       XX = XX.T
   244                                                   elif XX.shape != (X.shape[0], 1):
   245                                                       raise ValueError(
   246                                                           "Incompatible dimensions for X and X_norm_squared")
   247                                               else:
   248      1000        36429     36.4      0.6          XX = row_norms(X, squared=True)[:, np.newaxis]
   249                                           
   250      1000         1251      1.3      0.0      if X is Y:  # shortcut in the common case euclidean_distances(X, X)
   251                                                   YY = XX.T
   252      1000          976      1.0      0.0      elif Y_norm_squared is not None:
   253      1000        15173     15.2      0.3          YY = np.atleast_2d(Y_norm_squared)
   254                                           
   255      1000         2450      2.5      0.0          if YY.shape != (1, Y.shape[0]):
   256                                                       raise ValueError(
   257                                                           "Incompatible dimensions for Y and Y_norm_squared")
   258                                               else:
   259                                                   YY = row_norms(Y, squared=True)[np.newaxis, :]
   260                                           
   261      1000      3846672   3846.7     67.8      distances = safe_sparse_dot(X, Y.T, dense_output=True)
   262      1000       108011    108.0      1.9      distances *= -2
   263      1000        64575     64.6      1.1      distances += XX
   264      1000        64196     64.2      1.1      distances += YY
   265      1000       128121    128.1      2.3      np.maximum(distances, 0, out=distances)
   266                                           
   267      1000         1648      1.6      0.0      if X is Y:
   268                                                   # Ensure that distances between vectors and themselves are set to 0.0.
   269                                                   # This may not be the case due to floating point rounding errors.
   270                                                   distances.flat[::distances.shape[0] + 1] = 0.0
   271                                           
   272      1000          941      0.9      0.0      return distances if squared else np.sqrt(distances, out=distances)
```

Digging a little deeper shows the timings int his function in this function.
As you can see most of this functions time is spent in `check_array`.

``` python
Total time: 1.40017 s
File: /home/joncrall/code/scikit-learn/sklearn/metrics/pairwise.py
Function: check_pairwise_arrays at line 58

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    58                                           @ut.profile
    59                                           def check_pairwise_arrays(X, Y, precomputed=False, dtype=None,
    60                                                                     force_all_finite=True):
   104      1000         8652      8.7      0.6      X, Y, dtype_float = _return_float_dtype(X, Y)
   105                                           
   106      1000          659      0.7      0.0      warn_on_dtype = dtype is not None
   107      1000          460      0.5      0.0      estimator = 'check_pairwise_arrays'
   108      1000          507      0.5      0.0      if dtype is None:
   109      1000          524      0.5      0.0          dtype = dtype_float
   110                                           
   111      1000          581      0.6      0.0      if Y is X or Y is None:
   112                                                   X = Y = check_array(X, accept_sparse='csr', dtype=dtype,
   113                                                                       warn_on_dtype=warn_on_dtype, estimator=estimator,
   114                                                                       force_all_finite=force_all_finite)
   115                                               else:
   116      1000          761      0.8      0.1          X = check_array(X, accept_sparse='csr', dtype=dtype,
   117      1000          481      0.5      0.0                          warn_on_dtype=warn_on_dtype, estimator=estimator,
   118      1000       153559    153.6     11.0                          force_all_finite=force_all_finite)
   119      1000          633      0.6      0.0          Y = check_array(Y, accept_sparse='csr', dtype=dtype,
   120      1000          514      0.5      0.0                          warn_on_dtype=warn_on_dtype, estimator=estimator,
   121      1000      1230357   1230.4     87.9                          force_all_finite=force_all_finite)
   122                                           
   123      1000          559      0.6      0.0      if precomputed:
   124                                                   if X.shape[1] != Y.shape[0]:
   125                                                       raise ValueError("Precomputed metric requires shape "
   126                                                                        "(n_queries, n_indexed). Got (%d, %d) "
   127                                                                        "for %d indexed." %
   128                                                                        (X.shape[0], X.shape[1], Y.shape[0]))
   129      1000         1287      1.3      0.1      elif X.shape[1] != Y.shape[1]:
   130                                                   raise ValueError("Incompatible dimension for X and Y matrices: "
   131                                                                    "X.shape[1] == %d while Y.shape[1] == %d" % (
   132                                                                        X.shape[1], Y.shape[1]))
   133                                           
   134      1000          638      0.6      0.0      return X, Y
```

Looking at `check_array` we see the offending function call to `_assert_all_finite`

``` python
Total time: 1.28438 s
File: /home/joncrall/code/scikit-learn/sklearn/utils/validation.py
Function: check_array at line 271

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   271                                           @ut.profile
   272                                           def check_array(array, accept_sparse=None, dtype="numeric", order=None,
   273                                                           copy=False, force_all_finite=True, ensure_2d=True,
   274                                                           allow_nd=False, ensure_min_samples=1, ensure_min_features=1,
   275                                                           warn_on_dtype=False, estimator=None):

   342      2001         2498      1.2      0.2      if isinstance(accept_sparse, str):
   343      2000         2531      1.3      0.2          accept_sparse = [accept_sparse]
   344                                           
   345                                               # store whether originally we wanted numeric dtype
   346      2001         4113      2.1      0.3      dtype_numeric = dtype == "numeric"
   347                                           
   348      2001         3419      1.7      0.3      dtype_orig = getattr(array, "dtype", None)
   349      2001         4128      2.1      0.3      if not hasattr(dtype_orig, 'kind'):
   350                                                   # not a data type (e.g. a column named dtype in a pandas DataFrame)
   351                                                   dtype_orig = None
   352                                           
   353      2001         1811      0.9      0.1      if dtype_numeric:
   354         1            1      1.0      0.0          if dtype_orig is not None and dtype_orig.kind == "O":
   355                                                       # if input is object, convert to float.
   356                                                       dtype = np.float64
   357                                                   else:
   358         1            1      1.0      0.0              dtype = None
   359                                           
   360      2001         4210      2.1      0.3      if isinstance(dtype, (list, tuple)):
   361                                                   if dtype_orig is not None and dtype_orig in dtype:
   362                                                       # no dtype conversion required
   363                                                       dtype = None
   364                                                   else:
   365                                                       # dtype conversion required. Let's select the first element of the
   366                                                       # list of accepted types.
   367                                                       dtype = dtype[0]
   368                                           
   369      2001         1944      1.0      0.2      if estimator is not None:
   370      2000         3129      1.6      0.2          if isinstance(estimator, six.string_types):
   371      2000         1908      1.0      0.1              estimator_name = estimator
   372                                                   else:
   373                                                       estimator_name = estimator.__class__.__name__
   374                                               else:
   375         1            1      1.0      0.0          estimator_name = "Estimator"
   376      2001         3926      2.0      0.3      context = " by %s" % estimator_name if estimator is not None else ""
   377                                           
   378      2001         3753      1.9      0.3      if sp.issparse(array):
   379                                                   array = _ensure_sparse_format(array, accept_sparse, dtype, copy,
   380                                                                                 force_all_finite)
   381                                               else:
   382      2001         8476      4.2      0.7          array = np.array(array, dtype=dtype, order=order, copy=copy)
   383                                           
   384      2001         2034      1.0      0.2          if ensure_2d:
   385      2001         2534      1.3      0.2              if array.ndim == 1:
   386                                                           if ensure_min_samples >= 2:
   387                                                               raise ValueError("%s expects at least 2 samples provided "
   388                                                                                "in a 2 dimensional array-like input"
   389                                                                                % estimator_name)
   390                                                           warnings.warn(
   391                                                               "Passing 1d arrays as data is deprecated in 0.17 and will "
   392                                                               "raise ValueError in 0.19. Reshape your data either using "
   393                                                               "X.reshape(-1, 1) if your data has a single feature or "
   394                                                               "X.reshape(1, -1) if it contains a single sample.",
   395                                                               DeprecationWarning)
   396      2001        16453      8.2      1.3              array = np.atleast_2d(array)
   397                                                       # To ensure that array flags are maintained
   398      2001         3891      1.9      0.3              array = np.array(array, dtype=dtype, order=order, copy=copy)
   399                                           
   400                                                   # make sure we actually converted to numeric:
   401      2001         2012      1.0      0.2          if dtype_numeric and array.dtype.kind == "O":
   402                                                       array = array.astype(np.float64)
   403      2001         2282      1.1      0.2          if not allow_nd and array.ndim >= 3:
   404                                                       raise ValueError("Found array with dim %d. %s expected <= 2."
   405                                                                        % (array.ndim, estimator_name))
   406      2001         1898      0.9      0.1          if force_all_finite:
   407      2001      1114783    557.1     86.8              _assert_all_finite(array)
   408                                           
   409      2001        61351     30.7      4.8      shape_repr = _shape_repr(array.shape)
   410      2001         2295      1.1      0.2      if ensure_min_samples > 0:
   411      2001        16251      8.1      1.3          n_samples = _num_samples(array)
   412      2001         2250      1.1      0.2          if n_samples < ensure_min_samples:
   413                                                       raise ValueError("Found array with %d sample(s) (shape=%s) while a"
   414                                                                        " minimum of %d is required%s."
   415                                                                        % (n_samples, shape_repr, ensure_min_samples,
   416                                                                           context))
   417                                           
   418      2001         2557      1.3      0.2      if ensure_min_features > 0 and array.ndim == 2:
   419      2001         2229      1.1      0.2          n_features = array.shape[1]
   420      2001         1982      1.0      0.2          if n_features < ensure_min_features:
   421                                                       raise ValueError("Found array with %d feature(s) (shape=%s) while"
   422                                                                        " a minimum of %d is required%s."
   423                                                                        % (n_features, shape_repr, ensure_min_features,
   424                                                                           context))
   425                                           
   426      2001         1958      1.0      0.2      if warn_on_dtype and dtype_orig is not None and array.dtype != dtype_orig:
   427                                                   msg = ("Data with input dtype %s was converted to %s%s."
   428                                                          % (dtype_orig, array.dtype, context))
   429                                                   warnings.warn(msg, _DataConversionWarning)
   430      2001         1776      0.9      0.1      return array
```

Disabling this check after it runs the first time gives a better profile.

We could probably even scrape a bit more performance by checking everything at
the start of kmeans++ and then disabling all subsequent checks. This should be
ok because the new centroids are always just previously existing ones. 

```
Total time: 3.82659 s
File: /home/joncrall/code/scikit-learn/sklearn/metrics/pairwise.py
Function: euclidean_distances at line 173

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   173                                           @ut.profile
   174                                           def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
   175                                                                   X_norm_squared=None, force_all_finite=True):
   238      1000       288126    288.1      7.5      X, Y = check_pairwise_arrays(X, Y, force_all_finite=force_all_finite)
   239                                           
   240      1000          718      0.7      0.0      if X_norm_squared is not None:
   241                                                   XX = check_array(X_norm_squared)
   242                                                   if XX.shape == (1, X.shape[0]):
   243                                                       XX = XX.T
   244                                                   elif XX.shape != (X.shape[0], 1):
   245                                                       raise ValueError(
   246                                                           "Incompatible dimensions for X and X_norm_squared")
   247                                               else:
   248      1000        21165     21.2      0.6          XX = row_norms(X, squared=True)[:, np.newaxis]
   249                                           
   250      1000          927      0.9      0.0      if X is Y:  # shortcut in the common case euclidean_distances(X, X)
   251                                                   YY = XX.T
   252      1000          699      0.7      0.0      elif Y_norm_squared is not None:
   253      1000         8768      8.8      0.2          YY = np.atleast_2d(Y_norm_squared)
   254                                           
   255      1000         1956      2.0      0.1          if YY.shape != (1, Y.shape[0]):
   256                                                       raise ValueError(
   257                                                           "Incompatible dimensions for Y and Y_norm_squared")
   258                                               else:
   259                                                   YY = row_norms(Y, squared=True)[np.newaxis, :]
   260                                           
   261      1000      3174245   3174.2     83.0      distances = safe_sparse_dot(X, Y.T, dense_output=True)
   262      1000        93573     93.6      2.4      distances *= -2
   263      1000        69584     69.6      1.8      distances += XX
   264      1000        72021     72.0      1.9      distances += YY
   265      1000        92431     92.4      2.4      np.maximum(distances, 0, out=distances)
   266                                           
   267      1000         1575      1.6      0.0      if X is Y:
   268                                                   # Ensure that distances between vectors and themselves are set to 0.0.
   269                                                   # This may not be the case due to floating point rounding errors.
   270                                                   distances.flat[::distances.shape[0] + 1] = 0.0
   271                                           
   272      1000          804      0.8      0.0      return distances if squared else np.sqrt(distances, out=distances)
```

Disabling the profiler and using a coarser function timer we get the following timings:

Without Checks: 3.9655s
With Checks: 4.9669s

This is a 20% decrease in the amount of time taken (1 second total).

To ensure that this speedup was not just for parameters resembling my problem I
did a gridsearch on various parameter values and looked at the percent change.
For larget datasets the change is consistently positive. There are a few
negative changes for small datasets, but this is likely because of random
fluctuations. For datasets with at least a .1 second speed increase, there is a
15% average improvement with the improvement increasing for larger datasets.

```
    n_clusters  n_features  per_cluster  new_speed  old_speed  percent_change  absolute_change
0         2000         512          200  45.520926  56.996406        0.201337        11.475480
1         2000         512          100  46.009816  57.047427        0.193481        11.037611
2         2000         512           10  46.023527  56.965505        0.192081        10.941978
3         2000         512            1  46.036122  57.028242        0.192749        10.992120
4         2000         128          200  13.359815  16.861238        0.207661         3.501423
5         2000         128          100  13.594423  16.169258        0.159243         2.574835
6         2000         128           10  13.041987  16.357325        0.202682         3.315338
7         2000         128            1  13.517229  15.883567        0.148980         2.366338
8         2000          32          200   4.691806   5.384530        0.128651         0.692724
9         2000          32          100   4.785984   5.434597        0.119349         0.648613
10        2000          32           10   4.816490   5.309634        0.092877         0.493144
11        2000          32            1   4.678081   5.419021        0.136729         0.740940
12        2000           4          200   2.194186   2.311234        0.050643         0.117048
13        2000           4          100   2.195776   2.310168        0.049517         0.114392
14        2000           4           10   2.197284   2.313143        0.050087         0.115859
15        2000           4            1   2.245128   2.298406        0.023181         0.053278
16        1000         512          200  10.325005  13.263920        0.221572         2.938915
17        1000         512          100  10.372535  13.245843        0.216922         2.873308
18        1000         512           10  10.340922  13.195515        0.216331         2.854593
19        1000         512            1  10.377185  13.245806        0.216568         2.868621
20        1000         128          200   2.862865   3.559318        0.195670         0.696453
21        1000         128          100   2.814686   3.682527        0.235664         0.867841
22        1000         128           10   2.866434   3.692132        0.223637         0.825698
23        1000         128            1   3.000796   3.592812        0.164778         0.592016
24        1000          32          200   1.063762   1.172979        0.093111         0.109217
25        1000          32          100   1.053794   1.172330        0.101111         0.118536
26        1000          32           10   1.042551   1.164388        0.104636         0.121837
27        1000          32            1   1.045254   1.165895        0.103475         0.120641
28        1000           4          200   0.576731   0.612182        0.057909         0.035451
29        1000           4          100   0.576767   0.609157        0.053172         0.032390
30        1000           4           10   0.598036   0.607962        0.016327         0.009926
31        1000           4            1   0.578046   0.610441        0.053068         0.032395
32         100         512          200   0.124780   0.144742        0.137913         0.019962
33         100         512          100   0.122643   0.144813        0.153094         0.022170
34         100         512           10   0.123119   0.142057        0.133312         0.018938
35         100         512            1   0.122787   0.144781        0.151913         0.021994
36         100         128          200   0.049460   0.058768        0.158387         0.009308
37         100         128          100   0.060528   0.072691        0.167326         0.012163
38         100         128           10   0.049410   0.061536        0.197052         0.012126
39         100         128            1   0.052959   0.061433        0.137941         0.008474
40         100          32          200   0.029961   0.035051        0.145223         0.005090
41         100          32          100   0.028987   0.033165        0.125970         0.004178
42         100          32           10   0.030262   0.039366        0.231266         0.009104
43         100          32            1   0.028978   0.033200        0.127173         0.004222
44         100           4          200   0.022328   0.027136        0.177188         0.004808
45         100           4          100   0.015451   0.017483        0.116230         0.002032
46         100           4           10   0.014638   0.016714        0.124215         0.002076
47         100           4            1   0.014893   0.018615        0.199944         0.003722
48          10         512          200   0.003733   0.002868       -0.301604        -0.000865
49          10         512          100   0.002347   0.002843        0.174507         0.000496
50          10         512           10   0.002344   0.002907        0.193718         0.000563
51          10         512            1   0.002358   0.006877        0.657086         0.004519
52          10         128          200   0.001717   0.002016        0.148196         0.000299
53          10         128          100   0.007036   0.002073       -2.394020        -0.004963
54          10         128           10   0.001862   0.002053        0.093021         0.000191
55          10         128            1   0.001747   0.002061        0.152244         0.000314
56          10          32          200   0.001596   0.001831        0.128385         0.000235
57          10          32          100   0.001543   0.001787        0.136606         0.000244
58          10          32           10   0.001550   0.001786        0.132159         0.000236
59          10          32            1   0.001551   0.001857        0.164719         0.000306
60          10           4          200   0.001525   0.001715        0.110663         0.000190
61          10           4          100   0.007363   0.001704       -3.320974        -0.005659
62          10           4           10   0.001505   0.001696        0.112470         0.000191
63          10           4            1   0.001494   0.009352        0.840255         0.007858
```

The script I used to generate these numbers is:

``` python
"""
python speedup_kmeans.py --profile
python speedup_kmeans.py

For 1000 clusters and 10000 datapoints:
    5 seconds with checks
    3 seconds without checks
    3 seconds without checks and with out safe_dot
"""
from __future__ import absolute_import, division, print_function, unicode_literals
import utool as ut
import sklearn  # NOQA
from sklearn.datasets.samples_generator import make_blobs
from sklearn.utils.extmath import row_norms, squared_norm  # NOQA
import sklearn.cluster
import numpy as np
from sklearn.metrics.pairwise import euclidean_distances  # NOQA
(print, rrr, profile) = ut.inject2(__name__, '[tester]')


#@profile
def test_kmeans_plus_plus_speed(n_clusters=1000, n_features=128, per_cluster=10, fix=True):
    # Make random cluster centers on a ball
    rng = np.random.RandomState(42)
    centers = rng.rand(n_clusters, n_features)
    centers /= np.linalg.norm(centers, axis=0)[None, :]
    (centers * 512).astype(np.int) / 512
    centers /= np.linalg.norm(centers, axis=0)[None, :]

    n_samples = n_clusters * 10
    n_clusters, n_features = centers.shape
    X, true_labels = make_blobs(n_samples=n_samples, centers=centers,
                                cluster_std=1., random_state=42)

    x_squared_norms = row_norms(X, squared=True)

    _k_init = sklearn.cluster.k_means_._k_init
    random_state = rng
    n_local_trials = None  # NOQA

    #print('Testing kmeans init')
    with ut.Timer('testing kmeans init') as t:
        centers = _k_init(X, n_clusters, random_state=random_state, x_squared_norms=x_squared_norms, fix=fix)
    #print('Done testing kmeans init')
    return t.ellapsed


def main():
    basis = {
        'n_clusters': [10, 100, 1000, 2000][::-1],
        'n_features': [4, 32, 128, 512][::-1],
        'per_cluster': [1, 10, 100, 200][::-1],
    }
    vals = []
    for kw in ut.ProgIter(ut.all_dict_combinations(basis), lbl='gridsearch',
                          bs=False, adjust=False, freq=1):
        print(kw)
        new_speed = test_kmeans_plus_plus_speed(fix=True, **kw)
        old_speed = test_kmeans_plus_plus_speed(fix=False, **kw)
        kw['new_speed'] = new_speed
        kw['old_speed'] = old_speed
        vals.append(kw)

    import pandas as pd
    pd.options.display.max_rows = 64
    pd.options.display.width = 100
    pd.options.display.max_ = 64
    df = pd.DataFrame.from_dict(vals)
    df['percent_change'] = (df['old_speed'] - df['new_speed']) / df['old_speed']
    df = df.reindex_axis(['n_clusters', 'n_features', 'per_cluster', 'new_speed', 'old_speed', 'percent_change'], axis=1)
    df['absolute_change'] = (df['old_speed'] - df['new_speed'])
    print(df)

    print(df['percent_change'][df['absolute_change'] > .1].mean())
    #print(df.loc[df['percent_change'].argsort()[::-1]])

    #try:
    #    profile.dump_stats('out.lprof')
    #    profile.print_stats(stripzeros=True)
    #except Exception:
    #    pass

#if __name__ == '__main__':
#    main()
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7383)

<!-- Reviewable:end -->
