### PR TITLE
[MRG + 1] ENH raise error when scoring=sklearn.metrics.{classification,ranking,…}

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -248,7 +248,20 @@ def check_scoring(estimator, scoring=None, allow_none=False):
     if not hasattr(estimator, 'fit'):
         raise TypeError("estimator should be an estimator implementing "
                         "'fit' method, %r was passed" % estimator)
+    if isinstance(scoring, six.string_types):
+        return get_scorer(scoring)
     elif has_scoring:
+        # Heuristic to ensure user has not passed a metric
+        module = getattr(scoring, '__module__', None)
+        if hasattr(module, 'startswith') and \
+           module.startswith('sklearn.metrics.') and \
+           not module.startswith('sklearn.metrics.scorer') and \
+           not module.startswith('sklearn.metrics.tests.'):
+            raise ValueError('scoring value %r looks like it is a metric '
+                             'function rather than a scorer. A scorer should '
+                             'require an estimator as its first parameter. '
+                             'Please use `make_scorer` to convert a metric '
+                             'to a scorer.' % scoring)
         return get_scorer(scoring)
     elif hasattr(estimator, 'score'):
         return _passthrough_scorer

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -435,3 +435,14 @@ def test_deprecated_names():
         assert_warns_message(DeprecationWarning,
                              warning_msg,
                              cross_val_score, clf, X, y, scoring=name)
+
+
+def test_scoring_is_not_metric():
+    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
+                         LogisticRegression(), f1_score)
+    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
+                         LogisticRegression(), roc_auc_score)
+    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
+                         Ridge(), r2_score)
+    assert_raises_regexp(ValueError, 'make_scorer', check_scoring,
+                         KMeans(), adjusted_rand_score)


### PR DESCRIPTION
Fixes #6775, raising an error when the users passes `scoring=scoring object defined in sklearn.metrics but not in sklearn.metrics.scorer`. This is not very elegant, but it's more surely effective than other solutions. Largely supersedes #7040.
