### PR TITLE
Removed yield tests which are depricated in py.test

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -30,6 +30,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import skip_if_32bit
+from sklearn.utils.testing import does_yield
 
 from sklearn import datasets
 from sklearn.decomposition import TruncatedSVD
@@ -110,6 +111,7 @@ def check_classification_toy(name):
     assert_equal(leaf_indices.shape, (len(X), clf.n_estimators))
 
 
+@does_yield
 def test_classification_toy():
     for name in FOREST_CLASSIFIERS:
         yield check_classification_toy, name
@@ -134,6 +136,7 @@ def check_iris_criterion(name, criterion):
                                % (criterion, score))
 
 
+@does_yield
 def test_iris():
     for name, criterion in product(FOREST_CLASSIFIERS, ("gini", "entropy")):
         yield check_iris_criterion, name, criterion
@@ -158,6 +161,7 @@ def check_boston_criterion(name, criterion):
                                 "and score = %f" % (criterion, score))
 
 
+@does_yield
 def test_boston():
     for name, criterion in product(FOREST_REGRESSORS, ("mse", "mae", "friedman_mse")):
         yield check_boston_criterion, name, criterion
@@ -174,6 +178,7 @@ def check_regressor_attributes(name):
     assert_false(hasattr(r, "n_classes_"))
 
 
+@does_yield
 def test_regressor_attributes():
     for name in FOREST_REGRESSORS:
         yield check_regressor_attributes, name
@@ -192,6 +197,7 @@ def check_probability(name):
                                   np.exp(clf.predict_log_proba(iris.data)))
 
 
+@does_yield
 def test_probability():
     for name in FOREST_CLASSIFIERS:
         yield check_probability, name
@@ -206,6 +212,7 @@ def check_importances(name, criterion, X, y):
     importances = est.feature_importances_
     n_important = np.sum(importances > 0.1)
     assert_equal(importances.shape[0], 10)
+    print('n_important = %r' % (n_important,))
     assert_equal(n_important, 3)
 
     # XXX: Remove this test in 0.19 after transform support to estimators
@@ -234,6 +241,7 @@ def check_importances(name, criterion, X, y):
         assert_less(np.abs(importances - importances_bis).mean(), 0.001)
 
 
+@does_yield
 @skip_if_32bit
 def test_importances():
     X, y = datasets.make_classification(n_samples=500, n_features=10,
@@ -346,6 +354,7 @@ def check_unfitted_feature_importances(name):
                   "feature_importances_")
 
 
+@does_yield
 def test_unfitted_feature_importances():
     for name in FOREST_ESTIMATORS:
         yield check_unfitted_feature_importances, name
@@ -375,6 +384,7 @@ def check_oob_score(name, X, y, n_estimators=20):
         assert_warns(UserWarning, est.fit, X, y)
 
 
+@does_yield
 def test_oob_score():
     for name in FOREST_CLASSIFIERS:
         yield check_oob_score, name, iris.data, iris.target
@@ -415,6 +425,7 @@ def check_oob_score_raise_error(name):
                                                   bootstrap=False).fit, X, y)
 
 
+@does_yield
 def test_oob_score_raise_error():
     for name in FOREST_ESTIMATORS:
         yield check_oob_score_raise_error, name
@@ -426,6 +437,7 @@ def check_gridsearch(name):
     clf.fit(iris.data, iris.target)
 
 
+@does_yield
 def test_gridsearch():
     # Check that base trees can be grid-searched.
     for name in FOREST_CLASSIFIERS:
@@ -447,6 +459,7 @@ def check_parallel(name, X, y):
     assert_array_almost_equal(y1, y2, 3)
 
 
+@does_yield
 def test_parallel():
     for name in FOREST_CLASSIFIERS:
         yield check_parallel, name, iris.data, iris.target
@@ -470,6 +483,7 @@ def check_pickle(name, X, y):
     assert_equal(score, score2)
 
 
+@does_yield
 def test_pickle():
     for name in FOREST_CLASSIFIERS:
         yield check_pickle, name, iris.data[::2], iris.target[::2]
@@ -505,6 +519,7 @@ def check_multioutput(name):
             assert_equal(log_proba[1].shape, (4, 4))
 
 
