### PR TITLE
[MRG+1] learning_curve takes error_score parameter and propagates it.

### DIFF
--- a/sklearn/learning_curve.py
+++ b/sklearn/learning_curve.py
@@ -28,7 +28,8 @@ __all__ = ['learning_curve', 'validation_curve']
 
 def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
                    cv=None, scoring=None, exploit_incremental_learning=False,
-                   n_jobs=1, pre_dispatch="all", verbose=0):
+                   n_jobs=1, pre_dispatch="all", verbose=0,
+                   error_score='raise'):
     """Learning curve.
 
     Determines cross-validated training and test scores for different training
@@ -75,7 +76,7 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, 
+        either binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. In all
         other cases, :class:`sklearn.model_selection.KFold` is used.
 
@@ -101,6 +102,12 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
 
     verbose : integer, optional
         Controls the verbosity: the higher, the more messages.
+
+    error_score : 'raise' (default) or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
 
     Returns
     -------
@@ -156,7 +163,8 @@ def learning_curve(estimator, X, y, train_sizes=np.linspace(0.1, 1.0, 5),
     else:
         out = parallel(delayed(_fit_and_score)(
             clone(estimator), X, y, scorer, train[:n_train_samples], test,
-            verbose, parameters=None, fit_params=None, return_train_score=True)
+            verbose, parameters=None, fit_params=None, return_train_score=True,
+            error_score=error_score)
             for train, test in cv for n_train_samples in train_sizes_abs)
         out = np.array(out)[:, :2]
         n_cv_folds = out.shape[0] // n_unique_ticks
@@ -289,7 +297,7 @@ def validation_curve(estimator, X, y, param_name, param_range, cv=None,
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, 
+        either binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. In all
         other cases, :class:`sklearn.model_selection.KFold` is used.
 

--- a/sklearn/tests/test_learning_curve.py
+++ b/sklearn/tests/test_learning_curve.py
@@ -84,6 +84,15 @@ class MockEstimatorWithParameter(BaseEstimator):
         return X is self.X_subset
 
 
+class MockEstimatorFailing(BaseEstimator):
+    """Dummy classifier to test error_score in learning curve"""
+    def fit(self, X_subset, y_subset):
+        raise ValueError()
+
+    def score(self, X=None, y=None):
+        return None
+
+
 def test_learning_curve():
     X, y = make_classification(n_samples=30, n_features=1, n_informative=1,
                                n_redundant=0, n_classes=2,
@@ -134,6 +143,24 @@ def test_learning_curve_verbose():
         sys.stdout = old_stdout
 
     assert("[learning_curve]" in out)
+
+
+def test_learning_curve_error_score():
+    X, y = make_classification(n_samples=30, n_features=1, n_informative=1,
+                               n_redundant=0, n_classes=2,
+                               n_clusters_per_class=1, random_state=0)
+    estimator = MockEstimatorFailing()
+    _, _, test_scores = learning_curve(estimator, X, y, cv=3, error_score=0)
+    all_zeros = not np.any(test_scores)
+    assert(all_zeros)
+
+
+def test_learning_curve_error_score_default_raise():
+    X, y = make_classification(n_samples=30, n_features=1, n_informative=1,
+                               n_redundant=0, n_classes=2,
+                               n_clusters_per_class=1, random_state=0)
+    estimator = MockEstimatorFailing()
+    assert_raises(ValueError, learning_curve, estimator, X, y, cv=3)
 
 
 def test_learning_curve_incremental_learning_not_possible():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #7370 

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Learning curve will fail in some cases (not produce a learning curve). For example if using an estimator that raises when only one class is present - this may happen for the first iterations (small number of training samples). To fix this, learning_curve now takes error_score as a parameter and propagates it, the parameter's default value in learning_curve is 'raise' so the current behavior of failing is maintained - but this gives the option to set it to a value and have a learning_curve produced despite it failing for some iterations.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7397)

<!-- Reviewable:end -->
