### PR TITLE
Make sklearn scorers tolerant of generators.

### DIFF
--- a/sklearn/metrics/scorer.py
+++ b/sklearn/metrics/scorer.py
@@ -19,6 +19,7 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 # License: Simplified BSD
 
 from abc import ABCMeta, abstractmethod
+import collections
 import warnings
 
 import numpy as np
@@ -29,6 +30,7 @@ from . import (r2_score, median_absolute_error, mean_absolute_error,
                precision_score, recall_score, log_loss)
 from .cluster import adjusted_rand_score
 from ..utils.multiclass import type_of_target
+from ..utils.validation import _is_arraylike
 from ..externals import six
 from ..base import is_regressor
 
@@ -89,6 +91,10 @@ class _PredictScorer(_BaseScorer):
         super(_PredictScorer, self).__call__(estimator, X, y_true,
                                              sample_weight=sample_weight)
         y_pred = estimator.predict(X)
+        if not _is_arraylike(y_pred) and isinstance(y_pred,
+                                                    collections.Iterable):
+            y_pred = np.array(list(y_pred))
+
         if sample_weight is not None:
             return self._sign * self._score_func(y_true, y_pred,
                                                  sample_weight=sample_weight,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Makes sklearn metrics accept generators return from Estimators' predict() method. Estimators in tf.learn will soon default to returning generators from predict() and this change is meant to retain compatibility.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Calling .predict() on a tf.learn Estimator will soon default to returning a
generator instead of a numpy array.
