### PR TITLE
DOC parameter is called "sample_weight", not "sample_weights"

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -356,7 +356,7 @@ Trees and ensembles
      by dynamically generating attribute ``estimators_samples_`` only when it is
      needed. By `David Staub`_.
 
-   - Added ``n_jobs`` and ``sample_weights`` parameters for
+   - Added ``n_jobs`` and ``sample_weight`` parameters for
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
      :issue:`5805` by `Ibraim Ganiev`_.
 
@@ -366,7 +366,7 @@ Linear, kernelized and related models
      available in the multinomial case. :issue:`5251` by `Tom Dupre la Tour`_.
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
-     :class:`svm.LinearSVR` now support ``sample_weights``.
+     :class:`svm.LinearSVR` now support ``sample_weight``.
      By `Imaculate`_.
 
    - Add parameter ``loss`` to :class:`linear_model.RANSACRegressor` to measure the
@@ -882,7 +882,7 @@ Enhancements
    - :class:`cluster.mean_shift_.MeanShift` now supports parallel execution,
      as implemented in the ``mean_shift`` function. By `Martino Sorbaro`_.
 
-   - :class:`naive_bayes.GaussianNB` now supports fitting with ``sample_weights``.
+   - :class:`naive_bayes.GaussianNB` now supports fitting with ``sample_weight``.
      By `Jan Hendrik Metzen`_.
 
    - :class:`dummy.DummyClassifier` now supports a prior fitting strategy.


### PR DESCRIPTION
I've fixed a few typos in `sample_weight` parameter name.
