### PR TITLE
[MRG+1] Add sample_weight parameter to cohen_kappa_score

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,8 +31,8 @@ Enhancements
      <https://github.com/scikit-learn/scikit-learn/pull/4939>`_) by `Andrea
      Esuli`_.
 
-   - Add ``sample_weight`` parameter to `metrics.cohen_kappa_score`. By Victor
-     Poughon.
+   - Add ``sample_weight`` parameter to :func:`metrics.cohen_kappa_score` by
+     Victor Poughon.
 
 Bug fixes
 .........

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,9 @@ Enhancements
      <https://github.com/scikit-learn/scikit-learn/pull/4939>`_) by `Andrea
      Esuli`_.
 
+   - Add ``sample_weight`` parameter to `metrics.cohen_kappa_score`. By Victor
+     Poughon.
+
 Bug fixes
 .........
 

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -18,6 +18,7 @@ the lower the better
 #          Jatin Shah <jatindshah@gmail.com>
 #          Saurabh Jha <saurabh.jhaa@gmail.com>
 #          Bernardo Stein <bernardovstein@gmail.com>
+#          Victor Poughon <victor.poughon@cnes.fr>
 # License: BSD 3 clause
 
 from __future__ import division
@@ -275,7 +276,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     return CM
 
 
-def cohen_kappa_score(y1, y2, labels=None, weights=None):
+def cohen_kappa_score(y1, y2, labels=None, weights=None, sample_weight=None):
     """Cohen's kappa: a statistic that measures inter-annotator agreement.
 
     This function computes Cohen's kappa [1]_, a score that expresses the level
@@ -311,6 +312,9 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
         List of weighting type to calculate the score. None means no weighted;
         "linear" means linear weighted; "quadratic" means quadratic weighted.
 
+    sample_weight : array-like of shape = [n_samples], optional
+        Sample weights.
+
     Returns
     -------
     kappa : float
@@ -328,7 +332,8 @@ def cohen_kappa_score(y1, y2, labels=None, weights=None):
     .. [3] `Wikipedia entry for the Cohen's kappa.
             <https://en.wikipedia.org/wiki/Cohen%27s_kappa>`_
     """
-    confusion = confusion_matrix(y1, y2, labels=labels)
+    confusion = confusion_matrix(y1, y2, labels=labels,
+                                 sample_weight=sample_weight)
     n_classes = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)

--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -18,7 +18,6 @@ the lower the better
 #          Jatin Shah <jatindshah@gmail.com>
 #          Saurabh Jha <saurabh.jhaa@gmail.com>
 #          Bernardo Stein <bernardovstein@gmail.com>
-#          Victor Poughon <victor.poughon@cnes.fr>
 # License: BSD 3 clause
 
 from __future__ import division

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -368,7 +368,6 @@ NOT_SYMMETRIC_METRICS = [
 
 # No Sample weight support
 METRICS_WITHOUT_SAMPLE_WEIGHT = [
-    "cohen_kappa_score",
     "confusion_matrix", # Left this one here because the tests in this file do
                         # not work for confusion_matrix, as its output is a
                         # matrix instead of a number. Testing of


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

NA
#### What does this implement/fix? Explain your changes.

This adds a sample_weight parameter to sklearn.metrics.cohen_kappa_score. The implementation simply forwards the argument to the underlying confusion_matrix call.
#### Any other comments?

It would be better to add a specific test in test_cohen_kappa() ([here](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/tests/test_classification.py#L314)), but I don't know how to get reference kappa values for this test. Note that cohen_kappa_score is removed from METRICS_WITHOUT_SAMPLE_WEIGHT in test_common.py, which should provide additional testing, although not specific to this metric.

Finally I couldn't manage to run the full test suite locally so I'm relying on travis-ci here.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
