### PR TITLE
[MRG + 1] DOC :issue: role to simplify what's news

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'numpy_ext.numpydoc',
     'sphinx.ext.linkcode', 'sphinx.ext.doctest',
     'sphinx_gallery.gen_gallery',
+    'sphinx_issues',
 ]
 
 # pngmath / imgmath compatibility layer for different sphinx versions
@@ -267,6 +268,13 @@ def make_carousel_thumbs(app, exception):
         if os.path.exists(image):
             c_thumb = os.path.join(image_dir, glr_plot[:-4] + '_carousel.png')
             sphinx_gallery.gen_rst.scale_image(image, c_thumb, max_width, 190)
+
+
+# Config for sphinx_issues
+
+issues_uri = 'https://github.com/scikit-learn/scikit-learn/issues/{issue}'
+issues_github_path = 'scikit-learn/scikit-learn'
+issues_user_uri = 'https://github.com/{user}'
 
 
 def setup(app):

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -22,7 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from docutils import nodes, utils
+try:
+    from docutils import nodes, utils
+except ImportError:
+    # Load lazily so that test-sphinxext does not require docutils dependency
+    pass
 
 __version__ = '0.2.0'
 __author__ = 'Steven Loria'

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""A Sphinx extension for linking to your project's issue tracker."""
+"""
+Copyright 2014 Steven Loria
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from docutils import nodes, utils
+
+__version__ = '0.2.0'
+__author__ = 'Steven Loria'
+__license__ = 'MIT'
+
+
+def user_role(name, rawtext, text, lineno,
+              inliner, options=None, content=None):
+    """Sphinx role for linking to a user profile. Defaults to linking to
+    Github profiles, but the profile URIS can be configured via the
+    ``issues_user_uri`` config value.
+
+    Example: ::
+
+        :user:`sloria`
+    """
+    options = options or {}
+    content = content or []
+    username = utils.unescape(text).strip()
+    config = inliner.document.settings.env.app.config
+    if config.issues_user_uri:
+        ref = config.issues_user_uri.format(user=username)
+    else:
+        ref = 'https://github.com/{0}'.format(username)
+    text = '@{0}'.format(username)
+    link = nodes.reference(text=text, refuri=ref, **options)
+    return [link], []
+
+
+def _make_issue_node(issue_no, config, options=None):
+    options = options or {}
+    if issue_no not in ('-', '0'):
+        if config.issues_uri:
+            ref = config.issues_uri.format(issue=issue_no)
+        elif config.issues_github_path:
+            ref = 'https://github.com/{0}/issues/{1}'.format(
+                config.issues_github_path, issue_no
+            )
+        issue_text = '#{0}'.format(issue_no)
+        link = nodes.reference(text=issue_text, refuri=ref, **options)
+    else:
+        link = None
+    return link
+
+
+def issue_role(name, rawtext, text, lineno,
+               inliner, options=None, content=None):
+    """Sphinx role for linking to an issue. Must have
+    `issues_uri` or `issues_github_path` configured in ``conf.py``.
+
+    Examples: ::
+
+        :issue:`123`
+        :issue:`42,45`
+    """
+    options = options or {}
+    content = content or []
+    issue_nos = [each.strip() for each in utils.unescape(text).split(',')]
+    config = inliner.document.settings.env.app.config
+    ret = []
+    for i, issue_no in enumerate(issue_nos):
+        node = _make_issue_node(issue_no, config, options=options)
+        ret.append(node)
+        if i != len(issue_nos) - 1:
+            sep = nodes.raw(text=', ', format='html')
+            ret.append(sep)
+    return ret, []
+
+
+def setup(app):
+    # Format template for issues URI
+    # e.g. 'https://github.com/sloria/marshmallow/issues/{issue}
+    app.add_config_value('issues_uri', default=None, rebuild='html')
+    # Shortcut for Github, e.g. 'sloria/marshmallow'
+    app.add_config_value('issues_github_path', default=None, rebuild='html')
+    # Format template for user profile URI
+    # e.g. 'https://github.com/{user}'
+    app.add_config_value('issues_user_uri', default=None, rebuild='html')
+    app.add_role('issue', issue_role)
+    app.add_role('user', user_role)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,18 +23,15 @@ Enhancements
      more efficient, taking a fast path to declare a node a leaf if its weight
      is less than 2 * the minimum. Note that the constructed tree will be
      different from previous versions where ``min_weight_fraction_leaf`` is
-     used. (`#7441 <https://github.com/scikit-learn/scikit-learn/pull/7441>`_)
-     by `Nelson Liu`_.
+     used. :issue:`7441` by `Nelson Liu`_.
 
    - Added ``average`` parameter to perform weights averaging in
-     :class:`linear_model.PassiveAggressiveClassifier`. (`#4939
-     <https://github.com/scikit-learn/scikit-learn/pull/4939>`_) by `Andrea
-     Esuli`_.
+     :class:`linear_model.PassiveAggressiveClassifier`. :issue:`4939`
+     by :user:`Andrea Esuli <aesuli>`.
 
    - Custom metrics for the :mod:`sklearn.neighbors` binary trees now have
      fewer constraints: they must take two 1d-arrays and return a float.
-     (`#6288 <https://github.com/scikit-learn/scikit-learn/pull/6288>`_) by
-     `Jake VanderPlas`_.
+     :issue:`6288` by `Jake VanderPlas`_.
 
    - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
      now support sparse input for prediction.
@@ -45,21 +42,16 @@ Bug fixes
 .........
 
    - :class:`sklearn.manifold.LocallyLinearEmbedding` now correctly handles
-     integer inputs
-     (`#6282 <https://github.com/scikit-learn/scikit-learn/pull/6282>`_) by
-     `Jake Vanderplas`_.
+     integer inputs. :issue:`6282` by `Jake Vanderplas`_.
 
    - The ``min_weight_fraction_leaf`` parameter of tree-based classifiers and
      regressors now assumes uniform sample weights by default if the
      ``sample_weight`` argument is not passed to the ``fit`` function.
-     Previously, the parameter was silently ignored. (`#7301
-     <https://github.com/scikit-learn/scikit-learn/pull/7301>`_) by `Nelson
-     Liu`_.
+     Previously, the parameter was silently ignored. :issue:`7301`
+     by `Nelson Liu`_.
 
    - Numerical issue with :class:`linear_model.RidgeCV` on centered data when
-     `n_features > n_samples`. (`#6178
-     <https://github.com/scikit-learn/scikit-learn/pull/6178>`_) by `Bertrand
-     Thirion`_
+     `n_features > n_samples`. :issue:`6178` by `Bertrand Thirion`_
 
 .. _changes_0_18_1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,8 +63,7 @@ Bug fixes
 
    - Fix issue where ``min_grad_norm`` and ``n_iter_without_progress``
      parameters were not being utilised by :class:`manifold.TSNE`.
-     :issue:`6497`
-     by `Sebastian Säger`_
+     :issue:`6497` by `Sebastian Säger`_
 
 
 .. _changes_0_18:
@@ -196,10 +195,10 @@ Classifiers and Regressors
      examples are provided. By `Jan Hendrik Metzen`_.
 
    - Added new supervised learning algorithm: :ref:`Multi-layer Perceptron <multilayer_perceptron>`
-     (:issue:`3204`) by `Issam H. Laradji`_
+     :issue:`3204` by `Issam H. Laradji`_
 
    - Added :class:`linear_model.HuberRegressor`, a linear model robust to outliers.
-     (:issue:`5291`) by `Manoj Kumar`_.
+     :issue:`5291` by `Manoj Kumar`_.
 
    - Added the :class:`multioutput.MultiOutputRegressor` meta-estimator. It
      converts single output regressors to multi-ouput regressors by fitting
@@ -209,9 +208,7 @@ Other estimators
 
    - New :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
      replace former mixture models, employing faster inference
-     for sounder results.
-     (:issue:`7295`) by
-     `Wei Xue`_ and `Thierry Guillemot`_.
+     for sounder results. :issue:`7295` by `Wei Xue`_ and `Thierry Guillemot`_.
 
    - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
      and it is available calling with parameter ``svd_solver='randomized'``.
@@ -219,8 +216,7 @@ Other estimators
      behavior of PCA is recovered by ``svd_solver='full'``. An additional solver
      calls ``arpack`` and performs truncated (non-randomized) SVD. By default,
      the best solver is selected depending on the size of the input and the
-     number of components requested.
-     (:issue:`5299`) by `Giorgio Patrini`_.
+     number of components requested. :issue:`5299` by `Giorgio Patrini`_.
 
    - Added two functions for mutual information estimation:
      :func:`feature_selection.mutual_info_classif` and
@@ -247,15 +243,12 @@ Model selection and evaluation
 
    - Added new cross-validation splitter
      :class:`model_selection.TimeSeriesSplit` to handle time series data.
-     (:issue:`6586`) by `YenChen
-     Lin`_
+     :issue:`6586` by `YenChen Lin`_
 
    - The cross-validation iterators are replaced by cross-validation splitters
      available from :mod:`sklearn.model_selection`, allowing for nested
-     cross-validation.
-     See :ref:`model_selection_changes` for more information.
-     (:issue:`4294`) by
-     `Raghav R V`_.
+     cross-validation. See :ref:`model_selection_changes` for more information.
+     :issue:`4294` by `Raghav R V`_.
 
 Enhancements
 ............
@@ -266,12 +259,10 @@ Trees and ensembles
      the mean absolute error. This criterion can also be used in
      :class:`ensemble.ExtraTreesRegressor`,
      :class:`ensemble.RandomForestRegressor`, and the gradient boosting
-     estimators. (:issue:`6667`) by `Nelson
-     Liu`_.
+     estimators. :issue:`6667` by `Nelson Liu`_.
 
    - Added weighted impurity-based early stopping criterion for decision tree
-     growth. (:issue:`6954`) by `Nelson
-     Liu`_
+     growth. :issue:`6954` by `Nelson Liu`_
 
    - The random forest, extra tree and decision tree estimators now has a
      method ``decision_path`` which returns the decision path of samples in
@@ -282,12 +273,11 @@ Trees and ensembles
 
    - Random forest, extra trees, decision trees and gradient boosting estimator
      accept the parameter ``min_samples_split`` and ``min_samples_leaf``
-     provided as a percentage of the training samples. By
-     `yelite`_ and `Arnaud Joly`_.
+     provided as a percentage of the training samples. By `yelite`_ and `Arnaud Joly`_.
 
    - Gradient boosting estimators accept the parameter ``criterion`` to specify
-     to splitting criterion used in built decision trees. (:issue:`6667`) by `Nelson
-     Liu`_.
+     to splitting criterion used in built decision trees.
+     :issue:`6667` by `Nelson Liu`_.
 
    - The memory footprint is reduced (sometimes greatly) for
      :class:`ensemble.bagging.BaseBagging` and classes that inherit from it,
@@ -298,15 +288,12 @@ Trees and ensembles
 
    - Added ``n_jobs`` and ``sample_weights`` parameters for
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
-     (:issue:`5805`)
-     By `Ibraim Ganiev`_.
+     :issue:`5805` by `Ibraim Ganiev`_.
 
 Linear, kernelized and related models
 
    - In :class:`linear_model.LogisticRegression`, the SAG solver is now
-     available in the multinomial case.
-     (:issue:`5251`)
-     By `Tom Dupre la Tour`_.
+     available in the multinomial case. :issue:`5251` by `Tom Dupre la Tour`_.
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
      :class:`svm.LinearSVR` now support ``sample_weights``.
@@ -329,13 +316,11 @@ Linear, kernelized and related models
    - :class:`linear_model.ElasticNet` and :class:`linear_model.Lasso`
      now works with ``np.float32`` input data without converting it
      into ``np.float64``. This allows to reduce the memory
-     consumption.
-     (:issue:`6913`)
-     By `YenChen Lin`_.
+     consumption. :issue:`6913` by `YenChen Lin`_.
 
    - :class:`semi_supervised.LabelPropagation` and :class:`semi_supervised.LabelSpreading`
      now accept arbitrary kernel functions in addition to strings ``knn`` and ``rbf``.
-     (:issue:`5762`) By `Utkarsh Upadhyay`_.
+     :issue:`5762` by `Utkarsh Upadhyay`_.
 
 Decomposition, manifold learning and clustering
 
@@ -345,18 +330,15 @@ Decomposition, manifold learning and clustering
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     (:issue:`6846`)
-     By `Sebastian Säger`_ and `YenChen Lin`_.
+     :issue:`6846` by `Sebastian Säger`_ and `YenChen Lin`_.
 
 Preprocessing and feature selection
 
    - :class:`preprocessing.RobustScaler` now accepts ``quantile_range`` parameter.
-     (:issue:`5929`)
-     By `Konstantin Podshumok`_.
+     :issue:`5929` by `Konstantin Podshumok`_.
 
    - :class:`feature_extraction.FeatureHasher` now accepts string values.
-     (:issue:`6173`) By `Ryad Zenine`_
-     and `Devashish Deshpande`_.
+     :issue:`6173` by `Ryad Zenine`_ and `Devashish Deshpande`_.
 
    - Keyword arguments can now be supplied to ``func`` in
      :class:`preprocessing.FunctionTransformer` by means of the ``kw_args``
@@ -380,9 +362,7 @@ Model evaluation and meta-estimators
    - The new ``cv_results_`` attribute of :class:`model_selection.GridSearchCV`
      (and :class:`model_selection.RandomizedSearchCV`) can be easily imported
      into pandas as a ``DataFrame``. Ref :ref:`model_selection_changes` for
-     more information.
-     (:issue:`6697`) by
-     `Raghav R V`_.
+     more information. :issue:`6697` by `Raghav R V`_.
 
    - Generalization of :func:`model_selection.cross_val_predict`.
      One can pass method names such as `predict_proba` to be used in the cross
@@ -392,19 +372,18 @@ Model evaluation and meta-estimators
    - The training scores and time taken for training followed by scoring for
      each search candidate are now available at the ``cv_results_`` dict.
      See :ref:`model_selection_changes` for more information.
-     (:issue:`7325`) By `Eugene Chen`_ and `Raghav R V`_.
+     :issue:`7325` by `Eugene Chen`_ and `Raghav R V`_.
 
 Metrics
 
    - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
-     (:issue:`7239`) by `Hong Guangguo`_ with help from `Mads Jensen`_ and `Nelson Liu`_.
+     :issue:`7239` by `Hong Guangguo`_ with help from `Mads Jensen`_ and `Nelson Liu`_.
 
    - Support sparse contingency matrices in cluster evaluation
      (:mod:`metrics.cluster.supervised`) to scale to a large number of
      clusters.
-     (:issue:`7419`)
-     By `Gregory Stupp`_ and `Joel Nothman`_.
+     :issue:`7419` by `Gregory Stupp`_ and `Joel Nothman`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
      By `Jatin Shah`_ and `Raghav R V`_.
@@ -445,15 +424,11 @@ Miscellaneous
      `Manvendra Singh`_.
 
    - Simplification of the ``clone`` function, deprecate support for estimators
-     that modify parameters in ``__init__``.
-     (:issue:`5540`)
-     By `Andreas Müller`_.
+     that modify parameters in ``__init__``. :issue:`5540` by `Andreas Müller`_.
 
    - When unpickling a scikit-learn estimator in a different version than the one
      the estimator was trained with, a ``UserWarning`` is raised, see :ref:`the documentation
-     on model persistence <persistence_limitations>`
-     for more details.
-     (:issue:`7248`)
+     on model persistence <persistence_limitations>` for more details. (:issue:`7248`)
      By `Andreas Müller`_.
 
 Bug fixes
@@ -472,13 +447,11 @@ Trees and ensembles
     - Fix bug where :class:`ensemble.AdaBoostClassifier` and
       :class:`ensemble.AdaBoostRegressor` would perform poorly if the
       ``random_state`` was fixed
-      (:issue:`7411`).
-      By `Joel Nothman`_.
+      (:issue:`7411`). By `Joel Nothman`_.
 
     - Fix bug in ensembles with randomization where the ensemble would not
       set ``random_state`` on base estimators in a pipeline or similar nesting.
-      (:issue:`7411`).
-      Note, results for :class:`ensemble.BaggingClassifier`
+      (:issue:`7411`). Note, results for :class:`ensemble.BaggingClassifier`
       :class:`ensemble.BaggingRegressor`, :class:`ensemble.AdaBoostClassifier`
       and :class:`ensemble.AdaBoostRegressor` will now differ from previous
       versions. By `Joel Nothman`_.
@@ -491,8 +464,7 @@ Linear, kernelized and related models
 
     - Fix bug in :class:`linear_model.LogisticRegressionCV` where
       ``solver='liblinear'`` did not accept ``class_weights='balanced``.
-      (:issue:`6817`).
-      By `Tom Dupre la Tour`_.
+      (:issue:`6817`). By `Tom Dupre la Tour`_.
 
     - Fix bug in :class:`neighbors.RadiusNeighborsClassifier` where an error
       occurred when there were outliers being labelled and a weight function
@@ -505,22 +477,22 @@ Linear, kernelized and related models
 Decomposition, manifold learning and clustering
 
     - :class:`decomposition.RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
-      (:issue:`5141`) by `Giorgio Patrini`_.
+      :issue:`5141` by `Giorgio Patrini`_.
 
     - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.
       In practice this is enough for obtaining a good approximation of the
       true eigenvalues/vectors in the presence of noise. When `n_components` is
       small (``< .1 * min(X.shape)``) `n_iter` is set to 7, unless the user specifies
       a higher number. This improves precision with few components.
-      (:issue:`5299`) by `Giorgio Patrini`_.
+      :issue:`5299` by `Giorgio Patrini`_.
 
     - Whiten/non-whiten inconsistency between components of :class:`decomposition.PCA`
       and :class:`decomposition.RandomizedPCA` (now factored into PCA, see the
       New features) is fixed. `components_` are stored with no whitening.
-      (:issue:`5299`) by `Giorgio Patrini`_.
+      :issue:`5299` by `Giorgio Patrini`_.
 
     - Fixed bug in :func:`manifold.spectral_embedding` where diagonal of unnormalized
-      Laplacian matrix was incorrectly set to 1. (:issue:`4995`) By `Peter Fischer`_.
+      Laplacian matrix was incorrectly set to 1. :issue:`4995` by `Peter Fischer`_.
 
     - Fixed incorrect initialization of :func:`utils.arpack.eigsh` on all
       occurrences. Affects :class:`cluster.bicluster.SpectralBiclustering`,
@@ -541,7 +513,7 @@ Model evaluation and meta-estimators
 
     - :class:`model_selection.StratifiedKFold` now raises error if all n_labels
       for individual classes is less than n_folds.
-      (:issue:`6182`) by `Devashish Deshpande`_.
+      :issue:`6182` by `Devashish Deshpande`_.
 
     - Fixed bug in :class:`model_selection.StratifiedShuffleSplit`
       where train and test sample could overlap in some edge cases,
@@ -550,12 +522,11 @@ Model evaluation and meta-estimators
 
     - Fix in :class:`sklearn.model_selection.StratifiedShuffleSplit` to
       return splits of size ``train_size`` and ``test_size`` in all cases
-      (:issue:`6472`).
-      By `Andreas Müller`_.
+      (:issue:`6472`). By `Andreas Müller`_.
 
     - Cross-validation of :class:`OneVsOneClassifier` and
       :class:`OneVsRestClassifier` now works with precomputed kernels.
-      (:issue:`7350`) By `Russell Smith`_.
+      :issue:`7350` by `Russell Smith`_.
 
     - Fix incomplete ``predict_proba`` method delegation from
       :class:`model_selection.GridSearchCV` to
@@ -576,8 +547,7 @@ Metrics
 
     - :func:`metrics.pairwise.pairwise_distances` now converts arrays to
       boolean arrays when required in ``scipy.spatial.distance``.
-      (:issue:`5460`)
-      By `Tom Dupre la Tour`_.
+      :issue:`5460` by `Tom Dupre la Tour`_.
 
     - Fix sparse input support in :func:`metrics.silhouette_score` as well as
       example examples/text/document_clustering.py. By `YenChen Lin`_.
@@ -590,22 +560,20 @@ Miscellaneous
 
     - :func:`model_selection.tests._search._check_param_grid` now works correctly with all types
       that extends/implements `Sequence` (except string), including range (Python 3.x) and xrange
-      (Python 2.x).
-      (:issue:`7323`) by Viacheslav Kovalevskyi.
+      (Python 2.x). :issue:`7323` by Viacheslav Kovalevskyi.
 
     - :func:`utils.extmath.randomized_range_finder` is more numerically stable when many
       power iterations are requested, since it applies LU normalization by default.
       If ``n_iter<2`` numerical issues are unlikely, thus no normalization is applied.
       Other normalization options are available: ``'none', 'LU'`` and ``'QR'``.
-      (:issue:`5141`) by `Giorgio Patrini`_.
+      :issue:`5141` by `Giorgio Patrini`_.
 
     - Fix a bug where some formats of ``scipy.sparse`` matrix, and estimators
       with them as parameters, could not be passed to :func:`base.clone`.
       By `Loic Esteve`_.
 
     - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
-      (:issue:`7101`)
-      By `Ibraim Ganiev`_.
+      :issue:`7101` by `Ibraim Ganiev`_.
 
 
 API changes summary
@@ -627,8 +595,7 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Gaussian mixture with a
      Dirichlet process prior faster than before.
-     (:issue:`7295`) by
-     `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`7295` by `Wei Xue`_ and `Thierry Guillemot`_.
 
    - The old :class:`mixture.VBGMM` is deprecated in favor of the new
      :class:`mixture.BayesianGaussianMixture` (with the parameter
@@ -636,14 +603,12 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Variational Bayesian Gaussian
      mixture faster than before.
-     (:issue:`6651`) by
-     `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`6651` by `Wei Xue`_ and `Thierry Guillemot`_.
 
    - The old :class:`mixture.GMM` is deprecated in favor of the new
      :class:`mixture.GaussianMixture`. The new class computes the Gaussian mixture
      faster than before and some of computational problems have been solved.
-     (:issue:`6666`) by
-     `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`6666` by `Wei Xue`_ and `Thierry Guillemot`_.
 
 Model evaluation and meta-estimators
 
@@ -651,26 +616,21 @@ Model evaluation and meta-estimators
      :mod:`sklearn.learning_curve` have been deprecated and the classes and
      functions have been reorganized into the :mod:`sklearn.model_selection`
      module. Ref :ref:`model_selection_changes` for more information.
-     (:issue:`4294`) by
-     `Raghav R V`_.
+     :issue:`4294` by `Raghav R V`_.
 
    - The ``grid_scores_`` attribute of :class:`model_selection.GridSearchCV`
      and :class:`model_selection.RandomizedSearchCV` is deprecated in favor of
      the attribute ``cv_results_``.
      Ref :ref:`model_selection_changes` for more information.
-     (:issue:`6697`) by
-     `Raghav R V`_.
+     :issue:`6697` by `Raghav R V`_.
 
    - The parameters ``n_iter`` or ``n_folds`` in old CV splitters are replaced
      by the new parameter ``n_splits`` since it can provide a consistent
      and unambiguous interface to represent the number of train-test splits.
-     (:issue:`7187`)
-     by `YenChen Lin`_.
+     :issue:`7187` by `YenChen Lin`_.
 
    - ``classes`` parameter was renamed to ``labels`` in
-     :func:`metrics.hamming_loss`.
-     (:issue:`7260`) by
-     `Sebastián Vanrell`_.
+     :func:`metrics.hamming_loss`. :issue:`7260` by `Sebastián Vanrell`_.
 
    - The splitter classes ``LabelKFold``, ``LabelShuffleSplit``,
      ``LeaveOneLabelOut`` and ``LeavePLabelsOut`` are renamed to
@@ -683,8 +643,7 @@ Model evaluation and meta-estimators
      :class:`model_selection.LeavePGroupsOut` is renamed to
      ``groups``. Additionally in :class:`model_selection.LeavePGroupsOut`,
      the parameter ``n_labels`` is renamed to ``n_groups``.
-     (:issue:`6660`)
-     by `Raghav R V`_.
+     :issue:`6660` by `Raghav R V`_.
 
 Code Contributors
 -----------------
@@ -868,8 +827,7 @@ Enhancements
    - Added the :func:`metrics.cohen_kappa_score` metric.
 
    - Added a ``warm_start`` constructor parameter to the bagging ensemble
-     models to increase the size of the ensemble. By
-     `Tim Head`_.
+     models to increase the size of the ensemble. By `Tim Head`_.
 
    - Added option to use multi-output regression metrics without averaging.
      By Konstantin Shmelkov and `Michael Eickenberg`_.
@@ -1076,8 +1034,7 @@ Bug fixes
     - Fixed temporarily :class:`linear_model.Ridge`, which was incorrect
       when fitting the intercept in the case of sparse data. The fix
       automatically changes the solver to 'sag' in this case.
-      (:issue:`5360`)
-      By `Tom Dupre la Tour`_.
+      :issue:`5360` by `Tom Dupre la Tour`_.
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (:issue:`4478`)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,8 +35,7 @@ Enhancements
 
    - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
      now support sparse input for prediction.
-     (`#6101 <https://github.com/scikit-learn/scikit-learn/pull/6101>`_)
-     By `Ibraim Ganiev`_.
+     :issue:`6101` by `Ibraim Ganiev`_.
 
 Bug fixes
 .........

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,7 +63,7 @@ Bug fixes
 
    - Fix issue where ``min_grad_norm`` and ``n_iter_without_progress``
      parameters were not being utilised by :class:`manifold.TSNE`.
-     `#6497 <https://github.com/scikit-learn/scikit-learn/pull/6497>`_
+     :issue:`6497`
      by `Sebastian Säger`_
 
 
@@ -196,10 +196,10 @@ Classifiers and Regressors
      examples are provided. By `Jan Hendrik Metzen`_.
 
    - Added new supervised learning algorithm: :ref:`Multi-layer Perceptron <multilayer_perceptron>`
-     (`#3204 <https://github.com/scikit-learn/scikit-learn/pull/3204>`_) by `Issam H. Laradji`_
+     (:issue:`3204`) by `Issam H. Laradji`_
 
    - Added :class:`linear_model.HuberRegressor`, a linear model robust to outliers.
-     (`#5291 <https://github.com/scikit-learn/scikit-learn/pull/5291>`_) by `Manoj Kumar`_.
+     (:issue:`5291`) by `Manoj Kumar`_.
 
    - Added the :class:`multioutput.MultiOutputRegressor` meta-estimator. It
      converts single output regressors to multi-ouput regressors by fitting
@@ -210,7 +210,7 @@ Other estimators
    - New :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
      replace former mixture models, employing faster inference
      for sounder results.
-     (`#7295 <https://github.com/scikit-learn/scikit-learn/pull/7295>`_) by
+     (:issue:`7295`) by
      `Wei Xue`_ and `Thierry Guillemot`_.
 
    - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
@@ -220,7 +220,7 @@ Other estimators
      calls ``arpack`` and performs truncated (non-randomized) SVD. By default,
      the best solver is selected depending on the size of the input and the
      number of components requested.
-     (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
+     (:issue:`5299`) by `Giorgio Patrini`_.
 
    - Added two functions for mutual information estimation:
      :func:`feature_selection.mutual_info_classif` and
@@ -247,15 +247,14 @@ Model selection and evaluation
 
    - Added new cross-validation splitter
      :class:`model_selection.TimeSeriesSplit` to handle time series data.
-     (`#6586
-     <https://github.com/scikit-learn/scikit-learn/pull/6586>`_) by `YenChen
+     (:issue:`6586`) by `YenChen
      Lin`_
 
    - The cross-validation iterators are replaced by cross-validation splitters
      available from :mod:`sklearn.model_selection`, allowing for nested
      cross-validation.
      See :ref:`model_selection_changes` for more information.
-     (`#4294 <https://github.com/scikit-learn/scikit-learn/pull/4294>`_) by
+     (:issue:`4294`) by
      `Raghav R V`_.
 
 Enhancements
@@ -267,13 +266,11 @@ Trees and ensembles
      the mean absolute error. This criterion can also be used in
      :class:`ensemble.ExtraTreesRegressor`,
      :class:`ensemble.RandomForestRegressor`, and the gradient boosting
-     estimators. (`#6667
-     <https://github.com/scikit-learn/scikit-learn/pull/6667>`_) by `Nelson
+     estimators. (:issue:`6667`) by `Nelson
      Liu`_.
 
    - Added weighted impurity-based early stopping criterion for decision tree
-     growth. (`#6954
-     <https://github.com/scikit-learn/scikit-learn/pull/6954>`_) by `Nelson
+     growth. (:issue:`6954`) by `Nelson
      Liu`_
 
    - The random forest, extra tree and decision tree estimators now has a
@@ -289,8 +286,7 @@ Trees and ensembles
      `yelite`_ and `Arnaud Joly`_.
 
    - Gradient boosting estimators accept the parameter ``criterion`` to specify
-     to splitting criterion used in built decision trees. (`#6667
-     <https://github.com/scikit-learn/scikit-learn/pull/6667>`_) by `Nelson
+     to splitting criterion used in built decision trees. (:issue:`6667`) by `Nelson
      Liu`_.
 
    - The memory footprint is reduced (sometimes greatly) for
@@ -302,14 +298,14 @@ Trees and ensembles
 
    - Added ``n_jobs`` and ``sample_weights`` parameters for
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
-     (`#5805 <https://github.com/scikit-learn/scikit-learn/pull/5805>`_)
+     (:issue:`5805`)
      By `Ibraim Ganiev`_.
 
 Linear, kernelized and related models
 
    - In :class:`linear_model.LogisticRegression`, the SAG solver is now
      available in the multinomial case.
-     (`#5251 <https://github.com/scikit-learn/scikit-learn/pull/5251>`_)
+     (:issue:`5251`)
      By `Tom Dupre la Tour`_.
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
@@ -325,8 +321,7 @@ Linear, kernelized and related models
 
    - Isotonic regression (:class:`isotonic.IsotonicRegression`) now uses a better algorithm to avoid
      `O(n^2)` behavior in pathological cases, and is also generally faster
-     (`#6601 <https://github.com/scikit-learn/scikit-learn/pull/6691>`_).
-     By `Antony Lee`_.
+     (:issue:`#6691`). By `Antony Lee`_.
 
    - :class:`naive_bayes.GaussianNB` now accepts data-independent class-priors
      through the parameter ``priors``. By `Guillaume Lemaitre`_.
@@ -335,12 +330,12 @@ Linear, kernelized and related models
      now works with ``np.float32`` input data without converting it
      into ``np.float64``. This allows to reduce the memory
      consumption.
-     (`#6913 <https://github.com/scikit-learn/scikit-learn/pull/6913>`_)
+     (:issue:`6913`)
      By `YenChen Lin`_.
 
    - :class:`semi_supervised.LabelPropagation` and :class:`semi_supervised.LabelSpreading`
      now accept arbitrary kernel functions in addition to strings ``knn`` and ``rbf``.
-     (`#5762 <https://github.com/scikit-learn/scikit-learn/pull/5762>`_) By `Utkarsh Upadhyay`_.
+     (:issue:`5762`) By `Utkarsh Upadhyay`_.
 
 Decomposition, manifold learning and clustering
 
@@ -350,17 +345,17 @@ Decomposition, manifold learning and clustering
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     (`#6846 <https://github.com/scikit-learn/scikit-learn/pull/6846>`_)
+     (:issue:`6846`)
      By `Sebastian Säger`_ and `YenChen Lin`_.
 
 Preprocessing and feature selection
 
    - :class:`preprocessing.RobustScaler` now accepts ``quantile_range`` parameter.
-     (`#5929 <https://github.com/scikit-learn/scikit-learn/pull/5929>`_)
+     (:issue:`5929`)
      By `Konstantin Podshumok`_.
 
    - :class:`feature_extraction.FeatureHasher` now accepts string values.
-     (`#6173 <https://github.com/scikit-learn/scikit-learn/pull/6173>`_) By `Ryad Zenine`_
+     (:issue:`6173`) By `Ryad Zenine`_
      and `Devashish Deshpande`_.
 
    - Keyword arguments can now be supplied to ``func`` in
@@ -386,7 +381,7 @@ Model evaluation and meta-estimators
      (and :class:`model_selection.RandomizedSearchCV`) can be easily imported
      into pandas as a ``DataFrame``. Ref :ref:`model_selection_changes` for
      more information.
-     (`#6697 <https://github.com/scikit-learn/scikit-learn/pull/6697>`_) by
+     (:issue:`6697`) by
      `Raghav R V`_.
 
    - Generalization of :func:`model_selection.cross_val_predict`.
@@ -397,20 +392,18 @@ Model evaluation and meta-estimators
    - The training scores and time taken for training followed by scoring for
      each search candidate are now available at the ``cv_results_`` dict.
      See :ref:`model_selection_changes` for more information.
-     (`#7324 <https://github.com/scikit-learn/scikit-learn/pull/7325>`_)
-     By `Eugene Chen`_ and `Raghav R V`_.
+     (:issue:`7325`) By `Eugene Chen`_ and `Raghav R V`_.
 
 Metrics
 
    - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
-     (`#7239 <https://github.com/scikit-learn/scikit-learn/pull/7239/>`_)
-     by `Hong Guangguo`_ with help from `Mads Jensen`_ and `Nelson Liu`_.
+     (:issue:`7239`) by `Hong Guangguo`_ with help from `Mads Jensen`_ and `Nelson Liu`_.
 
    - Support sparse contingency matrices in cluster evaluation
      (:mod:`metrics.cluster.supervised`) to scale to a large number of
      clusters.
-     (`#7419 <https://github.com/scikit-learn/scikit-learn/pull/7419>`_)
+     (:issue:`7419`)
      By `Gregory Stupp`_ and `Joel Nothman`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
@@ -441,26 +434,26 @@ Miscellaneous
 
    - Added parameter ``return_X_y`` and return type ``(data, target) : tuple`` option to
      :func:`load_iris` dataset
-     `#7049 <https://github.com/scikit-learn/scikit-learn/pull/7049>`_,
+     :issue:`7049`,
      :func:`load_breast_cancer` dataset
-     `#7152 <https://github.com/scikit-learn/scikit-learn/pull/7152>`_,
+     :issue:`7152`,
      :func:`load_digits` dataset,
      :func:`load_diabetes` dataset,
      :func:`load_linnerud` dataset,
      :func:`load_boston` dataset
-     `#7154 <https://github.com/scikit-learn/scikit-learn/pull/7154>`_ by
+     :issue:`7154` by
      `Manvendra Singh`_.
 
    - Simplification of the ``clone`` function, deprecate support for estimators
      that modify parameters in ``__init__``.
-     (`#5540 <https://github.com/scikit-learn/scikit-learn/pull/5540>`_)
+     (:issue:`5540`)
      By `Andreas Müller`_.
 
    - When unpickling a scikit-learn estimator in a different version than the one
      the estimator was trained with, a ``UserWarning`` is raised, see :ref:`the documentation
      on model persistence <persistence_limitations>`
      for more details.
-     (`#7248 <https://github.com/scikit-learn/scikit-learn/pull/7248>`_)
+     (:issue:`7248`)
      By `Andreas Müller`_.
 
 Bug fixes
@@ -479,12 +472,12 @@ Trees and ensembles
     - Fix bug where :class:`ensemble.AdaBoostClassifier` and
       :class:`ensemble.AdaBoostRegressor` would perform poorly if the
       ``random_state`` was fixed
-      (`#7411 <https://github.com/scikit-learn/scikit-learn/pull/7411>`_).
+      (:issue:`7411`).
       By `Joel Nothman`_.
 
     - Fix bug in ensembles with randomization where the ensemble would not
       set ``random_state`` on base estimators in a pipeline or similar nesting.
-      (`#7411 <https://github.com/scikit-learn/scikit-learn/pull/7411>`_).
+      (:issue:`7411`).
       Note, results for :class:`ensemble.BaggingClassifier`
       :class:`ensemble.BaggingRegressor`, :class:`ensemble.AdaBoostClassifier`
       and :class:`ensemble.AdaBoostRegressor` will now differ from previous
@@ -494,17 +487,16 @@ Linear, kernelized and related models
 
     - Fixed incorrect gradient computation for ``loss='squared_epsilon_insensitive'`` in
       :class:`linear_model.SGDClassifier` and :class:`linear_model.SGDRegressor`
-      (`#6764 <https://github.com/scikit-learn/scikit-learn/pull/6764>`_). By `Wenhua Yang`_.
+      (:issue:`6764`). By `Wenhua Yang`_.
 
     - Fix bug in :class:`linear_model.LogisticRegressionCV` where
       ``solver='liblinear'`` did not accept ``class_weights='balanced``.
-      (`#6817 <https://github.com/scikit-learn/scikit-learn/pull/6817>`_).
+      (:issue:`6817`).
       By `Tom Dupre la Tour`_.
 
     - Fix bug in :class:`neighbors.RadiusNeighborsClassifier` where an error
       occurred when there were outliers being labelled and a weight function
-      specified (`#6902
-      <https://github.com/scikit-learn/scikit-learn/issues/6902>`_).  By
+      specified (:issue:`6902`).  By
       `LeonieBorne <https://github.com/LeonieBorne>`_.
 
     - Fix :class:`linear_model.ElasticNet` sparse decision function to match
@@ -513,27 +505,27 @@ Linear, kernelized and related models
 Decomposition, manifold learning and clustering
 
     - :class:`decomposition.RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
-      (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+      (:issue:`5141`) by `Giorgio Patrini`_.
 
     - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.
       In practice this is enough for obtaining a good approximation of the
       true eigenvalues/vectors in the presence of noise. When `n_components` is
       small (``< .1 * min(X.shape)``) `n_iter` is set to 7, unless the user specifies
       a higher number. This improves precision with few components.
-      (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
+      (:issue:`5299`) by `Giorgio Patrini`_.
 
     - Whiten/non-whiten inconsistency between components of :class:`decomposition.PCA`
       and :class:`decomposition.RandomizedPCA` (now factored into PCA, see the
       New features) is fixed. `components_` are stored with no whitening.
-      (`#5299 <https://github.com/scikit-learn/scikit-learn/pull/5299>`_) by `Giorgio Patrini`_.
+      (:issue:`5299`) by `Giorgio Patrini`_.
 
     - Fixed bug in :func:`manifold.spectral_embedding` where diagonal of unnormalized
-      Laplacian matrix was incorrectly set to 1. (`#4995 <https://github.com/scikit-learn/scikit-learn/pull/4995>`_) By `Peter Fischer`_.
+      Laplacian matrix was incorrectly set to 1. (:issue:`4995`) By `Peter Fischer`_.
 
     - Fixed incorrect initialization of :func:`utils.arpack.eigsh` on all
       occurrences. Affects :class:`cluster.bicluster.SpectralBiclustering`,
       :class:`decomposition.KernelPCA`, :class:`manifold.LocallyLinearEmbedding`,
-      and :class:`manifold.SpectralEmbedding` (`#5012 <https://github.com/scikit-learn/scikit-learn/pull/5012>`_). By `Peter Fischer`_.
+      and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By `Peter Fischer`_.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver of
       :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
@@ -542,35 +534,32 @@ Decomposition, manifold learning and clustering
 Preprocessing and feature selection
 
     - :func:`preprocessing.data._transform_selected` now always passes a copy
-      of ``X`` to transform function when ``copy=True`` (`#7194
-      <https://github.com/scikit-learn/scikit-learn/issues/7194>`_). By `Caio
+      of ``X`` to transform function when ``copy=True`` (:issue:`7194`). By `Caio
       Oliveira <https://github.com/caioaao>`_.
 
 Model evaluation and meta-estimators
 
     - :class:`model_selection.StratifiedKFold` now raises error if all n_labels
       for individual classes is less than n_folds.
-      (`#6182 <https://github.com/scikit-learn/scikit-learn/pull/6182>`_) by `Devashish Deshpande`_.
+      (:issue:`6182`) by `Devashish Deshpande`_.
 
     - Fixed bug in :class:`model_selection.StratifiedShuffleSplit`
       where train and test sample could overlap in some edge cases,
-      see `#6121 <https://github.com/scikit-learn/scikit-learn/issues/6121>`_ for
+      see :issue:`6121` for
       more details. By `Loic Esteve`_.
 
     - Fix in :class:`sklearn.model_selection.StratifiedShuffleSplit` to
       return splits of size ``train_size`` and ``test_size`` in all cases
-      (`#6472 <https://github.com/scikit-learn/scikit-learn/pull/6472>`_).
+      (:issue:`6472`).
       By `Andreas Müller`_.
 
     - Cross-validation of :class:`OneVsOneClassifier` and
       :class:`OneVsRestClassifier` now works with precomputed kernels.
-      (`#7350 <https://github.com/scikit-learn/scikit-learn/pull/7350/>`_)
-      By `Russell Smith`_.
+      (:issue:`7350`) By `Russell Smith`_.
 
     - Fix incomplete ``predict_proba`` method delegation from
       :class:`model_selection.GridSearchCV` to
-      :class:`linear_model.SGDClassifier` (`#7159
-      <https://github.com/scikit-learn/scikit-learn/pull/7159>`_)
+      :class:`linear_model.SGDClassifier` (:issue:`7159`)
       by `Yichuan Liu <https://github.com/yl565>`_.
 
 Metrics
@@ -587,7 +576,7 @@ Metrics
 
     - :func:`metrics.pairwise.pairwise_distances` now converts arrays to
       boolean arrays when required in ``scipy.spatial.distance``.
-      (`#5460 <https://github.com/scikit-learn/scikit-learn/pull/5460>`_)
+      (:issue:`5460`)
       By `Tom Dupre la Tour`_.
 
     - Fix sparse input support in :func:`metrics.silhouette_score` as well as
@@ -595,28 +584,27 @@ Metrics
 
     - :func:`metrics.roc_curve` and :func:`metrics.precision_recall_curve` no
       longer round ``y_score`` values when creating ROC curves; this was causing
-      problems for users with very small differences in scores (`#7353
-      <https://github.com/scikit-learn/scikit-learn/pull/7353>`_).
+      problems for users with very small differences in scores (:issue:`7353`).
 
 Miscellaneous
 
     - :func:`model_selection.tests._search._check_param_grid` now works correctly with all types
       that extends/implements `Sequence` (except string), including range (Python 3.x) and xrange
       (Python 2.x).
-      (`#7323 <https://github.com/scikit-learn/scikit-learn/pull/7323>`_) by Viacheslav Kovalevskyi.
+      (:issue:`7323`) by Viacheslav Kovalevskyi.
 
     - :func:`utils.extmath.randomized_range_finder` is more numerically stable when many
       power iterations are requested, since it applies LU normalization by default.
       If ``n_iter<2`` numerical issues are unlikely, thus no normalization is applied.
       Other normalization options are available: ``'none', 'LU'`` and ``'QR'``.
-      (`#5141 <https://github.com/scikit-learn/scikit-learn/pull/5141>`_) by `Giorgio Patrini`_.
+      (:issue:`5141`) by `Giorgio Patrini`_.
 
     - Fix a bug where some formats of ``scipy.sparse`` matrix, and estimators
       with them as parameters, could not be passed to :func:`base.clone`.
       By `Loic Esteve`_.
 
     - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
-      (`#7101 <https://github.com/scikit-learn/scikit-learn/pull/7101>`_)
+      (:issue:`7101`)
       By `Ibraim Ganiev`_.
 
 
@@ -639,7 +627,7 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Gaussian mixture with a
      Dirichlet process prior faster than before.
-     (`#7295 <https://github.com/scikit-learn/scikit-learn/pull/7295>`_) by
+     (:issue:`7295`) by
      `Wei Xue`_ and `Thierry Guillemot`_.
 
    - The old :class:`mixture.VBGMM` is deprecated in favor of the new
@@ -648,13 +636,13 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Variational Bayesian Gaussian
      mixture faster than before.
-     (`#6651 <https://github.com/scikit-learn/scikit-learn/pull/6651>`_) by
+     (:issue:`6651`) by
      `Wei Xue`_ and `Thierry Guillemot`_.
 
    - The old :class:`mixture.GMM` is deprecated in favor of the new
      :class:`mixture.GaussianMixture`. The new class computes the Gaussian mixture
      faster than before and some of computational problems have been solved.
-     (`#6666 <https://github.com/scikit-learn/scikit-learn/pull/6666>`_) by
+     (:issue:`6666`) by
      `Wei Xue`_ and `Thierry Guillemot`_.
 
 Model evaluation and meta-estimators
@@ -663,25 +651,25 @@ Model evaluation and meta-estimators
      :mod:`sklearn.learning_curve` have been deprecated and the classes and
      functions have been reorganized into the :mod:`sklearn.model_selection`
      module. Ref :ref:`model_selection_changes` for more information.
-     (`#4294 <https://github.com/scikit-learn/scikit-learn/pull/4294>`_) by
+     (:issue:`4294`) by
      `Raghav R V`_.
 
    - The ``grid_scores_`` attribute of :class:`model_selection.GridSearchCV`
      and :class:`model_selection.RandomizedSearchCV` is deprecated in favor of
      the attribute ``cv_results_``.
      Ref :ref:`model_selection_changes` for more information.
-     (`#6697 <https://github.com/scikit-learn/scikit-learn/pull/6697>`_) by
+     (:issue:`6697`) by
      `Raghav R V`_.
 
    - The parameters ``n_iter`` or ``n_folds`` in old CV splitters are replaced
      by the new parameter ``n_splits`` since it can provide a consistent
      and unambiguous interface to represent the number of train-test splits.
-     (`#7187 <https://github.com/scikit-learn/scikit-learn/pull/7187>`_)
+     (:issue:`7187`)
      by `YenChen Lin`_.
 
    - ``classes`` parameter was renamed to ``labels`` in
      :func:`metrics.hamming_loss`.
-     (`#7260 <https://github.com/scikit-learn/scikit-learn/pull/7260>`_) by
+     (:issue:`7260`) by
      `Sebastián Vanrell`_.
 
    - The splitter classes ``LabelKFold``, ``LabelShuffleSplit``,
@@ -695,7 +683,7 @@ Model evaluation and meta-estimators
      :class:`model_selection.LeavePGroupsOut` is renamed to
      ``groups``. Additionally in :class:`model_selection.LeavePGroupsOut`,
      the parameter ``n_labels`` is renamed to ``n_groups``.
-     (`#6660 <https://github.com/scikit-learn/scikit-learn/pull/6660>`_)
+     (:issue:`6660`)
      by `Raghav R V`_.
 
 Code Contributors
@@ -778,24 +766,20 @@ Bug fixes
     - Fixed reading of Bunch pickles generated with scikit-learn
       version <= 0.16. This can affect users who have already
       downloaded a dataset with scikit-learn 0.16 and are loading it
-      with scikit-learn 0.17. See `#6196
-      <https://github.com/scikit-learn/scikit-learn/issues/6196>`_ for
+      with scikit-learn 0.17. See :issue:`6196` for
       how this affected :func:`datasets.fetch_20newsgroups`. By `Loic
       Esteve`_.
 
     - Fixed a bug that prevented using ROC AUC score to perform grid search on
-      several CPU / cores on large arrays. See `#6147
-      <https://github.com/scikit-learn/scikit-learn/issues/6147>`_
+      several CPU / cores on large arrays. See :issue:`6147`
       By `Olivier Grisel`_.
 
     - Fixed a bug that prevented to properly set the ``presort`` parameter
-      in :class:`ensemble.GradientBoostingRegressor`. See `#5857
-      <https://github.com/scikit-learn/scikit-learn/issues/5857>`_
+      in :class:`ensemble.GradientBoostingRegressor`. See :issue:`5857`
       By Andrew McCulloh.
 
     - Fixed a joblib error when evaluating the perplexity of a
-      :class:`decomposition.LatentDirichletAllocation` model. See `#6258
-      <https://github.com/scikit-learn/scikit-learn/issues/6258>`_
+      :class:`decomposition.LatentDirichletAllocation` model. See :issue:`6258`
       By Chyi-Kwei Yau.
 
 .. _changes_0_17:
@@ -842,13 +826,13 @@ New features
    - :class:`decomposition.LatentDirichletAllocation` implements the Latent
      Dirichlet Allocation topic model with online  variational
      inference. By `Chyi-Kwei Yau`_, with code based on an implementation
-     by Matt Hoffman. (`#3659 <https://github.com/scikit-learn/scikit-learn/pull/3659>`_)
+     by Matt Hoffman. (:issue:`3659`)
 
    - The new solver ``sag`` implements a Stochastic Average Gradient descent
      and is available in both :class:`linear_model.LogisticRegression` and
      :class:`linear_model.Ridge`. This solver is very efficient for large
      datasets. By `Danny Sullivan`_ and `Tom Dupre la Tour`_.
-     (`#4738 <https://github.com/scikit-learn/scikit-learn/pull/4738>`_)
+     (:issue:`4738`)
 
    - The new solver ``cd`` implements a Coordinate Descent in
      :class:`decomposition.NMF`. Previous solver based on Projected Gradient is
@@ -864,7 +848,7 @@ Enhancements
 ............
    - :class:`manifold.TSNE` now supports approximate optimization via the
      Barnes-Hut method, leading to much faster fitting. By Christopher Erick Moody.
-     (`#4025 <https://github.com/scikit-learn/scikit-learn/pull/4025>`_)
+     (:issue:`4025`)
 
    - :class:`cluster.mean_shift_.MeanShift` now supports parallel execution,
      as implemented in the ``mean_shift`` function. By `Martino Sorbaro`_.
@@ -987,11 +971,10 @@ Enhancements
      each try. By `Jacob Schreiber`_.
 
    - Add ``sample_weight`` support to :class:`linear_model.LinearRegression`.
-     By Sonny Hu. (`#4481 <https://github.com/scikit-learn/scikit-learn/pull/4881>`_)
+     By Sonny Hu. (:issue:`#4881`)
 
    - Add ``n_iter_without_progress`` to :class:`manifold.TSNE` to control
-     the stopping criterion. By Santi Villalba.
-     (`#5185 <https://github.com/scikit-learn/scikit-learn/pull/5186>`_)
+     the stopping criterion. By Santi Villalba. (:issue:`5186`)
 
    - Added optional parameter ``random_state`` in :class:`linear_model.Ridge`
      , to set the seed of the pseudo random generator used in ``sag`` solver. By `Tom Dupre la Tour`_.
@@ -1032,7 +1015,7 @@ Enhancements
 
    - Added ``positive`` option to :class:`linear_model.Lars` and
      :func:`linear_model.lars_path` to force coefficients to be positive.
-     (`#5131 <https://github.com/scikit-learn/scikit-learn/pull/5131>`)
+     (:issue:`5131`)
 
    - Added the ``X_norm_squared`` parameter to :func:`metrics.pairwise.euclidean_distances`
      to provide precomputed squared norms for ``X``.
@@ -1064,7 +1047,7 @@ Bug fixes
 
     - All regressors now consistently handle and warn when given ``y`` that is of
       shape ``(n_samples, 1)``. By `Andreas Müller`_ and Henry Lin.
-      (`#5431 <https://github.com/scikit-learn/scikit-learn/pull/5431>`_)
+      (:issue:`5431`)
 
     - Fix in :class:`cluster.KMeans` cluster reassignment for sparse input by
       `Lars Buitinck`_.
@@ -1077,15 +1060,15 @@ Bug fixes
 
     - Fixed the ``predict_proba`` method of :class:`linear_model.LogisticRegression`
       to use soft-max instead of one-vs-rest normalization. By `Manoj Kumar`_.
-      (`#5182 <https://github.com/scikit-learn/scikit-learn/pull/5182>`_)
+      (:issue:`5182`)
 
     - Fixed the :func:`partial_fit` method of :class:`linear_model.SGDClassifier`
       when called with ``average=True``. By `Andrew Lamb`_.
-      (`#5282 <https://github.com/scikit-learn/scikit-learn/pull/5282>`_)
+      (:issue:`5282`)
 
     - Dataset fetchers use different filenames under Python 2 and Python 3 to
       avoid pickling compatibility issues. By `Olivier Grisel`_.
-      (`#5355 <https://github.com/scikit-learn/scikit-learn/pull/5355>`_)
+      (:issue:`5355`)
 
     - Fixed a bug in :class:`naive_bayes.GaussianNB` which caused classification
       results to depend on scale. By `Jake Vanderplas`_.
@@ -1093,12 +1076,11 @@ Bug fixes
     - Fixed temporarily :class:`linear_model.Ridge`, which was incorrect
       when fitting the intercept in the case of sparse data. The fix
       automatically changes the solver to 'sag' in this case.
-      (`#5360 <https://github.com/scikit-learn/scikit-learn/pull/5360>`_)
+      (:issue:`5360`)
       By `Tom Dupre la Tour`_.
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
-      with a large number of features and fewer samples. (`#4478
-      <https://github.com/scikit-learn/scikit-learn/pull/4478>`_)
+      with a large number of features and fewer samples. (:issue:`4478`)
       By `Andreas Müller`_, `Loic Esteve`_ and `Giorgio Patrini`_.
 
     - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
@@ -1120,14 +1102,14 @@ Bug fixes
 
     - Fixed inconsistent memory layout in the coordinate descent solver
       that affected :class:`linear_model.DictionaryLearning` and
-      :class:`covariance.GraphLasso`. (`#5337 <https://github.com/scikit-learn/scikit-learn/pull/5337>`_)
+      :class:`covariance.GraphLasso`. (:issue:`5337`)
       By `Olivier Grisel`_.
 
     - :class:`manifold.LocallyLinearEmbedding` no longer ignores the ``reg``
       parameter.
 
     - Nearest Neighbor estimators with custom distance metrics can now be pickled.
-      (`4362 <https://github.com/scikit-learn/scikit-learn/pull/4362>`_)
+      (:issue:`4362`)
 
     - Fixed a bug in :class:`pipeline.FeatureUnion` where ``transformer_weights``
       were not properly handled when performing grid-searches.
@@ -1137,7 +1119,7 @@ Bug fixes
       ``class_weight='balanced'```or ``class_weight='auto'``.
       By `Tom Dupre la Tour`_.
 
-    - Fixed bug `#5495 <https://github.com/scikit-learn/scikit-learn/issues/5495>`_ when
+    - Fixed bug :issue:`5495` when
       doing OVR(SVC(decision_function_shape="ovr")). Fixed by `Elvis Dohmatob`_.
 
 


### PR DESCRIPTION
I find the issue links in what's new to take up far too much space. The [sphinx-issues](https://github.com/sloria/sphinx-issues) project provides RST roles to simplify this, which I have here imported. I've just translated a sample to the role format, and will do more by regular expression shortly if others think this is a good idea.

~~It would also be good to use something like:~~

```
:user:`Joel Nothman <jnothman>`
```

~~for irregular contributors so we don't often need to modify the list of hyperlink targets at the bottom of the file. However, sphinx-issues [does not currently support custom anchor text](https://github.com/sloria/sphinx-issues/issues/1)~~
