### PR TITLE
[MRG + 1] Fix min_samples_split and min_samples_leaf validation for float vs int

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -509,7 +509,7 @@ def test_error():
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=.6).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=0.).fit, X, y)
-        assert_raises(ValueError, TreeEstimator(min_samples_leaf=3.0).fit, X, y)
+        assert_raises(ValueError, TreeEstimator(min_samples_leaf=3.).fit, X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_weight_fraction_leaf=-1).fit,
                       X, y)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -509,6 +509,7 @@ def test_error():
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=.6).fit, X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_leaf=0.).fit, X, y)
+        assert_raises(ValueError, TreeEstimator(min_samples_leaf=3.0).fit, X, y)
         assert_raises(ValueError,
                       TreeEstimator(min_weight_fraction_leaf=-1).fit,
                       X, y)
@@ -520,6 +521,8 @@ def test_error():
         assert_raises(ValueError, TreeEstimator(min_samples_split=0.0).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(min_samples_split=1.1).fit,
+                      X, y)
+        assert_raises(ValueError, TreeEstimator(min_samples_split=2.5).fit,
                       X, y)
         assert_raises(ValueError, TreeEstimator(max_depth=-1).fit, X, y)
         assert_raises(ValueError, TreeEstimator(max_features=42).fit, X, y)

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -217,24 +217,30 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         if isinstance(self.min_samples_leaf, (numbers.Integral, np.integer)):
             if not 1 <= self.min_samples_leaf:
-                raise ValueError("min_samples_leaf must at least 1 "
-                                 "or in (0, 0.5], got %s" % self.min_samples_leaf)
+                raise ValueError("min_samples_leaf must be "
+                                 "at least 1 "
+                                 "or in (0, 0.5], "
+                                 "got %s" % self.min_samples_leaf)
             min_samples_leaf = self.min_samples_leaf
         else:  # float
             if not 0. < self.min_samples_leaf <= 0.5:
-                raise ValueError("min_samples_leaf must be at least 1 "
-                                 "or in (0, 0.5], got %s" % self.min_samples_leaf)
+                raise ValueError("min_samples_leaf must be "
+                                 "at least 1 "
+                                 "or in (0, 0.5], "
+                                 "got %s" % self.min_samples_leaf)
             min_samples_leaf = int(ceil(self.min_samples_leaf * n_samples))
 
         if isinstance(self.min_samples_split, (numbers.Integral, np.integer)):
             if not 2 <= self.min_samples_split:
-                raise ValueError("min_samples_split must be at least 2"
-                                 " or in (0, 1], got %s" % self.min_samples_split)
+                raise ValueError("min_samples_split must be "
+                                 "at least 2 or in (0, 1], "
+                                 "got %s" % self.min_samples_split)
             min_samples_split = self.min_samples_split
         else:  # float
             if not 0. < self.min_samples_split <= 1.:
-                raise ValueError("min_samples_split must be at least 2"
-                                 " or in (0, 1], got %s" % self.min_samples_split)
+                raise ValueError("min_samples_split must be "
+                                 "at least 2 or in (0, 1], "
+                                 "got %s" % self.min_samples_split)
 
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)
@@ -313,8 +319,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                                np.sum(sample_weight))
 
         if self.min_impurity_split < 0.:
-            raise ValueError("min_impurity_split must be greater than or equal "
-                             "to 0")
+            raise ValueError("min_impurity_split must be greater than "
+                             "or equal to 0")
 
         presort = self.presort
         # Allow presort to be 'auto', which means True if the dataset is dense,
@@ -377,7 +383,8 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                                            min_samples_leaf,
                                            min_weight_leaf,
                                            max_depth,
-                                           max_leaf_nodes, self.min_impurity_split)
+                                           max_leaf_nodes,
+                                           self.min_impurity_split)
 
         builder.build(self.tree_, X, y, sample_weight, X_idx_sorted)
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -217,31 +217,28 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
 
         if isinstance(self.min_samples_leaf, (numbers.Integral, np.integer)):
             if not 1 <= self.min_samples_leaf:
-                raise ValueError("min_samples_leaf must be "
-                                 "at least 1 "
-                                 "or in (0, 0.5], "
-                                 "got %s" % self.min_samples_leaf)
+                raise ValueError("min_samples_leaf must be at least 1 "
+                                 "or in (0, 0.5], got %s"
+                                 % self.min_samples_leaf)
             min_samples_leaf = self.min_samples_leaf
         else:  # float
             if not 0. < self.min_samples_leaf <= 0.5:
