### PR TITLE
  Provided a fix for issue #7140 - Minor discrepancy in hashing feature

### DIFF
--- a/examples/ensemble/plot_random_forest_embedding.py
+++ b/examples/ensemble/plot_random_forest_embedding.py
@@ -15,7 +15,7 @@ non-linear dimensionality reduction or non-linear classification.
 Points that are neighboring often share the same leaf of a tree and therefore
 share large parts of their hashed representation. This allows to
 separate two concentric circles simply based on the principal components of the
-transformed data.
+transformed data with truncated SVD.
 
 In high-dimensional spaces, linear classifiers often achieve
 excellent accuracy. For sparse binary data, BernoulliNB
@@ -39,9 +39,9 @@ X, y = make_circles(factor=0.5, random_state=0, noise=0.05)
 hasher = RandomTreesEmbedding(n_estimators=10, random_state=0, max_depth=3)
 X_transformed = hasher.fit_transform(X)
 
-# Visualize result using PCA
-pca = TruncatedSVD(n_components=2)
-X_reduced = pca.fit_transform(X_transformed)
+# Visualize result after dimensionality reduction using truncated SVD
+svd = TruncatedSVD(n_components=2)
+X_reduced = svd.fit_transform(X_transformed)
 
 # Learn a Naive Bayes classifier on the transformed data
 nb = BernoulliNB()
@@ -64,7 +64,7 @@ ax.set_yticks(())
 
 ax = plt.subplot(222)
 ax.scatter(X_reduced[:, 0], X_reduced[:, 1], c=y, s=50)
-ax.set_title("PCA reduction (2d) of transformed data (%dd)" %
+ax.set_title("Truncated SVD reduction (2d) of transformed data (%dd)" %
              X_transformed.shape[1])
 ax.set_xticks(())
 ax.set_yticks(())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue #7140
#### What does this implement/fix? Explain your changes.

Fixes small documentation discrepancy reported as issue #7140. Changes made to the /examples/ensemble/plot_random_forest_embedding.py. The made changes are to reflect that the example uses truncated SVD rather than PCA. The 2nd graph now has a new title, which may be a little long.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

  transformation example.
