### PR TITLE
[MRG+1] make export_graphviz return string if out_file is None

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -160,7 +160,7 @@ render these plots inline using the `Image()` function::
                              class_names=iris.target_names,  # doctest: +SKIP
                              filled=True, rounded=True,  # doctest: +SKIP
                              special_characters=True)  # doctest: +SKIP
-    >>> graph = pydotplus.graph_from_dot_data(dot_data.getvalue())  # doctest: +SKIP
+    >>> graph = pydotplus.graph_from_dot_data(dot_data)  # doctest: +SKIP
     >>> Image(graph.create_png())  # doctest: +SKIP
 
 .. only:: html

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -145,9 +145,8 @@ a PDF file (or any other supported file type) directly in Python::
 
     >>> from sklearn.externals.six import StringIO  # doctest: +SKIP
     >>> import pydotplus # doctest: +SKIP
-    >>> dot_data = StringIO() # doctest: +SKIP
-    >>> tree.export_graphviz(clf, out_file=dot_data) # doctest: +SKIP
-    >>> graph = pydotplus.graph_from_dot_data(dot_data.getvalue()) # doctest: +SKIP
+    >>> dot_data = tree.export_graphviz(clf) # doctest: +SKIP
+    >>> graph = pydotplus.graph_from_dot_data(dot_data) # doctest: +SKIP
     >>> graph.write_pdf("iris.pdf") # doctest: +SKIP
 
 The :func:`export_graphviz` exporter also supports a variety of aesthetic
@@ -156,8 +155,7 @@ using explicit variable and class names if desired. IPython notebooks can also
 render these plots inline using the `Image()` function::
 
     >>> from IPython.display import Image  # doctest: +SKIP
-    >>> dot_data = StringIO()  # doctest: +SKIP
-    >>> tree.export_graphviz(clf, out_file=dot_data,  # doctest: +SKIP
+    >>> dot_data = tree.export_graphviz(clf,  # doctest: +SKIP
                              feature_names=iris.feature_names,  # doctest: +SKIP
                              class_names=iris.target_names,  # doctest: +SKIP
                              filled=True, rounded=True,  # doctest: +SKIP

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -145,7 +145,7 @@ a PDF file (or any other supported file type) directly in Python::
 
     >>> from sklearn.externals.six import StringIO  # doctest: +SKIP
     >>> import pydotplus # doctest: +SKIP
-    >>> dot_data = tree.export_graphviz(clf) # doctest: +SKIP
+    >>> dot_data = tree.export_graphviz(clf, out_file=None) # doctest: +SKIP
     >>> graph = pydotplus.graph_from_dot_data(dot_data) # doctest: +SKIP
     >>> graph.write_pdf("iris.pdf") # doctest: +SKIP
 
@@ -155,7 +155,7 @@ using explicit variable and class names if desired. IPython notebooks can also
 render these plots inline using the `Image()` function::
 
     >>> from IPython.display import Image  # doctest: +SKIP
-    >>> dot_data = tree.export_graphviz(clf,  # doctest: +SKIP
+    >>> dot_data = tree.export_graphviz(clf,  out_file=None, # doctest: +SKIP
                              feature_names=iris.feature_names,  # doctest: +SKIP
                              class_names=iris.target_names,  # doctest: +SKIP
                              filled=True, rounded=True,  # doctest: +SKIP

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -84,8 +84,8 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
     decision_tree : decision tree classifier
         The decision tree to be exported to GraphViz.
 
-    out_file : file object or string, optional (default=None)
-        Handle or name of the output file. If ``None``, return the result is
+    out_file : file object or string, optional (default='tree.dot')
+        Handle or name of the output file. If ``None``, the result is
         returned as a string.
 
     max_depth : int, optional (default=None)
@@ -138,7 +138,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
     -------
     dot_data : string
         String representation of the input tree in GraphViz dot format.
-        Only returned if out_file is None.
+        Only returned if ``out_file`` is None.
 
     Examples
     --------

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -416,10 +416,10 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
                                "; ".join(r for r in ranks[rank]) + "} ;\n")
         out_file.write("}")
 
-        #write the file or return the string
-        try: #out_file is a StringIO buffer
+        # If out_file is a StringIO buffer, return its contents
+        try:
             return out_file.getvalue()
-        except AttributeError: # out_file is not a StringIO buffer
+        except AttributeError:
             pass
 
     finally:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -87,7 +87,7 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
 
     out_file : file object or string, optional (default='tree.dot')
         Handle or name of the output file. If ``None``, the result is
-        returned as a string.
+        returned as a string. This will the default from version 0.20.
 
     max_depth : int, optional (default=None)
         The maximum depth of the representation. If None, the tree is fully
@@ -140,6 +140,8 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
     dot_data : string
         String representation of the input tree in GraphViz dot format.
         Only returned if ``out_file`` is None.
+
+        .. versionadded:: 0.18
 
     Examples
     --------
@@ -373,8 +375,9 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
     return_string = False
     try:
         if out_file == 'tree.dot':
-            warnings.warn("out_file can be set to None from 0.18, "
-                          "this will be the default in 0.20.", DeprecationWarning)
+            warnings.warn("out_file can be set to None starting from 0.18. "
+                          "This will be the default in 0.20.",
+                          DeprecationWarning)
 
         if isinstance(out_file, six.string_types):
             if six.PY3:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -61,7 +61,7 @@ def _color_brew(n):
     return color_list
 
 
-class Sentinel:
+class Sentinel(object):
     def __repr__():
         return '"tree.dot"'
 SENTINEL = Sentinel()

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -60,7 +60,7 @@ def _color_brew(n):
     return color_list
 
 
-def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
+def export_graphviz(decision_tree, out_file=None, max_depth=None,
                     feature_names=None, class_names=None, label='all',
                     filled=False, leaves_parallel=False, impurity=True,
                     node_ids=False, proportion=False, rotate=False,
@@ -84,8 +84,9 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
     decision_tree : decision tree classifier
         The decision tree to be exported to GraphViz.
 
-    out_file : file object or string, optional (default="tree.dot")
-        Handle or name of the output file.
+    out_file : file object or string, optional (default=None)
+        Handle or name of the output file. If ``None``, return the result is
+        returned as a string.
 
     max_depth : int, optional (default=None)
         The maximum depth of the representation. If None, the tree is fully
@@ -370,6 +371,9 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
                 out_file = open(out_file, "wb")
             own_file = True
 
+        if out_file is None:
+            out_file = six.StringIO()
+
         # The depth of each node for plotting with 'leaf' option
         ranks = {'leaves': []}
         # The colors to render each node with
@@ -411,6 +415,12 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
                 out_file.write("{rank=same ; " +
                                "; ".join(r for r in ranks[rank]) + "} ;\n")
         out_file.write("}")
+
+        #write the file or return the string
+        try: #out_file is a StringIO buffer
+            return out_file.getvalue()
+        except AttributeError: # out_file is not a StringIO buffer
+            pass
 
     finally:
         if own_file:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -61,7 +61,7 @@ def _color_brew(n):
     return color_list
 
 
-def export_graphviz(decision_tree, out_file='tree.dot', max_depth=None,
+def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
                     feature_names=None, class_names=None, label='all',
                     filled=False, leaves_parallel=False, impurity=True,
                     node_ids=False, proportion=False, rotate=False,

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -61,7 +61,11 @@ def _color_brew(n):
     return color_list
 
 
-def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
+class Sentinel:
+    __repr__ = lambda x: '"tree.dot"'
+SENTINEL = Sentinel()
+
+def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
                     feature_names=None, class_names=None, label='all',
                     filled=False, leaves_parallel=False, impurity=True,
                     node_ids=False, proportion=False, rotate=False,
@@ -374,10 +378,11 @@ def export_graphviz(decision_tree, out_file="tree.dot", max_depth=None,
     own_file = False
     return_string = False
     try:
-        if out_file == 'tree.dot':
+        if out_file == SENTINEL:
             warnings.warn("out_file can be set to None starting from 0.18. "
                           "This will be the default in 0.20.",
                           DeprecationWarning)
+            out_file = "tree.dot"
 
         if isinstance(out_file, six.string_types):
             if six.PY3:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -134,6 +134,12 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
         When set to ``False``, ignore special characters for PostScript
         compatibility.
 
+    Returns
+    -------
+    dot_data : string
+        String representation of the input tree in GraphViz dot format.
+        Only returned if out_file is None.
+
     Examples
     --------
     >>> from sklearn.datasets import load_iris
@@ -363,6 +369,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
                 out_file.write('%d -> %d ;\n' % (parent, node_id))
 
     own_file = False
+    return_string = False
     try:
         if isinstance(out_file, six.string_types):
             if six.PY3:
@@ -372,6 +379,7 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
             own_file = True
 
         if out_file is None:
+            return_string = True
             out_file = six.StringIO()
 
         # The depth of each node for plotting with 'leaf' option
@@ -416,11 +424,8 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
                                "; ".join(r for r in ranks[rank]) + "} ;\n")
         out_file.write("}")
 
-        # If out_file is a StringIO buffer, return its contents
-        try:
+        if return_string:
             return out_file.getvalue()
-        except AttributeError:
-            pass
 
     finally:
         if own_file:

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -11,6 +11,7 @@ This module defines export functions for decision trees.
 # License: BSD 3 clause
 
 import numpy as np
+import warnings
 
 from ..externals import six
 
@@ -60,7 +61,7 @@ def _color_brew(n):
     return color_list
 
 
-def export_graphviz(decision_tree, out_file=None, max_depth=None,
+def export_graphviz(decision_tree, out_file='tree.dot', max_depth=None,
                     feature_names=None, class_names=None, label='all',
                     filled=False, leaves_parallel=False, impurity=True,
                     node_ids=False, proportion=False, rotate=False,
@@ -371,6 +372,10 @@ def export_graphviz(decision_tree, out_file=None, max_depth=None,
     own_file = False
     return_string = False
     try:
+        if out_file == 'tree.dot':
+            warnings.warn("out_file can be set to None from 0.18, "
+                          "this will be the default in 0.20.", DeprecationWarning)
+
         if isinstance(out_file, six.string_types):
             if six.PY3:
                 out_file = open(out_file, "w", encoding="utf-8")

--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -62,8 +62,10 @@ def _color_brew(n):
 
 
 class Sentinel:
-    __repr__ = lambda x: '"tree.dot"'
+    def __repr__():
+        return '"tree.dot"'
 SENTINEL = Sentinel()
+
 
 def export_graphviz(decision_tree, out_file=SENTINEL, max_depth=None,
                     feature_names=None, class_names=None, label='all',

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -30,7 +30,7 @@ def test_graphviz_toy():
     clf.fit(X, y)
 
     # Test export code
-    contents1  = export_graphviz(clf, out_file=None)
+    contents1 = export_graphviz(clf, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -46,7 +46,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with feature_names
-    contents1 = export_graphviz(clf, out_file=None, feature_names=["feature0", "feature1"])
+    contents1 = export_graphviz(clf, feature_names=["feature0", "feature1"])
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -62,7 +62,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with class_names
-    contents1 = export_graphviz(clf, out_file=None, class_names=["yes", "no"])
+    contents1 = export_graphviz(clf, class_names=["yes", "no"])
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -80,7 +80,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test plot_options
-    contents1 = export_graphviz(clf, out_file=None, filled=True, impurity=False,
+    contents1 = export_graphviz(clf, filled=True, impurity=False,
                     proportion=True, special_characters=True, rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
@@ -101,7 +101,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test max_depth
-    contents1 = export_graphviz(clf, out_file=None, max_depth=0, class_names=True)
+    contents1 = export_graphviz(clf, max_depth=0, class_names=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -115,7 +115,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test max_depth with plot_options
-    contents1 = export_graphviz(clf, out_file=None, max_depth=0, filled=True,
+    contents1 = export_graphviz(clf, max_depth=0, filled=True,
                     node_ids=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
@@ -136,7 +136,7 @@ def test_graphviz_toy():
                                  random_state=2)
     clf = clf.fit(X, y2, sample_weight=w)
 
-    contents1 = export_graphviz(clf, out_file=None, filled=True, impurity=False)
+    contents1 = export_graphviz(clf, filled=True, impurity=False)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="X[0] <= 0.0\\nsamples = 6\\n' \
@@ -168,7 +168,7 @@ def test_graphviz_toy():
                                 random_state=2)
     clf.fit(X, y)
 
-    contents1 = export_graphviz(clf, out_file=None, filled=True, leaves_parallel=True,
+    contents1 = export_graphviz(clf, filled=True, leaves_parallel=True,
                     rotate=True, rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
@@ -196,7 +196,7 @@ def test_graphviz_toy():
     clf = DecisionTreeClassifier(max_depth=3)
     clf.fit(X, y_degraded)
 
-    contents1 = export_graphviz(clf, out_file=None, filled=True)
+    contents1 = export_graphviz(clf, filled=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="gini = 0.0\\nsamples = 6\\nvalue = 6.0", fillcolor="#e5813900"] ;\n' \

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -81,7 +81,8 @@ def test_graphviz_toy():
 
     # Test plot_options
     contents1 = export_graphviz(clf, filled=True, impurity=False,
-                                proportion=True, special_characters=True, rounded=True)
+                                proportion=True, special_characters=True,
+                                rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -200,7 +200,7 @@ def test_graphviz_toy():
     clf = DecisionTreeClassifier(max_depth=3)
     clf.fit(X, y_degraded)
 
-    contents1 = export_graphviz(clf, filled=True)
+    contents1 = export_graphviz(clf, filled=True, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="gini = 0.0\\nsamples = 6\\nvalue = 6.0", ' \

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -81,7 +81,7 @@ def test_graphviz_toy():
 
     # Test plot_options
     contents1 = export_graphviz(clf, filled=True, impurity=False,
-                    proportion=True, special_characters=True, rounded=True)
+                                proportion=True, special_characters=True, rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \
@@ -116,7 +116,7 @@ def test_graphviz_toy():
 
     # Test max_depth with plot_options
     contents1 = export_graphviz(clf, max_depth=0, filled=True,
-                    node_ids=True)
+                                node_ids=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="node #0\\nX[0] <= 0.0\\ngini = 0.5\\n' \
@@ -169,7 +169,7 @@ def test_graphviz_toy():
     clf.fit(X, y)
 
     contents1 = export_graphviz(clf, filled=True, leaves_parallel=True,
-                    rotate=True, rounded=True)
+                                rotate=True, rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -46,7 +46,8 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with feature_names
-    contents1 = export_graphviz(clf, feature_names=["feature0", "feature1"])
+    contents1 = export_graphviz(clf, feature_names=["feature0", "feature1"],
+                                out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -62,7 +63,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with class_names
-    contents1 = export_graphviz(clf, class_names=["yes", "no"])
+    contents1 = export_graphviz(clf, class_names=["yes", "no"], out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -82,7 +83,7 @@ def test_graphviz_toy():
     # Test plot_options
     contents1 = export_graphviz(clf, filled=True, impurity=False,
                                 proportion=True, special_characters=True,
-                                rounded=True)
+                                rounded=True, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \
@@ -102,7 +103,8 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test max_depth
-    contents1 = export_graphviz(clf, max_depth=0, class_names=True)
+    contents1 = export_graphviz(clf, max_depth=0,
+                                class_names=True, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -117,7 +119,7 @@ def test_graphviz_toy():
 
     # Test max_depth with plot_options
     contents1 = export_graphviz(clf, max_depth=0, filled=True,
-                                node_ids=True)
+                                out_file=None, node_ids=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="node #0\\nX[0] <= 0.0\\ngini = 0.5\\n' \
@@ -137,7 +139,8 @@ def test_graphviz_toy():
                                  random_state=2)
     clf = clf.fit(X, y2, sample_weight=w)
 
-    contents1 = export_graphviz(clf, filled=True, impurity=False)
+    contents1 = export_graphviz(clf, filled=True,
+                                impurity=False, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="X[0] <= 0.0\\nsamples = 6\\n' \
@@ -170,7 +173,7 @@ def test_graphviz_toy():
     clf.fit(X, y)
 
     contents1 = export_graphviz(clf, filled=True, leaves_parallel=True,
-                                rotate=True, rounded=True)
+                                out_file=None, rotate=True, rounded=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \
@@ -200,7 +203,8 @@ def test_graphviz_toy():
     contents1 = export_graphviz(clf, filled=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
-                '0 [label="gini = 0.0\\nsamples = 6\\nvalue = 6.0", fillcolor="#e5813900"] ;\n' \
+                '0 [label="gini = 0.0\\nsamples = 6\\nvalue = 6.0", ' \
+                'fillcolor="#e5813900"] ;\n' \
                 '}'
 
     assert_equal(contents1, contents2)

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -30,9 +30,7 @@ def test_graphviz_toy():
     clf.fit(X, y)
 
     # Test export code
-    out = StringIO()
-    export_graphviz(clf, out_file=out)
-    contents1 = out.getvalue()
+    contents1  = export_graphviz(clf, out_file=None)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -48,9 +46,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with feature_names
-    out = StringIO()
-    export_graphviz(clf, out_file=out, feature_names=["feature0", "feature1"])
-    contents1 = out.getvalue()
+    contents1 = export_graphviz(clf, out_file=None, feature_names=["feature0", "feature1"])
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -66,9 +62,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test with class_names
-    out = StringIO()
-    export_graphviz(clf, out_file=out, class_names=["yes", "no"])
-    contents1 = out.getvalue()
+    contents1 = export_graphviz(clf, out_file=None, class_names=["yes", "no"])
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -86,10 +80,8 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test plot_options
-    out = StringIO()
-    export_graphviz(clf, out_file=out, filled=True, impurity=False,
+    contents1 = export_graphviz(clf, out_file=None, filled=True, impurity=False,
                     proportion=True, special_characters=True, rounded=True)
-    contents1 = out.getvalue()
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \
@@ -109,9 +101,7 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test max_depth
-    out = StringIO()
-    export_graphviz(clf, out_file=out, max_depth=0, class_names=True)
-    contents1 = out.getvalue()
+    contents1 = export_graphviz(clf, out_file=None, max_depth=0, class_names=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box] ;\n' \
                 '0 [label="X[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n' \
@@ -125,10 +115,8 @@ def test_graphviz_toy():
     assert_equal(contents1, contents2)
 
     # Test max_depth with plot_options
-    out = StringIO()
-    export_graphviz(clf, out_file=out, max_depth=0, filled=True,
+    contents1 = export_graphviz(clf, out_file=None, max_depth=0, filled=True,
                     node_ids=True)
-    contents1 = out.getvalue()
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="node #0\\nX[0] <= 0.0\\ngini = 0.5\\n' \
@@ -148,9 +136,7 @@ def test_graphviz_toy():
                                  random_state=2)
     clf = clf.fit(X, y2, sample_weight=w)
 
-    out = StringIO()
-    export_graphviz(clf, out_file=out, filled=True, impurity=False)
-    contents1 = out.getvalue()
+    contents1 = export_graphviz(clf, out_file=None, filled=True, impurity=False)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="X[0] <= 0.0\\nsamples = 6\\n' \
@@ -182,10 +168,8 @@ def test_graphviz_toy():
                                 random_state=2)
     clf.fit(X, y)
 
-    out = StringIO()
-    export_graphviz(clf, out_file=out, filled=True, leaves_parallel=True,
+    contents1 = export_graphviz(clf, out_file=None, filled=True, leaves_parallel=True,
                     rotate=True, rounded=True)
-    contents1 = out.getvalue()
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled, rounded", color="black", ' \
                 'fontname=helvetica] ;\n' \
@@ -212,9 +196,7 @@ def test_graphviz_toy():
     clf = DecisionTreeClassifier(max_depth=3)
     clf.fit(X, y_degraded)
 
-    out = StringIO()
-    export_graphviz(clf, out_file=out, filled=True)
-    contents1 = out.getvalue()
+    contents1 = export_graphviz(clf, out_file=None, filled=True)
     contents2 = 'digraph Tree {\n' \
                 'node [shape=box, style="filled", color="black"] ;\n' \
                 '0 [label="gini = 0.0\\nsamples = 6\\nvalue = 6.0", fillcolor="#e5813900"] ;\n' \


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #6261.
#### What does this implement/fix? Explain your changes.

Clean up the API for `export_graphviz` to make it possible to create visualisations with `pydotplus` without needing to use `StringIO`.  Following the example of `DataFrame.to_csv`, if no file name is provided, now it will just return the output as as a string.
#### Any other comments?

Tested this in Ipython Notebook for both Python 2 and 3.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
