### PR TITLE
[MRG + 1] MAINT: Return self for fit in Spectral Biclustering and CoClustering

### DIFF
--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -117,14 +117,11 @@ class BaseSpectral(six.with_metaclass(ABCMeta, BaseEstimator,
         ----------
         X : array-like, shape (n_samples, n_features)
 
-        Returns
-        -------
-        self : object
-            Returns the instance itself.
         """
         X = check_array(X, accept_sparse='csr', dtype=np.float64)
         self._check_parameters()
-        return self._fit(X)
+        self._fit(X)
+        return self
 
     def _svd(self, array, n_components, n_discard):
         """Returns first `n_components` left and right singular
@@ -295,7 +292,6 @@ class SpectralCoclustering(BaseSpectral):
                                for c in range(self.n_clusters))
         self.columns_ = np.vstack(self.column_labels_ == c
                                   for c in range(self.n_clusters))
-        return self
 
 
 class SpectralBiclustering(BaseSpectral):
@@ -480,7 +476,6 @@ class SpectralBiclustering(BaseSpectral):
         self.columns_ = np.vstack(self.column_labels_ == label
                                   for _ in range(n_row_clusters)
                                   for label in range(n_col_clusters))
-        return self
 
     def _fit_best_piecewise(self, vectors, n_best, n_clusters):
         """Find the ``n_best`` vectors that are best approximated by piecewise

--- a/sklearn/cluster/bicluster.py
+++ b/sklearn/cluster/bicluster.py
@@ -117,10 +117,14 @@ class BaseSpectral(six.with_metaclass(ABCMeta, BaseEstimator,
         ----------
         X : array-like, shape (n_samples, n_features)
 
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
         """
         X = check_array(X, accept_sparse='csr', dtype=np.float64)
         self._check_parameters()
-        self._fit(X)
+        return self._fit(X)
 
     def _svd(self, array, n_components, n_discard):
         """Returns first `n_components` left and right singular
@@ -291,6 +295,7 @@ class SpectralCoclustering(BaseSpectral):
                                for c in range(self.n_clusters))
         self.columns_ = np.vstack(self.column_labels_ == c
                                   for c in range(self.n_clusters))
+        return self
 
 
 class SpectralBiclustering(BaseSpectral):
@@ -475,6 +480,7 @@ class SpectralBiclustering(BaseSpectral):
         self.columns_ = np.vstack(self.column_labels_ == label
                                   for _ in range(n_row_clusters)
                                   for label in range(n_col_clusters))
+        return self
 
     def _fit_best_piecewise(self, vectors, n_best, n_clusters):
         """Find the ``n_best`` vectors that are best approximated by piecewise


### PR DESCRIPTION
Regarding gh-6126

Fix ``fit`` method to return ``self`` for ``SpectralBiclustering`` and ``SpectralCoclustering``, but the common tests still skip the bicluster classes.

This is a temporary fix for 0.18.1 and will try to make the common tests as part of gh-6141.
