### PR TITLE
[MRG + 1] FIX Validate and convert X, y and groups to ndarray before splitting

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -26,7 +26,6 @@ from scipy.misc import comb
 from ..utils import indexable, check_random_state, safe_indexing
 from ..utils.validation import _num_samples, column_or_1d
 from ..utils.validation import check_array
-from ..utils.validation import check_consistent_length
 from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -753,12 +753,12 @@ class LeaveOneGroupOut(BaseCrossValidator):
     >>> X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
     >>> y = np.array([1, 2, 1, 2])
     >>> groups = np.array([1, 1, 2, 2])
-    >>> lol = LeaveOneGroupOut()
-    >>> lol.get_n_splits(X, y, groups)
+    >>> logo = LeaveOneGroupOut()
+    >>> logo.get_n_splits(X, y, groups)
     2
-    >>> print(lol)
+    >>> print(logo)
     LeaveOneGroupOut()
-    >>> for train_index, test_index in lol.split(X, y, groups):
+    >>> for train_index, test_index in logo.split(X, y, groups):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]
@@ -810,7 +810,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
         """
         if groups is None:
             raise ValueError("The groups parameter should not be None")
-        return len(np.unique(indexable(groups)))
+        return len(np.unique(groups))
 
 
 class LeavePGroupsOut(BaseCrossValidator):
@@ -841,12 +841,12 @@ class LeavePGroupsOut(BaseCrossValidator):
     >>> X = np.array([[1, 2], [3, 4], [5, 6]])
     >>> y = np.array([1, 2, 1])
     >>> groups = np.array([1, 2, 3])
-    >>> lpl = LeavePGroupsOut(n_groups=2)
-    >>> lpl.get_n_splits(X, y, groups)
+    >>> lpgo = LeavePGroupsOut(n_groups=2)
+    >>> lpgo.get_n_splits(X, y, groups)
     3
-    >>> print(lpl)
+    >>> print(lpgo)
     LeavePGroupsOut(n_groups=2)
-    >>> for train_index, test_index in lpl.split(X, y, groups):
+    >>> for train_index, test_index in lpgo.split(X, y, groups):
     ...    print("TRAIN:", train_index, "TEST:", test_index)
     ...    X_train, X_test = X[train_index], X[test_index]
     ...    y_train, y_test = y[train_index], y[test_index]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -474,6 +474,8 @@ class GroupKFold(_BaseKFold):
     def _iter_test_indices(self, X, y, groups):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
+        groups = check_array(groups, ensure_2d=False, dtype=None)
+        check_consistent_length(X, groups)
 
         unique_groups, groups = np.unique(groups, return_inverse=True)
         n_groups = len(unique_groups)
@@ -775,7 +777,8 @@ class LeaveOneGroupOut(BaseCrossValidator):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
         # We make a copy of groups to avoid side-effects during iteration
-        groups = np.array(groups, copy=True)
+        groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
+        check_consistent_length(X, groups)
         unique_groups = np.unique(groups)
         if len(unique_groups) <= 1:
             raise ValueError(
@@ -868,7 +871,8 @@ class LeavePGroupsOut(BaseCrossValidator):
     def _iter_test_masks(self, X, y, groups):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
-        groups = np.array(groups, copy=True)
+        groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
+        check_consistent_length(X, groups)
         unique_groups = np.unique(groups)
         if self.n_groups >= len(unique_groups):
             raise ValueError(
@@ -903,8 +907,11 @@ class LeavePGroupsOut(BaseCrossValidator):
         n_splits : int
             Returns the number of splitting iterations in the cross-validator.
         """
+        X, y, groups = indexable(X, y, groups)
         if groups is None:
             raise ValueError("The groups parameter should not be None")
+        groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
+        check_consistent_length(X, groups)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -475,7 +475,6 @@ class GroupKFold(_BaseKFold):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
-        check_consistent_length(X, groups)
 
         unique_groups, groups = np.unique(groups, return_inverse=True)
         n_groups = len(unique_groups)
@@ -622,6 +621,10 @@ class StratifiedKFold(_BaseKFold):
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
 
