### PR TITLE
[MRG+1] Use sparse cluster contingency matrix by default

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -330,6 +330,11 @@ Enhancements
      (`#7248 <https://github.com/scikit-learn/scikit-learn/pull/7248>_`)
      By `Andreas Müller`_.
 
+   - Support sparse contingency matrices in cluster evaluation
+     (:mod:`metrics.cluster.supervised`) and use these by default.
+     (`#7419 <https://github.com/scikit-learn/scikit-learn/pull/7419>_`)
+     By `Gregory Stupp`_ and `Joel Nothman`_.
+
 Bug fixes
 .........
 
@@ -4543,3 +4548,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Sebastián Vanrell: https://github.com/srvanrell
 
 .. _Robert McGibbon: https://github.com/rmcgibbo
+
+.. _Gregory Stupp: https://github.com/stuppie

--- a/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/expected_mutual_info_fast.pyx
@@ -28,8 +28,8 @@ def expected_mutual_information(contingency, int n_samples):
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
     N = <DOUBLE>n_samples
-    a = np.sum(contingency, axis=1).astype(np.int32)
-    b = np.sum(contingency, axis=0).astype(np.int32)
+    a = np.ravel(contingency.sum(axis=1).astype(np.int32))
+    b = np.ravel(contingency.sum(axis=0).astype(np.int32))
     # There are three major terms to the EMI equation, which are multiplied to
     # and then summed over varying nij values.
     # While nijs[0] will never be used, having it simplifies the indexing.

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -16,11 +16,12 @@ from math import log
 
 import numpy as np
 from scipy.misc import comb
-from scipy.sparse import coo_matrix, find
-from scipy.sparse.data import _data_matrix
+from scipy.sparse import coo_matrix
+from scipy import sparse
 
 from .expected_mutual_info_fast import expected_mutual_information
 from ...utils.fixes import bincount
+from ...utils.validation import check_array
 
 
 def comb2(n):
@@ -72,7 +73,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000,
         `max_n_classes` is ignored.
 
     sparse: boolean, optional.
-        If True, return a sparse continency matrix. If ``eps is not None``,
+        If True, return a sparse CSR continency matrix. If ``eps is not None``,
         and ``sparse is True``, will throw ValueError.
 
     Returns
@@ -106,18 +107,21 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000,
                               (class_idx, cluster_idx)),
                              shape=(n_classes, n_clusters),
                              dtype=np.int)
-    if not sparse:
+    if sparse:
+        contingency = contingency.tocsr()
+        contingency.sum_duplicates()
+    else:
         contingency = contingency.toarray()
-    if eps is not None:
-        # don't use += as contingency is integer
-        contingency = contingency + eps
+        if eps is not None:
+            # don't use += as contingency is integer
+            contingency = contingency + eps
     return contingency
 
 
 # clustering measures
 
 def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
-                        contingency=None):
+                        sparse=False):
     """Rand index adjusted for chance.
 
     The Rand Index computes a similarity measure between two clusterings
@@ -153,11 +157,6 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
         Maximal number of classes handled by the adjusted_rand_score
         metric. Setting it too high can lead to MemoryError or OS
         freeze
-
-    contingency: {None, sparse matrix}, shape = [n_classes_true, n_classes_pred]
-        A contingency matrix given by the :func:`contingency_matrix` function.
-        If value is ``None``, it will be computed, otherwise the given value is
-        used, with ``labels_true`` and ``labels_pred`` ignored.
 
     Returns
     -------
@@ -208,16 +207,10 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
     adjusted_mutual_info_score: Adjusted Mutual Information
 
     """
-    if contingency is None:
-        labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
-        n_samples = labels_true.shape[0]
-        n_classes = np.unique(labels_true).shape[0]
-        n_clusters = np.unique(labels_pred).shape[0]
-    elif isinstance(contingency, _data_matrix):
-        n_samples = contingency.nnz
-        n_classes, n_clusters = contingency.shape
-    else:
-        raise ValueError("'contingency' must be a sparse matrix or None")
+    labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
+    n_samples = labels_true.shape[0]
+    n_classes = np.unique(labels_true).shape[0]
+    n_clusters = np.unique(labels_pred).shape[0]
 
     # Special limit cases: no clustering since the data is not split;
     # or trivial clustering where each document is assigned a unique cluster.
@@ -227,10 +220,9 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
                     n_classes == n_clusters == n_samples):
         return 1.0
 
-    # Compute contingency matrix if we weren't given it
-    if contingency is None:
-        contingency = contingency_matrix(labels_true, labels_pred,
-                                         max_n_classes=max_n_classes)
+    contingency = contingency_matrix(labels_true, labels_pred,
+                                     max_n_classes=max_n_classes,
+                                     sparse=sparse)
 
     # Compute the ARI using the contingency data
     if isinstance(contingency, np.ndarray):
@@ -238,13 +230,13 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
         sum_comb_c = sum(comb2(n_c) for n_c in contingency.sum(axis=1))
         sum_comb_k = sum(comb2(n_k) for n_k in contingency.sum(axis=0))
         sum_comb = sum(comb2(n_ij) for n_ij in contingency.flatten())
