### PR TITLE
[MRG + 2] FIX Be robust to non re-entrant/ non deterministic cv.split calls

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -550,6 +550,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         base_estimator = clone(self.estimator)
         pre_dispatch = self.pre_dispatch
 
+        cv_iter = list(cv.split(X, y, groups))
         out = Parallel(
             n_jobs=self.n_jobs, verbose=self.verbose,
             pre_dispatch=pre_dispatch
@@ -561,7 +562,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                   return_times=True, return_parameters=True,
                                   error_score=self.error_score)
           for parameters in parameter_iterable
-          for train, test in cv.split(X, y, groups))
+          for train, test in cv_iter)
 
         # if one choose to see train score, "out" will contain train score info
         if self.return_train_score:

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1467,7 +1467,7 @@ class PredefinedSplit(BaseCrossValidator):
 class _CVIterableWrapper(BaseCrossValidator):
     """Wrapper class for old style cv objects and iterables."""
     def __init__(self, cv):
-        self.cv = cv
+        self.cv = list(cv)
 
     def get_n_splits(self, X=None, y=None, groups=None):
         """Returns the number of splitting iterations in the cross-validator

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -960,7 +960,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
-    cv_iter = cv.split(X, y, groups)
+    cv_iter = list(cv.split(X, y, groups))
 
     scorer = check_scoring(estimator, scoring=scoring)
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1,4 +1,3 @@
-
 """
 The :mod:`sklearn.model_selection._validation` module includes classes and
 functions to validate the model.
@@ -129,6 +128,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
+    cv_iter = cv.split(X, y, groups)
     scorer = check_scoring(estimator, scoring=scoring)
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
@@ -137,7 +137,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
     scores = parallel(delayed(_fit_and_score)(clone(estimator), X, y, scorer,
                                               train, test, verbose, None,
                                               fit_params)
-                      for train, test in cv.split(X, y, groups))
+                      for train, test in cv_iter)
     return np.array(scores)[:, 0]
 
 
@@ -384,6 +384,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
+    cv_iter = cv.split(X, y, groups)
 
     # Ensure the estimator has implemented the passed decision function
     if not callable(getattr(estimator, method)):
@@ -396,7 +397,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
                         pre_dispatch=pre_dispatch)
     prediction_blocks = parallel(delayed(_fit_and_predict)(
         clone(estimator), X, y, train, test, verbose, fit_params, method)
-        for train, test in cv.split(X, y, groups))
+        for train, test in cv_iter)
 
     # Concatenate the predictions
     predictions = [pred_block_i for pred_block_i, _ in prediction_blocks]
@@ -750,9 +751,8 @@ def learning_curve(estimator, X, y, groups=None,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
-    cv_iter = cv.split(X, y, groups)
     # Make a list since we will be iterating multiple times over the folds
-    cv_iter = list(cv_iter)
+    cv_iter = list(cv.split(X, y, groups))
     scorer = check_scoring(estimator, scoring=scoring)
 
     n_max_training_samples = len(cv_iter[0][0])
@@ -961,6 +961,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
+    cv_iter = cv.split(X, y, groups)
 
     scorer = check_scoring(estimator, scoring=scoring)
 
@@ -969,7 +970,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
     out = parallel(delayed(_fit_and_score)(
         estimator, X, y, scorer, train, test, verbose,
         parameters={param_name: v}, fit_params=None, return_train_score=True)
-        for train, test in cv.split(X, y, groups) for v in param_range)
+        for train, test in cv_iter for v in param_range)
 
     out = np.asarray(out)
     n_params = len(param_range)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -128,7 +128,7 @@ def cross_val_score(estimator, X, y=None, groups=None, scoring=None, cv=None,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
-    cv_iter = cv.split(X, y, groups)
+    cv_iter = list(cv.split(X, y, groups))
     scorer = check_scoring(estimator, scoring=scoring)
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
@@ -384,7 +384,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None, n_jobs=1,
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
-    cv_iter = cv.split(X, y, groups)
+    cv_iter = list(cv.split(X, y, groups))
 
     # Ensure the estimator has implemented the passed decision function
     if not callable(getattr(estimator, method)):
@@ -775,9 +775,8 @@ def learning_curve(estimator, X, y, groups=None,
     if exploit_incremental_learning:
         classes = np.unique(y) if is_classifier(estimator) else None
         out = parallel(delayed(_incremental_fit_estimator)(
-            clone(estimator), X, y, classes, train,
-            test, train_sizes_abs, scorer, verbose)
-            for train, test in cv_iter)
+            clone(estimator), X, y, classes, train, test, train_sizes_abs,
+            scorer, verbose) for train, test in cv_iter)
     else:
         train_test_proportions = []
         for train, test in cv_iter:

