### PR TITLE
[MRG+1] label binarizer not used consistently in CalibratedClassifierCV

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -138,6 +138,12 @@ Bug fixes
      ``partial_fit`` was less than the total number of classes in the
      data. :issue:`7786` by `Srivatsan Ramesh`_
 
+   - Fixes issue in :class:`calibration.CalibratedClassifierCV` where
+     the sum of probabilities of each class for a data was not 1, and
+     ``CalibratedClassifierCV`` now handles the case where the training set
+     has less number of classes than the total data. :issue:`7799` by
+     `Srivatsan Ramesh`_
+
 
 API changes summary
 -------------------

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -51,7 +51,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
         The method to use for calibration. Can be 'sigmoid' which
         corresponds to Platt's method or 'isotonic' which is a
         non-parametric approach. It is not advised to use isotonic calibration
-        with too few calibration samples ``(<<1000)`` since it tends to overfit.
+        with too few calibration samples ``(<<1000)`` since it tends to
+        overfit.
         Use sigmoids (Platt's calibration) in this case.
 
     cv : integer, cross-validation generator, iterable or "prefit", optional
@@ -64,8 +65,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`sklearn.model_selection.StratifiedKFold` is used. If ``y`` 
-        is neither binary nor multiclass, :class:`sklearn.model_selection.KFold`
+        :class:`sklearn.model_selection.StratifiedKFold` is used. If ``y`` is
+        neither binary nor multiclass, :class:`sklearn.model_selection.KFold`
         is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -295,11 +295,8 @@ class _CalibratedClassifier(object):
             raise RuntimeError('classifier has no decision_function or '
                                'predict_proba method.')
 
-        if hasattr(self.base_estimator, "classes_"):
-            idx_pos_class = self.label_encoder_.\
-                transform(self.base_estimator.classes_)
-        else:
-            idx_pos_class = np.arange(df.shape[1])
+        idx_pos_class = self.label_encoder_.\
+            transform(self.base_estimator.classes_)
 
         return df, idx_pos_class
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -178,9 +178,11 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
                     this_estimator, method=self.method)
                 if sample_weight is not None:
                     calibrated_classifier.fit(X[test], y[test],
+                                              np.unique(y[train]),
                                               sample_weight[test])
                 else:
-                    calibrated_classifier.fit(X[test], y[test])
+                    calibrated_classifier.fit(X[test], y[test],
+                                              np.unique(y[train]))
                 self.calibrated_classifiers_.append(calibrated_classifier)
 
         return self
@@ -289,7 +291,7 @@ class _CalibratedClassifier(object):
 
         return df, idx_pos_class
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, classes=None, sample_weight=None):
         """Calibrate the fitted model
 
         Parameters
@@ -300,6 +302,10 @@ class _CalibratedClassifier(object):
         y : array-like, shape (n_samples,)
             Target values.
 
+        classes : array-like, shape (n_classes,)
+            Contains unique classes used to fit the base estimator.
+            if None, then classes is extracted from the given target values.
+
         sample_weight : array-like, shape = [n_samples] or None
             Sample weights. If None, then samples are equally weighted.
 
@@ -309,7 +315,11 @@ class _CalibratedClassifier(object):
             Returns an instance of self.
         """
         lb = LabelBinarizer()
-        Y = lb.fit_transform(y)
+        if classes is None:
+            lb.fit(y)
+        else:
+            lb.fit(classes)
+        Y = lb.transform(y)
         self.classes_ = lb.classes_
 
         df, idx_pos_class = self._preproc(X)

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -178,11 +178,11 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
                     this_estimator, method=self.method)
                 if sample_weight is not None:
                     calibrated_classifier.fit(X[test], y[test],
-                                              np.unique(y[train]),
-                                              sample_weight[test])
+                                              sample_weight[test],
+                                              np.unique(y[train]))
                 else:
                     calibrated_classifier.fit(X[test], y[test],
-                                              np.unique(y[train]))
+                                              classes=np.unique(y[train]))
                 self.calibrated_classifiers_.append(calibrated_classifier)
 
         return self
