### PR TITLE
[MRG + 1] BF: avoid importing from inside joblib

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -24,7 +24,7 @@ from ..utils.extmath import row_norms, safe_sparse_dot
 from ..preprocessing import normalize
 from ..externals.joblib import Parallel
 from ..externals.joblib import delayed
-from ..externals.joblib.parallel import cpu_count
+from ..externals.joblib import cpu_count
 
 from .pairwise_fast import _chi2_kernel_fast, _sparse_manhattan
 


### PR DESCRIPTION
Debian replaces externals.joblib by an import to joblib, because they
hate duplication. Hence importing from inside joblib doesn't work, and
the line that I removed creates a bug.

See
http://lists.alioth.debian.org/pipermail/neurodebian-users/2016-October/001093.html
