### PR TITLE
[MRG+½] label_binarize also for binary case

### DIFF
--- a/sklearn/preprocessing/label.py
+++ b/sklearn/preprocessing/label.py
@@ -512,7 +512,8 @@ class LabelBinarizer(BaseEstimator, TransformerMixin):
         return y_inv
 
 
-def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
+def label_binarize(y, classes=None, neg_label=0, pos_label=1,
+                   sparse_output=False, two_column_binary=False):
     """Binarize labels in a one-vs-all fashion
 
     Several regression and binary classification algorithms are
@@ -528,8 +529,10 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
     y : array-like
         Sequence of integer labels or multilabel data to encode.
 
-    classes : array-like of shape [n_classes]
+    classes : array-like of shape [n_classes] (default: None)
         Uniquely holds the label for each class.
+        If classes is None it takes all unique classes in y and sorts them,
+        such that classes = numpy.unique(y)
 
     neg_label : int (default: 0)
         Value with which negative labels must be encoded.
@@ -539,6 +542,11 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
 
     sparse_output : boolean (default: False),
         Set to true if output binary array is desired in CSR sparse format
+
+    two_column_binary : boolean (default: False),
+        When true, binary targets are transformed to a 2d array;
+        when false, binary targets are transformed to a 1d array.
+
 
     Returns
     -------
@@ -553,18 +561,32 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
            [0, 0, 0, 1]])
 
     The class ordering is preserved:
-
     >>> label_binarize([1, 6], classes=[1, 6, 4, 2])
     array([[1, 0, 0, 0],
            [0, 1, 0, 0]])
 
     Binary targets transform to a column vector
+    >>> label_binarize([0, 1, 1, 0], neg_label=-2, pos_label=0)
+    array([[-2],
+           [ 0],
+           [ 0],
+           [-2]])
 
-    >>> label_binarize(['yes', 'no', 'no', 'yes'], classes=['no', 'yes'])
-    array([[1],
-           [0],
-           [0],
-           [1]])
+    Binary with example for positive and negative labels
+    >>> label_binarize(['yes', 'no', 'no', 'yes'], classes=['no', 'yes'],
+    ...                neg_label=-1, pos_label=2)
+    array([[ 2],
+           [-1],
+           [-1],
+           [ 2]])
+
+    Binary targets transform to a two-column matrix
+    >>> label_binarize(['yes', 'no', 'no', 'yes'], classes=['yes', 'no'],
+    ...                two_column_binary=True)
+    array([[1, 0],
+           [0, 1],
+           [0, 1],
+           [1, 0]])
 
     See also
     --------
@@ -575,23 +597,15 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
         # XXX Workaround that will be removed when list of list format is
         # dropped
         y = check_array(y, accept_sparse='csr', ensure_2d=False, dtype=None)
-    else:
-        if _num_samples(y) == 0:
+    elif _num_samples(y) == 0:
             raise ValueError('y has 0 samples: %r' % y)
     if neg_label >= pos_label:
         raise ValueError("neg_label={0} must be strictly less than "
                          "pos_label={1}.".format(neg_label, pos_label))
 
-    if (sparse_output and (pos_label == 0 or neg_label != 0)):
-        raise ValueError("Sparse binarization is only supported with non "
-                         "zero pos_label and zero neg_label, got "
-                         "pos_label={0} and neg_label={1}"
-                         "".format(pos_label, neg_label))
-
-    # To account for pos_label == 0 in the dense case
-    pos_switch = pos_label == 0
-    if pos_switch:
-        pos_label = -neg_label
+    if (sparse_output and neg_label != 0):
+        raise ValueError("Sparse binarization is only supported with non zero "
+                         "neg_label={}".format(neg_label))
 
     y_type = type_of_target(y)
     if 'multioutput' in y_type:
@@ -601,18 +615,21 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
         raise ValueError("The type of target data is not known")
 
     n_samples = y.shape[0] if sp.issparse(y) else len(y)
+    if classes is None:
+        classes = np.unique(y)
+    else:
+        classes = np.asarray(classes)
     n_classes = len(classes)
-    classes = np.asarray(classes)
 
     if y_type == "binary":
         if n_classes == 1:
             if sparse_output:
                 return sp.csr_matrix((n_samples, 1), dtype=int)
             else:
-                Y = np.zeros((len(y), 1), dtype=np.int)
-                Y += neg_label
-                return Y
-        elif len(classes) >= 3:
+                y_matrix = np.empty((len(y), 1), dtype=np.int)
+                y_matrix.fill(neg_label)
+                return y_matrix
+        elif n_classes >= 3:
             y_type = "multiclass"
 
     sorted_class = np.sort(classes)
@@ -627,46 +644,51 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
         y_in_classes = np.in1d(y, classes)
         y_seen = y[y_in_classes]
         indices = np.searchsorted(sorted_class, y_seen)
-        indptr = np.hstack((0, np.cumsum(y_in_classes)))
-
-        data = np.empty_like(indices)
-        data.fill(pos_label)
-        Y = sp.csr_matrix((data, indices, indptr),
-                          shape=(n_samples, n_classes))
-    elif y_type == "multilabel-indicator":
-        Y = sp.csr_matrix(y)
-        if pos_label != 1:
-            data = np.empty_like(Y.data)
+        if pos_label != 0:
+            ind_ptr = np.hstack((0, np.cumsum(y_in_classes)))
+            data = np.empty_like(indices)
             data.fill(pos_label)
-            Y.data = data
+            y_matrix = sp.csr_matrix((data, indices, ind_ptr),
+                                     shape=(n_samples, n_classes))
+        else:
+            ind_ptr = np.arange(len(y_in_classes))
+            data = np.empty((n_samples, n_classes))
+            data.fill(neg_label)
+            data[ind_ptr, indices] = 0
+            y_matrix = sp.csr_matrix(data)
+
+    elif y_type == "multilabel-indicator":
+        y_matrix = sp.csr_matrix(y)
+        if pos_label != 1:
+            data = np.empty_like(y_matrix.data)
+            data.fill(pos_label)
+            y_matrix.data = data
     else:
         raise ValueError("%s target data is not supported with label "
                          "binarization" % y_type)
 
     if not sparse_output:
-        Y = Y.toarray()
-        Y = Y.astype(int, copy=False)
+        y_matrix = y_matrix.toarray()
+        y_matrix = y_matrix.astype(int, copy=False)
 
-        if neg_label != 0:
-            Y[Y == 0] = neg_label
+        if neg_label != 0 and pos_label != 0:
+            y_matrix[y_matrix == 0] = neg_label
 
-        if pos_switch:
-            Y[Y == pos_label] = 0
     else:
-        Y.data = Y.data.astype(int, copy=False)
+        y_matrix.data = y_matrix.data.astype(int, copy=False)
 
     # preserve label ordering
     if np.any(classes != sorted_class):
         indices = np.searchsorted(sorted_class, classes)
-        Y = Y[:, indices]
+        y_matrix = y_matrix[:, indices]
 
-    if y_type == "binary":
+    if y_type == "binary" and not two_column_binary:
         if sparse_output:
-            Y = Y.getcol(-1)
+            y_matrix = y_matrix.getcol(-1)
         else:
-            Y = Y[:, -1].reshape((-1, 1))
+            y_matrix = y_matrix[:, -1].reshape((-1, 1))
 
-    return Y
+    return y_matrix
 
 
 def _inverse_binarize_multiclass(y, classes):

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -43,7 +43,7 @@ def test_label_binarizer():
     # For dense case:
     inp = ["pos", "pos", "pos", "pos"]
     lb = LabelBinarizer(sparse_output=False)
-    expected = np.array([[0, 0, 0, 0]]).T
+    expected = np.zeros((len(inp), 1), dtype=int)
     got = lb.fit_transform(inp)
     assert_array_equal(lb.classes_, ["pos"])
     assert_array_equal(expected, got)
@@ -505,12 +505,11 @@ def check_binarized_results(y, classes, pos_label, neg_label, expected):
             inversed = _inverse_binarize_multiclass(binarized, classes=classes)
 
         else:
+            threshold = ((neg_label + pos_label) / 2.)
             inversed = _inverse_binarize_thresholding(binarized,
                                                       output_type=y_type,
                                                       classes=classes,
-                                                      threshold=((neg_label +
-                                                                 pos_label) /
-                                                                 2.))
+                                                      threshold=threshold)
 
         assert_array_equal(toarray(inversed), toarray(y))
 
@@ -549,7 +548,7 @@ def test_label_binarize_multiclass():
     classes = [0, 1, 2]
     pos_label = 2
     neg_label = 0
-    expected = 2 * np.eye(3)
+    expected = pos_label * np.eye(3)
 
     check_binarized_results(y, classes, pos_label, neg_label, expected)
 
@@ -578,6 +577,8 @@ def test_label_binarize_multilabel():
 def test_invalid_input_label_binarize():
     assert_raises(ValueError, label_binarize, [0, 2], classes=[0, 2],
                   pos_label=0, neg_label=1)
+    assert_raises(ValueError, label_binarize, [0, 2], classes=[0, 2],
+                  pos_label=0, neg_label=0)
 
 
 def test_inverse_binarize_multiclass():


### PR DESCRIPTION
#### Reference Issue #6191
#### What does this implement/fix? Explain your changes.

changes in function label_binarize(...):
- extended doc string
- change pos and neg labels just to be non equal
- added param to force return matrix even for binary case
- minor code cleaning (rename Y -> y_out according pep8)

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests