### PR TITLE
[MRG] ENH rename l-bfgs to lbfgs in MLP for the sake of consistency

### DIFF
--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -86,9 +86,9 @@ training samples::
     >>> from sklearn.neural_network import MLPClassifier
     >>> X = [[0., 0.], [1., 1.]]
     >>> y = [0, 1]
-    >>> clf = MLPClassifier(algorithm='l-bfgs', alpha=1e-5, hidden_layer_sizes=(5, 2), random_state=1)
+    >>> clf = MLPClassifier(algorithm='lbgfs', alpha=1e-5, hidden_layer_sizes=(5, 2), random_state=1)
     >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    MLPClassifier(activation='relu', algorithm='l-bfgs', alpha=1e-05,
+    MLPClassifier(activation='relu', algorithm='lbgfs', alpha=1e-05,
            batch_size='auto', beta_1=0.9, beta_2=0.999, early_stopping=False,
            epsilon=1e-08, hidden_layer_sizes=(5, 2), learning_rate='constant',
            learning_rate_init=0.001, max_iter=200, momentum=0.9,
@@ -132,10 +132,10 @@ indices where the value is `1` represents the assigned classes of that sample::
 
     >>> X = [[0., 0.], [1., 1.]]
     >>> y = [[0, 1], [1, 1]]
-    >>> clf = MLPClassifier(algorithm='l-bfgs', alpha=1e-5,
+    >>> clf = MLPClassifier(algorithm='lbgfs', alpha=1e-5,
     ...                     hidden_layer_sizes=(15,), random_state=1)
     >>> clf.fit(X, y)
-    MLPClassifier(activation='relu', algorithm='l-bfgs', alpha=1e-05,
+    MLPClassifier(activation='relu', algorithm='lbgfs', alpha=1e-05,
            batch_size='auto', beta_1=0.9, beta_2=0.999, early_stopping=False,
            epsilon=1e-08, hidden_layer_sizes=(15,), learning_rate='constant',
            learning_rate_init=0.001, max_iter=200, momentum=0.9,

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -86,14 +86,16 @@ training samples::
     >>> from sklearn.neural_network import MLPClassifier
     >>> X = [[0., 0.], [1., 1.]]
     >>> y = [0, 1]
-    >>> clf = MLPClassifier(algorithm='lbgfs', alpha=1e-5, hidden_layer_sizes=(5, 2), random_state=1)
-    >>> clf.fit(X, y) # doctest: +NORMALIZE_WHITESPACE
-    MLPClassifier(activation='relu', algorithm='lbgfs', alpha=1e-05,
-           batch_size='auto', beta_1=0.9, beta_2=0.999, early_stopping=False,
+    >>> clf = MLPClassifier(solver='lbgfs', alpha=1e-5,
+    ...                     hidden_layer_sizes=(5, 2), random_state=1)
+    ...
+    >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
+    MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
+           beta_1=0.9, beta_2=0.999, early_stopping=False,
            epsilon=1e-08, hidden_layer_sizes=(5, 2), learning_rate='constant',
            learning_rate_init=0.001, max_iter=200, momentum=0.9,
            nesterovs_momentum=True, power_t=0.5, random_state=1, shuffle=True,
-           tol=0.0001, validation_fraction=0.1, verbose=False,
+           solver='lbgfs', tol=0.0001, validation_fraction=0.1, verbose=False,
            warm_start=False)
 
 After fitting (training), the model can predict labels for new samples::
@@ -124,7 +126,7 @@ of probability estimates :math:`P(y|x)` per sample :math:`x`::
 applying `Softmax <https://en.wikipedia.org/wiki/Softmax_activation_function>`_
 as the output function.
 
-Further, the algorithm supports :ref:`multi-label classification <multiclass>`
+Further, the model supports :ref:`multi-label classification <multiclass>`
 in which a sample can belong to more than one class. For each class, the raw
 output passes through the logistic function. Values larger or equal to `0.5`
 are rounded to `1`, otherwise to `0`. For a predicted output of a sample, the
@@ -132,15 +134,16 @@ indices where the value is `1` represents the assigned classes of that sample::
 
     >>> X = [[0., 0.], [1., 1.]]
     >>> y = [[0, 1], [1, 1]]
-    >>> clf = MLPClassifier(algorithm='lbgfs', alpha=1e-5,
+    >>> clf = MLPClassifier(solver='lbgfs', alpha=1e-5,
     ...                     hidden_layer_sizes=(15,), random_state=1)
-    >>> clf.fit(X, y)
-    MLPClassifier(activation='relu', algorithm='lbgfs', alpha=1e-05,
-           batch_size='auto', beta_1=0.9, beta_2=0.999, early_stopping=False,
+    ...
+    >>> clf.fit(X, y)                         # doctest: +NORMALIZE_WHITESPACE
+    MLPClassifier(activation='relu', alpha=1e-05, batch_size='auto',
+           beta_1=0.9, beta_2=0.999, early_stopping=False,
            epsilon=1e-08, hidden_layer_sizes=(15,), learning_rate='constant',
            learning_rate_init=0.001, max_iter=200, momentum=0.9,
            nesterovs_momentum=True, power_t=0.5, random_state=1, shuffle=True,
-           tol=0.0001, validation_fraction=0.1, verbose=False,
+           solver='lbgfs', tol=0.0001, validation_fraction=0.1, verbose=False,
            warm_start=False)
     >>> clf.predict([1., 2.])
     array([[1, 1]])
@@ -208,19 +211,19 @@ for the network.
 More details can be found in the documentation of
 `SGD <http://scikit-learn.org/stable/modules/sgd.html>`_
 
-Adam is similar to SGD in a sense that it is a stochastic optimization
-algorithm, but it can automatically adjust the amount to update parameters
-based on adaptive estimates of lower-order moments.
+Adam is similar to SGD in a sense that it is a stochastic optimizer, but it can
+automatically adjust the amount to update parameters based on adaptive estimates
+of lower-order moments.
 
 With SGD or Adam, training supports online and mini-batch learning.
 
-L-BFGS is a fast learning algorithm that approximates the Hessian matrix which
-represents the second-order partial derivative of a function. Further it
-approximates the inverse of the Hessian matrix to perform parameter updates.
-The implementation uses the Scipy version of
-`L-BFGS <http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html>`__..
+L-BFGS is a solver that approximates the Hessian matrix which represents the
+second-order partial derivative of a function. Further it approximates the
+inverse of the Hessian matrix to perform parameter updates. The implementation
+uses the Scipy version of `L-BFGS
+<http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html>`_.
 
-If the selected algorithm is 'L-BFGS', training does not support online nor
+If the selected solver is 'L-BFGS', training does not support online nor
 mini-batch learning.
 
 

--- a/examples/neural_networks/plot_mlp_training_curves.py
+++ b/examples/neural_networks/plot_mlp_training_curves.py
@@ -8,6 +8,9 @@ learning strategies, including SGD and Adam. Because of time-constraints, we
 use several small datasets, for which L-BFGS might be more suitable. The
 general trend shown in these examples seems to carry over to larger datasets,
 however.
+
+Note that those results can be highly dependent on the value of
+``learning_rate_init``.
 """
 
 print(__doc__)
@@ -17,19 +20,19 @@ from sklearn.preprocessing import MinMaxScaler
 from sklearn import datasets
 
 # different learning rate schedules and momentum parameters
-params = [{'algorithm': 'sgd', 'learning_rate': 'constant', 'momentum': 0,
+params = [{'solver': 'sgd', 'learning_rate': 'constant', 'momentum': 0,
            'learning_rate_init': 0.2},
-          {'algorithm': 'sgd', 'learning_rate': 'constant', 'momentum': .9,
+          {'solver': 'sgd', 'learning_rate': 'constant', 'momentum': .9,
            'nesterovs_momentum': False, 'learning_rate_init': 0.2},
-          {'algorithm': 'sgd', 'learning_rate': 'constant', 'momentum': .9,
+          {'solver': 'sgd', 'learning_rate': 'constant', 'momentum': .9,
            'nesterovs_momentum': True, 'learning_rate_init': 0.2},
-          {'algorithm': 'sgd', 'learning_rate': 'invscaling', 'momentum': 0,
+          {'solver': 'sgd', 'learning_rate': 'invscaling', 'momentum': 0,
            'learning_rate_init': 0.2},
-          {'algorithm': 'sgd', 'learning_rate': 'invscaling', 'momentum': .9,
+          {'solver': 'sgd', 'learning_rate': 'invscaling', 'momentum': .9,
            'nesterovs_momentum': True, 'learning_rate_init': 0.2},
-          {'algorithm': 'sgd', 'learning_rate': 'invscaling', 'momentum': .9,
+          {'solver': 'sgd', 'learning_rate': 'invscaling', 'momentum': .9,
            'nesterovs_momentum': False, 'learning_rate_init': 0.2},
-          {'algorithm': 'adam'}]
+          {'solver': 'adam', 'learning_rate_init': 0.01}]
 
 labels = ["constant learning-rate", "constant with momentum",
           "constant with Nesterov's momentum",

--- a/examples/neural_networks/plot_mnist_filters.py
+++ b/examples/neural_networks/plot_mnist_filters.py
@@ -33,9 +33,9 @@ X_train, X_test = X[:60000], X[60000:]
 y_train, y_test = y[:60000], y[60000:]
 
 # mlp = MLPClassifier(hidden_layer_sizes=(100, 100), max_iter=400, alpha=1e-4,
-#                     algorithm='sgd', verbose=10, tol=1e-4, random_state=1)
+#                     solver='sgd', verbose=10, tol=1e-4, random_state=1)
 mlp = MLPClassifier(hidden_layer_sizes=(50,), max_iter=10, alpha=1e-4,
-                    algorithm='sgd', verbose=10, tol=1e-4, random_state=1,
+                    solver='sgd', verbose=10, tol=1e-4, random_state=1,
                     learning_rate_init=.1)
 
 mlp.fit(X_train, y_train)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -133,7 +133,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         with respect to the different parameters given in the initialization.
 
         Returned gradients are packed in a single vector so it can be used
-        in l-bfgs
+        in lbgfs
 
         Parameters
         ----------
@@ -344,8 +344,8 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
             # First time training the model
             self._initialize(y, layer_units)
 
-        # l-bfgs does not support mini-batches
-        if self.algorithm == 'l-bfgs':
+        # lbgfs does not support mini-batches
+        if self.algorithm == 'lbgfs':
             batch_size = n_samples
         elif self.batch_size == 'auto':
             batch_size = min(200, n_samples)
@@ -374,7 +374,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                                  intercept_grads, layer_units, incremental)
 
         # Run the LBFGS algorithm
-        elif self.algorithm == 'l-bfgs':
+        elif self.algorithm == 'lbgfs':
             self._fit_lbfgs(X, y, activations, deltas, coef_grads,
                             intercept_grads, layer_units)
         return self
@@ -421,7 +421,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
         if self.learning_rate not in ["constant", "invscaling", "adaptive"]:
             raise ValueError("learning rate %s is not supported. " %
                              self.learning_rate)
-        supported_algorithms = _STOCHASTIC_ALGOS + ["l-bfgs"]
+        supported_algorithms = _STOCHASTIC_ALGOS + ["lbgfs"]
         if self.algorithm not in supported_algorithms:
             raise ValueError("The algorithm %s is not supported. "
                              " Expected one of: %s" %
@@ -679,7 +679,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
 class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
     """Multi-layer Perceptron classifier.
 
-    This algorithm optimizes the log-loss function using l-bfgs or gradient
+    This algorithm optimizes the log-loss function using lbgfs or gradient
     descent.
 
     Parameters
@@ -703,10 +703,10 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         - 'relu', the rectified linear unit function,
           returns f(x) = max(0, x)
 
-    algorithm : {'l-bfgs', 'sgd', 'adam'}, default 'adam'
+    algorithm : {'lbgfs', 'sgd', 'adam'}, default 'adam'
         The algorithm for weight optimization.
 
-        - 'l-bfgs' is an optimization algorithm in the family of
+        - 'lbgfs' is an optimization algorithm in the family of
           quasi-Newton methods.
 
         - 'sgd' refers to stochastic gradient descent.
@@ -717,7 +717,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
         Note: The default algorithm 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of
         both training time and validation score.
-        For small datasets, however, 'l-bfgs' can converge faster and perform
+        For small datasets, however, 'lbgfs' can converge faster and perform
         better.
 
     alpha : float, optional, default 0.0001
@@ -725,7 +725,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 
     batch_size : int, optional, default 'auto'
         Size of minibatches for stochastic optimizers.
-        If the algorithm is 'l-bfgs', the classifier will not use minibatch.
+        If the algorithm is 'lbgfs', the classifier will not use minibatch.
         When set to "auto", `batch_size=min(200, n_samples)`
 
     learning_rate : {'constant', 'invscaling', 'adaptive'}, default 'constant'
@@ -1021,7 +1021,7 @@ class MLPClassifier(BaseMultilayerPerceptron, ClassifierMixin):
 class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
     """Multi-layer Perceptron regressor.
 
-    This algorithm optimizes the squared-loss using l-bfgs or gradient descent.
+    This algorithm optimizes the squared-loss using lbgfs or gradient descent.
 
     Parameters
     ----------
@@ -1044,10 +1044,10 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         - 'relu', the rectified linear unit function,
           returns f(x) = max(0, x)
 
-    algorithm : {'l-bfgs', 'sgd', 'adam'}, default 'adam'
+    algorithm : {'lbgfs', 'sgd', 'adam'}, default 'adam'
         The algorithm for weight optimization.
 
-        - 'l-bfgs' is an optimization algorithm in the family of
+        - 'lbgfs' is an optimization algorithm in the family of
           quasi-Newton methods.
 
         - 'sgd' refers to stochastic gradient descent.
@@ -1058,7 +1058,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
         Note: The default algorithm 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of
         both training time and validation score.
-        For small datasets, however, 'l-bfgs' can converge faster and perform
+        For small datasets, however, 'lbgfs' can converge faster and perform
         better.
 
     alpha : float, optional, default 0.0001
@@ -1066,7 +1066,7 @@ class MLPRegressor(BaseMultilayerPerceptron, RegressorMixin):
 
     batch_size : int, optional, default 'auto'
         Size of minibatches for stochastic optimizers.
-        If the algorithm is 'l-bfgs', the classifier will not use minibatch.
+        If the algorithm is 'lbgfs', the classifier will not use minibatch.
         When set to "auto", `batch_size=min(200, n_samples)`
 
     learning_rate : {'constant', 'invscaling', 'adaptive'}, default 'constant'

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -74,7 +74,7 @@ def test_fit():
     # Test that the algorithm solution is equal to a worked out example.
     X = np.array([[0.6, 0.8, 0.7]])
     y = np.array([0])
-    mlp = MLPClassifier(algorithm='sgd', learning_rate_init=0.1, alpha=0.1,
+    mlp = MLPClassifier(solver='sgd', learning_rate_init=0.1, alpha=0.1,
                         activation='logistic', random_state=1, max_iter=1,
                         hidden_layer_sizes=2, momentum=0)
     # set weights
@@ -179,7 +179,7 @@ def test_gradient():
 
         for activation in ACTIVATION_TYPES:
             mlp = MLPClassifier(activation=activation, hidden_layer_sizes=10,
-                                algorithm='lbgfs', alpha=1e-5,
+                                solver='lbgfs', alpha=1e-5,
                                 learning_rate_init=0.2, max_iter=1,
                                 random_state=1)
             mlp.fit(X, y)
@@ -238,7 +238,7 @@ def test_lbfgs_classification():
         expected_shape_dtype = (X_test.shape[0], y_train.dtype.kind)
 
         for activation in ACTIVATION_TYPES:
-            mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=50,
+            mlp = MLPClassifier(solver='lbgfs', hidden_layer_sizes=50,
                                 max_iter=150, shuffle=True, random_state=1,
                                 activation=activation)
             mlp.fit(X_train, y_train)
@@ -253,7 +253,7 @@ def test_lbfgs_regression():
     X = Xboston
     y = yboston
     for activation in ACTIVATION_TYPES:
-        mlp = MLPRegressor(algorithm='lbgfs', hidden_layer_sizes=50,
+        mlp = MLPRegressor(solver='lbgfs', hidden_layer_sizes=50,
                            max_iter=150, shuffle=True, random_state=1,
                            activation=activation)
         mlp.fit(X, y)
@@ -269,7 +269,7 @@ def test_learning_rate_warmstart():
     X = [[3, 2], [1, 6], [5, 6], [-2, -4]]
     y = [1, 1, 1, 0]
     for learning_rate in ["invscaling", "constant"]:
-        mlp = MLPClassifier(algorithm='sgd', hidden_layer_sizes=4,
+        mlp = MLPClassifier(solver='sgd', hidden_layer_sizes=4,
                             learning_rate=learning_rate, max_iter=1,
                             power_t=0.25, warm_start=True)
         with ignore_warnings(category=ConvergenceWarning):
@@ -290,14 +290,14 @@ def test_multilabel_classification():
     # test fit method
     X, y = make_multilabel_classification(n_samples=50, random_state=0,
                                           return_indicator=True)
-    mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=50, alpha=1e-5,
+    mlp = MLPClassifier(solver='lbgfs', hidden_layer_sizes=50, alpha=1e-5,
                         max_iter=150, random_state=0, activation='logistic',
                         learning_rate_init=0.2)
     mlp.fit(X, y)
     assert_equal(mlp.score(X, y), 1)
 
     # test partial fit method
-    mlp = MLPClassifier(algorithm='sgd', hidden_layer_sizes=50, max_iter=150,
+    mlp = MLPClassifier(solver='sgd', hidden_layer_sizes=50, max_iter=150,
                         random_state=0, activation='logistic', alpha=1e-5,
                         learning_rate_init=0.2)
     for i in range(100):
@@ -308,7 +308,7 @@ def test_multilabel_classification():
 def test_multioutput_regression():
     # Test that multi-output regression works as expected
     X, y = make_regression(n_samples=200, n_targets=5)
-    mlp = MLPRegressor(algorithm='lbgfs', hidden_layer_sizes=50, max_iter=200,
+    mlp = MLPRegressor(solver='lbgfs', hidden_layer_sizes=50, max_iter=200,
                        random_state=1)
     mlp.fit(X, y)
     assert_greater(mlp.score(X, y), 0.9)
@@ -318,7 +318,7 @@ def test_partial_fit_classes_error():
     # Tests that passing different classes to partial_fit raises an error
     X = [[3, 2]]
     y = [0]
-    clf = MLPClassifier(algorithm='sgd')
+    clf = MLPClassifier(solver='sgd')
     clf.partial_fit(X, y, classes=[0, 1])
     assert_raises(ValueError, clf.partial_fit, X, y, classes=[1, 2])
 
@@ -330,13 +330,13 @@ def test_partial_fit_classification():
     for X, y in classification_datasets:
         X = X
         y = y
-        mlp = MLPClassifier(algorithm='sgd', max_iter=100, random_state=1,
+        mlp = MLPClassifier(solver='sgd', max_iter=100, random_state=1,
                             tol=0, alpha=1e-5, learning_rate_init=0.2)
 
         with ignore_warnings(category=ConvergenceWarning):
             mlp.fit(X, y)
         pred1 = mlp.predict(X)
-        mlp = MLPClassifier(algorithm='sgd', random_state=1, alpha=1e-5,
+        mlp = MLPClassifier(solver='sgd', random_state=1, alpha=1e-5,
                             learning_rate_init=0.2)
         for i in range(100):
             mlp.partial_fit(X, y, classes=np.unique(y))
@@ -352,14 +352,14 @@ def test_partial_fit_regression():
     y = yboston
 
     for momentum in [0, .9]:
-        mlp = MLPRegressor(algorithm='sgd', max_iter=100, activation='relu',
+        mlp = MLPRegressor(solver='sgd', max_iter=100, activation='relu',
                            random_state=1, learning_rate_init=0.01,
                            batch_size=X.shape[0], momentum=momentum)
         with warnings.catch_warnings(record=True):
             # catch convergence warning
             mlp.fit(X, y)
         pred1 = mlp.predict(X)
-        mlp = MLPRegressor(algorithm='sgd', activation='relu',
+        mlp = MLPRegressor(solver='sgd', activation='relu',
                            learning_rate_init=0.01, random_state=1,
                            batch_size=X.shape[0], momentum=momentum)
         for i in range(100):
@@ -378,13 +378,10 @@ def test_partial_fit_errors():
 
     # no classes passed
     assert_raises(ValueError,
-                  MLPClassifier(
-                      algorithm='sgd').partial_fit,
-                  X, y,
-                  classes=[2])
+                  MLPClassifier(solver='sgd').partial_fit, X, y, classes=[2])
 
     # lbgfs doesn't support partial_fit
-    assert_false(hasattr(MLPClassifier(algorithm='lbgfs'), 'partial_fit'))
+    assert_false(hasattr(MLPClassifier(solver='lbgfs'), 'partial_fit'))
 
 
 def test_params_errors():
@@ -410,7 +407,7 @@ def test_params_errors():
     assert_raises(ValueError, clf(beta_2=-0.5).fit, X, y)
     assert_raises(ValueError, clf(epsilon=-0.5).fit, X, y)
 
-    assert_raises(ValueError, clf(algorithm='hadoken').fit, X, y)
+    assert_raises(ValueError, clf(solver='hadoken').fit, X, y)
     assert_raises(ValueError, clf(learning_rate='converge').fit, X, y)
     assert_raises(ValueError, clf(activation='cloak').fit, X, y)
 
@@ -466,7 +463,7 @@ def test_predict_proba_multilabel():
                                           return_indicator=True)
     n_samples, n_classes = Y.shape
 
-    clf = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=30,
+    clf = MLPClassifier(solver='lbgfs', hidden_layer_sizes=30,
                         random_state=0)
     clf.fit(X, Y)
     y_proba = clf.predict_proba(X)
@@ -488,7 +485,7 @@ def test_sparse_matrices():
     X = X_digits_binary[:50]
     y = y_digits_binary[:50]
     X_sparse = csr_matrix(X)
-    mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=15,
+    mlp = MLPClassifier(solver='lbgfs', hidden_layer_sizes=15,
                         random_state=1)
     mlp.fit(X, y)
     pred1 = mlp.predict(X)
@@ -502,10 +499,10 @@ def test_sparse_matrices():
 
 def test_tolerance():
     # Test tolerance.
-    # It should force the algorithm to exit the loop when it converges.
+    # It should force the solver to exit the loop when it converges.
     X = [[3, 2], [1, 6]]
     y = [1, 0]
-    clf = MLPClassifier(tol=0.5, max_iter=3000, algorithm='sgd')
+    clf = MLPClassifier(tol=0.5, max_iter=3000, solver='sgd')
     clf.fit(X, y)
     assert_greater(clf.max_iter, clf.n_iter_)
 
@@ -514,7 +511,7 @@ def test_verbose_sgd():
     # Test verbose.
     X = [[3, 2], [1, 6]]
     y = [1, 0]
-    clf = MLPClassifier(algorithm='sgd', max_iter=2, verbose=10,
+    clf = MLPClassifier(solver='sgd', max_iter=2, verbose=10,
                         hidden_layer_sizes=2)
     old_stdout = sys.stdout
     sys.stdout = output = StringIO()
@@ -531,7 +528,7 @@ def test_early_stopping():
     X = X_digits_binary[:100]
     y = y_digits_binary[:100]
     tol = 0.2
-    clf = MLPClassifier(tol=tol, max_iter=3000, algorithm='sgd',
+    clf = MLPClassifier(tol=tol, max_iter=3000, solver='sgd',
                         early_stopping=True)
     clf.fit(X, y)
     assert_greater(clf.max_iter, clf.n_iter_)
@@ -546,7 +543,7 @@ def test_early_stopping():
 def test_adaptive_learning_rate():
     X = [[3, 2], [1, 6]]
     y = [1, 0]
-    clf = MLPClassifier(tol=0.5, max_iter=3000, algorithm='sgd',
+    clf = MLPClassifier(tol=0.5, max_iter=3000, solver='sgd',
                         learning_rate='adaptive')
     clf.fit(X, y)
     assert_greater(clf.max_iter, clf.n_iter_)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -179,7 +179,7 @@ def test_gradient():
 
         for activation in ACTIVATION_TYPES:
             mlp = MLPClassifier(activation=activation, hidden_layer_sizes=10,
-                                algorithm='l-bfgs', alpha=1e-5,
+                                algorithm='lbgfs', alpha=1e-5,
                                 learning_rate_init=0.2, max_iter=1,
                                 random_state=1)
             mlp.fit(X, y)
@@ -238,7 +238,7 @@ def test_lbfgs_classification():
         expected_shape_dtype = (X_test.shape[0], y_train.dtype.kind)
 
         for activation in ACTIVATION_TYPES:
-            mlp = MLPClassifier(algorithm='l-bfgs', hidden_layer_sizes=50,
+            mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=50,
                                 max_iter=150, shuffle=True, random_state=1,
                                 activation=activation)
             mlp.fit(X_train, y_train)
@@ -253,7 +253,7 @@ def test_lbfgs_regression():
     X = Xboston
     y = yboston
     for activation in ACTIVATION_TYPES:
-        mlp = MLPRegressor(algorithm='l-bfgs', hidden_layer_sizes=50,
+        mlp = MLPRegressor(algorithm='lbgfs', hidden_layer_sizes=50,
                            max_iter=150, shuffle=True, random_state=1,
                            activation=activation)
         mlp.fit(X, y)
@@ -290,7 +290,7 @@ def test_multilabel_classification():
     # test fit method
     X, y = make_multilabel_classification(n_samples=50, random_state=0,
                                           return_indicator=True)
-    mlp = MLPClassifier(algorithm='l-bfgs', hidden_layer_sizes=50, alpha=1e-5,
+    mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=50, alpha=1e-5,
                         max_iter=150, random_state=0, activation='logistic',
                         learning_rate_init=0.2)
     mlp.fit(X, y)
@@ -308,7 +308,7 @@ def test_multilabel_classification():
 def test_multioutput_regression():
     # Test that multi-output regression works as expected
     X, y = make_regression(n_samples=200, n_targets=5)
-    mlp = MLPRegressor(algorithm='l-bfgs', hidden_layer_sizes=50, max_iter=200,
+    mlp = MLPRegressor(algorithm='lbgfs', hidden_layer_sizes=50, max_iter=200,
                        random_state=1)
     mlp.fit(X, y)
     assert_greater(mlp.score(X, y), 0.9)
@@ -383,8 +383,8 @@ def test_partial_fit_errors():
                   X, y,
                   classes=[2])
 
-    # l-bfgs doesn't support partial_fit
-    assert_false(hasattr(MLPClassifier(algorithm='l-bfgs'), 'partial_fit'))
+    # lbgfs doesn't support partial_fit
+    assert_false(hasattr(MLPClassifier(algorithm='lbgfs'), 'partial_fit'))
 
 
 def test_params_errors():
@@ -466,7 +466,7 @@ def test_predict_proba_multilabel():
                                           return_indicator=True)
     n_samples, n_classes = Y.shape
 
-    clf = MLPClassifier(algorithm='l-bfgs', hidden_layer_sizes=30,
+    clf = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=30,
                         random_state=0)
     clf.fit(X, Y)
     y_proba = clf.predict_proba(X)
@@ -488,7 +488,7 @@ def test_sparse_matrices():
     X = X_digits_binary[:50]
     y = y_digits_binary[:50]
     X_sparse = csr_matrix(X)
-    mlp = MLPClassifier(algorithm='l-bfgs', hidden_layer_sizes=15,
+    mlp = MLPClassifier(algorithm='lbgfs', hidden_layer_sizes=15,
                         random_state=1)
     mlp.fit(X, y)
     pred1 = mlp.predict(X)


### PR DESCRIPTION
The goal of this PR is to get the MLP API consistent with `LogisticRegression` and co.

I wonder if we should rename `algorithm` to `solver` to be even more consistent. Any opinion @amueller @jnothman @agramfort ...?