-    elif isinstance(contingency, _data_matrix):
+    elif sparse.issparse(contingency):
         # For a sparse matrix
-        sum_comb_c = sum(
-            comb2(n_c) for n_c in np.array(contingency.sum(axis=1)))
-        sum_comb_k = sum(
-            comb2(n_k) for n_k in np.array(contingency.sum(axis=0)).T)
-        sum_comb = sum(comb2(n_ij) for n_ij in find(contingency)[2])
+        sum_comb_c = sum(comb2(n_c)
+                         for n_c in np.ravel(contingency.sum(axis=1)))
+        sum_comb_k = sum(comb2(n_k)
+                         for n_k in np.ravel(contingency.sum(axis=0)))
+        sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)
     else:
         raise ValueError(
             "Unsupported type for 'contingency': " + str(type(contingency)))
@@ -423,9 +415,9 @@ def homogeneity_score(labels_true, labels_pred, max_n_classes=5000,
       0.0...
 
     """
-    return \
-    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                       max_n_classes=max_n_classes)[0]
+    return homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                              sparse=sparse,
+                                              max_n_classes=max_n_classes)[0]
 
 
 def completeness_score(labels_true, labels_pred, max_n_classes=5000,
@@ -505,9 +497,9 @@ def completeness_score(labels_true, labels_pred, max_n_classes=5000,
       0.0
 
     """
-    return \
-    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                       max_n_classes=max_n_classes)[1]
+    return homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                              sparse=sparse,
+                                              max_n_classes=max_n_classes)[1]
 
 
 def v_measure_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
@@ -677,6 +669,11 @@ def mutual_info_score(labels_true, labels_pred, contingency=None,
         labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
         contingency = contingency_matrix(labels_true, labels_pred,
                                          max_n_classes=max_n_classes)
+    else:
+        contingency = check_array(contingency,
+                                  accept_sparse=['csr', 'csc', 'coo'],
+                                  dtype=[int, np.int32, np.int64])
+
     if isinstance(contingency, np.ndarray):
         # For an array
         contingency = np.array(contingency, dtype='float')
@@ -684,37 +681,38 @@ def mutual_info_score(labels_true, labels_pred, contingency=None,
         pi = np.sum(contingency, axis=1)
         pj = np.sum(contingency, axis=0)
         outer = np.outer(pi, pj)
-        nnz = contingency != 0.0
+        nz = contingency != 0.0
         # normalized contingency
-        contingency_nm = contingency[nnz]
+        contingency_nm = contingency[nz]
         log_contingency_nm = np.log(contingency_nm)
         contingency_nm /= contingency_sum
         # log(a / b) should be calculated as log(a) - log(b) for
         # possible loss of precision
-        log_outer = -np.log(outer[nnz]) + log(pi.sum()) + log(pj.sum())
+        log_outer = -np.log(outer[nz]) + log(pi.sum()) + log(pj.sum())
         mi = (contingency_nm * (log_contingency_nm - log(contingency_sum))
               + contingency_nm * log_outer)
         return mi.sum()
-    elif isinstance(contingency, _data_matrix):
+    elif sparse.issparse(contingency):
         # For a sparse matrix
         contingency_sum = contingency.sum()
         pi = np.array(contingency.sum(axis=1))
         pj = np.array(contingency.sum(axis=0)).T
-        nnzx, nnzy, nnz_val = find(contingency)
-        log_contingency_nm = np.log(nnz_val)
-        contingency_nm = nnz_val * 1.0 / contingency_sum
-        # Don't need to calculate the full outer product. Just for the non-zero values
-        outer = np.array([pi[x] * pj[y] for x, y in zip(nnzx, nnzy)]).T
+        nzx, nzy, nz_val = sparse.find(contingency)
+        log_contingency_nm = np.log(nz_val)
+        contingency_nm = nz_val * 1.0 / contingency_sum
+        # Don't need to calculate the full outer product, just for non-zeroes
+        outer = pi.take(nzx) * pj.take(nzy)
         log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
-        mi = contingency_nm * (log_contingency_nm - log(contingency_sum)) + \
-             contingency_nm * log_outer
+        mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
+              contingency_nm * log_outer)
         return mi.sum()
     else:
         raise ValueError(
             "Unsupported type for 'contingency': " + str(type(contingency)))
 
 
-def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
+def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000,
+                               sparse=False):
     """Adjusted Mutual Information between two clusterings.
 
     Adjusted Mutual Information (AMI) is an adjustment of the Mutual
@@ -803,8 +801,9 @@ def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
                 classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
     contingency = contingency_matrix(labels_true, labels_pred,
-                                     max_n_classes=max_n_classes)
-    contingency = np.array(contingency, dtype='float')
+                                     max_n_classes=max_n_classes,
+                                     sparse=sparse)
+    contingency = contingency.astype(float)
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
                            contingency=contingency)
@@ -816,7 +815,8 @@ def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     return ami
 
 
-def normalized_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
+def normalized_mutual_info_score(labels_true, labels_pred, sparse=False,
+                                 max_n_classes=5000):
     """Normalized Mutual Information between two clusterings.
 
     Normalized Mutual Information (NMI) is an normalization of the Mutual
