### PR TITLE
[MRG + 1] Move n_iter and get_params invariance tests to common estimator_checks

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -28,10 +28,8 @@ from sklearn.cluster.bicluster import BiclusterMixin
 from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils.estimator_checks import (
     _yield_all_checks,
-    CROSS_DECOMPOSITION,
     check_parameters_default_constructible,
-    check_class_weight_balanced_linear_classifier,
-    check_non_transformer_estimators_n_iter)
+    check_class_weight_balanced_linear_classifier)
 
 
 def test_all_estimator_no_base_class():
@@ -160,39 +158,3 @@ def test_all_tests_are_importable():
                  '{0} do not have `tests` subpackages. Perhaps they require '
                  '__init__.py or an add_subpackage directive in the parent '
                  'setup.py'.format(missing_tests))
-
-
-def test_non_transformer_estimators_n_iter():
-    # Test that all estimators of type which are non-transformer
-    # and which have an attribute of max_iter, return the attribute
-    # of n_iter atleast 1.
-    for est_type in ['regressor', 'classifier', 'cluster']:
-        regressors = all_estimators(type_filter=est_type)
-        for name, Estimator in regressors:
-            # LassoLars stops early for the default alpha=1.0 for
-            # the iris dataset.
-            if name == 'LassoLars':
-                estimator = Estimator(alpha=0.)
-            else:
-                with ignore_warnings(category=DeprecationWarning):
-                    estimator = Estimator()
-            if hasattr(estimator, "max_iter"):
-                # These models are dependent on external solvers like
-                # libsvm and accessing the iter parameter is non-trivial.
-                if name in (['Ridge', 'SVR', 'NuSVR', 'NuSVC',
-                             'RidgeClassifier', 'SVC', 'RandomizedLasso',
-                             'LogisticRegressionCV']):
-                    continue
-
-                # Tested in test_transformer_n_iter below
-                elif (name in CROSS_DECOMPOSITION or
-                      name in ['LinearSVC', 'LogisticRegression']):
-                    continue
-
-                else:
-                    # Multitask models related to ENet cannot handle
-                    # if y is mono-output.
-                    yield (_named_check(
-                        check_non_transformer_estimators_n_iter, name),
-                        name, estimator, 'Multi' in name)
-

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -31,9 +31,7 @@ from sklearn.utils.estimator_checks import (
     CROSS_DECOMPOSITION,
     check_parameters_default_constructible,
     check_class_weight_balanced_linear_classifier,
-    check_transformer_n_iter,
-    check_non_transformer_estimators_n_iter,
-    check_get_params_invariance)
+    check_non_transformer_estimators_n_iter)
 
 
 def test_all_estimator_no_base_class():
@@ -198,17 +196,3 @@ def test_non_transformer_estimators_n_iter():
                         check_non_transformer_estimators_n_iter, name),
                         name, estimator, 'Multi' in name)
 
-
-def test_transformer_n_iter():
-    transformers = all_estimators(type_filter='transformer')
-    for name, Estimator in transformers:
-        with ignore_warnings(category=DeprecationWarning):
-            estimator = Estimator()
-        # Dependent on external solvers and hence accessing the iter
-        # param is non-trivial.
-        external_solver = ['Isomap', 'KernelPCA', 'LocallyLinearEmbedding',
-                           'RandomizedLasso', 'LogisticRegressionCV']
-
-        if hasattr(estimator, "max_iter") and name not in external_solver:
-            yield _named_check(
-                check_transformer_n_iter, name), name, estimator

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -212,22 +212,3 @@ def test_transformer_n_iter():
         if hasattr(estimator, "max_iter") and name not in external_solver:
             yield _named_check(
                 check_transformer_n_iter, name), name, estimator
