### PR TITLE
[MRG+1] DOC use the class_with_call template for kernels

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -572,7 +572,7 @@ Kernels:
 
 .. autosummary::
   :toctree: generated/
-  :template: class.rst
+  :template: class_with_call.rst
 
   gaussian_process.kernels.Kernel
   gaussian_process.kernels.Sum


### PR DESCRIPTION
This documents `__call__`