### PR TITLE
[MRG] DOC Description of X missing in KMeans.fit (#7772)

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -874,6 +874,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         Parameters
         ----------
         X : array-like or sparse matrix, shape=(n_samples, n_features)
+            Training instances to cluster.
         """
         random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)
@@ -1308,8 +1309,8 @@ class MiniBatchKMeans(KMeans):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
-            Coordinates of the data points to cluster
+        X : array-like or sparse matrix, shape=(n_samples, n_features)
+            Training instances to cluster.
         """
         random_state = check_random_state(self.random_state)
         X = check_array(X, accept_sparse="csr", order='C',


### PR DESCRIPTION
Addressed issue #7772:

Added "Training instances to cluster" as explanation in fit() methods in k_means_.py. Also made both docstring match in terms of parameter descriptions for X in fit(): "X : array-like or sparse matrix, shape=(n_samples, n_features)". This convention is according to that proposed by amueller in #3791.
