### PR TITLE
[MRG+1] Added override of fit_transform to LabelBinarizer

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -352,8 +352,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         Y : numpy array or CSR matrix of shape [n_samples, n_classes]
             Shape will be [n_samples, 1] for binary problems.
         """
-        self.fit(y)
-        return self.transform(y)
+        return super(fit_transform, self).fit_transform(y)
     
     
     def inverse_transform(self, Y, threshold=None):

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -333,7 +333,29 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                               pos_label=self.pos_label,
                               neg_label=self.neg_label,
                               sparse_output=self.sparse_output)
+    
+    def fit_transform(self, y):
+        """Fit label binarizer and transform multi-class labels to binary labels.
+        
+        The output of transform is sometimes referred to by some authors as the
+        1-of-K coding scheme.
 
+        Parameters
+        ----------
+        y : numpy array or sparse matrix of shape (n_samples,) or
+            (n_samples, n_classes) Target values. The 2-d matrix should only
+            contain 0 and 1, represents multilabel classification. Sparse
+            matrix can be CSR, CSC, COO, DOK, or LIL.
+
+        Returns
+        -------
+        Y : numpy array or CSR matrix of shape [n_samples, n_classes]
+            Shape will be [n_samples, 1] for binary problems.
+        """
+        self.fit(y)
+        return self.transform(y)
+    
+    
     def inverse_transform(self, Y, threshold=None):
         """Transform binary labels back to multi-class labels
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -285,7 +285,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array of shape (n_samples,) or (n_samples, n_classes)
+        y : array of shape (n_samples,) or (n_samples, n_classes)
             Target values. The 2-d matrix should only contain 0 and 1,
             represents multilabel classification.
 
@@ -312,14 +312,13 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array or sparse matrix of shape (n_samples,) or
-            (n_samples, n_classes) Target values. The 2-d matrix should only
-            contain 0 and 1, represents multilabel classification. Sparse
-            matrix can be CSR, CSC, COO, DOK, or LIL.
+        y : array or sparse matrix of shape (n_samples,) or (n_samples, n_classes) 
+            Target values. The 2-d matrix should only contain 0 and 1, and represents 
+            multilabel classification. Sparse matrix can be CSR, CSC, COO, DOK, or LIL.
 
         Returns
         -------
-        Y : numpy array or CSR matrix of shape [n_samples, n_classes]
+        Y : array or CSR matrix of shape [n_samples, n_classes]
             Shape will be [n_samples, 1] for binary problems.
         """
         return self.fit(y).transform(y)
@@ -332,8 +331,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : numpy array or sparse matrix of shape (n_samples,) or
-            (n_samples, n_classes) Target values. The 2-d matrix should only
+        y : array or sparse matrix of shape (n_samples,) or (n_samples, n_classes) 
+            Target values. The 2-d matrix should only
             contain 0 and 1, represents multilabel classification. Sparse
             matrix can be CSR, CSC, COO, DOK, or LIL.
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -304,6 +304,26 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         self.classes_ = unique_labels(y)
         return self
 
+    def fit_transform(self, y):
+        """Fit label binarizer and transform multi-class labels to binary labels.
+        
+        The output of transform is sometimes referred to by some authors as the
+        1-of-K coding scheme.
+
+        Parameters
+        ----------
+        y : numpy array or sparse matrix of shape (n_samples,) or
+            (n_samples, n_classes) Target values. The 2-d matrix should only
+            contain 0 and 1, represents multilabel classification. Sparse
+            matrix can be CSR, CSC, COO, DOK, or LIL.
+
+        Returns
+        -------
+        Y : numpy array or CSR matrix of shape [n_samples, n_classes]
+            Shape will be [n_samples, 1] for binary problems.
+        """
+        return self.fit(y).transform(y)
+
     def transform(self, y):
         """Transform multi-class labels to binary labels
 
@@ -333,27 +353,6 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                               pos_label=self.pos_label,
                               neg_label=self.neg_label,
                               sparse_output=self.sparse_output)
