### PR TITLE
[MRG] Support for multi-class roc_auc scores

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -252,6 +252,7 @@ Some also work in the multilabel case:
    precision_recall_fscore_support
    precision_score
    recall_score
+   roc_auc_score
    zero_one_loss
 
 
@@ -261,14 +262,6 @@ Some work with binary and multilabel (but not multiclass) problems:
    :template: function.rst
 
    average_precision_score
-
-
-And some work with binary, multilabel, and multiclass problems:
-
-.. autosummary::
-   :template: function.rst
-
-    roc_auc_score
 
 
 In the following sub-sections, we will describe each of those functions,
@@ -987,8 +980,12 @@ Compared to metrics such as the subset accuracy, the Hamming loss, or the
 F1 score, ROC doesn't require optimizing a threshold for each label.
 
 The :func:`roc_auc_score` function can also be used in multi-class
-classification, where the predicted class labels are provided in
-an array with values from 0 to `n_classes`, and the scores are the
+classification. Two averaging strategies are currently supported: the
+Hand & Till (2001) one-vs-one algorithm computes the average of the pairwise
+ROC AUC scores, and the Provost & Domingos (2001) one-vs-rest algorithm
+computes the average of the ROC AUC scores for each class against
+all other classes. In both cases, the predicted class labels are provided in
+an array with values from 0 to `n_classes`, and the scores correspond to the
 probability estimates that a sample belongs to a particular class.
 
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -999,7 +999,7 @@ Using the uniform class distribution:
         
 Using the a priori class distribution:
 
-.. math:: \frac{1}{c(c-1)}\sum_{j=1}^c\sum_{k \neq j}^c p(j)\textnormal{AUC}(j, k)
+.. math:: \frac{1}{c-1}\sum_{j=1}^c\sum_{k \neq j}^c p(j)\textnormal{AUC}(j, k)
 
 **One-vs-rest Algorithm**
 [PD2000]_: AUC of each class against the rest. This treats

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -254,13 +254,21 @@ Some also work in the multilabel case:
    recall_score
    zero_one_loss
 
-And some work with binary and multilabel (but not multiclass) problems:
+
+Some work with binary and multilabel (but not multiclass) problems:
 
 .. autosummary::
    :template: function.rst
 
    average_precision_score
-   roc_auc_score
+
+
+And some work with binary, multilabel, and multiclass problems:
+
+.. autosummary::
+   :template: function.rst
+
+    roc_auc_score
 
 
 In the following sub-sections, we will describe each of those functions,
@@ -976,9 +984,12 @@ In multi-label classification, the :func:`roc_auc_score` function is
 extended by averaging over the labels as :ref:`above <average>`.
 
 Compared to metrics such as the subset accuracy, the Hamming loss, or the
-F1 score, ROC doesn't require optimizing a threshold for each label. The
-:func:`roc_auc_score` function can also be used in multi-class classification,
-if the predicted outputs have been binarized.
+F1 score, ROC doesn't require optimizing a threshold for each label.
+
+The :func:`roc_auc_score` function can also be used in multi-class
+classification, where the predicted class labels are provided in
+an array with values from 0 to `n_classes`, and the scores are the
+probability estimates that a sample belongs to a particular class.
 
 
 .. image:: ../auto_examples/model_selection/images/sphx_glr_plot_roc_002.png

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -981,13 +981,37 @@ F1 score, ROC doesn't require optimizing a threshold for each label.
 
 The :func:`roc_auc_score` function can also be used in multi-class
 classification. Two averaging strategies are currently supported: the
-Hand & Till (2001) one-vs-one algorithm computes the average of the pairwise
-ROC AUC scores, and the Provost & Domingos (2001) one-vs-rest algorithm
+[HT2001]_ one-vs-one algorithm computes the average of the pairwise
+ROC AUC scores, and the [PD2000]_ one-vs-rest algorithm
 computes the average of the ROC AUC scores for each class against
 all other classes. In both cases, the predicted class labels are provided in
-an array with values from 0 to `n_classes`, and the scores correspond to the
+an array with values from 0 to ``n_classes``, and the scores correspond to the
 probability estimates that a sample belongs to a particular class.
 
+**One-vs-one Algorithm**
+[HT2001]_: AUC of each class against each other, computing
+the AUC of all possible pairwise combinations :math:`c(c-1)` for a
+:math:`c`-dimensional classifier.
+
+Using the uniform class distribution:
+
+.. math:: \frac{1}{c(c-1)}\sum_{j=1}^c\sum_{k \neq j}^c \textnormal{AUC}(j, k)
+        
+Using the a priori class distribution:
+
+.. math:: \frac{1}{c(c-1)}\sum_{j=1}^c\sum_{k \neq j}^c p(j)\textnormal{AUC}(j, k)
+
+**One-vs-rest Algorithm**
+[PD2000]_: AUC of each class against the rest. This treats
+a :math:`c`-dimensional classifier as :math:`c` two-dimensional classifiers.
+
+Using the uniform class distribution:
+
+.. math:: \frac{\sum_{j=1}^c \textnormal{AUC}(j, \textnormal{rest}_j)}{c}
+
+Using the a priori class distribution
+
+.. math:: \frac{\sum_{j=1}^c p(j)\textnormal{AUC}(j, \textnormal{rest}_j)}{c}
 
 .. image:: ../auto_examples/model_selection/images/sphx_glr_plot_roc_002.png
    :target: ../auto_examples/model_selection/plot_roc.html
@@ -1007,6 +1031,18 @@ probability estimates that a sample belongs to a particular class.
   * See :ref:`sphx_glr_auto_examples_applications_plot_species_distribution_modeling.py`
     for an example of using ROC to
     model species distribution.
+
+.. topic:: References:
+
+    .. [HT2001] Hand, D.J. and Till, R.J., 2001. `A simple generalisation
+       of the area under the ROC curve for multiple class classification problems.
+       <http://link.springer.com/article/10.1023/A:1010920819831>`_
+       Machine learning, 45(2), pp.171-186.
+    .. [PD2000] Provost, F. and Domingos, P., 2000.
+       `Well-trained PETs: Improving probability estimation trees.
+       <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.33.309&rep=rep1&type=pdf>`_
+       CeDER Working Paper #IS-00-04, Stern School of Business, New
+       York University, NY 10012.
 
 .. _zero_one_loss:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -980,36 +980,36 @@ Compared to metrics such as the subset accuracy, the Hamming loss, or the
 F1 score, ROC doesn't require optimizing a threshold for each label.
 
 The :func:`roc_auc_score` function can also be used in multi-class