-
-
-def test_get_params_invariance():
-    # Test for estimators that support get_params, that
-    # get_params(deep=False) is a subset of get_params(deep=True)
-    # Related to issue #4465
-
-    estimators = all_estimators(include_meta_estimators=False,
-                                include_other=True)
-    for name, Estimator in estimators:
-        if hasattr(Estimator, 'get_params'):
-            # If class is deprecated, ignore deprecated warnings
-            if hasattr(Estimator.__init__, "deprecated_original"):
-                with ignore_warnings():
-                    yield _named_check(
-                        check_get_params_invariance, name), name, Estimator
-            else:
-                yield _named_check(
-                    check_get_params_invariance, name), name, Estimator

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1484,20 +1484,17 @@ def multioutput_estimator_convert_y_2d(name, y):
 
 
 @ignore_warnings(category=DeprecationWarning)
-def check_non_transformer_estimators_n_iter(name, Estimator,
-                                            multi_output=False):
-    # Test that estimators that are not transformers with an attribute max_iter,
-    # return the attribute of n_iter at least 1.
+def check_non_transformer_estimators_n_iter(name, Estimator):
+    # Test that estimators that are not transformers with an attribute
+    # max_iter, return the attribute of n_iter at least 1.
 
     # These models are dependent on external solvers like
     # libsvm and accessing the iter parameter is non-trivial.
-    not_run_check_n_iter = ['Ridge', 'SVR', 'NuSVR', 'NuSVC', 'RidgeClassifier',
-                            'SVC', 'RandomizedLasso', 'LogisticRegressionCV',
-                            'LinearSVC', 'LogisticRegression']
+    not_run_check_n_iter = ['Ridge', 'SVR', 'NuSVR', 'NuSVC',
+                            'RidgeClassifier', 'SVC', 'RandomizedLasso',
+                            'LogisticRegressionCV', 'LinearSVC',
+                            'LogisticRegression']
 
-    # Models made for multi-class scenarios
-    not_run_check_n_iter += ['MultiTaskElasticNet', 'MultiTaskElasticNetCV',
-                             'MultiTaskLasso', 'MultiTaskLassoCV']
     # Tested in test_transformer_n_iter
     not_run_check_n_iter += CROSS_DECOMPOSITION
     if name in not_run_check_n_iter:
