### PR TITLE
[MRG + 1] Changed Contributor's Guide to Development Guide #7690

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Development
 
 We welcome new contributors of all experience levels. The scikit-learn
 community goals are to be helpful, welcoming, and effective. The
-`Contributor's Guide <http://scikit-learn.org/stable/developers/index.html>`_ 
+`Development Guide <http://scikit-learn.org/stable/developers/index.html>`_ 
 has detailed information about contributing code, documentation, tests, and
 more. We've included some basic information in this README.
 

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -64,7 +64,7 @@ Documentation of scikit-learn 0.19.dev0
           <!-- row -->
             <div class="row-fluid">
                 <div class="span4 box">
-                    <h2><a href="developers/index.html">Contributing</a></h2>
+                    <h2><a href="developers/index.html">Development</a></h2>
                             <blockquote>Information on how to contribute. This also
                             contains useful information for advanced users, for example
                             how to build their own estimators.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#7690
#### What does this implement/fix? Explain your changes.

Changed the name of the link to the developer's guide to "development" from "contributor's".
#### Any other comments?

Could also change name to "Developer's Guide" to match what the linked to page says if that would be preferred.  I ran the `make` and `make flake8-diff` tests and got some warnings/errors, even though I never changed the code.  Can post the exact messages if anyone wants them but figured I'd open this anyways to get this started.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
