### PR TITLE
[WIP] algorithm='auto' should always work for nearest neighbors

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -419,12 +419,14 @@ depends on a number of factors:
   a significant fraction of the total cost.  If very few query points
   will be required, brute force is better than a tree-based method.
 
-Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2` 
-and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the 
-``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of 
-``'kd_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the 
-same order as the number of training points, and that ``leaf_size`` is 
+Currently, ``algorithm = 'auto'`` selects ``'kd_tree'`` if :math:`k < N/2`
+and the ``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
+``'kd_tree'``. It selects ``'ball_tree'`` if :math:`k < N/2` and the
+``'effective_metric_'`` is in the ``'VALID_METRICS'`` list of
+``'ball_tree'``. It selects ``'brute'`` if :math:`k < N/2` and the
+``'effective_metric_'`` is not in the ``'VALID_METRICS'`` list of
+``'kd_tree'`` or ``'ball_tree'``. It selects ``'brute'`` if :math:`k >= N/2`. This choice is based on the assumption that the number of query points is at least the
+same order as the number of training points, and that ``leaf_size`` is
 close to its default value of ``30``.
 
 Effect of ``leaf_size``
@@ -666,7 +668,7 @@ the :math:`m` nearest neighbors of a point :math:`q`. First, a top-down
 traversal is performed using a binary search to identify the leaf having the
 longest prefix match (maximum depth) with :math:`q`'s label after subjecting
 :math:`q` to the same hash functions. :math:`M >> m` points (total candidates)
-are extracted from the forest, moving up from the previously found maximum 
+are extracted from the forest, moving up from the previously found maximum
 depth towards the root synchronously across all trees in the bottom-up
 traversal. `M` is set to  :math:`cl` where :math:`c`, the number of candidates
 extracted from each tree, is a constant. Finally, the similarity of each of

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -128,6 +128,8 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                 alg_check = 'brute'
             else:
                 alg_check = 'ball_tree'
+                if metric not in VALID_METRICS[alg_check]:
+                    alg_check = 'brute'
         else:
             alg_check = algorithm
 
@@ -229,8 +231,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     self.metric != 'precomputed'):
                 if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
-                else:
+                elif self.effective_metric_ in VALID_METRICS['ball_tree']:
                     self._fit_method = 'ball_tree'
+                else:
+                    self._fit_method = 'brute'
             else:
                 self._fit_method = 'brute'
 

--- a/sklearn/neighbors/base.py
+++ b/sklearn/neighbors/base.py
@@ -126,10 +126,10 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
         if algorithm == 'auto':
             if metric == 'precomputed':
                 alg_check = 'brute'
-            else:
+            elif callable(metric) or metric in VALID_METRICS['ball_tree']:
                 alg_check = 'ball_tree'
-                if metric not in VALID_METRICS[alg_check]:
-                    alg_check = 'brute'
+            else:
+                alg_check = 'brute'
         else:
             alg_check = algorithm
 
@@ -231,7 +231,8 @@ class NeighborsBase(six.with_metaclass(ABCMeta, BaseEstimator)):
                     self.metric != 'precomputed'):
                 if self.effective_metric_ in VALID_METRICS['kd_tree']:
                     self._fit_method = 'kd_tree'
-                elif self.effective_metric_ in VALID_METRICS['ball_tree']:
+                elif (callable(self.effective_metric_) or
+                      self.effective_metric_ in VALID_METRICS['ball_tree']):
                     self._fit_method = 'ball_tree'
                 else:
                     self._fit_method = 'brute'

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -15,8 +15,9 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.validation import check_random_state
-from sklearn.metrics.pairwise import (pairwise_distances,
-                                      PAIRWISE_DISTANCE_FUNCTIONS)
+from sklearn.metrics.pairwise import pairwise_distances
+from sklearn.neighbors.base import (VALID_METRICS,
+                                      VALID_METRICS_SPARSE)
 from sklearn import neighbors, datasets
 from sklearn.exceptions import DataConversionWarning
 
@@ -150,7 +151,7 @@ def test_precomputed(random_state=42):
                 neighbors.RadiusNeighborsClassifier,
                 neighbors.KNeighborsRegressor,
                 neighbors.RadiusNeighborsRegressor):
-        print(Est)
+        
         est = Est(metric='euclidean')
         est.radius = est.n_neighbors = 1
         pred_X = est.fit(X, target).predict(Y)
@@ -985,21 +986,23 @@ def test_callable_metric():
 
     dist1, ind1 = nbrs1.kneighbors(X)
     dist2, ind2 = nbrs2.kneighbors(X)
-
+    
+    assert_true(nbrs1._fit_method, 'ball_tree')
+    assert_true(nbrs2._fit_method, 'ball_tree')
+    
     assert_array_almost_equal(dist1, dist2)
 
 
 def test_algo_auto_metrics():
     X = rng.rand(12, 3)
     Xcsr = csr_matrix(X)
-    Valid_Metrics = dict(dense = ['precomputed', 'sqeuclidean',
-                             'yule', 'cosine', 'correlation'],
-                         sparse=PAIRWISE_DISTANCE_FUNCTIONS.keys())
-    for metric in Valid_Metrics['dense']:
+  
+    for metric in VALID_METRICS['brute']:
         nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                         metric=metric).fit(X)
         assert_true(nn._fit_method, 'brute')
-    for metric in Valid_Metrics['sparse']:
+
+    for metric in VALID_METRICS_SPARSE['brute']:
         nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
                                         metric=metric).fit(Xcsr)
         assert_true(nn._fit_method, 'brute')

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -15,7 +15,8 @@ from sklearn.utils.testing import assert_warns
 from sklearn.utils.testing import ignore_warnings
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.validation import check_random_state
-from sklearn.metrics.pairwise import pairwise_distances
+from sklearn.metrics.pairwise import (pairwise_distances,
+                                      PAIRWISE_DISTANCE_FUNCTIONS)
 from sklearn import neighbors, datasets
 from sklearn.exceptions import DataConversionWarning
 
@@ -986,6 +987,22 @@ def test_callable_metric():
     dist2, ind2 = nbrs2.kneighbors(X)
 
     assert_array_almost_equal(dist1, dist2)
+
+
+def test_algo_auto_metrics():
+    X = rng.rand(12, 3)
+    Xcsr = csr_matrix(X)
+    Valid_Metrics = dict(dense = ['precomputed', 'sqeuclidean',
+                             'yule', 'cosine', 'correlation'],
+                         sparse=PAIRWISE_DISTANCE_FUNCTIONS.keys())
+    for metric in Valid_Metrics['dense']:
+        nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
+                                        metric=metric).fit(X)
+        assert_true(nn._fit_method, 'brute')
+    for metric in Valid_Metrics['sparse']:
+        nn = neighbors.NearestNeighbors(n_neighbors=3, algorithm='auto',
+                                        metric=metric).fit(Xcsr)
+        assert_true(nn._fit_method, 'brute')
 
 
 def test_metric_params_interface():


### PR DESCRIPTION
Solves #4931. Continues work done in #5596 
#### What does this implement/fix? Explain your changes.

 'auto' should default to 'brute' when trees do not support the metric.
#### Any other comments?

Right now, the tests are failing on metric `mahalnobis`, `seuclidean` and `wminkowski`. Please do have a look and let me know if there is any particular reason for the failing tests.
