### PR TITLE
[MRG+1] BUG: MultiLabelBinarizer.fit_transform sometimes returns an invalid CSR matrix

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -732,7 +732,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         class_mapping = np.empty(len(tmp), dtype=dtype)
         class_mapping[:] = tmp
         self.classes_, inverse = np.unique(class_mapping, return_inverse=True)
-        yt.indices = inverse[yt.indices].astype(yt.indices.dtype, copy=False)
+        yt.indices = np.array(inverse[yt.indices], dtype=yt.indices.dtype, copy=False)
 
         if not self.sparse_output:
             yt = yt.toarray()

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -732,6 +732,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         class_mapping = np.empty(len(tmp), dtype=dtype)
         class_mapping[:] = tmp
         self.classes_, inverse = np.unique(class_mapping, return_inverse=True)
+        # ensure yt.indices keeps its current dtype
         yt.indices = np.array(inverse[yt.indices], dtype=yt.indices.dtype,
                               copy=False)
 

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -732,7 +732,7 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         class_mapping = np.empty(len(tmp), dtype=dtype)
         class_mapping[:] = tmp
         self.classes_, inverse = np.unique(class_mapping, return_inverse=True)
-        yt.indices = np.take(inverse, yt.indices)
+        yt.indices = inverse[yt.indices].astype(yt.indices.dtype, copy=False)
 
         if not self.sparse_output:
             yt = yt.toarray()

--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -732,7 +732,8 @@ class MultiLabelBinarizer(BaseEstimator, TransformerMixin):
         class_mapping = np.empty(len(tmp), dtype=dtype)
         class_mapping[:] = tmp
         self.classes_, inverse = np.unique(class_mapping, return_inverse=True)
-        yt.indices = np.array(inverse[yt.indices], dtype=yt.indices.dtype, copy=False)
+        yt.indices = np.array(inverse[yt.indices], dtype=yt.indices.dtype,
+                              copy=False)
 
         if not self.sparse_output:
             yt = yt.toarray()

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -226,6 +226,7 @@ def test_sparse_output_multilabel_binarizer():
             got = mlb.fit_transform(inp())
             assert_equal(issparse(got), sparse_output)
             if sparse_output:
+                # verify CSR assumption that indices and indptr have same dtype
                 assert_equal(got.indices.dtype, got.indptr.dtype)
                 got = got.toarray()
             assert_array_equal(indicator_mat, got)
@@ -237,6 +238,7 @@ def test_sparse_output_multilabel_binarizer():
             got = mlb.fit(inp()).transform(inp())
             assert_equal(issparse(got), sparse_output)
             if sparse_output:
+                # verify CSR assumption that indices and indptr have same dtype
                 assert_equal(got.indices.dtype, got.indptr.dtype)
                 got = got.toarray()
             assert_array_equal(indicator_mat, got)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -226,6 +226,7 @@ def test_sparse_output_multilabel_binarizer():
             got = mlb.fit_transform(inp())
             assert_equal(issparse(got), sparse_output)
             if sparse_output:
+                assert_equal(got.indices.dtype, got.indptr.dtype)
                 got = got.toarray()
             assert_array_equal(indicator_mat, got)
             assert_array_equal([1, 2, 3], mlb.classes_)
@@ -236,6 +237,7 @@ def test_sparse_output_multilabel_binarizer():
             got = mlb.fit(inp()).transform(inp())
             assert_equal(issparse(got), sparse_output)
             if sparse_output:
+                assert_equal(got.indices.dtype, got.indptr.dtype)
                 got = got.toarray()
             assert_array_equal(indicator_mat, got)
             assert_array_equal([1, 2, 3], mlb.classes_)


### PR DESCRIPTION
See https://github.com/scipy/scipy/issues/6719 for context.

The gist is that the `inverse` array may have a different dtype than `yt.indices`, which causes trouble down the line because, in those cases, `yt.indices` and `yt.indptr` have different dtypes.

Alternately, we could insert `yt.check_format(full_check=False)` after modifying the sparse matrix members.
