### PR TITLE
[MRG + 1] [TST] (half-cosmetic) use less nose.tools import to simplify future transition to py.test

### DIFF
--- a/doc/datasets/labeled_faces_fixture.py
+++ b/doc/datasets/labeled_faces_fixture.py
@@ -5,8 +5,8 @@ and cached in the past.
 """
 from os.path import exists
 from os.path import join
-from nose import SkipTest
 from sklearn.datasets import get_data_home
+from sklearn.utils.testing import SkipTest
 
 
 def setup_module(module):

--- a/doc/datasets/twenty_newsgroups_fixture.py
+++ b/doc/datasets/twenty_newsgroups_fixture.py
@@ -5,8 +5,9 @@ and cached in the past.
 """
 from os.path import exists
 from os.path import join
-from nose import SkipTest
+
 from sklearn.datasets import get_data_home
+from sklearn.utils.testing import SkipTest
 
 
 def setup_module(module):

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,10 +1,9 @@
 import numpy as np
-from sklearn.utils.testing import (assert_array_almost_equal,
+from sklearn.utils.testing import (assert_equal, assert_array_almost_equal,
                                    assert_array_equal, assert_true,
                                    assert_raise_message)
 from sklearn.datasets import load_linnerud
 from sklearn.cross_decomposition import pls_, CCA
-from nose.tools import assert_equal
 
 
 def test_pls():

--- a/sklearn/datasets/mldata.py
+++ b/sklearn/datasets/mldata.py
@@ -215,7 +215,7 @@ def fetch_mldata(dataname, target_name='label', data_name='data',
     return Bunch(**dataset)
 
 
-# The following is used by nosetests to setup the docstring tests fixture
+# The following is used by test runners to setup the docstring tests fixture
 
 def setup_module(module):
     # setup mock urllib2 module to avoid downloading from mldata.org

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 import warnings
-import nose
 import numpy
 from pickle import loads
 from pickle import dumps
@@ -27,6 +26,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import with_setup
 
 
 DATA_HOME = tempfile.mkdtemp(prefix="scikit_learn_data_home_test_")
@@ -84,7 +84,7 @@ def test_default_empty_load_files():
     assert_equal(res.DESCR, None)
 
 
-@nose.tools.with_setup(setup_load_files, teardown_load_files)
+@with_setup(setup_load_files, teardown_load_files)
 def test_default_load_files():
     res = load_files(LOAD_FILES_ROOT)
     assert_equal(len(res.filenames), 1)
@@ -93,7 +93,7 @@ def test_default_load_files():
     assert_equal(res.data, [b("Hello World!\n")])
 
 
-@nose.tools.with_setup(setup_load_files, teardown_load_files)
+@with_setup(setup_load_files, teardown_load_files)
 def test_load_files_w_categories_desc_and_encoding():
     category = os.path.abspath(TEST_CATEGORY_DIR1).split('/').pop()
     res = load_files(LOAD_FILES_ROOT, description="test",
@@ -104,7 +104,7 @@ def test_load_files_w_categories_desc_and_encoding():
     assert_equal(res.data, [u("Hello World!\n")])
 
 
-@nose.tools.with_setup(setup_load_files, teardown_load_files)
+@with_setup(setup_load_files, teardown_load_files)
 def test_load_files_wo_load_content():
     res = load_files(LOAD_FILES_ROOT, load_content=False)
     assert_equal(len(res.filenames), 1)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -7,14 +7,13 @@ import warnings
 import numpy as np
 from scipy import stats
 
-from nose.tools import assert_raises
-
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import assert_raises
 
 from sklearn.decomposition import FastICA, fastica, PCA
 from sklearn.decomposition.fastica_ import _gs_decorrelation

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -7,10 +7,11 @@ Testing for the base module (sklearn.ensemble.base).
 
 import numpy as np
 from numpy.testing import assert_equal
-from nose.tools import assert_true
 
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_not_equal
+from sklearn.utils.testing import assert_true
+
 from sklearn.datasets import load_iris
 from sklearn.ensemble import BaggingClassifier
 from sklearn.ensemble.base import _set_random_states

--- a/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting_loss_functions.py
@@ -7,9 +7,8 @@ from numpy.testing import assert_array_equal
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_equal
 
-from nose.tools import assert_raises
-
 from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_raises
 from sklearn.ensemble.gradient_boosting import BinomialDeviance
 from sklearn.ensemble.gradient_boosting import LogOddsEstimator
 from sklearn.ensemble.gradient_boosting import LeastSquaresError

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from sklearn.feature_extraction import FeatureHasher
-
-from nose.tools import assert_raises, assert_true
-from numpy.testing import assert_array_equal, assert_equal
+from sklearn.utils.testing import assert_raises, assert_true, assert_equal
 
 
 def test_feature_hasher_dicts():

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -70,7 +70,7 @@ def test_feature_hasher_pairs_with_string_values():
     x2_nz = np.abs(x2[x2 != 0])
     assert_equal([1], x1_nz)
     assert_equal([1], x2_nz)
-    assert_equal(x1, x2)
+    assert_array_equal(x1, x2)
 
 
 def test_hash_empty_input():

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -6,14 +6,13 @@ import numpy as np
 import scipy as sp
 from scipy import ndimage
 
-from nose.tools import assert_equal, assert_true
 from numpy.testing import assert_raises
 
 from sklearn.feature_extraction.image import (
     img_to_graph, grid_to_graph, extract_patches_2d,
     reconstruct_from_patches_2d, PatchExtractor, extract_patches)
 from sklearn.utils.graph import connected_components
-from sklearn.utils.testing import SkipTest
+from sklearn.utils.testing import SkipTest, assert_equal, assert_true
 from sklearn.utils.fixes import sp_version
 
 if sp_version < (0, 12):

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -21,19 +21,15 @@ from sklearn.svm import LinearSVC
 from sklearn.base import clone
 
 import numpy as np
-from nose import SkipTest
-from nose.tools import assert_equal
-from nose.tools import assert_false
-from nose.tools import assert_not_equal
-from nose.tools import assert_true
-from nose.tools import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_raises
 from sklearn.utils.random import choice
-from sklearn.utils.testing import (assert_in, assert_less, assert_greater,
+from sklearn.utils.testing import (assert_equal, assert_false, assert_true,
+                                   assert_not_equal, assert_almost_equal,
+                                   assert_in, assert_less, assert_greater,
                                    assert_warns_message, assert_raise_message,
-                                   clean_warning_registry)
+                                   clean_warning_registry, SkipTest)
 
 from collections import defaultdict, Mapping
 from functools import partial

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -1,12 +1,12 @@
 import numpy as np
 from scipy import sparse as sp
 
-from nose.tools import assert_raises, assert_equal
 from numpy.testing import assert_array_equal
 
 from sklearn.base import BaseEstimator
 from sklearn.feature_selection.base import SelectorMixin
 from sklearn.utils import check_array
+from sklearn.utils.testing import assert_raises, assert_equal
 
 
 class StepSelector(SelectorMixin, BaseEstimator):

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -1,13 +1,13 @@
 import numpy as np
 import scipy.sparse as sp
 
-from nose.tools import assert_raises, assert_true
-
+from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_almost_equal
+from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import skip_if_32bit
 

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -3,7 +3,6 @@ Testing Recursive feature elimination
 """
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-from nose.tools import assert_equal, assert_true
 from scipy import sparse
 
 from sklearn.feature_selection.rfe import RFE, RFECV
@@ -15,7 +14,7 @@ from sklearn.model_selection import cross_val_score
 
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater, assert_equal, assert_true
 
 from sklearn.metrics import make_scorer
 from sklearn.metrics import get_scorer

--- a/sklearn/gaussian_process/tests/test_gaussian_process.py
+++ b/sklearn/gaussian_process/tests/test_gaussian_process.py
@@ -5,16 +5,13 @@ Testing for Gaussian Process module (sklearn.gaussian_process)
 # Author: Vincent Dubourg <vincent.dubourg@gmail.com>
 # License: BSD 3 clause
 
-from nose.tools import raises
-from nose.tools import assert_true
-
 import numpy as np
 
 from sklearn.gaussian_process import GaussianProcess
 from sklearn.gaussian_process import regression_models as regression
 from sklearn.gaussian_process import correlation_models as correlation
 from sklearn.datasets import make_regression
-from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater, assert_true, raises
 
 
 f = lambda x: x * np.sin(x)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -1,9 +1,8 @@
-from nose.tools import assert_equal
-
 import numpy as np
 from scipy import linalg
 
 from sklearn.model_selection import train_test_split
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_less

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -15,12 +15,13 @@ from numpy.testing import assert_array_equal, assert_array_less
 from numpy.testing import assert_array_almost_equal, assert_warns
 from scipy.linalg import norm
 from scipy.optimize import fmin_bfgs
-from nose.tools import raises, assert_almost_equal
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LinearRegression, TheilSenRegressor
 from sklearn.linear_model.theil_sen import _spatial_median, _breakdown_point
 from sklearn.linear_model.theil_sen import _modified_weiszfeld_step
-from sklearn.utils.testing import assert_greater, assert_less
+from sklearn.utils.testing import (
+        assert_almost_equal, assert_greater, assert_less, raises,
+)
 
 
 @contextmanager

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -1,5 +1,4 @@
 from itertools import product
-from nose.tools import assert_true
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
@@ -10,6 +9,8 @@ from sklearn.manifold.locally_linear import barycenter_kneighbors_graph
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_true
 
 eigen_solvers = ['dense', 'arpack']
 
@@ -129,7 +130,6 @@ def test_pipeline():
 
 # Test the error raised when the weight matrix is singular
 def test_singular_matrix():
-    from nose.tools import assert_raises
     M = np.ones((10, 3))
     f = ignore_warnings
     assert_raises(ValueError, f(manifold.locally_linear_embedding),

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -1,8 +1,8 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from nose.tools import assert_raises
 from sklearn.manifold import mds
+from sklearn.utils.testing import assert_raises
 
 
 def test_smacof():

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -1,6 +1,3 @@
-from nose.tools import assert_true
-from nose.tools import assert_equal
-
 from scipy.sparse import csr_matrix
 from scipy.sparse import csc_matrix
 from scipy.sparse import coo_matrix
@@ -8,9 +5,6 @@ from scipy.linalg import eigh
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
-
-from nose.tools import assert_raises
-from nose.plugins.skip import SkipTest
 
 from sklearn.manifold.spectral_embedding_ import SpectralEmbedding
 from sklearn.manifold.spectral_embedding_ import _graph_is_connected
@@ -22,6 +16,8 @@ from sklearn.cluster import KMeans
 from sklearn.datasets.samples_generator import make_blobs
 from sklearn.utils.graph import graph_laplacian
 from sklearn.utils.extmath import _deterministic_vector_sign_flip
+from sklearn.utils.testing import assert_true, assert_equal, assert_raises
+from sklearn.utils.testing import SkipTest
 
 
 # non centered, sparse centers to check the

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,7 +1,4 @@
 import numpy as np
-from nose.tools import assert_almost_equal
-from nose.tools import assert_equal
-from numpy.testing import assert_array_almost_equal
 
 from sklearn.metrics.cluster import adjusted_mutual_info_score
 from sklearn.metrics.cluster import adjusted_rand_score
@@ -15,7 +12,12 @@ from sklearn.metrics.cluster import homogeneity_score
 from sklearn.metrics.cluster import mutual_info_score
 from sklearn.metrics.cluster import normalized_mutual_info_score
 from sklearn.metrics.cluster import v_measure_score
-from sklearn.utils.testing import assert_raise_message
+
+from sklearn.utils.testing import (
+        assert_equal, assert_almost_equal, assert_raise_message,
+)
+from numpy.testing import assert_array_almost_equal
+
 
 score_funcs = [
     adjusted_rand_score,

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -8,15 +8,15 @@ import unittest
 import copy
 import sys
 
-from nose.tools import assert_true
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_raises)
 from scipy import stats
 from sklearn import mixture
 from sklearn.datasets.samples_generator import make_spd_matrix
-from sklearn.utils.testing import (assert_greater, assert_raise_message,
-                                   assert_warns_message, ignore_warnings)
+from sklearn.utils.testing import (assert_true, assert_greater,
+                                   assert_raise_message, assert_warns_message,
+                                   ignore_warnings)
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.externals.six.moves import cStringIO as StringIO
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_array_almost_equal
 import scipy
 from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
-from nose import SkipTest
+from sklearn.utils.testing import SkipTest
 
 
 def dist_func(x1, x2, p):

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -1,8 +1,8 @@
-from nose.tools import assert_equal
 import numpy as np
 
 from sklearn.utils import testing
 from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils.testing import assert_equal, assert_array_equal
 
 
 def _make_func(args_store, kwargs_store, func=lambda X, *a, **k: X):
@@ -21,7 +21,7 @@ def test_delegate_to_func():
     args_store = []
     kwargs_store = {}
     X = np.arange(10).reshape((5, 2))
-    testing.assert_array_equal(
+    assert_array_equal(
         FunctionTransformer(_make_func(args_store, kwargs_store)).transform(X),
         X,
         'transform should have returned X unchanged',
@@ -48,7 +48,7 @@ def test_delegate_to_func():
     kwargs_store.clear()
     y = object()
 
-    testing.assert_array_equal(
+    assert_array_equal(
         FunctionTransformer(
             _make_func(args_store, kwargs_store),
             pass_y=True,
@@ -78,7 +78,7 @@ def test_np_log():
     X = np.arange(10).reshape((5, 2))
 
     # Test that the numpy.log example still works.
-    testing.assert_array_equal(
+    assert_array_equal(
         FunctionTransformer(np.log1p).transform(X),
         np.log1p(X),
     )
@@ -90,8 +90,8 @@ def test_kw_arg():
     F = FunctionTransformer(np.around, kw_args=dict(decimals=3))
 
     # Test that rounding is correct
-    testing.assert_array_equal(F.transform(X),
-                                  np.around(X, decimals=3))
+    assert_array_equal(F.transform(X),
+                       np.around(X, decimals=3))
 
 
 def test_kw_arg_update():
@@ -102,8 +102,7 @@ def test_kw_arg_update():
     F.kw_args['decimals'] = 1
 
     # Test that rounding is correct
-    testing.assert_array_equal(F.transform(X),
-                                  np.around(X, decimals=1))
+    assert_array_equal(F.transform(X), np.around(X, decimals=1))
 
 
 def test_kw_arg_reset():
@@ -114,8 +113,7 @@ def test_kw_arg_reset():
     F.kw_args = dict(decimals=1)
 
     # Test that rounding is correct
-    testing.assert_array_equal(F.transform(X),
-                               np.around(X, decimals=1))
+    assert_array_equal(F.transform(X), np.around(X, decimals=1))
 
 
 def test_inverse_transform():
@@ -123,8 +121,10 @@ def test_inverse_transform():
 
     # Test that inverse_transform works correctly
     F = FunctionTransformer(
-            func=np.sqrt,
-            inverse_func=np.around, inv_kw_args=dict(decimals=3))
-    testing.assert_array_equal(
-            F.inverse_transform(F.transform(X)),
-            np.around(np.sqrt(X), decimals=3))
+        func=np.sqrt,
+        inverse_func=np.around, inv_kw_args=dict(decimals=3),
+    )
+    assert_array_equal(
+        F.inverse_transform(F.transform(X)),
+        np.around(np.sqrt(X), decimals=3),
+    )

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -1,8 +1,8 @@
 """ test the label propagation module """
 
-import nose
 import numpy as np
 
+from sklearn.utils.testing import assert_equal
 from sklearn.semi_supervised import label_propagation
 from sklearn.metrics.pairwise import rbf_kernel
 from numpy.testing import assert_array_almost_equal
@@ -27,7 +27,7 @@ def test_fit_transduction():
     labels = [0, 1, -1]
     for estimator, parameters in ESTIMATORS:
         clf = estimator(**parameters).fit(samples, labels)
-        nose.tools.assert_equal(clf.transduction_[2], 1)
+        assert_equal(clf.transduction_[2], 1)
 
 
 def test_distribution():

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -7,8 +7,7 @@ from sklearn.svm.bounds import l1_min_c
 from sklearn.svm import LinearSVC
 from sklearn.linear_model.logistic import LogisticRegression
 
-from sklearn.utils.testing import assert_equal, assert_true, raises
-from sklearn.utils.testing import clean_warning_registry
+from sklearn.utils.testing import assert_true, raises
 from sklearn.utils.testing import assert_raise_message
 
 

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -1,7 +1,3 @@
-import nose
-from nose.tools import assert_equal, assert_true
-from sklearn.utils.testing import clean_warning_registry
-from sklearn.utils.testing import assert_raise_message
 import warnings
 
 import numpy as np
@@ -10,6 +6,10 @@ from scipy import sparse as sp
 from sklearn.svm.bounds import l1_min_c
 from sklearn.svm import LinearSVC
 from sklearn.linear_model.logistic import LogisticRegression
+
+from sklearn.utils.testing import assert_equal, assert_true, raises
+from sklearn.utils.testing import clean_warning_registry
+from sklearn.utils.testing import assert_raise_message
 
 
 dense_X = [[-1, 0], [0, 1], [1, 1], [1, 1]]
@@ -66,13 +66,13 @@ def check_l1_min_c(X, y, loss, fit_intercept=True, intercept_scaling=None):
                 (np.asarray(clf.intercept_) != 0).any())
 
 
-@nose.tools.raises(ValueError)
+@raises(ValueError)
 def test_ill_posed_min_c():
     X = [[0, 0], [0, 0]]
     y = [0, 1]
     l1_min_c(X, y)
 
 
-@nose.tools.raises(ValueError)
+@raises(ValueError)
 def test_unsupported_loss():
     l1_min_c(dense_X, Y1, 'l1')

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_raises, assert_true, assert_false
-
 import numpy as np
 from scipy import sparse
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -10,7 +8,8 @@ from sklearn.datasets import make_classification, load_digits, make_blobs
 from sklearn.svm.tests import test_svm
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils.testing import (assert_warns, assert_raise_message,
+from sklearn.utils.testing import (assert_raises, assert_true, assert_false,
+                                   assert_warns, assert_raise_message,
                                    ignore_warnings)
 
 # test sample 1

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -9,17 +9,17 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_allclose
 from scipy import sparse
-from nose.tools import assert_raises, assert_true, assert_equal, assert_false
 from sklearn import svm, linear_model, datasets, metrics, base
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import make_classification, make_blobs
 from sklearn.metrics import f1_score
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_equal, assert_true, assert_false
 from sklearn.utils.testing import assert_greater, assert_in, assert_less
 from sklearn.utils.testing import assert_raises_regexp, assert_warns
 from sklearn.utils.testing import assert_warns_message, assert_raise_message
-from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import ignore_warnings, assert_raises
 from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-from nose import SkipTest
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
@@ -12,6 +11,7 @@ from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import SkipTest
 
 from sklearn.datasets import make_blobs
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -4,14 +4,11 @@ Testing for export functions of decision trees (sklearn.tree.export).
 
 from re import finditer
 
-from numpy.testing import assert_equal
-from nose.tools import assert_raises
-
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.tree import export_graphviz
 from sklearn.externals.six import StringIO
-from sklearn.utils.testing import assert_in
+from sklearn.utils.testing import assert_in, assert_equal, assert_raises
 
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]

--- a/sklearn/utils/sparsetools/tests/test_traversal.py
+++ b/sklearn/utils/sparsetools/tests/test_traversal.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
-from nose import SkipTest
-
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from sklearn.utils.testing import SkipTest
+
 try:
     from scipy.sparse.csgraph import breadth_first_tree, depth_first_tree,\
         csgraph_to_dense, csgraph_from_dense

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -36,6 +36,7 @@ import tempfile
 import shutil
 import os.path as op
 import atexit
+import unittest
 
 # WindowsError only exist on Windows
 try:
@@ -47,19 +48,7 @@ import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.externals import joblib
 
-# Conveniently import all assertions in one place.
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
-from nose.tools import assert_true
-from nose.tools import assert_false
-from nose.tools import assert_raises
 from nose.tools import raises
-try:
-    from nose.tools import assert_dict_equal
-except ImportError:
-    # Not in old versions of nose, but is only for formatting anyway
-    assert_dict_equal = assert_equal
-from nose import SkipTest
 from nose import with_setup
 
 from numpy.testing import assert_almost_equal
@@ -82,10 +71,23 @@ __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
            "assert_approx_equal"]
 
 
+_dummy = unittest.TestCase('__init__')
+assert_equal = _dummy.assertEqual
+assert_not_equal = _dummy.assertNotEqual
+assert_true = _dummy.assertTrue
+assert_false = _dummy.assertFalse
+assert_raises = _dummy.assertRaises
+SkipTest = unittest.SkipTest
+
+# raises?
+
+assert_dict_equal = _dummy.assertDictEqual
+
 try:
-    from nose.tools import assert_in, assert_not_in
+    assert_in = _dummy.assertIn
+    assert_not_in = _dummy.assertNotIn
 except ImportError:
-    # Nose < 1.0.0
+    # Python <= 2.6
 
     def assert_in(x, container):
         assert_true(x in container, msg="%r in %r" % (x, container))
@@ -94,9 +96,9 @@ except ImportError:
         assert_false(x in container, msg="%r in %r" % (x, container))
 
 try:
-    from nose.tools import assert_raises_regex
+    assert_raises_reges = _dummy.assertRaisesRegex
 except ImportError:
-    # for Python 2
+    # for Python 2.6
     def assert_raises_regex(expected_exception, expected_regexp,
                             callable_obj=None, *args, **kwargs):
         """Helper function to check for message patterns in exceptions."""
@@ -378,13 +380,10 @@ class _IgnoreWarnings(object):
 
 
 try:
-    from nose.tools import assert_less
+    assert_less = _dummy.assertLess
+    assert_greater = _dummy.assertGreater
 except ImportError:
     assert_less = _assert_less
-
-try:
-    from nose.tools import assert_greater
-except ImportError:
     assert_greater = _assert_greater
 
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -68,7 +68,7 @@ __all__ = ["assert_equal", "assert_not_equal", "assert_raises",
            "assert_array_almost_equal", "assert_array_less",
            "assert_less", "assert_less_equal",
            "assert_greater", "assert_greater_equal",
-           "assert_approx_equal"]
+           "assert_approx_equal", "SkipTest"]
 
 
 _dummy = unittest.TestCase('__init__')
@@ -77,7 +77,7 @@ assert_not_equal = _dummy.assertNotEqual
 assert_true = _dummy.assertTrue
 assert_false = _dummy.assertFalse
 assert_raises = _dummy.assertRaises
-SkipTest = unittest.SkipTest
+SkipTest = unittest.case.SkipTest
 
 # raises?
 
@@ -96,7 +96,7 @@ except AttributeError:
         assert_false(x in container, msg="%r in %r" % (x, container))
 
 try:
-    assert_raises_reges = _dummy.assertRaisesRegex
+    assert_raises_regex = _dummy.assertRaisesRegex
 except AttributeError:
     # for Python 2.6
     def assert_raises_regex(expected_exception, expected_regexp,

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -86,7 +86,7 @@ assert_dict_equal = _dummy.assertDictEqual
 try:
     assert_in = _dummy.assertIn
     assert_not_in = _dummy.assertNotIn
-except ImportError:
+except AttributeError:
     # Python <= 2.6
 
     def assert_in(x, container):
@@ -97,7 +97,7 @@ except ImportError:
 
 try:
     assert_raises_reges = _dummy.assertRaisesRegex
-except ImportError:
+except AttributeError:
     # for Python 2.6
     def assert_raises_regex(expected_exception, expected_regexp,
                             callable_obj=None, *args, **kwargs):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -382,7 +382,7 @@ class _IgnoreWarnings(object):
 try:
     assert_less = _dummy.assertLess
     assert_greater = _dummy.assertGreater
-except ImportError:
+except AttributeError:
     assert_less = _assert_less
     assert_greater = _assert_greater
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -84,8 +84,6 @@ except AttributeError:
     # Python <= 2.6, we stil need nose here
     from nose import SkipTest
 
-# raises?
-
 
 try:
     assert_dict_equal = _dummy.assertDictEqual

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -77,7 +77,12 @@ assert_not_equal = _dummy.assertNotEqual
 assert_true = _dummy.assertTrue
 assert_false = _dummy.assertFalse
 assert_raises = _dummy.assertRaises
-SkipTest = unittest.case.SkipTest
+
+try:
+    SkipTest = unittest.case.SkipTest
+except AttributeError:
+    # Python <= 2.6, we stil need nose here
+    from nose import SkipTest
 
 # raises?
 

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -86,13 +86,15 @@ except AttributeError:
 
 # raises?
 
-assert_dict_equal = _dummy.assertDictEqual
 
 try:
+    assert_dict_equal = _dummy.assertDictEqual
     assert_in = _dummy.assertIn
     assert_not_in = _dummy.assertNotIn
 except AttributeError:
     # Python <= 2.6
+
+    assert_dict_equal = assert_equal
 
     def assert_in(x, container):
         assert_true(x in container, msg="%r in %r" % (x, container))

--- a/sklearn/utils/tests/test_bench.py
+++ b/sklearn/utils/tests/test_bench.py
@@ -2,7 +2,7 @@
 import datetime
 
 from sklearn.utils.bench import total_seconds
-from nose.tools import assert_equal
+from sklearn.utils.testing import assert_equal
 
 
 def test_total_seconds():

--- a/sklearn/utils/tests/test_fast_dict.py
+++ b/sklearn/utils/tests/test_fast_dict.py
@@ -1,10 +1,11 @@
 """ Test fast_dict.
 """
 import numpy as np
-from nose.tools import assert_equal
 
 from sklearn.utils.fast_dict import IntFloatDict, argmin
+from sklearn.utils.testing import assert_equal
 from sklearn.externals.six.moves import xrange
+
 
 def test_int_float_dict():
     rng = np.random.RandomState(0)

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -5,14 +5,11 @@
 
 import numpy as np
 
-from nose.tools import assert_equal
-from nose.tools import assert_false
-from nose.tools import assert_true
 from numpy.testing import (assert_almost_equal,
                            assert_array_almost_equal)
-
 from sklearn.utils.fixes import divide, expit
 from sklearn.utils.fixes import astype
+from sklearn.utils.testing import assert_equal, assert_false, assert_true
 
 
 def test_expit():

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_true, assert_false
+from sklearn.utils.testing import assert_true, assert_false
 from sklearn.utils.metaestimators import if_delegate_has_method
 
 

--- a/sklearn/utils/tests/test_murmurhash.py
+++ b/sklearn/utils/tests/test_murmurhash.py
@@ -7,7 +7,7 @@ from sklearn.externals.six import b, u
 from sklearn.utils.murmurhash import murmurhash3_32
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
-from nose.tools import assert_equal, assert_true
+from sklearn.utils.testing import assert_equal, assert_true
 
 
 def test_mmhash3_int():

--- a/sklearn/utils/tests/test_seq_dataset.py
+++ b/sklearn/utils/tests/test_seq_dataset.py
@@ -3,13 +3,13 @@
 # License: BSD 3 clause
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import scipy.sparse as sp
 
 from sklearn.utils.seq_dataset import ArrayDataset, CSRDataset
 from sklearn.datasets import load_iris
 
-from numpy.testing import assert_array_equal
-from nose.tools import assert_equal
+from sklearn.utils.testing import assert_equal
 
 iris = load_iris()
 X = iris.data.astype(np.float64)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -2,9 +2,8 @@ import warnings
 import unittest
 import sys
 
-from nose.tools import assert_raises
-
 from sklearn.utils.testing import (
+    assert_raises,
     _assert_less,
     _assert_greater,
     assert_less_equal,

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -8,9 +8,9 @@ from itertools import product
 import numpy as np
 from numpy.testing import assert_array_equal
 import scipy.sparse as sp
-from nose.tools import assert_raises, assert_true, assert_false, assert_equal
 
-from sklearn.utils.testing import assert_raises_regexp
+from sklearn.utils.testing import assert_true, assert_false, assert_equal
+from sklearn.utils.testing import assert_raises, assert_raises_regexp
 from sklearn.utils.testing import assert_no_warnings
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_warns


### PR DESCRIPTION
#### Reference Issue

Contributing my experiments with ideas from #7319 issue
#### What does this implement/fix? Explain your changes.

Replaces most occasions of `import nose` and `from nose.tools import` with `from sklearn.utils.testing import`
#### Any other comments?

For now we can't get rid of nosetests completely because numpy.testing is built on top of them and there is a lot of `numpy.testing` imports.
But with that and with strong recommendation to not import anything from `nose` we will be able to replace it as soon as `numpy` will.

Also, with this PR setting $NOSETESTS to pytest should just work without any significant code changes.
