### PR TITLE
[MRG] Add species distribution dataset to classes.rst

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -259,6 +259,7 @@ Loaders
    datasets.load_mlcomp
    datasets.load_sample_image
    datasets.load_sample_images
+   datasets.fetch_species_distributions
    datasets.load_svmlight_file
    datasets.load_svmlight_files
    datasets.dump_svmlight_file


### PR DESCRIPTION
#### Reference Issue

None
#### What does this implement/fix? Explain your changes.

While working on #7429 I saw that the `species_distribution` dataset is not in `classes.rst`. This fixes that.
