### PR TITLE
[MRG+1] Throw an error with explicit message if n_estimators is not an integer.

### DIFF
--- a/sklearn/ensemble/base.py
+++ b/sklearn/ensemble/base.py
@@ -6,6 +6,7 @@ Base class for ensemble-based estimators.
 # License: BSD 3 clause
 
 import numpy as np
+import numbers
 
 from ..base import clone
 from ..base import BaseEstimator
@@ -55,6 +56,10 @@ class BaseEnsemble(BaseEstimator, MetaEstimatorMixin):
     def _validate_estimator(self, default=None):
         """Check the estimator and the n_estimator attribute, set the
         `base_estimator_` attribute."""
+        if not isinstance(self.n_estimators, (numbers.Integral, np.integer)):
+            raise ValueError("n_estimators must be an integer, "
+                             "got {0}.".format(type(self.n_estimators)))
+
         if self.n_estimators <= 0:
             raise ValueError("n_estimators must be greater than zero, "
                              "got {0}.".format(self.n_estimators))

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -34,7 +34,7 @@ def test_base():
 
     np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                         n_estimators=np.int32(3))
-    np_int_e.fit(iris.data, iris.target)
+    np_int_ensemble.fit(iris.data, iris.target)
 
 
 def test_base_zero_n_estimators():

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -32,7 +32,7 @@ def test_base():
 
     assert_true(isinstance(ensemble[0], Perceptron))
 
-    np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(), 
+    np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(),
                                         n_estimators=np.int32(3))
     np_int_e.fit(iris.data, iris.target)
 
@@ -40,7 +40,8 @@ def test_base():
 def test_base_zero_n_estimators():
     # Check that instantiating a BaseEnsemble with n_estimators<=0 raises
     # a ValueError.
-    ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators=0)
+    ensemble = BaggingClassifier(base_estimator=Perceptron(),
+                                 n_estimators=0)
     iris = load_iris()
     assert_raise_message(ValueError,
                          "n_estimators must be greater than zero, got 0.",
@@ -48,14 +49,16 @@ def test_base_zero_n_estimators():
 
 
 def test_base_not_int_n_estimators():
-    # Check that instantiating a BaseEnsemble with a string as n_estimators raises
-    # a ValueError requesting n_estimators to be supplied as an integer.
-    string_ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators='3')
+    # Check that instantiating a BaseEnsemble with a string as n_estimators
+    # raises a ValueError demanding n_estimators to be supplied as an integer.
+    string_ensemble = BaggingClassifier(base_estimator=Perceptron(),
+                                        n_estimators='3')
     iris = load_iris()
     assert_raise_message(ValueError,
                          "n_estimators must be an integer",
                          string_ensemble.fit, iris.data, iris.target)
-    float_ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators=3.0)
+    float_ensemble = BaggingClassifier(base_estimator=Perceptron(),
+                                       n_estimators=3.0)
     assert_raise_message(ValueError,
                          "n_estimators must be an integer",
                          float_ensemble.fit, iris.data, iris.target)

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -5,6 +5,7 @@ Testing for the base module (sklearn.ensemble.base).
 # Authors: Gilles Louppe
 # License: BSD 3 clause
 
+import numpy as np
 from numpy.testing import assert_equal
 from nose.tools import assert_true
 

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -32,6 +32,10 @@ def test_base():
 
     assert_true(isinstance(ensemble[0], Perceptron))
 
+    np_int_ensemble = BaggingClassifier(base_estimator=Perceptron(), 
+                                        n_estimators=np.int32(3))
+    np_int_e.fit(iris.data, iris.target)
+
 
 def test_base_zero_n_estimators():
     # Check that instantiating a BaseEnsemble with n_estimators<=0 raises
@@ -46,8 +50,12 @@ def test_base_zero_n_estimators():
 def test_base_not_int_n_estimators():
     # Check that instantiating a BaseEnsemble with a string as n_estimators raises
     # a ValueError requesting n_estimators to be supplied as an integer.
-    ensemble_string = BaggingClassifier(base_estimator=Perceptron(), n_estimators='3')
+    string_ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators='3')
     iris = load_iris()
     assert_raise_message(ValueError,
                          "n_estimators must be an integer",
-                         ensemble_string.fit, iris.data, iris.target)
+                         string_ensemble.fit, iris.data, iris.target)
+    float_ensemble = BaggingClassifier(base_estimator=Perceptron(), n_estimators=3.0)
+    assert_raise_message(ValueError,
+                         "n_estimators must be an integer",
+                         float_ensemble.fit, iris.data, iris.target)

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -41,3 +41,13 @@ def test_base_zero_n_estimators():
     assert_raise_message(ValueError,
                          "n_estimators must be greater than zero, got 0.",
                          ensemble.fit, iris.data, iris.target)
+
+
+def test_base_not_int_n_estimators():
+    # Check that instantiating a BaseEnsemble with a string as n_estimators raises
+    # a ValueError requesting n_estimators to be supplied as an integer.
+    ensemble_string = BaggingClassifier(base_estimator=Perceptron(), n_estimators='3')
+    iris = load_iris()
+    assert_raise_message(ValueError,
+                         "n_estmators must be an integer",
+                         ensemble_string.fit, iris.data, iris.target)

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -49,5 +49,5 @@ def test_base_not_int_n_estimators():
     ensemble_string = BaggingClassifier(base_estimator=Perceptron(), n_estimators='3')
     iris = load_iris()
     assert_raise_message(ValueError,
-                         "n_estmators must be an integer",
+                         "n_estimators must be an integer",
                          ensemble_string.fit, iris.data, iris.target)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Example: Fixes #7146
#### What does this implement/fix? Explain your changes.

Added type checking of n_estimators and made the corresponding error message explicit about the type issue.

I used the Type checking currently proposed in issue #7394 
#### Any other comments?

I got the intended behavior when testing with rf.fit(n_estimators=100), which works as expeced, and rf.fit(n_estimators='100') which throws the type error as expected.

Example error message with traceback:

```
Traceback (most recent call last):
File "", line 1, in
File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/ensemble/forest.py", line 247, in fit
self._validate_estimator()
File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/sklearn/ensemble/base.py", line 61, in _validate_estimator
"got {0}.".format(type(self.n_estimators)))
ValueError: n_estimators must be an integer, got <class 'str'>.
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