@@ -890,8 +890,9 @@ def normalized_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
                     classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
     contingency = contingency_matrix(labels_true, labels_pred,
-                                     max_n_classes=max_n_classes)
-    contingency = np.array(contingency, dtype='float')
+                                     max_n_classes=max_n_classes,
+                                     sparse=sparse)
+    contingency = contingency.astype(float)
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
                            contingency=contingency)
@@ -902,7 +903,8 @@ def normalized_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     return nmi
 
 
-def fowlkes_mallows_score(labels_true, labels_pred, max_n_classes=5000):
+def fowlkes_mallows_score(labels_true, labels_pred, sparse=False,
+                          max_n_classes=5000):
     """Measure the similarity of two clusterings of a set of points.
 
     The Fowlkes-Mallows index (FMI) is defined as the geometric mean between of
@@ -973,10 +975,16 @@ def fowlkes_mallows_score(labels_true, labels_pred, max_n_classes=5000):
     n_samples, = labels_true.shape
 
     c = contingency_matrix(labels_true, labels_pred,
-                           max_n_classes=max_n_classes)
-    tk = np.dot(c.ravel(), c.ravel()) - n_samples
-    pk = np.sum(np.sum(c, axis=0) ** 2) - n_samples
-    qk = np.sum(np.sum(c, axis=1) ** 2) - n_samples
+                           max_n_classes=max_n_classes,
+                           sparse=sparse)
+    if sparse:
+        tk = np.dot(c.data, c.data) - n_samples
+        pk = np.sum(np.asarray(c.sum(axis=0)).ravel() ** 2) - n_samples
+        qk = np.sum(np.asarray(c.sum(axis=1)).ravel() ** 2) - n_samples
+    else:
+        tk = np.dot(c.ravel(), c.ravel()) - n_samples
+        pk = np.sum(np.sum(c, axis=0) ** 2) - n_samples
+        qk = np.sum(np.sum(c, axis=1) ** 2) - n_samples
 
     return tk / np.sqrt(pk * qk) if tk != 0. else 0.
 

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -204,9 +204,8 @@ def adjusted_rand_score(labels_true, labels_pred):
             n_classes == n_clusters == n_samples):
         return 1.0
 
-    contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
-
     # Compute the ARI using the contingency data
+    contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
     sum_comb_c = sum(comb2(n_c) for n_c in np.ravel(contingency.sum(axis=1)))
     sum_comb_k = sum(comb2(n_k) for n_k in np.ravel(contingency.sum(axis=0)))
     sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -10,6 +10,7 @@ better.
 #          Arnaud Fouchet <foucheta@gmail.com>
 #          Thierry Guillemot <thierry.guillemot.work@gmail.com>
 #          Gregory Stupp <stuppie@gmail.com>
+#          Joel Nothman <joel.nothman@gmail.com>
 # License: BSD 3 clause
 
 from math import log

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -610,8 +610,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None):
         # log(a / b) should be calculated as log(a) - log(b) for
         # possible loss of precision
         log_outer = -np.log(outer[nz]) + log(pi.sum()) + log(pj.sum())
-        mi = (contingency_nm * (log_contingency_nm - log(contingency_sum))
-              + contingency_nm * log_outer)
+        mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
+              contingency_nm * log_outer)
         return mi.sum()
     elif sparse.issparse(contingency):
         # For a sparse matrix

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -207,21 +207,9 @@ def adjusted_rand_score(labels_true, labels_pred):
     contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
 
     # Compute the ARI using the contingency data
-    if isinstance(contingency, np.ndarray):
-        # For an array
-        sum_comb_c = sum(comb2(n_c) for n_c in contingency.sum(axis=1))
-        sum_comb_k = sum(comb2(n_k) for n_k in contingency.sum(axis=0))
-        sum_comb = sum(comb2(n_ij) for n_ij in contingency.flatten())
-    elif sp.issparse(contingency):
-        # For a sparse matrix
-        sum_comb_c = sum(comb2(n_c)
-                         for n_c in np.ravel(contingency.sum(axis=1)))
-        sum_comb_k = sum(comb2(n_k)
-                         for n_k in np.ravel(contingency.sum(axis=0)))
-        sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)
-    else:
-        raise ValueError(
-            "Unsupported type for 'contingency': " + str(type(contingency)))
+    sum_comb_c = sum(comb2(n_c) for n_c in np.ravel(contingency.sum(axis=1)))
+    sum_comb_k = sum(comb2(n_k) for n_k in np.ravel(contingency.sum(axis=0)))
+    sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)
 
     prod_comb = (sum_comb_c * sum_comb_k) / float(comb(n_samples, 2))
     mean_comb = (sum_comb_k + sum_comb_c) / 2.

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -48,7 +48,8 @@ def check_clusterings(labels_true, labels_pred):
     return labels_true, labels_pred
 
 
-def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, sparse=False):
+def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000,
+                       sparse=False):
     """Build a contingency matrix describing the relationship between labels.
 
     Parameters
