### PR TITLE
[MRG + 1] Fix for OvR partial_fit bug

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -257,7 +257,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             self.label_binarizer_ = LabelBinarizer(sparse_output=True)
             self.label_binarizer_.fit(self.classes_)
 
-        if not set(self.classes_).issuperset(y):
+        if np.setdiff1d(y, self.classes_):
             raise ValueError(("Mini-batch contains {0} while classes " +
                              "must be subset of {1}").format(np.unique(y),
                                                              self.classes_))

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -245,15 +245,15 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         """
         if _check_partial_fit_first_call(self, classes):
             if not hasattr(self.estimator, "partial_fit"):
-                raise ValueError("Base estimator {0}, doesn't have partial_fit"
-                                 "method".format(self.estimator))
+                raise ValueError("Base estimator {0}, doesn't have "
+                                 "partial_fit method".format(self.estimator))
             self.estimators_ = [clone(self.estimator) for _ in range
                                 (self.n_classes_)]
 
-            # A sparse LabelBinarizer, with sparse_output=True, has been shown to
-            # outperform or match a dense label binarizer in all cases and has also
-            # resulted in less or equal memory consumption in the fit_ovr function
-            # overall.
+            # A sparse LabelBinarizer, with sparse_output=True, has been
+            # shown to outperform or match a dense label binarizer in all
+            # cases and has also resulted in less or equal memory consumption
+            # in the fit_ovr function overall.
             self.label_binarizer_ = LabelBinarizer(sparse_output=True)
             self.label_binarizer_.fit(self.classes_)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -245,8 +245,8 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         """
         if _check_partial_fit_first_call(self, classes):
             if not hasattr(self.estimator, "partial_fit"):
-                raise ValueError("Base estimator {0}, doesn't have "
-                                 "partial_fit method".format(self.estimator))
+                raise ValueError(("Base estimator {0}, doesn't have "
+                                 "partial_fit method").format(self.estimator))
             self.estimators_ = [clone(self.estimator) for _ in range
                                 (self.n_classes_)]
 
@@ -258,9 +258,9 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             self.label_binarizer_.fit(self.classes_)
 
         if not set(self.classes_).issuperset(y):
-            raise ValueError("Mini-batch contains {0} while classes " +
-                             "must be subset of {1}".format(np.unique(y),
-                                                            self.classes_))
+            raise ValueError(("Mini-batch contains {0} while classes " +
+                             "must be subset of {1}").format(np.unique(y),
+                                                             self.classes_))
 
         Y = self.label_binarizer_.transform(y)
         Y = Y.tocsc()

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_equal, assert_raises_regex
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_true
@@ -123,10 +123,14 @@ def test_ovr_partial_fit_exceptions():
     # It should raise ValueError
     y1 = [5] + y[7:-1]
     assert_raises(ValueError, ovr.partial_fit, X=X[7:], y=y1)
+    assert_raises_regex(ValueError, "Mini-batch contains \[.+\] while classes"
+                                    " must be subset of \[.+\]",
+                        ovr.partial_fit, X=X[7:], y=y1)
 
 
 def test_ovr_ovo_regressor():
-    # test that ovr and ovo work on regressors which don't have a decision_function
+    # test that ovr and ovo work on regressors which don't have a decision_
+    # function
     ovr = OneVsRestClassifier(DecisionTreeRegressor())
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
     assert_equal(len(ovr.estimators_), n_classes)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -90,19 +90,10 @@ def test_ovr_partial_fit():
     assert_greater(np.mean(y == pred), 0.65)
 
     # Test when mini batches doesn't have all classes
-    # with MultinomialNB
+    # with SGDClassifier
     X = np.abs(np.random.randn(14, 2))
     y = [1, 1, 1, 1, 2, 3, 3, 0, 0, 2, 3, 1, 2, 3]
-    ovr = OneVsRestClassifier(MultinomialNB())
-    ovr.partial_fit(X[:7], y[:7], np.unique(y))
-    ovr.partial_fit(X[7:], y[7:])
-    pred = ovr.predict(X)
-    ovr1 = OneVsRestClassifier(MultinomialNB())
-    pred1 = ovr1.fit(X, y).predict(X)
-    assert_equal(np.mean(pred == y), np.mean(pred1 == y))
 
-    # Test when mini batches doesn't have all classes
-    # with SGDClassifier
     ovr = OneVsRestClassifier(SGDClassifier(n_iter=1, shuffle=False,
                                             random_state=0))
     ovr.partial_fit(X[:7], y[:7], np.unique(y))
@@ -122,7 +113,6 @@ def test_ovr_partial_fit_exceptions():
     # A new class value which was not in the first call of partial_fit
     # It should raise ValueError
     y1 = [5] + y[7:-1]
-    assert_raises(ValueError, ovr.partial_fit, X=X[7:], y=y1)
     assert_raises_regex(ValueError, "Mini-batch contains \[.+\] while classes"
                                     " must be subset of \[.+\]",
                         ovr.partial_fit, X=X[7:], y=y1)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -22,7 +22,8 @@ from sklearn.metrics import recall_score
 from sklearn.svm import LinearSVC, SVC
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import (LinearRegression, Lasso, ElasticNet, Ridge,
-                                  Perceptron, LogisticRegression, SGDClassifier)
+                                  Perceptron, LogisticRegression,
+                                  SGDClassifier)
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.model_selection import GridSearchCV, cross_val_score
 from sklearn.pipeline import Pipeline


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

PR #6239 and issue #6203 
#### What does this implement/fix? Explain your changes.

`partial_fit()` of OvR was not working properly when the mini-batches did not contain all the classes.
The `LabelBinarizer.fit()` should be called with `classes_` parameter and not the `y` parameter of `partial_fit()`
And added tests to check the `partial_fit()` function.
#### Any other comments?

The PR #6239 did not seem to be the correct fix.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
