### PR TITLE
[MRG+1] DOC FIX: update warning about random seed with scipy

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -113,9 +113,12 @@ consecutive calls.
 
     .. warning::
 
-        The distributions in ``scipy.stats`` do not allow specifying a random
-        state. Instead, they use the global numpy random state, that can be seeded
-        via ``np.random.seed`` or set using ``np.random.set_state``.
+        The distributions in ``scipy.stats`` prior to version scipy 0.16
+        do not allow specifying a random state. Instead, they use the global
+        numpy random state, that can be seeded via ``np.random.seed`` or set
+        using ``np.random.set_state``. However, beginning scikit-learn 0.18,
+        the :mod:`sklearn.model_selection` module sets the random state provided
+        by the user if scipy >= 0.16 is also available.
 
 For continuous parameters, such as ``C`` above, it is important to specify
 a continuous distribution to take full advantage of the randomization. This way,


### PR DESCRIPTION
Closes #7364 

This is a simple doc fix following discussion with @amueller. The warning now looks like this
![update_warning](https://cloud.githubusercontent.com/assets/15852194/19086791/dd351cc6-8a6f-11e6-9e49-f56548d312a0.png)
