### PR TITLE
[MRG] Fix coverage definition and raise ValueError if y_true has one or more rows with no true label

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1127,21 +1127,21 @@ the ground truth labels.
 Coverage error
 --------------
 
-The :func:`coverage_error` function computes the average number of labels that
-have to be included in the final prediction such that all true labels
-are predicted. This is useful if you want to know how many top-scored-labels
-you have to predict in average without missing any true one. The best value
-of this metrics is thus the average number of true labels.
+The :func:`coverage_error` function evaluates how far we need, on average, to go
+down the ranked list of labels in order to cover all the relevant labels of the
+example. This is useful if one wants to know how many top-scored labels need to
+be predicted, on average, without missing any true ones. The best value of this
+metric is thus the average number of true labels minus 1.
 
 Formally, given a binary indicator matrix of the ground truth labels
 :math:`y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}` and the
-score associated with each label
+target scores associated with each label
 :math:`\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}`,
 the coverage is defined as
 
 .. math::
   coverage(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
-    \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij}
+    \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij} - 1
 
 with :math:`\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|`.
 Given the rank definition, ties in ``y_scores`` are broken by giving the
@@ -1154,7 +1154,7 @@ Here is a small example of usage of this function::
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> coverage_error(y_true, y_score)
-    2.5
+    1.5
 
 .. _label_ranking_average_precision:
 

--- a/sklearn/metrics/ranking.py
+++ b/sklearn/metrics/ranking.py
@@ -670,12 +670,16 @@ def coverage_error(y_true, y_score, sample_weight=None):
     if y_true.shape != y_score.shape:
         raise ValueError("y_true and y_score have different shape")
 
+    if np.any(np.sum(y_true, axis=1) == 0):
+        raise ValueError("one or more rows in y_true have no true label")
+
     y_score_mask = np.ma.masked_array(y_score, mask=np.logical_not(y_true))
     y_min_relevant = y_score_mask.min(axis=1).reshape((-1, 1))
     coverage = (y_score >= y_min_relevant).sum(axis=1)
     coverage = coverage.filled(0)
+    coverage = np.average(coverage, weights=sample_weight) - 1
 
-    return np.average(coverage, weights=sample_weight)
+    return coverage
 
 
 def label_ranking_loss(y_true, y_score, sample_weight=None):

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -838,67 +838,69 @@ def test_label_ranking_avp():
 
 def test_coverage_error():
     # Toy case
-    assert_almost_equal(coverage_error([[0, 1]], [[0.25, 0.75]]), 1)
-    assert_almost_equal(coverage_error([[0, 1]], [[0.75, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[1, 1]], [[0.75, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[0, 0]], [[0.75, 0.25]]), 0)
+    assert_almost_equal(coverage_error([[0, 1]], [[0.25, 0.75]]), 0)
+    assert_almost_equal(coverage_error([[0, 1]], [[0.75, 0.25]]), 1)
+    assert_almost_equal(coverage_error([[1, 1]], [[0.75, 0.25]]), 1)
 
-    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.25, 0.5, 0.75]]), 0)
-    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.75]]), 1)
-    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.75]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.75]]), 2)
-    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.75]]), 3)
-    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.75]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.75]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.75]]), 3)
+    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.75]]), 0)
+    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.75]]), 1)
+    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.75]]), 1)
+    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.75]]), 2)
+    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.75]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.75]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.75]]), 2)
 
-    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.75, 0.5, 0.25]]), 0)
-    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.75, 0.5, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.75, 0.5, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.75, 0.5, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.75, 0.5, 0.25]]), 1)
-    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.75, 0.5, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.75, 0.5, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.75, 0.5, 0.25]]), 3)
+    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.75, 0.5, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.75, 0.5, 0.25]]), 1)
+    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.75, 0.5, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.75, 0.5, 0.25]]), 0)
+    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.75, 0.5, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.75, 0.5, 0.25]]), 1)
+    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.75, 0.5, 0.25]]), 2)
 
