### PR TITLE
[MRG] #7627 Add a "filename" attribute to datasets that have a CSV file

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -136,10 +136,27 @@ learn::
     <sphx_glr_auto_examples_classification_plot_digits_classification.py>` illustrates how starting
     from the original problem one can shape the data for consumption in
     scikit-learn.
-    
+
 .. topic:: Loading from external datasets
 
     To load from an external dataset, please refer to :ref:`loading external datasets <external_datasets>`.
+
+.. topic:: Accessing source files
+
+    All standard datasets which you can import with ``load_`` have underlying source files that
+    you can read manually (consider numpy.loadtxt and pandas for analysis).
+    The data and target can be stored in one file (e.g. iris, boston, breast_cancer) or
+    in several (e.g. diabetes, linnerud).
+
+      >>> boston = load_boston()
+      >>> print(boston.filename)
+      .*/sklearn/datasets/data/boston_house_prices.csv
+
+      >>> diabetes = load_diabetes()
+      >>> print(diabetes.data_filename)
+      .*/sklearn/datasets/data/diabetes_data.csv.gz
+      >>> print(diabetes.target_filename)
+      .*/sklearn/datasets/data/diabetes_target.csv.gz
 
 Learning and predicting
 ------------------------

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -141,7 +141,7 @@ learn::
 
     To load from an external dataset, please refer to :ref:`loading external datasets <external_datasets>`.
 
-.. topic:: Accessing source files
+.. topic:: Loading from the data files
 
     All standard datasets which you can import with ``load_`` have underlying source files that
     you can read manually (consider numpy.loadtxt and pandas for analysis).

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -160,8 +160,8 @@ learn::
       >>> print(diabetes.target_filename)  # doctest: +SKIP
       (some-path)/sklearn/datasets/data/diabetes_target.csv.gz
 
-    Example of reading data file with numpy. Boston dataset contains
-    2 header lines, that is why we are going to skip them:
+    You can also read the data file directly with numpy. Consider the following example.
+    Boston dataset contains 2 header lines, that is why we are going to skip them:
 
       >>> import numpy as np
       >>> boston_data = np.loadtxt(boston.filename, delimiter=",", skiprows=2)

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -148,15 +148,17 @@ learn::
     The data and target can be stored in one file (e.g. iris, boston, breast_cancer) or
     in several (e.g. diabetes, linnerud).
 
+      >>> from sklearn.datasets import load_boston
       >>> boston = load_boston()
-      >>> print(boston.filename)
-      .*/sklearn/datasets/data/boston_house_prices.csv
+      >>> print(boston.filename)  # doctest: +SKIP
+      (some-path)/sklearn/datasets/data/boston_house_prices.csv
 
+      >>> from sklearn.datasets import load_diabetes
       >>> diabetes = load_diabetes()
-      >>> print(diabetes.data_filename)
-      .*/sklearn/datasets/data/diabetes_data.csv.gz
-      >>> print(diabetes.target_filename)
-      .*/sklearn/datasets/data/diabetes_target.csv.gz
+      >>> print(diabetes.data_filename)  # doctest: +SKIP
+      (some-path)/sklearn/datasets/data/diabetes_data.csv.gz
+      >>> print(diabetes.target_filename)  # doctest: +SKIP
+      (some-path)/sklearn/datasets/data/diabetes_target.csv.gz
 
 Learning and predicting
 ------------------------

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -161,7 +161,7 @@ learn::
       (some-path)/sklearn/datasets/data/diabetes_target.csv.gz
 
     You can also read the data file directly with numpy. Consider the following example.
-    Boston dataset contains 2 header lines, that is why we are going to skip them:
+    Boston dataset contains 2 header lines, that is why we are going to skip them::
 
       >>> import numpy as np
       >>> boston_data = np.loadtxt(boston.filename, delimiter=",", skiprows=2)
@@ -170,7 +170,7 @@ learn::
       >>> boston_data.shape  # also contains target columns
       (506, 14)
 
-    See also:
+    .. seealso::
         :func:`pandas.read_csv`
 
 Learning and predicting

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -144,8 +144,8 @@ learn::
 .. topic:: Loading from the data files
 
     All standard datasets which you can import with ``load_`` have underlying source files that
-    you can read manually (consider numpy.loadtxt and pandas for analysis).
-    The data and target can be stored in one file (e.g. iris, boston, breast_cancer) or
+    you can read manually (consider :func:`numpy.loadtxt` and `pandas <http://pandas.pydata.org/>`_
+    for analysis). The data and target can be stored in one file (e.g. iris, boston, breast_cancer) or
     in several (e.g. diabetes, linnerud).
 
       >>> from sklearn.datasets import load_boston
