### PR TITLE
[MRG+1] DOC: update persistence documentation with Joblib new behavior

### DIFF
--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -52,7 +52,7 @@ with::
 .. note::
 
    ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
-   instead of filenames, more information on persistence in Joblib is
+   instead of filenames. More information on data persistence with Joblib is
    available `here <https://pythonhosted.org/joblib/persistence.html>`_.
 
 .. _persistence_limitations:

--- a/doc/modules/model_persistence.rst
+++ b/doc/modules/model_persistence.rst
@@ -51,10 +51,9 @@ with::
 
 .. note::
 
-   joblib.dump returns a list of filenames. Each individual numpy array
-   contained in the ``clf`` object is serialized as a separate file on the
-   filesystem. All files are required in the same folder when reloading the
-   model with joblib.load.
+   ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
+   instead of filenames, more information on persistence in Joblib is
+   available `here <https://pythonhosted.org/joblib/persistence.html>`_.
 
 .. _persistence_limitations:
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -244,7 +244,7 @@ with::
 .. note::
 
     ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
-    instead of filenames, more information on persistence in Joblib is
+    instead of filenames. More information on data persistence with Joblib is
     available `here <https://pythonhosted.org/joblib/persistence.html>`_.
 
 Note that pickle has some security and maintainability issues. Please refer to

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -243,10 +243,9 @@ with::
 
 .. note::
 
-   joblib.dump returns a list of filenames. Each individual numpy array
-   contained in the ``clf`` object is serialized as a separate file on the
-   filesystem. All files are required in the same folder when reloading the
-   model with joblib.load.
+    ``joblib.dump`` and ``joblib.load`` functions also accept file-like object
+    instead of filenames, more information on persistence in Joblib is
+    available `here <https://pythonhosted.org/joblib/persistence.html>`_.
 
 Note that pickle has some security and maintainability issues. Please refer to
 section :ref:`model_persistence` for more detailed information about model


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
#### What does this implement/fix? Explain your changes.

Scikit-Learn recently switched to Joblib 0.10 where the persistence behavior changed slightly. I just replaced the text in the note mentioning all pickled numpy objects should be in the same folder (which is now wrong as they are all in the same file) by another one mentioning the possibility to use file-like objects instead of file names.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
