### PR TITLE
[MRG + 1] fix bug with negative values in cosine_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -574,7 +574,7 @@ def cosine_distances(X, Y=None):
     if X is Y or Y is None:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.
-        S.flat[::S.shape[0] + 1] = 0.0
+        S[np.diag_indices_from(S)] = 0.0
     return S
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -570,6 +570,11 @@ def cosine_distances(X, Y=None):
     S = cosine_similarity(X, Y)
     S *= -1
     S += 1
+    np.clip(S, 0, 2, out=S)
+    if X is Y or Y is None:
+        # Ensure that distances between vectors and themselves are set to 0.0.
+        # This may not be the case due to floating point rounding errors.
+        S.flat[::S.shape[0] + 1] = 0.0
     return S
 
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -408,7 +408,7 @@ def test_euclidean_distances():
 
 
 def test_cosine_distances():
-    # Check the pairwise cosine_distances distances computation
+    # Check the pairwise Cosine distances computation
     rng = np.random.RandomState(1337)
     x = np.abs(rng.rand(910))
     XA = np.vstack([x, x])
@@ -427,6 +427,14 @@ def test_cosine_distances():
     assert_true(np.all(D2 <= 2.))
     # check that diagonal elements are equal to 0 and non diagonal to 2
     assert_array_equal(D2, [[0., 2.], [2., 0.]])
+
+    # check large random matrix
+    X = np.abs(rng.rand(1000, 5000))
+    D = cosine_distances(X)
+    # check that diagonal elements are equal to 0
+    assert_array_almost_equal(D.flat[::D.shape[0] + 1], [0.] * D.shape[0])
+    assert_true(np.all(D >= 0.))
+    assert_true(np.all(D <= 2.))
 
 
 # Paired distances

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -418,7 +418,7 @@ def test_cosine_distances():
     assert_true(np.all(D >= 0.))
     assert_true(np.all(D <= 2.))
     # check that diagonal elements are equal to 0
-    assert_array_equal(D.flat[::D.shape[0] + 1], [0., 0.])
+    assert_array_equal(D[np.diag_indices_from(D)], [0., 0.])
 
     XB = np.vstack([x, -x])
     D2 = cosine_distances(XB)
@@ -432,7 +432,7 @@ def test_cosine_distances():
     X = np.abs(rng.rand(1000, 5000))
     D = cosine_distances(X)
     # check that diagonal elements are equal to 0
-    assert_array_almost_equal(D.flat[::D.shape[0] + 1], [0.] * D.shape[0])
+    assert_array_almost_equal(D[np.diag_indices_from(D)], [0.] * D.shape[0])
     assert_true(np.all(D >= 0.))
     assert_true(np.all(D <= 2.))
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -407,6 +407,28 @@ def test_euclidean_distances():
     assert_greater(np.max(np.abs(wrong_D - D1)), .01)
 
 
+def test_cosine_distances():
+    # Check the pairwise cosine_distances distances computation
+    rng = np.random.RandomState(1337)
+    x = np.abs(rng.rand(910))
+    XA = np.vstack([x, x])
+    D = cosine_distances(XA)
+    assert_array_almost_equal(D, [[0., 0.], [0., 0.]])
+    # check that all elements are in [0, 2]
+    assert_true(np.all(D >= 0.))
+    assert_true(np.all(D <= 2.))
+    # check that diagonal elements are equal to 0
+    assert_array_equal(D.flat[::D.shape[0] + 1], [0., 0.])
+
+    XB = np.vstack([x, -x])
+    D2 = cosine_distances(XB)
+    # check that all elements are in [0, 2]
+    assert_true(np.all(D2 >= 0.))
+    assert_true(np.all(D2 <= 2.))
+    # check that diagonal elements are equal to 0 and non diagonal to 2
+    assert_array_equal(D2, [[0., 2.], [2., 0.]])
+
+
 # Paired distances
 
 def test_paired_euclidean_distances():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #5772

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.

Fix bug `cosine_distances` returning small negative values.

Essentially:
- clip cosine distances to [0, 2].
- set distances between vectors and themselves to 0.
#### Any other comments?

Did it analogously as it was implemented in `euclidean_distances`.
