### PR TITLE
Rangespan testimonial has misformatted link

### DIFF
--- a/doc/testimonials/testimonials.rst
+++ b/doc/testimonials/testimonials.rst
@@ -293,7 +293,7 @@ Greg Lamp, Co-founder Yhat
 
    </span>
 
-`Rangespan <https://www.rangespan.com>_`
+`Rangespan <http://www.rangespan.com>`_
 ----------------------------------------
 
 .. raw:: html
@@ -302,7 +302,7 @@ Greg Lamp, Co-founder Yhat
 
 .. image:: images/rangespan.png
     :width: 120pt
-    :target: https://www.rangespan.com
+    :target: http://www.rangespan.com
 
 .. raw:: html
 


### PR DESCRIPTION
Reference Issue
Rangespan testimonial has misformatted link #7521

Fixed the formatting and URL of the Rangespan testimonial by changing the URL to use http instead of https and move the underscore so it goes from
`Rangespan <https://www.rangespan.com>_` (improperly formatted rst link with https)
to
`Rangespan <http://www.rangespan.com>`_ (properly formatted rst link with http)

I feel, we can add an extra comment/line in the section indicating that Rangeapan is been acquired by Google and their site is inactive now. This may avoid confusion.
