### PR TITLE
[MRG+1] Fix return_norm bug in preprocessing.normalize. Tests added.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,8 +64,8 @@ Enhancements
      (`#7723 <https://github.com/scikit-learn/scikit-learn/pull/7723>`_)
      by `Mikhail Korobov`_.
 
-   - For sparse matrices, :func:`preprocessing.normalize with ``return_norm=True``
-     will now raise a NotImplementedError with 'l1' or 'l2' norm and with norm 'max'
+   - For sparse matrices, :func:`preprocessing.normalize` with ``return_norm=True``
+     will now raise a ``NotImplementedError`` with 'l1' or 'l2' norm and with norm 'max'
      the norms returned will be the same as for dense matrices (:issue:`7771`).
      By `Ang Lu <https://github.com/luang008>`_.
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -583,6 +583,11 @@ Preprocessing and feature selection
       of ``X`` to transform function when ``copy=True`` (:issue:`7194`). By `Caio
       Oliveira <https://github.com/caioaao>`_.
 
+    - For sparse matrices, :func:`preprocessing.normalize with ``return_norm=True``
+      will now raise a NotImplementedError with 'l1' or 'l2' norm and with norm 'max'
+      the norms returned will be the same as for dense matrices (:issue:`7771`).
+      By `Ang Lu <https://github.com/luang008>`_.
+
 Model evaluation and meta-estimators
 
     - :class:`model_selection.StratifiedKFold` now raises error if all n_labels

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -64,6 +64,11 @@ Enhancements
      (`#7723 <https://github.com/scikit-learn/scikit-learn/pull/7723>`_)
      by `Mikhail Korobov`_.
 
+   - For sparse matrices, :func:`preprocessing.normalize with ``return_norm=True``
+     will now raise a NotImplementedError with 'l1' or 'l2' norm and with norm 'max'
+     the norms returned will be the same as for dense matrices (:issue:`7771`).
+     By `Ang Lu <https://github.com/luang008>`_.
+
 Bug fixes
 .........
 
@@ -582,11 +587,6 @@ Preprocessing and feature selection
     - :func:`preprocessing.data._transform_selected` now always passes a copy
       of ``X`` to transform function when ``copy=True`` (:issue:`7194`). By `Caio
       Oliveira <https://github.com/caioaao>`_.
-
-    - For sparse matrices, :func:`preprocessing.normalize with ``return_norm=True``
-      will now raise a NotImplementedError with 'l1' or 'l2' norm and with norm 'max'
-      the norms returned will be the same as for dense matrices (:issue:`7771`).
-      By `Ang Lu <https://github.com/luang008>`_.
 
 Model evaluation and meta-estimators
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1330,14 +1330,10 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         Normalized input X.
 
-    norms :
-        When X is sparse, an NotImplementedError will be raised for
-        norm 'l1' or 'l2'; an array of maximum elements along given axis
-        for norm 'max'.
-
-        When X is dense, an array of norms along given axis for dense matrix X.
-
-
+    norms : array, shape [n_samples] if axis=1 else [n_features]
+        An array of norms along given axis for X.
+        When X is sparse, an NotImplementedError will be raised
+        for norm 'l1' or 'l2'.
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1346,6 +1346,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         X = X.T
 
     if sparse.issparse(X):
+        norms = NotImplemented
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)
         elif norm == 'l2':

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1331,9 +1331,10 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         Normalized input X.
 
     norms : array
-        When X is sparse, an NotImplementedError will be raised for norm 'l1' or 'l2';
-        an array with same shape with X.data, where each element replaced by the maximum
-        element along given axis in X for norm 'max'.
+        When X is sparse, an NotImplementedError will be raised for
+        norm 'l1' or 'l2'; an array with same shape with X.data,
+        where each element is replaced by the maximum element
+        along given axis in X for norm 'max'.
 
         When X is dense, an array of norms along given axis for dense matrix X.
 
@@ -1361,7 +1362,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     if sparse.issparse(X):
         if return_norm and norm in ('l1', 'l2'):
