### PR TITLE
[MRG+1] Correcting length of explained_variance_ratio_, eigen solver, final PR

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,8 +69,11 @@ Bug fixes
      `#6497 <https://github.com/scikit-learn/scikit-learn/pull/6497>`_
      by `Sebastian Säger`_
 
-   - Attribute ``explained_variance_ratio`` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
-     calculated with SVD and Eigen solver are now of the same length. By `JPFrancoia`_
+   - Attribute ``explained_variance_ratio`` of
+     :class:`discriminant_analysis.LinearDiscriminantAnalysis` calculated
+     with SVD and Eigen solver are now of the same length. (`#7632
+     <https://github.com/scikit-learn/scikit-learn/pull/7632>`_).
+     By `JPFrancoia`_
 
 
 API changes summary
@@ -78,8 +81,11 @@ API changes summary
 
 Linear, kernelized and related models
 
-   - Length of `explained_variance_ratio` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
-     is now the same for Eigen and SVD solvers. By `JPFrancoia`_
+   - Length of `explained_variance_ratio` of
+     :class:`discriminant_analysis.LinearDiscriminantAnalysis`
+     is now the same for Eigen and SVD solvers. (`#7632
+     <https://github.com/scikit-learn/scikit-learn/pull/7632>`_).
+     By `JPFrancoia`_
 
 
 .. _changes_0_18:
@@ -550,8 +556,9 @@ Decomposition, manifold learning and clustering
       :class:`decomposition.KernelPCA`, :class:`manifold.LocallyLinearEmbedding`,
       and :class:`manifold.SpectralEmbedding` (`#5012 <https://github.com/scikit-learn/scikit-learn/pull/5012>`_). By `Peter Fischer`_.
 
-    - Attribute ``explained_variance_ratio_`` calculated with the SVD solver of
-      :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results. By `JPFrancoia`_
+    - Attribute ``explained_variance_ratio_`` calculated with the SVD solver
+      of :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
+      correct results. By `JPFrancoia`_
 
 Preprocessing and feature selection
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -520,8 +520,9 @@ Decomposition, manifold learning and clustering
       and :class:`manifold.SpectralEmbedding` (`#5012 <https://github.com/scikit-learn/scikit-learn/pull/5012>`_). By `Peter Fischer`_.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver of
-      :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
-      correct results. By `JPFrancoia`_
+      :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results.
+      Attribute `explained_variance_ratio` calculated with SVD and Eigen solver are now of
+      the same length. By `JPFrancoia`_
 
 Preprocessing and feature selection
 
@@ -614,6 +615,9 @@ Linear, kernelized and related models
 
    - Access to public attributes ``.X_`` and ``.y_`` has been deprecated in
      :class:`isotonic.IsotonicRegression`. By `Jonathan Arfa`_.
+
+   - Length of `explained_variance_ratio` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
+     is now the same for Eigen and SVD solvers.
 
 Decomposition, manifold learning and clustering
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -83,7 +83,8 @@ Linear, kernelized and related models
 
    - Length of `explained_variance_ratio` of
      :class:`discriminant_analysis.LinearDiscriminantAnalysis`