-classification. Two averaging strategies are currently supported: the
-[HT2001]_ one-vs-one algorithm computes the average of the pairwise
-ROC AUC scores, and the [PD2000]_ one-vs-rest algorithm
+classification. [F2009]_ Two averaging strategies are currently supported: the
+one-vs-one algorithm computes the average of the pairwise
+ROC AUC scores, and the one-vs-rest algorithm
 computes the average of the ROC AUC scores for each class against
 all other classes. In both cases, the predicted class labels are provided in
 an array with values from 0 to ``n_classes``, and the scores correspond to the
 probability estimates that a sample belongs to a particular class.
 
 **One-vs-one Algorithm**
-[HT2001]_: AUC of each class against each other, computing
+The AUC of each class against each other, computing
 the AUC of all possible pairwise combinations :math:`c(c-1)` for a
 :math:`c`-dimensional classifier.
 
-Using the uniform class distribution:
+[HT2001]_ Using the uniform class distribution:
 
 .. math:: \frac{1}{c(c-1)}\sum_{j=1}^c\sum_{k \neq j}^c \textnormal{AUC}(j, k)
         
-Using the a priori class distribution:
+[F2009]_ Weighted by the prevalence of classes `j` and `k`:
 
-.. math:: \frac{1}{c-1}\sum_{j=1}^c\sum_{k \neq j}^c p(j)\textnormal{AUC}(j, k)
+.. math:: \frac{1}{c-1}\sum_{j=1}^c\sum_{k \neq j}^c p(j \cup k)\textnormal{AUC}(j, k)
 
 **One-vs-rest Algorithm**
-[PD2000]_: AUC of each class against the rest. This treats
+AUC of each class against the rest. This treats
 a :math:`c`-dimensional classifier as :math:`c` two-dimensional classifiers.
 
-Using the uniform class distribution:
+[F2006]_ Using the uniform class distribution:
 
 .. math:: \frac{\sum_{j=1}^c \textnormal{AUC}(j, \textnormal{rest}_j)}{c}
 
-Using the a priori class distribution
+[F2001]_ Weighted by the a priori class distribution:
 
 .. math:: \frac{\sum_{j=1}^c p(j)\textnormal{AUC}(j, \textnormal{rest}_j)}{c}
 
@@ -1034,15 +1034,21 @@ Using the a priori class distribution
 
 .. topic:: References:
 
+    .. [F2001] Fawcett, T., 2001. `Using rule sets to maximize 
+       ROC performance <http://ieeexplore.ieee.org/document/989510/>`_
+       In Data Mining, 2001.
+       Proceedings IEEE International Conference, pp. 131-138.
+    .. [F2006] Fawcett, T., 2006. `An introduction to ROC analysis.
+       <http://www.sciencedirect.com/science/article/pii/S016786550500303X>`_
+       Pattern Recognition Letters, 27(8), pp. 861-874.
+    .. [F2009] Ferri, C., Hernandez-Orallo, J., and Modroiu, R., 2009.
+       `An experimental comparison of performance measures for classification.
+       <http://www.sciencedirect.com/science/article/pii/S0167865508002687>`_
+       Pattern Recognition Letters, 30(1), pp. 27-38.
     .. [HT2001] Hand, D.J. and Till, R.J., 2001. `A simple generalisation
        of the area under the ROC curve for multiple class classification problems.
        <http://link.springer.com/article/10.1023/A:1010920819831>`_
        Machine learning, 45(2), pp.171-186.
-    .. [PD2000] Provost, F. and Domingos, P., 2000.
-       `Well-trained PETs: Improving probability estimation trees.
-       <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.33.309&rep=rep1&type=pdf>`_
-       CeDER Working Paper #IS-00-04, Stern School of Business, New
-       York University, NY 10012.
 
 .. _zero_one_loss:
 

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -19,15 +19,39 @@ Multiclass settings
 -------------------
 
 ROC curves are typically used in binary classification to study the output of
-a classifier. In order to extend ROC curve and ROC area to multi-class
-or multi-label classification, it is necessary to binarize the output. One ROC
-curve can be drawn per label, but one can also draw a ROC curve by considering
+a classifier. Extensions of ROC curve and ROC area to multi-class
+or multi-label classification can use the One-vs-Rest or One-vs-One scheme.
+
+One-vs-Rest
+-----------
+
+The output is binarized and one ROC curve can be drawn per label,
+where the label is the positive class and all other labels are
+the negative class.
+
+The ROC area can be approximated by taking the average--unweighted or weighted
+by the a priori class distribution--of the one-vs-rest ROC areas.
+
+One can also draw a ROC curve by considering
 each element of the label indicator matrix as a binary prediction
 (micro-averaging).
 
-Another evaluation measure for multi-class classification is
+Another evaluation measure for one-vs-rest multi-class classification is
 macro-averaging, which gives equal weight to the classification of each
 label.
+
+One-vs-One
+----------
+
+Two ROC curves can be drawn per pair of labels because either of the two
+labels can be considered the positive class.
+
+The ROC area can be approximated by first computing the
+approximate ROC area of each label pair as the average of the
+two ROC AUC scores corresponding to that pair. The One-vs-One
+approximation of a multi-class ROC AUC score is the average--
+unweighted or weighted by the a priori class distribution--across
+all of the pairwise approximate ROC AUC scores.
 
 .. note::
 
@@ -42,7 +66,7 @@ import matplotlib.pyplot as plt
 from itertools import cycle
 
 from sklearn import svm, datasets
-from sklearn.metrics import roc_curve, auc
+from sklearn.metrics import roc_curve, auc, roc_auc_score
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import label_binarize
 from sklearn.multiclass import OneVsRestClassifier
