### PR TITLE
[WIP] DOC framework for keeping API refs for deprecated classes/funcs

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1349,3 +1349,20 @@ Low-level methods
    utils.estimator_checks.check_estimator
    utils.resample
    utils.shuffle
+
+
+Recently deprecated
+===================
+
+To be removed in 0.19
+---------------------
+
+
+To be removed in 0.20
+---------------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: deprecated_class.rst
+
+   grid_search.GridSearchCV

--- a/doc/templates/deprecated_class.rst
+++ b/doc/templates/deprecated_class.rst
@@ -1,0 +1,23 @@
+:mod:`{{module}}`.{{objname}}
+{{ underline }}==============
+
+.. meta::
+   :robots: noindex
+
+.. warning::
+   **DEPRECATED**
+
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+   {% endblock %}
+
+.. include:: {{module}}.{{objname}}.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/doc/templates/deprecated_class_with_call.rst
+++ b/doc/templates/deprecated_class_with_call.rst
@@ -1,0 +1,24 @@
+:mod:`{{module}}`.{{objname}}
+{{ underline }}===============
+
+.. meta::
+   :robots: noindex
+
+.. warning::
+   **DEPRECATED**
+
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+   .. automethod:: __call__
+   {% endblock %}
+
+.. include:: {{module}}.{{objname}}.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/doc/templates/deprecated_class_without_init.rst
+++ b/doc/templates/deprecated_class_without_init.rst
@@ -1,0 +1,19 @@
+:mod:`{{module}}`.{{objname}}
+{{ underline }}==============
+
+.. meta::
+   :robots: noindex
+
+.. warning::
+   **DEPRECATED**
+
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+.. include:: {{module}}.{{objname}}.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/doc/templates/deprecated_function.rst
+++ b/doc/templates/deprecated_function.rst
@@ -1,0 +1,19 @@
+:mod:`{{module}}`.{{objname}}
+{{ underline }}====================
+
+.. meta::
+   :robots: noindex
+
+.. warning::
+   **DEPRECATED**
+
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}
+
+.. include:: {{module}}.{{objname}}.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/doc/templates/generate_deprecated.sh
+++ b/doc/templates/generate_deprecated.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+for f in [^d]*; do (head -n2 < $f; echo '
+.. meta::
+   :robots: noindex
+
+.. warning::
+   **DEPRECATED**
+'; tail -n+3 $f) > deprecated_$f; done

--- a/doc/themes/scikit-learn/static/nature.css_t
+++ b/doc/themes/scikit-learn/static/nature.css_t
@@ -579,7 +579,7 @@ div.admonition {
     -moz-border-radius: 4px;
 }
 
-div.warning {
+div.warning, div.deprecated {
     color: #b94a48;
     background-color: #F3E5E5;
     border: 1px solid #eed3d7;

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -614,6 +614,10 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 class GridSearchCV(BaseSearchCV):
     """Exhaustive search over specified parameter values for an estimator.
 
+    .. deprecated:: 0.18
+        This module will be removed in 0.20.
+        Use :class:`sklearn.model_selection.GridSearchCV` instead.
+
     Important members are fit, predict.
 
     GridSearchCV implements a "fit" and a "score" method.


### PR DESCRIPTION
Fixes #7540 

I've put together a solution to #7540, consisting of:
- adding a section to `classes.rst` listing deprecated classes and functions
- adding templates for deprecated classes and functions which:
  - tell web crawlers not to index the deprecated API reference
  - start the page with a bold "DEPRECATED"
- optionally using the `.. deprecated::` directive to be more informative to the user
- styling this deprecated directive consistently with `.. warning::`

I would appreciate another contributor completing the work of:
- adding deprecated objects to `classes.rst`
- adding informative `.. deprecated::` messages as relevant

I would appreciate other core devs checking that this meets our needs as a solution to #7540.