-     is now the same for Eigen and SVD solvers. (`#7632
+     changed for both Eigen and SVD solvers. The attribute has now a length
+     of min(n_components, n_classes - 1). (`#7632
      <https://github.com/scikit-learn/scikit-learn/pull/7632>`_).
      By `JPFrancoia`_
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,18 @@ Bug fixes
      `#6497 <https://github.com/scikit-learn/scikit-learn/pull/6497>`_
      by `Sebastian Säger`_
 
+   - Attribute ``explained_variance_ratio`` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
+     calculated with SVD and Eigen solver are now of the same length. By `JPFrancoia`_
+
+
+API changes summary
+-------------------
+
+Linear, kernelized and related models
+
+   - Length of `explained_variance_ratio` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
+     is now the same for Eigen and SVD solvers. By `JPFrancoia`_
+
 
 .. _changes_0_18:
 
@@ -539,9 +551,7 @@ Decomposition, manifold learning and clustering
       and :class:`manifold.SpectralEmbedding` (`#5012 <https://github.com/scikit-learn/scikit-learn/pull/5012>`_). By `Peter Fischer`_.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver of
-      :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results.
-      Attribute `explained_variance_ratio` calculated with SVD and Eigen solver are now of
-      the same length. By `JPFrancoia`_
+      :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results. By `JPFrancoia`_
 
 Preprocessing and feature selection
 
@@ -634,9 +644,6 @@ Linear, kernelized and related models
 
    - Access to public attributes ``.X_`` and ``.y_`` has been deprecated in
      :class:`isotonic.IsotonicRegression`. By `Jonathan Arfa`_.
-
-   - Length of `explained_variance_ratio` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
-     is now the same for Eigen and SVD solvers.
 
 Decomposition, manifold learning and clustering
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,7 +69,7 @@ Bug fixes
      `#6497 <https://github.com/scikit-learn/scikit-learn/pull/6497>`_
      by `Sebastian Säger`_
 
-   - Attribute ``explained_variance_ratio`` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
+   - Attribute ``explained_variance_ratio`` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
      calculated with SVD and Eigen solver are now of the same length. By `JPFrancoia`_
 
 
@@ -78,7 +78,7 @@ API changes summary
 
 Linear, kernelized and related models
 
-   - Length of `explained_variance_ratio` of :clas:`discriminant_analysis.LinearDiscriminantAnalysis`
+   - Length of `explained_variance_ratio` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
      is now the same for Eigen and SVD solvers. By `JPFrancoia`_
 
 
@@ -551,7 +551,7 @@ Decomposition, manifold learning and clustering
       and :class:`manifold.SpectralEmbedding` (`#5012 <https://github.com/scikit-learn/scikit-learn/pull/5012>`_). By `Peter Fischer`_.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver of
-      :clas:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results. By `JPFrancoia`_
+      :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns correct results. By `JPFrancoia`_
 
 Preprocessing and feature selection
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -335,8 +335,15 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         St = _cov(X, shrinkage)  # total scatter
         Sb = St - Sw  # between scatter
 
+        # Get maximum length for explained_variance_ratio_
+        if self.n_components is None:
+            max_length_exp = len(self.classes_)
+        else:
+            max_length_exp = min(len(self.classes_), self.n_components)
+
         evals, evecs = linalg.eigh(Sb, Sw)
-        self.explained_variance_ratio_ = np.sort(evals / np.sum(evals))[::-1]
+        self.explained_variance_ratio_ = np.sort(evals / np.sum(evals)
+                                                 )[::-1][:max_length_exp]
         evecs = evecs[:, np.argsort(evals)[::-1]]  # sort eigenvectors
         # evecs /= np.linalg.norm(evecs, axis=0)  # doesn't work with numpy 1.6
         evecs /= np.apply_along_axis(np.linalg.norm, 0, evecs)

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -337,9 +337,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
 
         # Get maximum length for explained_variance_ratio_
         if self.n_components is None:
-            max_length_exp = len(self.classes_)
+            max_length_exp = len(self.classes_) - 1
         else:
-            max_length_exp = min(len(self.classes_), self.n_components)
+            max_length_exp = min(len(self.classes_) - 1, self.n_components)
 
         evals, evecs = linalg.eigh(Sb, Sw)
         self.explained_variance_ratio_ = np.sort(evals / np.sum(evals)
@@ -406,8 +406,14 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         # (n_classes) centers
         _, S, V = linalg.svd(X, full_matrices=0)
 
+        # Get maximum length for explained_variance_ratio_
+        if self.n_components is None:
+            max_length_exp = len(self.classes_) - 1
+        else:
+            max_length_exp = min(len(self.classes_) - 1, self.n_components)
+
         self.explained_variance_ratio_ = (S**2 / np.sum(
-                S**2))[:self.n_components]
+                S**2))[:max_length_exp]
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, V.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -171,10 +171,14 @@ def test_lda_explained_variance_ratio():
     clf_lda_eigen = LinearDiscriminantAnalysis(solver="eigen")
     clf_lda_eigen.fit(X, y)
     assert_almost_equal(clf_lda_eigen.explained_variance_ratio_.sum(), 1.0, 3)
+    assert_equal(clf_lda_eigen.explained_variance_ratio_.shape, (2,),
+                 "Unexpected length for explained_variance_ratio_")
 
     clf_lda_svd = LinearDiscriminantAnalysis(solver="svd")
     clf_lda_svd.fit(X, y)
     assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
+    assert_equal(clf_lda_svd.explained_variance_ratio_.shape, (2,),
+                 "Unexpected length for explained_variance_ratio_")
 
     assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
                               clf_lda_eigen.explained_variance_ratio_)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -176,14 +176,8 @@ def test_lda_explained_variance_ratio():
     clf_lda_svd.fit(X, y)
     assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
 
-    tested_length = min(clf_lda_svd.explained_variance_ratio_.shape[0],
-                        clf_lda_eigen.explained_variance_ratio_.shape[0])
-
-    # NOTE: clf_lda_eigen.explained_variance_ratio_ is not of n_components
-    # length. Make it the same length as clf_lda_svd.explained_variance_ratio_
-    # before comparison.
     assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
-                              clf_lda_eigen.explained_variance_ratio_[:tested_length])
+                              clf_lda_eigen.explained_variance_ratio_)
 
 
 def test_lda_orthogonality():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fix #6032 
#### What does this implement/fix? Explain your changes.

Attribute explained_variance_ratio_ from LinearDiscriminantAnalysis class will be of length n_components (eigen solver).
#### Any other comments?

This PR follows PR 7616. I mixed up my git history, so it was easier to open a new PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
