### PR TITLE
[MRG] Fix flake8_diff.sh git repo unshallowing

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -20,9 +20,6 @@ set -o pipefail
 PROJECT=scikit-learn/scikit-learn
 PROJECT_URL=https://github.com/$PROJECT.git
 
-echo "Remotes:"
-git remote --verbose
-
 # Find the remote with the project name (upstream in most cases)
 REMOTE=$(git remote -v | grep $PROJECT | cut -f1 | head -1 || echo '')
 
@@ -33,6 +30,19 @@ if [[ -z "$REMOTE" ]]; then
     TMP_REMOTE=tmp_reference_upstream
     REMOTE=$TMP_REMOTE
     git remote add $REMOTE $PROJECT_URL
+fi
+
+echo "Remotes:"
+echo '--------------------------------------------------------------------------------'
+git remote --verbose
+
+# Travis does the git clone with a limited depth (50 at the time of
+# writing). This may not be enough to find the common ancestor with
+# $REMOTE/master so we unshallow the git checkout
+if [[ -a .git/shallow ]]; then
+    echo -e '\nTrying to unshallow the repo:'
+    echo '--------------------------------------------------------------------------------'
+    git fetch --unshallow
 fi
 
 if [[ "$TRAVIS" == "true" ]]; then
@@ -46,50 +56,54 @@ if [[ "$TRAVIS" == "true" ]]; then
                 exit 0
             fi
             COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
-        else
-            # Travis does the git clone with a limited depth (50 at the time of
-            # writing). This may not be enough to find the common ancestor with
-            # $REMOTE/master so we unshallow the git checkout
-            git fetch --unshallow || echo "Unshallowing the git checkout failed"
         fi
     else
         # We want to fetch the code as it is in the PR branch and not
         # the result of the merge into master. This way line numbers
         # reported by Travis will match with the local code.
-        BRANCH_NAME=travis_pr_$TRAVIS_PULL_REQUEST
-        git fetch $REMOTE pull/$TRAVIS_PULL_REQUEST/head:$BRANCH_NAME
-        git checkout $BRANCH_NAME
+        LOCAL_BRANCH_REF=travis_pr_$TRAVIS_PULL_REQUEST
+        # In Travis the PR target is always origin
+        git fetch origin pull/$TRAVIS_PULL_REQUEST/head:refs/$LOCAL_BRANCH_REF
     fi
 fi
 
-
-echo -e '\nLast 2 commits:'
-echo '--------------------------------------------------------------------------------'
-git log -2 --pretty=short
-
 # If not using the commit range from Travis we need to find the common
-# ancestor between HEAD and $REMOTE/master
+# ancestor between $LOCAL_BRANCH_REF and $REMOTE/master
 if [[ -z "$COMMIT_RANGE" ]]; then
+    if [[ -z "$LOCAL_BRANCH_REF" ]]; then
+        LOCAL_BRANCH_REF=$(git rev-parse --abbrev-ref HEAD)
+    fi
+    echo -e "\nLast 2 commits in $LOCAL_BRANCH_REF:"
+    echo '--------------------------------------------------------------------------------'
+    git log -2 $LOCAL_BRANCH_REF
+
     REMOTE_MASTER_REF="$REMOTE/master"
     # Make sure that $REMOTE_MASTER_REF is a valid reference
+    echo -e "\nFetching $REMOTE_MASTER_REF"
+    echo '--------------------------------------------------------------------------------'
     git fetch $REMOTE master:refs/remotes/$REMOTE_MASTER_REF
+    LOCAL_BRANCH_SHORT_HASH=$(git rev-parse --short $LOCAL_BRANCH_REF)
+    REMOTE_MASTER_SHORT_HASH=$(git rev-parse --short $REMOTE_MASTER_REF)
 
-    COMMIT=$(git merge-base @ $REMOTE_MASTER_REF) || \
-        echo "No common ancestor found for $(git show @ -q) and $(git show $REMOTE_MASTER_REF -q)"
-
-    if [[ -n "$TMP_REMOTE" ]]; then
-        git remote remove $TMP_REMOTE
-    fi
+    COMMIT=$(git merge-base $LOCAL_BRANCH_REF $REMOTE_MASTER_REF) || \
+        echo "No common ancestor found for $(git show $LOCAL_BRANCH_REF -q) and $(git show $REMOTE_MASTER_REF -q)"
 
     if [ -z "$COMMIT" ]; then
         exit 1
     fi
 
-    echo -e "\nCommon ancestor between HEAD and $REMOTE_MASTER_REF is:"
-    echo '--------------------------------------------------------------------------------'
-    git show --no-patch $COMMIT
+    COMMIT_SHORT_HASH=$(git rev-parse --short $COMMIT)
 
-    COMMIT_RANGE="$(git rev-parse --short $COMMIT)..$(git rev-parse --short @)"
+    echo -e "\nCommon ancestor between $LOCAL_BRANCH_REF ($LOCAL_BRANCH_SHORT_HASH)"\
+         "and $REMOTE_MASTER_REF ($REMOTE_MASTER_SHORT_HASH) is $COMMIT_SHORT_HASH:"
+    echo '--------------------------------------------------------------------------------'
+    git show --no-patch $COMMIT_SHORT_HASH
+
+    COMMIT_RANGE="$COMMIT_SHORT_HASH..$LOCAL_BRANCH_SHORT_HASH"
+
+    if [[ -n "$TMP_REMOTE" ]]; then
+        git remote remove $TMP_REMOTE
+    fi
 
 else
     echo "Got the commit range from Travis: $COMMIT_RANGE"


### PR DESCRIPTION
which fixes the issue seen in https://github.com/scikit-learn/scikit-learn/pull/7027#issuecomment-251053764.

Enhancements:
- the script works on PRs targetting a fork rather than the reference
  repo
- improved logic about when to unshallow the repo
- fetching the upstream master branch into a reference rather than a
  branch (less intrusive for scripts than may run afterwards e.g. the
  ones in the after_success step)
- Better logging messages

I'll just wait the CI on this one and probably merge if everything is green.