@@ -151,8 +175,12 @@ plt.title('An extension of Receiver operating characteristic to multi-class '
 plt.legend(loc="lower right")
 plt.show()
 
-# TODO: roc_auc_score weighted and unweighted
-
+# Compute the One-vs-Rest ROC AUC score, weighted and unweighted
+unweighted_roc_auc_ovr = roc_auc_score(y_test, y_score, multiclass="ovr")
+weighted_roc_auc_ovr = roc_auc_score(
+    y_test, y_score, multiclass="ovr", average="weighted")
+print("One-vs-Rest ROC AUC scores: {0} (unweighted), {1} (weighted)".format(
+      unweighted_roc_auc_ovr, weighted_roc_auc_ovr))
 
 ##############################################################################
 # Plot ROC curves for the multiclass problem using One vs. One classification.
@@ -198,4 +226,9 @@ plt.title('An extension of Receiver operating characteristic to multi-class '
 plt.legend(bbox_to_anchor=(1.8, 0.55))
 plt.show()
 
-# TODO: roc_auc_scores
+# Compute the One-vs-One ROC AUC score, weighted and unweighted
+unweighted_roc_auc_ovo = roc_auc_score(y_test, y_score, multiclass="ovo")
+weighted_roc_auc_ovo = roc_auc_score(
+    y_test, y_score, multiclass="ovo", average="weighted")
+print("One-vs-One ROC AUC scores: {0} (unweighted), {1} (weighted)".format(
+      unweighted_roc_auc_ovo, weighted_roc_auc_ovo))

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -211,11 +211,11 @@ for pos in range(n_classes):
         plt.plot(fpr[(pos, neg)], tpr[(pos, neg)], lw=lw,
                  label='ROC curve of class {0} against class {1} '
                        '(area = {2:0.2f})'.format(
-                    pos, neg, roc_auc[(pos, neg)]))
+            pos, neg, roc_auc[(pos, neg)]))
         plt.plot(fpr[(neg, pos)], tpr[(neg, pos)], lw=lw,
                  label='ROC curve of class {0} against class {1} '
                        '(area = {2:0.2f})'.format(
-                    neg, pos, roc_auc[(neg, pos)]))
+            neg, pos, roc_auc[(neg, pos)]))
 plt.plot([0, 1], [0, 1], 'k--', lw=lw)
 plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -126,7 +126,8 @@ plt.show()
 # Plot ROC curves for the multiclass problem using One vs. Rest classification.
 
 # Compute micro-average ROC curve and ROC area
-fpr["micro"], tpr["micro"], _ = roc_curve(y_test.ravel(), y_score.ravel())
+fpr["micro"], tpr["micro"], _ = roc_curve(
+    y_test_binarized.ravel(), y_score.ravel())
 roc_auc["micro"] = auc(fpr["micro"], tpr["micro"])
 
 # Compute macro-average ROC curve and ROC area
@@ -169,7 +170,7 @@ plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])
 plt.xlabel('False Positive Rate')
 plt.ylabel('True Positive Rate')
-plt.title('An extension of Receiver operating characteristic to multi-class '
+plt.title('An extension of ROC to multi-class '
           'using One-vs-Rest')
 plt.legend(loc="lower right")
 plt.show()
@@ -206,11 +207,11 @@ for a, b in combinations(range(n_classes), 2):
 plt.figure()
 for a, b in combinations(range(n_classes), 2):
     plt.plot(fpr[(a, b)], tpr[(a, b)], lw=lw,
-             label='ROC curve of class {0} against class {1} '
+             label='ROC curve: class {0} vs. {1} '
                    '(area = {2:0.2f})'.format(
         a, b, roc_auc[(a, b)]))
     plt.plot(fpr[(b, a)], tpr[(b, a)], lw=lw,
-             label='ROC curve of class {0} against class {1} '
+             label='ROC curve: class {0} vs. {1} '
                    '(area = {2:0.2f})'.format(
         b, a, roc_auc[(b, a)]))
 plt.plot([0, 1], [0, 1], 'k--', lw=lw)
@@ -218,9 +219,9 @@ plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])
 plt.xlabel('False Positive Rate')
 plt.ylabel('True Positive Rate')
-plt.title('An extension of Receiver operating characteristic to multi-class '
+plt.title('An extension of ROC to multi-class '
           'using One-vs-One')
-plt.legend(bbox_to_anchor=(1.8, 0.55))
+plt.legend(bbox_to_anchor=(1.1, 0.30))
 plt.show()
 
 # Compute the One-vs-One ROC AUC score, weighted and unweighted

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -45,8 +45,8 @@ One-vs-One
 
 Two ROC curves can be drawn per pair of labels because either of the two
 labels can be considered the positive class (and the other the negative
-class). The ROC area of a label pair is approximated taking the average of these
-two ROC AUC scores.
+class). The ROC area of a label pair is approximated taking the average of
+these two ROC AUC scores.
 
 The One-vs-One approximation of a multi-class ROC AUC score is the average--
 unweighted or weighted by class prevalence--across all of the pairwise
@@ -187,7 +187,7 @@ print("One-vs-Rest ROC AUC scores: {0} (unweighted), {1} (weighted)".format(
 for a, b in combinations(range(n_classes), 2):
     # Filter `y_test` and `y_score` to only consider the current
     # `a` and `b` class pair.
-    ab_mask = np.logical_or(y_test == a, y_true == b)
+    ab_mask = np.logical_or(y_test == a, y_test == b)
     y_true_filtered = y_test[ab_mask]
     y_score_filtered = y_score[ab_mask]
 

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -196,13 +196,13 @@ for pos in range(n_classes):
         # Compute ROC curve and ROC area with `pos` as the positive class
         class_a = y_true_filtered == pos
         fpr[(pos, neg)], tpr[(pos, neg)], _ = roc_curve(
-                class_a, y_score_filtered[:, pos])
+            class_a, y_score_filtered[:, pos])
         roc_auc[(pos, neg)] = auc(fpr[(pos, neg)], tpr[(pos, neg)])
 
         # Compute ROC curve and ROC area with `neg` as the positive class
         class_b = y_true_filtered == neg
         fpr[(neg, pos)], tpr[(neg, pos)], _ = roc_curve(
-                class_b, y_score_filtered[:, neg])
+            class_b, y_score_filtered[:, neg])
         roc_auc[(neg, pos)] = auc(fpr[(neg, pos)], tpr[(neg, pos)])
 
 plt.figure()
@@ -211,11 +211,11 @@ for pos in range(n_classes):
         plt.plot(fpr[(pos, neg)], tpr[(pos, neg)], lw=lw,
                  label='ROC curve of class {0} against class {1} '
                        '(area = {2:0.2f})'.format(
-                        pos, neg, roc_auc[(pos, neg)]))
+                    pos, neg, roc_auc[(pos, neg)]))
         plt.plot(fpr[(neg, pos)], tpr[(neg, pos)], lw=lw,
                  label='ROC curve of class {0} against class {1} '
                        '(area = {2:0.2f})'.format(
-                        neg, pos, roc_auc[(neg, pos)]))
+                    neg, pos, roc_auc[(neg, pos)]))
 plt.plot([0, 1], [0, 1], 'k--', lw=lw)
 plt.xlim([0.0, 1.0])
 plt.ylim([0.0, 1.05])

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -176,18 +176,20 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
             if pos == neg:
                 continue
             ix = np.in1d(y_true.ravel(), [pos, neg])
