### PR TITLE
Sync docstring and definition default argument in kneighbors

### DIFF
--- a/sklearn/neighbors/approximate.py
+++ b/sklearn/neighbors/approximate.py
@@ -411,7 +411,7 @@ class LSHForest(BaseEstimator, KNeighborsMixin, RadiusNeighborsMixin):
             Number of neighbors required. If not provided, this will
             return the number specified at the initialization.
 
-        return_distance : boolean, optional (default = False)
+        return_distance : boolean, optional (default = True)
             Returns the distances of neighbors if set to True.
 
         Returns


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

As you can see in [docs](https://github.com/hnykda/scikit-learn/blob/master/sklearn/neighbors/approximate.py#L401), there is different default argument stated in `kneighbors` than it is in reality (False instead True). Very little change...
