### PR TITLE
[MRG + 1] Additional tests for checking the relation between predict_log_proba() and predict_proba()

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1015,6 +1015,11 @@ def check_classifiers_train(name, Classifier):
             assert_raises(ValueError, classifier.predict_proba, X.T)
             # raises error on malformed input for predict_proba
             assert_raises(ValueError, classifier.predict_proba, X.T)
+            if hasattr(classifier, "predict_log_proba"):
+                # predict_log_proba is a transformation of predict_proba
+                y_log_prob = classifier.predict_log_proba(X)
+                assert_array_almost_equal(y_log_prob, np.log(y_prob), 8)
+                assert_array_equal(np.argsort(y_log_prob), np.argsort(y_prob))
 
 
 @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
Hi, 

This is my first contribution. I added tests to check if the relation between predict_log_proba and predict_proba is upheld when both are available. I saw that there is a check already that applies the log-inverse transform to the predict_log_proba output and checks that the arrays returned are almost equals. I double-check it by comparing the ranks. Hope it is ok!

Fixes #7579
