### PR TITLE
[MRG + 1] fixed avoidable warnings in doc-test

### DIFF
--- a/doc/datasets/rcv1.rst
+++ b/doc/datasets/rcv1.rst
@@ -32,7 +32,7 @@ The target values are stored in a scipy CSR sparse matrix, with 804414 samples a
 Each sample can be identified by its ID, ranging (with gaps) from 2286 to 810596::
 
     >>> rcv1.sample_id[:3]
-    array([2286, 2287, 2288], dtype=int32)
+    array([2286, 2287, 2288], dtype=uint32)
 
 ``target_names``:
 The target values are the topics of each sample. Each sample belongs to at least one topic, and to up to 17 topics.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -443,16 +443,16 @@ and inferred labels::
 
    >>> from sklearn.metrics import classification_report
    >>> y_true = [0, 1, 2, 2, 0]
-   >>> y_pred = [0, 0, 2, 2, 0]
+   >>> y_pred = [0, 0, 2, 1, 0]
    >>> target_names = ['class 0', 'class 1', 'class 2']
    >>> print(classification_report(y_true, y_pred, target_names=target_names))
                 precision    recall  f1-score   support
    <BLANKLINE>
        class 0       0.67      1.00      0.80         2
        class 1       0.00      0.00      0.00         1
-       class 2       1.00      1.00      1.00         2
+       class 2       1.00      0.50      0.67         2
    <BLANKLINE>
-   avg / total       0.67      0.80      0.72         5
+   avg / total       0.67      0.60      0.59         5
    <BLANKLINE>
 
 .. topic:: Example:

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -145,9 +145,9 @@ indices where the value is `1` represents the assigned classes of that sample::
            nesterovs_momentum=True, power_t=0.5, random_state=1, shuffle=True,
            solver='lbfgs', tol=0.0001, validation_fraction=0.1, verbose=False,
            warm_start=False)
-    >>> clf.predict([1., 2.])
+    >>> clf.predict([[1., 2.]])
     array([[1, 1]])
-    >>> clf.predict([0., 0.])
+    >>> clf.predict([[0., 0.]])
     array([[0, 1]])
 
 See the examples below and the doc string of

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -563,4 +563,3 @@ upon the completion of this tutorial:
 
 * Have a look at the :ref:`Hashing Vectorizer <hashing_vectorizer>`
   as a memory efficient alternative to :class:`CountVectorizer`.
-


### PR DESCRIPTION
Woops. I guess I was just late for the release :)
Anyways, this should fix #7318.

The remaining warnings are due to deprecated classes that will be removed soon:

```
Doctest: gaussian_process.rst ... /Users/giorgio/dev/scikit-learn/sklearn/gaussian_process/kernels.py:288: RuntimeWarning: divide by zero encountered in log
  return np.log(np.vstack(bounds))
/Users/giorgio/dev/scikit-learn/sklearn/utils/deprecation.py:52: DeprecationWarning: Class GaussianProcess is deprecated; GaussianProcess was deprecated in version 0.18 and will be removed in 0.20. Use the GaussianProcessRegressor instead.
  warnings.warn(msg, category=DeprecationWarning)
/Users/giorgio/dev/scikit-learn/sklearn/utils/deprecation.py:70: DeprecationWarning: Function l1_cross_distances is deprecated; l1_cross_distances was deprecated in version 0.18 and will be removed in 0.20.
  warnings.warn(msg, category=DeprecationWarning)
```

or apparently due to nose (https://github.com/nose-devs/nose/issues/929)

```
/Users/giorgio/miniconda3/lib/python3.5/site-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
Doctest: unsupervised_learning.rst ... ok
/Users/giorgio/miniconda3/lib/python3.5/site-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
```

or numerical issues that are expected from the test and therefore seems legit to have

```
Doctest: gaussian_process.rst ... /Users/giorgio/dev/scikit-learn/sklearn/gaussian_process/kernels.py:288: RuntimeWarning: divide by zero encountered in log
  return np.log(np.vstack(bounds))
Doctest: model_evaluation.rst ... /Users/giorgio/dev/scikit-learn/sklearn/metrics/classification.py:1113: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples.
  'precision', 'predicted', average, warn_for)
Doctest: neural_networks_supervised.rst ... /Users/giorgio/dev/scikit-learn/sklearn/neural_network/multilayer_perceptron.py:563: ConvergenceWarning: Stochastic Optimizer: Maximum iterations reached and the optimization hasn't converged yet.
  % (), ConvergenceWarning)
```
