### PR TITLE
[MRG] MNT Tags built by sublime ctags may be of form (.)tags*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ scikit_learn.egg-info/
 .coverage
 coverage
 *.py,cover
-.tags
+.tags*
 tags
 covtype.data.gz
 20news-18828/


### PR DESCRIPTION
The sublime ctags generates tag files with names like `.tags_sorted_by_file`. It would be nice to git ignore those too...

@jnothman @lesteve @ogrisel

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7494)

<!-- Reviewable:end -->
