### PR TITLE
[MRG + 1] FIX: Update install instructions for Windows

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -80,10 +80,10 @@ Anaconda offers scikit-learn as part of its free distribution.
     via ``pip install``.
 
 
-Python(x,y) for Windows
+WinPython for Windows
 -----------------------
 
-The `Python(x,y) <https://python-xy.github.io>`_ project distributes
+The `WinPython <https://winpython.github.io/>`_ project distributes
 scikit-learn as an additional plugin.
 
 


### PR DESCRIPTION
Updates the Install instruction for scikit-learn in Windows to make use of WinPython instead of Python(x,y)
