### PR TITLE
[MRG + 1] Pipeline uses use fit_predict from 17.x

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -353,7 +353,7 @@ class Pipeline(_BasePipeline):
         -------
         y_pred : array-like
         """
-        Xt, fit_params = self._pre_transform(X, y, **fit_params)
+        Xt, fit_params = self._fit(X, y, **fit_params)
         return self.steps[-1][-1].fit_predict(Xt, y, **fit_params)
 
     @if_delegate_has_method(delegate='_final_estimator')

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -353,10 +353,7 @@ class Pipeline(_BasePipeline):
         -------
         y_pred : array-like
         """
-        Xt = X
-        for name, transform in self.steps[:-1]:
-            if transform is not None:
-                Xt = transform.fit_transform(Xt)
+        Xt, fit_params = self._pre_transform(X, y, **fit_params)
         return self.steps[-1][-1].fit_predict(Xt, y, **fit_params)
 
     @if_delegate_has_method(delegate='_final_estimator')

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -74,17 +74,11 @@ class Transf(NoInvTransf):
         return X
 
 
-class TransfFitParams(NoInvTransf):
+class TransfFitParams(Transf):
 
     def fit(self, X, y, **fit_params):
         self.fit_params = fit_params
         return self
-
-    def transform(self, X, y=None):
-        return X
-
-    def inverse_transform(self, X):
-        return X
 
 
 class Mult(BaseEstimator):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -330,7 +330,6 @@ def test_fit_predict_with_intermediate_fit_params():
     assert_true(pipe.named_steps['transf'].fit_params['should_get_this'])
     assert_true(pipe.named_steps['clf'].successful)
     assert_false('should_succeed' in pipe.named_steps['transf'].fit_params)
-    assert_false('should_succeed' in pipe.named_steps['transf'].fit_params)
 
 
 def test_feature_union():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -74,6 +74,19 @@ class Transf(NoInvTransf):
         return X
 
 
+class TransfFitParams(NoInvTransf):
+
+    def fit(self, X, y, **fit_params):
+        self.fit_params = fit_params
+        return self
+
+    def transform(self, X, y=None):
+        return X
+
+    def inverse_transform(self, X):
+        return X
+
+
 class Mult(BaseEstimator):
     def __init__(self, mult=1):
         self.mult = mult
@@ -108,6 +121,10 @@ class FitParamT(BaseEstimator):
 
     def predict(self, X):
         return self.successful
+
+    def fit_predict(self, X, y, should_succeed=False):
+        self.fit(X, y, should_succeed=should_succeed)
+        return self.predict(X)
 
 
 def test_pipeline_init():
@@ -306,6 +323,20 @@ def test_fit_predict_on_pipeline_without_fit_predict():
     assert_raises_regex(AttributeError,
                         "'PCA' object has no attribute 'fit_predict'",
                         getattr, pipe, 'fit_predict')
+
+
+def test_fit_predict_with_intermediate_fit_params():
+    # tests that Pipeline passes fit_params to intermediate steps
+    # when fit_predict is invoked
+    pipe = Pipeline([('transf', TransfFitParams()), ('clf', FitParamT())])
+    pipe.fit_predict(X=None,
+                     y=None,
+                     transf__should_get_this=True,
+                     clf__should_succeed=True)
+    assert_true(pipe.named_steps['transf'].fit_params['should_get_this'])
+    assert_true(pipe.named_steps['clf'].successful)
+    assert_false('should_succeed' in pipe.named_steps['transf'].fit_params)
+    assert_false('should_succeed' in pipe.named_steps['transf'].fit_params)
 
 
 def test_feature_union():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Previously, `**fit_params` were not passed to the `fit_transform` steps of the `fit_predict` method
