### PR TITLE
[MRG+1] Ngram Performance

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -135,10 +135,15 @@ class VectorizerMixin(object):
             original_tokens = tokens
             tokens = []
             n_original_tokens = len(original_tokens)
+
+            # bind method outside of loop to reduce overhead
+            tokens_append = tokens.append
+            space_join = " ".join
+
             for n in xrange(min_n,
                             min(max_n + 1, n_original_tokens + 1)):
                 for i in xrange(n_original_tokens - n + 1):
-                    tokens.append(" ".join(original_tokens[i: i + n]))
+                    tokens_append(space_join(original_tokens[i: i + n]))
 
         return tokens
 
@@ -150,9 +155,13 @@ class VectorizerMixin(object):
         text_len = len(text_document)
         ngrams = []
         min_n, max_n = self.ngram_range
+
+        # bind method outside of loop to reduce overhead
+        ngrams_append = ngrams.append
+
         for n in xrange(min_n, min(max_n + 1, text_len + 1)):
             for i in xrange(text_len - n + 1):
-                ngrams.append(text_document[i: i + n])
+                ngrams_append(text_document[i: i + n])
         return ngrams
 
     def _char_wb_ngrams(self, text_document):
@@ -165,15 +174,19 @@ class VectorizerMixin(object):
 
         min_n, max_n = self.ngram_range
         ngrams = []
+
+        # bind method outside of loop to reduce overhead
+        ngrams_append = ngrams.append
+
         for w in text_document.split():
             w = ' ' + w + ' '
             w_len = len(w)
             for n in xrange(min_n, max_n + 1):
                 offset = 0
-                ngrams.append(w[offset:offset + n])
+                ngrams_append(w[offset:offset + n])
                 while offset + n < w_len:
                     offset += 1
-                    ngrams.append(w[offset:offset + n])
+                    ngrams_append(w[offset:offset + n])
                 if offset == 0:   # count a short word (w_len < n) only once
                     break
         return ngrams

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -134,6 +134,8 @@ class VectorizerMixin(object):
         if max_n != 1:
             original_tokens = tokens
             if min_n == 1:
+                # no need to do any slicing for unigrams
+                # just iterate through the original tokens
                 tokens = list(original_tokens)
                 min_n += 1
             else:
@@ -160,6 +162,8 @@ class VectorizerMixin(object):
         text_len = len(text_document)
         min_n, max_n = self.ngram_range
         if min_n == 1:
+            # no need to do any slicing for unigrams
+            # iterate through the string
             ngrams = list(text_document)
             min_n += 1
         else:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -133,7 +133,12 @@ class VectorizerMixin(object):
         min_n, max_n = self.ngram_range
         if max_n != 1:
             original_tokens = tokens
-            tokens = []
+            if min_n == 1:
+                tokens = list(original_tokens)
+                min_n += 1
+            else:
+                tokens = []
+
             n_original_tokens = len(original_tokens)
 
             # bind method outside of loop to reduce overhead
@@ -153,8 +158,12 @@ class VectorizerMixin(object):
         text_document = self._white_spaces.sub(" ", text_document)
 
         text_len = len(text_document)
-        ngrams = []
         min_n, max_n = self.ngram_range
+        if min_n == 1:
+            ngrams = list(text_document)
+            min_n += 1
+        else:
+            ngrams = []
 
         # bind method outside of loop to reduce overhead
         ngrams_append = ngrams.append


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
#### What does this implement/fix? Explain your changes.

A couple of small changes to make ngram generation a little bit faster.
1. Bind the `tokens.append()` and `" ".join()` methods outside of the for-loops.
2. For unigrams, skip slicing entirely and just use `tokens = list(original_tokens)`.
#### Any other comments?

[Benchmarks](https://gist.github.com/jtdoepke/73057fb784c4b3dbcb6e98a7d481c219)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
