### PR TITLE
Throw an error with explicit message if n_estimators is not an integer.

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -6,6 +6,7 @@ Base class for ensemble-based estimators.
 # License: BSD 3 clause
 
 import numpy as np
+import numbers
 
 from ..base import clone
 from ..base import BaseEstimator
@@ -55,6 +56,10 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
     def _validate_estimator(self, default=None):
         """Check the estimator and the n_estimator attribute, set the
         `base_estimator_` attribute."""
+        if not isinstance(self.n_estimators, (numbers.Integral, np.integer)):
+        	raise ValueError("n_estimators must be an integer, "
+                             "got {0}.".format(type(self.n_estimators)))
+        
         if self.n_estimators <= 0:
             raise ValueError("n_estimators must be greater than zero, "
                              "got {0}.".format(self.n_estimators))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #7146 -->
#### What does this implement/fix? Explain your changes.

Added type checking of n_estimators and made the corresponding error message explicit about the type issue.

I used the Type checking currently proposed in issue #7394 
#### Any other comments?

I got the intended behavior when testing with rf.fit(n_estimators=100), which works as expeced, and rf.fit(n_estimators='100') which throws the type error as expected.

Example error message with traceback:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/ensemble/forest.py", line 247, in fit
    self._validate_estimator()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/ensemble/base.py", line 61, in _validate_estimator
    "got {0}.".format(type(self.n_estimators)))
ValueError: n_estimators must be an integer, got <class 'str'>.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