-    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.5, 0.75, 0.25]]), 0)
-    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.5, 0.75, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.5, 0.75, 0.25]]), 1)
-    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.5, 0.75, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.5, 0.75, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.5, 0.75, 0.25]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.5, 0.75, 0.25]]), 2)
-    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.5, 0.75, 0.25]]), 3)
+    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.5, 0.75, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.5, 0.75, 0.25]]), 0)
+    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.5, 0.75, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.5, 0.75, 0.25]]), 1)
+    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.5, 0.75, 0.25]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.5, 0.75, 0.25]]), 1)
+    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.5, 0.75, 0.25]]), 2)
+
+    # Cases with no true label
+    assert_raises(ValueError, coverage_error, [[0, 0]], [[0.75, 0.25]])
+    assert_raises(ValueError, coverage_error, [[0, 0, 0]], [[0.25, 0.5, 0.75]])
+    assert_raises(ValueError, coverage_error, [[0, 0, 0]], [[0.75, 0.5, 0.25]])
+    assert_raises(ValueError, coverage_error, [[0, 0, 0]], [[0.5, 0.75, 0.25]])
 
     # Non trival case
     assert_almost_equal(coverage_error([[0, 1, 0], [1, 1, 0]],
                                        [[0.1, 10., -3], [0, 1, 3]]),
-                        (1 + 3) / 2.)
+                        ((1 + 3) / 2.) - 1)
 
     assert_almost_equal(coverage_error([[0, 1, 0], [1, 1, 0], [0, 1, 1]],
                                        [[0.1, 10, -3], [0, 1, 3], [0, 2, 0]]),
-                        (1 + 3 + 3) / 3.)
+                        ((1 + 3 + 3) / 3.) - 1)
 
     assert_almost_equal(coverage_error([[0, 1, 0], [1, 1, 0], [0, 1, 1]],
                                        [[0.1, 10, -3], [3, 1, 3], [0, 2, 0]]),
-                        (1 + 3 + 3) / 3.)
+                        ((1 + 3 + 3) / 3.) - 1)
 
 
 def test_coverage_tie_handling():
-    assert_almost_equal(coverage_error([[0, 0]], [[0.5, 0.5]]), 0)
-    assert_almost_equal(coverage_error([[1, 0]], [[0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1]], [[0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[1, 1]], [[0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 0]], [[0.5, 0.5]]), 1)
+    assert_almost_equal(coverage_error([[0, 1]], [[0.5, 0.5]]), 1)
+    assert_almost_equal(coverage_error([[1, 1]], [[0.5, 0.5]]), 1)
 
-    assert_almost_equal(coverage_error([[0, 0, 0]], [[0.25, 0.5, 0.5]]), 0)
-    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.5]]), 2)
-    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 3)
-    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)
+    assert_almost_equal(coverage_error([[0, 0, 1]], [[0.25, 0.5, 0.5]]), 1)
+    assert_almost_equal(coverage_error([[0, 1, 0]], [[0.25, 0.5, 0.5]]), 1)
+    assert_almost_equal(coverage_error([[0, 1, 1]], [[0.25, 0.5, 0.5]]), 1)
+    assert_almost_equal(coverage_error([[1, 0, 0]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 0, 1]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 2)
+    assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 2)
 
+    assert_raises(ValueError, coverage_error, [[0, 0]], [[0.5, 0.5]])
+    assert_raises(ValueError, coverage_error, [[0, 0, 0]], [[0.25, 0.5, 0.5]])
 
 def test_label_ranking_loss():
     assert_almost_equal(label_ranking_loss([[0, 1]], [[0.25, 0.75]]), 0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

Fixes #7698 

<!-- Example: Fixes #1234 -->
#### What does this implement/fix? Explain your changes.
1. Add `-1` to the coverage definition.
2. Raise `ValueError` if `y_true` has one or more rows with no true label.
#### Any other comments?

No

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

…ows with no true labels
