### PR TITLE
[MRG + 1] Raised value error in HashingVectorizer and CountVectorizer

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -868,7 +868,7 @@ def test_countvectorizer_vocab_sets_when_pickling():
                             'salad', 'sparkling', 'tomato', 'water'])
     for x in range(0, 100):
         vocab_set = set(choice(vocab_words, size=5, replace=False,
-                        random_state=rng))
+                               random_state=rng))
         cv = CountVectorizer(vocabulary=vocab_set)
         unpickled_cv = pickle.loads(pickle.dumps(cv))
         cv.fit(ALL_FOOD_DOCS)
@@ -891,17 +891,18 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         unpickled_cv.fit(ALL_FOOD_DOCS)
         assert_equal(cv.get_feature_names(), unpickled_cv.get_feature_names())
 
+
 def test_countvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
     message = ("Iterable over raw text documents expected, "
-        "string object received.")
+               "string object received.")
     exception = ValueError
 
     def func():
         cv = CountVectorizer()
         cv.fit_transform('hello world!')
 
-    assert_raise_message(exception, message, func)        
+    assert_raise_message(exception, message, func)
 
 
 def test_stop_words_removal():
@@ -959,14 +960,14 @@ def test_hashingvectorizer_nan_in_docs():
 def test_hashingvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
     message = ("Iterable over raw text documents expected, "
-        "string object received.")
+               "string object received.")
     exception = ValueError
 
     def func():
         hv = HashingVectorizer()
         hv.fit_transform('hello world!')
 
-    assert_raise_message(exception, message, func)        
+    assert_raise_message(exception, message, func)
 
 
 def test_tfidfvectorizer_binary():
@@ -983,7 +984,7 @@ def test_tfidfvectorizer_binary():
 def test_tfidvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
     message = ("Iterable over raw text documents expected, "
-        "string object received.")
+               "string object received.")
     exception = ValueError
 
     def func():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -892,7 +892,7 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         assert_equal(cv.get_feature_names(), unpickled_cv.get_feature_names())
 
 
-def test_countvectorizer_string_object_as_input():
+def test_countvectorizer_error():
     # Ensure that string object is not given as input.
     cv = CountVectorizer()
     exception = ValueError
@@ -955,7 +955,7 @@ def test_hashingvectorizer_nan_in_docs():
     assert_raise_message(exception, message, func)
 
 
-def test_hashingvectorizer_string_object_as_input():
+def test_hashingvectorizer_error():
     # Ensure that string object is not given as input.
     hv = HashingVectorizer()
     exception = ValueError
@@ -976,7 +976,7 @@ def test_tfidfvectorizer_binary():
     assert_array_equal(X2.ravel(), [1, 1, 1, 0])
 
 
-def test_tfidvectorizer_string_object_as_input():
+def test_tfidvectorizer_error():
     # Ensure that string object is not given as input.
     tv = TfidfVectorizer()
     exception = ValueError

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -894,15 +894,13 @@ def test_countvectorizer_vocab_dicts_when_pickling():
 
 def test_countvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
-    message = ("Iterable over raw text documents expected, "
-               "string object received.")
+    cv = CountVectorizer()
     exception = ValueError
+    test_str = "hello world!"
 
-    def func():
-        cv = CountVectorizer()
-        cv.fit_transform('hello world!')
-
-    assert_raise_message(exception, message, func)
+    assert_raises(exception, cv.fit_transform, test_str)
+    assert_raises(exception, cv.fit, test_str)
+    assert_raises(exception, cv.transform, test_str)
 
 
 def test_stop_words_removal():
@@ -959,15 +957,13 @@ def test_hashingvectorizer_nan_in_docs():
 
 def test_hashingvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
-    message = ("Iterable over raw text documents expected, "
-               "string object received.")
+    hv = HashingVectorizer()
     exception = ValueError
+    test_str = "hello world!"
 
-    def func():
-        hv = HashingVectorizer()
-        hv.fit_transform('hello world!')
-
-    assert_raise_message(exception, message, func)
+    assert_raises(exception, hv.fit_transform, test_str)
+    assert_raises(exception, hv.fit, test_str)
+    assert_raises(exception, hv.transform, test_str)
 
 
 def test_tfidfvectorizer_binary():
@@ -983,15 +979,13 @@ def test_tfidfvectorizer_binary():
 
 def test_tfidvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
-    message = ("Iterable over raw text documents expected, "
-               "string object received.")
+    tv = TfidfVectorizer()
     exception = ValueError
+    test_str = "hello world!"
 
-    def func():
-        tv = TfidfVectorizer()
-        tv.fit_transform('hello world!')
-
-    assert_raise_message(exception, message, func)
+    assert_raises(exception, tv.fit_transform, test_str)
+    assert_raises(exception, tv.fit, test_str)
+    assert_raises(exception, tv.transform, test_str)
 
 
 def test_tfidfvectorizer_export_idf():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -892,17 +892,6 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         assert_equal(cv.get_feature_names(), unpickled_cv.get_feature_names())
 
 