+@does_yield
 def test_multioutput():
     for name in FOREST_CLASSIFIERS:
         yield check_multioutput, name
@@ -531,6 +546,7 @@ def check_classes_shape(name):
     assert_array_equal(clf.classes_, [[-1, 1], [-2, 2]])
 
 
+@does_yield
 def test_classes_shape():
     for name in FOREST_CLASSIFIERS:
         yield check_classes_shape, name
@@ -686,6 +702,7 @@ def check_max_leaf_nodes_max_depth(name):
     assert_equal(est.estimators_[0].tree_.max_depth, 1)
 
 
+@does_yield
 def test_max_leaf_nodes_max_depth():
     for name in FOREST_ESTIMATORS:
         yield check_max_leaf_nodes_max_depth, name
@@ -720,6 +737,7 @@ def check_min_samples_split(name):
                    "Failed with {0}".format(name))
 
 
+@does_yield
 def test_min_samples_split():
     for name in FOREST_ESTIMATORS:
         yield check_min_samples_split, name
@@ -757,6 +775,7 @@ def check_min_samples_leaf(name):
                    "Failed with {0}".format(name))
 
 
+@does_yield
 def test_min_samples_leaf():
     for name in FOREST_ESTIMATORS:
         yield check_min_samples_leaf, name
@@ -793,6 +812,7 @@ def check_min_weight_fraction_leaf(name):
                 name, est.min_weight_fraction_leaf))
 
 
+@does_yield
 def test_min_weight_fraction_leaf():
     for name in FOREST_ESTIMATORS:
         yield check_min_weight_fraction_leaf, name
@@ -824,6 +844,7 @@ def check_sparse_input(name, X, X_sparse, y):
                                   dense.fit_transform(X).toarray())
 
 
+@does_yield
 def test_sparse_input():
     X, y = datasets.make_multilabel_classification(random_state=0,
                                                    n_samples=50)
@@ -880,6 +901,7 @@ def check_memory_layout(name, dtype):
     assert_array_equal(est.fit(X, y).predict(X), y)
 
 
+@does_yield
 def test_memory_layout():
     for name, dtype in product(FOREST_CLASSIFIERS, [np.float64, np.float32]):
         yield check_memory_layout, name, dtype
@@ -901,6 +923,7 @@ def check_1d_input(name, X, X_2d, y):
         assert_raises(ValueError, est.predict, X)
 
 
+@does_yield
 @ignore_warnings
 def test_1d_input():
     X = iris.data[:, 0]
@@ -954,6 +977,7 @@ def check_class_weights(name):
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
 
+@does_yield
 def test_class_weights():
     for name in FOREST_CLASSIFIERS:
         yield check_class_weights, name
@@ -975,6 +999,7 @@ def check_class_weight_balanced_and_bootstrap_multi_output(name):
     ignore_warnings(clf.fit)(X, _y)
 
 
+@does_yield
 def test_class_weight_balanced_and_bootstrap_multi_output():
     for name in FOREST_CLASSIFIERS:
         yield check_class_weight_balanced_and_bootstrap_multi_output, name
@@ -1005,6 +1030,7 @@ def check_class_weight_errors(name):
     assert_raises(ValueError, clf.fit, X, _y)
 
 
+@does_yield
 def test_class_weight_errors():
     for name in FOREST_CLASSIFIERS:
         yield check_class_weight_errors, name
@@ -1037,6 +1063,7 @@ def check_warm_start(name, random_state=42):
                        err_msg="Failed with {0}".format(name))
 
 
+@does_yield
 def test_warm_start():
     for name in FOREST_ESTIMATORS:
         yield check_warm_start, name
@@ -1059,6 +1086,7 @@ def check_warm_start_clear(name):
     assert_array_almost_equal(clf_2.apply(X), clf.apply(X))
 
 
+@does_yield
 def test_warm_start_clear():
     for name in FOREST_ESTIMATORS:
         yield check_warm_start_clear, name
@@ -1074,6 +1102,7 @@ def check_warm_start_smaller_n_estimators(name):
     assert_raises(ValueError, clf.fit, X, y)
 
 
+@does_yield
 def test_warm_start_smaller_n_estimators():
     for name in FOREST_ESTIMATORS:
         yield check_warm_start_smaller_n_estimators, name
