### PR TITLE
[MRG+2] Fixed n**2 memory blowup in _labels_inertia_precompute_dense

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,12 @@ New features
 Enhancements
 ............
 
+   - :class:`cluster.MiniBatchKMeans` and :class:`cluster.KMeans`
+     now uses significantly less memory when assigning data points to their
+     nearest cluster center.
+     (`#7721 <https://github.com/scikit-learn/scikit-learn/pull/7721>`_)
+     By `Jon Crall`_.
+
    - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`
      that matches the ``classes_`` attribute of ``best_estimator_``. (`#7661
      <https://github.com/scikit-learn/scikit-learn/pull/7661>`_) by `Alyssa

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -556,11 +556,9 @@ def _labels_inertia_precompute_dense(X, x_squared_norms, centers, distances):
 
     # Breakup nearest neighbor distance computation into batches to prevent
     # memory blowup in the case of a large number of samples and clusters.
-    metric_kwargs = dict(squared=True)
-    # TODO: Once the functionality (PR #7383) is merged use check_inputs=False.
-    # metric_kwargs = dict(squared=True, check_inputs=False)
+    # TODO: Once PR #7383 is merged use check_inputs=False in metric_kwargs.
     labels, mindist = pairwise_distances_argmin_min(
-        X=X, Y=centers, metric='euclidean', metric_kwargs=metric_kwargs)
+        X=X, Y=centers, metric='euclidean', metric_kwargs={'squared': True})
     # cython k-means code assumes int32 inputs
     labels = labels.astype(np.int32)
     if n_samples == distances.shape[0]:

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -18,6 +18,7 @@ import scipy.sparse as sp
 
 from ..base import BaseEstimator, ClusterMixin, TransformerMixin
 from ..metrics.pairwise import euclidean_distances
+from ..metrics.pairwise import pairwise_distances_argmin_min
 from ..utils.extmath import row_norms, squared_norm, stable_cumsum
 from ..utils.sparsefuncs_fast import assign_rows_csr
 from ..utils.sparsefuncs import mean_variance_axis
@@ -552,17 +553,16 @@ def _labels_inertia_precompute_dense(X, x_squared_norms, centers, distances):
 
     """
     n_samples = X.shape[0]
-    k = centers.shape[0]
-    all_distances = euclidean_distances(centers, X, x_squared_norms,
-                                        squared=True)
-    labels = np.empty(n_samples, dtype=np.int32)
-    labels.fill(-1)
-    mindist = np.empty(n_samples)
-    mindist.fill(np.infty)
-    for center_id in range(k):
-        dist = all_distances[center_id]
-        labels[dist < mindist] = center_id
-        mindist = np.minimum(dist, mindist)
+
+    # Breakup nearest neighbor distance computation into batches to prevent
+    # memory blowup
+    metric_kwargs = dict(squared=True)
+    # Should use check_inputs=False when speedup_kmpp is merged
+    # metric_kwargs = dict(squared=True, check_inputs=False)
+    labels, mindist = pairwise_distances_argmin_min(
+        X=X, Y=centers, metric='euclidean', metric_kwargs=metric_kwargs)
+    # cython k-means code assumes int32 inputs
+    labels = labels.astype(np.int32)
     if n_samples == distances.shape[0]:
         # distances will be changed in-place
         distances[:] = mindist

--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -555,9 +555,9 @@ def _labels_inertia_precompute_dense(X, x_squared_norms, centers, distances):
     n_samples = X.shape[0]
 
     # Breakup nearest neighbor distance computation into batches to prevent
-    # memory blowup
+    # memory blowup in the case of a large number of samples and clusters.
     metric_kwargs = dict(squared=True)
-    # Should use check_inputs=False when speedup_kmpp is merged
+    # TODO: Once the functionality (PR #7383) is merged use check_inputs=False.
     # metric_kwargs = dict(squared=True, check_inputs=False)
     labels, mindist = pairwise_distances_argmin_min(
         X=X, Y=centers, metric='euclidean', metric_kwargs=metric_kwargs)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In k-means and minibatch-k-means, the `_labels_inertia_precompute_dense` function computes the nearest neighbors of a sample of test data points with the current cluster centers by computing the full distance matrix from every test point to every cluster center. When the number of cluster centers is large and the number of test data points is large this leads to a huge memory blowup. I ran out of memory quite fast on my 64GB memory machine when computing a 65K visual vocabulary using over one million 128-dimensional SIFT descriptors, even when using a modest batch size. 

Initially I was going to write a helper function that would batch this operation into a few chunks to avoid having the entire distance matrix represented in memory, but it turns out the function already exists in the sklearn codebase. Yay for reusable code!

I removed the old explicit `euclidean_distances` function followed by `argmin` and plugged in the `pairwise_distances_argmin_min`, which does batching internally. This change dramatically reduces the amount of memory used in the computation. 
#### Any other comments?

Initially I was going to wait to submit this until #7383 was merged and finished, but its such an important change that I wanted to make sure it was in the pipeline. I do want to note that if/when #7383 is merged, `check_inputs` should be set to False when calling `pairwise_distances_argmin_min`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
