### PR TITLE
[MRG+1] micro-optimize HashingVectorizer and FeatureHasher

### DIFF
--- a/sklearn/feature_extraction/_hashing.pyx
+++ b/sklearn/feature_extraction/_hashing.pyx
@@ -43,7 +43,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype):
 
     for x in raw_X:
         for f, v in x:
-            if isinstance(v, basestring):
+            if isinstance(v, (str, unicode)):
                 f = "%s%s%s" % (f, '=', v)
                 value = 1
             else:

--- a/sklearn/feature_extraction/_hashing.pyx
+++ b/sklearn/feature_extraction/_hashing.pyx
@@ -8,8 +8,6 @@ from libc.stdlib cimport abs
 cimport numpy as np
 import numpy as np
 
-from ..externals.six import string_types
-
 from sklearn.utils.murmurhash cimport murmurhash3_bytes_s32
 
 np.import_array()
@@ -45,7 +43,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype):
 
     for x in raw_X:
         for f, v in x:
-            if isinstance(v, string_types):
+            if isinstance(v, basestring):
                 f = "%s%s%s" % (f, '=', v)
                 value = 1
             else:
@@ -55,13 +53,13 @@ def transform(raw_X, Py_ssize_t n_features, dtype):
                 continue
 
             if isinstance(f, unicode):
-                f = f.encode("utf-8")
+                f = (<unicode>f).encode("utf-8")
             # Need explicit type check because Murmurhash does not propagate
             # all exceptions. Add "except *" there?
             elif not isinstance(f, bytes):
                 raise TypeError("feature names must be strings")
 
-            h = murmurhash3_bytes_s32(f, 0)
+            h = murmurhash3_bytes_s32(<bytes>f, 0)
 
             array.resize_smart(indices, len(indices) + 1)
             indices[len(indices) - 1] = abs(h) % n_features


### PR DESCRIPTION
There is a common gotcha in Cython code: even after a type check Cython compiles `txt.encode('utf-8')` to a code which looks up 'encode' method, then calls it as a Python method, this method has to find utf-8 codec, etc. 

``` py
if isinstance(f, unicode):
    f = f.encode("utf-8")
```

On the other hand,

``` py
if isinstance(f, unicode):
    f = (<unicode>f).encode("utf-8")
```

compiles directly to a PyUnicode_AsUTF8String call. 

Another gotcha is that if you declare argument type (e.g. bytes) and then pass a variable of type object, it does _more_ work, not less work because type is checked. Because we know a variable is bytes casting it to bytes allow to remove all these type checks and conversions.

The third thing I fixed is `string_types` lookup. "basestring" in Cython is the same as six.string_types; isinstance check gets compiled directly to C API calls this way.

These changes allow to make HashingVectorizer about 10% faster. Benchmark script:

``` py
from sklearn.datasets import fetch_20newsgroups
from sklearn.feature_extraction.text import HashingVectorizer

categories = ['alt.atheism', 'comp.graphics']
remove = ('headers', 'footers', 'quotes')
data_train = fetch_20newsgroups(subset='train', categories=categories,
                                shuffle=True, random_state=42,
                                remove=remove)
vec = HashingVectorizer()
%timeit vec.fit_transform(data_train.data[:100])
```

For me it runs in 13.8 ms before the changes and 11.5 ms after the changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7470)

<!-- Reviewable:end -->