--- a/sklearn/model_selection/tests/common.py
+++ b/sklearn/model_selection/tests/common.py
@@ -1,0 +1,23 @@
+"""
+Common utilities for testing model selection.
+"""
+
+import numpy as np
+
+from sklearn.model_selection import KFold
+
+
+class CustomSplitter:
+    """A wrapper to make KFold single entry cv iterator"""
+    def __init__(self, n_splits=4, n_samples=99):
+        self.n_splits = n_splits
+        self.n_samples = n_samples
+        self.indices = KFold(n_splits=n_splits).split(np.ones(n_samples))
+
+    def split(self, X=None, y=None, groups=None):
+        """Split can be called only once"""
+        for index in self.indices:
+            yield index
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        return self.n_splits

--- a/sklearn/model_selection/tests/common.py
+++ b/sklearn/model_selection/tests/common.py
@@ -7,12 +7,12 @@ import numpy as np
 from sklearn.model_selection import KFold
 
 
-class CustomSplitter:
+class OneTimeSplitter:
     """A wrapper to make KFold single entry cv iterator"""
     def __init__(self, n_splits=4, n_samples=99):
         self.n_splits = n_splits
         self.n_samples = n_samples
-        self.indices = KFold(n_splits=n_splits).split(np.ones(n_samples))
+        self.indices = iter(KFold(n_splits=n_splits).split(np.ones(n_samples)))
 
     def split(self, X=None, y=None, groups=None):
         """Split can be called only once"""

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -60,7 +60,7 @@ from sklearn.preprocessing import Imputer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import SGDClassifier
 
-from sklearn.model_selection.tests.common import CustomSplitter
+from sklearn.model_selection.tests.common import OneTimeSplitter
 
 
 # Neither of the following two estimators inherit from BaseEstimator,
@@ -1166,8 +1166,8 @@ def test_grid_search_cv_splits_consistency():
 
     gs = GridSearchCV(LinearSVC(random_state=0),
                       param_grid={'C': [0.1, 0.2, 0.3]},
-                      cv=CustomSplitter(n_splits=n_splits,
-                                        n_samples=n_samples))
+                      cv=OneTimeSplitter(n_splits=n_splits,
+                                         n_samples=n_samples))
     gs.fit(X, y)
 
     gs2 = GridSearchCV(LinearSVC(random_state=0),
@@ -1181,7 +1181,7 @@ def test_grid_search_cv_splits_consistency():
             cv_results.pop(key)
         return cv_results
 
-    # CustomSplitter is a non-re-entrant cv where split can be called only once
+    # OneTimeSplitter is a non-re-entrant cv where split can be called only once
     # if ``cv.split`` is called once per param setting in GridSearchCV.fit
     # the 2nd and 3rd parameter will not be evaluated as no train/test indices
     # will be generated for the 2nd and subsequent cv.split calls.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1178,4 +1178,8 @@ def test_grid_search_custom_cv_iter():
                        param_grid={'C': [0.1, 0.2, 0.3]}, cv=KFold(n_splits=5))
     gs2.fit(X, y)
 