-def test_countvectorizer_error():
-    # Ensure that string object is not given as input.
-    cv = CountVectorizer()
-    exception = ValueError
-    test_str = "hello world!"
-
-    assert_raises(exception, cv.fit_transform, test_str)
-    assert_raises(exception, cv.fit, test_str)
-    assert_raises(exception, cv.transform, test_str)
-
-
 def test_stop_words_removal():
     # Ensure that deleting the stop_words_ attribute doesn't affect transform
 
@@ -955,16 +944,6 @@ def test_hashingvectorizer_nan_in_docs():
     assert_raise_message(exception, message, func)
 
 
-def test_hashingvectorizer_error():
-    # Ensure that string object is not given as input.
-    hv = HashingVectorizer()
-    exception = ValueError
-    test_str = "hello world!"
-
-    assert_raises(exception, hv.fit_transform, test_str)
-    assert_raises(exception, hv.transform, test_str)
-
-
 def test_tfidfvectorizer_binary():
     # Non-regression test: TfidfVectorizer used to ignore its "binary" param.
     v = TfidfVectorizer(binary=True, use_idf=False, norm=None)
@@ -974,17 +953,6 @@ def test_tfidfvectorizer_binary():
     assert_array_equal(X.ravel(), [1, 1, 1, 0])
     X2 = v.transform(['hello world', 'hello hello']).toarray()
     assert_array_equal(X2.ravel(), [1, 1, 1, 0])
-
-
-def test_tfidvectorizer_error():
-    # Ensure that string object is not given as input.
-    tv = TfidfVectorizer()
-    exception = ValueError
-    test_str = "hello world!"
-
-    assert_raises(exception, tv.fit_transform, test_str)
-    assert_raises(exception, tv.fit, test_str)
-    assert_raises(exception, tv.transform, test_str)
 
 
 def test_tfidfvectorizer_export_idf():
@@ -999,3 +967,15 @@ def test_vectorizer_vocab_clone():
     vect_vocab.fit(ALL_FOOD_DOCS)
     vect_vocab_clone.fit(ALL_FOOD_DOCS)
     assert_equal(vect_vocab_clone.vocabulary_, vect_vocab.vocabulary_)
+
+
+def test_vectorizer_string_object_as_input():
+    message = ("Iterable over raw text documents expected, "
+               "string object received.")
+    for vec in [CountVectorizer(), TfidfVectorizer(), HashingVectorizer()]:
+        assert_raise_message(
+            ValueError, message, vec.fit_transform, "hello world!")
+        assert_raise_message(
+            ValueError, message, vec.fit, "hello world!")
+        assert_raise_message(
+            ValueError, message, vec.transform, "hello world!")

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -962,7 +962,6 @@ def test_hashingvectorizer_string_object_as_input():
     test_str = "hello world!"
 
     assert_raises(exception, hv.fit_transform, test_str)
-    assert_raises(exception, hv.fit, test_str)
     assert_raises(exception, hv.transform, test_str)
 
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -891,6 +891,18 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         unpickled_cv.fit(ALL_FOOD_DOCS)
         assert_equal(cv.get_feature_names(), unpickled_cv.get_feature_names())
 
+def test_hashingvectorizer_string_object_as_input():
+    # Ensure that string object is not given as input.
+    message = ("Iterable over raw text documents expected, "
+        "string object received.")
+    exception = ValueError
+
+    def func():
+        hv = HashingVectorizer()
+        hv.fit_transform('hello world!')
+
+    assert_raise_message(exception, message, func)        
+    
 
 def test_stop_words_removal():
     # Ensure that deleting the stop_words_ attribute doesn't affect transform
@@ -942,6 +954,19 @@ def test_hashingvectorizer_nan_in_docs():
         hv.fit_transform(['hello world', np.nan, 'hello hello'])
 
     assert_raise_message(exception, message, func)
+
+
+def test_hashingvectorizer_string_object_as_input():
+    # Ensure that string object is not given as input.
+    message = ("Iterable over raw text documents expected, "
+        "string object received.")
+    exception = ValueError
+
+    def func():
+        hv = HashingVectorizer()
+        hv.fit_transform('hello world!')
+
+    assert_raise_message(exception, message, func)        
 
 
 def test_tfidfvectorizer_binary():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -891,18 +891,18 @@ def test_countvectorizer_vocab_dicts_when_pickling():
         unpickled_cv.fit(ALL_FOOD_DOCS)
         assert_equal(cv.get_feature_names(), unpickled_cv.get_feature_names())
 