@@ -1100,6 +1129,7 @@ def check_warm_start_equal_n_estimators(name):
     assert_array_equal(clf.apply(X), clf_2.apply(X))
 
 
+@does_yield
 def test_warm_start_equal_n_estimators():
     for name in FOREST_ESTIMATORS:
         yield check_warm_start_equal_n_estimators, name
@@ -1137,6 +1167,7 @@ def check_warm_start_oob(name):
     assert_equal(clf.oob_score_, clf_3.oob_score_)
 
 
+@does_yield
 def test_warm_start_oob():
     for name in FOREST_CLASSIFIERS:
         yield check_warm_start_oob, name
@@ -1177,6 +1208,7 @@ def check_decision_path(name):
         assert_array_almost_equal(leave_indicator, np.ones(shape=n_samples))
 
 
+@does_yield
 def test_decision_path():
     for name in FOREST_CLASSIFIERS:
         yield check_decision_path, name

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -27,6 +27,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import skip_if_32bit
+from sklearn.utils.testing import does_yield
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import NotFittedError
 
@@ -70,6 +71,7 @@ def check_classification_toy(presort, loss):
     assert_equal(leaves.shape, (6, 10, 1))
 
 
+@does_yield
 def test_classification_toy():
     for presort, loss in product(('auto', True, False),
                                  ('deviance', 'exponential')):
@@ -177,6 +179,7 @@ def check_classification_synthetic(presort, loss):
     assert_less(error_rate, 0.08)
 
 
+@does_yield
 def test_classification_synthetic():
     for presort, loss in product(('auto', True, False), ('deviance', 'exponential')):
         yield check_classification_synthetic, presort, loss
@@ -212,6 +215,7 @@ def check_boston(presort, loss, subsample):
         last_y_pred = y_pred
 
 