@@ -67,7 +68,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     max_n_classes : int, optional (default=5000)
         Maximal number of classeses handled for contingency_matrix.
         This help to avoid Memory error with regression target
-        for mutual_information. If `sparse`, `max_n_classes` is ignored.
+        for mutual_information. If ``sparse is True``,
+        `max_n_classes` is ignored.
 
     sparse: boolean, optional.
         If True, return a sparse continency matrix. If ``eps is not None``,
@@ -75,11 +77,11 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
 
     Returns
     -------
-    contingency: {array-like, sparse matrix}, shape=[n_classes_true, n_classes_pred]
+    contingency: {array-like, sparse}, shape=[n_classes_true, n_classes_pred]
         Matrix :math:`C` such that :math:`C_{i, j}` is the number of samples in
         true class :math:`i` and in predicted class :math:`j`. If
         ``eps is None``, the dtype of this array will be integer. If ``eps`` is
-        given, the dtype will be float.
+        given, the dtype will be float. Will be sparse if ``sparse is True``
     """
 
     if eps is not None and sparse:
@@ -100,7 +102,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     # Using coo_matrix to accelerate simple histogram calculation,
     # i.e. bins are consecutive integers
     # Currently, coo_matrix is faster than histogram2d for simple cases
-    contingency = coo_matrix((np.ones(class_idx.shape[0]), (class_idx, cluster_idx)),
+    contingency = coo_matrix((np.ones(class_idx.shape[0]),
+                              (class_idx, cluster_idx)),
                              shape=(n_classes, n_clusters),
                              dtype=np.int)
     if not sparse:
@@ -113,7 +116,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
 
 # clustering measures
 
-def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingency=None):
+def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000,
+                        contingency=None):
     """Rand index adjusted for chance.
 
     The Rand Index computes a similarity measure between two clusterings
@@ -209,7 +213,7 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
         n_samples = labels_true.shape[0]
         n_classes = np.unique(labels_true).shape[0]
         n_clusters = np.unique(labels_pred).shape[0]
-    elif isinstance(contingency, _data_matrix):  # scipy.sparse.data._data_matrix
+    elif isinstance(contingency, _data_matrix):
         n_samples = contingency.nnz
         n_classes, n_clusters = contingency.shape
     else:
@@ -225,7 +229,8 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
 
     # Compute contingency matrix if we weren't given it
     if contingency is None:
-        contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+        contingency = contingency_matrix(labels_true, labels_pred,
+                                         max_n_classes=max_n_classes)
 
     # Compute the ARI using the contingency data
     if isinstance(contingency, np.ndarray):
@@ -235,18 +240,22 @@ def adjusted_rand_score(labels_true, labels_pred, max_n_classes=5000, contingenc
         sum_comb = sum(comb2(n_ij) for n_ij in contingency.flatten())
     elif isinstance(contingency, _data_matrix):
         # For a sparse matrix
-        sum_comb_c = sum(comb2(n_c) for n_c in np.array(contingency.sum(axis=1)))
-        sum_comb_k = sum(comb2(n_k) for n_k in np.array(contingency.sum(axis=0)).T)
+        sum_comb_c = sum(
+            comb2(n_c) for n_c in np.array(contingency.sum(axis=1)))
+        sum_comb_k = sum(
+            comb2(n_k) for n_k in np.array(contingency.sum(axis=0)).T)
         sum_comb = sum(comb2(n_ij) for n_ij in find(contingency)[2])
     else:
-        raise ValueError("Unsupported type for 'contingency': " + str(type(contingency)))
+        raise ValueError(
+            "Unsupported type for 'contingency': " + str(type(contingency)))
 
     prod_comb = (sum_comb_c * sum_comb_k) / float(comb(n_samples, 2))
     mean_comb = (sum_comb_k + sum_comb_c) / 2.
     return float((sum_comb - prod_comb) / (mean_comb - prod_comb))
 
 
-def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                       max_n_classes=5000, sparse=False):
     """Compute the homogeneity and completeness and V-Measure scores at once.
 
     Those metrics are based on normalized conditional entropy measures of
@@ -318,7 +327,8 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5
         contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
         MI = mutual_info_score(None, None, contingency=contingency)
     else:
-        MI = mutual_info_score(labels_true, labels_pred, max_n_classes=max_n_classes)
+        MI = mutual_info_score(labels_true, labels_pred,
+                               max_n_classes=max_n_classes)
 
     homogeneity = MI / (entropy_C) if entropy_C else 1.0
     completeness = MI / (entropy_K) if entropy_K else 1.0
@@ -332,7 +342,8 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=5
     return homogeneity, completeness, v_measure_score
 
 
-def homogeneity_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def homogeneity_score(labels_true, labels_pred, max_n_classes=5000,
+                      sparse=False):
     """Homogeneity metric of a cluster labeling given a ground truth.
 
     A clustering result satisfies homogeneity if all of its clusters
