### PR TITLE
[MRG] FIX HashingVectorizer + TfidfTransformer fails because of a stored zero

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -792,9 +792,9 @@ meaning that you don't have to call ``fit`` on it::
   >>> hv.transform(corpus)
   ...                                # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
   <4x10 sparse matrix of type '<... 'numpy.float64'>'
-      with 16 stored elements in Compressed Sparse ... format>
+      with 13 stored elements in Compressed Sparse ... format>
 
-You can see that 16 non-zero feature tokens were extracted in the vector
+You can see that 13 non-zero feature tokens were extracted in the vector
 output: this is less than the 19 non-zeros extracted previously by the
 :class:`CountVectorizer` on the same toy corpus. The discrepancy comes from
 hash function collisions because of the low value of the ``n_features`` parameter.

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -148,7 +148,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         X = sp.csr_matrix((values, indices, indptr), dtype=self.dtype,
                           shape=(n_samples, self.n_features))
         X.sum_duplicates()  # also sorts the indices
-        X.eliminate_zeros() # remove zeros caused by a hash collisions (#3637)
+        X.eliminate_zeros()  # remove zeros caused by hash collisions (#3637)
         if self.non_negative:
             np.abs(X.data, X.data)
         return X

--- a/sklearn/feature_extraction/hashing.py
+++ b/sklearn/feature_extraction/hashing.py
@@ -148,6 +148,7 @@ class FeatureHasher(BaseEstimator, TransformerMixin):
         X = sp.csr_matrix((values, indices, indptr), dtype=self.dtype,
                           shape=(n_samples, self.n_features))
         X.sum_duplicates()  # also sorts the indices
+        X.eliminate_zeros() # remove zeros caused by a hash collisions (#3637)
         if self.non_negative:
             np.abs(X.data, X.data)
         return X

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -107,3 +107,13 @@ def test_hasher_zeros():
     # Assert that no zeros are materialized in the output.
     X = FeatureHasher().transform([{'foo': 0}])
     assert_equal(X.data.shape, (0,))
+
+
+def test_hash_collision():
+    # Ensure that hash collision does not produce zero elements
+    # in the output sparse array (issue #3637)
+    raw_X = ["ab", "ac", "ad", "ae"]
+    fh = FeatureHasher(non_negative=False, input_type="string", n_features=1)
+    X = fh.transform(raw_X)
+    assert_true(len(X.data) <= 2*len(raw_X))  # we have feature collisions
+    assert_equal((X.data == 0.).sum(), 0)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -944,6 +944,15 @@ def test_hashingvectorizer_nan_in_docs():
     assert_raise_message(exception, message, func)
 
 
+def test_hashingvectorizer_hash_collision():
+    # Ensure that hash collision does not produce zero elements
+    # in the output sparse array (issue #3637)
+    text = 'investigation need records'
+    hv = HashingVectorizer(ngram_range=(1, 2), non_negative=True)
+    X = hv.transform([text])
+    assert_equal((X.data == 0.).sum(), 0)
+
+
 def test_tfidfvectorizer_binary():
     # Non-regression test: TfidfVectorizer used to ignore its "binary" param.
     v = TfidfVectorizer(binary=True, use_idf=False, norm=None)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -944,15 +944,6 @@ def test_hashingvectorizer_nan_in_docs():
     assert_raise_message(exception, message, func)
 
 
-def test_hashingvectorizer_hash_collision():
-    # Ensure that hash collision does not produce zero elements
-    # in the output sparse array (issue #3637)
-    text = 'investigation need records'
-    hv = HashingVectorizer(ngram_range=(1, 2), non_negative=True)
-    X = hv.transform([text])
-    assert_equal((X.data == 0.).sum(), 0)
-
-
 def test_tfidfvectorizer_binary():
     # Non-regression test: TfidfVectorizer used to ignore its "binary" param.
     v = TfidfVectorizer(binary=True, use_idf=False, norm=None)


### PR DESCRIPTION
Continuation of PR https://github.com/scikit-learn/scikit-learn/pull/5861, fixes issue https://github.com/scikit-learn/scikit-learn/issues/3637 .

This eliminates zeros that can occur after a hash collision in the sparse array output of the HashingVectorizer.

Also added a regression test, and checked that this had non-measurable impact on performance (benchmarked on the 20 newsgroup dataset).

~~**Edit:** circle-ci failed due to timeout, "command ./build_tools/circle/build_doc.sh took more than 10 minutes since last output": I can't do much about that as I think it's unrelated to this PR.~~