+    for key in ('mean_score_time', 'std_score_time',
+                'mean_fit_time', 'std_fit_time'):
+        gs.cv_results_.pop(key)
+        gs2.cv_results_.pop(key)
     np.testing.assert_equal(gs.cv_results_, gs2.cv_results_)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1163,16 +1163,17 @@ def test_grid_search_custom_cv_iter():
     class CustomSplitter():
         def __init__(self, n_samples=100):
             self.indices = KFold(n_splits=5).split(np.ones(n_samples))
+
         def split(self, X=None, y=None, groups=None):
             for index in self.indices:
                 yield index
+
         def get_n_splits(self, X=None, y=None, groups=None):
             return 5
 
     gs = GridSearchCV(LinearSVC(random_state=0),
                       param_grid={'C': [0.1, 0.2, 0.3]}, cv=CustomSplitter())
     gs.fit(X, y)
-
 
     gs2 = GridSearchCV(LinearSVC(random_state=0),
                        param_grid={'C': [0.1, 0.2, 0.3]}, cv=KFold(n_splits=5))

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1181,8 +1181,8 @@ def test_grid_search_cv_splits_consistency():
             cv_results.pop(key)
         return cv_results
 
-    # OneTimeSplitter is a non-re-entrant cv where split can be called only once
-    # if ``cv.split`` is called once per param setting in GridSearchCV.fit
+    # OneTimeSplitter is a non-re-entrant cv where split can be called only
+    # once if ``cv.split`` is called once per param setting in GridSearchCV.fit
     # the 2nd and 3rd parameter will not be evaluated as no train/test indices
     # will be generated for the 2nd and subsequent cv.split calls.
     # This is a check to make cv.split is not called once per param

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -60,21 +60,7 @@ from sklearn.preprocessing import Imputer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import SGDClassifier
 
-
-class CustomSplitter():
-    """A wrapper to make KFold single entry cv iterator"""
-    def __init__(self, n_splits=4, n_samples=99):
-        self.n_splits = n_splits
-        self.n_samples = n_samples
-        self.indices = KFold(n_splits=n_splits).split(np.ones(n_samples))
-
-    def split(self, X=None, y=None, groups=None):
-        """Split can be called only once"""
-        for index in self.indices:
-            yield index
-
-    def get_n_splits(self, X=None, y=None, groups=None):
-        return self.n_splits
+from sklearn.model_selection.tests.common import CustomSplitter
 
 
 # Neither of the following two estimators inherit from BaseEstimator,

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1185,7 +1185,7 @@ def test_grid_search_cv_splits_consistency():
     # once if ``cv.split`` is called once per param setting in GridSearchCV.fit
     # the 2nd and 3rd parameter will not be evaluated as no train/test indices
     # will be generated for the 2nd and subsequent cv.split calls.
-    # This is a check to make cv.split is not called once per param
+    # This is a check to make sure cv.split is not called once per param
     # setting.
     np.testing.assert_equal(_pop_time_keys(gs.cv_results_),
                             _pop_time_keys(gs2.cv_results_))

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1154,3 +1154,28 @@ def test_search_train_scores_set_to_false():
     gs = GridSearchCV(clf, param_grid={'C': [0.1, 0.2]},
                       return_train_score=False)
     gs.fit(X, y)
+
+
+def test_grid_search_custom_cv_iter():
+    # Check if a one time iterable is accepted as a cv parameter.
+    X, y = make_classification(n_samples=100, random_state=0)
+
+    class CustomSplitter():
+        def __init__(self, n_samples=100):
+            self.indices = KFold(n_splits=5).split(np.ones(n_samples))
+        def split(self, X=None, y=None, groups=None):
+            for index in self.indices:
+                yield index
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return 5
+
+    gs = GridSearchCV(LinearSVC(random_state=0),
+                      param_grid={'C': [0.1, 0.2, 0.3]}, cv=CustomSplitter())
+    gs.fit(X, y)
+
+
+    gs2 = GridSearchCV(LinearSVC(random_state=0),
+                       param_grid={'C': [0.1, 0.2, 0.3]}, cv=KFold(n_splits=5))
+    gs2.fit(X, y)
+
+    np.testing.assert_equal(gs.cv_results_, gs2.cv_results_)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -59,71 +59,7 @@ from sklearn.svm import SVC
 
 X = np.ones(10)
 y = np.arange(10) // 2
