### PR TITLE
[MRG] compute coverage on latest and greatest build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     # This environment tests that scikit-learn can be built against
     # versions of numpy, scipy with ATLAS that comes with Ubuntu Precise 12.04
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.4"
-      CACHED_BUILD_DIR="$HOME/sklearn_build_ubuntu" COVERAGE=true
+      CACHED_BUILD_DIR="$HOME/sklearn_build_ubuntu"
     # This environment tests the oldest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.6" INSTALL_MKL="false"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.21"
@@ -43,6 +43,7 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" PANDAS_VERSION="0.18.0"
       CYTHON_VERSION="0.23.4" CACHED_BUILD_DIR="$HOME/sklearn_build_latest"
+      COVERAGE=true
     # flake8 linting on diff wrt common ancestor with upstream/master
     - RUN_FLAKE8="true" SKIP_TESTS="true"
       DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"


### PR DESCRIPTION
This runs coveralls on the newest version, also including pandas.
All of the image tests were skipped on the old version because it didn't have the scipy.misc.face.
I feel like testing coverage on the newest version makes more sense. Also including pandas seems good.
