### PR TITLE
[WIP] Add dataframe test to common tests

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -33,7 +33,8 @@ from sklearn.utils.estimator_checks import (
     check_class_weight_balanced_linear_classifier,
     check_transformer_n_iter,
     check_non_transformer_estimators_n_iter,
-    check_get_params_invariance)
+    check_get_params_invariance,
+    check_estimator_data_frame)
 
 
 def test_all_estimator_no_base_class():
@@ -56,6 +57,20 @@ def test_all_estimators():
     for name, Estimator in estimators:
         # some can just not be sensibly default constructed
         yield (_named_check(check_parameters_default_constructible, name),
+               name, Estimator)
+
+
+def test_all_estimators_data_frame():
+    # Test that estimators are default-constructible, cloneable
+    # and have working repr.
+    estimators = all_estimators(include_meta_estimators=True)
+
+    # Meta sanity-check to make sure that the estimator introspection runs
+    # properly
+    assert_greater(len(estimators), 0)
+
+    for name, Estimator in estimators:
+        yield (_named_check(check_estimator_data_frame, name),
                name, Estimator)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -5,6 +5,7 @@ import warnings
 import sys
 import traceback
 import pickle
+import pandas
 from copy import deepcopy
 
 import numpy as np
@@ -1380,6 +1381,14 @@ def check_regressor_data_not_an_array(name, Estimator):
     X, y = _boston_subset(n_samples=50)
     y = multioutput_estimator_convert_y_2d(name, y)
     check_estimators_data_not_an_array(name, Estimator, X, y)
+
+
+def check_estimator_data_frame(name, Estimator):
+    X = np.array([[3, 0], [0, 1], [0, 2], [1, 1], [1, 2], [2, 1]])
+    X2 = pandas.DataFrame(X)
+    y = [1, 1, 1, 2, 2, 2]
+    y = multioutput_estimator_convert_y_2d(name, y)
+    check_estimators_data_not_an_array(name, Estimator, X2, y)
 
 
 @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

References #7528 
#### What does this implement/fix? Explain your changes.
- Add dataframe tests to tests/test_common.py
- Add new method in utils/check_estimators to assert if dataframe behaves the same as array.
#### Any other comments?

I am not able to pass the tests. More specifically I am getting an error:
`AttributeError: 'NotAnArray' object has no attribute 'shape'`

Any suggestions @amueller ?

Steps to reproduce: run `nosetests -v sklearn/tests/test_common.py`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
