### PR TITLE
[MRG] DOC release date in what's new

### DIFF
--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -48,3 +48,5 @@ Making a release
     $ python setup.py bdist_wininst upload
 
    And upload them also to sourceforge
+
+7. FOR FINAL RELEASE: Update the release date in What's New

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,8 @@ Bug fixes
 Version 0.18
 ============
 
+**September 28, 2016**
+
 .. _model_selection_changes:
 
 Model Selection Enhancements and API Changes


### PR DESCRIPTION
Whoops.

The release date should also be patched into the 0.18.X branch.
