### PR TITLE
BUG : Avoid dividing by zero (#7568)

### DIFF
--- a/sklearn/decomposition/base.py
+++ b/sklearn/decomposition/base.py
@@ -70,7 +70,7 @@ class _BasePCA(six.with_metaclass(ABCMeta, BaseEstimator, TransformerMixin)):
         exp_var = self.explained_variance_
         if self.whiten:
             components_ = components_ * np.sqrt(exp_var[:, np.newaxis])
-        exp_var_diff = np.maximum(exp_var - self.noise_variance_, 0.)
+        exp_var_diff = np.nanmax(exp_var - self.noise_variance_, 0.)
         precision = np.dot(components_, components_.T) / self.noise_variance_
         precision.flat[::len(precision) + 1] += 1. / exp_var_diff
         precision = np.dot(components_.T,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #7568 -->

Fixes #7568 
#### What does this implement/fix? Explain your changes.

I used `np.nanmax` instead of `np.maximum` to avoid division by zero in  `get_precision` in `decomposition/base.py` file.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