@@ -412,11 +423,13 @@ def homogeneity_score(labels_true, labels_pred, max_n_classes=5000, sparse=False
       0.0...
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                              max_n_classes=max_n_classes)[0]
+    return \
+    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
+                                       max_n_classes=max_n_classes)[0]
 
 
-def completeness_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
+def completeness_score(labels_true, labels_pred, max_n_classes=5000,
+                       sparse=False):
     """Completeness metric of a cluster labeling given a ground truth.
 
     A clustering result satisfies completeness if all the data points
@@ -492,8 +505,9 @@ def completeness_score(labels_true, labels_pred, max_n_classes=5000, sparse=Fals
       0.0
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
-                                              max_n_classes=max_n_classes)[1]
+    return \
+    homogeneity_completeness_v_measure(labels_true, labels_pred, sparse=sparse,
+                                       max_n_classes=max_n_classes)[1]
 
 
 def v_measure_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
@@ -597,11 +611,13 @@ def v_measure_score(labels_true, labels_pred, max_n_classes=5000, sparse=False):
       0.0...
 
     """
-    return homogeneity_completeness_v_measure(labels_true, labels_pred, max_n_classes=max_n_classes,
+    return homogeneity_completeness_v_measure(labels_true, labels_pred,
+                                              max_n_classes=max_n_classes,
                                               sparse=sparse)[2]
 
 
-def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=5000):
+def mutual_info_score(labels_true, labels_pred, contingency=None,
+                      max_n_classes=5000):
     """Mutual Information between two clusterings.
 
     The Mutual Information is a measure of the similarity between two labels of
@@ -636,7 +652,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
     labels_pred : array, shape = [n_samples]
         A clustering of the data into disjoint subsets.
 
-    contingency: {None, array, sparse matrix}, shape = [n_classes_true, n_classes_pred]
+    contingency: {None, array, sparse matrix},
+                shape = [n_classes_true, n_classes_pred]
         A contingency matrix given by the :func:`contingency_matrix` function.
         If value is ``None``, it will be computed, otherwise the given value is
         used, with ``labels_true`` and ``labels_pred`` ignored.
@@ -658,7 +675,8 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
     """
     if contingency is None:
         labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
-        contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+        contingency = contingency_matrix(labels_true, labels_pred,
+                                         max_n_classes=max_n_classes)
     if isinstance(contingency, np.ndarray):
         # For an array
         contingency = np.array(contingency, dtype='float')
@@ -684,14 +702,16 @@ def mutual_info_score(labels_true, labels_pred, contingency=None, max_n_classes=
         pj = np.array(contingency.sum(axis=0)).T
         nnzx, nnzy, nnz_val = find(contingency)
         log_contingency_nm = np.log(nnz_val)
-        contingency_nm = nnz_val * 1.0 / contingency_sum  # python2 integer division...
+        contingency_nm = nnz_val * 1.0 / contingency_sum
         # Don't need to calculate the full outer product. Just for the non-zero values
         outer = np.array([pi[x] * pj[y] for x, y in zip(nnzx, nnzy)]).T
         log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
-        mi = contingency_nm * (log_contingency_nm - log(contingency_sum)) + contingency_nm * log_outer
+        mi = contingency_nm * (log_contingency_nm - log(contingency_sum)) + \
+             contingency_nm * log_outer
         return mi.sum()
     else:
-        raise ValueError("Unsupported type for 'contingency': " + str(type(contingency)))
+        raise ValueError(
+            "Unsupported type for 'contingency': " + str(type(contingency)))
 
 
 def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
@@ -780,9 +800,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     # Special limit cases: no clustering since the data is not split.
     # This is a perfect match hence return 1.0.
     if (classes.shape[0] == clusters.shape[0] == 1 or
-                    classes.shape[0] == clusters.shape[0] == 0):
+                classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
-    contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    contingency = contingency_matrix(labels_true, labels_pred,
+                                     max_n_classes=max_n_classes)
     contingency = np.array(contingency, dtype='float')
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
@@ -868,7 +889,8 @@ def normalized_mutual_info_score(labels_true, labels_pred, max_n_classes=5000):
     if (classes.shape[0] == clusters.shape[0] == 1 or
                     classes.shape[0] == clusters.shape[0] == 0):
         return 1.0
-    contingency = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    contingency = contingency_matrix(labels_true, labels_pred,
+                                     max_n_classes=max_n_classes)
     contingency = np.array(contingency, dtype='float')
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred,
@@ -950,7 +972,8 @@ def fowlkes_mallows_score(labels_true, labels_pred, max_n_classes=5000):
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred, )
     n_samples, = labels_true.shape
 
-    c = contingency_matrix(labels_true, labels_pred, max_n_classes=max_n_classes)
+    c = contingency_matrix(labels_true, labels_pred,
+                           max_n_classes=max_n_classes)
     tk = np.dot(c.ravel(), c.ravel()) - n_samples
     pk = np.sum(np.sum(c, axis=0) ** 2) - n_samples
     qk = np.sum(np.sum(c, axis=1) ** 2) - n_samples

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -75,7 +75,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None, sparse=False):
 
     Returns
     -------
