### PR TITLE
[MRG] backport 0.18 release date and py2.6 deprecation warning to 0.18.X branch

### DIFF
--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -48,3 +48,5 @@ Making a release
     $ python setup.py bdist_wininst upload
 
    And upload them also to sourceforge
+
+7. FOR FINAL RELEASE: Update the release date in What's New

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,6 +9,8 @@ Release history
 Version 0.18
 ============
 
+**September 28, 2016**
+
 .. _model_selection_changes:
 
 Model Selection Enhancements and API Changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ Version 0.18
 
 **September 28, 2016**
 
+.. topic:: Last release with Python 2.6 support
+
+    Scikit-learn 0.18 will be the last version of scikit-learn to support Python 2.6.
+    Later versions of scikit-learn will require Python 2.7 or above.
+
 .. _model_selection_changes:
 
 Model Selection Enhancements and API Changes


### PR DESCRIPTION
This pull request backports two documentation changesets from the master branch:
- 21d238b: DOC release date in what's new (#7518)
- 4773044: add warning about python 2.6 being no longer supported (#7532, discussion in #7522)

If this PR is requested,  @NelleV can remove #7518 from the list of PRs that need backporting. (See https://github.com/scikit-learn/scikit-learn/pull/7518#issuecomment-250371480.)