+@does_yield
 def test_boston():
     for presort, loss, subsample in product(('auto', True, False),
                                             ('ls', 'lad', 'huber'),
@@ -234,6 +238,7 @@ def check_iris(presort, subsample, sample_weight):
     assert_equal(leaves.shape, (150, 100, 3))
 
 
+@does_yield
 def test_iris():
     ones = np.ones(len(iris.target))
     for presort, subsample, sample_weight in product(('auto', True, False),
@@ -1062,6 +1067,7 @@ def check_sparse_input(EstimatorClass, X, X_sparse, y):
                                   auto.predict_log_proba(X))
 
 
+@does_yield
 @skip_if_32bit
 def test_sparse_input():
     ests = (GradientBoostingClassifier, GradientBoostingRegressor)

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,6 +20,7 @@ from sklearn.base import clone
 from sklearn.utils.testing import (assert_equal, assert_almost_equal,
                                    assert_not_equal, assert_array_equal,
                                    assert_array_almost_equal)
+from sklearn.utils.testing import does_yield
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
@@ -192,6 +193,7 @@ def check_hyperparameters_equal(kernel1, kernel2):
             assert_equal(attr_value1, attr_value2)
 
 
+@does_yield
 def test_kernel_clone():
     # Test that sklearn's clone works correctly on kernels.
     bounds = (1e-5, 1e5)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import does_yield
 
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
@@ -459,6 +460,7 @@ def check_dense_sparse(test_func):
         assert_array_almost_equal(ret_dense, ret_sparse, decimal=3)
 
 
+@does_yield
 def test_dense_sparse():
     for test_func in (_test_ridge_loo,
                       _test_ridge_cv,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -22,6 +22,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import does_yield
 
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import average_precision_score
@@ -661,6 +662,7 @@ def check_single_sample_multioutput(name):
         metric(np.array([[i, j]]), np.array([[k, l]]))
 
 
+@does_yield
 def test_single_sample():
     for name in ALL_METRICS:
         if (name in METRIC_UNDEFINED_BINARY_MULTICLASS or
@@ -880,6 +882,7 @@ def check_averaging(name, y_true, y_true_binarize, y_pred, y_pred_binarize,
         raise ValueError("Metric is not recorded as having an average option")
 
 
+@does_yield
 def test_averaging_multiclass(n_samples=50, n_classes=3):
     random_state = check_random_state(0)
     y_true = random_state.randint(0, n_classes, size=(n_samples, ))
@@ -895,6 +898,7 @@ def test_averaging_multiclass(n_samples=50, n_classes=3):
                y_pred_binarize, y_score)
 
 
+@does_yield
 def test_averaging_multilabel(n_classes=5, n_samples=40):
     _, y = make_multilabel_classification(n_features=1, n_classes=n_classes,
                                           random_state=5, n_samples=n_samples,
@@ -910,6 +914,7 @@ def test_averaging_multilabel(n_classes=5, n_samples=40):
                y_pred_binarize, y_score)
 
 
+@does_yield
 def test_averaging_multilabel_all_zeroes():
     y_true = np.zeros((20, 3))
     y_pred = np.zeros((20, 3))
@@ -929,6 +934,7 @@ def test_averaging_multilabel_all_zeroes():
                      y_pred_binarize, is_multilabel=True)
 
 
+@does_yield
 def test_averaging_multilabel_all_ones():
     y_true = np.ones((20, 3))
     y_pred = np.ones((20, 3))
@@ -1011,6 +1017,7 @@ def check_sample_weight_invariance(name, metric, y1, y2):
                   sample_weight=np.hstack([sample_weight, sample_weight]))
 
 
+@does_yield
 def test_sample_weight_invariance(n_samples=50):
     random_state = check_random_state(0)
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -13,6 +13,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raises_regexp
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import does_yield
 
 from sklearn.externals.six import iteritems
 
@@ -193,18 +194,6 @@ def check_pairwise_parallel(func, metric, kwds):
         assert_array_almost_equal(S, S2)
 
 
-def test_pairwise_parallel():
-    wminkowski_kwds = {'w': np.arange(1, 5).astype('double'), 'p': 1}
-    metrics = [(pairwise_distances, 'euclidean', {}),
-               (pairwise_distances, wminkowski, wminkowski_kwds),
-               (pairwise_distances, 'wminkowski', wminkowski_kwds),
-               (pairwise_kernels, 'polynomial', {'degree': 1}),
-               (pairwise_kernels, callable_rbf_kernel, {'gamma': .1}),
-               ]
-    for func, metric, kwds in metrics:
-        yield check_pairwise_parallel, func, metric, kwds
-
-
 def test_pairwise_callable_nonstrict_metric():
     # paired_distances should allow callable metric where metric(x, x) != 0
     # Knowing that the callable is a strict metric would allow the diagonal to
@@ -216,6 +205,19 @@ def callable_rbf_kernel(x, y, **kwds):
     # Callable version of pairwise.rbf_kernel.
     K = rbf_kernel(np.atleast_2d(x), np.atleast_2d(y), **kwds)
     return K
+
+
+@does_yield
+def test_pairwise_parallel():
+    wminkowski_kwds = {'w': np.arange(1, 5).astype('double'), 'p': 1}
+    metrics = [(pairwise_distances, 'euclidean', {}),
+               (pairwise_distances, wminkowski, wminkowski_kwds),
+               (pairwise_distances, 'wminkowski', wminkowski_kwds),
+               (pairwise_kernels, 'polynomial', {'degree': 1}),
+               (pairwise_kernels, callable_rbf_kernel, {'gamma': .1}),
+               ]
+    for func, metric, kwds in metrics:
+        yield check_pairwise_parallel, func, metric, kwds
 
 
 def test_pairwise_kernels():    # Test the pairwise_kernels helper function.

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -20,6 +20,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import does_yield
 
 from sklearn.metrics import auc
 from sklearn.metrics import average_precision_score
@@ -820,6 +821,7 @@ def check_alternative_lrap_implementation(lrap_score, n_classes=5,
     assert_almost_equal(score_lrap, score_my_lrap)
 
 
+@does_yield
 def test_label_ranking_avp():
     for fn in [label_ranking_average_precision_score, _my_lrap]:
         yield check_lrap_toy, fn

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import does_yield
 
 from sklearn.base import BaseEstimator
 from sklearn.metrics import (f1_score, r2_score, roc_auc_score, fbeta_score,
@@ -410,6 +411,7 @@ def check_scorer_memmap(scorer_name):
     assert isinstance(score, numbers.Number), scorer_name
 
 
+@does_yield
 def test_scorer_memmap_input():
     # Non-regression test for #6147: some score functions would
     # return singleton memmap when computed on memmap data instead of scalar

--- a/sklearn/mixture/tests/test_gmm.py
+++ b/sklearn/mixture/tests/test_gmm.py
@@ -17,6 +17,7 @@ from sklearn.datasets.samples_generator import make_spd_matrix
 from sklearn.utils.testing import (assert_true, assert_greater,
                                    assert_raise_message, assert_warns_message,
                                    ignore_warnings)
+from sklearn.utils.testing import does_yield
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.externals.six.moves import cStringIO as StringIO
 
@@ -497,6 +498,7 @@ def check_positive_definite_covars(covariance_type):
             assert_greater(np.linalg.det(c), 0)
 
 
+@does_yield
 def test_positive_definite_covars():
     # Check positive definiteness for all covariance types
     for covariance_type in ["full", "tied", "diag", "spherical"]:

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -6,6 +6,7 @@ from sklearn.neighbors.ball_tree import (BallTree, NeighborsHeap,
                                          nodeheap_sort, DTYPE, ITYPE)
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils.testing import SkipTest, assert_allclose
+from sklearn.utils.testing import does_yield
 
 rng = np.random.RandomState(10)
 V = rng.rand(3, 3)
@@ -41,6 +42,7 @@ def brute_force_neighbors(X, Y, k, metric, **kwargs):
     return dist, ind
 
 
+@does_yield
 def test_ball_tree_query():
     np.random.seed(0)
     X = np.random.random((40, DIMENSION))
@@ -65,6 +67,7 @@ def test_ball_tree_query():
                            k, metric, kwargs)
 
 
+@does_yield
 def test_ball_tree_query_boolean_metrics():
     np.random.seed(0)
     X = np.random.random((40, 10)).round(0)
@@ -81,6 +84,7 @@ def test_ball_tree_query_boolean_metrics():
         yield check_neighbors, metric
 
 
+@does_yield
 def test_ball_tree_query_discrete_metrics():
     np.random.seed(0)
     X = (4 * np.random.random((40, 10))).round(0)
@@ -156,6 +160,7 @@ def compute_kernel_slow(Y, X, kernel, h):
         raise ValueError('kernel not recognized')
 
 
+@does_yield
 def test_ball_tree_kde(n_samples=100, n_features=3):
     np.random.seed(0)
     X = np.random.random((n_samples, n_features))
@@ -202,6 +207,7 @@ def test_gaussian_kde(n_samples=1000):
         assert_array_almost_equal(dens_bt, dens_gkde, decimal=3)
 
 
+@does_yield
 def test_ball_tree_two_point(n_samples=100, n_features=3):
     np.random.seed(0)
     X = np.random.random((n_samples, n_features))
@@ -220,6 +226,7 @@ def test_ball_tree_two_point(n_samples=100, n_features=3):
         yield check_two_point, r, dualtree
 
 
+@does_yield
 def test_ball_tree_pickle():
     np.random.seed(0)
     X = np.random.random((10, 3))

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -9,6 +9,7 @@ from scipy.spatial.distance import cdist
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.neighbors import BallTree
 from sklearn.utils.testing import SkipTest, assert_raises_regex
+from sklearn.utils.testing import does_yield
 
 
 def dist_func(x1, x2, p):

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -5,6 +5,7 @@ from sklearn.neighbors.kd_tree import (KDTree, NeighborsHeap,
                                        nodeheap_sort, DTYPE, ITYPE)
 from sklearn.neighbors.dist_metrics import DistanceMetric
 from sklearn.utils.testing import SkipTest, assert_allclose
+from sklearn.utils.testing import does_yield
 
 V = np.random.random((3, 3))
 V = np.dot(V, V.T)
@@ -24,6 +25,7 @@ def brute_force_neighbors(X, Y, k, metric, **kwargs):
     return dist, ind
 
 
+@does_yield
 def test_kd_tree_query():
     np.random.seed(0)
     X = np.random.random((40, DIMENSION))
@@ -107,6 +109,7 @@ def compute_kernel_slow(Y, X, kernel, h):
         raise ValueError('kernel not recognized')
 
 
+@does_yield
 def test_kd_tree_kde(n_samples=100, n_features=3):
     np.random.seed(0)
     X = np.random.random((n_samples, n_features))
@@ -152,6 +155,7 @@ def test_gaussian_kde(n_samples=1000):
         assert_array_almost_equal(dens_kdt, dens_gkde, decimal=3)
 
 
+@does_yield
 def test_kd_tree_two_point(n_samples=100, n_features=3):
     np.random.seed(0)
     X = np.random.random((n_samples, n_features))
@@ -170,6 +174,7 @@ def test_kd_tree_two_point(n_samples=100, n_features=3):
         yield check_two_point, r, dualtree
 
 
+@does_yield
 def test_kd_tree_pickle():
     import pickle
     np.random.seed(0)

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -1,6 +1,7 @@
 import numpy as np
 from sklearn.utils.testing import (assert_allclose, assert_raises,
                                    assert_equal)
+from sklearn.utils.testing import does_yield
 from sklearn.neighbors import KernelDensity, KDTree, NearestNeighbors
 from sklearn.neighbors.ball_tree import kernel_norm
 from sklearn.pipeline import make_pipeline
@@ -29,6 +30,7 @@ def compute_kernel_slow(Y, X, kernel, h):
         raise ValueError('kernel not recognized')
 
 
+@does_yield
 def test_kernel_density(n_samples=100, n_features=3):
     rng = np.random.RandomState(0)
     X = rng.randn(n_samples, n_features)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import does_yield
 from sklearn.utils.validation import check_random_state
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn import neighbors, datasets
@@ -1168,6 +1169,7 @@ def test_include_self_neighbors_graph():
     assert_array_equal(rng_not_self, [[0., 1.], [1., 0.]])
 
 
+@does_yield
 def test_same_knn_parallel():
     X, y = datasets.make_classification(n_samples=30, n_features=5,
                                         n_redundant=0, random_state=0)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import does_yield
 
 from sklearn.preprocessing.label import LabelBinarizer
 from sklearn.preprocessing.label import MultiLabelBinarizer
@@ -446,6 +447,7 @@ def check_binarized_results(y, classes, pos_label, neg_label, expected):
         assert_equal(issparse(inverse_output), issparse(y))
 
 
+@does_yield
 def test_label_binarize_binary():
     y = [0, 1, 0]
     classes = [0, 1]
@@ -465,6 +467,7 @@ def test_label_binarize_binary():
     yield check_binarized_results, y, classes, pos_label, neg_label, expected
 
 
+@does_yield
 def test_label_binarize_multiclass():
     y = [0, 1, 2]
     classes = [0, 1, 2]
@@ -478,6 +481,7 @@ def test_label_binarize_multiclass():
                   pos_label=pos_label, sparse_output=True)
 
 
+@does_yield
 def test_label_binarize_multilabel():
     y_ind = np.array([[0, 1, 0], [1, 1, 1], [0, 0, 0]])
     classes = [0, 1, 2]

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -9,6 +9,7 @@ from sklearn.linear_model.logistic import LogisticRegression
 
 from sklearn.utils.testing import assert_true, raises
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import does_yield
 
 
 dense_X = [[-1, 0], [0, 1], [1, 1], [1, 1]]
@@ -18,6 +19,7 @@ Y1 = [0, 1, 1, 1]
 Y2 = [2, 1, 0, 0]
 
 
+@does_yield
 def test_l1_min_c():
     losses = ['squared_hinge', 'log']
     Xs = {'sparse': sparse_X, 'dense': dense_X}

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -21,6 +21,7 @@ from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import _named_check
+from sklearn.utils.testing import does_yield
 
 import sklearn
 from sklearn.cluster.bicluster import BiclusterMixin
@@ -44,6 +45,7 @@ def test_all_estimator_no_base_class():
         assert_false(name.lower().startswith('base'), msg=msg)
 
 
+@does_yield
 def test_all_estimators():
     # Test that estimators are default-constructible, cloneable
     # and have working repr.
@@ -59,6 +61,7 @@ def test_all_estimators():
                name, Estimator)
 
 
