### PR TITLE
[MRG] Modify description of 'X' in k_means_.py fit methods.

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -874,6 +874,9 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         Parameters
         ----------
         X : array-like or sparse matrix, shape=(n_samples, n_features)
+            Numerical matrix of training samples to cluster. Each row
+            will represent a single training sample, a point in space of
+            'n_features' dimensions.
         """
         random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)
@@ -1308,8 +1311,10 @@ class MiniBatchKMeans(KMeans):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Coordinates of the data points to cluster
+        X : array-like or sparse matrix, shape=(n_samples, n_features)
+            Numerical matrix of training samples to cluster. Each row
+            will represent a single training sample, a point in space of
+            'n_features' dimensions.
         """
         random_state = check_random_state(self.random_state)
         X = check_array(X, accept_sparse="csr", order='C',


### PR DESCRIPTION
#### Reference Issue

Fixes #7772
#### What does this implement/fix? Explain your changes.

It modifies the description of existing description of 'X' in `MiniBatchKMeans.fit` method, and for the sake of consistence add a similar description in `KMeans.fit` method.
#### Any other comments?

There were discussions on the issue about using the term "coordinates" in reference to treat the training sample as a data point. I referred to documentation of similar use cases in R and Julia packages and did somewhat "best of both worlds" thing here. I'm available for amendments in the description right away !
#### References:
1. Julia Package Docs: http://clusteringjl.readthedocs.io/en/latest/kmeans.html#kmeans
2. R Package Docs: https://stat.ethz.ch/R-manual/R-devel/library/stats/html/kmeans.html
3. OpenCV docs: http://docs.opencv.org/2.4/modules/core/doc/clustering.html