@@ -291,7 +291,7 @@ class _CalibratedClassifier(object):
 
         return df, idx_pos_class
 
-    def fit(self, X, y, classes=None, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, classes=None):
         """Calibrate the fitted model
 
         Parameters
@@ -302,12 +302,12 @@ class _CalibratedClassifier(object):
         y : array-like, shape (n_samples,)
             Target values.
 
+        sample_weight : array-like, shape = [n_samples] or None
+            Sample weights. If None, then samples are equally weighted.
+
         classes : array-like, shape (n_classes,)
             Contains unique classes used to fit the base estimator.
             if None, then classes is extracted from the given target values.
-
-        sample_weight : array-like, shape = [n_samples] or None
-            Sample weights. If None, then samples are equally weighted.
 
         Returns
         -------

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -257,7 +257,7 @@ class _CalibratedClassifier(object):
         corresponds to Platt's method or 'isotonic' which is a
         non-parametric approach based on isotonic regression.
 
-    classes : array-like, shape (n_classes,)
+    classes : array-like, shape (n_classes,), optional
             Contains unique classes used to fit the base estimator.
             if None, then classes is extracted from the given target values
             in fit().

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -51,8 +51,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
         The method to use for calibration. Can be 'sigmoid' which
         corresponds to Platt's method or 'isotonic' which is a
         non-parametric approach. It is not advised to use isotonic calibration
-        with too few calibration samples ``(<<1000)`` since it tends to
-        overfit.
+        with too few calibration samples ``(<<1000)`` since it tends to overfit.
         Use sigmoids (Platt's calibration) in this case.
 
     cv : integer, cross-validation generator, iterable or "prefit", optional
@@ -66,8 +65,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
 
         For integer/None inputs, if ``y`` is binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. If ``y`` 
-        is neither binary nor multiclass,
-        :class:`sklearn.model_selection.KFold`
+        is neither binary nor multiclass, :class:`sklearn.model_selection.KFold`
         is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
@@ -100,7 +98,6 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
     .. [4] Predicting Good Probabilities with Supervised Learning,
            A. Niculescu-Mizil & R. Caruana, ICML 2005
     """
-
     def __init__(self, base_estimator=None, method='sigmoid', cv=3):
         self.base_estimator = base_estimator
         self.method = method
@@ -163,7 +160,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
             fit_parameters = signature(base_estimator.fit).parameters
             estimator_name = type(base_estimator).__name__
             if (sample_weight is not None
-                and "sample_weight" not in fit_parameters):
+                    and "sample_weight" not in fit_parameters):
                 warnings.warn("%s does not support sample_weight. Samples"
                               " weights are only used for the calibration"
                               " itself." % estimator_name)
@@ -278,7 +275,6 @@ class _CalibratedClassifier(object):
     .. [4] Predicting Good Probabilities with Supervised Learning,
            A. Niculescu-Mizil & R. Caruana, ICML 2005
     """
-
     def __init__(self, base_estimator, method='sigmoid', classes=None):
         self.base_estimator = base_estimator
         self.method = method
@@ -299,7 +295,7 @@ class _CalibratedClassifier(object):
                                'predict_proba method.')
 
         if hasattr(self.base_estimator, "classes_"):
-            idx_pos_class = self.label_encoder_. \
+            idx_pos_class = self.label_encoder_.\
                 transform(self.base_estimator.classes_)
         else:
             idx_pos_class = np.arange(df.shape[1])
@@ -470,7 +466,6 @@ class _SigmoidCalibration(BaseEstimator, RegressorMixin):
     b_ : float
         The intercept.
     """
