### PR TITLE
[MRG] backport release date of 0.18 to 0.18.X branch

### DIFF
--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -48,3 +48,5 @@ Making a release
     $ python setup.py bdist_wininst upload
 
    And upload them also to sourceforge
+
+7. FOR FINAL RELEASE: Update the release date in What's New

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,6 +9,8 @@ Release history
 Version 0.18
 ============
 
+**September 28, 2016**
+
 .. _model_selection_changes:
 
 Model Selection Enhancements and API Changes


### PR DESCRIPTION
#7580 was closed and the Python 2.6 deprecation warning is merged, but the release date is still not mentioned in the `0.18.X` branch. This pull request makes fixing that as simple as possible. It may be superfluous, but that's fine.
