### PR TITLE
[MRG][HOTFIX] BUGFIX _store train_scores only if return_train_score is True

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -603,7 +603,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
         _store('test_score', test_scores, splits=True, rank=True,
                weights=test_sample_counts if self.iid else None)
-        _store('train_score', train_scores, splits=True)
+        if self.return_train_score:
+            _store('train_score', train_scores, splits=True)
         _store('fit_time', fit_time)
         _store('score_time', score_time)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1140,3 +1140,13 @@ def test_stochastic_gradient_loss_param():
     assert_false(hasattr(clf, "predict_proba"))
     clf.fit(X, y)
     assert_false(hasattr(clf, "predict_proba"))
+
+
+def test_search_train_scores_set_to_false():
+    X = np.arange(6).reshape(6, -1)
+    y = [0, 0, 0, 1, 1, 1]
+    clf = LinearSVC(random_state=0)
+
+    gs = GridSearchCV(clf, param_grid={'C': [0.1, 0.2]},
+                      return_train_score=False)
+    gs.fit(X, y)


### PR DESCRIPTION
Extremely sorry for the sloppiness. This should be back ported into 0.18.

@amueller @jnothman Apologies :(