@@ -159,6 +159,19 @@ learn::
       (some-path)/sklearn/datasets/data/diabetes_data.csv.gz
       >>> print(diabetes.target_filename)  # doctest: +SKIP
       (some-path)/sklearn/datasets/data/diabetes_target.csv.gz
+
+    Example of reading data file with numpy. Boston dataset contains
+    2 header lines, that is why we are going to skip them:
+
+      >>> import numpy as np
+      >>> boston_data = np.loadtxt(boston.filename, delimiter=",", skiprows=2)
+      >>> boston.data.shape  # sklearn dataset
+      (506, 13)
+      >>> boston_data.shape  # also contains target columns
+      (506, 14)
+
+    See also:
+        :func:`pandas.read_csv`
 
 Learning and predicting
 ------------------------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -272,8 +272,9 @@ def load_iris(return_X_y=False):
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
-        meaning of the features, and 'DESCR', the
-        full description of the dataset.
+        meaning of the features, 'DESCR', the
+        full description of the dataset, 'filename', the physical location of
+        iris csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -292,7 +293,8 @@ def load_iris(return_X_y=False):
     ['setosa', 'versicolor', 'virginica']
     """
     module_path = dirname(__file__)
-    with open(join(module_path, 'data', 'iris.csv')) as csv_file:
+    iris_csv_filename = join(module_path, 'data', 'iris.csv')
+    with open(iris_csv_filename) as csv_file:
         data_file = csv.reader(csv_file)
         temp = next(data_file)
         n_samples = int(temp[0])
@@ -315,7 +317,8 @@ def load_iris(return_X_y=False):
                  target_names=target_names,
                  DESCR=fdescr,
                  feature_names=['sepal length (cm)', 'sepal width (cm)',
-                                'petal length (cm)', 'petal width (cm)'])
+                                'petal length (cm)', 'petal width (cm)'],
+                 filename=iris_csv_filename)
 
 
 def load_breast_cancer(return_X_y=False):

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -567,10 +567,10 @@ def load_linnerud(return_X_y=False):
         Dictionary-like object, the interesting attributes are: 'data' and
         'targets', the two multivariate datasets, with 'data' corresponding to
         the exercise and 'targets' corresponding to the physiological
-        measurements, as well as 'feature_names' and 'target_names'. In addition,
-        you will also have access to 'data_filename', the physical location of
-        linnerud data csv dataset, and 'target_filename', the physical location
-        of linnerud targets csv datataset.
+        measurements, as well as 'feature_names' and 'target_names'.
+        In addition, you will also have access to 'data_filename', the physical
+        location of linnerud data csv dataset, and 'target_filename', the
+        physical location of linnerud targets csv datataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -627,8 +627,8 @@ def load_boston(return_X_y=False):
     data : Bunch
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the regression targets,
-        and 'DESCR', the full description of the dataset,
-        'filename', the physical location of boston csv dataset.
+        'DESCR', the full description of the dataset,
+        and 'filename', the physical location of boston csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -350,7 +350,8 @@ def load_breast_cancer(return_X_y=False):
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
-        full description of the dataset.
+        full description of the dataset, 'filename', the physical location of
+        breast cancer csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -373,7 +374,8 @@ def load_breast_cancer(return_X_y=False):
     ['malignant', 'benign']
     """
     module_path = dirname(__file__)
-    with open(join(module_path, 'data', 'breast_cancer.csv')) as csv_file:
+    csv_filename = join(module_path, 'data', 'breast_cancer.csv')
+    with open(csv_filename) as csv_file:
         data_file = csv.reader(csv_file)
         first_line = next(data_file)
         n_samples = int(first_line[0])
