### PR TITLE
[MRG+1] DOC: Tidy up mds module documentation.

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -764,6 +764,7 @@ Kernels:
 
     manifold.locally_linear_embedding
     manifold.spectral_embedding
+    manifold.smacof
 
 
 .. _metrics_ref:

--- a/sklearn/manifold/__init__.py
+++ b/sklearn/manifold/__init__.py
@@ -4,9 +4,9 @@ The :mod:`sklearn.manifold` module implements data embedding techniques.
 
 from .locally_linear import locally_linear_embedding, LocallyLinearEmbedding
 from .isomap import Isomap
-from .mds import MDS
+from .mds import MDS, smacof
 from .spectral_embedding_ import SpectralEmbedding, spectral_embedding
 from .t_sne import TSNE
 
 __all__ = ['locally_linear_embedding', 'LocallyLinearEmbedding', 'Isomap',
-           'MDS', 'SpectralEmbedding', 'spectral_embedding', "TSNE"]
+           'MDS', 'smacof', 'SpectralEmbedding', 'spectral_embedding', "TSNE"]

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -36,7 +36,7 @@ def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
         ``init`` is used to determine the dimensionality of the embedding
         space.
 
-    init : ndarray, shape (n_samples, n_components), optional
+    init : ndarray, shape (n_samples, n_components), optional, default: None
         Starting configuration of the embedding to initialize the algorithm. By
         default, the algorithm is initialized with a randomly chosen array.
 