+            Note that providing ``y`` is sufficient to generate the splits and
+            hence ``np.zeros(n_samples)`` may be used as a placeholder for
+            ``X`` instead of actual training data.
+
         y : array-like, shape (n_samples,)
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
@@ -638,7 +641,6 @@ class StratifiedKFold(_BaseKFold):
             The testing set indices for that split.
         """
         y = check_array(y, ensure_2d=False, dtype=None)
-        check_consistent_length(X, y)
         return super(StratifiedKFold, self).split(X, y, groups)
 
 
@@ -702,11 +704,10 @@ class TimeSeriesSplit(_BaseKFold):
             and n_features is the number of features.
 
         y : array-like, shape (n_samples,)
-            The target variable for supervised learning problems.
+            Always ignored, exists for compatibility.
 
         groups : array-like, with shape (n_samples,), optional
-            Group labels for the samples used while splitting the dataset into
-            train/test set.
+            Always ignored, exists for compatibility.
 
         Returns
         -------
@@ -809,7 +810,7 @@ class LeaveOneGroupOut(BaseCrossValidator):
         """
         if groups is None:
             raise ValueError("The groups parameter should not be None")
-        return len(np.unique(groups))
+        return len(np.unique(indexable(groups)))
 
 
 class LeavePGroupsOut(BaseCrossValidator):
