### PR TITLE
[MRG+1] TST fix generated test names

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -20,6 +20,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import named_check
 
 import sklearn
 from sklearn.cluster.bicluster import BiclusterMixin
@@ -33,8 +34,7 @@ from sklearn.utils.estimator_checks import (
     check_class_weight_balanced_linear_classifier,
     check_transformer_n_iter,
     check_non_transformer_estimators_n_iter,
-    check_get_params_invariance,
-    _set_test_name)
+    check_get_params_invariance)
 
 
 def test_all_estimator_no_base_class():
@@ -56,7 +56,7 @@ def test_all_estimators():
 
     for name, Estimator in estimators:
         # some can just not be sensibly default constructed
-        yield (_set_test_name(check_parameters_default_constructible, name),
+        yield (named_check(check_parameters_default_constructible, name),
                name, Estimator)
 
 
@@ -72,9 +72,9 @@ def test_non_meta_estimators():
             if issubclass(Estimator, ProjectedGradientNMF):
                 # The ProjectedGradientNMF class is deprecated
                 with ignore_warnings():
-                    yield _set_test_name(check, name), name, Estimator
+                    yield named_check(check, name), name, Estimator
             else:
-                yield _set_test_name(check, name), name, Estimator
+                yield named_check(check, name), name, Estimator
 
 
 def test_configure():
@@ -116,7 +116,7 @@ def test_class_weight_balanced_linear_classifiers():
                 issubclass(clazz, LinearClassifierMixin))]
 
     for name, Classifier in linear_classifiers:
-        yield _set_test_name(check_class_weight_balanced_linear_classifier,
+        yield named_check(check_class_weight_balanced_linear_classifier,
                              name), name, Classifier
 
 
@@ -199,7 +199,7 @@ def test_non_transformer_estimators_n_iter():
                 else:
                     # Multitask models related to ENet cannot handle
                     # if y is mono-output.
-                    yield (_set_test_name(
+                    yield (named_check(
                         check_non_transformer_estimators_n_iter, name),
                         name, estimator, 'Multi' in name)
 
@@ -222,10 +222,10 @@ def test_transformer_n_iter():
             if isinstance(estimator, ProjectedGradientNMF):
                 # The ProjectedGradientNMF class is deprecated
                 with ignore_warnings():
-                    yield _set_test_name(
+                    yield named_check(
                         check_transformer_n_iter, name), name, estimator
             else:
-                yield _set_test_name(
+                yield named_check(
                     check_transformer_n_iter, name), name, estimator
 
 
@@ -241,8 +241,8 @@ def test_get_params_invariance():
             # If class is deprecated, ignore deprecated warnings
             if hasattr(Estimator.__init__, "deprecated_original"):
                 with ignore_warnings():
-                    yield _set_test_name(
+                    yield named_check(
                         check_get_params_invariance, name), name, Estimator
             else:
-                yield _set_test_name(
+                yield named_check(
                     check_get_params_invariance, name), name, Estimator

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -20,7 +20,7 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import ignore_warnings
-from sklearn.utils.testing import named_check
+from sklearn.utils.testing import _named_check
 
 import sklearn
 from sklearn.cluster.bicluster import BiclusterMixin
@@ -56,7 +56,7 @@ def test_all_estimators():
 
     for name, Estimator in estimators:
         # some can just not be sensibly default constructed
-        yield (named_check(check_parameters_default_constructible, name),
+        yield (_named_check(check_parameters_default_constructible, name),
                name, Estimator)
 
 
@@ -72,9 +72,9 @@ def test_non_meta_estimators():
             if issubclass(Estimator, ProjectedGradientNMF):
                 # The ProjectedGradientNMF class is deprecated
                 with ignore_warnings():
-                    yield named_check(check, name), name, Estimator
+                    yield _named_check(check, name), name, Estimator
             else:
-                yield named_check(check, name), name, Estimator
+                yield _named_check(check, name), name, Estimator
 
 
 def test_configure():
@@ -116,7 +116,7 @@ def test_class_weight_balanced_linear_classifiers():
                 issubclass(clazz, LinearClassifierMixin))]
 
     for name, Classifier in linear_classifiers:
-        yield named_check(check_class_weight_balanced_linear_classifier,
+        yield _named_check(check_class_weight_balanced_linear_classifier,
                              name), name, Classifier
 
 
@@ -199,7 +199,7 @@ def test_non_transformer_estimators_n_iter():
                 else:
                     # Multitask models related to ENet cannot handle
                     # if y is mono-output.
-                    yield (named_check(
+                    yield (_named_check(
                         check_non_transformer_estimators_n_iter, name),
                         name, estimator, 'Multi' in name)
 
@@ -222,10 +222,10 @@ def test_transformer_n_iter():
             if isinstance(estimator, ProjectedGradientNMF):
                 # The ProjectedGradientNMF class is deprecated
                 with ignore_warnings():
-                    yield named_check(
+                    yield _named_check(
                         check_transformer_n_iter, name), name, estimator
             else:
-                yield named_check(
+                yield _named_check(
                     check_transformer_n_iter, name), name, estimator
 
 
@@ -241,8 +241,8 @@ def test_get_params_invariance():
             # If class is deprecated, ignore deprecated warnings
             if hasattr(Estimator.__init__, "deprecated_original"):
                 with ignore_warnings():
-                    yield named_check(
+                    yield _named_check(
                         check_get_params_invariance, name), name, Estimator
             else:
-                yield named_check(
+                yield _named_check(
                     check_get_params_invariance, name), name, Estimator

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -75,18 +75,6 @@ DEPRECATED_TRANSFORM = [
     "GradientBoostingClassifier", "GradientBoostingRegressor"]
 
 
-class _set_test_name(object):
-    # Setting the description on the function itself can give incorrect results
-    # in failing tests
-    def __init__(self, function, name):
-        self.function = function
-        self.description = ("sklearn.tests.test_common.{0}({1})".format(
-            function.__name__, name))
-
-    def __call__(self, *args, **kwargs):
-        return self.function(*args, **kwargs)
-
-
 def _yield_non_meta_checks(name, Estimator):
     yield check_estimators_dtypes
     yield check_fit_score_takes_y

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -75,10 +75,16 @@ DEPRECATED_TRANSFORM = [
     "GradientBoostingClassifier", "GradientBoostingRegressor"]
 
 
-def _set_test_name(function, name):
-    function.description = ("sklearn.tests.test_common.{0}({1})".format(
-        function.__name__, name))
-    return function
+class _set_test_name(object):
+    # Setting the description on the function itself can give incorrect results
+    # in failing tests
+    def __init__(self, function, name):
+        self.function = function
+        self.description = ("sklearn.tests.test_common.{0}({1})".format(
+            function.__name__, name))
+
+    def __call__(self, *args, **kwargs):
+        return self.function(*args, **kwargs)
 
 
 def _yield_non_meta_checks(name, Estimator):

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -803,3 +803,24 @@ class TempMemmap(object):
 
 with_network = with_setup(check_skip_network)
 with_travis = with_setup(check_skip_travis)
+
+
+class named_check(object):
+    """Wraps a check to show a useful description
+
+    Parameters
+    ----------
+    check : function
+        Must have ``__name__`` and ``__call__``
+    arg_text : str
+        A summary of arguments to the check
+    """
+    # Setting the description on the function itself can give incorrect results
+    # in failing tests
+    def __init__(self, check, arg_text):
+        self.check = check
+        self.description = ("{0[1]}.{0[3]}:{1.__name__}({2})".format(
+            inspect.stack()[1], check, arg_text))
+
+    def __call__(self, *args, **kwargs):
+        return self.check(*args, **kwargs)

--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -805,7 +805,7 @@ with_network = with_setup(check_skip_network)
 with_travis = with_setup(check_skip_travis)
 
 
-class named_check(object):
+class _named_check(object):
     """Wraps a check to show a useful description
 
     Parameters


### PR DESCRIPTION
An adjustment to #7317. Will show correct estimator names, where old version repeatedly overwrote an attribute on a function, leading to issues with execution order.
