### PR TITLE
[MRG+1] CircleCI timeout extended

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ dependencies:
   # Check whether the doc build is required, install build dependencies and
   # run sphinx to build the doc.
   override:
-    - ./build_tools/circle/build_doc.sh
+    - ./build_tools/circle/build_doc.sh:
+        timeout: 3600 # seconds
 test:
   # Grep error on the documentation
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   # run sphinx to build the doc.
   override:
     - ./build_tools/circle/build_doc.sh:
-        timeout: 3600 # seconds
+        timeout: 3600 # in seconds
 test:
   # Grep error on the documentation
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   # run sphinx to build the doc.
   override:
     - ./build_tools/circle/build_doc.sh:
-        timeout: 3600 # in seconds
+        timeout: 3600 # seconds
 test:
   # Grep error on the documentation
   override:


### PR DESCRIPTION
This PR fixes the problem of previous CircleCI timeouts.

Recently some [CircleCI-builds time out](https://circleci.com/gh/scikit-learn/scikit-learn/tree/master), as `build_tools/circle/push_doc.sh` takes too long (30-40 min, [default-timeout: 10 min](https://circleci.com/docs/configuration/#modifiers)).

This PR sets the new timeout to 1 hour (the max. seems to be [2h](https://discuss.circleci.com/t/timeout-more-than-120-minutes)).

[The build fails on my fork](https://circleci.com/gh/jstriebel/scikit-learn/2), probably because credentials are missing. But the timeout-option seems to be OK.

Thanks for considering this PR.
