### PR TITLE
[RFC] Voting classifier flatten transform (#7230)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,11 @@ Enhancements
      (`#7723 <https://github.com/scikit-learn/scikit-learn/pull/7723>`_)
      by `Mikhail Korobov`_.
 
+   - Added ``flatten_transform`` parameter to :class:`ensemble.VotingClassifier`
+     to change output shape of `transform` method to 2 dimensional.
+     (`#7794 <https://github.com/scikit-learn/scikit-learn/pull/7794>`_)
+     by `Ibraim Ganiev`_.
+
 Bug fixes
 .........
 

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -259,6 +259,7 @@ def test_sample_weight():
     msg = ('Underlying estimator \'knn\' does not support sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)
 
+
 def test_transform():
     """Check trqansform method of VotingClassifier on toy dataset."""
     clf1 = LogisticRegression(random_state=123)

--- a/sklearn/ensemble/tests/test_voting_classifier.py
+++ b/sklearn/ensemble/tests/test_voting_classifier.py
@@ -210,7 +210,7 @@ def test_gridsearch():
     grid.fit(iris.data, iris.target)
 
 
-def test_parallel_predict():
+def test_parallel_fit():
     """Check parallel backend of VotingClassifier on toy dataset."""
     clf1 = LogisticRegression(random_state=123)
     clf2 = RandomForestClassifier(random_state=123)
@@ -258,3 +258,22 @@ def test_sample_weight():
         voting='soft')
     msg = ('Underlying estimator \'knn\' does not support sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)
+
+def test_transform():
+    """Check trqansform method of VotingClassifier on toy dataset."""
+    clf1 = LogisticRegression(random_state=123)
+    clf2 = RandomForestClassifier(random_state=123)
+    clf3 = GaussianNB()
+    X = np.array([[-1.1, -1.5], [-1.2, -1.4], [-3.4, -2.2], [1.1, 1.2]])
+    y = np.array([1, 1, 2, 2])
+
+    eclf1 = VotingClassifier(estimators=[
+        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
+        voting='soft').fit(X, y)
+    eclf2 = VotingClassifier(estimators=[
+        ('lr', clf1), ('rf', clf2), ('gnb', clf3)],
+        voting='soft',
+        flatten_transform=True).fit(X, y)
+
+    assert_array_equal(eclf1.transform(X).shape, (3, 4, 2))
+    assert_array_equal(eclf2.transform(X).shape, (4, 6))

--- a/sklearn/ensemble/voting_classifier.py
+++ b/sklearn/ensemble/voting_classifier.py
@@ -161,10 +161,6 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
                     raise ValueError('Underlying estimator \'%s\' does not support'
                                      ' sample weights.' % name)
 
-        if not self.flatten_transform and self.voting is 'soft':
-            warnings.warn("'flatten_transform' default value will be changed to True"
-                          "in 0.21.", DeprecationWarning)
-
         self.le_ = LabelEncoder()
         self.le_.fit(y)
         self.classes_ = self.le_.classes_
@@ -265,6 +261,8 @@ class VotingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         if self.voting == 'soft':
             probas = self._collect_probas(X)
             if not self.flatten_transform:
+                warnings.warn("'flatten_transform' default value will be"
+                              " changed to True in 0.21.", DeprecationWarning)
                 return probas
             else:
                 return np.hstack(probas)


### PR DESCRIPTION
#### Reference Issue

Fixes #7230
#### What does this implement/fix? Explain your changes.

It adds `flatten_transform` parameter to `VotingClassifier`, which changes shape of transform method's output to `[n_samples, n_classifiers * n_classes]` instead of `[n_classifiers, n_samples, n_classes]`,
 With this parameter turned on you can use `VotingClassifier` as a transformer, and feed its output to other estimators/transformers in `Pipeline`.
#### Any other comments?

None, make suggestions. I Summon @amueller into this PR :)