+@does_yield
 def test_non_meta_estimators():
     # input validation etc for non-meta estimators
     estimators = all_estimators()
@@ -98,6 +101,7 @@ def test_configure():
         os.chdir(cwd)
 
 
+@does_yield
 def test_class_weight_balanced_linear_classifiers():
     classifiers = all_estimators(type_filter='classifier')
 
@@ -164,6 +168,7 @@ def test_all_tests_are_importable():
                  'setup.py'.format(missing_tests))
 
 
+@does_yield
 def test_non_transformer_estimators_n_iter():
     # Test that all estimators of type which are non-transformer
     # and which have an attribute of max_iter, return the attribute
@@ -199,6 +204,7 @@ def test_non_transformer_estimators_n_iter():
                         name, estimator, 'Multi' in name)
 
 
+@does_yield
 def test_transformer_n_iter():
     transformers = all_estimators(type_filter='transformer')
     for name, Estimator in transformers:
@@ -214,6 +220,7 @@ def test_transformer_n_iter():
                 check_transformer_n_iter, name), name, estimator
 
 
+@does_yield
 def test_get_params_invariance():
     # Test for estimators that support get_params, that
     # get_params(deep=False) is a subset of get_params(deep=True)

--- a/sklearn/tests/test_cross_validation.py
+++ b/sklearn/tests/test_cross_validation.py
@@ -22,6 +22,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_warns_message
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import does_yield
 from sklearn.utils.mocking import CheckingClassifier, MockDataFrame
 
 with warnings.catch_warnings():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -15,6 +15,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import does_yield
 
 from sklearn.naive_bayes import GaussianNB, BernoulliNB, MultinomialNB
 
