### PR TITLE
[MRG+1] Warning raised by MultiTaskElasticNet.fit is now ConvergenceWarning.

### DIFF
--- a/sklearn/linear_model/coordinate_descent.py
+++ b/sklearn/linear_model/coordinate_descent.py
@@ -1737,7 +1737,8 @@ class MultiTaskElasticNet(Lasso):
 
         if self.dual_gap_ > self.eps_:
             warnings.warn('Objective did not converge, you might want'
-                          ' to increase the number of iterations')
+                          ' to increase the number of iterations',
+                          ConvergenceWarning)
 
         # return self for chaining fit and predict calls
         return self

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -9,6 +9,7 @@ from scipy import interpolate, sparse
 from copy import deepcopy
 
 from sklearn.datasets import load_boston
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_equal
@@ -391,6 +392,9 @@ def test_multi_task_lasso_and_enet():
     clf = MultiTaskElasticNet(alpha=1, tol=1e-8).fit(X, Y)
     assert_true(0 < clf.dual_gap_ < 1e-5)
     assert_array_almost_equal(clf.coef_[0], clf.coef_[1])
+
+    clf = MultiTaskElasticNet(alpha=1.0, tol=1e-8, max_iter=1)
+    assert_warns_message(ConvergenceWarning, 'did not converge', clf.fit, X, Y)
 
 
 def test_lasso_readonly_data():


### PR DESCRIPTION
#### Reference Issue
Fixes #7805

#### What does this implement/fix? Explain your changes.
It makes the `fit` method of `MultiTaskElasticNet` to raise a `ConvergenceWarning` instead of `UserWarning`.