@@ -411,7 +413,8 @@ def load_breast_cancer(return_X_y=False):
     return Bunch(data=data, target=target,
                  target_names=target_names,
                  DESCR=fdescr,
-                 feature_names=feature_names)
+                 feature_names=feature_names,
+                 filename=csv_filename)
 
 
 def load_digits(n_class=10, return_X_y=False):

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -610,7 +610,8 @@ def load_boston(return_X_y=False):
     data : Bunch
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the regression targets,
-        and 'DESCR', the full description of the dataset.
+        and 'DESCR', the full description of the dataset,
+        'filename', the physical location of boston csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -651,7 +652,8 @@ def load_boston(return_X_y=False):
                  target=target,
                  # last column is target value
                  feature_names=feature_names[:-1],
-                 DESCR=descr_text)
+                 DESCR=descr_text,
+                 filename=data_file_name)
 
 
 def load_sample_images():

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -520,12 +520,12 @@ def load_diabetes(return_X_y=False):
 
     (data, target) : tuple if ``return_X_y`` is True
 
-        .. versionadded:: 0.18    
+        .. versionadded:: 0.18
     """
     base_dir = join(dirname(__file__), 'data')
     data = np.loadtxt(join(base_dir, 'diabetes_data.csv.gz'))
     target = np.loadtxt(join(base_dir, 'diabetes_target.csv.gz'))
-    
+
     if return_X_y:
         return data, target
 
@@ -557,7 +557,7 @@ def load_linnerud(return_X_y=False):
         'targets', the two multivariate datasets, with 'data' corresponding to
         the exercise and 'targets' corresponding to the physiological
         measurements, as well as 'feature_names' and 'target_names'.
-    
+
     (data, target) : tuple if ``return_X_y`` is True
 
         .. versionadded:: 0.18
@@ -611,7 +611,7 @@ def load_boston(return_X_y=False):
 
     (data, target) : tuple if ``return_X_y`` is True
 
-        .. versionadded:: 0.18    
+        .. versionadded:: 0.18
 
     Examples
     --------

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -273,8 +273,8 @@ def load_iris(return_X_y=False):
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, 'DESCR', the
-        full description of the dataset, 'filename', the physical location of
-        iris csv dataset.
+        full description of the dataset, 'filename' (added in version 0.19),
+        the physical location of iris csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -350,8 +350,8 @@ def load_breast_cancer(return_X_y=False):
         'data', the data to learn, 'target', the classification labels,
         'target_names', the meaning of the labels, 'feature_names', the
         meaning of the features, and 'DESCR', the
-        full description of the dataset, 'filename', the physical location of
-        breast cancer csv dataset.
+        full description of the dataset, 'filename' (added in version 0.19),
+        the physical location of breast cancer csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -519,9 +519,9 @@ def load_diabetes(return_X_y=False):
     data : Bunch
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the regression target for each
-        sample, 'data_filename', the physical location of
-        diabetes data csv dataset, and 'target_filename', the physical location
-        of diabetes targets csv datataset.
+        sample, 'data_filename' (added in version 0.19), the physical location
+        of diabetes data csv dataset, and 'target_filename' (added in
+        version 0.19), the physical location of diabetes targets csv datataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
@@ -568,8 +568,9 @@ def load_linnerud(return_X_y=False):
         'targets', the two multivariate datasets, with 'data' corresponding to
         the exercise and 'targets' corresponding to the physiological
         measurements, as well as 'feature_names' and 'target_names'.
-        In addition, you will also have access to 'data_filename', the physical
-        location of linnerud data csv dataset, and 'target_filename', the
+        In addition, you will also have access to 'data_filename'
+        (added in version 0.19), the physical location of linnerud data csv
+        dataset, and 'target_filename' (added in version 0.19), the
         physical location of linnerud targets csv datataset.
 
     (data, target) : tuple if ``return_X_y`` is True
@@ -628,7 +629,8 @@ def load_boston(return_X_y=False):
         Dictionary-like object, the interesting attributes are:
         'data', the data to learn, 'target', the regression targets,
         'DESCR', the full description of the dataset,
-        and 'filename', the physical location of boston csv dataset.
+        and 'filename' (added in version 0.19), the physical location
+        of boston csv dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 

--- a/sklearn/datasets/base.py
+++ b/sklearn/datasets/base.py
@@ -518,23 +518,31 @@ def load_diabetes(return_X_y=False):
     -------
     data : Bunch
         Dictionary-like object, the interesting attributes are:
-        'data', the data to learn and 'target', the regression target for each
-        sample.
+        'data', the data to learn, 'target', the regression target for each
+        sample, 'data_filename', the physical location of
+        diabetes data csv dataset, and 'target_filename', the physical location
+        of diabetes targets csv datataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
         .. versionadded:: 0.18
     """
     base_dir = join(dirname(__file__), 'data')
