### PR TITLE
[MRG + 1] Update docs with new line_profiler signature and extension method

### DIFF
--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -221,12 +221,8 @@ us install ``line-profiler`` and wire it to IPython::
 
   Then register the line-profiler extension in ``~/.ipython/profile_default/ipython_config.py``::
 
-    c.TerminalIPythonApp.extensions = [
-        'line_profiler',
-    ]
-    c.InteractiveShellApp.extensions = [
-        'line_profiler',
-    ]
+    c.TerminalIPythonApp.extensions.append('line_profiler')
+    c.InteractiveShellApp.extensions.append('line_profiler')
 
   This will register the ``%lprun`` magic command in the IPython terminal
   application and the other frontends such as qtconsole and notebook.
@@ -298,12 +294,8 @@ Then, setup the magics in a manner similar to ``line_profiler``.
 
   Then register the extension in ``~/.ipython/profile_default/ipython_config.py`` alongside the line profiler::
 
-    c.TerminalIPythonApp.extensions = [
-        'line_profiler', 'memory_profiler',
-    ]
-    c.InteractiveShellApp.extensions = [
-        'line_profiler', 'memory_profiler',
-    ]
+    c.TerminalIPythonApp.extensions.append('memory_profiler')
+    c.InteractiveShellApp.extensions.append('memory_profiler')
 
   This will register the ``%memit`` and ``%mprun`` magic commands in the
   IPython terminal application and the other frontends such as qtconsole and

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -292,38 +292,17 @@ install the latest version::
 
 Then, setup the magics in a manner similar to ``line_profiler``.
 
-- **Under IPython <= 0.10**, edit ``~/.ipython/ipy_user_conf.py`` and
-  ensure the following lines are present::
-
-    import IPython.ipapi
-    ip = IPython.ipapi.get()
-
-  Towards the end of the file, define the ``%memit`` and ``%mprun`` magics::
-
-    import memory_profiler
-    ip.expose_magic('memit', memory_profiler.magic_memit)
-    ip.expose_magic('mprun', memory_profiler.magic_mprun)
-
 - **Under IPython 0.11+**, first create a configuration profile::
 
     $ ipython profile create
 
-  Then create a file named ``~/.ipython/extensions/memory_profiler_ext.py``
-  with the following content::
-
-    import memory_profiler
-
-    def load_ipython_extension(ip):
-        ip.define_magic('memit', memory_profiler.magic_memit)
-        ip.define_magic('mprun', memory_profiler.magic_mprun)
-
-  Then register it in ``~/.ipython/profile_default/ipython_config.py``::
+  Then register the extension in ``~/.ipython/profile_default/ipython_config.py`` alongside the line profiler::
 
     c.TerminalIPythonApp.extensions = [
-        'memory_profiler_ext',
+        'line_profiler', 'memory_profiler',
     ]
     c.InteractiveShellApp.extensions = [
-        'memory_profiler_ext',
+        'line_profiler', 'memory_profiler',
     ]
 
   This will register the ``%memit`` and ``%mprun`` magic commands in the

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -211,40 +211,21 @@ It is however still interesting to check what's happening inside the
 ``_nls_subproblem`` function which is the hotspot if we only consider
 Python code: it takes around 100% of the accumulated time of the module. In
 order to better understand the profile of this specific function, let
-us install ``line-prof`` and wire it to IPython::
+us install ``line-profiler`` and wire it to IPython::
 
   $ pip install line-profiler
 
-- **Under IPython <= 0.10**, edit ``~/.ipython/ipy_user_conf.py`` and
-  ensure the following lines are present::
-
-    import IPython.ipapi
-    ip = IPython.ipapi.get()
-
-  Towards the end of the file, define the ``%lprun`` magic::
-
-    import line_profiler
-    ip.expose_magic('lprun', line_profiler.magic_lprun)
-
-- **Under IPython 0.11+**, first create a configuration profile::
+- **Under IPython 0.13+**, first create a configuration profile::
 
     $ ipython profile create
 
-  Then create a file named ``~/.ipython/extensions/line_profiler_ext.py`` with
-  the following content::
-
-    import line_profiler
-
-    def load_ipython_extension(ip):
-        ip.define_magic('lprun', line_profiler.magic_lprun)
-
-  Then register it in ``~/.ipython/profile_default/ipython_config.py``::
+  Then register the line-profiler extension in ``~/.ipython/profile_default/ipython_config.py``::
 
     c.TerminalIPythonApp.extensions = [
-        'line_profiler_ext',
+        'line_profiler',
     ]
     c.InteractiveShellApp.extensions = [
-        'line_profiler_ext',
+        'line_profiler',
     ]
 
   This will register the ``%lprun`` magic command in the IPython terminal


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Fixes the line_profiler installation and setup under IPython 5.0+, which no longer supports the define_magic method for registering magic commands.  Since the magic command is now defined inside line_profiler, we don't need to create a custom extension and register it, we can just register the default line_profiler extension.
#### Any other comments?

Probably also worth looking at the memory profiler setup, which also defines a custom extension using define_magic

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