@@ -872,7 +873,6 @@ class LeavePGroupsOut(BaseCrossValidator):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
-        check_consistent_length(X, groups)
         unique_groups = np.unique(groups)
         if self.n_groups >= len(unique_groups):
             raise ValueError(
@@ -894,9 +894,11 @@ class LeavePGroupsOut(BaseCrossValidator):
         ----------
         X : object
             Always ignored, exists for compatibility.
+            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         y : object
             Always ignored, exists for compatibility.
+            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
@@ -907,11 +909,10 @@ class LeavePGroupsOut(BaseCrossValidator):
         n_splits : int
             Returns the number of splitting iterations in the cross-validator.
         """
-        X, y, groups = indexable(X, y, groups)
         if groups is None:
             raise ValueError("The groups parameter should not be None")
-        groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
-        check_consistent_length(X, groups)
+        X, y, groups = indexable(X, y, groups)
+        groups = check_array(groups, ensure_2d=False, dtype=None)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 
 
@@ -1109,7 +1110,6 @@ class GroupShuffleSplit(ShuffleSplit):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
         groups = check_array(groups, ensure_2d=False, dtype=None)
-        check_consistent_length(X, groups)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super(
                 GroupShuffleSplit, self)._iter_indices(X=classes):
@@ -1251,7 +1251,6 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     def _iter_indices(self, X, y, groups=None):
         n_samples = _num_samples(X)
         y = check_array(y, ensure_2d=False, dtype=None)
-        check_consistent_length(X, y)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
                                                   self.train_size)
         classes, y_indices = np.unique(y, return_inverse=True)
@@ -1305,6 +1304,10 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
 
+            Note that providing ``y`` is sufficient to generate the splits and
+            hence ``np.zeros(n_samples)`` may be used as a placeholder for
+            ``X`` instead of actual training data.
+
         y : array-like, shape (n_samples,)
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
@@ -1321,7 +1324,6 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             The testing set indices for that split.
         """
         y = check_array(y, ensure_2d=False, dtype=None)
-        check_consistent_length(X, y)
         return super(StratifiedShuffleSplit, self).split(X, y, groups)
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -25,6 +25,8 @@ import numpy as np
 from scipy.misc import comb
 from ..utils import indexable, check_random_state, safe_indexing
 from ..utils.validation import _num_samples, column_or_1d
+from ..utils.validation import check_array
+from ..utils.validation import check_consistent_length
 from ..utils.multiclass import type_of_target
 from ..externals.six import with_metaclass
 from ..externals.six.moves import zip
@@ -620,10 +622,10 @@ class StratifiedKFold(_BaseKFold):
 
         y : array-like, shape (n_samples,)
             The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
 
-        groups : array-like, with shape (n_samples,), optional
-            Group labels for the samples used while splitting the dataset into
-            train/test set.
+        groups : object
+            Always ignored, exists for compatibility.
 
         Returns
         -------
@@ -633,6 +635,8 @@ class StratifiedKFold(_BaseKFold):
         test : ndarray
             The testing set indices for that split.
         """
+        y = check_array(y, ensure_2d=False, dtype=None)
+        check_consistent_length(X, y)
         return super(StratifiedKFold, self).split(X, y, groups)
 
 
@@ -1097,6 +1101,8 @@ class GroupShuffleSplit(ShuffleSplit):
     def _iter_indices(self, X, y, groups):
         if groups is None:
             raise ValueError("The groups parameter should not be None")
+        groups = check_array(groups, ensure_2d=False, dtype=None)
+        check_consistent_length(X, groups)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super(
                 GroupShuffleSplit, self)._iter_indices(X=classes):
@@ -1237,6 +1243,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
     def _iter_indices(self, X, y, groups=None):
         n_samples = _num_samples(X)
+        y = check_array(y, ensure_2d=False, dtype=None)
+        check_consistent_length(X, y)
         n_train, n_test = _validate_shuffle_split(n_samples, self.test_size,
                                                   self.train_size)
         classes, y_indices = np.unique(y, return_inverse=True)
@@ -1292,10 +1300,10 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
         y : array-like, shape (n_samples,)
             The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
 
-        groups : array-like, with shape (n_samples,), optional
-            Group labels for the samples used while splitting the dataset into
-            train/test set.
+        groups : object
+            Always ignored, exists for compatibility.
 
         Returns
         -------
@@ -1305,6 +1313,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         test : ndarray
             The testing set indices for that split.
         """
+        y = check_array(y, ensure_2d=False, dtype=None)
+        check_consistent_length(X, y)
         return super(StratifiedShuffleSplit, self).split(X, y, groups)
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1631,7 +1631,7 @@ def train_test_split(*arrays, **options):
 
     stratify : array-like or None (default is None)
         If not None, data is split in a stratified fashion, using this as
-        the groups array.
+        the class labels.
 
     Returns
     -------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -911,8 +911,8 @@ class LeavePGroupsOut(BaseCrossValidator):
         """
         if groups is None:
             raise ValueError("The groups parameter should not be None")
-        X, y, groups = indexable(X, y, groups)
         groups = check_array(groups, ensure_2d=False, dtype=None)
+        X, y, groups = indexable(X, y, groups)
         return int(comb(len(np.unique(groups)), self.n_groups, exact=True))
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -779,7 +779,6 @@ class LeaveOneGroupOut(BaseCrossValidator):
             raise ValueError("The groups parameter should not be None")
         # We make a copy of groups to avoid side-effects during iteration
         groups = check_array(groups, copy=True, ensure_2d=False, dtype=None)
-        check_consistent_length(X, groups)
         unique_groups = np.unique(groups)
         if len(unique_groups) <= 1:
             raise ValueError(

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -669,9 +669,12 @@ def test_leave_group_out_changing_groups():
             assert_array_equal(test, test_chan)
 
     # n_splits = no of 2 (p) group combinations of the unique groups = 3C2 = 3
-    assert_equal(3, LeavePGroupsOut(n_groups=2).get_n_splits(X, y, groups))
+    assert_equal(
+        3, LeavePGroupsOut(n_groups=2).get_n_splits(X, y=X,
+                                                    groups=groups))
     # n_splits = no of unique groups (C(uniq_lbls, 1) = n_unique_groups)
-    assert_equal(3, LeaveOneGroupOut().get_n_splits(X, y, groups))
+    assert_equal(3, LeaveOneGroupOut().get_n_splits(X, y=X,
+                                                    groups=groups))
 
 
 def test_leave_one_p_group_out_error_on_fewer_number_of_groups():
@@ -838,18 +841,18 @@ def test_shufflesplit_reproducible():
                        list(a for a, b in ss.split(X)))
 
 
-def test_shufflesplit_list_input():
+def test_stratifiedshufflesplit_list_input():
     # Check that when y is a list / list of string labels, it works.
-    ss = ShuffleSplit(random_state=42)
+    sss = StratifiedShuffleSplit(test_size=2, random_state=42)
     X = np.ones(7)
     y1 = ['1'] * 4 + ['0'] * 3
     y2 = np.hstack((np.ones(4), np.zeros(3)))
     y3 = y2.tolist()
 
-    np.testing.assert_equal(list(ss.split(X, y1)),
-                            list(ss.split(X, y2)))
-    np.testing.assert_equal(list(ss.split(X, y3)),
-                            list(ss.split(X, y2)))
+    np.testing.assert_equal(list(sss.split(X, y1)),
+                            list(sss.split(X, y2)))
+    np.testing.assert_equal(list(sss.split(X, y3)),
+                            list(sss.split(X, y2)))
 
 
 def test_train_test_split_allow_nans():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -753,7 +753,7 @@ def test_leave_one_p_group_out():
 
                 # Third test:
                 # The number of groups in test must be equal to p_groups_out
-                assert_true(grps_test_unique.shape[0], p_groups_out)
+                assert_true(np.unique(groups_arr[test]).shape[0], p_groups_out)
 
 
 def test_leave_group_out_changing_groups():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -783,9 +783,7 @@ def test_leave_group_out_changing_groups():
 
 def test_leave_one_p_group_out_error_on_fewer_number_of_groups():
     X = y = groups = np.ones(0)
-    msg = ("The groups parameter contains fewer than 2 unique groups ([]). "
-           "LeaveOneGroupOut expects at least 2.")
-    assert_raise_message(ValueError, msg, next,
+    assert_raise_message(ValueError, "Found array with 0 sample(s)", next,
                          LeaveOneGroupOut().split(X, y, groups))
     X = y = groups = np.ones(1)
     msg = ("The groups parameter contains fewer than 2 unique groups ([ 1.]). "

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -616,8 +616,8 @@ def test_group_shuffle_split():
               [1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3],
               ['1', '1', '1', '1', '2', '2', '2', '3', '3', '3', '3', '3'])
 
-    for l in groups:
-        X = y = np.ones(len(l))
+    for groups_i in groups:
+        X = y = np.ones(len(groups_i))
         n_splits = 6
         test_size = 1./3
         slo = GroupShuffleSplit(n_splits, test_size=test_size, random_state=0)
@@ -626,20 +626,20 @@ def test_group_shuffle_split():
         repr(slo)
 
         # Test that the length is correct
-        assert_equal(slo.get_n_splits(X, y, groups=l), n_splits)
+        assert_equal(slo.get_n_splits(X, y, groups=groups_i), n_splits)
 
-        l_unique = np.unique(l)
+        l_unique = np.unique(groups_i)
+        l = np.asarray(groups_i)
 
-        for train, test in slo.split(X, y, groups=l):
+        for train, test in slo.split(X, y, groups=groups_i):
             # First test: no train group is in the test set and vice versa
-            l_arr = np.asarray(l)
-            l_train_unique = np.unique(l_arr[train])
-            l_test_unique = np.unique(l_arr[test])
-            assert_false(np.any(np.in1d(l_arr[train], l_test_unique)))
-            assert_false(np.any(np.in1d(l_arr[test], l_train_unique)))
+            l_train_unique = np.unique(l[train])
+            l_test_unique = np.unique(l[test])
+            assert_false(np.any(np.in1d(l[train], l_test_unique)))
+            assert_false(np.any(np.in1d(l[test], l_train_unique)))
 
             # Second test: train and test add up to all the data
-            assert_equal(l_arr[train].size + l_arr[test].size, l_arr.size)
+            assert_equal(l[train].size + l[test].size, l.size)
 
             # Third test: train and test are disjoint
             assert_array_equal(np.intersect1d(train, test), [])

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -906,13 +906,13 @@ def train_test_split_list_input():
     y2 = np.hstack((np.ones(4), np.zeros(3)))
     y3 = y2.tolist()
 
-    for stratify in ((y1, y2, y3), (None, None, None)):
+    for stratify in (True, False):
         X_train1, X_test1, y_train1, y_test1 = train_test_split(
-            X, y1, stratify=stratify[0], random_state=0)
+            X, y1, stratify=y1 if stratify else None, random_state=0)
         X_train2, X_test2, y_train2, y_test2 = train_test_split(
-            X, y2, stratify=stratify[1], random_state=0)
+            X, y2, stratify=y2 if stratify else None, random_state=0)
         X_train3, X_test3, y_train3, y_test3 = train_test_split(
-            X, y3, stratify=stratify[2], random_state=0)
+            X, y3, stratify=y3 if stratify else None, random_state=0)
 
         np.testing.assert_equal(X_train1, X_train2)
         np.testing.assert_equal(y_train2, y_train3)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -685,7 +685,6 @@ def test_leave_one_p_group_out():
             n_splits = all_n_splits[i, j]
             X = y = np.ones(len(groups_i))
             groups_unique = np.unique(groups_i)
-            n_groups = len(groups_unique)
 
             # Test that the length is correct
             assert_equal(cv.get_n_splits(X, y, groups=groups_i), n_splits)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -906,17 +906,18 @@ def train_test_split_list_input():
     y2 = np.hstack((np.ones(4), np.zeros(3)))
     y3 = y2.tolist()
 
-    X_train1, X_test1, y_train1, y_test1 = train_test_split(X, y1, stratify=y1,
-                                                            random_state=0)
-    X_train2, X_test2, y_train2, y_test2 = train_test_split(X, y2, stratify=y2,
-                                                            random_state=0)
-    X_train3, X_test3, y_train3, y_test3 = train_test_split(X, y3, stratify=y3,
-                                                            random_state=0)
+    for stratify in ((y1, y2, y3), (None, None, None)):
+        X_train1, X_test1, y_train1, y_test1 = train_test_split(
+            X, y1, stratify=stratify[0], random_state=0)
+        X_train2, X_test2, y_train2, y_test2 = train_test_split(
+            X, y2, stratify=stratify[1], random_state=0)
+        X_train3, X_test3, y_train3, y_test3 = train_test_split(
+            X, y3, stratify=stratify[2], random_state=0)
 
-    np.testing.assert_equal(X_train1, X_train2)
-    np.testing.assert_equal(y_train2, y_train3)
-    np.testing.assert_equal(X_test1, X_test3)
-    np.testing.assert_equal(y_test3, y_test2)
+        np.testing.assert_equal(X_train1, X_train2)
+        np.testing.assert_equal(y_train2, y_train3)
+        np.testing.assert_equal(X_test1, X_test3)
+        np.testing.assert_equal(y_test3, y_test2)
 
 
 def test_shufflesplit_errors():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -744,20 +744,14 @@ def test_leave_one_p_group_out():
             # Split using the original list / array / list of string groups_i
             for train, test in cv.split(X, y, groups=groups_i):
                 # First test: no train group is in the test set and vice versa
-                grps_train_unique = np.unique(groups_arr[train])
-                grps_test_unique = np.unique(groups_arr[test])
-                assert_false(np.any(np.in1d(groups_arr[train],
-                                            grps_test_unique)))
-                assert_false(np.any(np.in1d(groups_arr[test],
-                                            grps_train_unique)))
+                assert_array_equal(np.intersect1d(groups_arr[train],
+                                                  groups_arr[test]).tolist(),
+                                   [])
 
                 # Second test: train and test add up to all the data
                 assert_equal(len(train) + len(test), len(groups_i))
 
-                # Third test: train and test are disjoint
-                assert_array_equal(np.intersect1d(train, test), [])
-
-                # Fourth test:
+                # Third test:
                 # The number of groups in test must be equal to p_groups_out
                 assert_true(grps_test_unique.shape[0], p_groups_out)
 


### PR DESCRIPTION
Fixes #7582 and #7126

At sklearn 0.18.0

``` python
>>> from sklearn.model_selection import train_test_split
>>> X, y = [[1,], [2,], [3,], [4,], [5,], [6,]], ['1', '2', '1', '2', '1', '2']
>>> _ = train_test_split(X, y, stratify=y)
IndexError: index 0 is out of bounds for axis 1 with size 0
```

That is fixed after this PR.

This PR also cleans up some docstrings and adds test for `LeavePGroupsOut` and `LeaveOneGroupOut`...

@jnothman @amueller @lesteve Reviews please :)