-    contingency: {array-like, sparse}, shape=[n_classes_true, n_classes_pred]
+    contingency : {array-like, sparse}, shape=[n_classes_true, n_classes_pred]
         Matrix :math:`C` such that :math:`C_{i, j}` is the number of samples in
         true class :math:`i` and in predicted class :math:`j`. If
         ``eps is None``, the dtype of this array will be integer. If ``eps`` is

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -849,7 +849,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, sparse=False):
     .. [2] `Wikipedia entry for the Fowlkes-Mallows Index
            <https://en.wikipedia.org/wiki/Fowlkes-Mallows_index>`_
     """
-    labels_true, labels_pred = check_clusterings(labels_true, labels_pred, )
+    labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     n_samples, = labels_true.shape
 
     c = contingency_matrix(labels_true, labels_pred, sparse=True)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -70,6 +70,8 @@ def contingency_matrix(labels_true, labels_pred, eps=None, sparse=False):
         If True, return a sparse CSR continency matrix. If ``eps is not None``,
         and ``sparse is True``, will throw ValueError.
 
+        .. versionadded:: 0.18
+
     Returns
     -------
     contingency: {array-like, sparse}, shape=[n_classes_true, n_classes_pred]
@@ -80,7 +82,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None, sparse=False):
     """
 
     if eps is not None and sparse:
-        raise ValueError("Cannot set 'eps' and return a sparse matrix")
+        raise ValueError("Cannot set 'eps' when sparse=True")
 
     classes, class_idx = np.unique(labels_true, return_inverse=True)
     clusters, cluster_idx = np.unique(labels_pred, return_inverse=True)

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -210,9 +210,9 @@ def adjusted_rand_score(labels_true, labels_pred):
     sum_comb_k = sum(comb2(n_k) for n_k in np.ravel(contingency.sum(axis=0)))
     sum_comb = sum(comb2(n_ij) for n_ij in contingency.data)
 
-    prod_comb = (sum_comb_c * sum_comb_k) / float(comb(n_samples, 2))
+    prod_comb = (sum_comb_c * sum_comb_k) / comb(n_samples, 2)
     mean_comb = (sum_comb_k + sum_comb_c) / 2.
-    return float((sum_comb - prod_comb) / (mean_comb - prod_comb))
+    return (sum_comb - prod_comb) / (mean_comb - prod_comb)
 
 
 def homogeneity_completeness_v_measure(labels_true, labels_pred):

--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -67,7 +67,7 @@ def contingency_matrix(labels_true, labels_pred, eps=None, max_n_classes=5000, s
     max_n_classes : int, optional (default=5000)
         Maximal number of classeses handled for contingency_matrix.
         This help to avoid Memory error with regression target
-        for mutual_information.
+        for mutual_information. If `sparse`, `max_n_classes` is ignored.
 
     sparse: boolean, optional.
         If True, return a sparse continency matrix. If ``eps is not None``,

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,23 +1,21 @@
 import numpy as np
-
-from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.metrics.cluster import homogeneity_score
-from sklearn.metrics.cluster import completeness_score
-from sklearn.metrics.cluster import v_measure_score
-from sklearn.metrics.cluster import homogeneity_completeness_v_measure
-from sklearn.metrics.cluster import adjusted_mutual_info_score
-from sklearn.metrics.cluster import normalized_mutual_info_score
-from sklearn.metrics.cluster import mutual_info_score
-from sklearn.metrics.cluster import expected_mutual_information
-from sklearn.metrics.cluster import contingency_matrix
-from sklearn.metrics.cluster import fowlkes_mallows_score
-from sklearn.metrics.cluster import entropy
-
-from sklearn.utils.testing import assert_raise_message
 from nose.tools import assert_almost_equal
 from nose.tools import assert_equal
 from numpy.testing import assert_array_almost_equal
 
+from sklearn.metrics.cluster import adjusted_mutual_info_score
+from sklearn.metrics.cluster import adjusted_rand_score
+from sklearn.metrics.cluster import completeness_score
+from sklearn.metrics.cluster import contingency_matrix
+from sklearn.metrics.cluster import entropy
+from sklearn.metrics.cluster import expected_mutual_information
+from sklearn.metrics.cluster import fowlkes_mallows_score
+from sklearn.metrics.cluster import homogeneity_completeness_v_measure
+from sklearn.metrics.cluster import homogeneity_score
+from sklearn.metrics.cluster import mutual_info_score
+from sklearn.metrics.cluster import normalized_mutual_info_score
+from sklearn.metrics.cluster import v_measure_score
+from sklearn.utils.testing import assert_raise_message
 
 score_funcs = [
     adjusted_rand_score,
@@ -55,12 +53,14 @@ def test_perfect_matches():
         assert_equal(score_func([0., 1., 2.], [42., 7., 2.]), 1.0)
         assert_equal(score_func([0, 1, 2], [42, 7, 2]), 1.0)
 
+
 def test_homogeneity_completeness_v_measure_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
     h, c, v = homogeneity_completeness_v_measure(labels_a, labels_b)
-    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)
-    assert_array_almost_equal([h, c, v],[h_s, c_s, v_s])
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse=True)
+    assert_array_almost_equal([h, c, v], [h_s, c_s, v_s])
+
 
 """ Takes too long...
 def test_homogeneity_completeness_v_measure_large():
@@ -71,6 +71,7 @@ def test_homogeneity_completeness_v_measure_large():
     h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)    
     assert_raises(MemoryError, homogeneity_completeness_v_measure, labels_a, labels_b)
 """
