### PR TITLE
[MRG + 1] FIX Calling fit_transform instead of transform in Pipeline's fit_predict

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -356,7 +356,7 @@ class Pipeline(_BasePipeline):
         Xt = X
         for name, transform in self.steps[:-1]:
             if transform is not None:
-                Xt = transform.transform(Xt)
+                Xt = transform.fit_transform(Xt)
         return self.steps[-1][-1].fit_predict(Xt, y, **fit_params)
 
     @if_delegate_has_method(delegate='_final_estimator')

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -277,8 +277,10 @@ def test_fit_predict_on_pipeline():
     # transform and clustering steps separately
     iris = load_iris()
     scaler = StandardScaler()
-    scaler_for_pipeline = StandardScaler()
     km = KMeans(random_state=0)
+    # As pipeline doesn't clone estimators on construction,
+    # it must have its own estimators
+    scaler_for_pipeline = StandardScaler()
     km_for_pipeline = KMeans(random_state=0)
 
     # first compute the transform and clustering step separately

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -277,14 +277,16 @@ def test_fit_predict_on_pipeline():
     # transform and clustering steps separately
     iris = load_iris()
     scaler = StandardScaler()
+    scaler_for_pipeline = StandardScaler()
     km = KMeans(random_state=0)
+    km_for_pipeline = KMeans(random_state=0)
 
     # first compute the transform and clustering step separately
     scaled = scaler.fit_transform(iris.data)
     separate_pred = km.fit_predict(scaled)
 
     # use a pipeline to do the transform and clustering in one step
-    pipe = Pipeline([('scaler', scaler), ('Kmeans', km)])
+    pipe = Pipeline([('scaler', scaler_for_pipeline), ('Kmeans', km_for_pipeline)])
     pipeline_pred = pipe.fit_predict(iris.data)
 
     assert_array_almost_equal(pipeline_pred, separate_pred)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -286,7 +286,10 @@ def test_fit_predict_on_pipeline():
     separate_pred = km.fit_predict(scaled)
 
     # use a pipeline to do the transform and clustering in one step
-    pipe = Pipeline([('scaler', scaler_for_pipeline), ('Kmeans', km_for_pipeline)])
+    pipe = Pipeline([
+        ('scaler', scaler_for_pipeline),
+        ('Kmeans', km_for_pipeline)
+    ])
     pipeline_pred = pipe.fit_predict(iris.data)
 
     assert_array_almost_equal(pipeline_pred, separate_pred)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

This PR fixes issue #7558. 
#### What does this implement/fix? Explain your changes.

As discussed in #7558, each transformer in pipeline should call `fit_transform` instead of `transform` in `fit_predict`. `test_fix_predict_on_pipeline` is also fixed.