-def test_hashingvectorizer_string_object_as_input():
+def test_countvectorizer_string_object_as_input():
     # Ensure that string object is not given as input.
     message = ("Iterable over raw text documents expected, "
         "string object received.")
     exception = ValueError
 
     def func():
-        hv = HashingVectorizer()
-        hv.fit_transform('hello world!')
+        cv = CountVectorizer()
+        cv.fit_transform('hello world!')
 
     assert_raise_message(exception, message, func)        
-    
+
 
 def test_stop_words_removal():
     # Ensure that deleting the stop_words_ attribute doesn't affect transform
@@ -978,6 +978,19 @@ def test_tfidfvectorizer_binary():
     assert_array_equal(X.ravel(), [1, 1, 1, 0])
     X2 = v.transform(['hello world', 'hello hello']).toarray()
     assert_array_equal(X2.ravel(), [1, 1, 1, 0])
+
+
+def test_tfidvectorizer_string_object_as_input():
+    # Ensure that string object is not given as input.
+    message = ("Iterable over raw text documents expected, "
+        "string object received.")
+    exception = ValueError
+
+    def func():
+        tv = TfidfVectorizer()
+        tv.fit_transform('hello world!')
+
+    assert_raise_message(exception, message, func)
 
 
 def test_tfidfvectorizer_export_idf():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -473,9 +473,10 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
             Document-term matrix.
 
         """
-        if isinstance(X, str):
+        if isinstance(X, six.string_types):
             raise ValueError(
-                "Iterable over raw text documents expected, string object received.")
+                "Iterable over raw text documents expected, " 
+                "string object received.")
 
         analyzer = self.build_analyzer()
         X = self._get_hasher().transform(analyzer(doc) for doc in X)
@@ -797,9 +798,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         -------
         self
         """
-        if isinstance(raw_documents, str):
+        if isinstance(raw_documents, six.string_types):
             raise ValueError(
-                "Iterable over raw text documents expected, string object received.")
+                "Iterable over raw text documents expected, "
+                "string object received.")
 
         self.fit_transform(raw_documents)
         return self
@@ -823,9 +825,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         # We intentionally don't call the transform method to make
         # fit_transform overridable without unwanted side effects in
         # TfidfVectorizer.
-        if isinstance(raw_documents, str):
+        if isinstance(raw_documents, six.string_types):
             raise ValueError(
-                "Iterable over raw text documents expected, string object received.")
+                "Iterable over raw text documents expected, "
+                "string object received.")
 
         self._validate_vocabulary()
         max_df = self.max_df
@@ -876,9 +879,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         X : sparse matrix, [n_samples, n_features]
             Document-term matrix.
         """
-        if isinstance(raw_documents, str):
+        if isinstance(raw_documents, six.string_types):
             raise ValueError(
-                "Iterable over raw text documents expected, string object received.")
+                "Iterable over raw text documents expected, "
+                "string object received.")
         
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
@@ -1345,6 +1349,7 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
+
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
         # X is already a transformed view of raw_documents so

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -452,6 +452,11 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
     def fit(self, X, y=None):
         """Does nothing: this transformer is stateless."""
         # triggers a parameter validation
+        if isinstance(X, six.string_types):
+            raise ValueError(
+                "Iterable over raw text documents expected, "
+                "string object received.")
+
         self._get_hasher().fit(X, y=y)
         return self
 
@@ -798,11 +803,6 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         -------
         self
         """
-        if isinstance(raw_documents, six.string_types):
-            raise ValueError(
-                "Iterable over raw text documents expected, "
-                "string object received.")
-
         self.fit_transform(raw_documents)
         return self
 
@@ -1329,11 +1329,6 @@ class TfidfVectorizer(CountVectorizer):
         -------
         self : TfidfVectorizer
         """
-        if isinstance(raw_documents, six.string_types):
-            raise ValueError(
-                "Iterable over raw text documents expected, "
-                "string object received.")
-
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
         return self
@@ -1354,11 +1349,6 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
-        if isinstance(raw_documents, six.string_types):
-            raise ValueError(
-                "Iterable over raw text documents expected, "
-                "string object received.")
-
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
         # X is already a transformed view of raw_documents so
@@ -1385,11 +1375,6 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
-        if isinstance(raw_documents, six.string_types):
-            raise ValueError(
-                "Iterable over raw text documents expected, "
-                "string object received.")
-
         check_is_fitted(self, '_tfidf', 'The tfidf vector is not fitted')
 
         X = super(TfidfVectorizer, self).transform(raw_documents)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1329,6 +1329,11 @@ class TfidfVectorizer(CountVectorizer):
         -------
         self : TfidfVectorizer
         """
+        if isinstance(raw_documents, six.string_types):
+            raise ValueError(
+                "Iterable over raw text documents expected, "
+                "string object received.")
+            
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
         return self