@@ -223,6 +224,7 @@ def check_partial_fit(cls):
     assert_array_equal(clf1.feature_count_, clf3.feature_count_)
 
 
+@does_yield
 def test_discretenb_partial_fit():
     for cls in [MultinomialNB, BernoulliNB]:
         yield check_partial_fit, cls
@@ -378,12 +380,6 @@ def test_discretenb_provide_prior_with_partial_fit():
                                       clf_partial.class_log_prior_)
 
 
-def test_sample_weight_multiclass():
-    for cls in [BernoulliNB, MultinomialNB]:
-        # check shape consistency for number of samples at fit time
-        yield check_sample_weight_multiclass, cls
-
-
 def check_sample_weight_multiclass(cls):
     X = [
         [0, 0, 1],
@@ -404,6 +400,13 @@ def check_sample_weight_multiclass(cls):
     clf.partial_fit(X[2:3], y[2:3], sample_weight=sample_weight[2:3])
     clf.partial_fit(X[3:], y[3:], sample_weight=sample_weight[3:])
     assert_array_equal(clf.predict(X), [0, 1, 1, 2])
+
+
+@does_yield
+def test_sample_weight_multiclass():
+    for cls in [BernoulliNB, MultinomialNB]:
+        # check shape consistency for number of samples at fit time
+        yield check_sample_weight_multiclass, cls
 
 
 def test_sample_weight_mnb():

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -20,6 +20,7 @@ from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_in
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns
+from sklearn.utils.testing import does_yield
 from sklearn.exceptions import DataDimensionalityWarning
 
 all_sparse_random_matrix = [sparse_random_matrix]
@@ -113,6 +114,7 @@ def check_input_with_sparse_random_matrix(random_matrix):
                       random_matrix, n_components, n_features, density=density)
 
 