-            raise NotImplementedError("Currently 'return_norm' isn't implemented for "
+            raise NotImplementedError("'return_norm' isn't implemented for"
                                       "sparse matrix with norm 'l1' or 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1370,9 +1370,9 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
             inplace_csr_row_normalize_l2(X)
         elif norm == 'max':
             _, norms = min_max_axis(X, 1)
-            norms = norms.repeat(np.diff(X.indptr))
-            mask = norms != 0
-            X.data[mask] /= norms[mask]
+            norms_elementwise = norms.repeat(np.diff(X.indptr))
+            mask = norms_elementwise != 0
+            X.data[mask] /= norms_elementwise[mask]
     else:
         if norm == 'l1':
             norms = np.abs(X).sum(axis=1)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1357,8 +1357,8 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     if sparse.issparse(X):
         if return_norm and norm in ('l1', 'l2'):
-            raise NotImplementedError("return_norm=True is not implemented "
-                                      "for sparse matrices with norm 'l1' or 'l2'")
+            raise NotImplementedError("return_norm=True is not implemented for "
+                                      "sparse matrices with norm 'l1' or 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)
         elif norm == 'l2':

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1357,8 +1357,8 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     if sparse.issparse(X):
         if return_norm and norm in ('l1', 'l2'):
-            raise NotImplementedError("'return_norm' isn't implemented for"
-                                      "sparse matrix with norm 'l1' or 'l2'")
+            raise NotImplementedError("return_norm=True is not implemented "
+                                      "for sparse matrices with norm 'l1' or 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)
         elif norm == 'l2':

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1330,9 +1330,9 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         Normalized input X.
 
-    norms : array or NotImplemented
-        When X is sparse,  NotImplemented for norm 'l1' or 'l2', an array
-        with same shape with X.data, where each element replaced by the maximum
+    norms : array
+        When X is sparse, an NotImplementedError will be raised for norm 'l1' or 'l2';
+        an array with same shape with X.data, where each element replaced by the maximum
         element along given axis in X for norm 'max'.
 
         When X is dense, an array of norms along given axis for dense matrix X.
@@ -1361,7 +1361,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     if sparse.issparse(X):
         if return_norm and norm in ('l1', 'l2'):
-            raise NotImplementedError("Currently 'return_norm' isn't supported for "
+            raise NotImplementedError("Currently 'return_norm' isn't implemented for "
                                       "sparse matrix with norm 'l1' or 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1330,11 +1330,10 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         Normalized input X.
 
-    norms : array
+    norms :
         When X is sparse, an NotImplementedError will be raised for
-        norm 'l1' or 'l2'; an array with same shape with X.data,
-        where each element is replaced by the maximum element
-        along given axis in X for norm 'max'.
+        norm 'l1' or 'l2'; an array of maximum elements along given axis
+        for norm 'max'.
 
         When X is dense, an array of norms along given axis for dense matrix X.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1325,6 +1325,22 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     return_norm : boolean, default False
         whether to return the computed norms
 
+    Returns
+    -------
+    X : {array-like, sparse matrix}, shape [n_samples, n_features]
+        Normalized input X.
+
+    norms :
+        NotImplemented
+        Currently not implemented for sparse matrix X with norm 'l1' or 'l2'.
+
+        array, shape X.data.shape
+        an array of nnz element of X replaced by the maximum element along
+        given axis in input X for sparse matrix X with norm 'max'.
+
+        array, length n_samples (n_features if axis=0)
+        an array of norms along given axis for dense matrix X.
+
     See also
     --------
     Normalizer: Performs normalization using the ``Transformer`` API

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1357,8 +1357,9 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     if sparse.issparse(X):
         if return_norm and norm in ('l1', 'l2'):
-            raise NotImplementedError("return_norm=True is not implemented for "
-                                      "sparse matrices with norm 'l1' or 'l2'")
+            raise NotImplementedError("return_norm=True is not implemented "
+                                      "for sparse matrices with norm 'l1' "
+                                      "or norm 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)
         elif norm == 'l2':

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1332,7 +1332,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
 
     norms : array, shape [n_samples] if axis=1 else [n_features]
         An array of norms along given axis for X.
-        When X is sparse, an NotImplementedError will be raised
+        When X is sparse, a NotImplementedError will be raised
         for norm 'l1' or 'l2'.
 
     See also

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1330,16 +1330,14 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         Normalized input X.
 
-    norms :
-        NotImplemented
-        Currently not implemented for sparse matrix X with norm 'l1' or 'l2'.
+    norms : array or NotImplemented
+        When X is sparse,  NotImplemented for norm 'l1' or 'l2', an array
+        with same shape with X.data, where each element replaced by the maximum
+        element along given axis in X for norm 'max'.
 
-        array, shape X.data.shape
-        an array of nnz element of X replaced by the maximum element along
-        given axis in input X for sparse matrix X with norm 'max'.
+        When X is dense, an array of norms along given axis for dense matrix X.
 
-        array, length n_samples (n_features if axis=0)
-        an array of norms along given axis for dense matrix X.
+
 
     See also
     --------
@@ -1362,7 +1360,9 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         X = X.T
 
     if sparse.issparse(X):
-        norms = NotImplemented
+        if return_norm and norm in ('l1', 'l2'):
+            raise NotImplementedError("Currently 'return_norm' isn't supported for "
+                                      "sparse matrix with norm 'l1' or 'l2'")
         if norm == 'l1':
             inplace_csr_row_normalize_l1(X)
         elif norm == 'l2':

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1315,7 +1315,7 @@ def test_normalize():
 
                 assert_array_almost_equal(row_sums, ones)
 
-    # test return_norm
+    # Test return_norm
     X_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
     for norm in ('l1', 'l2', 'max'):
         _, norms = normalize(X_dense, norm=norm,

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1319,7 +1319,7 @@ def test_normalize():
     for X in (X_sparse,):
         for return_norm in (True,):
             for norm in ('l1', 'l2'):
-                X_norm, norms = normalize(X, norm=norm, 
+                X_norm, norms = normalize(X, norm=norm,
                                           return_norm=return_norm)
                 assert_equal(norms, NotImplemented)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1318,8 +1318,7 @@ def test_normalize():
     # Test return_norm
     X_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
     for norm in ('l1', 'l2', 'max'):
-        _, norms = normalize(X_dense, norm=norm,
-                             return_norm=True)
+        _, norms = normalize(X_dense, norm=norm, return_norm=True)
         if norm == 'l1':
             assert_array_almost_equal(norms, np.array([7.0, 1.0, 5.0]))
         elif norm == 'l2':

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1320,7 +1320,7 @@ def test_normalize():
         for return_norm in (True,):
             for norm in ('l1', 'l2'):
                 X_norm, norms = normalize(X, norm=norm, 
-                                             return_norm=return_norm)
+                                          return_norm=return_norm)
                 assert_equal(norms, NotImplemented)
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1302,18 +1302,18 @@ def test_normalize():
     for X in (X_dense, X_sparse):
         for dtype in (np.float32, np.float64):
             for norm in ('l1', 'l2'):
-                    X = X.astype(dtype)
-                    X_norm = normalize(X, norm=norm)
-                    assert_equal(X_norm.dtype, dtype)
+                X = X.astype(dtype)
+                X_norm = normalize(X, norm=norm)
+                assert_equal(X_norm.dtype, dtype)
 
-                    X_norm = toarray(X_norm)
-                    if norm == 'l1':
-                        row_sums = np.abs(X_norm).sum(axis=1)
-                    else:
-                        X_norm_squared = X_norm**2
-                        row_sums = X_norm_squared.sum(axis=1)
+                X_norm = toarray(X_norm)
+                if norm == 'l1':
+                    row_sums = np.abs(X_norm).sum(axis=1)
+                else:
+                    X_norm_squared = X_norm**2
+                    row_sums = X_norm_squared.sum(axis=1)
 
-                    assert_array_almost_equal(row_sums, ones)
+                assert_array_almost_equal(row_sums, ones)
 
     # test return_norm
     X_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1332,7 +1332,7 @@ def test_normalize():
         assert_raises(NotImplementedError, normalize, X_sparse,
                       norm=norm, return_norm=True)
     _, norms = normalize(X_sparse, norm='max', return_norm=True)
-    assert_array_almost_equal(norms, np.array([4.0, 4.0, 1.0, 3.0, 3.0]))
+    assert_array_almost_equal(norms, np.array([4.0, 1.0, 3.0]))
 
 
 def test_binarizer():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1318,14 +1318,14 @@ def test_normalize():
     # test return_norm for sparse matrix with norm l1/l2
     for X in (X_sparse,):
         for return_norm in (True,):
-            for norm in ('l1','l2'):
-                X_norm, norms = normalize(X, norm=norm, return_norm=return_norm)
-                assert_equal(norms,NotImplemented)
+            for norm in ('l1', 'l2'):
+                X_norm, norms = normalize(X, norm=norm, 
+                                             return_norm=return_norm)
+                assert_equal(norms, NotImplemented)
 
 
 
 
-        
 
 def test_binarizer():
     X_ = np.array([[1, 0, 5], [2, 3, -1]])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1328,14 +1328,11 @@ def test_normalize():
             assert_array_almost_equal(norms, np.array([4.0, 1.0, 3.0]))
 
     X_sparse = sparse.csr_matrix(X_dense)
-    for norm in ('l1', 'l2', 'max'):
-        _, norms = normalize(X_sparse, norm=norm,
-                             return_norm=True)
-        if norm == 'l1' or norm == 'l2':
-            assert_equal(norms, NotImplemented)
-        else:
-            assert_array_almost_equal(norms,
-                                      np.array([4.0, 4.0, 1.0, 3.0, 3.0]))
+    for norm in ('l1', 'l2'):
+        assert_raises(NotImplementedError, normalize, X_sparse,
+                      norm=norm, return_norm=True)
+    _, norms = normalize(X_sparse, norm='max', return_norm=True)
+    assert_array_almost_equal(norms, np.array([4.0, 4.0, 1.0, 3.0, 3.0]))
 
 
 def test_binarizer():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1315,6 +1315,17 @@ def test_normalize():
 
                 assert_array_almost_equal(row_sums, ones)
 
+    # test return_norm for sparse matrix with norm l1/l2
+    for X in (X_sparse,):
+        for return_norm in (True,):
+            for norm in ('l1','l2'):
+                X_norm, norms = normalize(X, norm=norm, return_norm=return_norm)
+                assert_equal(norms,NotImplemented)
+
+
+
+
+        
 
 def test_binarizer():
     X_ = np.array([[1, 0, 5], [2, 3, -1]])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1302,29 +1302,40 @@ def test_normalize():
     for X in (X_dense, X_sparse):
         for dtype in (np.float32, np.float64):
             for norm in ('l1', 'l2'):
-                X = X.astype(dtype)
-                X_norm = normalize(X, norm=norm)
-                assert_equal(X_norm.dtype, dtype)
+                    X = X.astype(dtype)
+                    X_norm = normalize(X, norm=norm)
+                    assert_equal(X_norm.dtype, dtype)
 
-                X_norm = toarray(X_norm)
-                if norm == 'l1':
-                    row_sums = np.abs(X_norm).sum(axis=1)
-                else:
-                    X_norm_squared = X_norm**2
-                    row_sums = X_norm_squared.sum(axis=1)
+                    X_norm = toarray(X_norm)
+                    if norm == 'l1':
+                        row_sums = np.abs(X_norm).sum(axis=1)
+                    else:
+                        X_norm_squared = X_norm**2
+                        row_sums = X_norm_squared.sum(axis=1)
 
-                assert_array_almost_equal(row_sums, ones)
+                    assert_array_almost_equal(row_sums, ones)
 
-    # test return_norm for sparse matrix with norm l1/l2
-    for X in (X_sparse,):
-        for return_norm in (True,):
-            for norm in ('l1', 'l2'):
-                X_norm, norms = normalize(X, norm=norm,
-                                          return_norm=return_norm)
-                assert_equal(norms, NotImplemented)
+    # test return_norm
+    X_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
+    for norm in ('l1', 'l2', 'max'):
+        _, norms = normalize(X_dense, norm=norm,
+                             return_norm=True)
+        if norm == 'l1':
+            assert_array_almost_equal(norms, np.array([7.0, 1.0, 5.0]))
+        elif norm == 'l2':
+            assert_array_almost_equal(norms, np.array([5.0, 1.0, 3.60555127]))
+        else:
+            assert_array_almost_equal(norms, np.array([4.0, 1.0, 3.0]))
 
-
-
+    X_sparse = sparse.csr_matrix(X_dense)
+    for norm in ('l1', 'l2', 'max'):
+        _, norms = normalize(X_sparse, norm=norm,
+                             return_norm=True)
+        if norm == 'l1' or norm == 'l2':
+            assert_equal(norms, NotImplemented)
+        else:
+            assert_array_almost_equal(norms,
+                                      np.array([4.0, 4.0, 1.0, 3.0, 3.0]))
 
 
 def test_binarizer():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

<!-- Example: Fixes #1234 -->
Fix #7771 
#### What does this implement/fix? Explain your changes.

Initialize variable **norm** as **NotImplemented** in order to avoid **UnboundLocalError**.
#### Any other comments?

Maybe we should implement **return_norm** for sparse matrix with norm l1/l2 later.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
