### PR TITLE
[MRG] Allow the `scorer` callable to return any object

### DIFF
--- a/sklearn/cross_validation.py
+++ b/sklearn/cross_validation.py
@@ -1694,9 +1694,6 @@ def _score(estimator, X_test, y_test, scorer):
         except ValueError:
             # non-scalar?
             pass
-    if not isinstance(score, numbers.Number):
-        raise ValueError("scoring must return a number, got %s (%s) instead."
-                         % (str(score), type(score)))
     return score
 
 


### PR DESCRIPTION
This `_score` function is (indirectly) a helper only for the `cross_val_score` function. I posit that we should allow the `scorer` argument (a callable) to return any object for these reasons:
1. It is safe to do so. The objects returned by the `scorer` callable are only collected into an ndarray. Easy squeezy.
2. When a user-defined `scorer` is passed-in, this allows for very flexible behavior. E.g. I have a scorer which returns a tuple of several metrics I want to track. This change allows me to actually use my scorer! I've tested it and it works great!

Please consider. Thank you all for such a great library.
