### PR TITLE
make labelencoder use dict lookup

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -128,10 +128,12 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
 
         classes = np.unique(y)
         _check_numpy_unicode_bug(classes)
-        if len(np.intersect1d(classes, self.classes_)) < len(classes):
-            diff = np.setdiff1d(classes, self.classes_)
-            raise ValueError("y contains new labels: %s" % str(diff))
-        return np.fromiter((self._hashtable[v] for v in y), dtype=np.int64)
+        try:
+            return np.fromiter((self._classes_lookup[v] for v in y),
+                               dtype=np.int64,
+                               count=y.shape[0])
+        except KeyError as e:
+            raise ValueError("y contains new label: %s" % e.args[0])
 
     def inverse_transform(self, y):
         """Transform labels back to original encoding.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -108,24 +108,8 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
+        self._hashtable = {c: i for i, c in enumerate(self.classes_)}
         return self
-
-    def fit_transform(self, y):
-        """Fit label encoder and return encoded labels
-
-        Parameters
-        ----------
-        y : array-like of shape [n_samples]
-            Target values.
-
-        Returns
-        -------
-        y : array-like of shape [n_samples]
-        """
-        y = column_or_1d(y, warn=True)
-        _check_numpy_unicode_bug(y)
-        self.classes_, y = np.unique(y, return_inverse=True)
-        return y
 
     def transform(self, y):
         """Transform labels to normalized encoding.
@@ -147,7 +131,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         if len(np.intersect1d(classes, self.classes_)) < len(classes):
             diff = np.setdiff1d(classes, self.classes_)
             raise ValueError("y contains new labels: %s" % str(diff))
-        return np.searchsorted(self.classes_, y)
+        return np.fromiter((self._hashtable[v] for v in y), dtype=np.int64)
 
     def inverse_transform(self, y):
         """Transform labels back to original encoding.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -108,7 +108,9 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
-        self._classes_lookup = {c: i for i, c in enumerate(self.classes_)}
+        self._classes_lookup = {}
+        for i, c in enumerate(self.classes_):
+            self._classes_lookup[c] = i
         return self
 
     def transform(self, y):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -108,7 +108,7 @@ class LabelEncoder(BaseEstimator, TransformerMixin):
         y = column_or_1d(y, warn=True)
         _check_numpy_unicode_bug(y)
         self.classes_ = np.unique(y)
-        self._hashtable = {c: i for i, c in enumerate(self.classes_)}
+        self._classes_lookup = {c: i for i, c in enumerate(self.classes_)}
         return self
 
     def transform(self, y):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #7432
#### What does this implement/fix? Explain your changes.

Use a dict lookup instead of `np.sortedsearch` for the label lookups. Also removed the custom `fit_transform` method, since the dict lookup is quicker than the `np.unique(return_index=True)` trick that was used here before.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7458)

<!-- Reviewable:end -->