+@does_yield
 def test_basic_property_of_random_matrix():
     # Check basic properties of random matrix generation
     for random_matrix in all_random_matrix:

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -30,6 +30,7 @@ from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import raises
 from sklearn.utils.testing import ignore_warnings
+from sklearn.utils.testing import does_yield
 
 from sklearn.utils.validation import check_random_state
 
@@ -698,6 +699,7 @@ def check_min_weight_fraction_leaf(name, datasets, sparse=False):
                 name, est.min_weight_fraction_leaf))
 
 
+@does_yield
 def test_min_weight_fraction_leaf():
     # Check on dense input
     for name in ALL_TREES:
@@ -772,6 +774,7 @@ def check_min_weight_fraction_leaf_with_min_samples_leaf(name, datasets,
                                           est.min_samples_leaf))
 
 
+@does_yield
 def test_min_weight_fraction_leaf_with_min_samples_leaf():
     # Check on dense input
     for name in ALL_TREES:
@@ -1111,6 +1114,7 @@ def check_class_weights(name):
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
 
 
+@does_yield
 def test_class_weights():
     for name in CLF_TREES:
         yield check_class_weights, name
@@ -1135,6 +1139,7 @@ def check_class_weight_errors(name):
     assert_raises(ValueError, clf.fit, X, _y)
 
 
