### PR TITLE
[MRG + 1] fixed comment in 20newsgroups example

### DIFF
--- a/examples/text/document_classification_20newsgroups.py
+++ b/examples/text/document_classification_20newsgroups.py
@@ -122,7 +122,8 @@ data_test = fetch_20newsgroups(subset='test', categories=categories,
                                remove=remove)
 print('data loaded')
 
-categories = data_train.target_names    # for case categories == None
+# order of labels in `target_names` can be different from `categories`
+target_names = data_train.target_names
 
 
 def size_mb(docs):
@@ -218,16 +219,15 @@ def benchmark(clf):
 
         if opts.print_top10 and feature_names is not None:
             print("top 10 keywords per class:")
-            for i, category in enumerate(categories):
+            for i, label in enumerate(target_names):
                 top10 = np.argsort(clf.coef_[i])[-10:]
-                print(trim("%s: %s"
-                      % (category, " ".join(feature_names[top10]))))
+                print(trim("%s: %s" % (label, " ".join(feature_names[top10]))))
         print()
 
     if opts.print_report:
         print("classification report:")
         print(metrics.classification_report(y_test, pred,
-                                            target_names=categories))
+                                            target_names=target_names))
 
     if opts.print_cm:
         print("confusion matrix:")


### PR DESCRIPTION
Here:

``` py
data_train = fetch_20newsgroups(subset='train', categories=categories,
                                shuffle=True, random_state=42,
                                remove=remove)
```

`data_train.target_names` must be used as category names even if categories is not None because the order can be different from `categories` order. 