-            y_true_filtered = y_true[np.where(ix.reshape(y_true.shape))]
-            y_score_filtered = y_score[np.where(ix)]
+            y_true_filtered = y_true[ix.reshape(y_true.shape)]
+            y_score_filtered = y_score[ix]
 
-            y_true_10 = y_true_filtered == pos
-            y_true_01 = y_true_filtered == neg
-            score_10 = binary_metric(
-                    y_true_10, y_score_filtered[:, pos])
-            score_01 = binary_metric(
-                    y_true_01, y_score_filtered[:, neg])
-            binary_avg_auc = (score_10 + score_01)/2.0
+            # compute score with `pos` as the positive class
+            class_a = y_true_filtered == pos
+            # compute score with `neg` as the positive class
+            class_b = y_true_filtered == neg
+            score_class_a = binary_metric(
+                    class_a, y_score_filtered[:, pos])
+            score_class_b = binary_metric(
+                    class_b, y_score_filtered[:, neg])
+            binary_avg_auc = (score_class_a + score_class_b) / 2.0
             if average == "weighted":
-                probability_pos = np.sum(y_true == pos)/float(y_true.size)
+                probability_pos = np.sum(y_true == pos) / float(y_true.size)
                 auc_scores_sum += binary_avg_auc * probability_pos
             else:
                 auc_scores_sum += binary_avg_auc

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -169,8 +169,7 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
     score : float
         Average the sum of the pairwise binary metric scores
     """
-    label_unique, label_counts = np.unique(y_true, return_counts=True)
-    n_labels = len(label_unique)
+    n_labels = len(np.unique(y_true))
     auc_scores_sum = 0
     for pos in range(n_labels):
         for neg in range(n_labels):

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -141,13 +141,13 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
     ----------
     y_true : array, shape = [n_samples]
         True multiclass labels.
-        Currently only handles labels with values 0 to n_classes - 1.
+        Assumes labels have been recoded to 0 to n_classes.
 
     y_score : array, shape = [n_samples, n_classes]
         Target scores corresponding to probability estimates of a sample
         belonging to a particular class
 
-    average : string, ['macro' (default), 'weighted']
+    average : 'macro' or 'weighted', default='macro'
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean. This does not take label imbalance into account. Classes
@@ -167,7 +167,7 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
     Returns
     -------
     score : float
-        Average the sum of the pairwise binary metric scores
+        Average the sum of pairwise binary metric scores
     """
     n_labels = len(np.unique(y_true))
     auc_scores_sum = 0

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -205,16 +205,3 @@ def _average_multiclass_score(binary_metric, y_true, y_score,
             else:
                 auc_scores_sum += binary_avg_auc
     return auc_scores_sum * (1.0 / (n_labels * (n_labels - 1.0)))
-    '''
-    else:
-        # Provost and Domingos 2001 (weighted)
-        auc_scores_sum = 0
-        for label in label_unique:
-            y_true_label = np.in1d(y_true.ravel(), label).astype(int)
-            y_score_label = y_score[:,label]
-            binary_output = binary_metric(y_true_label, y_score_label)
-            if average == "weighted":
-                binary_output *= (label_counts_map[label]/float(sum(label_counts_map.values())))
-            auc_scores_sum += binary_output
-        return auc_scores_sum
-    '''

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -158,10 +158,11 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
 
     binary_metric : callable, the binary metric function to use.
         Accepts the following as input
-            y_true' : array, shape = [n_samples']
-                Some sub-array of y_true
-            y_score' : array, shape = [n_samples']
-                Target scores corresponding to the probability estimates
+            y_true_target : array, shape = [n_samples_target]
+                Some sub-array of y_true for a pair of classes designated
+                positive and negative in the one-vs-one scheme.
+            y_score_target : array, shape = [n_samples_target]
+                Scores corresponding to the probability estimates
                 of a sample belonging to the designated positive class label
 
     Returns

--- a/sklearn/metrics/base.py
+++ b/sklearn/metrics/base.py
@@ -133,10 +133,9 @@ def _average_binary_score(binary_metric, y_true, y_score, average,
         return score
 
 
-def _average_multiclass_score(binary_metric, y_true, y_score,
-                              average, multiclass):
-
-    """Uses the binary metric for multiclass classification
+def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average):
+    """Uses the binary metric for one-vs-one multiclass classification,
+    where the score is computed according to the Hand & Till (2001) algorithm.
 
     Parameters
     ----------
@@ -165,27 +164,9 @@ def _average_multiclass_score(binary_metric, y_true, y_score,
     score : float
         Average the score.
         TODO: improve documentation on this line.
-
     """
-    average_options = ("macro", "weighted")
-    if average not in average_options:
-        raise ValueError("average has to be one of {0}"
-                         "".format(average_options))
-    multiclass_options = ("ovo", "ovr")
-    if multiclass not in multiclass_options:
-        raise ValueError("{0} is not supported for multiclass ROC AUC"
-                         "".format(multiclass))
-
-    check_consistent_length(y_true, y_score)
-    y_true = check_array(y_true)
-    y_score = check_array(y_score)
-
-    if y_true.ndim == 1:
-        y_true = y_true.reshape((-1, 1))
-
     label_unique, label_counts = np.unique(y_true, return_counts=True)
     n_labels = len(label_unique)
-    # Hand and Till 2001 (unweighted)
     auc_scores_sum = 0
     for pos in range(n_labels):
         for neg in range(n_labels):
@@ -204,4 +185,4 @@ def _average_multiclass_score(binary_metric, y_true, y_score,
                 auc_scores_sum += binary_avg_auc * probability_pos
             else:
                 auc_scores_sum += binary_avg_auc
-    return auc_scores_sum * (1.0 / (n_labels * (n_labels - 1.0)))
+    return auc_scores_sum / (n_labels * (n_labels - 1.0))

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -189,9 +189,6 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                   sample_weight=None):
     """Compute Area Under the Curve (AUC) from prediction scores
 
-    Note: this implementation is restricted to the binary classification task
-    or multilabel classification task in label indicator format.
-
     Read more in the :ref:`User Guide <roc_metrics>`.
 
     Parameters
@@ -203,6 +200,17 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
         Target scores, can either be probability estimates of the positive
         class, confidence values, or non-thresholded measure of decisions
         (as returned by "decision_function" on some classifiers).
+
+    multiclass : string, ['ovr' (default), 'ovo']
+        Note: multiclass ROC AUC currently only handles the 'macro' and
+        'weighted' averages.
+
+        ``'ovr'``:
+            Calculate metrics for the multiclass case using the one-vs-rest
+            approach.
+        ``'ovo'``:
+            Calculate metrics for the multiclass case using the one-vs-one
+            approach.
 
     average : string, [None, 'micro', 'macro' (default), 'samples', 'weighted']
         If ``None``, the scores for each class are returned. Otherwise,
@@ -274,8 +282,6 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                              "".format(multiclass))
 
         check_consistent_length(y_true, y_score)
-        y_true = check_array(y_true)
-        y_score = check_array(y_score)
 
         if y_true.ndim == 1:
             y_true = y_true.reshape((-1, 1))
@@ -286,8 +292,7 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
         else:
             y_true_multilabel = MultiLabelBinarizer().fit_transform(y_true)
             return _average_binary_score(_binary_roc_auc_score,
-                                         y_true_multilabel, y_score, average,
-                                         sample_weight=sample_weight)
+                                         y_true_multilabel, y_score, average)
 
 
 def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -289,13 +289,11 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
         check_array(y_true, ensure_2d=False)
         check_array(y_score)
 
