### PR TITLE
[MRG + 1] DOC add a section in what's new listing changed models

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,9 @@ occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
 * tree-based models using ``min_weight_fraction_leaf``
+* :class:`feature_selection.SelectFdr`
+
+Details are listed in the changelog below.
 
 (While we are trying to better inform users by providing this information, we
 cannot assure that this list is complete.)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,6 +10,19 @@ Version 0.19
 
 **In Development**
 
+Changed models
+--------------
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+* tree-based models using ``min_weight_fraction_leaf``
+
+(While we are trying to better inform users by providing this information, we
+cannot assure that this list is complete.)
+
 Changelog
 ---------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,8 +18,7 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-* tree-based models using ``min_weight_fraction_leaf``
-* :class:`feature_selection.SelectFdr`
+* *to be listed*
 
 Details are listed in the changelog below.
 


### PR DESCRIPTION
At least @amueller and I have mooted having this sort of listing in what's new, so that changes in modelling with saved code/data can be anticipated. I think it would be best built progressively. For example, if merged, #7703 will add a few entries; we've got a bug fix coming in `SelectFdr`, etc.