-    
-    def fit_transform(self, y):
-        """Fit label binarizer and transform multi-class labels to binary labels.
-        
-        The output of transform is sometimes referred to by some authors as the
-        1-of-K coding scheme.
-
-        Parameters
-        ----------
-        y : numpy array or sparse matrix of shape (n_samples,) or
-            (n_samples, n_classes) Target values. The 2-d matrix should only
-            contain 0 and 1, represents multilabel classification. Sparse
-            matrix can be CSR, CSC, COO, DOK, or LIL.
-
-        Returns
-        -------
-        Y : numpy array or CSR matrix of shape [n_samples, n_classes]
-            Shape will be [n_samples, 1] for binary problems.
-        """
-        return super(fit_transform, self).fit_transform(y)
-    
     
     def inverse_transform(self, Y, threshold=None):
         """Transform binary labels back to multi-class labels

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -285,7 +285,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : array of shape (n_samples,) or (n_samples, n_classes)
+        y : array of shape [n_samples,] or [n_samples, n_classes]
             Target values. The 2-d matrix should only contain 0 and 1,
             represents multilabel classification.
 
@@ -308,13 +308,13 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         """Fit label binarizer and transform multi-class labels to binary
         labels.
 
-        The output of transform is sometimes referred to by some authors as
+        The output of transform is sometimes referred to    as
         the 1-of-K coding scheme.
 
         Parameters
         ----------
-        y : array or sparse matrix of shape (n_samples,) or \
-(n_samples, n_classes)
+        y : array or sparse matrix of shape [n_samples,] or \
+            [n_samples, n_classes]
             Target values. The 2-d matrix should only contain 0 and 1,
             represents multilabel classification. Sparse matrix can be
             CSR, CSC, COO, DOK, or LIL.
@@ -334,8 +334,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        y : array or sparse matrix of shape (n_samples,) or \
-(n_samples, n_classes)
+        y : array or sparse matrix of shape [n_samples,] or \
+            [n_samples, n_classes]
             Target values. The 2-d matrix should only contain 0 and 1,
             represents multilabel classification. Sparse matrix can be
             CSR, CSC, COO, DOK, or LIL.

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -305,16 +305,19 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         return self
 
     def fit_transform(self, y):
-        """Fit label binarizer and transform multi-class labels to binary labels.
+        """Fit label binarizer and transform multi-class labels to binary
+        labels.
 
-        The output of transform is sometimes referred to by some authors as the
-        1-of-K coding scheme.
+        The output of transform is sometimes referred to by some authors as
+        the 1-of-K coding scheme.
 
         Parameters
         ----------
-        y : array or sparse matrix of shape (n_samples,) or (n_samples, n_classes) 
-            Target values. The 2-d matrix should only contain 0 and 1, and represents 
-            multilabel classification. Sparse matrix can be CSR, CSC, COO, DOK, or LIL.
+        y : array or sparse matrix of shape (n_samples,) or \
+(n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1,
+            represents multilabel classification. Sparse matrix can be
+            CSR, CSC, COO, DOK, or LIL.
 
         Returns
         -------
@@ -326,15 +329,16 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
     def transform(self, y):
         """Transform multi-class labels to binary labels
 
-        The output of transform is sometimes referred to by some authors as the
-        1-of-K coding scheme.
+        The output of transform is sometimes referred to by some authors as
+        the 1-of-K coding scheme.
 
         Parameters
         ----------
-        y : array or sparse matrix of shape (n_samples,) or (n_samples, n_classes) 
-            Target values. The 2-d matrix should only
-            contain 0 and 1, represents multilabel classification. Sparse
-            matrix can be CSR, CSC, COO, DOK, or LIL.
+        y : array or sparse matrix of shape (n_samples,) or \
+(n_samples, n_classes)
+            Target values. The 2-d matrix should only contain 0 and 1,
+            represents multilabel classification. Sparse matrix can be
+            CSR, CSC, COO, DOK, or LIL.
 
         Returns
         -------

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -306,7 +306,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
 
     def fit_transform(self, y):
         """Fit label binarizer and transform multi-class labels to binary labels.
-        
+
         The output of transform is sometimes referred to by some authors as the
         1-of-K coding scheme.
 
@@ -353,7 +353,7 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
                               pos_label=self.pos_label,
                               neg_label=self.neg_label,
                               sparse_output=self.sparse_output)
-    
+
     def inverse_transform(self, Y, threshold=None):
         """Transform binary labels back to multi-class labels
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#7238
#### What does this implement/fix? Explain your changes.

Added an override of the `fit_transform` method to the LabelBinarizer class and provided a
new docstring based on the `fit` and `transform` docstrings. 
#### Any other comments?

To keep the original behavior, I'm assuming I should call the base class
`fit_transform` method? Let me know if you want it to do something else.

Also, I haven't had a chance to run tests on the change yet, but will do that when
I get home this afternoon.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
