### PR TITLE
[WIP] multioutput: get_estimators_attributes

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -127,7 +127,8 @@ class MultiOutputEstimator(six.with_metaclass(ABCMeta, BaseEstimator)):
         -------
         attributes : list of attributes
             Attributes of the fitted estimators.
-            If not fitted yet, single attribute of the initial estimator (still as a list).
+            If not fitted yet, single attribute of the initial estimator
+            (still as a list).
         """
         try:
             check_is_fitted(self, 'estimators_')

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -135,7 +135,7 @@ class MultiOutputEstimator(six.with_metaclass(ABCMeta, BaseEstimator)):
         except NotFittedError:
             estimators = [self.estimator]
 
-        attributes = [getattr(e, param_name) for e in estimators]
+        attributes = [getattr(e, attribute_name) for e in estimators]
         return attributes
 
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -22,6 +22,7 @@ from .base import RegressorMixin, ClassifierMixin
 from .utils import check_array, check_X_y
 from .utils.fixes import parallel_helper
 from .utils.validation import check_is_fitted, has_fit_parameter
+from .exceptions import NotFittedError
 from .externals.joblib import Parallel, delayed
 from .externals import six
 
@@ -112,6 +113,30 @@ class MultiOutputEstimator(six.with_metaclass(ABCMeta, BaseEstimator)):
                                          for e in self.estimators_)
 
         return np.asarray(y).T
+
+    def get_estimators_attributes(self, attribute_name):
+        """Get the given attribute from all estimators that were fitted,
+         or from the initial given estimator.
+
+        Parameters
+        ----------
+        attribute_name : string
+            Name of the attribute of the estimators.
+
+        Returns
+        -------
+        attributes : list of attributes
+            Attributes of the fitted estimators.
+            If not fitted yet, single attribute of the initial estimator (still as a list).
+        """
+        try:
+            check_is_fitted(self, 'estimators_')
+            estimators = self.estimators_
+        except NotFittedError:
+            estimators = [self.estimator]
+
+        attributes = [getattr(e, param_name) for e in estimators]
+        return attributes
 
 
 class MultiOutputRegressor(MultiOutputEstimator, RegressorMixin):


### PR DESCRIPTION
This PR adds a the possibility to easily get a list of attributes from the estimators used in a multioutput regression or classification. If this enhancement is considered useful, I will also add a test for this.

---

One use-case is GridSearchCV:

```
from sklearn.datasets import load_linnerud
from sklearn.model_selection import GridSearchCV
from sklearn.multioutput import MultiOutputRegressor
from sklearn.svm import SVR

linnerud = load_linnerud()
X = linnerud.data
Y = linnerud.target

param_grid = {
    "C":     [10** exp for exp in range(6)],
    "gamma": [10**-exp for exp in range(6)]
}

grid_search = GridSearchCV(SVR(), param_grid)
multi_grid_search = MultiOutputRegressor(grid_search)
multi_grid_search.fit(X, Y)

# currently needed:
params = [estimator.best_params_ for estimator in multi_grid_search.estimators_]
# using get_estimators_attributes:
params = multi_grid_search.get_estimators_attributes("best_params_")
```

---

Tasks:
- [ ] somebody else considers this useful
- [ ] get_estimators_attributes is tested