-P_sparse = coo_matrix(np.eye(5))
 digits = load_digits()
-
-
-class MockClassifier(object):
-    """Dummy classifier to test the cross-validation"""
-
-    def __init__(self, a=0, allow_nd=False):
-        self.a = a
-        self.allow_nd = allow_nd
-
-    def fit(self, X, Y=None, sample_weight=None, class_prior=None,
-            sparse_sample_weight=None, sparse_param=None, dummy_int=None,
-            dummy_str=None, dummy_obj=None, callback=None):
-        """The dummy arguments are to test that this fit function can
-        accept non-array arguments through cross-validation, such as:
-            - int
-            - str (this is actually array-like)
-            - object
-            - function
-        """
-        self.dummy_int = dummy_int
-        self.dummy_str = dummy_str
-        self.dummy_obj = dummy_obj
-        if callback is not None:
-            callback(self)
-
-        if self.allow_nd:
-            X = X.reshape(len(X), -1)
-        if X.ndim >= 3 and not self.allow_nd:
-            raise ValueError('X cannot be d')
-        if sample_weight is not None:
-            assert_true(sample_weight.shape[0] == X.shape[0],
-                        'MockClassifier extra fit_param sample_weight.shape[0]'
-                        ' is {0}, should be {1}'.format(sample_weight.shape[0],
-                                                        X.shape[0]))
-        if class_prior is not None:
-            assert_true(class_prior.shape[0] == len(np.unique(y)),
-                        'MockClassifier extra fit_param class_prior.shape[0]'
-                        ' is {0}, should be {1}'.format(class_prior.shape[0],
-                                                        len(np.unique(y))))
-        if sparse_sample_weight is not None:
-            fmt = ('MockClassifier extra fit_param sparse_sample_weight'
-                   '.shape[0] is {0}, should be {1}')
-            assert_true(sparse_sample_weight.shape[0] == X.shape[0],
-                        fmt.format(sparse_sample_weight.shape[0], X.shape[0]))
-        if sparse_param is not None:
-            fmt = ('MockClassifier extra fit_param sparse_param.shape '
-                   'is ({0}, {1}), should be ({2}, {3})')
-            assert_true(sparse_param.shape == P_sparse.shape,
-                        fmt.format(sparse_param.shape[0],
-                                   sparse_param.shape[1],
-                                   P_sparse.shape[0], P_sparse.shape[1]))
-        return self
-
-    def predict(self, T):
-        if self.allow_nd:
-            T = T.reshape(len(T), -1)
-        return T[:, 0]
-
-    def score(self, X=None, Y=None):
-        return 1. / (1 + np.abs(self.a))
-
-    def get_params(self, deep=False):
-        return {'a': self.a, 'allow_nd': self.allow_nd}
 
 
 @ignore_warnings
@@ -907,6 +843,14 @@ def test_cv_iterable_wrapper():
 
     # Check if get_n_splits works correctly
     assert_equal(len(cv), wrapped_old_skf.get_n_splits())
+
+    kf_iter = KFold(n_splits=5).split(X, y)
+    kf_iter_wrapped = check_cv(kf_iter)
+    # Since the wrapped iterable is enlisted and stored,
+    # split can be called any number of times to produce
+    # consistent results
+    assert_array_equal(list(kf_iter_wrapped.split(X, y)),
+                       list(kf_iter_wrapped.split(X, y)))
 
 
 def test_group_kfold():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -857,14 +857,8 @@ def test_cv_iterable_wrapper():
     kf_randomized_iter_wrapped = check_cv(kf_randomized_iter)
     assert_array_equal(list(kf_randomized_iter_wrapped.split(X, y)),
                        list(kf_randomized_iter_wrapped.split(X, y)))