-                raise ValueError("min_samples_leaf must be "
-                                 "at least 1 "
-                                 "or in (0, 0.5], "
-                                 "got %s" % self.min_samples_leaf)
+                raise ValueError("min_samples_leaf must be at least 1 "
+                                 "or in (0, 0.5], got %s"
+                                 % self.min_samples_leaf)
             min_samples_leaf = int(ceil(self.min_samples_leaf * n_samples))
 
         if isinstance(self.min_samples_split, (numbers.Integral, np.integer)):
             if not 2 <= self.min_samples_split:
-                raise ValueError("min_samples_split must be "
-                                 "at least 2 or in (0, 1], "
-                                 "got %s" % self.min_samples_split)
+                raise ValueError("min_samples_split must be at least 2 "
+                                 "or in (0, 1], got %s"
+                                 % self.min_samples_split)
             min_samples_split = self.min_samples_split
         else:  # float
             if not 0. < self.min_samples_split <= 1.:
-                raise ValueError("min_samples_split must be "
-                                 "at least 2 or in (0, 1], "
-                                 "got %s" % self.min_samples_split)
-
+                raise ValueError("min_samples_split must be at least 2 "
+                                 "or in (0, 1], got %s"
+                                 % self.min_samples_split)
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)
 

--- a/sklearn/tree/tree.py
+++ b/sklearn/tree/tree.py
@@ -216,13 +216,26 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
                           else self.max_leaf_nodes)
 
         if isinstance(self.min_samples_leaf, (numbers.Integral, np.integer)):
+            if not 1 <= self.min_samples_leaf:
+                raise ValueError("min_samples_leaf must at least 1 "
+                                 "or in (0, 0.5], got %s" % self.min_samples_leaf)
             min_samples_leaf = self.min_samples_leaf
         else:  # float
+            if not 0. < self.min_samples_leaf <= 0.5:
+                raise ValueError("min_samples_leaf must be at least 1 "
+                                 "or in (0, 0.5], got %s" % self.min_samples_leaf)
             min_samples_leaf = int(ceil(self.min_samples_leaf * n_samples))
 
         if isinstance(self.min_samples_split, (numbers.Integral, np.integer)):
+            if not 2 <= self.min_samples_split:
+                raise ValueError("min_samples_split must be at least 2"
+                                 " or in (0, 1], got %s" % self.min_samples_split)
             min_samples_split = self.min_samples_split
         else:  # float
+            if not 0. < self.min_samples_split <= 1.:
+                raise ValueError("min_samples_split must be at least 2"
+                                 " or in (0, 1], got %s" % self.min_samples_split)
+
             min_samples_split = int(ceil(self.min_samples_split * n_samples))
             min_samples_split = max(2, min_samples_split)
 
@@ -258,15 +271,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator,
         if len(y) != n_samples:
             raise ValueError("Number of labels=%d does not match "
                              "number of samples=%d" % (len(y), n_samples))
-        if not (0. < self.min_samples_split <= 1. or
-                2 <= self.min_samples_split):
-            raise ValueError("min_samples_split must be in at least 2"
-                             " or in (0, 1], got %s" % min_samples_split)
-        if not (0. < self.min_samples_leaf <= 0.5 or
-                1 <= self.min_samples_leaf):
-            raise ValueError("min_samples_leaf must be at least than 1 "
-                             "or in (0, 0.5], got %s" % min_samples_leaf)
-
         if not 0 <= self.min_weight_fraction_leaf <= 0.5:
             raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
         if max_depth <= 0:


### PR DESCRIPTION
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #7603 
#### What does this implement/fix? Explain your changes.

The float and int values of `min_samples_split` and `min_samples_leaf` were not being properly checked, because large float values could pass the int check. I fixed the checks and moved them to a better location before the parameters are used. I also fixed the wording of the warning and its return value as it was improperly reporting `min_samples_split` and `min_samples_leaf` when it should have been reporting the value of `self.min_samples_split` and `self.min_samples_leaf`. Lastly, I added a non-regression test for this to the test suite.
#### Any other comments?

@mgoldwasser mentioned:

>  In theory, it would be useless to set min_samples_split to 1.0 or more, or min_samples_leaf to 0.5 or more

This is indeed true, and we do check for this. However, we don't validate that `min_samples_split` and `min_samples_leaf` are less than (1.0 \* n_samples) and (0.5 \* n_samples) when ints are provided; should we add this?
