### PR TITLE
[MRG + 1] fix test_20news_vectorized

### DIFF
--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -58,7 +58,11 @@ def test_20news_length_consistency():
 
 def test_20news_vectorized():
     # This test is slow.
-    raise SkipTest("Test too slow.")
+    try:
+        data = datasets.fetch_20newsgroups(
+            subset='all', download_if_missing=False, shuffle=False)
+    except IOError:
+        raise SkipTest("Download 20 newsgroups to run this test")
 
     bunch = datasets.fetch_20newsgroups_vectorized(subset="train")
     assert_true(sp.isspmatrix_csr(bunch.data))

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -59,24 +59,27 @@ def test_20news_length_consistency():
 def test_20news_vectorized():
     # This test is slow.
     try:
-        data = datasets.fetch_20newsgroups(
-            subset='all', download_if_missing=False, shuffle=False)
+        data = datasets.fetch_20newsgroups(subset='all',
+                                           download_if_missing=False)
     except IOError:
         raise SkipTest("Download 20 newsgroups to run this test")
 
+    # test subset = train
     bunch = datasets.fetch_20newsgroups_vectorized(subset="train")
     assert_true(sp.isspmatrix_csr(bunch.data))
     assert_equal(bunch.data.shape, (11314, 130107))
     assert_equal(bunch.target.shape[0], 11314)
     assert_equal(bunch.data.dtype, np.float64)
 
+    # test subset = test
     bunch = datasets.fetch_20newsgroups_vectorized(subset="test")
     assert_true(sp.isspmatrix_csr(bunch.data))
     assert_equal(bunch.data.shape, (7532, 130107))
     assert_equal(bunch.target.shape[0], 7532)
     assert_equal(bunch.data.dtype, np.float64)
 
-    bunch = datasets.fetch_20newsgroups_vectorized(subset="all")
+    # test subset = all
+    bunch = data
     assert_true(sp.isspmatrix_csr(bunch.data))
     assert_equal(bunch.data.shape, (11314 + 7532, 130107))
     assert_equal(bunch.target.shape[0], 11314 + 7532)

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -58,8 +58,8 @@ def test_20news_length_consistency():
 
 def test_20news_vectorized():
     try:
-        data = datasets.fetch_20newsgroups(subset='all',
-                                           download_if_missing=False)
+        datasets.fetch_20newsgroups(subset='all',
+                                    download_if_missing=False)
     except IOError:
         raise SkipTest("Download 20 newsgroups to run this test")
 
@@ -78,8 +78,9 @@ def test_20news_vectorized():
     assert_equal(bunch.data.dtype, np.float64)
 
     # test subset = all
-    bunch = data
+    bunch = datasets.fetch_20newsgroups_vectorized(subset='all')
     assert_true(sp.isspmatrix_csr(bunch.data))
     assert_equal(bunch.data.shape, (11314 + 7532, 130107))
     assert_equal(bunch.target.shape[0], 11314 + 7532)
     assert_equal(bunch.data.dtype, np.float64)
+-

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -83,4 +83,3 @@ def test_20news_vectorized():
     assert_equal(bunch.data.shape, (11314 + 7532, 130107))
     assert_equal(bunch.target.shape[0], 11314 + 7532)
     assert_equal(bunch.data.dtype, np.float64)
-

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -83,4 +83,4 @@ def test_20news_vectorized():
     assert_equal(bunch.data.shape, (11314 + 7532, 130107))
     assert_equal(bunch.target.shape[0], 11314 + 7532)
     assert_equal(bunch.data.dtype, np.float64)
--
+

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -62,18 +62,18 @@ def test_20news_vectorized():
 
     bunch = datasets.fetch_20newsgroups_vectorized(subset="train")
     assert_true(sp.isspmatrix_csr(bunch.data))
-    assert_equal(bunch.data.shape, (11314, 107428))
+    assert_equal(bunch.data.shape, (11314, 130107))
     assert_equal(bunch.target.shape[0], 11314)
     assert_equal(bunch.data.dtype, np.float64)
 
     bunch = datasets.fetch_20newsgroups_vectorized(subset="test")
     assert_true(sp.isspmatrix_csr(bunch.data))
-    assert_equal(bunch.data.shape, (7532, 107428))
+    assert_equal(bunch.data.shape, (7532, 130107))
     assert_equal(bunch.target.shape[0], 7532)
     assert_equal(bunch.data.dtype, np.float64)
 
     bunch = datasets.fetch_20newsgroups_vectorized(subset="all")
     assert_true(sp.isspmatrix_csr(bunch.data))
-    assert_equal(bunch.data.shape, (11314 + 7532, 107428))
+    assert_equal(bunch.data.shape, (11314 + 7532, 130107))
     assert_equal(bunch.target.shape[0], 11314 + 7532)
     assert_equal(bunch.data.dtype, np.float64)

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -57,7 +57,6 @@ def test_20news_length_consistency():
 
 
 def test_20news_vectorized():
-    # This test is slow.
     try:
         data = datasets.fetch_20newsgroups(subset='all',
                                            download_if_missing=False)


### PR DESCRIPTION
#### Reference Issue

None
#### What does this implement/fix? Explain your changes.

Was mucking around in the test cases for `20newsgroups` and noticed that this test (which is not run due to being too slow) was failing on latest master. Maybe something changed in the vectorization that caused the number of features to change?

Alternatively, if we don't want to maintain something like this, perhaps we should remove the test?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7431)

<!-- Reviewable:end -->
