### PR TITLE
[MRG + 2] add sample_weight support to Pipeline.score

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -60,6 +60,10 @@ Enhancements
    - Added ``norm_order`` parameter to :class:`feature_selection.SelectFromModel`
      to enable selection of the norm order when ``coef_`` is more than 1D
 
+   - Added ``sample_weight`` parameter to :meth:`pipeline.Pipeline.score`.
+     (`#7723 <https://github.com/scikit-learn/scikit-learn/pull/7723>`_)
+     by `Mikhail Korobov`_.
+
 Bug fixes
 .........
 
@@ -4675,7 +4679,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Yannick Schwartz: https://team.inria.fr/parietal/schwarty/
 
-.. _Mikhail Korobov: http://kmike.ru/pages/about/
+.. _Mikhail Korobov: https://github.com/kmike
 
 .. _Kyle Kastner: http://kastnerkyle.github.io
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -481,7 +481,7 @@ class Pipeline(_BasePipeline):
         return Xt
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def score(self, X, y=None, **score_params):
+    def score(self, X, y=None, sample_weight=None):
         """Apply transforms, and score with the final estimator
 
         Parameters
@@ -494,8 +494,9 @@ class Pipeline(_BasePipeline):
             Targets used for scoring. Must fulfill label requirements for all
             steps of the pipeline.
 
-        **score_params : dict of string -> object
-            Parameters passed to the ``score`` method of the final estimator.
+        sample_weight : array-like, default=None
+            If not None, this argument is passed as ``sample_weight`` keyword
+            argument to the ``score`` method of the final estimator.
 
         Returns
         -------
@@ -505,6 +506,9 @@ class Pipeline(_BasePipeline):
         for name, transform in self.steps[:-1]:
             if transform is not None:
                 Xt = transform.transform(Xt)
+        score_params = {}
+        if sample_weight is not None:
+            score_params['sample_weight'] = sample_weight
         return self.steps[-1][-1].score(Xt, y, **score_params)
 
     @property

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -481,7 +481,7 @@ class Pipeline(_BasePipeline):
         return Xt
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def score(self, X, y=None):
+    def score(self, X, y=None, **score_params):
         """Apply transforms, and score with the final estimator
 
         Parameters
@@ -494,6 +494,9 @@ class Pipeline(_BasePipeline):
             Targets used for scoring. Must fulfill label requirements for all
             steps of the pipeline.
 
+        **score_params : dict of string -> object
+            Parameters passed to the ``score`` method of the final estimator.
+
         Returns
         -------
         score : float
@@ -502,7 +505,7 @@ class Pipeline(_BasePipeline):
         for name, transform in self.steps[:-1]:
             if transform is not None:
                 Xt = transform.transform(Xt)
-        return self.steps[-1][-1].score(Xt, y)
+        return self.steps[-1][-1].score(Xt, y, **score_params)
 
     @property
     def classes_(self):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -120,6 +120,11 @@ class FitParamT(BaseEstimator):
         self.fit(X, y, should_succeed=should_succeed)
         return self.predict(X)
 
+    def score(self, X, y=None, sample_weight=None):
+        if sample_weight is not None:
+            X = X * sample_weight
+        return np.sum(X)
+
 
 def test_pipeline_init():
     # Test the various init parameters of the pipeline.
@@ -212,6 +217,16 @@ def test_pipeline_fit_params():
     # and transformer params should not be changed
     assert_true(pipe.named_steps['transf'].a is None)
     assert_true(pipe.named_steps['transf'].b is None)
+
+
+def test_pipeline_score_params():
+    # Pipeline should pass score parameters
+    X = np.array([[1, 2]])
+    pipe = Pipeline([('transf', Transf()), ('clf', FitParamT())])
+    pipe.fit(X, y=None)
+    assert_equal(pipe.score(X), 3)
+    assert_equal(pipe.score(X, y=None), 3)
+    assert_equal(pipe.score(X, sample_weight=np.array([2, 3])), 8)
 
 
 def test_pipeline_raise_set_params_error():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -217,6 +217,12 @@ def test_pipeline_fit_params():
     # and transformer params should not be changed
     assert_true(pipe.named_steps['transf'].a is None)
     assert_true(pipe.named_steps['transf'].b is None)
+    # invalid parameters should raise an error message
+    assert_raise_message(
+        TypeError,
+        "fit() got an unexpected keyword argument 'bad'",
+        pipe.fit, None, None, clf__bad=True
+    )
 
 
 def test_pipeline_score_params():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -227,6 +227,7 @@ def test_pipeline_score_params():
     assert_equal(pipe.score(X), 3)
     assert_equal(pipe.score(X, y=None), 3)
     assert_equal(pipe.score(X, sample_weight=np.array([2, 3])), 8)
+    assert_raises(TypeError, pipe.score, X, foo='bar')
 
 
 def test_pipeline_raise_set_params_error():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -225,18 +225,28 @@ def test_pipeline_fit_params():
     )
 
 
-def test_pipeline_score_params():
-    # Pipeline should pass score parameters
+def test_pipeline_sample_weight_supported():
+    # Pipeline should pass sample_weight
     X = np.array([[1, 2]])
     pipe = Pipeline([('transf', Transf()), ('clf', FitParamT())])
     pipe.fit(X, y=None)
     assert_equal(pipe.score(X), 3)
     assert_equal(pipe.score(X, y=None), 3)
+    assert_equal(pipe.score(X, y=None, sample_weight=None), 3)
     assert_equal(pipe.score(X, sample_weight=np.array([2, 3])), 8)
+
+
+def test_pipeline_sample_weight_unsupported():
+    # When sample_weight is None it shouldn't be passed
+    X = np.array([[1, 2]])
+    pipe = Pipeline([('transf', Transf()), ('clf', Mult())])
+    pipe.fit(X, y=None)
+    assert_equal(pipe.score(X), 3)
+    assert_equal(pipe.score(X, sample_weight=None), 3)
     assert_raise_message(
         TypeError,
-        "score() got an unexpected keyword argument 'foo'",
-        pipe.score, X, foo='bar'
+        "score() got an unexpected keyword argument 'sample_weight'",
+        pipe.score, X, sample_weight=np.array([2, 3])
     )
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -227,7 +227,11 @@ def test_pipeline_score_params():
     assert_equal(pipe.score(X), 3)
     assert_equal(pipe.score(X, y=None), 3)
     assert_equal(pipe.score(X, sample_weight=np.array([2, 3])), 8)
-    assert_raises(TypeError, pipe.score, X, foo='bar')
+    assert_raise_message(
+        TypeError,
+        "score() got an unexpected keyword argument 'foo'",
+        pipe.score, X, foo='bar'
+    )
 
 
 def test_pipeline_raise_set_params_error():


### PR DESCRIPTION
Many estimators support `sample_weight` argument in their .score function - e.g. default .score implementation in ClassifierMixin provides this feature. In this PR kwargs support is added to  Pipeline.score, similar to `**fit_params` in Pipeline.fit; this allows to pass sample_weight to pipeline.score(...).