-    try:
-        assert_array_equal(list(kf_iter_wrapped.split(X, y)),
-                           list(kf_randomized_iter_wrapped.split(X, y)))
-    except AssertionError:
-        pass
-    else:
-        raise AssertionError("After randomization, wrapped kfold (with "
-                             "shuffle) did not produce differing results.")
+    assert_true(np.any(np.array(list(kf_iter_wrapped.split(X, y))) !=
+                       np.array(list(kf_randomized_iter_wrapped.split(X, y)))))
 
 
 def test_group_kfold():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -848,9 +848,23 @@ def test_cv_iterable_wrapper():
     kf_iter_wrapped = check_cv(kf_iter)
     # Since the wrapped iterable is enlisted and stored,
     # split can be called any number of times to produce
-    # consistent results
+    # consistent results.
     assert_array_equal(list(kf_iter_wrapped.split(X, y)),
                        list(kf_iter_wrapped.split(X, y)))
+    # If the splits are randomized, successive calls to split yields different
+    # results
+    kf_randomized_iter = KFold(n_splits=5, shuffle=True).split(X, y)
+    kf_randomized_iter_wrapped = check_cv(kf_iter)
+    assert_array_equal(list(kf_randomized_iter_wrapped.split(X, y)),
+                       list(kf_randomized_iter_wrapped.split(X, y)))
+    try:
+        assert_array_equal(list(kf_iter_wrapped.split(X, y)),
+                           list(kf_randomized_iter_wrapped.split(X, y)))
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("After randomization, wrapped kfold (with "
+                             "shuffle) did not produce differing results.")
 
 
 def test_group_kfold():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -854,7 +854,7 @@ def test_cv_iterable_wrapper():
     # If the splits are randomized, successive calls to split yields different
     # results
     kf_randomized_iter = KFold(n_splits=5, shuffle=True).split(X, y)
-    kf_randomized_iter_wrapped = check_cv(kf_iter)
+    kf_randomized_iter_wrapped = check_cv(kf_randomized_iter)
     assert_array_equal(list(kf_randomized_iter_wrapped.split(X, y)),
                        list(kf_randomized_iter_wrapped.split(X, y)))
     try:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -60,7 +60,7 @@ from sklearn.utils import shuffle
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_multilabel_classification
 
-from sklearn.model_selection.tests.common import CustomSplitter
+from sklearn.model_selection.tests.common import OneTimeSplitter
 
 
 try:
@@ -646,7 +646,7 @@ def test_learning_curve():
         with warnings.catch_warnings(record=True) as w:
             train_sizes2, train_scores2, test_scores2 = learning_curve(
                 estimator, X, y,
-                cv=CustomSplitter(n_splits=n_splits, n_samples=n_samples),
+                cv=OneTimeSplitter(n_splits=n_splits, n_samples=n_samples),
                 train_sizes=np.linspace(0.1, 1.0, 10),
                 shuffle=shuffle_train)
         if len(w) > 0:
@@ -850,9 +850,9 @@ def test_validation_curve_cv_splits_consistency():
 
     scores1 = validation_curve(SVC(kernel='linear', random_state=0), X, y,
                                'C', [0.1, 0.1, 0.2, 0.2],
-                               cv=CustomSplitter(n_splits=n_splits,
-                                                 n_samples=n_samples))
-    # The CustomSplitter is a non-re-entrant cv splitter. Unless, the
+                               cv=OneTimeSplitter(n_splits=n_splits,
+                                                  n_samples=n_samples))
+    # The OneTimeSplitter is a non-re-entrant cv splitter. Unless, the
     # `split` is called for each parameter, the following should produce
     # identical results for param setting 1 param setting 2 as both have
     # the same C value.
@@ -873,7 +873,7 @@ def test_validation_curve_cv_splits_consistency():
                                'C', [0.1, 0.1, 0.2, 0.2],
                                cv=KFold(n_splits=n_splits))
 