+
 
 def test_homogeneous_but_not_complete_labeling():
     # homogeneous but not complete clustering
@@ -203,37 +204,60 @@ def test_contingency_matrix_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
     C = contingency_matrix(labels_a, labels_b)
-    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True).toarray()
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse=True).toarray()
     assert_array_almost_equal(C, C_sparse)
-    
+
 
 def test_adjusted_rand_score_sparse():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
-    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True)
-    assert_almost_equal(adjusted_rand_score(labels_a,labels_b), adjusted_rand_score(None, None, C_sparse))
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse=True)
+    assert_almost_equal(adjusted_rand_score(labels_a, labels_b), adjusted_rand_score(None, None, contingency=C_sparse))
 
 
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(np.int):
-        labels_a, labels_b = np.ones(i, dtype=np.int),\
-            np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
-        assert_equal(v_measure_score(labels_a, labels_b), 0.0)
-        assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+        labels_a, labels_b = np.ones(i, dtype=np.int), \
+                             np.arange(i, dtype=np.int)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(v_measure_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b, max_n_classes=1e4), 0.0)
 
 
 def test_v_measure_and_mutual_information(seed=36):
     # Check relation between v_measure, entropy and mutual information
     for i in np.logspace(1, 4, 4).astype(np.int):
         random_state = np.random.RandomState(seed)
-        labels_a, labels_b = random_state.randint(0, 10, i),\
-            random_state.randint(0, 10, i)
+        labels_a, labels_b = random_state.randint(0, 10, i), \
+                             random_state.randint(0, 10, i)
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)
+
+
+def test_max_n_classes():
+    rng = np.random.RandomState(seed=0)
+    labels_true = rng.rand(53)
+    labels_pred = rng.rand(53)
+    labels_zero = np.zeros(53)
+    labels_true[:2] = 0
+    labels_zero[:3] = 1
+    labels_pred[:2] = 0
+    for score_func in score_funcs:
+        expected = ("Too many classes for a clustering metric. If you "
+                    "want to increase the limit, pass parameter "
+                    "max_n_classes to the scoring function")
+        assert_raise_message(ValueError, expected, score_func,
+                             labels_true, labels_pred,
+                             max_n_classes=50)
+        expected = ("Too many clusters for a clustering metric. If you "
+                    "want to increase the limit, pass parameter "
+                    "max_n_classes to the scoring function")
+        assert_raise_message(ValueError, expected, score_func,
+                             labels_zero, labels_pred,
+                             max_n_classes=50)
 
 
 def test_fowlkes_mallows_score():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -55,6 +55,22 @@ def test_perfect_matches():
         assert_equal(score_func([0., 1., 2.], [42., 7., 2.]), 1.0)
         assert_equal(score_func([0, 1, 2], [42, 7, 2]), 1.0)
 
+def test_homogeneity_completeness_v_measure_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    h, c, v = homogeneity_completeness_v_measure(labels_a, labels_b)
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)
+    assert_array_almost_equal([h, c, v],[h_s, c_s, v_s])
+
+""" Takes too long...
+def test_homogeneity_completeness_v_measure_large():
+    # This will fail without sparse matrices with any reasonable amount of RAM (<~1TB)
+    from random import randrange
+    labels_a = [randrange(100000) for x in range(1000000)]
+    labels_b = [randrange(100000) for x in range(1000000)]
+    h_s, c_s, v_s = homogeneity_completeness_v_measure(labels_a, labels_b, sparse = True)    
+    assert_raises(MemoryError, homogeneity_completeness_v_measure, labels_a, labels_b)
+"""
 
 def test_homogeneous_but_not_complete_labeling():
     # homogeneous but not complete clustering
@@ -183,19 +199,30 @@ def test_contingency_matrix():
     assert_array_almost_equal(C, C2 + .1)
 
 
+def test_contingency_matrix_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    C = contingency_matrix(labels_a, labels_b)
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True).toarray()
+    assert_array_almost_equal(C, C_sparse)
+    
+
+def test_adjusted_rand_score_sparse():
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse = True)
+    assert_almost_equal(adjusted_rand_score(labels_a,labels_b), adjusted_rand_score(None, None, C_sparse))
+
+
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(np.int):
         labels_a, labels_b = np.ones(i, dtype=np.int),\
             np.arange(i, dtype=np.int)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b,
-                                                  max_n_classes=1e4), 0.0)
-        assert_equal(v_measure_score(labels_a, labels_b,
-                                     max_n_classes=1e4), 0.0)
-        assert_equal(adjusted_mutual_info_score(labels_a, labels_b,
-                                                max_n_classes=1e4), 0.0)
-        assert_equal(normalized_mutual_info_score(labels_a, labels_b,
-                                                  max_n_classes=1e4), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(v_measure_score(labels_a, labels_b), 0.0)
+        assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)
+        assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
 
 
 def test_v_measure_and_mutual_information(seed=36):
