### PR TITLE
[WIP] Catch convergence warnings in common tests.

### DIFF
--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -1,10 +1,14 @@
+import warnings
+
 import scipy.sparse as sp
 import numpy as np
 import sys
 from sklearn.externals.six.moves import cStringIO as StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils.testing import assert_raises_regex, assert_true
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils.testing import (assert_raises_regex, assert_true,
+                                   assert_warns_message, ignore_warnings)
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import check_estimators_unfitted
 from sklearn.ensemble import AdaBoostClassifier
@@ -92,9 +96,13 @@ def test_check_estimator():
         sys.stdout = old_stdout
     assert_true(msg in string_buffer.getvalue())
 
-    # doesn't error on actual estimator
-    check_estimator(AdaBoostClassifier)
-    check_estimator(MultiTaskElasticNet)
+    with ignore_warnings(category=ConvergenceWarning):
+        # doesn't error on actual estimator
+        check_estimator(AdaBoostClassifier)
+        check_estimator(MultiTaskElasticNet)
+
+    assert_warns_message(ConvergenceWarning, 'Objective did not converge',
+                         check_estimator, MultiTaskElasticNet)
 
 
 def test_check_estimators_unfitted():


### PR DESCRIPTION
#### Reference Issue
Fixes #7744

#### What does this implement/fix? Explain your changes.
This PR modifies common tests to catch convergence warnings and assert them. This is done since `max_iter` of estimators is deliberately set low to ensure fast execution.

#### Any other comments?
@amueller I wasn't sure what needed to be done exactly but this happens now:

```
$ nosetests --traverse-namespace utils/tests/test_estimator_checks.py
..
----------------------------------------------------------------------
Ran 2 tests in 2.872s

OK
```

as opposed to initial situation (current master) where:

```
$ nosetests --traverse-namespace utils/tests/test_estimator_checks.py
/home/karan/Documents/scikit-learn/sklearn/linear_model/coordinate_descent.py:1739: UserWarning: Objective did not converge, you might want to increase the number of iterations
  warnings.warn('Objective did not converge, you might want'
/home/karan/Documents/scikit-learn/sklearn/linear_model/coordinate_descent.py:1739: UserWarning: Objective did not converge, you might want to increase the number of iterations
  warnings.warn('Objective did not converge, you might want'
/home/karan/Documents/scikit-learn/sklearn/linear_model/coordinate_descent.py:1739: UserWarning: Objective did not converge, you might want to increase the number of iterations
  warnings.warn('Objective did not converge, you might want'
..
----------------------------------------------------------------------
Ran 2 tests in 2.237s

OK
```