@@ -1349,6 +1354,10 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
+        if isinstance(raw_documents, six.string_types):
+            raise ValueError(
+                "Iterable over raw text documents expected, "
+                "string object received.")
 
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
@@ -1376,6 +1385,11 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
+        if isinstance(raw_documents, six.string_types):
+            raise ValueError(
+                "Iterable over raw text documents expected, "
+                "string object received.")
+
         check_is_fitted(self, '_tfidf', 'The tfidf vector is not fitted')
 
         X = super(TfidfVectorizer, self).transform(raw_documents)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -475,7 +475,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         """
         if isinstance(X, six.string_types):
             raise ValueError(
-                "Iterable over raw text documents expected, " 
+                "Iterable over raw text documents expected, "
                 "string object received.")
 
         analyzer = self.build_analyzer()
@@ -883,7 +883,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
             raise ValueError(
                 "Iterable over raw text documents expected, "
                 "string object received.")
-        
+
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
 
@@ -1333,7 +1333,7 @@ class TfidfVectorizer(CountVectorizer):
             raise ValueError(
                 "Iterable over raw text documents expected, "
                 "string object received.")
-            
+
         X = super(TfidfVectorizer, self).fit_transform(raw_documents)
         self._tfidf.fit(X)
         return self

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -475,7 +475,7 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
         """
         if isinstance(X, str):
             raise ValueError(
-                "iterable over raw text documents expected, string object received")
+                "Iterable over raw text documents expected, string object received.")
 
         analyzer = self.build_analyzer()
         X = self._get_hasher().transform(analyzer(doc) for doc in X)
@@ -799,7 +799,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         """
         if isinstance(raw_documents, str):
             raise ValueError(
-                "iterable over raw text documents expected, string object received")
+                "Iterable over raw text documents expected, string object received.")
 
         self.fit_transform(raw_documents)
         return self
@@ -825,7 +825,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         # TfidfVectorizer.
         if isinstance(raw_documents, str):
             raise ValueError(
-                "iterable over raw text documents expected, string object received")
+                "Iterable over raw text documents expected, string object received.")
 
         self._validate_vocabulary()
         max_df = self.max_df
@@ -878,7 +878,7 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         """
         if isinstance(raw_documents, str):
             raise ValueError(
-                "iterable over raw text documents expected, string object given")
+                "Iterable over raw text documents expected, string object received.")
         
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -473,6 +473,10 @@ class HashingVectorizer(BaseEstimator, VectorizerMixin):
             Document-term matrix.
 
         """
+        if isinstance(X, str):
+            raise ValueError(
+                "iterable over raw text documents expected, string object received")
+
         analyzer = self.build_analyzer()
         X = self._get_hasher().transform(analyzer(doc) for doc in X)
         if self.binary:
@@ -793,6 +797,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         -------
         self
         """
+        if isinstance(raw_documents, str):
+            raise ValueError(
+                "iterable over raw text documents expected, string object received")
+
         self.fit_transform(raw_documents)
         return self
 
@@ -815,6 +823,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         # We intentionally don't call the transform method to make
         # fit_transform overridable without unwanted side effects in
         # TfidfVectorizer.
+        if isinstance(raw_documents, str):
+            raise ValueError(
+                "iterable over raw text documents expected, string object received")
+
         self._validate_vocabulary()
         max_df = self.max_df
         min_df = self.min_df
@@ -864,6 +876,10 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
         X : sparse matrix, [n_samples, n_features]
             Document-term matrix.
         """
+        if isinstance(raw_documents, str):
+            raise ValueError(
+                "iterable over raw text documents expected, string object given")
+        
         if not hasattr(self, 'vocabulary_'):
             self._validate_vocabulary()
 


### PR DESCRIPTION
Fixes #7505 

Raised the value error in `fit`, `fit_transform`, `transform` in both the classes. 

Test1 - 

``` python
from sklearn.feature_extraction.text import CountVectorizer
X = CountVectorizer().fit_transform("hello world!")
```

Output1 - 

```
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    X = CountVectorizer().fit_transform("hello world!")
  File "/Users/mehul/scikit-learn/sklearn/feature_extraction/text.py", line 828, in fit_transform
    "Iterable over raw text documents expected, string object received.")
ValueError: Iterable over raw text documents expected, string object received.
```

Test2 - 

``` python
from sklearn.feature_extraction.text import HashingVectorizer
X = HashingVectorizer().fit_transform("hello world!")
```

Output2 - 

```
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    X = HashingVectorizer().fit_transform("hello world!")
  File "/Users/mehul/scikit-learn/sklearn/feature_extraction/text.py", line 478, in transform
    "Iterable over raw text documents expected, string object received.")
ValueError: Iterable over raw text documents expected, string object received.

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scikit-learn/scikit-learn/7507)

<!-- Reviewable:end -->