-        if y_true.ndim == 1:
-            y_true = y_true.reshape((-1, 1))
-
         if multiclass == "ovo":
             return _average_multiclass_ovo_score(
                 _binary_roc_auc_score, y_true, y_score, average)
         else:
+            y_true = y_true.reshape((-1, 1))
             y_true_multilabel = MultiLabelBinarizer().fit_transform(y_true)
             return _average_binary_score(_binary_roc_auc_score,
                                          y_true_multilabel, y_score, average)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -278,13 +278,18 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
         # validation for multiclass parameter specifications
         average_options = ("macro", "weighted")
         if average not in average_options:
-            raise ValueError("average has to be one of {0}"
+            raise ValueError("Parameter 'average' must be one of {0}."
                              "".format(average_options))
         multiclass_options = ("ovo", "ovr")
         if multiclass not in multiclass_options:
-            raise ValueError("'{0}' is not supported for multiclass ROC AUC"
-                             "".format(multiclass))
-
+            raise ValueError("Parameter multiclass='{0}' is not supported"
+                             " for multiclass ROC AUC. 'multiclass' must be"
+                             " one of {1}.".format(
+                                 multiclass, multiclass_options))
+        if sample_weight is not None:
+            raise ValueError("Parameter 'sample_weight' is not supported"
+                             " for multiclass ROC AUC. 'sample_weight' must"
+                             " be None.")
         check_consistent_length(y_true, y_score)
         check_array(y_true, ensure_2d=False)
         check_array(y_score)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -34,7 +34,7 @@ from ..utils.stats import rankdata
 from ..utils.sparsefuncs import count_nonzero
 from ..exceptions import UndefinedMetricWarning
 
-from .base import _average_binary_score
+from .base import _average_binary_score, _average_multiclass_score
 
 
 def auc(x, y, reorder=False):
@@ -184,7 +184,7 @@ def average_precision_score(y_true, y_score, average="macro",
                                  average, sample_weight=sample_weight)
 
 
-def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
+def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro", sample_weight=None):
     """Compute Area Under the Curve (AUC) from prediction scores
 
     Note: this implementation is restricted to the binary classification task
@@ -246,6 +246,7 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
     0.75
 
     """
+
     def _binary_roc_auc_score(y_true, y_score, sample_weight=None):
         if len(np.unique(y_true)) != 2:
             raise ValueError("Only one class present in y_true. ROC AUC score "
@@ -255,10 +256,24 @@ def roc_auc_score(y_true, y_score, average="macro", sample_weight=None):
                                         sample_weight=sample_weight)
         return auc(fpr, tpr, reorder=True)
 
-    return _average_binary_score(
-        _binary_roc_auc_score, y_true, y_score, average,
-        sample_weight=sample_weight)
-
+    if type_of_target(y_true) != "multiclass":
+        return _average_binary_score(
+            _binary_roc_auc_score, y_true, y_score, average,
+            sample_weight=sample_weight)
+    else:
+        '''
+        average_options = (None, "macro", "weighted")
+        if average not in average_options:
+            raise ValueError("average has to be one of {0}"
+                             "".format(average_options))
+        multiclass_options = ("ovo", "ovr")
+        if multiclass not in multiclass_options:
+            raise ValueError("{0} is not supported for multiclass ROC AUC"
+                             "".format(multiclass))
+        '''
+        return _average_multiclass_score(
+            _binary_roc_auc_score, y_true, y_score,
+            average, multiclass)
 
 def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     """Calculate true and false positives per binary classification threshold.

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -288,6 +288,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
 
     pos_label : int or str, default=None
         The label of the positive class
+A
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -23,6 +23,7 @@ import warnings
 import numpy as np
 from scipy.sparse import csr_matrix
 
+from ..preprocessing import MultiLabelBinarizer
 from ..utils import assert_all_finite
 from ..utils import check_consistent_length
 from ..utils import column_or_1d, check_array
@@ -260,7 +261,7 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro", sample_wei
         return _average_binary_score(
             _binary_roc_auc_score, y_true, y_score, average,
             sample_weight=sample_weight)
-    else:
+    elif multiclass == "ovo":
         '''
         average_options = (None, "macro", "weighted")
         if average not in average_options:
@@ -274,6 +275,13 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro", sample_wei
         return _average_multiclass_score(
             _binary_roc_auc_score, y_true, y_score,
             average, multiclass)
+    else:
+        print y_true
+        y_true = y_true.reshape((-1, 1))
+        y_true_multilabels = MultiLabelBinarizer().fit_transform(y_true)
+        return _average_binary_score(_binary_roc_auc_score,
+               y_true_multilabels, y_score, average, sample_weight=sample_weight)
+
 
 def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     """Calculate true and false positives per binary classification threshold.
@@ -288,7 +296,6 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
 
     pos_label : int or str, default=None
         The label of the positive class
-A
 
     sample_weight : array-like of shape = [n_samples], optional
         Sample weights.

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -195,11 +195,15 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
     ----------
     y_true : array, shape = [n_samples] or [n_samples, n_classes]
         True binary labels in binary label indicators.
+        The multiclass case expects shape = [n_samples] and labels
+        with values from 0 to (n_classes-1), inclusive.
 
     y_score : array, shape = [n_samples] or [n_samples, n_classes]
         Target scores, can either be probability estimates of the positive
         class, confidence values, or non-thresholded measure of decisions
         (as returned by "decision_function" on some classifiers).
+        The multiclass case expects shape = [n_samples, n_classes]
+        where the scores correspond to probability estimates.
 
     multiclass : string, ['ovr' (default), 'ovo']
         Note: multiclass ROC AUC currently only handles the 'macro' and
@@ -282,6 +286,8 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                              "".format(multiclass))
 
         check_consistent_length(y_true, y_score)