@@ -168,7 +168,7 @@ def smacof(dissimilarities, metric=True, n_components=2, init=None, n_init=8,
         ``init`` is used to determine the dimensionality of the embedding
         space.
 
-    init : ndarray, shape (n_samples, n_components), optional
+    init : ndarray, shape (n_samples, n_components), optional, default: None
         Starting configuration of the embedding to initialize the algorithm. By
         default, the algorithm is initialized with a randomly chosen array.
 
@@ -198,10 +198,10 @@ def smacof(dissimilarities, metric=True, n_components=2, init=None, n_init=8,
         Relative tolerance with respect to stress at which to declare
         convergence.
 
-    random_state : integer or numpy.RandomState, optional
-        The generator used to initialize the centers. If an integer is
-        given, it fixes the seed. Defaults to the global numpy random
-        number generator.
+    random_state : integer or numpy.RandomState, optional, default: None
+        The generator used to initialize the centers. If an integer is given,
+        it fixes the seed. Defaults to the global numpy random number
+        generator.
 
     return_n_iter : bool, optional, default: False
         Whether or not to return the number of iterations.
@@ -314,10 +314,10 @@ class MDS(BaseEstimator):
         (``n_cpus + 1 + n_jobs``) are used. Thus for ``n_jobs = -2``, all CPUs
         but one are used.
 
-    random_state : integer or numpy.RandomState, optional
-        The generator used to initialize the centers. If an integer is
-        given, it fixes the seed. Defaults to the global numpy random
-        number generator.
+    random_state : integer or numpy.RandomState, optional, default: None
+        The generator used to initialize the centers. If an integer is given,
+        it fixes the seed. Defaults to the global numpy random number
+        generator.
 
     dissimilarity : 'euclidean' | 'precomputed', optional, default: 'euclidean'
         Dissimilarity measure to use:
@@ -378,7 +378,7 @@ class MDS(BaseEstimator):
             Input data. If ``dissimilarity=='precomputed'``, the input should
             be the dissimilarity matrix.
 
-        init : ndarray, shape (n_samples,), optional
+        init : ndarray, shape (n_samples,), optional, default: None
             Starting configuration of the embedding to initialize the SMACOF
             algorithm. By default, the algorithm is initialized with a randomly
             chosen array.
@@ -396,7 +396,7 @@ class MDS(BaseEstimator):
             Input data. If ``dissimilarity=='precomputed'``, the input should
             be the dissimilarity matrix.
 
-        init : ndarray, shape (n_samples,), optional
+        init : ndarray, shape (n_samples,), optional, default: None
             Starting configuration of the embedding to initialize the SMACOF
             algorithm. By default, the algorithm is initialized with a randomly
             chosen array.

--- a/sklearn/manifold/mds.py
+++ b/sklearn/manifold/mds.py
@@ -17,60 +17,62 @@ from ..externals.joblib import delayed
 from ..isotonic import IsotonicRegression
 
 
-def _smacof_single(similarities, metric=True, n_components=2, init=None,
+def _smacof_single(dissimilarities, metric=True, n_components=2, init=None,
                    max_iter=300, verbose=0, eps=1e-3, random_state=None):
     """
     Computes multidimensional scaling using SMACOF algorithm
 
     Parameters
     ----------
-    similarities: symmetric ndarray, shape [n * n]
-        similarities between the points
+    dissimilarities : ndarray, shape (n_samples, n_samples)
+        Pairwise dissimilarities between the points. Must be symmetric.
 
-    metric: boolean, optional, default: True
-        compute metric or nonmetric SMACOF algorithm
+    metric : boolean, optional, default: True
+        Compute metric or nonmetric SMACOF algorithm.
 
-    n_components: int, optional, default: 2
-        number of dimension in which to immerse the similarities
-        overwritten if initial array is provided.
+    n_components : int, optional, default: 2
+        Number of dimensions in which to immerse the dissimilarities. If an
+        ``init`` array is provided, this option is overridden and the shape of
+        ``init`` is used to determine the dimensionality of the embedding
+        space.
 
-    init: {None or ndarray}, optional
-        if None, randomly chooses the initial configuration
-        if ndarray, initialize the SMACOF algorithm with this array
+    init : ndarray, shape (n_samples, n_components), optional
+        Starting configuration of the embedding to initialize the algorithm. By
+        default, the algorithm is initialized with a randomly chosen array.
 
-    max_iter: int, optional, default: 300
-        Maximum number of iterations of the SMACOF algorithm for a single run
+    max_iter : int, optional, default: 300
+        Maximum number of iterations of the SMACOF algorithm for a single run.
 
-    verbose: int, optional, default: 0
-        level of verbosity
+    verbose : int, optional, default: 0
+        Level of verbosity.
 
-    eps: float, optional, default: 1e-6
-        relative tolerance w.r.t stress to declare converge
+    eps : float, optional, default: 1e-3
+        Relative tolerance with respect to stress at which to declare
+        convergence.
 
-    random_state: integer or numpy.RandomState, optional
+    random_state : integer or numpy.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
     Returns
     -------
-    X: ndarray (n_samples, n_components), float
-               coordinates of the n_samples points in a n_components-space
+    X : ndarray, shape (n_samples, n_components)
+        Coordinates of the points in a ``n_components``-space.
 
-    stress_: float
+    stress : float
         The final value of the stress (sum of squared distance of the
-        disparities and the distances for all constrained points)
+        disparities and the distances for all constrained points).
 
     n_iter : int
-        Number of iterations run.
-
+        The number of iterations corresponding to the best stress.
     """
-    similarities = check_symmetric(similarities, raise_exception=True)
+    dissimilarities = check_symmetric(dissimilarities, raise_exception=True)
 
-    n_samples = similarities.shape[0]
+    n_samples = dissimilarities.shape[0]
     random_state = check_random_state(random_state)
 
-    sim_flat = ((1 - np.tri(n_samples)) * similarities).ravel()
+    sim_flat = ((1 - np.tri(n_samples)) * dissimilarities).ravel()
     sim_flat_w = sim_flat[sim_flat != 0]
     if init is None:
         # Randomly choose initial configuration
@@ -91,10 +93,10 @@ def _smacof_single(similarities, metric=True, n_components=2, init=None,
         dis = euclidean_distances(X)
 
         if metric:
-            disparities = similarities
+            disparities = dissimilarities
         else:
             dis_flat = dis.ravel()
-            # similarities with 0 are considered as missing values
+            # dissimilarities with 0 are considered as missing values
             dis_flat_w = dis_flat[sim_flat != 0]
 
             # Compute the disparities using a monotonic regression
@@ -129,18 +131,18 @@ def _smacof_single(similarities, metric=True, n_components=2, init=None,
     return X, stress, it + 1
 
 
-def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
+def smacof(dissimilarities, metric=True, n_components=2, init=None, n_init=8,
            n_jobs=1, max_iter=300, verbose=0, eps=1e-3, random_state=None,
            return_n_iter=False):
     """
-    Computes multidimensional scaling using SMACOF (Scaling by Majorizing a
-    Complicated Function) algorithm
+    Computes multidimensional scaling using the SMACOF algorithm.
 
-    The SMACOF algorithm is a multidimensional scaling algorithm: it minimizes
-    a objective function, the *stress*, using a majorization technique. The
-    Stress Majorization, also known as the Guttman Transform, guarantees a
-    monotone convergence of Stress, and is more powerful than traditional
-    techniques such as gradient descent.
+    The SMACOF (Scaling by MAjorizing a COmplicated Function) algorithm is a
+    multidimensional scaling algorithm which minimizes an objective function
+    (the *stress*) using a majorization technique. Stress majorization, also
+    known as the Guttman Transform, guarantees a monotone convergence of
+    stress, and is more powerful than traditional techniques such as gradient
+    descent.
 
     The SMACOF algorithm for metric MDS can summarized by the following steps:
 
@@ -149,70 +151,73 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
     3. Compute the Guttman Transform
     4. Iterate 2 and 3 until convergence.
 
-    The nonmetric algorithm adds a monotonic regression steps before computing
+    The nonmetric algorithm adds a monotonic regression step before computing
     the stress.
 
     Parameters
     ----------
-    similarities : symmetric ndarray, shape (n_samples, n_samples)
-        similarities between the points
+    dissimilarities : ndarray, shape (n_samples, n_samples)
+        Pairwise dissimilarities between the points. Must be symmetric.
 
     metric : boolean, optional, default: True
-        compute metric or nonmetric SMACOF algorithm
+        Compute metric or nonmetric SMACOF algorithm.
 
     n_components : int, optional, default: 2
-        number of dimension in which to immerse the similarities
-        overridden if initial array is provided.
+        Number of dimensions in which to immerse the dissimilarities. If an
+        ``init`` array is provided, this option is overridden and the shape of
+        ``init`` is used to determine the dimensionality of the embedding
+        space.
 
-    init : {None or ndarray of shape (n_samples, n_components)}, optional
-        if None, randomly chooses the initial configuration
-        if ndarray, initialize the SMACOF algorithm with this array
+    init : ndarray, shape (n_samples, n_components), optional
+        Starting configuration of the embedding to initialize the algorithm. By
+        default, the algorithm is initialized with a randomly chosen array.
 
     n_init : int, optional, default: 8
-        Number of time the smacof algorithm will be run with different
-        initialisation. The final results will be the best output of the
-        n_init consecutive runs in terms of stress.
+        Number of times the SMACOF algorithm will be run with different
+        initializations. The final results will be the best output of the runs,
+        determined by the run with the smallest final stress. If ``init`` is
+        provided, this option is overridden and a single run is performed.
 
     n_jobs : int, optional, default: 1
-
-        The number of jobs to use for the computation. This works by breaking
-        down the pairwise matrix into n_jobs even slices and computing them in
-        parallel.
+        The number of jobs to use for the computation. If multiple
+        initializations are used (``n_init``), each run of the algorithm is
+        computed in parallel.
 
         If -1 all CPUs are used. If 1 is given, no parallel computing code is
-        used at all, which is useful for debugging. For n_jobs below -1,
-        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
-        are used.
+        used at all, which is useful for debugging. For ``n_jobs`` below -1,
+        (``n_cpus + 1 + n_jobs``) are used. Thus for ``n_jobs = -2``, all CPUs
+        but one are used.
 
     max_iter : int, optional, default: 300
-        Maximum number of iterations of the SMACOF algorithm for a single run
+        Maximum number of iterations of the SMACOF algorithm for a single run.
 
     verbose : int, optional, default: 0
-        level of verbosity
+        Level of verbosity.
 
-    eps : float, optional, default: 1e-6
-        relative tolerance w.r.t stress to declare converge
+    eps : float, optional, default: 1e-3
+        Relative tolerance with respect to stress at which to declare
+        convergence.
 
     random_state : integer or numpy.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
-    return_n_iter : bool
+    return_n_iter : bool, optional, default: False
         Whether or not to return the number of iterations.
 
     Returns
     -------
-    X : ndarray (n_samples,n_components)
-        Coordinates of the n_samples points in a n_components-space
+    X : ndarray, shape (n_samples, n_components)
+        Coordinates of the points in a ``n_components``-space.
 
     stress : float
         The final value of the stress (sum of squared distance of the
-        disparities and the distances for all constrained points)
+        disparities and the distances for all constrained points).
 
     n_iter : int
-        The number of iterations corresponding to the best stress.
-        Returned only if `return_n_iter` is set to True.
+        The number of iterations corresponding to the best stress. Returned
+        only if ``return_n_iter`` is set to ``True``.
 
     Notes
     -----
@@ -226,7 +231,7 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
     hypothesis" Kruskal, J. Psychometrika, 29, (1964)
     """
 
-    similarities = check_array(similarities)
+    dissimilarities = check_array(dissimilarities)
     random_state = check_random_state(random_state)
 
     if hasattr(init, '__array__'):
@@ -243,7 +248,7 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
     if n_jobs == 1:
         for it in range(n_init):
             pos, stress, n_iter_ = _smacof_single(
-                similarities, metric=metric,
+                dissimilarities, metric=metric,
                 n_components=n_components, init=init,
                 max_iter=max_iter, verbose=verbose,
                 eps=eps, random_state=random_state)
@@ -255,7 +260,7 @@ def smacof(similarities, metric=True, n_components=2, init=None, n_init=8,
         seeds = random_state.randint(np.iinfo(np.int32).max, size=n_init)
         results = Parallel(n_jobs=n_jobs, verbose=max(verbose - 1, 0))(
             delayed(_smacof_single)(
-                similarities, metric=metric, n_components=n_components,
+                dissimilarities, metric=metric, n_components=n_components,
                 init=init, max_iter=max_iter, verbose=verbose, eps=eps,
                 random_state=seed)
             for seed in seeds)
@@ -278,56 +283,60 @@ class MDS(BaseEstimator):
 
     Parameters
     ----------
-    metric : boolean, optional, default: True
-        compute metric or nonmetric SMACOF (Scaling by Majorizing a
-        Complicated Function) algorithm
-
     n_components : int, optional, default: 2
-        number of dimension in which to immerse the similarities
-        overridden if initial array is provided.
+        Number of dimensions in which to immerse the dissimilarities.
+
+    metric : boolean, optional, default: True
+        If ``True``, perform metric MDS; otherwise, perform nonmetric MDS.
 
     n_init : int, optional, default: 4
-        Number of time the smacof algorithm will be run with different
-        initialisation. The final results will be the best output of the
-        n_init consecutive runs in terms of stress.
+        Number of times the SMACOF algorithm will be run with different
+        initializations. The final results will be the best output of the runs,
+        determined by the run with the smallest final stress.
 
     max_iter : int, optional, default: 300
-        Maximum number of iterations of the SMACOF algorithm for a single run
+        Maximum number of iterations of the SMACOF algorithm for a single run.
 
     verbose : int, optional, default: 0
-        level of verbosity
+        Level of verbosity.
 
-    eps : float, optional, default: 1e-6
-        relative tolerance w.r.t stress to declare converge
+    eps : float, optional, default: 1e-3
+        Relative tolerance with respect to stress at which to declare
+        convergence.
 
     n_jobs : int, optional, default: 1
-        The number of jobs to use for the computation. This works by breaking
-        down the pairwise matrix into n_jobs even slices and computing them in
-        parallel.
+        The number of jobs to use for the computation. If multiple
+        initializations are used (``n_init``), each run of the algorithm is
+        computed in parallel.
 
         If -1 all CPUs are used. If 1 is given, no parallel computing code is
-        used at all, which is useful for debugging. For n_jobs below -1,
-        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
-        are used.
+        used at all, which is useful for debugging. For ``n_jobs`` below -1,
+        (``n_cpus + 1 + n_jobs``) are used. Thus for ``n_jobs = -2``, all CPUs
+        but one are used.
 
     random_state : integer or numpy.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
 
-    dissimilarity : string
-        Which dissimilarity measure to use.
-        Supported are 'euclidean' and 'precomputed'.
+    dissimilarity : 'euclidean' | 'precomputed', optional, default: 'euclidean'
+        Dissimilarity measure to use:
 
+        - 'euclidean':
+            Pairwise Euclidean distances between points in the dataset.
+
+        - 'precomputed':
+            Pre-computed dissimilarities are passed directly to ``fit`` and
+            ``fit_transform``.
 
     Attributes
     ----------
-    embedding_ : array-like, shape [n_components, n_samples]
-        Stores the position of the dataset in the embedding space
+    embedding_ : array-like, shape (n_components, n_samples)
+        Stores the position of the dataset in the embedding space.
 
     stress_ : float
         The final value of the stress (sum of squared distance of the
-        disparities and the distances for all constrained points)
+        disparities and the distances for all constrained points).
 
 
     References
@@ -365,13 +374,14 @@ class MDS(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape=[n_samples, n_features], or [n_samples, n_samples] \
-                if dissimilarity='precomputed'
-            Input data.
+        X : array, shape (n_samples, n_features) or (n_samples, n_samples)
+            Input data. If ``dissimilarity=='precomputed'``, the input should
+            be the dissimilarity matrix.
 
-        init : {None or ndarray, shape (n_samples,)}, optional
-            If None, randomly chooses the initial configuration
-            if ndarray, initialize the SMACOF algorithm with this array.
+        init : ndarray, shape (n_samples,), optional
+            Starting configuration of the embedding to initialize the SMACOF
+            algorithm. By default, the algorithm is initialized with a randomly
+            chosen array.
         """
         self.fit_transform(X, init=init)
         return self
@@ -382,14 +392,14 @@ class MDS(BaseEstimator):
 
         Parameters
         ----------
-        X : array, shape=[n_samples, n_features], or [n_samples, n_samples] \
-                if dissimilarity='precomputed'
-            Input data.
+        X : array, shape (n_samples, n_features) or (n_samples, n_samples)
+            Input data. If ``dissimilarity=='precomputed'``, the input should
+            be the dissimilarity matrix.
 
-        init : {None or ndarray, shape (n_samples,)}, optional
-            If None, randomly chooses the initial configuration
-            if ndarray, initialize the SMACOF algorithm with this array.
-
+        init : ndarray, shape (n_samples,), optional
+            Starting configuration of the embedding to initialize the SMACOF
+            algorithm. By default, the algorithm is initialized with a randomly
+            chosen array.
         """
         X = check_array(X)
         if X.shape[0] == X.shape[1] and self.dissimilarity != "precomputed":


### PR DESCRIPTION
#### Reference Issue

Fixes issue #5510. In renaming `similarities -> dissimilarities`, I noticed several other things worth fixing in the mds documentation.
#### What does this implement/fix? Explain your changes.
- rename `similarities -> dissimilarities` in `smacof`
- expose `smacof` in the `sklearn.manifold` package
- expose `smacof` in the API docs
- miscellaneous clarifications and grammar fixes
- default values of `eps` corrected
#### Any other comments?

I have found that there doesn't seem to be clear set of conventions for documentation. I tried to base my changes on examples elsewhere in the project, but there is some variability. For example, I'm not sure what the best way is to document the `dissimilarity` argument for `MDS`. I see things like:

```
dissimilarity : {'euclidean', 'precomputed'}
```

and 

```
dissimilarity : 'euclidean' | 'precomputed'
```

Furthermore, sometimes the word `optional` is added and sometimes it's not. Sometimes the default value is provided and sometimes it's not. Etc. If there is some agreement on these conventions, I'd be happy to start working on tidying up documentation elsewhere as well.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7453)

<!-- Reviewable:end -->
