### PR TITLE
[MRG + 1] use == instead of 'is' for string comparison

### DIFF
--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -279,7 +279,7 @@ def test_set_get_params():
         index = 0
         params = kernel.get_params()
         for hyperparameter in kernel.hyperparameters:
-            if hyperparameter.bounds is "fixed":
+            if hyperparameter.bounds == "fixed":
                 continue
             size = hyperparameter.n_elements
             if size > 1:  # anisotropic kernels
@@ -294,7 +294,7 @@ def test_set_get_params():
         index = 0
         value = 10  # arbitrary value
         for hyperparameter in kernel.hyperparameters:
-            if hyperparameter.bounds is "fixed":
+            if hyperparameter.bounds == "fixed":
                 continue
             size = hyperparameter.n_elements
             if size > 1:  # anisotropic kernels

--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -120,7 +120,7 @@ def _check_precisions(precisions, covariance_type, n_components, n_features):
     """
     precisions = check_array(precisions, dtype=[np.float64, np.float32],
                              ensure_2d=False,
-                             allow_nd=covariance_type is 'full')
+                             allow_nd=covariance_type == 'full')
 
     precisions_shape = {'full': (n_components, n_features, n_features),
                         'tied': (n_features, n_features),
@@ -321,7 +321,7 @@ def _compute_precision_cholesky(covariances, covariance_type):
             precisions_chol[k] = linalg.solve_triangular(cov_chol,
                                                          np.eye(n_features),
                                                          lower=True).T
-    elif covariance_type is 'tied':
+    elif covariance_type == 'tied':
         _, n_features = covariances.shape
         try:
             cov_chol = linalg.cholesky(covariances, lower=True)
@@ -633,11 +633,11 @@ class GaussianMixture(BaseMixture):
             self.covariances_ = covariances
             self.precisions_cholesky_ = _compute_precision_cholesky(
                 covariances, self.covariance_type)
-        elif self.covariance_type is 'full':
+        elif self.covariance_type == 'full':
             self.precisions_cholesky_ = np.array(
                 [linalg.cholesky(prec_init, lower=True)
                  for prec_init in self.precisions_init])
-        elif self.covariance_type is 'tied':
+        elif self.covariance_type == 'tied':
             self.precisions_cholesky_ = linalg.cholesky(self.precisions_init,
                                                         lower=True)
         else:
@@ -686,12 +686,12 @@ class GaussianMixture(BaseMixture):
         # Attributes computation
         _, n_features = self.means_.shape
 
-        if self.covariance_type is 'full':
+        if self.covariance_type == 'full':
             self.precisions_ = np.empty(self.precisions_cholesky_.shape)
             for k, prec_chol in enumerate(self.precisions_cholesky_):
                 self.precisions_[k] = np.dot(prec_chol, prec_chol.T)
 
-        elif self.covariance_type is 'tied':
+        elif self.covariance_type == 'tied':
             self.precisions_ = np.dot(self.precisions_cholesky_,
                                       self.precisions_cholesky_.T)
         else:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -894,7 +894,7 @@ def check_clustering(name, Alg):
     pred = alg.labels_
     assert_greater(adjusted_rand_score(pred, y), 0.4)
     # fit another time with ``fit_predict`` and compare results
-    if name is 'SpectralClustering':
+    if name == 'SpectralClustering':
         # there is no way to make Spectral clustering deterministic :(
         return
     set_random_state(alg)


### PR DESCRIPTION
More issues like https://github.com/scikit-learn/scikit-learn/commit/d9bd30e2f78dbae9ec131dee0c19f04061dc0ca8 are fixed. I grepped for `is '` and `is "`.
