### PR TITLE
[MRG + 1] ElasticNetCV: raise ValueError if l1_ratio=0

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -49,10 +49,10 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
         Xy = np.dot(X.T, y) that can be precomputed.
 
     l1_ratio : float
-        The elastic net mixing parameter, with ``0 <= l1_ratio <= 1``.
-        For ``l1_ratio = 0`` the penalty is an L2 penalty. ``For
-        l1_ratio = 1`` it is an L1 penalty.  For ``0 < l1_ratio <
-        1``, the penalty is a combination of L1 and L2.
+        The elastic net mixing parameter, with ``0 < l1_ratio <= 1``.
+        For ``l1_ratio = 0`` the penalty is an L2 penalty. (currently not
+        supported) ``For l1_ratio = 1`` it is an L1 penalty. For
+        ``0 < l1_ratio <1``, the penalty is a combination of L1 and L2.
 
     eps : float, optional
         Length of the path. ``eps=1e-3`` means that
@@ -77,6 +77,11 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
     copy_X : boolean, optional, default True
         If ``True``, X will be copied; else, it may be overwritten.
     """
+    if l1_ratio == 0:
+        raise ValueError("Automatic alpha grid generation is not supported for"
+                         " l1_ratio=0. Please supply a grid by providing "
+                         "your estimator with the appropriate `alphas=` "
+                         "argument.")
     n_samples = len(y)
 
     sparse_center = False

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -728,3 +728,17 @@ def test_enet_l1_ratio():
                          ElasticNetCV(l1_ratio=0).fit, X, y)
     assert_raise_message(ValueError, msg,
                          MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)
+
+    # Test that l1_ratio=0 is allowed if we supply a grid manually
+    alphas = [0.1, 10]
+    est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    est = ElasticNetCV(l1_ratio=0, alphas=alphas)
+    est_desired.fit(X, y)
+    est.fit(X, y)
+    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+
+    est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
+    est.fit(X, X)
+    est_desired.fit(X, X)
+    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -729,7 +729,7 @@ def test_enet_l1_ratio():
     assert_raise_message(ValueError, msg,
                          MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)
 
-    # Test that l1_ratio=0 is allowed if we supply a grid manually
+    # Test that l1_ratio=0 is allowed if we supply a grid manually.
     alphas = [0.1, 10]
     est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
     est = ElasticNetCV(l1_ratio=0, alphas=alphas)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -718,7 +718,7 @@ def test_enet_float_precision():
 def test_enet_l1_ratio():
     # Test that an error message is raised if an estimator that
     # uses _alpha_grid is called with l1_ratio=0
-    msg = ("Automatic alpha grid generation is not supported for  l1_ratio=0. "
+    msg = ("Automatic alpha grid generation is not supported for l1_ratio=0. "
            "Please supply a grid by providing your estimator with the "
            "appropriate `alphas=` argument.")
     X = np.array([[1, 2, 4, 5, 8], [3, 5, 7, 7, 8]]).T

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -729,7 +729,7 @@ def test_enet_l1_ratio():
     assert_raise_message(ValueError, msg,
                          MultiTaskElasticNetCV(l1_ratio=0).fit, X, y[:, None])
 
-    # Test that l1_ratio=0 is allowed if we supply a grid manually.
+    # Test that l1_ratio=0 is allowed if we supply a grid manually
     alphas = [0.1, 10]
     est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
     est = ElasticNetCV(l1_ratio=0, alphas=alphas)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -729,16 +729,16 @@ def test_enet_l1_ratio():
     assert_raise_message(ValueError, msg,
                          MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)
 
-    # Test that l1_ratio=0 is allowed if we supply a grid manually.
-    alphas = [0.1, 10]
-    est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    est = ElasticNetCV(l1_ratio=0, alphas=alphas)
-    est_desired.fit(X, y)
-    est.fit(X, y)
-    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
-
-    est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
-    est.fit(X, X)
-    est_desired.fit(X, X)
-    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+    # Test that l1_ratio=0 is allowed if we supply a grid manually
+    # alphas = [0.1, 10]
+    # est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    # est = ElasticNetCV(l1_ratio=0, alphas=alphas)
+    # est_desired.fit(X, y)
+    # est.fit(X, y)
+    # assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+    #
+    # est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    # est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
+    # est.fit(X, X)
+    # est_desired.fit(X, X)
+    # assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -730,15 +730,17 @@ def test_enet_l1_ratio():
                          MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)
 
     # Test that l1_ratio=0 is allowed if we supply a grid manually
-    # alphas = [0.1, 10]
-    # est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    # est = ElasticNetCV(l1_ratio=0, alphas=alphas)
-    # est_desired.fit(X, y)
-    # est.fit(X, y)
-    # assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
-    #
-    # est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    # est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
-    # est.fit(X, X)
-    # est_desired.fit(X, X)
-    # assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+    alphas = [0.1, 10]
+    est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    est = ElasticNetCV(l1_ratio=0, alphas=alphas)
+    with ignore_warnings():
+        est_desired.fit(X, y)
+        est.fit(X, y)
+    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+
+    est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
+    est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
+    with ignore_warnings():
+        est.fit(X, X)
+        est_desired.fit(X, X)
+    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -724,22 +724,23 @@ def test_enet_l1_ratio():
     X = np.array([[1, 2, 4, 5, 8], [3, 5, 7, 7, 8]]).T
     y = np.array([12, 10, 11, 21, 5])
 
-    assert_raise_message(ValueError, msg,
-                         ElasticNetCV(l1_ratio=0).fit, X, y)
-    assert_raise_message(ValueError, msg,
-                         MultiTaskElasticNetCV(l1_ratio=0).fit, X, y[:, None])
+    assert_raise_message(ValueError, msg, ElasticNetCV(
+        l1_ratio=0, random_state=42).fit, X, y)
+    assert_raise_message(ValueError, msg, MultiTaskElasticNetCV(
+        l1_ratio=0, random_state=42).fit, X, y[:, None])
 
     # Test that l1_ratio=0 is allowed if we supply a grid manually
     alphas = [0.1, 10]
-    est_desired = ElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    est = ElasticNetCV(l1_ratio=0, alphas=alphas)
+    estkwds = {'alphas': alphas, 'random_state': 42}
+    est_desired = ElasticNetCV(l1_ratio=0.00001, **estkwds)
+    est = ElasticNetCV(l1_ratio=0, **estkwds)
     with ignore_warnings():
         est_desired.fit(X, y)
         est.fit(X, y)
     assert_array_almost_equal(est.coef_, est_desired.coef_, decimal=5)
 
-    est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
-    est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
+    est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, **estkwds)
+    est = MultiTaskElasticNetCV(l1_ratio=0, **estkwds)
     with ignore_warnings():
         est.fit(X, y[:, None])
         est_desired.fit(X, y[:, None])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -17,6 +17,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regex
+from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import ignore_warnings
@@ -712,3 +713,18 @@ def test_enet_float_precision():
             assert_array_almost_equal(intercept[np.float32],
                                       intercept[np.float64],
                                       decimal=4)
+
+
+def test_enet_l1_ratio():
+    # Test that an error message is raised if an estimator that
+    # uses _alpha_grid is called with l1_ratio=0
+    msg = ("Automatic alpha grid generation is not supported for  l1_ratio=0. "
+           "Please supply a grid by providing your estimator with the "
+           "appropriate `alphas=` argument.")
+    X = np.array([[1, 2, 4, 5, 8], [3, 5, 7, 7, 8]]).T
+    y = np.array([12, 10, 11, 21, 5])
+
+    assert_raise_message(ValueError, msg,
+                         ElasticNetCV(l1_ratio=0).fit, X, y)
+    assert_raise_message(ValueError, msg,
+                         MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -736,11 +736,11 @@ def test_enet_l1_ratio():
     with ignore_warnings():
         est_desired.fit(X, y)
         est.fit(X, y)
-    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+    assert_array_almost_equal(est.coef_, est_desired.coef_, decimal=5)
 
     est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
     est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
     with ignore_warnings():
         est.fit(X, X)
         est_desired.fit(X, X)
-    assert_almost_equal(est.coef_, est_desired.coef_, decimal=5)
+    assert_array_almost_equal(est.coef_, est_desired.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -727,7 +727,7 @@ def test_enet_l1_ratio():
     assert_raise_message(ValueError, msg,
                          ElasticNetCV(l1_ratio=0).fit, X, y)
     assert_raise_message(ValueError, msg,
-                         MultiTaskElasticNetCV(l1_ratio=0).fit, X, X)
+                         MultiTaskElasticNetCV(l1_ratio=0).fit, X, y[:, None])
 
     # Test that l1_ratio=0 is allowed if we supply a grid manually.
     alphas = [0.1, 10]
@@ -741,6 +741,6 @@ def test_enet_l1_ratio():
     est_desired = MultiTaskElasticNetCV(l1_ratio=0.00001, alphas=alphas)
     est = MultiTaskElasticNetCV(l1_ratio=0, alphas=alphas)
     with ignore_warnings():
-        est.fit(X, X)
-        est_desired.fit(X, X)
+        est.fit(X, y[:, None])
+        est_desired.fit(X, y[:, None])
     assert_array_almost_equal(est.coef_, est_desired.coef_, decimal=5)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -588,24 +588,28 @@ def test_logistic_regression_sample_weights():
         # Test that passing sample_weight as ones is the same as
         # not passing them at all (default None)
         for solver in ['lbfgs', 'liblinear']:
-            clf_sw_none = LR(solver=solver, fit_intercept=False)
+            clf_sw_none = LR(solver=solver, fit_intercept=False,
+                             random_state=42)
             clf_sw_none.fit(X, y)
-            clf_sw_ones = LR(solver=solver, fit_intercept=False)
+            clf_sw_ones = LR(solver=solver, fit_intercept=False,
+                             random_state=42)
             clf_sw_ones.fit(X, y, sample_weight=np.ones(y.shape[0]))
             assert_array_almost_equal(
                 clf_sw_none.coef_, clf_sw_ones.coef_, decimal=4)
 
         # Test that sample weights work the same with the lbfgs,
         # newton-cg, and 'sag' solvers
-        clf_sw_lbfgs = LR(solver='lbfgs', fit_intercept=False)
+        clf_sw_lbfgs = LR(solver='lbfgs', fit_intercept=False, random_state=42)
         clf_sw_lbfgs.fit(X, y, sample_weight=sample_weight)
-        clf_sw_n = LR(solver='newton-cg', fit_intercept=False)
+        clf_sw_n = LR(solver='newton-cg', fit_intercept=False, random_state=42)
         clf_sw_n.fit(X, y, sample_weight=sample_weight)
-        clf_sw_sag = LR(solver='sag', fit_intercept=False, tol=1e-10)
+        clf_sw_sag = LR(solver='sag', fit_intercept=False, tol=1e-10,
+                        random_state=42)
         # ignore convergence warning due to small dataset
         with ignore_warnings():
             clf_sw_sag.fit(X, y, sample_weight=sample_weight)
-        clf_sw_liblinear = LR(solver='liblinear', fit_intercept=False)
+        clf_sw_liblinear = LR(solver='liblinear', fit_intercept=False,
+                              random_state=42)
         clf_sw_liblinear.fit(X, y, sample_weight=sample_weight)
         assert_array_almost_equal(
             clf_sw_lbfgs.coef_, clf_sw_n.coef_, decimal=4)
@@ -619,9 +623,9 @@ def test_logistic_regression_sample_weights():
         # to be 2 for all instances of class 2
         for solver in ['lbfgs', 'liblinear']:
             clf_cw_12 = LR(solver=solver, fit_intercept=False,
-                           class_weight={0: 1, 1: 2})
+                           class_weight={0: 1, 1: 2}, random_state=42)
             clf_cw_12.fit(X, y)
-            clf_sw_12 = LR(solver=solver, fit_intercept=False)
+            clf_sw_12 = LR(solver=solver, fit_intercept=False, random_state=42)
             clf_sw_12.fit(X, y, sample_weight=sample_weight)
             assert_array_almost_equal(
                 clf_cw_12.coef_, clf_sw_12.coef_, decimal=4)
@@ -630,19 +634,21 @@ def test_logistic_regression_sample_weights():
     # since the patched liblinear code is different.
     clf_cw = LogisticRegression(
         solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
-        penalty="l1", tol=1e-5)
+        penalty="l1", tol=1e-5, random_state=42)
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, penalty="l1", tol=1e-5)
+        solver="liblinear", fit_intercept=False, penalty="l1", tol=1e-5,
+        random_state=42)
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 
     clf_cw = LogisticRegression(
         solver="liblinear", fit_intercept=False, class_weight={0: 1, 1: 2},
-        penalty="l2", dual=True)
+        penalty="l2", dual=True, random_state=42)
     clf_cw.fit(X, y)
     clf_sw = LogisticRegression(
-        solver="liblinear", fit_intercept=False, penalty="l2", dual=True)
+        solver="liblinear", fit_intercept=False, penalty="l2", dual=True,
+        random_state=42)
     clf_sw.fit(X, y, sample_weight)
     assert_array_almost_equal(clf_cw.coef_, clf_sw.coef_, decimal=4)
 


### PR DESCRIPTION
#### Reference Issue

Fixes #7551
#### What does this implement/fix? Explain your changes.

Before,

``` py
import numpy as np
from sklearn.linear_model import ElasticNetCV
X = np.array([[1, 2, 4, 5, 8], [3, 5, 7, 7, 8]]).T
y = np.array([12, 10, 11, 21, 5])

est = ElasticNetCV(l1_ratio=0).fit(X, y)
```

gives the runtime error `UnboundLocalError: local variable 'best_l1_ratio' referenced before assignment`

Now it returns `ValueError: l1_ratio = 0 not supported`
