### PR TITLE
[MRG + 3] OneVsRestClassifier: don't expose predict_proba and decision_function if base estimator doesn't support them

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -50,7 +50,7 @@ from .utils.validation import check_X_y
 from .utils.multiclass import (_check_partial_fit_first_call,
                                check_classification_targets,
                                _ovr_decision_function)
-from .utils.metaestimators import _safe_split
+from .utils.metaestimators import _safe_split, if_delegate_has_method
 
 from .externals.joblib import Parallel
 from .externals.joblib import delayed
@@ -309,6 +309,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
                                       shape=(n_samples, len(self.estimators_)))
             return self.label_binarizer_.inverse_transform(indicator)
 
+    @if_delegate_has_method('estimator')
     def predict_proba(self, X):
         """Probability estimates.
 
@@ -347,6 +348,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
+    @if_delegate_has_method('estimator')
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. This can only be used with estimators which implement the
@@ -361,9 +363,6 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
         T : array-like, shape = [n_samples, n_classes]
         """
         check_is_fitted(self, 'estimators_')
-        if not hasattr(self.estimators_[0], "decision_function"):
-            raise AttributeError(
-                "Base estimator doesn't have a decision_function attribute.")
         return np.array([est.decision_function(X).ravel()
                          for est in self.estimators_]).T
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -309,7 +309,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
                                       shape=(n_samples, len(self.estimators_)))
             return self.label_binarizer_.inverse_transform(indicator)
 
-    @if_delegate_has_method('estimator')
+    @if_delegate_has_method(['_first_estimator', 'estimator'])
     def predict_proba(self, X):
         """Probability estimates.
 
@@ -348,7 +348,7 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
             Y /= np.sum(Y, axis=1)[:, np.newaxis]
         return Y
 
-    @if_delegate_has_method('estimator')
+    @if_delegate_has_method(['_first_estimator', 'estimator'])
     def decision_function(self, X):
         """Returns the distance of each sample from the decision boundary for
         each class. This can only be used with estimators which implement the
@@ -398,6 +398,10 @@ class OneVsRestClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""
         return getattr(self.estimator, "_pairwise", False)
+
+    @property
+    def _first_estimator(self):
+        return self.estimators_[0]
 
 
 def _fit_ovo_binary(estimator, X, y, i, j):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -326,6 +326,14 @@ def test_ovr_multilabel_predict_proba():
         assert_false(hasattr(decision_only, 'predict_proba'))
         assert_true(hasattr(decision_only, 'decision_function'))
 
+        # Estimator which can get predict_proba enabled after fitting
+        gs = GridSearchCV(svm.SVC(probability=False),
+                          param_grid={'probability': [True]})
+        proba_after_fit = OneVsRestClassifier(gs)
+        assert_false(hasattr(proba_after_fit, 'predict_proba'))
+        proba_after_fit.fit(X_train, Y_train)
+        assert_true(hasattr(proba_after_fit, 'predict_proba'))
+
         Y_pred = clf.predict(X_test)
         Y_proba = clf.predict_proba(X_test)
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -314,14 +314,17 @@ def test_ovr_multilabel_predict_proba():
         X_test = X[80:]
         clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
-        # decision function only estimator. Fails in current implementation.
+        # Decision function only estimator.
         decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-        assert_raises(AttributeError, decision_only.predict_proba, X_test)
+        assert not hasattr(decision_only, 'predict_proba')
+        assert hasattr(decision_only, 'decision_function')
 
         # Estimator with predict_proba disabled, depending on parameters.
         decision_only = OneVsRestClassifier(svm.SVC(probability=False))
+        assert not hasattr(decision_only, 'predict_proba')
         decision_only.fit(X_train, Y_train)
-        assert_raises(AttributeError, decision_only.predict_proba, X_test)
+        assert not hasattr(decision_only, 'predict_proba')
+        assert hasattr(decision_only, 'decision_function')
 
         Y_pred = clf.predict(X_test)
         Y_proba = clf.predict_proba(X_test)
@@ -339,9 +342,10 @@ def test_ovr_single_label_predict_proba():
     X_test = X[80:]
     clf = OneVsRestClassifier(base_clf).fit(X_train, Y_train)
 
-    # decision function only estimator. Fails in current implementation.
+    # Decision function only estimator.
     decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-    assert_raises(AttributeError, decision_only.predict_proba, X_test)
+    assert not hasattr(decision_only, 'predict_proba')
+    assert hasattr(decision_only, 'decision_function')
 
     Y_pred = clf.predict(X_test)
     Y_proba = clf.predict_proba(X_test)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -316,15 +316,15 @@ def test_ovr_multilabel_predict_proba():
 
         # Decision function only estimator.
         decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-        assert not hasattr(decision_only, 'predict_proba')
-        assert hasattr(decision_only, 'decision_function')
+        assert_false(hasattr(decision_only, 'predict_proba'))
+        assert_true(hasattr(decision_only, 'decision_function'))
 
         # Estimator with predict_proba disabled, depending on parameters.
         decision_only = OneVsRestClassifier(svm.SVC(probability=False))
-        assert not hasattr(decision_only, 'predict_proba')
+        assert_false(hasattr(decision_only, 'predict_proba'))
         decision_only.fit(X_train, Y_train)
-        assert not hasattr(decision_only, 'predict_proba')
-        assert hasattr(decision_only, 'decision_function')
+        assert_false(hasattr(decision_only, 'predict_proba'))
+        assert_true(hasattr(decision_only, 'decision_function'))
 
         Y_pred = clf.predict(X_test)
         Y_proba = clf.predict_proba(X_test)
@@ -344,8 +344,8 @@ def test_ovr_single_label_predict_proba():
 
     # Decision function only estimator.
     decision_only = OneVsRestClassifier(svm.SVR()).fit(X_train, Y_train)
-    assert not hasattr(decision_only, 'predict_proba')
-    assert hasattr(decision_only, 'decision_function')
+    assert_false(hasattr(decision_only, 'predict_proba'))
+    assert_true(hasattr(decision_only, 'decision_function'))
 
     Y_pred = clf.predict(X_test)
     Y_proba = clf.predict_proba(X_test)


### PR DESCRIPTION
Currently OneVsRestClassifier has predict_proba and decision_function methods even if base estimator doesn't have them. This makes it harder to check if an estimator supports predict_proba or not because it is not enough to run `hasattr(estimator, 'predict_proba')`, one have to special-case OneVsRestClassifier.

In this PR it is changed, so that OneVsRestClassifier is more similar to Pipeline: if base estimator doesn't provide predit_proba or decision_function then OneVsRestClassifier also doesn't provide them.

It is not 100% backwards compatible: AttributeError is raised earlier, on ovr.decision_function / ovr.predict_proba access, not when these methods are called.