### PR TITLE
Simple estimator_check defensive fix

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -678,7 +678,7 @@ def check_fit_score_takes_y(name, Estimator):
         if func is not None:
             func(X, y)
             args = [p.name for p in signature(func).parameters.values()]
-            assert_true(args[1] in ["y", "Y"],
+            assert_true(len(args) > 1 and args[1] in ["y", "Y"],
                         "Expected y or Y as second argument for method "
                         "%s of %s. Got arguments: %r."
                         % (func_name, Estimator.__name__, args))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In `estimator_checks.check_estimator`, adds a check to ensure that there exists >1 parameter in the user's `fit`(/adjacent) functions before trying to get the name of the second parameter.
#### Any other comments?

I know there is a lot of work going on around `check_estimator`, but this seems to be a straightforward fix.
