### PR TITLE
Add shuffle to GroupKFold cross-validation generator

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -975,6 +975,16 @@ def test_group_kfold():
         assert_greater_equal(tolerance,
                              abs(sum(folds == i) - ideal_n_groups_per_fold))
 
+    # Tests GroupKFold with shuffle
+    lkf_shuffle = GroupKFold(n_splits=n_splits, shuffle=True, random_state=1)
+    folds = np.zeros(n_samples)
+    for i, (_, test) in enumerate(lkf_shuffle.split(X, y, groups)):
+        folds[test] = i
+
+    for i in np.unique(folds):
+        assert_greater_equal(tolerance,
+                             abs(sum(folds == i) - ideal_n_groups_per_fold))
+
     # Check that each group appears only in 1 fold
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -991,7 +1001,6 @@ def test_group_kfold():
     X = y = np.ones(len(groups))
     assert_raises_regexp(ValueError, "Cannot have number of splits.*greater",
                          next, GroupKFold(n_splits=3).split(X, y, groups))
-
 
 def test_time_series_cv():
     X = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14]]


### PR DESCRIPTION
As discussed in https://github.com/scikit-learn/scikit-learn/pull/7506, I’ve added shuffle as an additional argument to GroupKFold.

**Here is a small example:**

```
import numpy as np
from sklearn.model_selection import GroupKFold

lkf_shuffle = GroupKFold(n_splits=2, shuffle=True)
X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18], [19, 20, 21]], np.int32)
y = np.array(['a', 'a', 'c', 'c', 'b', 'b', 'd'])
groups = np.array(['l1', 'l1', 'l1', 'l2', 'l2', 'l3', 'l4'])

for (train, test) in lkf_shuffle.split(X, y, groups):
    print(train, test)

(array([3, 4, 5, 6]), array([0, 1, 2]))
(array([0, 1, 2]), array([3, 4, 5, 6]))

(array([3, 4, 5]), array([0, 1, 2, 6]))
(array([0, 1, 2, 6]), array([3, 4, 5]))

(array([0, 1, 2, 5]), array([3, 4, 6]))
(array([3, 4, 6]), array([0, 1, 2, 5]))

(array([3, 4]), array([0, 1, 2, 5, 6]))
(array([0, 1, 2, 5, 6]), array([3, 4]))
```

**without shuffle:**

```
lkf = GroupKFold(n_splits=2)
for (train, test) in lkf.split(X, y, groups):
    print(train, test)

(array([3, 4, 6]), array([0, 1, 2, 5]))
(array([0, 1, 2, 5]), array([3, 4, 6]))


```
