### PR TITLE
[WIP] DOC: Changing the docString of OneClassSVM.decision_function(…

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -1037,7 +1037,8 @@ class OneClassSVM(BaseLibSVM):
         return self
 
     def decision_function(self, X):
-        """Distance of the samples X to the separating hyperplane.
+        """Component of the samples in the direction perpendicular to the separating
+        hyperplane.
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference Issue

Addressing issue #7713 
#### What does this implement/fix? Explain your changes.

This updates the docString of the OneClassSVM.decision_function() to remove any discrepancies that exist due to the present docString regarding the direction along which the distance to the separating hyperplane is to be measured.
#### Any other comments?

Also, to make it more clear, we could add that high scores mean inlier and low scores mean outlier as suggested in the thread.
