### PR TITLE
Better default min_samples for RANSACRegressor

### DIFF
--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -91,7 +91,7 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         `min_samples` is chosen as ``X.shape[1] + 1``. This parameter is highly
         depedent upon the model, so if a base_estimator other than
         `LinearRegression` is used, the user must provide a value. For example,
-        when RANSAC is used to find correspondances between images, a value of
+        when RANSAC is used to find correspondences between images, a value of
         4 is appropriate for stereo images, and 2 is appropriate for images of
         a rigid body in motion.
 

--- a/sklearn/linear_model/ransac.py
+++ b/sklearn/linear_model/ransac.py
@@ -88,7 +88,12 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         `min_samples < 1`. This is typically chosen as the minimal number of
         samples necessary to estimate the given `base_estimator`. By default a
         ``sklearn.linear_model.LinearRegression()`` estimator is assumed and
-        `min_samples` is chosen as ``X.shape[1] + 1``.
+        `min_samples` is chosen as ``X.shape[1] + 1``. This parameter is highly
+        depedent upon the model, so if a base_estimator other than
+        `LinearRegression` is used, the user must provide a value. For example,
+        when RANSAC is used to find correspondances between images, a value of
+        4 is appropriate for stereo images, and 2 is appropriate for images of
+        a rigid body in motion.
 
     residual_threshold : float, optional
         Maximum residual for a data sample to be classified as an inlier.
@@ -229,8 +234,13 @@ class RANSACRegressor(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
             base_estimator = LinearRegression()
 
         if self.min_samples is None:
-            # assume linear model by default
-            min_samples = X.shape[1] + 1
+            if isinstance(base_estimator, LinearRegression):
+                min_samples = X.shape[1] + 1
+            else:
+                raise ValueError("a value for min_samples must be provided "
+                                 "for models other than LinearRegression. The "
+                                 "appropriate value will be dependent on the "
+                                 "precise model.")
         elif 0 < self.min_samples < 1:
             min_samples = np.ceil(self.min_samples * X.shape[0])
         elif self.min_samples >= 1:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->

Fixes #6437 
#### What does this implement/fix? Explain your changes.

By default, RANSACRegressor uses a sample size based on the number of features in the input, which is appropriate for linear regression (which is used by default) but not for other models. This patch raises a ValueError if a model is used other than linear regression and no sample size is provided.
#### Any other comments?

Based on the discussion in the issue thread, there seemed to be no default option that could possibly be appropriate for an arbitrary model because the appropriate sample size is different for each problem. This raises an error early instead of going ahead with hyperparameters that will probably cause the regression to fail.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
