### PR TITLE
[MRG + 2] Documentation should mention the Need Contributor label

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -307,7 +307,11 @@ following rules before submitting:
 Issues for New Contributors
 ---------------------------
 
-New contributors should look for the following tags when looking for issues.
+New contributors should look for the following tags when looking for issues. 
+We strongly recommend that new contributors tackle "easy" issues first: this 
+helps the contributor become familiar with the contribution workflow, and 
+for the core devs to become acquainted with the contributor; besides which, 
+we frequently underestimate how easy an issue is to solve!
 
 .. topic:: Easy Tags
 
@@ -470,9 +474,10 @@ There are three other tags to help new contributors:
     Might need some knowledge of machine learning or the package,
     but is still approachable for someone new to the project.
 
-:New Contributor:
-    This tag marks an issue which currently lacks a contributor.
-    These issues can range in difficulty, and may not be approachable
+:Needs Contributor:
+    This tag marks an issue which currently lacks a contributor or a 
+    PR that needs another contributor to take over the work. These 
+    issues can range in difficulty, and may not be approachable
     for new contributors. Note that not all issues which need
     contributors will have this tag.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -305,7 +305,8 @@ following rules before submitting:
 .. _new_contributors:
 
 Issues for New Contributors
-----------------
+---------------------------
+
 New contributors should look for the following tags when looking for issues.
 
 .. topic:: Easy Tags

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -308,25 +308,23 @@ Issues for New Contributors
 ----------------
 New contributors should look for the following tags when looking for issues.
 
-Easy Tags
------------
+.. topic:: Easy Tags
 
-A great way to start contributing to scikit-learn is to pick an item from the
-list of `Easy issues
-<https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aopen+label%3AEasy+is%3Aissue>`_
-in the issue tracker. Resolving these issues allow you to start contributing
-to the project without much prior knowledge. Your assistance in this area will
-be greatly appreciated by the more experienced developers as it helps free up
-their time to concentrate on other issues.
+    A great way to start contributing to scikit-learn is to pick an item from the
+    list of `Easy issues
+    <https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aopen+label%3AEasy+is%3Aissue>`_
+    in the issue tracker. Resolving these issues allow you to start contributing
+    to the project without much prior knowledge. Your assistance in this area will
+    be greatly appreciated by the more experienced developers as it helps free up
+    their time to concentrate on other issues.
 
-Need Contributor Tags
----------------------
+.. topic:: Need Contributor Tags
 
-We often use the Need Contributor tag to mark issues regardless of difficulty. Additionally, 
-we use the Need Contributor tag to mark Pull Requests which have been abandoned
-by their original contributor and are available for someone to pick up where the original
-contributor left off. The list of issues with the Need Contributor tag can be found
-`here <https://github.com/scikit-learn/scikit-learn/labels/Need%20Contributor>`_ .
+    We often use the Need Contributor tag to mark issues regardless of difficulty. Additionally, 
+    we use the Need Contributor tag to mark Pull Requests which have been abandoned
+    by their original contributor and are available for someone to pick up where the original
+    contributor left off. The list of issues with the Need Contributor tag can be found
+    `here <https://github.com/scikit-learn/scikit-learn/labels/Need%20Contributor>`_ .
 
 
 .. _contribute_documentation:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -304,6 +304,10 @@ following rules before submitting:
 
 .. _easy_issues:
 
+
+New Contributors
+----------------
+
 Easy Issues
 -----------
 
@@ -314,6 +318,10 @@ in the issue tracker. Resolving these issues allow you to start contributing
 to the project without much prior knowledge. Your assistance in this area will
 be greatly appreciated by the more experienced developers as it helps free up
 their time to concentrate on other issues.
+
+Contributors Needed
+-------------------
+
 
 .. _contribute_documentation:
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -326,6 +326,7 @@ New contributors should look for the following tags when looking for issues.
     contributor left off. The list of issues with the Need Contributor tag can be found
     `here <https://github.com/scikit-learn/scikit-learn/labels/Need%20Contributor>`_ .
 
+    Note that not all issues which need contributors will have this tag.
 
 .. _contribute_documentation:
 
@@ -469,9 +470,10 @@ There are three other tags to help new contributors:
     but is still approachable for someone new to the project.
 
 :New Contributor:
-    This tag marks an issue which is currently lacking a contributor.
+    This tag marks an issue which currently lacks a contributor.
     These issues can range in difficulty, and may not be approachable
-    for new contributors.
+    for new contributors. Note that not all issues which need
+    contributors will have this tag.
 
 
 Other ways to contribute

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -12,7 +12,7 @@ The project is hosted on https://github.com/scikit-learn/scikit-learn
 Scikit-learn is somewhat :ref:`selective <selectiveness>` when it comes to
 adding new algorithms, and the best way to contribute and to help the project
 is to start working on known issues.
-See :ref:`easy_issues` to get started.
+See :ref:`new_contributors` to get started.
 
 .. topic:: **Our community, our values**
 
@@ -302,13 +302,13 @@ following rules before submitting:
    or link to a `gist <https://gist.github.com>`_. If an exception is raised,
    please provide the traceback.
 
-.. _easy_issues:
+.. _new_contributors:
 
-
-New Contributors
+Issues for New Contributors
 ----------------
+New contributors should look for the following tags when looking for issues.
 
-Easy Issues
+Easy Tags
 -----------
 
 A great way to start contributing to scikit-learn is to pick an item from the
@@ -319,8 +319,14 @@ to the project without much prior knowledge. Your assistance in this area will
 be greatly appreciated by the more experienced developers as it helps free up
 their time to concentrate on other issues.
 
-Contributors Needed
--------------------
+Need Contributor Tags
+---------------------
+
+We often use the Need Contributor tag to mark issues regardless of difficulty. Additionally, 
+we use the Need Contributor tag to mark Pull Requests which have been abandoned
+by their original contributor and are available for someone to pick up where the original
+contributor left off. The list of issues with the Need Contributor tag can be found
+`here <https://github.com/scikit-learn/scikit-learn/labels/Need%20Contributor>`_ .
 
 
 .. _contribute_documentation:
@@ -454,7 +460,7 @@ should have (at least) one of the following tags:
 :New Feature:
     Feature requests and pull requests implementing a new feature.
 
-There are two other tags to help new contributors:
+There are three other tags to help new contributors:
 
 :Easy:
     This issue can be tackled by anyone, no experience needed.
@@ -463,6 +469,11 @@ There are two other tags to help new contributors:
 :Moderate:
     Might need some knowledge of machine learning or the package,
     but is still approachable for someone new to the project.
+
+:New Contributor:
+    This tag marks an issue which is currently lacking a contributor.
+    These issues can range in difficulty, and may not be approachable
+    for new contributors.
 
 
 Other ways to contribute


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#7588
#### What does this implement/fix? Explain your changes.

Added a "Issues for New Contributors" section with explanation of Easy and Need Contributor labels
#### Any other comments?

I still need to do some reformatting. The _new_contributors anchor tag seems to be broken (as do a few others in the file). I'm also thinking it may make sense to move the New Contributor section below the table containing label overviews so that the information is co-located. Any thoughts?
- [x] Fix _new_contributors tag
- [x] Consider moving New Contributor section below table with label overview

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
