### PR TITLE
[MRG+1] Fix regression in silhouette_score for clusters of size 1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -467,9 +467,9 @@ Bug fixes
       (`#7350 <https://github.com/scikit-learn/scikit-learn/pull/7350/>`_)
       By `Russell Smith`_.
 
-    - Fix regression in :func:`metrics.silhouette_score` in which clusters of
-      size 1 were incorrectly scored. By `Ramana Subramanyam
-      <https://github.com/Sentient07>`_.
+    - Fix bug in :func:`metrics.silhouette_score` in which clusters of
+      size 1 were incorrectly scored. They should get a score of 0.
+      By `Joel Nothman`_.
 
 
 API changes summary

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -471,6 +471,10 @@ Bug fixes
       size 1 were incorrectly scored. They should get a score of 0.
       By `Joel Nothman`_.
 
+    - Fix bug in :func:`metrics.silhouette_samples` so that it now works with
+      arbitrary labels, not just those ranging from 0 to n_clusters - 1.
+      By `Joel Nothman`_.
+
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -467,6 +467,10 @@ Bug fixes
       (`#7350 <https://github.com/scikit-learn/scikit-learn/pull/7350/>`_)
       By `Russell Smith`_.
 
+    - Fix regression in :func:`metrics.silhouette_score` in which clusters of
+      size 1 were incorrectly scored. By `Ramana Subramanyam
+      <https://github.com/Sentient07>`_.
+
 
 API changes summary
 -------------------

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -58,11 +58,10 @@ def test_silhouette():
             assert_almost_equal(score_euclidean, score_dense_with_sampling)
 
 
-def test_no_nan():
+def test_cluster_size_1():
     # Assert Silhouette Coefficient != nan when there is 1 sample in a class.
-    # This tests for the condition that caused issue 960.
-    # Note that there is only one sample in cluster 0. This used to cause the
-    # silhouette_score to return nan (see bug #960).
+    # The original silhouette paper suggests that while arbitrary,
+    # single-sample clusters should receive a score of 0.
     labels = np.array([1, 0, 1, 1, 1])
     # The distance matrix doesn't actually matter.
     D = np.random.RandomState(0).rand(len(labels), len(labels))
@@ -70,6 +69,7 @@ def test_no_nan():
     assert_false(np.isnan(silhouette))
     ss = silhouette_samples(D, labels, metric='precomputed')
     assert_false(np.isnan(ss).any())
+    assert_equal(ss[1], 0.)
 
 
 def test_correct_labelsize():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -14,7 +14,6 @@ from sklearn.metrics.cluster import silhouette_score
 from sklearn.metrics.cluster import silhouette_samples
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.cluster import calinski_harabaz_score
-from sklearn.metrics import pairwise_distances
 
 
 def test_silhouette():
@@ -68,11 +67,11 @@ def test_cluster_size_1():
     X = [[0.], [1.], [1.], [2.], [3.], [3.]]
     labels = np.array([0, 1, 1, 1, 2, 2])
 
-    # Cluster 1: 1 sample -> score of 0 by Rousseeuw's convention
-    # Cluster 2: intra-cluster = [.5, .5, 1]
+    # Cluster 0: 1 sample -> score of 0 by Rousseeuw's convention
+    # Cluster 1: intra-cluster = [.5, .5, 1]
     #            inter-cluster = [1, 1, 1]
     #            silhouette    = [.5, .5, 0]
-    # Cluster 3: intra-cluster = [0, 0]
+    # Cluster 2: intra-cluster = [0, 0]
     #            inter-cluster = [arbitrary, arbitrary]
     #            silhouette    = [1., 1.]
 
@@ -107,7 +106,9 @@ def test_non_encoded_labels():
     X = dataset.data
     labels = dataset.target
     assert_equal(
-        silhouette_score(X, labels + 10), silhouette_score(X, labels))
+        silhouette_score(X, labels * 2 + 10), silhouette_score(X, labels))
+    assert_array_equal(
+        silhouette_samples(X, labels * 2 + 10), silhouette_samples(X, labels))
 
 
 def test_non_numpy_labels():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -10,6 +10,8 @@ from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_greater
 from sklearn.metrics.cluster import silhouette_score