-
     def fit(self, X, y, sample_weight=None):
         """Fit the model using X, y as training data.
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -176,7 +176,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin):
 
                 calibrated_classifier = _CalibratedClassifier(
                     this_estimator, method=self.method,
-                    classes=np.unique(y[train]))
+                    classes=self.classes_)
                 if sample_weight is not None:
                     calibrated_classifier.fit(X[test], y[test],
                                               sample_weight[test])

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -303,5 +303,4 @@ def test_calibration_prob_sum():
     clf_prob.fit(X, y)
     probs = clf_prob.predict_proba(X)
     n_classes = len(y)
-    assert_array_almost_equal(probs, np.full((X.shape[0], n_classes),
-                                             1/n_classes))
+    assert_array_almost_equal(probs, 1/n_classes)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -302,4 +302,6 @@ def test_calibration_prob_sum():
     clf_prob = CalibratedClassifierCV(clf, method="sigmoid", cv=LeaveOneOut())
     clf_prob.fit(X, y)
     probs = clf_prob.predict_proba(X)
-    assert_array_almost_equal(probs.sum(axis=1), np.ones(probs.shape[0]))
+    n_classes = len(y)
+    assert_array_almost_equal(probs, np.full((X.shape[0], n_classes),
+                                             1/n_classes))

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -305,4 +305,3 @@ def test_calibration_prob_sum():
     probs = clf_prob.predict_proba(X)
     n_classes = len(y)
     assert_array_almost_equal(probs, 1/n_classes)
-test_calibration_prob_sum()

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -300,5 +300,7 @@ def test_calibration_less_classes():
 
     for i, calibrated_classifier in \
             enumerate(cal_clf.calibrated_classifiers_):
-        assert_array_equal(calibrated_classifier.predict_proba(X)[:, i],
-                           np.zeros(len(y)))
+        proba = calibrated_classifier.predict_proba(X)
+        assert_array_equal(proba[:, i], np.zeros(len(y)))
+        assert_equal(np.all(np.hstack([proba[:, :i],
+                                       proba[:, i + 1:]])), True)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -280,14 +280,26 @@ def test_calibration_nan_imputer():
 
 
 def test_calibration_prob_sum():
-    """Test that sum of probabilities is 1"""
+    # Test that sum of probabilities is 1. A non-regression test for
+    # issue #7796
     num_classes = 2
-    X, y = make_classification(n_samples=100, n_features=20,
-                               n_informative=18, n_redundant=2,
+    X, y = make_classification(n_samples=10, n_features=5,
                                n_classes=num_classes)
     clf = LinearSVC(C=1.0)
     clf_prob = CalibratedClassifierCV(clf, method="sigmoid", cv=LeaveOneOut())
     clf_prob.fit(X, y)
 
     probs = clf_prob.predict_proba(X)
-    assert_array_equal(probs.sum(axis=1), np.ones(probs.shape[0]))
+    assert_array_almost_equal(probs.sum(axis=1), np.ones(probs.shape[0]))
+
+    # Test to check calibration works fine when train set in a test-train
+    # split does not contain all classes
+    # Since this test uses LOO, at each iteration train set will not contain a
+    # class label
+    X = np.random.randn(10, 5)
+    y = np.arange(10)
+    clf = LinearSVC(C=1.0)
+    clf_prob = CalibratedClassifierCV(clf, method="sigmoid", cv=LeaveOneOut())
+    clf_prob.fit(X, y)
+    probs = clf_prob.predict_proba(X)
+    assert_array_almost_equal(probs.sum(axis=1), np.ones(probs.shape[0]))

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1,6 +1,7 @@
 # Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 # License: BSD 3 clause
 
+from __future__ import division
 import numpy as np
 from scipy import sparse
 from sklearn.model_selection import LeaveOneOut
@@ -304,3 +305,4 @@ def test_calibration_prob_sum():
     probs = clf_prob.predict_proba(X)
     n_classes = len(y)
     assert_array_almost_equal(probs, 1/n_classes)
+test_calibration_prob_sum()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
#7796 

#### What does this implement/fix? Explain your changes.
The `LabelBinarizer()` was not used consistently in `CalibratedClassifierCV` In the example provided in the issue #7796 , the when using `LeaveOneOut` the test set will have only one class, whereas the train set has two classes. Two different instances of the `LabelBinarizer` are used to encode the test and train set.
So, I have added a new argument 'classes' in the `fit()` function of `_CalibratedClassifier` class (which contains the unique classes of the test set), as I didn't know of any other method to solve this issue. If someone has a better solution I can change it.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->