### PR TITLE
[MRG] DOC: Adding documentation for the argument X in fit()

### DIFF
--- a/sklearn/cluster/k_means_.py
+++ b/sklearn/cluster/k_means_.py
@@ -875,6 +875,7 @@ class KMeans(BaseEstimator, ClusterMixin, TransformerMixin):
         Parameters
         ----------
         X : array-like or sparse matrix, shape=(n_samples, n_features)
+            Coordinates of training data points to cluster
         """
         random_state = check_random_state(self.random_state)
         X = self._check_fit_data(X)


### PR DESCRIPTION
#### Reference Issue

<!-- Example: Fixes #1234 -->

Addressing #7772 
#### What does this implement/fix? Explain your changes.

This adds a more clear description for the argument X of the function fit() [here.](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/cluster/k_means_.py#871)
#### Any other comments?

Since we are computing the centroid, using 'Coordinates' seems more intuitive. Also, [this](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/cluster/k_means_.py#L800) example here helps to understand how X could be visualized as a point in a d-dimensional space.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
