### PR TITLE
[MRG+1] fixed missing next button (bug #7539)

### DIFF
--- a/doc/themes/scikit-learn/layout.html
+++ b/doc/themes/scikit-learn/layout.html
@@ -217,7 +217,7 @@
     <div class="sphinxsidebar">
     <div class="sphinxsidebarwrapper">
 
-    {%- if rellinks[1:] %}
+    {%- if rellinks %}
 
     {%- if parents %}
         <div class="rel">
@@ -225,10 +225,7 @@
         <div class="rel rellarge">
     {% endif %}
 
-  <!-- rellinks[1:] is an ugly hack to avoid link to module
-  index -->
-
-    {%- for rellink in rellinks[1:]|reverse %}
+    {%- for rellink in rellinks|reverse %}
         <div class="rellink">
         <a href="{{ pathto(rellink[0]) }}"
         {{ accesskey(rellink[2]) }}>{{ rellink[3]|capitalize }}
@@ -326,7 +323,7 @@
     {% else %}
      <div class="rel rellarge">
     {% endif %}
-    {%- for rellink in rellinks[1:]|reverse %}
+    {%- for rellink in rellinks|reverse %}
     <div class="{{ loop.cycle('buttonPrevious', 'buttonNext') }}">
       <a href="{{ pathto(rellink[0]) }}">{{ loop.cycle('Previous', 'Next') }}
       </a>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #7539 
#### What does this implement/fix? Explain your changes.

Fixed the broken next button in docs by altering the page loop variable

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
