### PR TITLE
[MRG+2] switch to multinomial composition for mixture sampling

### DIFF
--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -385,7 +385,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
 
         _, n_features = self.means_.shape
         rng = check_random_state(self.random_state)
-        n_samples_comp = np.round(self.weights_ * n_samples).astype(int)
+        n_samples_comp = rng.multinomial(n_samples, self.weights_).astype(int)
 
         if self.covariance_type == 'full':
             X = np.vstack([

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -385,7 +385,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
 
         _, n_features = self.means_.shape
         rng = check_random_state(self.random_state)
-        n_samples_comp = rng.multinomial(n_samples, self.weights_).astype(int)
+        n_samples_comp = rng.multinomial(n_samples, self.weights_)
 
         if self.covariance_type == 'full':
             X = np.vstack([

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -918,7 +918,7 @@ def test_property():
 
 def test_sample():
     rng = np.random.RandomState(0)
-    rand_data = RandomData(rng, scale=7)
+    rand_data = RandomData(rng, scale=7, n_components=3)
     n_features, n_components = rand_data.n_features, rand_data.n_components
 
     for covar_type in COVARIANCE_TYPE:
@@ -937,7 +937,8 @@ def test_sample():
         # Just to make sure the class samples correctly
         n_samples = 20000
         X_s, y_s = gmm.sample(n_samples)
-        for k in range(n_features):
+
+        for k in range(n_components):
             if covar_type == 'full':
                 assert_array_almost_equal(gmm.covariances_[k],
                                           np.cov(X_s[y_s == k].T), decimal=1)
@@ -954,15 +955,16 @@ def test_sample():
                     decimal=1)
 
         means_s = np.array([np.mean(X_s[y_s == k], 0)
-                           for k in range(n_features)])
+                           for k in range(n_components)])
         assert_array_almost_equal(gmm.means_, means_s, decimal=1)
 
-        # Check that sizes that are drawn match what is requested
-        assert_equal(X_s.shape, (n_samples, n_components))
-        for sample_size in range(1, 50):
-            X_s, _ = gmm.sample(sample_size)
-            assert_equal(X_s.shape, (sample_size, n_components))
+        # Check shapes of sampled data, see
+        # https://github.com/scikit-learn/scikit-learn/issues/7701
+        assert_equal(X_s.shape, (n_samples, n_features))
 
+        for sample_size in range(1, 100):
+            X_s, _ = gmm.sample(sample_size)
+            assert_equal(X_s.shape, (sample_size, n_features))
 
 
 @ignore_warnings(category=ConvergenceWarning)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -935,7 +935,8 @@ def test_sample():
                              gmm.sample, 0)
 
         # Just to make sure the class samples correctly
-        X_s, y_s = gmm.sample(20000)
+        n_samples = 20000
+        X_s, y_s = gmm.sample(n_samples)
         for k in range(n_features):
             if covar_type == 'full':
                 assert_array_almost_equal(gmm.covariances_[k],
@@ -955,6 +956,13 @@ def test_sample():
         means_s = np.array([np.mean(X_s[y_s == k], 0)
                            for k in range(n_features)])
         assert_array_almost_equal(gmm.means_, means_s, decimal=1)
+
+        # Check that sizes that are drawn match what is requested
+        assert_equal(X_s.shape, (n_samples, n_components))
+        for sample_size in range(1, 50):
+            X_s, _ = gmm.sample(sample_size)
+            assert_equal(X_s.shape, (sample_size, n_components))
+
 
 
 @ignore_warnings(category=ConvergenceWarning)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

fixes #7701 
#### What does this implement/fix? Explain your changes.

This changes the way mixture models construct the composition of new samples. Specifically, any subclass deriving from`BaseMixture.sample` is affected. 

Instead of rounding the composition vector from `weights * n_samples`, this draws the composition vector from a multinomial distribution. Thus, samples return are guaranteed to have the number of observations requested by the user. However, the composition of the sample is now stochastic. 

In addition, this adds tests to ensure that `n_samples` are returned when `mixture.sample(n_samples)` is called. 

This may affect scaling for mixture models with a very large number of dimensions, since the multinational composition draw may be slow. But, this composition draw only occurs once during sampling. 
#### Any other comments?

None. Thanks for the great package!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