-    # CustomSplitter is basically unshuffled KFold(n_splits=5). Sanity check.
+    # OneTimeSplitter is basically unshuffled KFold(n_splits=5). Sanity check.
     assert_array_almost_equal(np.array(scores3), np.array(scores1))
 
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -854,7 +854,7 @@ def test_validation_curve_cv_splits_consistency():
                                                   n_samples=n_samples))
     # The OneTimeSplitter is a non-re-entrant cv splitter. Unless, the
     # `split` is called for each parameter, the following should produce
-    # identical results for param setting 1 param setting 2 as both have
+    # identical results for param setting 1 and param setting 2 as both have
     # the same C value.
     assert_array_almost_equal(*np.vsplit(np.hstack(scores1)[(0, 2, 1, 3), :],
                                          2))

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -111,38 +111,6 @@ class MockIncrementalImprovingEstimator(MockImprovingEstimator):
         self.x = X[0]
 
 
-class MockImprovingEstimatorRoundedScores(BaseEstimator):
-    """Dummy classifier to test the learning curve
-
-    This will give scores with precision of 0.1 so as to produce similar scores
-    for almost similar train fractions
-    """
-    def __init__(self, n_max_train_sizes):
-        self.n_max_train_sizes = n_max_train_sizes
-        self.train_sizes = 0
-        self.X_subset = None
-
-    def fit(self, X_subset, y_subset=None):
-        self.X_subset = X_subset
-        self.train_sizes = X_subset.shape[0]
-        return self
-
-    def predict(self, X):
-        raise NotImplementedError
-
-    def score(self, X=None, Y=None):
-        # training score becomes worse (2 -> 1), test error better (0 -> 1)
-        if self._is_training_data(X):
-            return np.round((2. - float(self.train_sizes) /
-                             self.n_max_train_sizes), 1)
-        else:
-            return np.round((float(self.train_sizes) /
-                             self.n_max_train_sizes), 1)
-
-    def _is_training_data(self, X):
-        return X is self.X_subset
-
-
 class MockEstimatorWithParameter(BaseEstimator):
     """Dummy classifier to test the validation curve"""
     def __init__(self, param=0.5):
@@ -595,6 +563,7 @@ def test_learning_curve():
                                n_informative=1, n_redundant=0, n_classes=2,
                                n_clusters_per_class=1, random_state=0)
     estimator = MockImprovingEstimator(n_samples * ((n_splits - 1) / n_splits))
+<<<<<<< 0ea6a4ca74186b4e12ca631b78a3041ee9765f43
     for shuffle_train in [False, True]:
         with warnings.catch_warnings(record=True) as w:
             train_sizes, train_scores, test_scores = learning_curve(
@@ -638,18 +607,6 @@ def test_learning_curve():
                 shuffle=shuffle_train)
         if len(w) > 0:
             raise RuntimeError("Unexpected warning: %r" % w[0].message)
-
-        # KFold(..., shuffle=True) is non deterministic as random_state
-        # is not set.
-        # However this should not affect the consistency of cv folds across the
-        # different train sizes to ensure that the cross-vadiation scores
-        # remain comparable.
-        # The MockImprovingEstimatorRoundedScores produces similar scores for
-        # train sizes (0.1 and 0.15) and (0.9 and 0.95)
-        assert_array_almost_equal(train_scores3[0, :], train_scores3[1, :])
-        assert_array_almost_equal(train_scores3[2, :], train_scores3[3, :])
-        assert_array_almost_equal(test_scores3[0, :], test_scores3[1, :])
-        assert_array_almost_equal(test_scores3[2, :], test_scores3[3, :])
 
 
 def test_learning_curve_unsupervised():


### PR DESCRIPTION
Fixes #6726 
- To make consistent splits for all parameter settings when the cv iterators are non re-entrant (thanks to Joel for the word!) and non deterministic for successive `split` calls, we call split once and store it as a list that will be iterated multiple times.
- Similarly in `_CVIterableWrapper`, we store the list rather than the cv object and iterate on it... (NOTE that this would make previously (intentionally) non deterministic cv iterables, deterministic with consistent output for successive `split` calls. Do we want that to happen?) 
