### PR TITLE
DOC: fix return value doc for mixture.base._e_step

### DIFF
--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -250,8 +250,8 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
 
         Returns
         -------
-        log_prob_norm : array, shape (n_samples,)
-            Logarithm of the probability of each sample in X.
+        log_prob_norm : float
+            Mean of the logarithms of the probabilities of each sample in X
 
         log_responsibility : array, shape (n_samples, n_components)
             Logarithm of the posterior probabilities (or responsibilities) of


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

The listed return value of `mixture.base._e_step` should reflect that the mean of `log_prob_norm` only returns a single value, rather than an array-like value.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