-    data = np.loadtxt(join(base_dir, 'diabetes_data.csv.gz'))
-    target = np.loadtxt(join(base_dir, 'diabetes_target.csv.gz'))
+
+    data_filename = join(base_dir, 'diabetes_data.csv.gz')
+    data = np.loadtxt(data_filename)
+
+    target_filename = join(base_dir, 'diabetes_target.csv.gz')
+    target = np.loadtxt(target_filename)
 
     if return_X_y:
         return data, target
 
     return Bunch(data=data, target=target,
                  feature_names=['age', 'sex', 'bmi', 'bp',
-                                's1', 's2', 's3', 's4', 's5', 's6'])
+                                's1', 's2', 's3', 's4', 's5', 's6'],
+                 data_filename=data_filename,
+                 target_filename=target_filename)
 
 
 def load_linnerud(return_X_y=False):
@@ -559,22 +567,29 @@ def load_linnerud(return_X_y=False):
         Dictionary-like object, the interesting attributes are: 'data' and
         'targets', the two multivariate datasets, with 'data' corresponding to
         the exercise and 'targets' corresponding to the physiological
-        measurements, as well as 'feature_names' and 'target_names'.
+        measurements, as well as 'feature_names' and 'target_names'. In addition,
+        you will also have access to 'data_filename', the physical location of
+        linnerud data csv dataset, and 'target_filename', the physical location
+        of linnerud targets csv datataset.
 
     (data, target) : tuple if ``return_X_y`` is True
 
         .. versionadded:: 0.18
     """
     base_dir = join(dirname(__file__), 'data/')
+    data_filename = join(base_dir, 'linnerud_exercise.csv')
+    target_filename = join(base_dir, 'linnerud_physiological.csv')
+
     # Read data
-    data_exercise = np.loadtxt(base_dir + 'linnerud_exercise.csv', skiprows=1)
-    data_physiological = np.loadtxt(base_dir + 'linnerud_physiological.csv',
-                                    skiprows=1)
+    data_exercise = np.loadtxt(data_filename, skiprows=1)
+    data_physiological = np.loadtxt(target_filename, skiprows=1)
+
     # Read header
-    with open(base_dir + 'linnerud_exercise.csv') as f:
+    with open(data_filename) as f:
         header_exercise = f.readline().split()
-    with open(base_dir + 'linnerud_physiological.csv') as f:
+    with open(target_filename) as f:
         header_physiological = f.readline().split()
+
     with open(dirname(__file__) + '/descr/linnerud.rst') as f:
         descr = f.read()
 
@@ -584,7 +599,9 @@ def load_linnerud(return_X_y=False):
     return Bunch(data=data_exercise, feature_names=header_exercise,
                  target=data_physiological,
                  target_names=header_physiological,
-                 DESCR=descr)
+                 DESCR=descr,
+                 data_filename=data_filename,
+                 target_filename=target_filename)
 
 
 def load_boston(return_X_y=False):

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -234,6 +234,7 @@ def test_load_boston():
     assert_equal(res.target.size, 506)
     assert_equal(res.feature_names.size, 13)
     assert_true(res.DESCR)
+    assert_true(res.filename)
 
     # test return_X_y option
     X_y_tuple = load_boston(return_X_y=True)

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -218,6 +218,7 @@ def test_load_breast_cancer():
     assert_equal(res.target.size, 569)
     assert_equal(res.target_names.size, 2)
     assert_true(res.DESCR)
+    assert_true(res.filename)
 
     # test return_X_y option
     X_y_tuple = load_breast_cancer(return_X_y=True)

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -195,6 +195,7 @@ def test_load_linnerud():
     assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
 
+
 def test_load_iris():
     res = load_iris()
     assert_equal(res.data.shape, (150, 4))
@@ -239,6 +240,7 @@ def test_load_boston():
     assert_true(isinstance(X_y_tuple, tuple))
     assert_array_equal(X_y_tuple[0], bunch.data)
     assert_array_equal(X_y_tuple[1], bunch.target)
+
 
 def test_loads_dumps_bunch():
     bunch = Bunch(x="x")

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -172,6 +172,8 @@ def test_load_diabetes():
     assert_equal(res.data.shape, (442, 10))
     assert_true(res.target.size, 442)
     assert_equal(len(res.feature_names), 10)
+    assert_true(res.data_filename)
+    assert_true(res.target_filename)
 
     # test return_X_y option
     X_y_tuple = load_diabetes(return_X_y=True)
@@ -187,6 +189,8 @@ def test_load_linnerud():
     assert_equal(res.target.shape, (20, 3))
     assert_equal(len(res.target_names), 3)
     assert_true(res.DESCR)
+    assert_true(res.data_filename)
+    assert_true(res.target_filename)
 
     # test return_X_y option
     X_y_tuple = load_linnerud(return_X_y=True)

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -201,6 +201,7 @@ def test_load_iris():
     assert_equal(res.target.size, 150)
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
+    assert_true(res.filename)
 
     # test return_X_y option
     X_y_tuple = load_iris(return_X_y=True)

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -172,8 +172,8 @@ def test_load_diabetes():
     assert_equal(res.data.shape, (442, 10))
     assert_true(res.target.size, 442)
     assert_equal(len(res.feature_names), 10)
-    assert_true(res.data_filename)
-    assert_true(res.target_filename)
+    assert_true(os.path.exists(res.data_filename))
+    assert_true(os.path.exists(res.target_filename))
 
     # test return_X_y option
     X_y_tuple = load_diabetes(return_X_y=True)
@@ -189,8 +189,8 @@ def test_load_linnerud():
     assert_equal(res.target.shape, (20, 3))
     assert_equal(len(res.target_names), 3)
     assert_true(res.DESCR)
-    assert_true(res.data_filename)
-    assert_true(res.target_filename)
+    assert_true(os.path.exists(res.data_filename))
+    assert_true(os.path.exists(res.target_filename))
 
     # test return_X_y option
     X_y_tuple = load_linnerud(return_X_y=True)
@@ -206,7 +206,7 @@ def test_load_iris():
     assert_equal(res.target.size, 150)
     assert_equal(res.target_names.size, 3)
     assert_true(res.DESCR)
-    assert_true(res.filename)
+    assert_true(os.path.exists(res.filename))
 
     # test return_X_y option
     X_y_tuple = load_iris(return_X_y=True)
@@ -222,7 +222,7 @@ def test_load_breast_cancer():
     assert_equal(res.target.size, 569)
     assert_equal(res.target_names.size, 2)
     assert_true(res.DESCR)
-    assert_true(res.filename)
+    assert_true(os.path.exists(res.filename))
 
     # test return_X_y option
     X_y_tuple = load_breast_cancer(return_X_y=True)
@@ -238,7 +238,7 @@ def test_load_boston():
     assert_equal(res.target.size, 506)
     assert_equal(res.feature_names.size, 13)
     assert_true(res.DESCR)
-    assert_true(res.filename)
+    assert_true(os.path.exists(res.filename))
 
     # test return_X_y option
     X_y_tuple = load_boston(return_X_y=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue: #7627
#### What does this implement/fix? Explain your changes.
- As per issue description, this change provide filename for load_iris, load_boston, load_breast_cancer
- data_filename and target_filenames are added to load_diabetes, load_linnerud
- fix PEP8 issues in dataset/base.py and relevant test file
#### Any other comments?

// all question about contribution are resolved

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Alexey
