### PR TITLE
[MRG + 1] Fix _get_importances.

### DIFF
--- a/sklearn/feature_selection/from_model.py
+++ b/sklearn/feature_selection/from_model.py
@@ -14,17 +14,16 @@ from ..exceptions import NotFittedError
 
 def _get_feature_importances(estimator):
     """Retrieve or aggregate feature importances from estimator"""
-    if hasattr(estimator, "feature_importances_"):
-        importances = estimator.feature_importances_
+    importances = getattr(estimator, "feature_importances_", None)
 
-    elif hasattr(estimator, "coef_"):
+    if importances is None and hasattr(estimator, "coef_"):
         if estimator.coef_.ndim == 1:
             importances = np.abs(estimator.coef_)
 
         else:
             importances = np.sum(np.abs(estimator.coef_), axis=0)
 
-    else:
+    elif importances is None:
         raise ValueError(
             "The underlying estimator %s has no `coef_` or "
             "`feature_importances_` attribute. Either pass a fitted estimator"

--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -171,9 +171,9 @@ class RFE(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
             # Get coefs
             if hasattr(estimator, 'coef_'):
                 coefs = estimator.coef_
-            elif hasattr(estimator, 'feature_importances_'):
-                coefs = estimator.feature_importances_
             else:
+                coefs = getattr(estimator, 'feature_importances_', None)
+            if coefs is None:
                 raise RuntimeError('The classifier does not expose '
                                    '"coef_" or "feature_importances_" '
                                    'attributes')


### PR DESCRIPTION
Fixes #7481.

Not to use expensive `hasattr`, call `getattr` explicitly.
And call `getattr` only once.