+from sklearn.metrics.cluster import silhouette_samples
+from sklearn.metrics import pairwise_distances
 from sklearn.metrics.cluster import calinski_harabaz_score
 from sklearn.metrics import pairwise_distances
 
@@ -66,6 +68,8 @@ def test_no_nan():
     D = np.random.RandomState(0).rand(len(labels), len(labels))
     silhouette = silhouette_score(D, labels, metric='precomputed')
     assert_false(np.isnan(silhouette))
+    ss = silhouette_samples(D, labels, metric='precomputed')
+    assert_false(np.isnan(ss).any())
 
 
 def test_correct_labelsize():

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -89,15 +89,8 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
            <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
-    X, labels = check_X_y(X, labels, accept_sparse=['csc', 'csr'])
-    le = LabelEncoder()
-    labels = le.fit_transform(labels)
-    n_labels = len(le.classes_)
-    n_samples = X.shape[0]
-
-    check_number_of_labels(n_labels, n_samples)
-
     if sample_size is not None:
+        X, labels = check_X_y(X, labels, accept_sparse=['csc', 'csr'])
         random_state = check_random_state(random_state)
         indices = random_state.permutation(X.shape[0])[:sample_size]
         if metric == "precomputed":
@@ -167,8 +160,10 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
        <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
 
     """
+    X, labels = check_X_y(X, labels, accept_sparse=['csc', 'csr'])
     le = LabelEncoder()
     labels = le.fit_transform(labels)
+    check_number_of_labels(len(le.classes_), X.shape[0])
 
     distances = pairwise_distances(X, metric=metric, **kwds)
     unique_labels = le.classes_
@@ -176,11 +171,11 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     # For sample i, store the mean distance of the cluster to which
     # it belongs in intra_clust_dists[i]
-    intra_clust_dists = np.ones(distances.shape[0], dtype=distances.dtype)
+    intra_clust_dists = np.zeros(distances.shape[0], dtype=distances.dtype)
 
     # For sample i, store the mean distance of the second closest
     # cluster in inter_clust_dists[i]
-    inter_clust_dists = np.inf * intra_clust_dists
+    inter_clust_dists = np.inf + intra_clust_dists
 
     for curr_label in range(len(unique_labels)):
 
@@ -194,8 +189,6 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
         if n_samples_curr_lab != 0:
             intra_clust_dists[mask] = np.sum(
                 current_distances[:, mask], axis=1) / n_samples_curr_lab
-        else:
-            intra_clust_dists[mask] = 0
 
         # Now iterate over all other labels, finding the mean
         # cluster distance that is closest to every sample.

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -205,7 +205,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     sil_samples = inter_clust_dists - intra_clust_dists
     sil_samples /= np.maximum(intra_clust_dists, inter_clust_dists)
-    return sil_samples
+    # nan values are for clusters of size 1, and should be 0
+    return np.nan_to_num(sil_samples)
 
 
 def calinski_harabaz_score(X, labels):

--- a/sklearn/metrics/cluster/unsupervised.py
+++ b/sklearn/metrics/cluster/unsupervised.py
@@ -204,7 +204,8 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
                     inter_clust_dists[mask], other_distances)
 
     sil_samples = inter_clust_dists - intra_clust_dists
-    sil_samples /= np.maximum(intra_clust_dists, inter_clust_dists)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sil_samples /= np.maximum(intra_clust_dists, inter_clust_dists)
     # nan values are for clusters of size 1, and should be 0
     return np.nan_to_num(sil_samples)
 


### PR DESCRIPTION
fixes the regression described in #5988. #6089, and the initial patch here, were incorrect. ~~Replaces #6089. This is #6089 rebased with an error context manager.~~