+@does_yield
 def test_class_weight_errors():
     for name in CLF_TREES:
         yield check_class_weight_errors, name
@@ -1283,6 +1288,7 @@ def check_sparse_input(tree, dataset, max_depth=None):
                                           y_log_proba)
 
 
+@does_yield
 def test_sparse_input():
     for tree, dataset in product(SPARSE_TREES,
                                  ("clf_small", "toy", "digits", "multilabel",
@@ -1342,6 +1348,7 @@ def check_sparse_parameters(tree, dataset):
     assert_array_almost_equal(s.predict(X), d.predict(X))
 
 
+@does_yield
 def test_sparse_parameters():
     for tree, dataset in product(SPARSE_TREES,
                                  ["sparse-pos", "sparse-neg", "sparse-mix",
@@ -1369,6 +1376,7 @@ def check_sparse_criterion(tree, dataset):
         assert_array_almost_equal(s.predict(X), d.predict(X))
 
 
+@does_yield
 def test_sparse_criterion():
     for tree, dataset in product(SPARSE_TREES,
                                  ["sparse-pos", "sparse-neg", "sparse-mix",
@@ -1445,6 +1453,7 @@ def check_explicit_sparse_zeros(tree, max_depth=3,
                                       d.predict_proba(X2))
 
 
+@does_yield
 def test_explicit_sparse_zeros():
     for tree in SPARSE_TREES:
         yield (check_explicit_sparse_zeros, tree)
@@ -1465,6 +1474,7 @@ def check_raise_error_on_1d_input(name):
     assert_raises(ValueError, est.predict, [X])
 
 
+@does_yield
 @ignore_warnings
 def test_1d_input():
     for name in ALL_TREES:
@@ -1495,6 +1505,7 @@ def check_min_weight_leaf_split_level(name):
                                            sample_weight)
 
 
+@does_yield
 def test_min_weight_leaf_split_level():
     for name in ALL_TREES:
         yield check_min_weight_leaf_split_level, name
@@ -1518,6 +1529,7 @@ def check_public_apply_sparse(name):
                        est.tree_.apply(X_small32))
 
 
+@does_yield
 def test_public_apply():
     for name in ALL_TREES:
         yield (check_public_apply, name)
@@ -1530,6 +1542,7 @@ def check_presort_sparse(est, X, y):
     assert_raises(ValueError, est.fit, X, y)
 
 
+@does_yield
 def test_presort_sparse():
     ests = (DecisionTreeClassifier(presort=True),
             DecisionTreeRegressor(presort=True))
@@ -1581,6 +1594,7 @@ def check_decision_path(name):
     assert_less_equal(est.tree_.max_depth, max_depth)
 
 
+@does_yield
 def test_decision_path():
     for name in ALL_TREES:
         yield (check_decision_path, name)
@@ -1592,6 +1606,7 @@ def check_no_sparse_y_support(name):
     assert_raises(TypeError, TreeEstimator(random_state=0).fit, X, y)
 
 
+@does_yield
 def test_no_sparse_y_support():
     # Currently we don't support sparse y
     for name in ALL_TREES:

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -1,4 +1,5 @@
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import does_yield
 
 from sklearn.utils.stats import rankdata
 
@@ -13,6 +14,7 @@ _cases = (
 )
 
 
+@does_yield
 def test_cases():
 
     def check_case(values, method, expected):


### PR DESCRIPTION
Running tests on my machine results in a large amount of warnings from py.test about yield tests.
I'm running pytest version 3.0.1.  An example of a warning line is: 

```
======================================================= pytest-warning summary =======================================================
WC1 ./sklearn/tree/tests/test_tree.py yield tests are deprecated, and scheduled to be removed in pytest 4.0
....
```

The warning repeats for over 200 instances of this problem. 

Each instance of the yield tests looks like it was generating a tuple of a function and its arguments. 
To resolve the issue I simply called the function instead of yielding the tuple.
