### PR TITLE
[MRG+2] DOC add info to conventions for multi-label fitting

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -346,12 +346,11 @@ Here, the default kernel ``rbf`` is first changed to ``linear`` after the
 estimator has been constructed via ``SVC()``, and changed back to ``rbf`` to
 refit the estimator and to make a second prediction.
 
-Multiclass vs. Multilabel Fitting
+Multiclass vs. multilabel fitting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using :class:`multiclass classifiers <sklearn.multiclass>`,
-the format of returned predictions is dependent on the format of the target data fit upon. More specifically, a classifier fit on multiclass labels will return multiclass
-predictions, whereas a classifier fit on label indicators will return multilabel predictions::
+the learning and prediction task that is performed is dependent on the format of the target data fit upon::
 
     >>> from sklearn.svm import SVC
     >>> from sklearn.multiclass import OneVsRestClassifier
@@ -364,6 +363,10 @@ predictions, whereas a classifier fit on label indicators will return multilabel
     >>> classif.fit(X, y).predict(X)
     array([0, 0, 1, 1, 2])
 
+In the above case, the classifier is fit on a 1d array of multiclass labels and the ``predict()``
+method therefore provides corresponding multiclass predictions.
+It is also possible to fit upon a 2d array of binary label indicators::
+
     >>> y = LabelBinarizer().fit_transform(y)
     >>> classif.fit(X, y).predict(X)
     array([[1, 0, 0],
@@ -372,8 +375,25 @@ predictions, whereas a classifier fit on label indicators will return multilabel
            [0, 0, 0],
            [0, 0, 0]])
 
-In the first case, the classifier is fit on a 1d array of multiclass labels.
-The ``predict()`` method therefore provides corresponding multiclass predictions.
-In the second case, the classification target is provided to ``fit()``  as
-a 2d array of binary label indicators, using the :class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>`.
-In this case ``predict()`` returns a 2d array representing the corresponding multi-label predictions.
+Here, the classifier is ``fit()``  on a 2d binary label representation of ``y``,
+using the :class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>`.
+In this case ``predict()`` returns a 2d array representing the corresponding multilabel predictions.
+
+Note that the fourth and fifth instances returned all zeroes, indicating that they
+matched none of the three labels ``fit`` upon. With multilabel outputs, it is similarly possible for on instance to
+be assigned multiple labels::
+
+  >> from sklearn.preprocessing import MultiLabelBinarizer
+  >> y = [[0, 1], [0, 2], [1, 3], [0, 2, 3], [2, 4]]
+  >> y = preprocessing.MultiLabelBinarizer().fit_transform(y)
+  >> classif.fit(X, y).predict(X)
+  array([[1, 1, 0, 0, 0],
+         [1, 0, 1, 0, 0],
+         [0, 1, 0, 1, 0],
+         [1, 0, 1, 1, 0],
+         [0, 0, 1, 0, 1]])
+
+In this case, the classifier is fit upon instances each assigned multiple labels.
+The :class:`MultiLabelBinarizer <sklearn.preprocessing.MultiLabelBinarizer>` is used
+to binarize the 2d array of multilabels to ``fit`` upon. As a result, ``predict()`` returns
+a 2d array with multiple predicted labels for each instance.

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -350,7 +350,8 @@ Multiclass vs. multilabel fitting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using :class:`multiclass classifiers <sklearn.multiclass>`,
-the learning and prediction task that is performed is dependent on the format of the target data fit upon::
+the learning and prediction task that is performed is dependent on the format of
+the target data fit upon::
 
     >>> from sklearn.svm import SVC
     >>> from sklearn.multiclass import OneVsRestClassifier
@@ -363,8 +364,8 @@ the learning and prediction task that is performed is dependent on the format of
     >>> classif.fit(X, y).predict(X)
     array([0, 0, 1, 1, 2])
 
-In the above case, the classifier is fit on a 1d array of multiclass labels and the ``predict()``
-method therefore provides corresponding multiclass predictions.
+In the above case, the classifier is fit on a 1d array of multiclass labels and
+the ``predict()`` method therefore provides corresponding multiclass predictions.
 It is also possible to fit upon a 2d array of binary label indicators::
 
     >>> y = LabelBinarizer().fit_transform(y)
