### PR TITLE
[MRG + 1] Printing the total time in cross_validation

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -266,7 +266,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         msg += ", score=%f" % test_score
     if verbose > 1:
         total_time = score_time + fit_time
-        end_msg = "%s -%s" % (msg, logger.short_format_time(total_time))
+        end_msg = "%s, total=%s" % (msg, logger.short_format_time(total_time))
         print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
 
     ret = [train_score, test_score] if return_train_score else [test_score]

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -265,7 +265,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     if verbose > 2:
         msg += ", score=%f" % test_score
     if verbose > 1:
-        end_msg = "%s -%s" % (msg, logger.short_format_time(score_time))
+        end_msg = "%s -%s" % (msg, logger.short_format_time(score_time + fit_time))
         print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
 
     ret = [train_score, test_score] if return_train_score else [test_score]

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -265,7 +265,8 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     if verbose > 2:
         msg += ", score=%f" % test_score
     if verbose > 1:
-        end_msg = "%s -%s" % (msg, logger.short_format_time(score_time + fit_time))
+        total_time = score_time + fit_time
+        end_msg = "%s -%s" % (msg, logger.short_format_time(total_time))
         print("[CV] %s %s" % ((64 - len(end_msg)) * '.', end_msg))
 
     ret = [train_score, test_score] if return_train_score else [test_score]


### PR DESCRIPTION
#### Reference Issue

Fixes #7639 
#### What does this implement/fix? Explain your changes.

Initially when doing cross_validation with verbose set, the code was printing the `score_time` instead of the `score_time + fit_time`. This PR fixes that and prints the total time.
#### Any other comments?

@jnothman if you could elaborate on the test which you said has to be done in the comments of the issue #7639 I can add that also to this PR.