+        check_array(y_true, ensure_2d=False)
+        check_array(y_score)
 
         if y_true.ndim == 1:
             y_true = y_true.reshape((-1, 1))

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -282,7 +282,7 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                              "".format(average_options))
         multiclass_options = ("ovo", "ovr")
         if multiclass not in multiclass_options:
-            raise ValueError("{0} is not supported for multiclass ROC AUC"
+            raise ValueError("'{0}' is not supported for multiclass ROC AUC"
                              "".format(multiclass))
 
         check_consistent_length(y_true, y_score)

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -23,7 +23,7 @@ import warnings
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from ..preprocessing import MultiLabelBinarizer
+from ..preprocessing import LabelBinarizer
 from ..utils import assert_all_finite
 from ..utils import check_consistent_length
 from ..utils import column_or_1d, check_array
@@ -299,7 +299,7 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                 _binary_roc_auc_score, y_true, y_score, average)
         else:
             y_true = y_true.reshape((-1, 1))
-            y_true_multilabel = MultiLabelBinarizer().fit_transform(y_true)
+            y_true_multilabel = LabelBinarizer().fit_transform(y_true)
             return _average_binary_score(_binary_roc_auc_score,
                                          y_true_multilabel, y_score, average)
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -289,8 +289,8 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
                                  multiclass, multiclass_options))
         if sample_weight is not None:
             raise ValueError("Parameter 'sample_weight' is not supported"
-                             " for multiclass ROC AUC. 'sample_weight' must"
-                             " be None.")
+                             " for multiclass one-vs-one ROC AUC."
+                             " 'sample_weight' must be None in this case.")
 
         if multiclass == "ovo":
             return _average_multiclass_ovo_score(
@@ -298,8 +298,9 @@ def roc_auc_score(y_true, y_score, multiclass="ovr", average="macro",
         else:
             y_true = y_true.reshape((-1, 1))
             y_true_multilabel = LabelBinarizer().fit_transform(y_true)
-            return _average_binary_score(_binary_roc_auc_score,
-                                         y_true_multilabel, y_score, average)
+            return _average_binary_score(
+                 _binary_roc_auc_score, y_true_multilabel, y_score, average,
+                 sample_weight=sample_weight)
     else:
         return _average_binary_score(
             _binary_roc_auc_score, y_true, y_score, average,

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -415,7 +415,7 @@ def test_multi_auc_toydata():
         roc_auc_score(y_true, y_scores, multiclass="ovr", average="weighted"),
         result_weighted)
 
-    result_unweighted = out_0 + out_1 + out_2
+    result_unweighted = (out_0 + out_1 + out_2)/3.0
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovr"),
         result_unweighted)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -332,14 +332,23 @@ def test_multi_roc_auc_toydata():
     y_scores = np.array([[0.714, 0.072, 0.214], [0.837, 0.143, 0.020], [0.714, 0.072, 0.214]])
     assert_almost_equal(roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.666666666663)
 
-    y_true = np.array([0, 0, 1, 1])
-    y_scores_binary = np.array([0.1, 0.4, 0.35, 0.8])
-    y_scores_multi = []
-    for y_score in y_scores_binary:
-        y_scores_multi.append([1 - y_score, y_score])
-    y_scores_multi = np.array(y_scores_multi)
-    assert_almost_equal(roc_auc_score(y_true, y_scores_multi, multiclass="ovo"),
-        roc_auc_score(y_true, y_scores_binary))
+    y_true = np.array([0, 1, 0, 2])
+    y_scores = np.array([[0.1, 0.8, 0.1], [0.3, 0.4, 0.3], [0.35, 0.5, 0.15], [0, 0.2, 0.8]])
+    assert_almost_equal(roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.75)
+    #y_scores_multi = []
+    #for y_score in y_scores_binary:
+    #    y_scores_multi.append([1 - y_score, y_score])
+    #y_scores_multi = np.array(y_scores_multi)
+    #assert_almost_equal(roc_auc_score(y_true, y_scores_multi, multiclass="ovo"),
+    #    roc_auc_score(y_true, y_scores_binary))
+
+    y_true = np.array([0, 1, 2, 2])
+    y_scores = np.array([[1.0, 0.0, 0.0], [0.1, 0.5, 0.4], [0.1, 0.1, 0.8], [0.3, 0.3, 0.4]])
+    out_0 = roc_auc_score([1, 0, 0, 0], y_scores[:,0])
+    out_1 = roc_auc_score([0, 1, 0, 0], y_scores[:,1])
+    out_2 = roc_auc_score([0, 0, 1, 1], y_scores[:,2])
+    result = out_0 * 0.25 + out_1 * 0.25 + out_2 * 0.5
+    assert_almost_equal(roc_auc_score(y_true, y_scores, multiclass="ovr"), result)
 
 def test_roc_curve_drop_intermediate():
     # Test that drop_intermediate drops the correct thresholds

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -435,15 +435,22 @@ def test_auc_score_multi_error():
     rng = check_random_state(404)
     y_pred = rng.rand(10)
     y_true = rng.randint(0, 3, size=10)
-    assert_raise_message(ValueError,
-                         "average has to be one of ('macro', 'weighted')",
+    average_error_msg = ("Parameter 'average' must be one of " +
+                         "('macro', 'weighted').")
+    assert_raise_message(ValueError, average_error_msg,
                          roc_auc_score, y_true, y_pred, average="sample")
-    assert_raise_message(ValueError,
-                         "average has to be one of ('macro', 'weighted')",
+    assert_raise_message(ValueError, average_error_msg,
                          roc_auc_score, y_true, y_pred, average="micro")
-    assert_raise_message(ValueError,
-                         "'invalid' is not supported for multiclass ROC AUC",
+    multiclass_error_msg = ("Parameter multiclass='invalid' is not " +
+                            "supported for multiclass ROC AUC. 'multiclass' " +
+                            "must be one of ('ovo', 'ovr').")
+    assert_raise_message(ValueError, multiclass_error_msg,
                          roc_auc_score, y_true, y_pred, multiclass="invalid")
+    sample_weight_error_msg = ("Parameter 'sample_weight' is not supported " +
+                               "for multiclass ROC AUC. 'sample_weight' " +
+                               "must be None.")
+    assert_raise_message(ValueError, sample_weight_error_msg,
+                         roc_auc_score, y_true, y_pred, sample_weight=[])
 
 
 def test_auc_score_non_binary_class():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -404,12 +404,19 @@ def test_multi_auc_toydata():
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.75)
 
+    y_true = np.array([0, 1, 0, 2])
+    y_scores = np.array(
+        [[0.1, 0.8, 0.1], [0.3, 0.4, 0.3], [0.35, 0.5, 0.15], [0, 0.2, 0.8]])
+    assert_almost_equal(
+        roc_auc_score(y_true, y_scores, multiclass="ovo", average="weighted"),
+        0.23958333333)
+
     y_true = np.array([0, 1, 2, 2])
     y_scores = np.array(
         [[1.0, 0.0, 0.0], [0.1, 0.5, 0.4], [0.1, 0.1, 0.8], [0.3, 0.3, 0.4]])
-    out_0 = roc_auc_score([1, 0, 0, 0], y_scores[:,0])
-    out_1 = roc_auc_score([0, 1, 0, 0], y_scores[:,1])
-    out_2 = roc_auc_score([0, 0, 1, 1], y_scores[:,2])
+    out_0 = roc_auc_score([1, 0, 0, 0], y_scores[:, 0])
+    out_1 = roc_auc_score([0, 1, 0, 0], y_scores[:, 1])
+    out_2 = roc_auc_score([0, 0, 1, 1], y_scores[:, 2])
     result_weighted = out_0 * 0.25 + out_1 * 0.25 + out_2 * 0.5
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovr", average="weighted"),
@@ -420,6 +427,7 @@ def test_multi_auc_toydata():
         roc_auc_score(y_true, y_scores, multiclass="ovr"),
         result_unweighted)
 
+
 def test_auc_score_multi_error():
     # Test that roc_auc_score function returns an error when trying
     # to compute multiclass AUC for parameters where an output
@@ -428,11 +436,12 @@ def test_auc_score_multi_error():
     y_pred = rng.rand(10)
     y_true = rng.randint(0, 3, size=10)
     assert_raise_message(ValueError,
-			"average has to be one of (None, 'macro', 'weighted')",
+                         "average has to be one of ('macro', 'weighted')",
                          roc_auc_score, y_true, y_pred, average="sample")
     assert_raise_message(ValueError,
-			 "average has to be one of (None, 'macro', 'weighted')",
+                         "average has to be one of ('macro', 'weighted')",
                          roc_auc_score, y_true, y_pred, average="micro")
+
 
 def test_auc_score_non_binary_class():
     # Test that roc_auc_score function returns an error when trying

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -327,6 +327,19 @@ def test_roc_curve_toydata():
     assert_almost_equal(roc_auc_score(y_true, y_score, average="samples"), .5)
     assert_almost_equal(roc_auc_score(y_true, y_score, average="micro"), .5)
 
+def test_multi_roc_auc_toydata():
+    y_true = np.array([0, 1, 2])
+    y_scores = np.array([[0.714, 0.072, 0.214], [0.837, 0.143, 0.020], [0.714, 0.072, 0.214]])
+    assert_almost_equal(roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.666666666663)
+
+    y_true = np.array([0, 0, 1, 1])
+    y_scores_binary = np.array([0.1, 0.4, 0.35, 0.8])
+    y_scores_multi = []
+    for y_score in y_scores_binary:
+        y_scores_multi.append([1 - y_score, y_score])
+    y_scores_multi = np.array(y_scores_multi)
+    assert_almost_equal(roc_auc_score(y_true, y_scores_multi, multiclass="ovo"),
+        roc_auc_score(y_true, y_scores_binary))
 
 def test_roc_curve_drop_intermediate():
     # Test that drop_intermediate drops the correct thresholds

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -417,10 +417,10 @@ def test_multi_auc_toydata():
     score_21 = roc_auc_score([0, 1], [0.3, 0.8])
     average_score_12 = (score_12 + score_21) / 2.
 
-    ovo_coefficient = 2. / (n_labels * (n_labels - 1))
     # Unweighted, one-vs-one multiclass ROC AUC algorithm
     sum_avg_scores = average_score_01 + average_score_02 + average_score_12
-    ovo_unweighted_score = ovo_coefficient * sum_avg_scores
+    ovo_unweighted_coefficient = 2. / (n_labels * (n_labels - 1))
+    ovo_unweighted_score = ovo_unweighted_coefficient * sum_avg_scores
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo"),
         ovo_unweighted_score)
@@ -430,7 +430,8 @@ def test_multi_auc_toydata():
     weighted_sum_avg_scores = (0.5 * average_score_01 +
                                0.5 * average_score_02 +
                                0.25 * average_score_12)
-    ovo_weighted_score = ovo_coefficient * weighted_sum_avg_scores
+    ovo_weighted_coefficient = 2. / (n_labels - 1)
+    ovo_weighted_score = ovo_weighted_coefficient * weighted_sum_avg_scores
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo", average="weighted"),
         ovo_weighted_score)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -441,6 +441,9 @@ def test_auc_score_multi_error():
     assert_raise_message(ValueError,
                          "average has to be one of ('macro', 'weighted')",
                          roc_auc_score, y_true, y_pred, average="micro")
