### PR TITLE
[MRG + 1] rfecv: verbosity: Set verbose threshold low bound from 2 to 1

### DIFF
--- a/sklearn/feature_selection/rfe.py
+++ b/sklearn/feature_selection/rfe.py
@@ -406,7 +406,7 @@ class RFECV(RFE, MetaEstimatorMixin):
 
         rfe = RFE(estimator=self.estimator,
                   n_features_to_select=n_features_to_select,
-                  step=self.step, verbose=self.verbose - 1)
+                  step=self.step, verbose=self.verbose)
 
         # Determine the number of subsets of features by fitting across
         # the train folds and choosing the "features_to_select" parameter

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -218,6 +218,7 @@ def test_rfecv_verbose_output():
     rfecv.fit(X, y)
 
     verbose_output = sys.stdout
+    verbose_output.seek(0)
     assert_greater(len(verbose_output.readline()), 0)
 
 

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -204,7 +204,7 @@ def test_rfecv_mockclassifier():
 
 
 def test_rfecv_verbose_output():
-    """Check verbose=1 is producing an output."""
+    # Check verbose=1 is producing an output.
     from sklearn.externals.six.moves import cStringIO as StringIO
     import sys
     sys.stdout = StringIO()

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -203,6 +203,24 @@ def test_rfecv_mockclassifier():
     assert_equal(len(rfecv.ranking_), X.shape[1])
 
 
+def test_rfecv_verbose_output():
+    """Check verbose=1 is producing an output."""
+    from sklearn.externals.six.moves import cStringIO as StringIO
+    import sys
+    sys.stdout = StringIO()
+
+    generator = check_random_state(0)
+    iris = load_iris()
+    X = np.c_[iris.data, generator.normal(size=(len(iris.data), 6))]
+    y = list(iris.target)
+
+    rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, cv=5, verbose=1)
+    rfecv.fit(X, y)
+
+    verbose_output = sys.stdout
+    assert_greater(len(verbose_output.readline()), 0)
+
+
 def test_rfe_estimator_tags():
     rfe = RFE(SVC(kernel='linear'))
     assert_equal(rfe._estimator_type, "classifier")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #7643 
#### What does this implement/fix? Explain your changes.

Now the current state of RFECV is printed when the verbosity (`verbose=`) is setted to **1** (or more.)

At line 407 of `rfe.py`:

```
rfe = RFE(estimator=self.estimator,
                  n_features_to_select=n_features_to_select,
                  step=self.step, verbose=self.verbose)
```