@@ -207,29 +234,6 @@ def test_v_measure_and_mutual_information(seed=36):
         assert_almost_equal(v_measure_score(labels_a, labels_b),
                             2.0 * mutual_info_score(labels_a, labels_b) /
                             (entropy(labels_a) + entropy(labels_b)), 0)
-
-
-def test_max_n_classes():
-    rng = np.random.RandomState(seed=0)
-    labels_true = rng.rand(53)
-    labels_pred = rng.rand(53)
-    labels_zero = np.zeros(53)
-    labels_true[:2] = 0
-    labels_zero[:3] = 1
-    labels_pred[:2] = 0
-    for score_func in score_funcs:
-        expected = ("Too many classes for a clustering metric. If you "
-                    "want to increase the limit, pass parameter "
-                    "max_n_classes to the scoring function")
-        assert_raise_message(ValueError, expected, score_func,
-                             labels_true, labels_pred,
-                             max_n_classes=50)
-        expected = ("Too many clusters for a clustering metric. If you "
-                    "want to increase the limit, pass parameter "
-                    "max_n_classes to the scoring function")
-        assert_raise_message(ValueError, expected, score_func,
-                             labels_zero, labels_pred,
-                             max_n_classes=50)
 
 
 def test_fowlkes_mallows_score():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -139,9 +139,16 @@ def test_adjusted_mutual_info_score():
     # Mutual information
     mi = mutual_info_score(labels_a, labels_b)
     assert_almost_equal(mi, 0.41022, 5)
-    # Expected mutual information
+    # with provided sparse contingency
+    C = contingency_matrix(labels_a, labels_b, sparse=True)
+    mi = mutual_info_score(labels_a, labels_b, contingency=C)
+    assert_almost_equal(mi, 0.41022, 5)
+    # with provided dense contingency
     C = contingency_matrix(labels_a, labels_b)
-    n_samples = np.sum(C)
+    mi = mutual_info_score(labels_a, labels_b, contingency=C)
+    assert_almost_equal(mi, 0.41022, 5)
+    # Expected mutual information
+    n_samples = C.sum()
     emi = expected_mutual_information(C, n_samples)
     assert_almost_equal(emi, 0.15042, 5)
     # Adjusted mutual information

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -187,6 +187,10 @@ def test_contingency_matrix_sparse():
     C = contingency_matrix(labels_a, labels_b)
     C_sparse = contingency_matrix(labels_a, labels_b, sparse=True).toarray()
     assert_array_almost_equal(C, C_sparse)
+    C_sparse = assert_raise_message(ValueError,
+                                    "Cannot set 'eps' when sparse=True",
+                                    contingency_matrix, labels_a, labels_b,
+                                    eps=1e-10, sparse=True)
 
 
 def test_exactly_zero_info_score():

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -203,8 +203,8 @@ def test_contingency_matrix_sparse():
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(np.int):
-        labels_a, labels_b = np.ones(i, dtype=np.int), \
-                             np.arange(i, dtype=np.int)
+        labels_a, labels_b = (np.ones(i, dtype=np.int),
+                              np.arange(i, dtype=np.int))
         assert_equal(normalized_mutual_info_score(labels_a, labels_b), 0.0)
         assert_equal(v_measure_score(labels_a, labels_b), 0.0)
         assert_equal(adjusted_mutual_info_score(labels_a, labels_b), 0.0)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -208,11 +208,15 @@ def test_contingency_matrix_sparse():
     assert_array_almost_equal(C, C_sparse)
 
 
-def test_adjusted_rand_score_sparse():
+def test_sparse_scores():
     labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
     labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
-    C_sparse = contingency_matrix(labels_a, labels_b, sparse=True)
-    assert_almost_equal(adjusted_rand_score(labels_a, labels_b), adjusted_rand_score(None, None, contingency=C_sparse))
+    for metric in [adjusted_rand_score, adjusted_mutual_info_score,
+                   normalized_mutual_info_score,
+                   homogeneity_completeness_v_measure,
+                   fowlkes_mallows_score]:
+        assert_array_almost_equal(metric(labels_a, labels_b),
+                                  metric(labels_a, labels_b, sparse=True))
 
 
 def test_exactly_zero_info_score():


### PR DESCRIPTION
Supersedes #7203. Obviates the need for `max_n_classes`, to some extent and removes it as unreleased API (introduced in #5445 to fix #4976).

A sparse contingency matrix should handle the common case with a large number of clusters that overlap among them is sparse; where there are few clusters we suffer a penalty for using a sparse contingency matrix, but this penalty is small in absolute term.

The change is being benchmarked on my [`sparse_cluster_contingency_option`](https://github.com/scikit-learn/scikit-learn/compare/master...jnothman:sparse_cluster_contingency_option?expand=1) branch, performing multiple segmentations of an image into different numbers of clusters, then timing the evaluation of metrics for different contingency matrix shapes. Benchmarks will be posted shortly.