+    assert_raise_message(ValueError,
+                         "'invalid' is not supported for multiclass ROC AUC",
+                         roc_auc_score, y_true, y_pred, multiclass="invalid")
 
 
 def test_auc_score_non_binary_class():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -392,40 +392,42 @@ def test_auc_errors():
 
 
 def test_multi_auc_toydata():
-    y_true = np.array([0, 1, 2])
-    y_scores = np.array(
-        [[0.714, 0.072, 0.214], [0.837, 0.143, 0.020], [0.714, 0.072, 0.214]])
-    assert_almost_equal(
-        roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.666666666663)
-
+    # Tests the unweighted, one-vs-one multiclass ROC AUC algorithm
+    # on a small example, representative of an expected use case.
     y_true = np.array([0, 1, 0, 2])
     y_scores = np.array(
         [[0.1, 0.8, 0.1], [0.3, 0.4, 0.3], [0.35, 0.5, 0.15], [0, 0.2, 0.8]])
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo"), 0.75)
 
-    y_true = np.array([0, 1, 0, 2])
-    y_scores = np.array(
-        [[0.1, 0.8, 0.1], [0.3, 0.4, 0.3], [0.35, 0.5, 0.15], [0, 0.2, 0.8]])
+    # Tests the weighted, one-vs-one multiclass ROC AUC algorithm
+    # on the same input
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo", average="weighted"),
         0.23958333333)
 