@@ -1511,9 +1508,7 @@ def check_non_transformer_estimators_n_iter(name, Estimator,
     if hasattr(estimator, 'max_iter'):
         iris = load_iris()
         X, y_ = iris.data, iris.target
-
-        if multi_output:
-            y_ = np.reshape(y_, (-1, 1))
+        y_ = multioutput_estimator_convert_y_2d(name, y_)
 
         set_random_state(estimator, 0)
         if name == 'AffinityPropagation':

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -218,6 +218,7 @@ def _yield_all_checks(name, Estimator):
     yield check_fit2d_1feature
     yield check_fit1d_1feature
     yield check_fit1d_1sample
+    yield check_get_params_invariance
 
 
 def check_estimator(Estimator):
@@ -1516,7 +1517,9 @@ def check_transformer_n_iter(name, estimator):
         assert_greater_equal(estimator.n_iter_, 1)
 
 
+@ignore_warnings(category=DeprecationWarning)
 def check_get_params_invariance(name, estimator):
+    # Checks if get_params(deep=False) is a subset of get_params(deep=True)
     class T(BaseEstimator):
         """Mock classifier
         """

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1485,8 +1485,8 @@ def multioutput_estimator_convert_y_2d(name, y):
 
 @ignore_warnings(category=DeprecationWarning)
 def check_non_transformer_estimators_n_iter(name, Estimator):
-    # Test that estimators that are not transformers with an attribute
-    # max_iter, return the attribute of n_iter at least 1.
+    # Test that estimators that are not transformers with a parameter
+    # max_iter, return the attribute of n_iter_ at least 1.
 
     # These models are dependent on external solvers like
     # libsvm and accessing the iter parameter is non-trivial.
@@ -1524,8 +1524,8 @@ def check_non_transformer_estimators_n_iter(name, Estimator):
 
 @ignore_warnings(category=DeprecationWarning)
 def check_transformer_n_iter(name, Estimator):
-    # Test that transformers with an attribute max_iter, return the attribute
-    # of n_iter at least 1.
+    # Test that transformers with a parameter max_iter, return the
+    # attribute of n_iter_ at least 1.
     estimator = Estimator()
     if hasattr(estimator, "max_iter"):
         if name in CROSS_DECOMPOSITION:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -108,21 +108,6 @@ def _yield_non_meta_checks(name, Estimator):
     # give the same answer as before.
     yield check_estimators_pickle
 
-    # FIXME find out how to incorporate the following line as
-    #       the test runs for more estimators than before and
-    #       fails for some of them. Before this commit, the
-    #       test only fan for:
-    # for est_type in ['regressor', 'classifier', 'cluster']:
-
-    # These models are dependent on external solvers like
-    # libsvm and accessing the iter parameter is non-trivial.
-    not_run_check_n_iter = ['Ridge', 'SVR', 'NuSVR', 'NuSVC', 'RidgeClassifier',
-                            'SVC', 'RandomizedLasso', 'LogisticRegressionCV']
-    # Tested in test_transformer_n_iter
-    not_run_check_n_iter += CROSS_DECOMPOSITION + ['LinearSVC', 'LogisticRegression']
-    if name not in not_run_check_n_iter:
-        yield check_non_transformer_estimators_n_iter
-
 
 def _yield_classifier_checks(name, Classifier):
     # test classifiers can handle non-array data
@@ -146,6 +131,8 @@ def _yield_classifier_checks(name, Classifier):
     yield check_estimators_unfitted
     if 'class_weight' in Classifier().get_params().keys():
         yield check_class_weight_classifiers
+
+    yield check_non_transformer_estimators_n_iter
 
 
 @ignore_warnings(category=DeprecationWarning)
@@ -187,6 +174,7 @@ def _yield_regressor_checks(name, Regressor):
     if name != "GaussianProcessRegressor":
         # Test if NotFittedError is raised
         yield check_estimators_unfitted
+    yield check_non_transformer_estimators_n_iter
 
 
 def _yield_transformer_checks(name, Transformer):
@@ -217,6 +205,7 @@ def _yield_clustering_checks(name, Clusterer):
         # let's not test that here.
         yield check_clustering
         yield check_estimators_partial_fit_n_features
+    yield check_non_transformer_estimators_n_iter
 
 
 def _yield_all_checks(name, Estimator):
@@ -1499,6 +1488,20 @@ def check_non_transformer_estimators_n_iter(name, Estimator,
                                             multi_output=False):
     # Test that estimators that are not transformers with an attribute max_iter,
     # return the attribute of n_iter at least 1.
+
+    # These models are dependent on external solvers like
+    # libsvm and accessing the iter parameter is non-trivial.
+    not_run_check_n_iter = ['Ridge', 'SVR', 'NuSVR', 'NuSVC', 'RidgeClassifier',
+                            'SVC', 'RandomizedLasso', 'LogisticRegressionCV',
+                            'LinearSVC', 'LogisticRegression']
+
+    # Models made for multi-class scenarios
+    not_run_check_n_iter += ['MultiTaskElasticNet', 'MultiTaskElasticNetCV',
+                             'MultiTaskLasso', 'MultiTaskLassoCV']
+    # Tested in test_transformer_n_iter
+    not_run_check_n_iter += CROSS_DECOMPOSITION
+    if name in not_run_check_n_iter:
+        return
 
     # LassoLars stops early for the default alpha=1.0 the iris dataset.
     if name == 'LassoLars':


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Partially fixes issue #7533 by moving  tests relating to n_iter and invariance of get_params to common estimator_checks.
#### Any other comments?

Right now, test_transformer_n_iter() in utils/estimator_checks.py fails for some estimators that are not transformers. The reason is most likely that the test is now run for some estimators for which it is not applicable. This still needs to be fixed, see: https://github.com/scikit-learn/scikit-learn/commit/f534c3409b1a1e524e7c1e632c93b31d223d578e
