### PR TITLE
[WIP] Fix ZeroDivisionWarning in Matern Kernel

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1320,9 +1320,12 @@ class Matern(RBF):
                 D = squareform(dists**2)[:, :, np.newaxis]
 
             if self.nu == 0.5:
-                dist = np.ma.masked_array(np.sqrt(D.sum(2))[:, :, np.newaxis])
-                D = np.ma.masked_array(D)
-                K_gradient = K[..., np.newaxis] * (D / dist).filled(0)
+                K_gradient = np.zeros_like(D)
+                dist = np.repeat(
+                    np.sqrt(D.sum(2))[:, :, np.newaxis], D.shape[-1], axis=2)
+                nz_dist = dist != 0.0
+                K_gradient[nz_dist] = (
+                    (K[..., np.newaxis] * D)[nz_dist] / dist[nz_dist])
             elif self.nu == 1.5:
                 K_gradient = \
                     3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1321,8 +1321,8 @@ class Matern(RBF):
 
             if self.nu == 0.5:
                 dist = np.ma.masked_array(np.sqrt(D.sum(2))[:, :, np.newaxis])
-                K_gradient = K[..., np.newaxis] * D / dist
-                K_gradient = K_gradient.filled(0)
+                D = np.ma.masked_array(D)
+                K_gradient = K[..., np.newaxis] * (D / dist).filled(0)
             elif self.nu == 1.5:
                 K_gradient = \
                     3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1320,9 +1320,9 @@ class Matern(RBF):
                 D = squareform(dists**2)[:, :, np.newaxis]
 
             if self.nu == 0.5:
-                K_gradient = K[..., np.newaxis] * D \
-                    / np.sqrt(D.sum(2))[:, :, np.newaxis]
-                K_gradient[~np.isfinite(K_gradient)] = 0
+                dist = np.ma.masked_array(np.sqrt(D.sum(2))[:, :, np.newaxis])
+                K_gradient = K[..., np.newaxis] * D / dist
+                K_gradient = K_gradient.filled(0)
             elif self.nu == 1.5:
                 K_gradient = \
                     3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -317,4 +317,4 @@ def test_repr_kernels():
 
 def test_no_warnings_matern_eval_gradient():
     mat = Matern(length_scale=[0.5, 2.0], nu=0.5)
-    assert_no_warnings(mat, X, eval_gradient=True)
+    assert_no_warnings(mat.__call__, X, eval_gradient=True)

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,7 +20,8 @@ from sklearn.base import clone
 
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
                                    assert_not_equal, assert_array_equal,
-                                   assert_array_almost_equal)
+                                   assert_array_almost_equal,
+                                   assert_no_warnings)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -312,3 +313,8 @@ def test_repr_kernels():
 
     for kernel in kernels:
         repr(kernel)
+
+
+def test_no_warnings_matern_eval_gradient():
+    mat = Matern(length_scale=[0.5, 2.0], nu=0.5)
+    assert_no_warnings(mat, X, eval_gradient=True)


### PR DESCRIPTION
#### Reference Issue

Fixes what @amueller thought was the issue in https://github.com/scikit-learn/scikit-learn/issues/5664,
though that's not really the issue [edited by @amueller so that the issue remains open after this fix is merged]
#### What does this implement/fix? Explain your changes.

The previous code had got around the case where the distance equals zero by setting the gradient to zero after finding where it becomes infinite that raises a `ZeroDivisionWarning`. This is another solution using masked arrays in NumPy. I am unable to reproduce any other warning on master with the latest versions of NumPy and SciPy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7385)

<!-- Reviewable:end -->