+    # Tests the unweighted, one-vs-rest multiclass ROC AUC algorithm
+    # on a small example, representative of an expected use case.
     y_true = np.array([0, 1, 2, 2])
     y_scores = np.array(
         [[1.0, 0.0, 0.0], [0.1, 0.5, 0.4], [0.1, 0.1, 0.8], [0.3, 0.3, 0.4]])
+    # Compute the expected result by individually computing the 'one-vs-rest'
+    # ROC AUC scores for classes 0, 1, and 2.
     out_0 = roc_auc_score([1, 0, 0, 0], y_scores[:, 0])
     out_1 = roc_auc_score([0, 1, 0, 0], y_scores[:, 1])
     out_2 = roc_auc_score([0, 0, 1, 1], y_scores[:, 2])
+    result_unweighted = (out_0 + out_1 + out_2)/3.0
+
+    assert_almost_equal(
+        roc_auc_score(y_true, y_scores, multiclass="ovr"),
+        result_unweighted)
+
+    # Tests the weighted, one-vs-rest multiclass ROC AUC algorithm
+    # on the same input
     result_weighted = out_0 * 0.25 + out_1 * 0.25 + out_2 * 0.5
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovr", average="weighted"),
         result_weighted)
-
-    result_unweighted = (out_0 + out_1 + out_2)/3.0
-    assert_almost_equal(
-        roc_auc_score(y_true, y_scores, multiclass="ovr"),
-        result_unweighted)
 
 
 def test_auc_score_multi_error():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -446,7 +446,7 @@ def test_multi_ovr_auc_toydata():
     out_0 = roc_auc_score([1, 0, 0, 0], y_scores[:, 0])
     out_1 = roc_auc_score([0, 1, 0, 0], y_scores[:, 1])
     out_2 = roc_auc_score([0, 0, 1, 1], y_scores[:, 2])
-    result_unweighted = (out_0 + out_1 + out_2)/3.
+    result_unweighted = (out_0 + out_1 + out_2) / 3.
 
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovr"),
@@ -491,22 +491,23 @@ def test_auc_score_multi_error():
     rng = check_random_state(404)
     y_pred = rng.rand(10)
     y_true = rng.randint(0, 3, size=10)
-    average_error_msg = ("Parameter 'average' must be one of " +
+    average_error_msg = ("Parameter 'average' must be one of "
                          "('macro', 'weighted') for multiclass problems.")
     assert_raise_message(ValueError, average_error_msg,
                          roc_auc_score, y_true, y_pred, average="sample")
     assert_raise_message(ValueError, average_error_msg,
                          roc_auc_score, y_true, y_pred, average="micro")
-    multiclass_error_msg = ("Parameter multiclass='invalid' is not " +
-                            "supported for multiclass ROC AUC. 'multiclass' " +
+    multiclass_error_msg = ("Parameter multiclass='invalid' is not "
+                            "supported for multiclass ROC AUC. 'multiclass' "
                             "must be one of ('ovo', 'ovr').")
     assert_raise_message(ValueError, multiclass_error_msg,
                          roc_auc_score, y_true, y_pred, multiclass="invalid")
-    sample_weight_error_msg = ("Parameter 'sample_weight' is not supported " +
-                               "for multiclass ROC AUC. 'sample_weight' " +
-                               "must be None.")
+    sample_weight_error_msg = ("Parameter 'sample_weight' is not supported "
+                               "for multiclass one-vs-one ROC AUC. "
+                               "'sample_weight' must be None in this case.")
     assert_raise_message(ValueError, sample_weight_error_msg,
-                         roc_auc_score, y_true, y_pred, sample_weight=[])
+                         roc_auc_score, y_true, y_pred,
+                         multiclass="ovo", sample_weight=[])
 
 
 def test_auc_score_non_binary_class():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -427,11 +427,9 @@ def test_multi_ovo_auc_toydata():
 
     # Weighted, one-vs-one multiclass ROC AUC algorithm
     # Each term is weighted by the posterior for the positive label.
-    weighted_sum_avg_scores = (0.75 * average_score_01 +
-                               0.75 * average_score_02 +
-                               0.50 * average_score_12)
-    ovo_weighted_coefficient = 1. / (n_labels * (n_labels - 1))
-    ovo_weighted_score = ovo_weighted_coefficient * weighted_sum_avg_scores
+    pair_scores = [average_score_01, average_score_02, average_score_12]
+    prevalence = [0.75, 0.75, 0.50]
+    ovo_weighted_score = np.average(pair_scores, weights=prevalence)
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multiclass="ovo", average="weighted"),
         ovo_weighted_score)
@@ -480,7 +478,7 @@ def test_multi_auc_score_under_permutation():
                 y_true_perm = np.take(perm, y_true)
                 score = roc_auc_score(y_true_perm, y_score_perm,
                                       multiclass=multiclass, average=average)
-                if not same_score_under_permutation:
+                if same_score_under_permutation is None:
                     same_score_under_permutation = score
                 else:
                     assert_almost_equal(score, same_score_under_permutation)
@@ -712,8 +710,6 @@ def test_score_scale_invariance():
     # issue #3864 (and others), where overly aggressive rounding was causing
     # problems for users with very small y_score values
     y_true, _, probas_pred = make_prediction(binary=True)
-    print(y_true.shape)
-    print(probas_pred.shape)
     roc_auc = roc_auc_score(y_true, probas_pred)
     roc_auc_scaled_up = roc_auc_score(y_true, 100 * probas_pred)
     roc_auc_scaled_down = roc_auc_score(y_true, 1e-6 * probas_pred)


### PR DESCRIPTION
#### Reference Issue

Issue [3298](https://github.com/scikit-learn/scikit-learn/issues/3298)
#### What does this implement/fix? Explain your changes.

Incorporates ROC AUC computations for some multiclass ROC AUC algorithms:
- Hand & Till, 2001 one vs one
- Provost & Domingo, 2000 one vs rest
#### Any other comments?

I wanted to just get in an initial PR for this issue because I am sure there will be many modifications/suggestions from everyone.

_TODOS_
- [x] I haven't implemented comprehensive testing for edge cases yet. I've added a few short tests to assess correctness of the different algorithms, but would also like more feedback on this specific area.
- [x] Updating documentation
- [x] PEP8!
- [x] Check compatibility for different versions of Python & packages supported by sklearn. (e.g. one failure was with numpy: `TypeError: unique() got an unexpected keyword argument 'return_counts'`)