@@ -377,11 +378,12 @@ It is also possible to fit upon a 2d array of binary label indicators::
 
 Here, the classifier is ``fit()``  on a 2d binary label representation of ``y``,
 using the :class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>`.
-In this case ``predict()`` returns a 2d array representing the corresponding multilabel predictions.
+In this case ``predict()`` returns a 2d array representing the corresponding
+multilabel predictions.
 
-Note that the fourth and fifth instances returned all zeroes, indicating that they
-matched none of the three labels ``fit`` upon. With multilabel outputs, it is similarly possible for on instance to
-be assigned multiple labels::
+Note that the fourth and fifth instances returned all zeroes, indicating that
+they matched none of the three labels ``fit`` upon. With multilabel outputs, it
+is similarly possible for an instance to be assigned multiple labels::
 
   >> from sklearn.preprocessing import MultiLabelBinarizer
   >> y = [[0, 1], [0, 2], [1, 3], [0, 2, 3], [2, 4]]
@@ -394,6 +396,6 @@ be assigned multiple labels::
          [0, 0, 1, 0, 1]])
 
 In this case, the classifier is fit upon instances each assigned multiple labels.
-The :class:`MultiLabelBinarizer <sklearn.preprocessing.MultiLabelBinarizer>` is used
-to binarize the 2d array of multilabels to ``fit`` upon. As a result, ``predict()`` returns
-a 2d array with multiple predicted labels for each instance.
+The :class:`MultiLabelBinarizer <sklearn.preprocessing.MultiLabelBinarizer>` is
+used to binarize the 2d array of multilabels to ``fit`` upon. As a result,
+``predict()`` returns a 2d array with multiple predicted labels for each instance.

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -310,34 +310,6 @@ Here, the first ``predict()`` returns an integer array, since ``iris.target``
 (an integer array) was used in ``fit``. The second ``predict()`` returns a string
 array, since ``iris.target_names`` was for fitting.
 
-Similarly, when using `multiclass classifiers <http://scikit-learn.org/stable/modules/multiclass.html>`_,
-the format of the target data used for fitting determines whether multiclass or multilabel predictions will be returned::
-
-    >>> from sklearn.svm import SVC
-    >>> from sklearn.multiclass import OneVsRestClassifier
-    >>> from sklearn.preprocessing import LabelBinarizer
-
-    >>> X = [[1, 2], [2, 4], [4, 5], [3, 2], [3, 1]]
-    >>> y = [0, 0, 1, 1, 2]
-
-    >>> classif = OneVsRestClassifier(estimator=SVC(random_state=0))
-    >>> classif.fit(X, y).predict(X)
-    array([0, 0, 1, 1, 2])
-
-    >>> y = LabelBinarizer().fit_transform(y)
-    >>> classif.fit(X, y).predict(X)
-    array([[1, 0, 0],
-           [1, 0, 0],
-           [0, 1, 0],
-           [0, 0, 0],
-           [0, 0, 0]])
-
-In the first case, the target is fit on the multiclass labels provided by ``iris.target``.
-The ``predict()`` method therefore provides multiclass predictions. In the second case, the
-classification target is provided to the ``fit`` method as binary indicators via the
-:class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>` . In this case ``predict()``
-returns a 2d array representing the corresponding multi-label predictions.
-
 Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -373,3 +345,35 @@ more than once will overwrite what was learned by any previous ``fit()``::
 Here, the default kernel ``rbf`` is first changed to ``linear`` after the
 estimator has been constructed via ``SVC()``, and changed back to ``rbf`` to
 refit the estimator and to make a second prediction.
+
+Multiclass vs. Multilabel Fitting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using :class:`multiclass classifiers <sklearn.multiclass>`,
+the format of returned predictions is dependent on the format of the target data fit upon. More specifically, a classifier fit on multiclass labels will return multiclass
+predictions, whereas a classifier fit on label indicators will return multilabel predictions::
+
+    >>> from sklearn.svm import SVC
+    >>> from sklearn.multiclass import OneVsRestClassifier
+    >>> from sklearn.preprocessing import LabelBinarizer
+
+    >>> X = [[1, 2], [2, 4], [4, 5], [3, 2], [3, 1]]
+    >>> y = [0, 0, 1, 1, 2]
+
+    >>> classif = OneVsRestClassifier(estimator=SVC(random_state=0))
+    >>> classif.fit(X, y).predict(X)
+    array([0, 0, 1, 1, 2])
+
+    >>> y = LabelBinarizer().fit_transform(y)
+    >>> classif.fit(X, y).predict(X)
+    array([[1, 0, 0],
+           [1, 0, 0],
+           [0, 1, 0],
+           [0, 0, 0],
+           [0, 0, 0]])
+
+In the first case, the classifier is fit on a 1d array of multiclass labels.
+The ``predict()`` method therefore provides corresponding multiclass predictions.
+In the second case, the classification target is provided to ``fit()``  as
+a 2d array of binary label indicators, using the :class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>`.
+In this case ``predict()`` returns a 2d array representing the corresponding multi-label predictions.

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -310,6 +310,33 @@ Here, the first ``predict()`` returns an integer array, since ``iris.target``
 (an integer array) was used in ``fit``. The second ``predict()`` returns a string
 array, since ``iris.target_names`` was for fitting.
 
+Similarly, when using `multiclass classifiers <http://scikit-learn.org/stable/modules/multiclass.html>`_,
+the format of the target data used for fitting determines whether multiclass or multilabel predictions will be returned::
+
+    >>> from sklearn.svm import SVC
+    >>> from sklearn.multiclass import OneVsRestClassifier
+    >>> from sklearn.preprocessing import LabelBinarizer
+
+    >>> X = [[1, 2], [2, 4], [4, 5], [3, 2], [3, 1]]
+    >>> y = [0, 0, 1, 1, 2]
+
+    >>> classif = OneVsRestClassifier(estimator=SVC(random_state=0))
+    >>> classif.fit(X, y).predict(X)
+    array([0, 0, 1, 1, 2])
+
+    >>> y = LabelBinarizer().fit_transform(y)
+    >>> classif.fit(X, y).predict(X)
+    array([[1, 0, 0],
+           [1, 0, 0],
+           [0, 1, 0],
+           [0, 0, 0],
+           [0, 0, 0]])
+
+In the first case, the target is fit on the multiclass labels provided by ``iris.target``.
+The ``predict()`` method therefore provides multiclass predictions. In the second case, the
+classification target is provided to the ``fit`` method as binary indicators via the
+:class:`LabelBinarizer <sklearn.preprocessing.LabelBinarizer>` . In this case ``predict()``
+returns a 2d array representing the corresponding multi-label predictions.
 
 Refitting and updating parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Reference Issue

Fixes #4639
#### What does this implement/fix? Explain your changes.

I added documentation to the Quick Start conventions, documenting how multiclass classifiers will act when fit on classifications vs. binary label indicators.
#### Any other comments?

This is my first pull request to Scikit-Learn, so please let me know if there is anything that should be done differently. I spoke with @amueller regarding this contribution, and he suggested this location for the new documentation. However, I'm not positive whether it should be under the type casting section.

Andy, please let me know if I misunderstood the issue. I tried to demonstrate the difference you described, but I'm not 100% sure this was what the issue was referring to.
