### PR TITLE
Fixed issue where yield test wrapped with skip_if_32bit was not run

### DIFF
--- a/sklearn/utils/testing.py
+++ b/sklearn/utils/testing.py
@@ -674,6 +674,8 @@ def set_random_state(estimator, random_state=0):
 
 def if_matplotlib(func):
     """Test decorator that skips test if matplotlib not installed."""
+    if inspect.isgeneratorfunction(func):
+        raise NotImplementedError('testwraper needs a generator version')
     @wraps(func)
     def run_test(*args, **kwargs):
         try:
@@ -691,14 +693,28 @@ def if_matplotlib(func):
 
 def skip_if_32bit(func):
     """Test decorator that skips tests on 32bit platforms."""
-    @wraps(func)
-    def run_test(*args, **kwargs):
-        bits = 8 * struct.calcsize("P")
-        if bits == 32:
-            raise SkipTest('Test skipped on 32bit platforms.')
-        else:
-            return func(*args, **kwargs)
-    return run_test
+    if inspect.isgeneratorfunction(func):
+        @wraps(func)
+        def gen_test():
+            # Fix issue with yield tests not being run
+            def _skip():
+                raise SkipTest('Test skipped on 32bit platforms.')
+            bits = 8 * struct.calcsize("P")
+            for tup in func():
+                if bits == 32:
+                    yield (_skip,)
+                else:
+                    yield tup
+        return gen_test
+    else:
+        @wraps(func)
+        def run_test(*args, **kwargs):
+            bits = 8 * struct.calcsize("P")
+            if bits == 32:
+                raise SkipTest('Test skipped on 32bit platforms.')
+            else:
+                return func(*args, **kwargs)
+        return run_test
 
 
 def if_not_mac_os(versions=('10.7', '10.8', '10.9'),
@@ -707,6 +723,8 @@ def if_not_mac_os(versions=('10.7', '10.8', '10.9'),
     """Test decorator that skips test if OS is Mac OS X and its
     major version is one of ``versions``.
     """
+    if inspect.isgeneratorfunction(func):
+        raise NotImplementedError('testwraper needs a generator version')
     warnings.warn("if_not_mac_os is deprecated in 0.17 and will be removed"
                   " in 0.19: use the safer and more generic"
                   " if_safe_multiprocessing_with_blas instead",
@@ -742,6 +760,8 @@ def if_safe_multiprocessing_with_blas(func):
     errors on interactively defined functions. It therefore not enabled by
     default.
     """
+    if inspect.isgeneratorfunction(func):
+        raise NotImplementedError('testwraper needs a generator version')
     @wraps(func)
     def run_test(*args, **kwargs):
         if sys.platform == 'darwin':


### PR DESCRIPTION
In #7654 I discovered that a yield test was not being run by nosetests because it was wrapped in skip_if_32bit. 

Previously 
`nosetests sklearn.ensemble.tests.test_forest:test_importances --verbose` would output 

```
sklearn.ensemble.tests.test_forest.test_importances ... ok
----------------------------------------------------------------------
Ran 1 test in 0.000s
OK
```

However, this success was simply because nothing was being run. 

With the change all 10 of the tests embeded in this one function are run. Unfortunately they are all failing. 

```
(venv2) joncrall@hyrule:~/code/scikit-learn$ nosetests sklearn.ensemble.tests.test_forest:test_importances --verbose
sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesClassifier', 'gini', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesClassifier', 'entropy', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('RandomForestClassifier', 'gini', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('RandomForestClassifier', 'entropy', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'friedman_mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'mae', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'friedman_mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL
sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'mae', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 , ... FAIL

======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesClassifier', 'gini', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesClassifier', 'entropy', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('RandomForestClassifier', 'gini', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('RandomForestClassifier', 'entropy', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'friedman_mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('ExtraTreesRegressor', 'mae', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'friedman_mse', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


======================================================================
FAIL: sklearn.ensemble.tests.test_forest.test_importances('RandomForestRegressor', 'mae', array([[ 0.31727627,  1.05972592, -0.1446832 , ...,  0.5589773 ,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/venv2/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/joncrall/code/scikit-learn/sklearn/ensemble/tests/test_forest.py", line 209, in check_importances
    assert_equal(n_important, 3)
AssertionError: 2 != 3
    '2 != 3' = '%s != %s' % (safe_repr(2), safe_repr(3))
    '2 != 3' = self._formatMessage('2 != 3', '2 != 3')
>>  raise self.failureException('2 != 3')


----------------------------------------------------------------------
Ran 10 tests in 1.109s

FAILED (failures=10)
```

What I did to fix the initial problem was in `skip_if_32bit` I checked if the input function was a generator. 
If it was not then the function runs like it used to. If it is a generator I create a different wrapper that re-yields the results if the function is enabled and yields functions that raise SkipTest errors if the function is disabled. 

I also raised NotImplemented errors in other wrappers if a generator function is passed in.  
