### PR TITLE
[MRG] DOC numpydoc requires space between name and column

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -372,8 +372,8 @@ Finally, follow the formatting rules below to make it consistently good:
 
         See also
         --------
-        SelectKBest: Select features based on the k highest scores.
-        SelectFpr: Select features based on a false positive rate test.
+        SelectKBest : Select features based on the k highest scores.
+        SelectFpr : Select features based on a false positive rate test.
 
     * For unwritten formatting rules, try to follow existing good works:
 


### PR DESCRIPTION
This patch fixes a tiny mistake in the contributing guidelines of the See also
section. The space between the function name and description was missing.
