### PR TITLE
[MRG + 2] DOC adding :user: role to whats_new

### DIFF
--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -22,11 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-try:
-    from docutils import nodes, utils
-except ImportError:
-    # Load lazily so that test-sphinxext does not require docutils dependency
-    pass
+from docutils import nodes, utils
+from sphinx.util.nodes import split_explicit_title
 
 __version__ = '0.2.0'
 __author__ = 'Steven Loria'
@@ -45,13 +42,20 @@ def user_role(name, rawtext, text, lineno,
     """
     options = options or {}
     content = content or []
-    username = utils.unescape(text).strip()
+    has_explicit_title, title, target = split_explicit_title(text)
+
+    target = utils.unescape(target).strip()
+    title = utils.unescape(title).strip()
     config = inliner.document.settings.env.app.config
     if config.issues_user_uri:
-        ref = config.issues_user_uri.format(user=username)
+        ref = config.issues_user_uri.format(user=target)
     else:
-        ref = 'https://github.com/{0}'.format(username)
-    text = '@{0}'.format(username)
+        ref = 'https://github.com/{0}'.format(target)
+    if has_explicit_title:
+        text = title
+    else:
+        text = '@{0}'.format(target)
+
     link = nodes.reference(text=text, refuri=ref, **options)
     return [link], []
 

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -22,8 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from docutils import nodes, utils
-from sphinx.util.nodes import split_explicit_title
+try:
+    from docutils import nodes, utils
+except ImportError:
+    # Load lazily so that test-sphinxext does not require docutils dependency
+    pass
 
 __version__ = '0.2.0'
 __author__ = 'Steven Loria'

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 try:
     from docutils import nodes, utils
+    from sphinx.util.nodes import split_explicit_title
 except ImportError:
     # Load lazily so that test-sphinxext does not require docutils dependency
     pass

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -282,7 +282,8 @@ Other estimators
 
    - New :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
      replace former mixture models, employing faster inference
-     for sounder results. :issue:`7295` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
+     for sounder results. :issue:`7295` by :user:`Wei Xue<xuewei4d>` and 
+     :user:`Thierry Guillemot<tguillemot>`.
 
    - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
      and it is available calling with parameter ``svd_solver='randomized'``.
@@ -404,7 +405,8 @@ Decomposition, manifold learning and clustering
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     :issue:`6846` by :user:`Sebastian Säger<ssaeger>` and :user:`YenChen Lin<yenchenlin>`.
+     :issue:`6846` by :user:`Sebastian Säger<ssaeger>` and 
+     :user:`YenChen Lin<yenchenlin>`.
 
 Preprocessing and feature selection
 
@@ -412,7 +414,8 @@ Preprocessing and feature selection
      :issue:`5929` by :user:`Konstantin Podshumok<podshumok>`.
 
    - :class:`feature_extraction.FeatureHasher` now accepts string values.
-     :issue:`6173` by :user:`Ryad Zenine<ryadzenine>` and :user:`Devashish Deshpande<dsquareindia>`.
+     :issue:`6173` by :user:`Ryad Zenine<ryadzenine>` and 
+     :user:`Devashish Deshpande<dsquareindia>`.
 
    - Keyword arguments can now be supplied to ``func`` in
      :class:`preprocessing.FunctionTransformer` by means of the ``kw_args``
@@ -425,7 +428,8 @@ Preprocessing and feature selection
 Model evaluation and meta-estimators
 
    - :class:`multiclass.OneVsOneClassifier` and :class:`multiclass.OneVsRestClassifier`
-     now support ``partial_fit``. By :user:`Asish Panda<kaichogami>` and :user:`Philipp Dowling<phdowling>`.
+     now support ``partial_fit``. By :user:`Asish Panda<kaichogami>` and 
+     :user:`Philipp Dowling<phdowling>`.
 
    - Added support for substituting or disabling :class:`pipeline.Pipeline`
      and :class:`pipeline.FeatureUnion` components using the ``set_params``
@@ -452,7 +456,8 @@ Metrics
 
    - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
-     :issue:`7239` by :user:`Hong Guangguo<hongguangguo>` with help from :user:`Mads Jensen<indianajensen>` and :user:`Nelson Liu<nelson-liu>`.
+     :issue:`7239` by :user:`Hong Guangguo<hongguangguo>` with help from 
+     :user:`Mads Jensen<indianajensen>` and :user:`Nelson Liu<nelson-liu>`.
 
    - Support sparse contingency matrices in cluster evaluation
      (:mod:`metrics.cluster.supervised`) to scale to a large number of
@@ -571,7 +576,8 @@ Decomposition, manifold learning and clustering
     - Fixed incorrect initialization of :func:`utils.arpack.eigsh` on all
       occurrences. Affects :class:`cluster.bicluster.SpectralBiclustering`,
       :class:`decomposition.KernelPCA`, :class:`manifold.LocallyLinearEmbedding`,
-      and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By :user:`Peter Fischer<yanlend>`.
+      and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By 
+      :user:`Peter Fischer<yanlend>`.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver
       of :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
@@ -853,8 +859,8 @@ New features
      :class:`cross_validation.LabelShuffleSplit` generate train-test folds,
      respectively similar to :class:`cross_validation.KFold` and
      :class:`cross_validation.ShuffleSplit`, except that the folds are
-     conditioned on a label array. By `Brian McFee`_, :user:`Jean Kossaifi<JeanKossaifi>` and
-     `Gilles Louppe`_.
+     conditioned on a label array. By `Brian McFee`_, :user:`Jean 
+     Kossaifi<JeanKossaifi>` and `Gilles Louppe`_.
 
    - :class:`decomposition.LatentDirichletAllocation` implements the Latent
      Dirichlet Allocation topic model with online  variational
@@ -884,7 +890,8 @@ Enhancements
      (:issue:`4025`)
 
    - :class:`cluster.mean_shift_.MeanShift` now supports parallel execution,
-     as implemented in the ``mean_shift`` function. By :user:`Martino Sorbaro<martinosorb>`.
+     as implemented in the ``mean_shift`` function. By :user:`Martino
+     Sorbaro<martinosorb>`.
 
    - :class:`naive_bayes.GaussianNB` now supports fitting with ``sample_weight``.
      By `Jan Hendrik Metzen`_.
@@ -942,7 +949,8 @@ Enhancements
      By `Trevor Stephens`_.
 
    - Provide an option for sparse output from
-     :func:`sklearn.metrics.pairwise.cosine_similarity`. By :user:`Jaidev Deshpande<jaidevd>`.
+     :func:`sklearn.metrics.pairwise.cosine_similarity`. By 
+     :user:`Jaidev Deshpande<jaidevd>`.
 
    - Add :func:`minmax_scale` to provide a function interface for
      :class:`MinMaxScaler`. By :user:`Thomas Unterthiner<untom>`.
@@ -989,7 +997,8 @@ Enhancements
      regressors and gradient boosting estimators by computing a proxy
      of the impurity improvement during the tree growth. The proxy quantity is
      such that the split that maximizes this value also maximizes the impurity
-     improvement. By `Arnaud Joly`_, :user:`Jacob Schreiber<jmschrei>` and `Gilles Louppe`_.
+     improvement. By `Arnaud Joly`_, :user:`Jacob Schreiber<jmschrei>`
+     and `Gilles Louppe`_.
 
    - Speed up tree based methods by reducing the number of computations needed
      when computing the impurity measure taking into account linear
@@ -1151,7 +1160,8 @@ Bug fixes
       By `Tom Dupre la Tour`_.
 
     - Fixed bug :issue:`5495` when
-      doing OVR(SVC(decision_function_shape="ovr")). Fixed by :user:`Elvis Dohmatob<dohmatob>`.
+      doing OVR(SVC(decision_function_shape="ovr")). Fixed by 
+      :user:`Elvis Dohmatob<dohmatob>`.
 
 
 API changes summary
@@ -1196,7 +1206,8 @@ API changes summary
       which are below a certain threshold value instead.
 
     - :class:`cluster.KMeans` re-runs cluster-assignments in case of non-convergence,
-      to ensure consistency of ``predict(X)`` and ``labels_``. By :user:`Vighnesh Birodkar<vighneshbirodkar>`.
+      to ensure consistency of ``predict(X)`` and ``labels_``. By
+      :user:`Vighnesh Birodkar<vighneshbirodkar>`.
 
     - Classifier and Regressor models are now tagged as such using the
       ``_estimator_type`` attribute.
@@ -1464,7 +1475,8 @@ Enhancements
      `newton-cg` by Simon Wu.
 
    - ``DictVectorizer`` can now perform ``fit_transform`` on an iterable in a
-     single pass, when giving the option ``sort=False``. By :user:`Dan Blanchard<dan-blanchard>`.
+     single pass, when giving the option ``sort=False``. By :user:`Dan
+     Blanchard<dan-blanchard>`.
 
    - :class:`GridSearchCV` and :class:`RandomizedSearchCV` can now be
      configured to work with estimators that may fail and raise errors on
@@ -1825,7 +1837,8 @@ Bug fixes
 ---------
 
   - Fixed handling of the ``p`` parameter of the Minkowski distance that was
-    previously ignored in nearest neighbors models. By :user:`Nikolay Mayorov<nmayorov>`.
+    previously ignored in nearest neighbors models. By :user:`Nikolay
+    Mayorov<nmayorov>`.
 
   - Fixed duplicated alphas in :class:`linear_model.LassoLars` with early
     stopping on 32 bit Python. By `Olivier Grisel`_ and `Fabian Pedregosa`_.
@@ -4708,4 +4721,3 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Tom Dupre la Tour: https://github.com/TomDLT
 
 .. _Nelle Varoquaux: https://github.com/nellev
-

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1380,7 +1380,7 @@ New features
      sample sizes than :class:`svm.SVR` with linear kernel. By
      `Fabian Pedregosa`_ and Qiang Luo.
 
-   - Incremental fit for :class:`GaussianNB  <naive_bayes.GaussianNB>`.
+   - Incremental fit for :class:`GaussianNB <naive_bayes.GaussianNB>`.
 
    - Added ``sample_weight`` support to :class:`dummy.DummyClassifier` and
      :class:`dummy.DummyRegressor`. By `Arnaud Joly`_.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,7 +30,7 @@ Enhancements
 
    - :class:`cluster.MiniBatchKMeans` and :class:`cluster.KMeans`
      now uses significantly less memory when assigning data points to their
-     nearest cluster center. :issue:`7721` by `Jon Crall`_.
+     nearest cluster center. :issue:`7721` by :user:`Jon Crall<Erotemic>`.
 
    - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`
      that matches the ``classes_`` attribute of ``best_estimator_``. (`#7661
@@ -68,7 +68,7 @@ Enhancements
 
    - ``check_estimator`` now attempts to ensure that methods transform, predict, etc.
      do not set attributes on the estimator.
-     :issue:`7533` by `Ekaterina Krivich`_.
+     :issue:`7533` by :user:`Ekaterina Krivich<kiote>`.
 
 Bug fixes
 .........
@@ -94,7 +94,8 @@ Bug fixes
      :issue:`7680` by :user:`Ibraim Ganiev<olologin>`.
 
    - Fixed a bug where :class:`decomposition.NMF` sets its ``n_iters_``
-     attribute in `transform()`. :issue:`7553` by `Ekaterina Krivich`_.
+     attribute in `transform()`. :issue:`7553` by :user:`Ekaterina
+     Krivich<kiote>`.
 
 .. _changes_0_18_1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1831,7 +1831,7 @@ Pedregosa, Florian Wilhelm, floydsoft, Félix-Antoine Fortin, Gael Varoquaux,
 Garrett-R, Gilles Louppe, gpassino, gwulfs, Hampus Bengtsson, Hamzeh Alsalhi,
 Hanna Wallach, Harry Mavroforakis, Hasil Sharma, Helder, Herve Bredin,
 Hsiang-Fu Yu, Hugues SALAMIN, Ian Gilmore, Ilambharathi Kanniah, Imran Haque,
-isms, Jake Vanderplas, Jan Dlabal, Jan Hendrik Metzen, Jatin Shah, Javier López
+isms, Jake VanderPlas, Jan Dlabal, Jan Hendrik Metzen, Jatin Shah, Javier López
 Peña, jdcaballero, Jean Kossaifi, Jeff Hammerbacher, Joel Nothman, Jonathan
 Helmus, Joseph, Kaicheng Zhang, Kevin Markham, Kyle Beauchamp, Kyle Kastner,
 Lagacherie Matthieu, Lars Buitinck, Laurent Direr, leepei, Loic Esteve, Luis
@@ -1913,7 +1913,7 @@ Bug fixes
 
    - Support unseen labels :class:`preprocessing.LabelBinarizer` to restore
      the default behavior of 0.14.1 for backward compatibility. By
-     :user:`Hamzeh Alsalhi<hamsal>`.
+     :user:`Hamzeh Alsalhi <hamsal>`.
 
    - Fixed the :class:`cluster.KMeans` stopping criterion that prevented early
      convergence detection. By Edward Raff and `Gael Varoquaux`_.
@@ -2329,7 +2329,7 @@ List of contributors for release 0.15 by number of commits.
 *  21	Maheshakya Wijewardena
 *  21	Brooke Osborn
 *  21	Hamzeh Alsalhi
-*  21	Jake Vanderplas
+*  21	Jake VanderPlas
 *  21	Philippe Gervais
 *  19	Bala Subrahmanyam Varanasi
 *  12	Ronald Phlypo
@@ -2563,7 +2563,7 @@ Changelog
      estimates when trained under log loss or modified Huber loss.
 
    - Hyperlinks to documentation in example code on the website by
-     :user:`Martin Luessi<mluessi>`.
+     :user:`Martin Luessi <mluessi>`.
 
    - Fixed bug in :class:`preprocessing.MinMaxScaler` causing incorrect scaling
      of the features for non-default ``feature_range`` settings. By `Andreas
@@ -2776,7 +2776,7 @@ List of contributors for release 0.14 by number of commits.
  * 102  Noel Dawe
  *  99  Kemal Eren
  *  79  Joel Nothman
- *  75  Jake Vanderplas
+ *  75  Jake VanderPlas
  *  73  Nelle Varoquaux
  *  71  Vlad Niculae
  *  65  Peter Prettenhofer

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,13 +36,13 @@ Enhancements
    - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`
      that matches the ``classes_`` attribute of ``best_estimator_``. (`#7661
      <https://github.com/scikit-learn/scikit-learn/pull/7661>`_) by `Alyssa
-     Batula`_ and `Dylan Werner-Meier`_.
+     Batula`_ and :user:`Dylan Werner-Meier<unautre>`.
 
    - The ``min_weight_fraction_leaf`` constraint in tree construction is now
      more efficient, taking a fast path to declare a node a leaf if its weight
      is less than 2 * the minimum. Note that the constructed tree will be
      different from previous versions where ``min_weight_fraction_leaf`` is
-     used. :issue:`7441` by `Nelson Liu`_.
+     used. :issue:`7441` by :user:`Nelson Liu<nelson-liu>`.
 
    - Added ``average`` parameter to perform weights averaging in
      :class:`linear_model.PassiveAggressiveClassifier`. :issue:`4939`
@@ -54,20 +54,20 @@ Enhancements
 
    - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
      now support sparse input for prediction.
-     :issue:`6101` by `Ibraim Ganiev`_.
+     :issue:`6101` by :user:`Ibraim Ganiev<olologin>`.
 
    - Added ``shuffle`` and ``random_state`` parameters to shuffle training
      data before taking prefixes of it based on training sizes in
      :func:`model_selection.learning_curve`.
      (`#7506` <https://github.com/scikit-learn/scikit-learn/pull/7506>_) by
-     `Narine Kokhlikyan`_.
+     :user:`Narine Kokhlikyan<NarineK>`.
 
    - Added ``norm_order`` parameter to :class:`feature_selection.SelectFromModel`
      to enable selection of the norm order when ``coef_`` is more than 1D
 
    - Added ``sample_weight`` parameter to :meth:`pipeline.Pipeline.score`.
      (`#7723 <https://github.com/scikit-learn/scikit-learn/pull/7723>`_)
-     by `Mikhail Korobov`_.
+     by :user:`Mikhail Korobov<kmike>`.
 
 Bug fixes
 .........
@@ -76,7 +76,7 @@ Bug fixes
      exactly implement Benjamini-Hochberg procedure. It formerly may have
      selected fewer features than it should.
      (`#7490 <https://github.com/scikit-learn/scikit-learn/pull/7490>`_) by
-     `Peng Meng`_.
+     :user:`Peng Meng<mpjlu>`.
 
    - :class:`sklearn.manifold.LocallyLinearEmbedding` now correctly handles
      integer inputs. :issue:`6282` by `Jake Vanderplas`_.
@@ -85,14 +85,14 @@ Bug fixes
      regressors now assumes uniform sample weights by default if the
      ``sample_weight`` argument is not passed to the ``fit`` function.
      Previously, the parameter was silently ignored. :issue:`7301`
-     by `Nelson Liu`_.
+     by :user:`Nelson Liu<nelson-liu>`.
 
    - Numerical issue with :class:`linear_model.RidgeCV` on centered data when
      `n_features > n_samples`. :issue:`6178` by `Bertrand Thirion`_
 
    - Tree splitting criterion classes' cloning/pickling is now memory safe
      (`#7680 <https://github.com/scikit-learn/scikit-learn/pull/7680>`_).
-     By `Ibraim Ganiev`_.
+     By :user:`Ibraim Ganiev<olologin>`.
 
 .. _changes_0_18_1:
 
@@ -121,13 +121,13 @@ Bug fixes
 
    - Fix issue where ``min_grad_norm`` and ``n_iter_without_progress``
      parameters were not being utilised by :class:`manifold.TSNE`.
-     :issue:`6497` by `Sebastian Säger`_
+     :issue:`6497` by :user:`Sebastian Säger<ssaeger>`
 
    - Attribute ``explained_variance_ratio`` of
      :class:`discriminant_analysis.LinearDiscriminantAnalysis` calculated
      with SVD and Eigen solver are now of the same length. (`#7632
      <https://github.com/scikit-learn/scikit-learn/pull/7632>`_).
-     By `JPFrancoia`_
+     By :user:`JPFrancoia<JPFrancoia>`
 
    - Fixes issue in :ref:`univariate_feature_selection` where score 
      functions were not accepting multi-label targets.(`#7676
@@ -145,7 +145,7 @@ Linear, kernelized and related models
      changed for both Eigen and SVD solvers. The attribute has now a length
      of min(n_components, n_classes - 1). (`#7632
      <https://github.com/scikit-learn/scikit-learn/pull/7632>`_).
-     By `JPFrancoia`_
+     By :user:`JPFrancoia<JPFrancoia>`
 
 
 .. _changes_0_18:
@@ -277,20 +277,20 @@ Classifiers and Regressors
      examples are provided. By `Jan Hendrik Metzen`_.
 
    - Added new supervised learning algorithm: :ref:`Multi-layer Perceptron <multilayer_perceptron>`
-     :issue:`3204` by `Issam H. Laradji`_
+     :issue:`3204` by :user:`Issam H. Laradji<IssamLaradji>`
 
    - Added :class:`linear_model.HuberRegressor`, a linear model robust to outliers.
      :issue:`5291` by `Manoj Kumar`_.
 
    - Added the :class:`multioutput.MultiOutputRegressor` meta-estimator. It
      converts single output regressors to multi-ouput regressors by fitting
-     one regressor per output. By `Tim Head`_.
+     one regressor per output. By :user:`Tim Head<betatim>`.
 
 Other estimators
 
    - New :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
      replace former mixture models, employing faster inference
-     for sounder results. :issue:`7295` by `Wei Xue`_ and `Thierry Guillemot`_.
+     for sounder results. :issue:`7295` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
 
    - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
      and it is available calling with parameter ``svd_solver='randomized'``.
@@ -298,14 +298,14 @@ Other estimators
      behavior of PCA is recovered by ``svd_solver='full'``. An additional solver
      calls ``arpack`` and performs truncated (non-randomized) SVD. By default,
      the best solver is selected depending on the size of the input and the
-     number of components requested. :issue:`5299` by `Giorgio Patrini`_.
+     number of components requested. :issue:`5299` by :user:`Giorgio Patrini<giorgiop>`.
 
    - Added two functions for mutual information estimation:
      :func:`feature_selection.mutual_info_classif` and
      :func:`feature_selection.mutual_info_regression`. These functions can be
      used in :class:`feature_selection.SelectKBest` and
      :class:`feature_selection.SelectPercentile` as score functions.
-     By `Andrea Bravi`_ and `Nikolay Mayorov`_.
+     By :user:`Andrea Bravi<AndreaBravi>` and :user:`Nikolay Mayorov<nmayorov>`.
 
    - Added the :class:`ensemble.IsolationForest` class for anomaly detection based on
      random forests. By `Nicolas Goix`_.
@@ -317,20 +317,20 @@ Model selection and evaluation
 
    - Added :func:`metrics.cluster.fowlkes_mallows_score`, the Fowlkes Mallows
      Index which measures the similarity of two clusterings of a set of points
-     By `Arnaud Fouchet`_ and `Thierry Guillemot`_.
+     By :user:`Arnaud Fouchet<afouchet>` and :user:`Thierry Guillemot<tguillemot>`.
 
    - Added :func:`metrics.calinski_harabaz_score`, which computes the Calinski
      and Harabaz score to evaluate the resulting clustering of a set of points.
-     By `Arnaud Fouchet`_ and `Thierry Guillemot`_.
+     By :user:`Arnaud Fouchet<afouchet>` and :user:`Thierry Guillemot<tguillemot>`.
 
    - Added new cross-validation splitter
      :class:`model_selection.TimeSeriesSplit` to handle time series data.
-     :issue:`6586` by `YenChen Lin`_
+     :issue:`6586` by :user:`YenChen Lin<yenchenlin>`
 
    - The cross-validation iterators are replaced by cross-validation splitters
      available from :mod:`sklearn.model_selection`, allowing for nested
      cross-validation. See :ref:`model_selection_changes` for more information.
-     :issue:`4294` by `Raghav R V`_.
+     :issue:`4294` by :user:`Raghav R V<raghavrv>`.
 
 Enhancements
 ............
@@ -341,10 +341,10 @@ Trees and ensembles
      the mean absolute error. This criterion can also be used in
      :class:`ensemble.ExtraTreesRegressor`,
      :class:`ensemble.RandomForestRegressor`, and the gradient boosting
-     estimators. :issue:`6667` by `Nelson Liu`_.
+     estimators. :issue:`6667` by :user:`Nelson Liu<nelson-liu>`.
 
    - Added weighted impurity-based early stopping criterion for decision tree
-     growth. :issue:`6954` by `Nelson Liu`_
+     growth. :issue:`6954` by :user:`Nelson Liu<nelson-liu>`
 
    - The random forest, extra tree and decision tree estimators now has a
      method ``decision_path`` which returns the decision path of samples in
@@ -355,72 +355,72 @@ Trees and ensembles
 
    - Random forest, extra trees, decision trees and gradient boosting estimator
      accept the parameter ``min_samples_split`` and ``min_samples_leaf``
-     provided as a percentage of the training samples. By `yelite`_ and `Arnaud Joly`_.
+     provided as a percentage of the training samples. By :user:`yelite<yelite>` and `Arnaud Joly`_.
 
    - Gradient boosting estimators accept the parameter ``criterion`` to specify
      to splitting criterion used in built decision trees.
-     :issue:`6667` by `Nelson Liu`_.
+     :issue:`6667` by :user:`Nelson Liu<nelson-liu>`.
 
    - The memory footprint is reduced (sometimes greatly) for
      :class:`ensemble.bagging.BaseBagging` and classes that inherit from it,
      i.e, :class:`ensemble.BaggingClassifier`,
      :class:`ensemble.BaggingRegressor`, and :class:`ensemble.IsolationForest`,
      by dynamically generating attribute ``estimators_samples_`` only when it is
-     needed. By `David Staub`_.
+     needed. By :user:`David Staub<staubda>`.
 
    - Added ``n_jobs`` and ``sample_weight`` parameters for
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
-     :issue:`5805` by `Ibraim Ganiev`_.
+     :issue:`5805` by :user:`Ibraim Ganiev<olologin>`.
 
 Linear, kernelized and related models
 
    - In :class:`linear_model.LogisticRegression`, the SAG solver is now
-     available in the multinomial case. :issue:`5251` by `Tom Dupre la Tour`_.
+     available in the multinomial case. :issue:`5251` by :user:`Tom Dupre la Tour<TomDLT>`.
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
      :class:`svm.LinearSVR` now support ``sample_weight``.
-     By `Imaculate`_.
+     By :user:`Imaculate<Imaculate>`.
 
    - Add parameter ``loss`` to :class:`linear_model.RANSACRegressor` to measure the
      error on the samples for every trial. By `Manoj Kumar`_.
 
    - Prediction of out-of-sample events with Isotonic Regression
      (:class:`isotonic.IsotonicRegression`) is now much faster (over 1000x in tests with synthetic
-     data). By `Jonathan Arfa`_.
+     data). By :user:`Jonathan Arfa<jarfa>`.
 
    - Isotonic regression (:class:`isotonic.IsotonicRegression`) now uses a better algorithm to avoid
      `O(n^2)` behavior in pathological cases, and is also generally faster
      (:issue:`#6691`). By `Antony Lee`_.
 
    - :class:`naive_bayes.GaussianNB` now accepts data-independent class-priors
-     through the parameter ``priors``. By `Guillaume Lemaitre`_.
+     through the parameter ``priors``. By :user:`Guillaume Lemaitre<glemaitre>`.
 
    - :class:`linear_model.ElasticNet` and :class:`linear_model.Lasso`
      now works with ``np.float32`` input data without converting it
      into ``np.float64``. This allows to reduce the memory
-     consumption. :issue:`6913` by `YenChen Lin`_.
+     consumption. :issue:`6913` by :user:`YenChen Lin<yenchenlin>`.
 
    - :class:`semi_supervised.LabelPropagation` and :class:`semi_supervised.LabelSpreading`
      now accept arbitrary kernel functions in addition to strings ``knn`` and ``rbf``.
-     :issue:`5762` by `Utkarsh Upadhyay`_.
+     :issue:`5762` by :user:`Utkarsh Upadhyay<musically-ut>`.
 
 Decomposition, manifold learning and clustering
 
    - Added ``inverse_transform`` function to :class:`decomposition.NMF` to compute
-     data matrix of original shape. By `Anish Shah`_.
+     data matrix of original shape. By :user:`Anish Shah<AnishShah>`.
 
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     :issue:`6846` by `Sebastian Säger`_ and `YenChen Lin`_.
+     :issue:`6846` by :user:`Sebastian Säger<ssaeger>` and :user:`YenChen Lin<yenchenlin>`.
 
 Preprocessing and feature selection
 
    - :class:`preprocessing.RobustScaler` now accepts ``quantile_range`` parameter.
-     :issue:`5929` by `Konstantin Podshumok`_.
+     :issue:`5929` by :user:`Konstantin Podshumok<podshumok>`.
 
    - :class:`feature_extraction.FeatureHasher` now accepts string values.
-     :issue:`6173` by `Ryad Zenine`_ and `Devashish Deshpande`_.
+     :issue:`6173` by :user:`Ryad Zenine<ryadzenine>` and :user:`Devashish Deshpande<dsquareindia>`.
 
    - Keyword arguments can now be supplied to ``func`` in
      :class:`preprocessing.FunctionTransformer` by means of the ``kw_args``
@@ -428,53 +428,53 @@ Preprocessing and feature selection
 
    - :class:`feature_selection.SelectKBest` and :class:`feature_selection.SelectPercentile`
      now accept score functions that take X, y as input and return only the scores.
-     By `Nikolay Mayorov`_.
+     By :user:`Nikolay Mayorov<nmayorov>`.
 
 Model evaluation and meta-estimators
 
    - :class:`multiclass.OneVsOneClassifier` and :class:`multiclass.OneVsRestClassifier`
-     now support ``partial_fit``. By `Asish Panda`_ and `Philipp Dowling`_.
+     now support ``partial_fit``. By :user:`Asish Panda<kaichogami>` and :user:`Philipp Dowling<phdowling>`.
 
    - Added support for substituting or disabling :class:`pipeline.Pipeline`
      and :class:`pipeline.FeatureUnion` components using the ``set_params``
      interface that powers :mod:`sklearn.grid_search`.
      See :ref:`sphx_glr_plot_compare_reduction.py`. By `Joel Nothman`_ and
-     `Robert McGibbon`_.
+     :user:`Robert McGibbon<rmcgibbo>`.
 
    - The new ``cv_results_`` attribute of :class:`model_selection.GridSearchCV`
      (and :class:`model_selection.RandomizedSearchCV`) can be easily imported
      into pandas as a ``DataFrame``. Ref :ref:`model_selection_changes` for
-     more information. :issue:`6697` by `Raghav R V`_.
+     more information. :issue:`6697` by :user:`Raghav R V<raghavrv>`.
 
    - Generalization of :func:`model_selection.cross_val_predict`.
      One can pass method names such as `predict_proba` to be used in the cross
      validation framework instead of the default `predict`.
-     By `Ori Ziv`_ and `Sears Merritt`_.
+     By :user:`Ori Ziv<zivori>` and :user:`Sears Merritt<merritts>`.
 
    - The training scores and time taken for training followed by scoring for
      each search candidate are now available at the ``cv_results_`` dict.
      See :ref:`model_selection_changes` for more information.
-     :issue:`7325` by `Eugene Chen`_ and `Raghav R V`_.
+     :issue:`7325` by :user:`Eugene Chen<eyc88>` and :user:`Raghav R V<raghavrv>`.
 
 Metrics
 
    - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
-     :issue:`7239` by `Hong Guangguo`_ with help from `Mads Jensen`_ and `Nelson Liu`_.
+     :issue:`7239` by :user:`Hong Guangguo<hongguangguo>` with help from :user:`Mads Jensen<indianajensen>` and :user:`Nelson Liu<nelson-liu>`.
 
    - Support sparse contingency matrices in cluster evaluation
      (:mod:`metrics.cluster.supervised`) to scale to a large number of
      clusters.
-     :issue:`7419` by `Gregory Stupp`_ and `Joel Nothman`_.
+     :issue:`7419` by :user:`Gregory Stupp<stuppie>` and `Joel Nothman`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
-     By `Jatin Shah`_ and `Raghav R V`_.
+     By :user:`Jatin Shah<jatinshah>` and :user:`Raghav R V<raghavrv>`.
 
    - Speed up :func:`metrics.silhouette_score` by using vectorized operations.
      By `Manoj Kumar`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.confusion_matrix`.
-     By `Bernardo Stein`_.
+     By :user:`Bernardo Stein<DanielSidhion>`.
 
 Miscellaneous
 
@@ -483,15 +483,15 @@ Miscellaneous
 
    - Codebase does not contain C/C++ cython generated files: they are
      generated during build. Distribution packages will still contain generated
-     C/C++ files. By `Arthur Mensch`_.
+     C/C++ files. By :user:`Arthur Mensch<arthurmensch>`.
 
    - Reduce the memory usage for 32-bit float input arrays of
      :func:`utils.sparse_func.mean_variance_axis` and
      :func:`utils.sparse_func.incr_mean_variance_axis` by supporting cython
-     fused types. By `YenChen Lin`_.
+     fused types. By :user:`YenChen Lin<yenchenlin>`.
 
    - The :func:`ignore_warnings` now accept a category argument to ignore only
-     the warnings of a specified type. By `Thierry Guillemot`_.
+     the warnings of a specified type. By :user:`Thierry Guillemot<tguillemot>`.
 
    - Added parameter ``return_X_y`` and return type ``(data, target) : tuple`` option to
      :func:`load_iris` dataset
@@ -503,7 +503,7 @@ Miscellaneous
      :func:`load_linnerud` dataset,
      :func:`load_boston` dataset
      :issue:`7154` by
-     `Manvendra Singh`_.
+     :user:`Manvendra Singh<manu-chroma>`.
 
    - Simplification of the ``clone`` function, deprecate support for estimators
      that modify parameters in ``__init__``. :issue:`5540` by `Andreas Müller`_.
@@ -542,11 +542,11 @@ Linear, kernelized and related models
 
     - Fixed incorrect gradient computation for ``loss='squared_epsilon_insensitive'`` in
       :class:`linear_model.SGDClassifier` and :class:`linear_model.SGDRegressor`
-      (:issue:`6764`). By `Wenhua Yang`_.
+      (:issue:`6764`). By :user:`Wenhua Yang<geekoala>`.
 
     - Fix bug in :class:`linear_model.LogisticRegressionCV` where
       ``solver='liblinear'`` did not accept ``class_weights='balanced``.
-      (:issue:`6817`). By `Tom Dupre la Tour`_.
+      (:issue:`6817`). By :user:`Tom Dupre la Tour<TomDLT>`.
 
     - Fix bug in :class:`neighbors.RadiusNeighborsClassifier` where an error
       occurred when there were outliers being labelled and a weight function
@@ -559,31 +559,31 @@ Linear, kernelized and related models
 Decomposition, manifold learning and clustering
 
     - :class:`decomposition.RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
-      :issue:`5141` by `Giorgio Patrini`_.
+      :issue:`5141` by :user:`Giorgio Patrini<giorgiop>`.
 
     - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.
       In practice this is enough for obtaining a good approximation of the
       true eigenvalues/vectors in the presence of noise. When `n_components` is
       small (``< .1 * min(X.shape)``) `n_iter` is set to 7, unless the user specifies
       a higher number. This improves precision with few components.
-      :issue:`5299` by `Giorgio Patrini`_.
+      :issue:`5299` by :user:`Giorgio Patrini<giorgiop>`.
 
     - Whiten/non-whiten inconsistency between components of :class:`decomposition.PCA`
       and :class:`decomposition.RandomizedPCA` (now factored into PCA, see the
       New features) is fixed. `components_` are stored with no whitening.
-      :issue:`5299` by `Giorgio Patrini`_.
+      :issue:`5299` by :user:`Giorgio Patrini<giorgiop>`.
 
     - Fixed bug in :func:`manifold.spectral_embedding` where diagonal of unnormalized
-      Laplacian matrix was incorrectly set to 1. :issue:`4995` by `Peter Fischer`_.
+      Laplacian matrix was incorrectly set to 1. :issue:`4995` by :user:`Peter Fischer<yanlend>`.
 
     - Fixed incorrect initialization of :func:`utils.arpack.eigsh` on all
       occurrences. Affects :class:`cluster.bicluster.SpectralBiclustering`,
       :class:`decomposition.KernelPCA`, :class:`manifold.LocallyLinearEmbedding`,
-      and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By `Peter Fischer`_.
+      and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By :user:`Peter Fischer<yanlend>`.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver
       of :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
-      correct results. By `JPFrancoia`_
+      correct results. By :user:`JPFrancoia<JPFrancoia>`
 
 Preprocessing and feature selection
 
@@ -595,12 +595,12 @@ Model evaluation and meta-estimators
 
     - :class:`model_selection.StratifiedKFold` now raises error if all n_labels
       for individual classes is less than n_folds.
-      :issue:`6182` by `Devashish Deshpande`_.
+      :issue:`6182` by :user:`Devashish Deshpande<dsquareindia>`.
 
     - Fixed bug in :class:`model_selection.StratifiedShuffleSplit`
       where train and test sample could overlap in some edge cases,
       see :issue:`6121` for
-      more details. By `Loic Esteve`_.
+      more details. By :user:`Loic Esteve<lesteve>`.
 
     - Fix in :class:`sklearn.model_selection.StratifiedShuffleSplit` to
       return splits of size ``train_size`` and ``test_size`` in all cases
@@ -608,7 +608,7 @@ Model evaluation and meta-estimators
 
     - Cross-validation of :class:`OneVsOneClassifier` and
       :class:`OneVsRestClassifier` now works with precomputed kernels.
-      :issue:`7350` by `Russell Smith`_.
+      :issue:`7350` by :user:`Russell Smith<rsmith54>`.
 
     - Fix incomplete ``predict_proba`` method delegation from
       :class:`model_selection.GridSearchCV` to
@@ -629,10 +629,10 @@ Metrics
 
     - :func:`metrics.pairwise.pairwise_distances` now converts arrays to
       boolean arrays when required in ``scipy.spatial.distance``.
-      :issue:`5460` by `Tom Dupre la Tour`_.
+      :issue:`5460` by :user:`Tom Dupre la Tour<TomDLT>`.
 
     - Fix sparse input support in :func:`metrics.silhouette_score` as well as
-      example examples/text/document_clustering.py. By `YenChen Lin`_.
+      example examples/text/document_clustering.py. By :user:`YenChen Lin<yenchenlin>`.
 
     - :func:`metrics.roc_curve` and :func:`metrics.precision_recall_curve` no
       longer round ``y_score`` values when creating ROC curves; this was causing
@@ -648,14 +648,14 @@ Miscellaneous
       power iterations are requested, since it applies LU normalization by default.
       If ``n_iter<2`` numerical issues are unlikely, thus no normalization is applied.
       Other normalization options are available: ``'none', 'LU'`` and ``'QR'``.
-      :issue:`5141` by `Giorgio Patrini`_.
+      :issue:`5141` by :user:`Giorgio Patrini<giorgiop>`.
 
     - Fix a bug where some formats of ``scipy.sparse`` matrix, and estimators
       with them as parameters, could not be passed to :func:`base.clone`.
-      By `Loic Esteve`_.
+      By :user:`Loic Esteve<lesteve>`.
 
     - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
-      :issue:`7101` by `Ibraim Ganiev`_.
+      :issue:`7101` by :user:`Ibraim Ganiev<olologin>`.
 
 
 API changes summary
@@ -667,7 +667,7 @@ Linear, kernelized and related models
      Use ``loss`` instead. By `Manoj Kumar`_.
 
    - Access to public attributes ``.X_`` and ``.y_`` has been deprecated in
-     :class:`isotonic.IsotonicRegression`. By `Jonathan Arfa`_.
+     :class:`isotonic.IsotonicRegression`. By :user:`Jonathan Arfa<jarfa>`.
 
 Decomposition, manifold learning and clustering
 
@@ -677,7 +677,7 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Gaussian mixture with a
      Dirichlet process prior faster than before.
-     :issue:`7295` by `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`7295` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
 
    - The old :class:`mixture.VBGMM` is deprecated in favor of the new
      :class:`mixture.BayesianGaussianMixture` (with the parameter
@@ -685,12 +685,12 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Variational Bayesian Gaussian
      mixture faster than before.
-     :issue:`6651` by `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`6651` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
 
    - The old :class:`mixture.GMM` is deprecated in favor of the new
      :class:`mixture.GaussianMixture`. The new class computes the Gaussian mixture
      faster than before and some of computational problems have been solved.
-     :issue:`6666` by `Wei Xue`_ and `Thierry Guillemot`_.
+     :issue:`6666` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
 
 Model evaluation and meta-estimators
 
@@ -698,21 +698,21 @@ Model evaluation and meta-estimators
      :mod:`sklearn.learning_curve` have been deprecated and the classes and
      functions have been reorganized into the :mod:`sklearn.model_selection`
      module. Ref :ref:`model_selection_changes` for more information.
-     :issue:`4294` by `Raghav R V`_.
+     :issue:`4294` by :user:`Raghav R V<raghavrv>`.
 
    - The ``grid_scores_`` attribute of :class:`model_selection.GridSearchCV`
      and :class:`model_selection.RandomizedSearchCV` is deprecated in favor of
      the attribute ``cv_results_``.
      Ref :ref:`model_selection_changes` for more information.
-     :issue:`6697` by `Raghav R V`_.
+     :issue:`6697` by :user:`Raghav R V<raghavrv>`.
 
    - The parameters ``n_iter`` or ``n_folds`` in old CV splitters are replaced
      by the new parameter ``n_splits`` since it can provide a consistent
      and unambiguous interface to represent the number of train-test splits.
-     :issue:`7187` by `YenChen Lin`_.
+     :issue:`7187` by :user:`YenChen Lin<yenchenlin>`.
 
    - ``classes`` parameter was renamed to ``labels`` in
-     :func:`metrics.hamming_loss`. :issue:`7260` by `Sebastián Vanrell`_.
+     :func:`metrics.hamming_loss`. :issue:`7260` by :user:`Sebastián Vanrell<srvanrell>`.
 
    - The splitter classes ``LabelKFold``, ``LabelShuffleSplit``,
      ``LeaveOneLabelOut`` and ``LeavePLabelsOut`` are renamed to
@@ -725,7 +725,7 @@ Model evaluation and meta-estimators
      :class:`model_selection.LeavePGroupsOut` is renamed to
      ``groups``. Additionally in :class:`model_selection.LeavePGroupsOut`,
      the parameter ``n_labels`` is renamed to ``n_groups``.
-     :issue:`6660` by `Raghav R V`_.
+     :issue:`6660` by :user:`Raghav R V<raghavrv>`.
 
 Code Contributors
 -----------------
@@ -837,7 +837,7 @@ New features
 ............
 
    - All the Scaler classes but :class:`preprocessing.RobustScaler` can be fitted online by
-     calling `partial_fit`. By `Giorgio Patrini`_.
+     calling `partial_fit`. By :user:`Giorgio Patrini<giorgiop>`.
 
    - The new class :class:`ensemble.VotingClassifier` implements a
      "majority rule" / "soft voting" ensemble classifier to combine
@@ -846,12 +846,12 @@ New features
    - The new class :class:`preprocessing.RobustScaler` provides an
      alternative to :class:`preprocessing.StandardScaler` for feature-wise
      centering and range normalization that is robust to outliers.
-     By `Thomas Unterthiner`_.
+     By :user:`Thomas Unterthiner<untom>`.
 
    - The new class :class:`preprocessing.MaxAbsScaler` provides an
      alternative to :class:`preprocessing.MinMaxScaler` for feature-wise
      range normalization when the data is already centered or sparse.
-     By `Thomas Unterthiner`_.
+     By :user:`Thomas Unterthiner<untom>`.
 
    - The new class :class:`preprocessing.FunctionTransformer` turns a Python
      function into a ``Pipeline``-compatible transformer object.
@@ -861,18 +861,18 @@ New features
      :class:`cross_validation.LabelShuffleSplit` generate train-test folds,
      respectively similar to :class:`cross_validation.KFold` and
      :class:`cross_validation.ShuffleSplit`, except that the folds are
-     conditioned on a label array. By `Brian McFee`_, `Jean Kossaifi`_ and
+     conditioned on a label array. By `Brian McFee`_, :user:`Jean Kossaifi<JeanKossaifi>` and
      `Gilles Louppe`_.
 
    - :class:`decomposition.LatentDirichletAllocation` implements the Latent
      Dirichlet Allocation topic model with online  variational
-     inference. By `Chyi-Kwei Yau`_, with code based on an implementation
+     inference. By :user:`Chyi-Kwei Yau<chyikwei>`, with code based on an implementation
      by Matt Hoffman. (:issue:`3659`)
 
    - The new solver ``sag`` implements a Stochastic Average Gradient descent
      and is available in both :class:`linear_model.LogisticRegression` and
      :class:`linear_model.Ridge`. This solver is very efficient for large
-     datasets. By `Danny Sullivan`_ and `Tom Dupre la Tour`_.
+     datasets. By :user:`Danny Sullivan<dsullivan7>` and :user:`Tom Dupre la Tour<TomDLT>`.
      (:issue:`4738`)
 
    - The new solver ``cd`` implements a Coordinate Descent in
@@ -883,7 +883,7 @@ New features
      ``eta``, ``beta`` and ``nls_max_iter``. New parameters ``alpha`` and
      ``l1_ratio`` control L1 and L2 regularization, and ``shuffle`` adds a
      shuffling step in the ``cd`` solver.
-     By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
+     By :user:`Tom Dupre la Tour<TomDLT>` and `Mathieu Blondel`_.
 
 Enhancements
 ............
@@ -892,7 +892,7 @@ Enhancements
      (:issue:`4025`)
 
    - :class:`cluster.mean_shift_.MeanShift` now supports parallel execution,
-     as implemented in the ``mean_shift`` function. By `Martino Sorbaro`_.
+     as implemented in the ``mean_shift`` function. By :user:`Martino Sorbaro<martinosorb>`.
 
    - :class:`naive_bayes.GaussianNB` now supports fitting with ``sample_weight``.
      By `Jan Hendrik Metzen`_.
@@ -901,7 +901,7 @@ Enhancements
      By `Arnaud Joly`_.
 
    - Added a ``fit_predict`` method for :class:`mixture.GMM` and subclasses.
-     By `Cory Lorenz`_.
+     By :user:`Cory Lorenz<clorenz7>`.
 
    - Added the :func:`metrics.label_ranking_loss` metric.
      By `Arnaud Joly`_.
@@ -909,10 +909,10 @@ Enhancements
    - Added the :func:`metrics.cohen_kappa_score` metric.
 
    - Added a ``warm_start`` constructor parameter to the bagging ensemble
-     models to increase the size of the ensemble. By `Tim Head`_.
+     models to increase the size of the ensemble. By :user:`Tim Head<betatim>`.
 
    - Added option to use multi-output regression metrics without averaging.
-     By Konstantin Shmelkov and `Michael Eickenberg`_.
+     By Konstantin Shmelkov and :user:`Michael Eickenberg<eickenberg>`.
 
    - Added ``stratify`` option to :func:`cross_validation.train_test_split`
      for stratified splitting. By Miroslav Batchkarov.
@@ -925,7 +925,7 @@ Enhancements
 
    - Improved speed of ``newton-cg`` solver in
      :class:`linear_model.LogisticRegression`, by avoiding loss computation.
-     By `Mathieu Blondel`_ and `Tom Dupre la Tour`_.
+     By `Mathieu Blondel`_ and :user:`Tom Dupre la Tour<TomDLT>`.
 
    - The ``class_weight="auto"`` heuristic in classifiers supporting
      ``class_weight`` was deprecated and replaced by the ``class_weight="balanced"``
@@ -950,16 +950,16 @@ Enhancements
      By `Trevor Stephens`_.
 
    - Provide an option for sparse output from
-     :func:`sklearn.metrics.pairwise.cosine_similarity`. By `Jaidev Deshpande`_.
+     :func:`sklearn.metrics.pairwise.cosine_similarity`. By :user:`Jaidev Deshpande<jaidevd>`.
 
    - Add :func:`minmax_scale` to provide a function interface for
-     :class:`MinMaxScaler`. By `Thomas Unterthiner`_.
+     :class:`MinMaxScaler`. By :user:`Thomas Unterthiner<untom>`.
 
    - ``dump_svmlight_file`` now handles multi-label datasets.
      By Chih-Wei Chang.
 
    - RCV1 dataset loader (:func:`sklearn.datasets.fetch_rcv1`).
-     By `Tom Dupre la Tour`_.
+     By :user:`Tom Dupre la Tour<TomDLT>`.
 
    - The "Wisconsin Breast Cancer" classical two-class classification dataset
      is now included in scikit-learn, available with
@@ -970,14 +970,14 @@ Enhancements
      parallelism when many very short tasks are executed in parallel, for
      instance by the :class:`grid_search.GridSearchCV` meta-estimator
      with ``n_jobs > 1`` used with a large grid of parameters on a small
-     dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and `Loic Esteve`_.
+     dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and :user:`Loic Esteve<lesteve>`.
 
    - For more details about changes in joblib 0.9.3 see the release notes:
      https://github.com/joblib/joblib/blob/master/CHANGES.rst#release-093
 
    - Improved speed (3 times per iteration) of
      :class:`decomposition.DictLearning` with coordinate descent method
-     from :class:`linear_model.Lasso`. By `Arthur Mensch`_.
+     from :class:`linear_model.Lasso`. By :user:`Arthur Mensch<arthurmensch>`.
 
    - Parallel processing (threaded) for queries of nearest neighbors
      (using the ball-tree) by Nikolay Mayorov.
@@ -991,13 +991,13 @@ Enhancements
 
    - :class:`tree.DecisionTreeClassifier` now exposes an ``apply`` method
      for retrieving the leaf indices samples are predicted as. By
-     `Daniel Galvez`_ and `Gilles Louppe`_.
+     :user:`Daniel Galvez<galv>` and `Gilles Louppe`_.
 
    - Speed up decision tree regressors, random forest regressors, extra trees
      regressors and gradient boosting estimators by computing a proxy
      of the impurity improvement during the tree growth. The proxy quantity is
      such that the split that maximizes this value also maximizes the impurity
-     improvement. By `Arnaud Joly`_, `Jacob Schreiber`_ and `Gilles Louppe`_.
+     improvement. By `Arnaud Joly`_, :user:`Jacob Schreiber<jmschrei>` and `Gilles Louppe`_.
 
    - Speed up tree based methods by reducing the number of computations needed
      when computing the impurity measure taking into account linear
@@ -1008,7 +1008,7 @@ Enhancements
    - :class:`ensemble.GradientBoostingRegressor` and
      :class:`ensemble.GradientBoostingClassifier` now expose an ``apply``
      method for retrieving the leaf indices each sample ends up in under
-     each try. By `Jacob Schreiber`_.
+     each try. By :user:`Jacob Schreiber<jmschrei>`.
 
    - Add ``sample_weight`` support to :class:`linear_model.LinearRegression`.
      By Sonny Hu. (:issue:`#4881`)
@@ -1017,12 +1017,12 @@ Enhancements
      the stopping criterion. By Santi Villalba. (:issue:`5186`)
 
    - Added optional parameter ``random_state`` in :class:`linear_model.Ridge`
-     , to set the seed of the pseudo random generator used in ``sag`` solver. By `Tom Dupre la Tour`_.
+     , to set the seed of the pseudo random generator used in ``sag`` solver. By :user:`Tom Dupre la Tour<TomDLT>`.
 
    - Added optional parameter ``warm_start`` in
      :class:`linear_model.LogisticRegression`. If set to True, the solvers
      ``lbfgs``, ``newton-cg`` and ``sag`` will be initialized with the
-     coefficients computed in the previous fit. By `Tom Dupre la Tour`_.
+     coefficients computed in the previous fit. By :user:`Tom Dupre la Tour<TomDLT>`.
 
    - Added ``sample_weight`` support to :class:`linear_model.LogisticRegression` for
      the ``lbfgs``, ``newton-cg``, and ``sag`` solvers. By `Valentin Stolbunov`_.
@@ -1031,15 +1031,15 @@ Enhancements
    - Added optional parameter ``presort`` to :class:`ensemble.GradientBoostingRegressor`
      and :class:`ensemble.GradientBoostingClassifier`, keeping default behavior
      the same. This allows gradient boosters to turn off presorting when building
-     deep trees or using sparse data. By `Jacob Schreiber`_.
+     deep trees or using sparse data. By :user:`Jacob Schreiber<jmschrei>`.
 
    - Altered :func:`metrics.roc_curve` to drop unnecessary thresholds by
-     default. By `Graham Clenaghan`_.
+     default. By :user:`Graham Clenaghan<gclenaghan>`.
 
    - Added :class:`feature_selection.SelectFromModel` meta-transformer which can
      be used along with estimators that have `coef_` or `feature_importances_`
      attribute to select important features of the input data. By
-     `Maheshakya Wijewardena`_, `Joel Nothman`_ and `Manoj Kumar`_.
+     :user:`Maheshakya Wijewardena<maheshakya>`, `Joel Nothman`_ and `Manoj Kumar`_.
 
    - Added :func:`metrics.pairwise.laplacian_kernel`.  By `Clyde Fare <https://github.com/Clyde-fare>`_.
 
@@ -1083,14 +1083,14 @@ Bug fixes
       in the final fit. By `Manoj Kumar`_.
 
     - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing
-      oob_score and X is a sparse.csc_matrix. By `Ankur Ankan`_.
+      oob_score and X is a sparse.csc_matrix. By :user:`Ankur Ankan<ankurankan>`.
 
     - All regressors now consistently handle and warn when given ``y`` that is of
       shape ``(n_samples, 1)``. By `Andreas Müller`_ and Henry Lin.
       (:issue:`5431`)
 
     - Fix in :class:`cluster.KMeans` cluster reassignment for sparse input by
-      `Lars Buitinck`_.
+      :user:`Lars Buitinck<larsmans>`.
 
     - Fixed a bug in :class:`lda.LDA` that could cause asymmetric covariance
       matrices when using shrinkage. By `Martin Billinger`_.
@@ -1103,7 +1103,7 @@ Bug fixes
       (:issue:`5182`)
 
     - Fixed the :func:`partial_fit` method of :class:`linear_model.SGDClassifier`
-      when called with ``average=True``. By `Andrew Lamb`_.
+      when called with ``average=True``. By :user:`Andrew Lamb<andylamb>`.
       (:issue:`5282`)
 
     - Dataset fetchers use different filenames under Python 2 and Python 3 to
@@ -1116,15 +1116,15 @@ Bug fixes
     - Fixed temporarily :class:`linear_model.Ridge`, which was incorrect
       when fitting the intercept in the case of sparse data. The fix
       automatically changes the solver to 'sag' in this case.
-      :issue:`5360` by `Tom Dupre la Tour`_.
+      :issue:`5360` by :user:`Tom Dupre la Tour<TomDLT>`.
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (:issue:`4478`)
-      By `Andreas Müller`_, `Loic Esteve`_ and `Giorgio Patrini`_.
+      By `Andreas Müller`_, :user:`Loic Esteve<lesteve>` and :user:`Giorgio Patrini<giorgiop>`.
 
     - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
       platform dependent output, and failed on `fit_transform`.
-      By `Arthur Mensch`_.
+      By :user:`Arthur Mensch<arthurmensch>`.
 
     - Fixes to the ``Bunch`` class used to store datasets.
 
@@ -1156,10 +1156,10 @@ Bug fixes
     - Fixed a bug in :class:`linear_model.LogisticRegression` and
       :class:`linear_model.LogisticRegressionCV` when using
       ``class_weight='balanced'```or ``class_weight='auto'``.
-      By `Tom Dupre la Tour`_.
+      By :user:`Tom Dupre la Tour<TomDLT>`.
 
     - Fixed bug :issue:`5495` when
-      doing OVR(SVC(decision_function_shape="ovr")). Fixed by `Elvis Dohmatob`_.
+      doing OVR(SVC(decision_function_shape="ovr")). Fixed by :user:`Elvis Dohmatob<dohmatob>`.
 
 
 API changes summary
@@ -1167,12 +1167,12 @@ API changes summary
     - Attribute `data_min`, `data_max` and `data_range` in
       :class:`preprocessing.MinMaxScaler` are deprecated and won't be available
       from 0.19. Instead, the class now exposes `data_min_`, `data_max_`
-      and `data_range_`. By `Giorgio Patrini`_.
+      and `data_range_`. By :user:`Giorgio Patrini<giorgiop>`.
 
     - All Scaler classes now have an `scale_` attribute, the feature-wise
       rescaling applied by their `transform` methods. The old attribute `std_`
       in :class:`preprocessing.StandardScaler` is deprecated and superseded
-      by `scale_`; it won't be available in 0.19. By `Giorgio Patrini`_.
+      by `scale_`; it won't be available in 0.19. By :user:`Giorgio Patrini<giorgiop>`.
 
     - :class:`svm.SVC`` and :class:`svm.NuSVC` now have an ``decision_function_shape``
       parameter to make their decision function of shape ``(n_samples, n_classes)``
@@ -1183,7 +1183,7 @@ API changes summary
       caused confusion in how the array elements should be interpreted
       as features or as samples. All data arrays are now expected
       to be explicitly shaped ``(n_samples, n_features)``.
-      By `Vighnesh Birodkar`_.
+      By :user:`Vighnesh Birodkar<vighneshbirodkar>`.
 
     - :class:`lda.LDA` and :class:`qda.QDA` have been moved to
       :class:`discriminant_analysis.LinearDiscriminantAnalysis` and
@@ -1204,7 +1204,7 @@ API changes summary
       which are below a certain threshold value instead.
 
     - :class:`cluster.KMeans` re-runs cluster-assignments in case of non-convergence,
-      to ensure consistency of ``predict(X)`` and ``labels_``. By `Vighnesh Birodkar`_.
+      to ensure consistency of ``predict(X)`` and ``labels_``. By :user:`Vighnesh Birodkar<vighneshbirodkar>`.
 
     - Classifier and Regressor models are now tagged as such using the
       ``_estimator_type`` attribute.
@@ -1357,7 +1357,7 @@ New features
 ............
 
    - The new :class:`neighbors.LSHForest` implements locality-sensitive hashing
-     for approximate nearest neighbors search. By `Maheshakya Wijewardena`_.
+     for approximate nearest neighbors search. By :user:`Maheshakya Wijewardena<maheshakya>`.
 
    - Added :class:`svm.LinearSVR`. This class uses the liblinear implementation
      of Support Vector Regression which is much faster for large
@@ -1380,7 +1380,7 @@ New features
 
    - Added ``warm_start`` constructor parameter to make it possible for any
      trained forest model to grow additional trees incrementally. By
-     `Laurent Direr`_.
+     :user:`Laurent Direr<ldirer>`.
 
    - Added ``sample_weight`` support to :class:`ensemble.GradientBoostingClassifier` and
      :class:`ensemble.GradientBoostingRegressor`. By `Peter Prettenhofer`_.
@@ -1391,22 +1391,22 @@ New features
 
    - Averaged SGD for :class:`SGDClassifier <linear_model.SGDClassifier>`
      and :class:`SGDRegressor <linear_model.SGDRegressor>` By
-     `Danny Sullivan`_.
+     :user:`Danny Sullivan<dsullivan7>`.
 
    - Added :func:`cross_val_predict <cross_validation.cross_val_predict>`
      function which computes cross-validated estimates. By `Luis Pedro Coelho`_
 
    - Added :class:`linear_model.TheilSenRegressor`, a robust
-     generalized-median-based estimator. By `Florian Wilhelm`_.
+     generalized-median-based estimator. By :user:`Florian Wilhelm<FlorianWilhelm>`.
 
    - Added :func:`metrics.median_absolute_error`, a robust metric.
-     By `Gael Varoquaux`_ and `Florian Wilhelm`_.
+     By `Gael Varoquaux`_ and :user:`Florian Wilhelm<FlorianWilhelm>`.
 
    - Add :class:`cluster.Birch`, an online clustering algorithm. By
      `Manoj Kumar`_, `Alexandre Gramfort`_ and `Joel Nothman`_.
 
    - Added shrinkage support to :class:`discriminant_analysis.LinearDiscriminantAnalysis`
-     using two new solvers. By `Clemens Brunner`_ and `Martin Billinger`_.
+     using two new solvers. By :user:`Clemens Brunner<cle1109>` and `Martin Billinger`_.
 
    - Added :class:`kernel_ridge.KernelRidge`, an implementation of
      kernelized ridge regression.
@@ -1417,12 +1417,12 @@ New features
 
    - Added :class:`cross_validation.PredefinedSplit` cross-validation
      for fixed user-provided cross-validation folds.
-     By `Thomas Unterthiner`_.
+     By :user:`Thomas Unterthiner<untom>`.
 
    - Added :class:`calibration.CalibratedClassifierCV`, an approach for
      calibrating the predicted probabilities of a classifier.
      By `Alexandre Gramfort`_, `Jan Hendrik Metzen`_, `Mathieu Blondel`_
-     and `Balazs Kegl`_.
+     and :user:`Balazs Kegl<kegl>`.
 
 
 Enhancements
@@ -1435,7 +1435,7 @@ Enhancements
      By `Manoj Kumar`_
 
    - Add support for sample weights in scorer objects.  Metrics with sample
-     weight support will automatically benefit from it. By `Noel Dawe`_ and
+     weight support will automatically benefit from it. By :user:`Noel Dawe<ndawe>` and
      `Vlad Niculae`_.
 
    - Added ``newton-cg`` and `lbfgs` solver support in
@@ -1447,11 +1447,11 @@ Enhancements
 
    - Add ``sample_weight`` parameter to
      :func:`metrics.jaccard_similarity_score` and :func:`metrics.log_loss`.
-     By `Jatin Shah`_.
+     By :user:`Jatin Shah<jatinshah>`.
 
    - Support sparse multilabel indicator representation in
      :class:`preprocessing.LabelBinarizer` and
-     :class:`multiclass.OneVsRestClassifier` (by `Hamzeh Alsalhi`_ with thanks
+     :class:`multiclass.OneVsRestClassifier` (by :user:`Hamzeh Alsalhi<hamsal>` with thanks
      to Rohit Sivaprasad), as well as evaluation metrics (by
      `Joel Nothman`_).
 
@@ -1468,24 +1468,24 @@ Enhancements
      :class:`linear_model.LogisticRegression` to implement a Logistic
      Regression solver that minimizes the cross-entropy or multinomial loss
      instead of the default One-vs-Rest setting. Supports `lbfgs` and
-     `newton-cg` solvers. By `Lars Buitinck`_ and `Manoj Kumar`_. Solver option
+     `newton-cg` solvers. By :user:`Lars Buitinck<larsmans>` and `Manoj Kumar`_. Solver option
      `newton-cg` by Simon Wu.
 
    - ``DictVectorizer`` can now perform ``fit_transform`` on an iterable in a
-     single pass, when giving the option ``sort=False``. By `Dan Blanchard`_.
+     single pass, when giving the option ``sort=False``. By :user:`Dan Blanchard<dan-blanchard>`.
 
    - :class:`GridSearchCV` and :class:`RandomizedSearchCV` can now be
      configured to work with estimators that may fail and raise errors on
      individual folds. This option is controlled by the `error_score`
      parameter. This does not affect errors raised on re-fit. By
-     `Michal Romaniuk`_.
+     :user:`Michal Romaniuk<romaniukm>`.
 
    - Add ``digits`` parameter to `metrics.classification_report` to allow
      report to show different precision of floating point numbers. By
-     `Ian Gilmore`_.
+     :user:`Ian Gilmore<agileminor>`.
 
    - Add a quantile prediction strategy to the :class:`dummy.DummyRegressor`.
-     By `Aaron Staple`_.
+     By :user:`Aaron Staple<staple>`.
 
    - Add ``handle_unknown`` option to :class:`preprocessing.OneHotEncoder` to
      handle unknown categorical features more gracefully during transform.
@@ -1504,7 +1504,7 @@ Enhancements
      in their constructor. By `Manoj Kumar`_.
 
    - Added decision function for :class:`multiclass.OneVsOneClassifier`
-     By `Raghav R V`_ and `Kyle Beauchamp`_.
+     By :user:`Raghav R V<raghavrv>` and :user:`Kyle Beauchamp<kyleabeauchamp>`.
 
    - :func:`neighbors.kneighbors_graph` and :func:`radius_neighbors_graph`
      support non-Euclidean metrics. By `Manoj Kumar`_
@@ -1518,7 +1518,7 @@ Enhancements
    - :class:`cluster.DBSCAN` now supports sparse input and sample weights and
      has been optimized: the inner loop has been rewritten in Cython and
      radius neighbors queries are now computed in batch. By `Joel Nothman`_
-     and `Lars Buitinck`_.
+     and :user:`Lars Buitinck<larsmans>`.
 
    - Add ``class_weight`` parameter to automatically weight samples by class
      frequency for :class:`ensemble.RandomForestClassifier`,
@@ -1543,7 +1543,7 @@ Enhancements
      instead of its sum over all samples. By `Hervé Bredin`_.
 
    - The outcome of :func:`manifold.spectral_embedding` was made deterministic
-     by flipping the sign of eigenvectors. By `Hasil Sharma`_.
+     by flipping the sign of eigenvectors. By :user:`Hasil Sharma<Hasil-Sharma>`.
 
    - Significant performance and memory usage improvements in
      :class:`preprocessing.PolynomialFeatures`. By `Eric Martin`_.
@@ -1562,10 +1562,10 @@ Documentation improvements
 ..........................
 
    - Added example of using :class:`FeatureUnion` for heterogeneous input.
-     By `Matt Terry`_
+     By :user:`Matt Terry<mrterry>`
 
    - Documentation on scorers was improved, to highlight the handling of loss
-     functions. By `Matt Pico`_.
+     functions. By :user:`Matt Pico<MattpSoftware>`.
 
    - A discrepancy between liblinear output and scikit-learn's wrappers
      is now noted. By `Manoj Kumar`_.
@@ -1603,11 +1603,11 @@ Bug fixes
       `Matteo Visconti di Oleggio Castello`_.
 
     - :class:`feature_selection.RFECV` now correctly handles cases when
-      ``step`` is not equal to 1. By `Nikolay Mayorov`_
+      ``step`` is not equal to 1. By :user:`Nikolay Mayorov<nmayorov>`
 
     - The :class:`decomposition.PCA` now undoes whitening in its
       ``inverse_transform``. Also, its ``components_`` now always have unit
-      length. By `Michael Eickenberg`_.
+      length. By :user:`Michael Eickenberg<eickenberg>`.
 
     - Fix incomplete download of the dataset when
       :func:`datasets.download_20newsgroups` is called. By `Manoj Kumar`_.
@@ -1617,14 +1617,14 @@ Bug fixes
 
     - Calling ``partial_fit`` with ``class_weight=='auto'`` throws an
       appropriate error message and suggests a work around.
-      By `Danny Sullivan`_.
+      By :user:`Danny Sullivan<dsullivan7>`.
 
     - :class:`RBFSampler <kernel_approximation.RBFSampler>` with ``gamma=g``
       formerly approximated :func:`rbf_kernel <metrics.pairwise.rbf_kernel>`
       with ``gamma=g/2.``; the definition of ``gamma`` is now consistent,
       which may substantially change your results if you use a fixed value.
       (If you cross-validated over ``gamma``, it probably doesn't matter
-      too much.) By `Dougal Sutherland`_.
+      too much.) By :user:`Dougal Sutherland<dougalsutherland>`.
 
     - Pipeline object delegate the ``classes_`` attribute to the underlying
       estimator. It allows, for instance, to make bagging of a pipeline object.
@@ -1652,7 +1652,7 @@ Bug fixes
 
     - Fix handling of precomputed affinity matrices in
       :class:`cluster.AgglomerativeClustering` when using connectivity
-      constraints. By `Cathy Deng`_
+      constraints. By :user:`Cathy Deng<cathydeng>`
 
     - Correct ``partial_fit`` handling of ``class_prior`` for
       :class:`sklearn.naive_bayes.MultinomialNB` and
@@ -1678,7 +1678,7 @@ Bug fixes
       By `Garret-R <https://github.com/Garrett-R>`_.
 
     - Fixed round off errors with non positive-definite covariance matrices
-      in GMM. By `Alexis Mignon`_.
+      in GMM. By :user:`Alexis Mignon<AlexisMignon>`.
 
     - Fixed a error in the computation of conditional probabilities in
       :class:`naive_bayes.BernoulliNB`. By Hanna Wallach.
@@ -1720,7 +1720,7 @@ API changes summary
       now returns two probabilities per sample in the multiclass case; this
       is consistent with other estimators and with the method's documentation,
       but previous versions accidentally returned only the positive
-      probability. Fixed by Will Lamond and `Lars Buitinck`_.
+      probability. Fixed by Will Lamond and :user:`Lars Buitinck<larsmans>`.
 
     - Change default value of precompute in :class:`ElasticNet` and :class:`Lasso`
       to False. Setting precompute to "auto" was found to be slower when
@@ -1751,7 +1751,7 @@ API changes summary
 
     - From now onwards, all estimators will uniformly raise ``NotFittedError``
       (:class:`utils.validation.NotFittedError`), when any of the ``predict``
-      like methods are called before the model is fit. By `Raghav R V`_.
+      like methods are called before the model is fit. By :user:`Raghav R V<raghavrv>`.
 
     - Input data validation was refactored for more consistent input
       validation. The ``check_arrays`` function was replaced by ``check_array``
@@ -1786,7 +1786,7 @@ API changes summary
       :class:`linear_model.PassiveAgressiveRegressor` now defaults to ``True``.
 
     - :class:`cluster.DBSCAN` now uses a deterministic initialization. The
-      `random_state` parameter is deprecated. By `Erich Schubert`_.
+      `random_state` parameter is deprecated. By :user:`Erich Schubert<kno10>`.
 
 Code Contributors
 -----------------
@@ -1833,7 +1833,7 @@ Bug fixes
 ---------
 
   - Fixed handling of the ``p`` parameter of the Minkowski distance that was
-    previously ignored in nearest neighbors models. By `Nikolay Mayorov`_.
+    previously ignored in nearest neighbors models. By :user:`Nikolay Mayorov<nmayorov>`.
 
   - Fixed duplicated alphas in :class:`linear_model.LassoLars` with early
     stopping on 32 bit Python. By `Olivier Grisel`_ and `Fabian Pedregosa`_.
@@ -1855,7 +1855,7 @@ Bug fixes
   - The ``transform`` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
     now projects the input on the most discriminant directions. By Martin Billinger.
 
-  - Fixed potential overflow in ``_tree.safe_realloc`` by `Lars Buitinck`_.
+  - Fixed potential overflow in ``_tree.safe_realloc`` by :user:`Lars Buitinck<larsmans>`.
 
   - Performance optimization in :class:`isotonic.IsotonicRegression`.
     By Robert Bradshaw.
@@ -1863,8 +1863,8 @@ Bug fixes
   - ``nose`` is non-longer a runtime dependency to import ``sklearn``, only for
     running the tests. By `Joel Nothman`_.
 
-  - Many documentation and website fixes by `Joel Nothman`_, `Lars Buitinck`_
-    `Matt Pico`_, and others.
+  - Many documentation and website fixes by `Joel Nothman`_, :user:`Lars Buitinck<larsmans>`
+    :user:`Matt Pico<MattpSoftware>`, and others.
 
 .. _changes_0_15_1:
 
@@ -1879,11 +1879,11 @@ Bug fixes
    - Made :func:`cross_validation.cross_val_score` use
      :class:`cross_validation.KFold` instead of
      :class:`cross_validation.StratifiedKFold` on multi-output classification
-     problems. By `Nikolay Mayorov`_.
+     problems. By :user:`Nikolay Mayorov<nmayorov>`.
 
    - Support unseen labels :class:`preprocessing.LabelBinarizer` to restore
      the default behavior of 0.14.1 for backward compatibility. By
-     `Hamzeh Alsalhi`_.
+     :user:`Hamzeh Alsalhi<hamsal>`.
 
    - Fixed the :class:`cluster.KMeans` stopping criterion that prevented early
      convergence detection. By Edward Raff and `Gael Varoquaux`_.
@@ -1947,27 +1947,27 @@ New features
      the user guide for details and examples. By `Gilles Louppe`_.
 
    - New unsupervised feature selection algorithm
-     :class:`feature_selection.VarianceThreshold`, by `Lars Buitinck`_.
+     :class:`feature_selection.VarianceThreshold`, by :user:`Lars Buitinck<larsmans>`.
 
    - Added :class:`linear_model.RANSACRegressor` meta-estimator for the robust
      fitting of regression models. By Johannes Schönberger.
 
    - Added :class:`cluster.AgglomerativeClustering` for hierarchical
      agglomerative clustering with average linkage, complete linkage and
-     ward strategies, by  `Nelle Varoquaux`_ and `Gael Varoquaux`_.
+     ward strategies, by  :user:`Nelle Varoquaux<nellev>` and `Gael Varoquaux`_.
 
    - Shorthand constructors :func:`pipeline.make_pipeline` and
-     :func:`pipeline.make_union` were added by `Lars Buitinck`_.
+     :func:`pipeline.make_union` were added by :user:`Lars Buitinck<larsmans>`.
 
    - Shuffle option for :class:`cross_validation.StratifiedKFold`.
-     By `Jeffrey Blackburne`_.
+     By :user:`Jeffrey Blackburne<jblackburne>`.
 
    - Incremental learning (``partial_fit``) for Gaussian Naive Bayes by
      Imran Haque.
 
    - Added ``partial_fit`` to :class:`BernoulliRBM
      <neural_network.BernoulliRBM>`
-     By `Danny Sullivan`_.
+     By :user:`Danny Sullivan<dsullivan7>`.
 
    - Added :func:`learning_curve <learning_curve.learning_curve>` utility to
      chart performance with respect to training size. See
@@ -1987,7 +1987,7 @@ Enhancements
 
    - Add sparse input support to :class:`ensemble.AdaBoostClassifier` and
      :class:`ensemble.AdaBoostRegressor` meta-estimators.
-     By `Hamzeh Alsalhi`_.
+     By :user:`Hamzeh Alsalhi<hamsal>`.
 
    - Memory improvements of decision trees, by `Arnaud Joly`_.
 
@@ -2040,7 +2040,7 @@ Enhancements
 
    - Add ``min_weight_fraction_leaf`` pre-pruning parameter to tree-based
      methods: the minimum weighted fraction of the input samples required to be
-     at a leaf node. By `Noel Dawe`_.
+     at a leaf node. By :user:`Noel Dawe<ndawe>`.
 
    - Added :func:`metrics.pairwise_distances_argmin_min`, by Philippe Gervais.
 
@@ -2048,7 +2048,7 @@ Enhancements
      :class:`cluster.MeanShift`, by `Mathieu Blondel`_.
 
    - Vector and matrix multiplications have been optimised throughout the
-     library by `Denis Engemann`_, and `Alexandre Gramfort`_.
+     library by :user:`Denis Engemann<dengemann>`, and `Alexandre Gramfort`_.
      In particular, they should take less memory with older NumPy versions
      (prior to 1.7.2).
 
@@ -2057,11 +2057,11 @@ Enhancements
 
    - The training algorithm for :class:`decomposition.NMF` is faster for
      sparse matrices and has much lower memory complexity, meaning it will
-     scale up gracefully to large datasets. By `Lars Buitinck`_.
+     scale up gracefully to large datasets. By :user:`Lars Buitinck<larsmans>`.
 
    - Added svd_method option with default value to "randomized" to
      :class:`decomposition.FactorAnalysis` to save memory and
-     significantly speedup computation by `Denis Engemann`_, and
+     significantly speedup computation by :user:`Denis Engemann<dengemann>`, and
      `Alexandre Gramfort`_.
 
    - Changed :class:`cross_validation.StratifiedKFold` to try and
@@ -2077,7 +2077,7 @@ Enhancements
      by `Robert Layton`_ and `Joel Nothman`_.
 
    - Norm computations optimized for NumPy 1.6 and later versions by
-     `Lars Buitinck`_. In particular, the k-means algorithm no longer
+     :user:`Lars Buitinck<larsmans>`. In particular, the k-means algorithm no longer
      needs a temporary data structure the size of its input.
 
    - :class:`dummy.DummyClassifier` can now be used to predict a constant
@@ -2085,7 +2085,7 @@ Enhancements
 
    - :class:`dummy.DummyRegressor` has now a strategy parameter which allows
      to predict the mean, the median of the training set or a constant
-     output value. By `Maheshakya Wijewardena`_.
+     output value. By :user:`Maheshakya Wijewardena<maheshakya>`.
 
    - Multi-label classification output in multilabel indicator format
      is now supported by :func:`metrics.roc_auc_score` and
@@ -2097,7 +2097,7 @@ Enhancements
 
    - Speed and memory usage improvements to the SGD algorithm for linear
      models: it now uses threads, not separate processes, when ``n_jobs>1``.
-     By `Lars Buitinck`_.
+     By :user:`Lars Buitinck<larsmans>`.
 
    - Grid search and cross validation allow NaNs in the input arrays so that
      preprocessors such as :class:`preprocessing.Imputer
@@ -2105,7 +2105,7 @@ Enhancements
      avoiding potentially skewed results.
 
    - Ridge regression can now deal with sample weights in feature space
-     (only sample space until then). By `Michael Eickenberg`_.
+     (only sample space until then). By :user:`Michael Eickenberg<eickenberg>`.
      Both solutions are provided by the Cholesky solver.
 
    - Several classification and regression metrics now support weighted
@@ -2122,7 +2122,7 @@ Enhancements
      :func:`metrics.mean_squared_error`,
      :func:`metrics.mean_absolute_error`,
      :func:`metrics.r2_score`.
-     By `Noel Dawe`_.
+     By :user:`Noel Dawe<ndawe>`.
 
    - Speed up of the sample generator
      :func:`datasets.make_multilabel_classification`. By `Joel Nothman`_.
@@ -2136,14 +2136,14 @@ Documentation improvements
      Original tutorial created by several authors including
      `Olivier Grisel`_, Lars Buitinck and many others.
      Tutorial integration into the scikit-learn documentation
-     by `Jaques Grobler`_
+     by :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
 
    - Added :ref:`Computational Performance <computational_performance>`
      documentation. Discussion and examples of prediction latency / throughput
      and different factors that have influence over speed. Additional tips for
      building faster models and choosing a relevant compromise between speed
      and predictive power.
-     By `Eustache Diemert`_.
+     By :user:`Eustache Diemert<oddskool>`.
 
 Bug fixes
 .........
@@ -2164,7 +2164,7 @@ Bug fixes
 
    - Fixed incorrect estimation of the degrees of freedom in
      :func:`feature_selection.f_regression` when variates are not centered.
-     By `Virgile Fritsch`_.
+     By :user:`Virgile Fritsch<VirgileFritsch>`.
 
    - Fixed a race condition in parallel processing with
      ``pre_dispatch != "all"`` (for instance, in ``cross_val_score``).
@@ -2268,7 +2268,7 @@ API changes summary
      weighted array that was returned was wrong. By `Manoj Kumar`_.
 
    - Fix :class:`cross_validation.Bootstrap` to return ``ValueError``
-     when ``n_train + n_test > n``. By `Ronald Phlypo`_.
+     when ``n_train + n_test > n``. By :user:`Ronald Phlypo<rphlypo>`.
 
 
 People
@@ -2458,7 +2458,7 @@ Changelog
      consumption in all tree-based estimators. By `Gilles Louppe`_.
 
    - Added :class:`ensemble.AdaBoostClassifier` and
-     :class:`ensemble.AdaBoostRegressor`, by `Noel Dawe`_  and
+     :class:`ensemble.AdaBoostRegressor`, by :user:`Noel Dawe<ndawe>`  and
      `Gilles Louppe`_. See the :ref:`AdaBoost <adaboost>` section of the user
      guide for details and examples.
 
@@ -2476,8 +2476,8 @@ Changelog
    - Added :ref:`Restricted Boltzmann Machines<rbm>`
      (:class:`neural_network.BernoulliRBM`). By `Yann Dauphin`_.
 
-   - Python 3 support by `Justin Vincent`_, `Lars Buitinck`_,
-     `Subhodeep Moitra`_ and `Olivier Grisel`_. All tests now pass under
+   - Python 3 support by :user:`Justin Vincent<justinvf>`, :user:`Lars Buitinck<larsmans>`,
+     :user:`Subhodeep Moitra<smoitra87>` and `Olivier Grisel`_. All tests now pass under
      Python 3.3.
 
    - Ability to pass one penalty (alpha value) per target in
@@ -2485,19 +2485,19 @@ Changelog
 
    - Fixed :mod:`sklearn.linear_model.stochastic_gradient.py` L2 regularization
      issue (minor practical significance).
-     By `Norbert Crombach`_ and `Mathieu Blondel`_ .
+     By :user:`Norbert Crombach<norbert>` and `Mathieu Blondel`_ .
 
    - Added an interactive version of `Andreas Müller`_'s
      `Machine Learning Cheat Sheet (for scikit-learn)
      <http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html>`_
      to the documentation. See :ref:`Choosing the right estimator <ml_map>`.
-     By `Jaques Grobler`_.
+     By :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`.
 
    - :class:`grid_search.GridSearchCV` and
      :func:`cross_validation.cross_val_score` now support the use of advanced
      scoring function such as area under the ROC curve and f-beta scores.
      See :ref:`scoring_parameter` for details. By `Andreas Müller`_
-     and `Lars Buitinck`_.
+     and :user:`Lars Buitinck<larsmans>`.
      Passing a function from :mod:`sklearn.metrics` as ``score_func`` is
      deprecated.
 
@@ -2533,7 +2533,7 @@ Changelog
      estimates when trained under log loss or modified Huber loss.
 
    - Hyperlinks to documentation in example code on the website by
-     `Martin Luessi`_.
+     :user:`Martin Luessi<mluessi>`.
 
    - Fixed bug in :class:`preprocessing.MinMaxScaler` causing incorrect scaling
      of the features for non-default ``feature_range`` settings. By `Andreas
@@ -2544,14 +2544,14 @@ Changelog
      now supports percentage values. By `Gilles Louppe`_.
 
    - Performance improvements in :class:`isotonic.IsotonicRegression` by
-     `Nelle Varoquaux`_.
+     :user:`Nelle Varoquaux<nellev>`.
 
    - :func:`metrics.accuracy_score` has an option normalize to return
      the fraction or the number of correctly classified sample
      by `Arnaud Joly`_.
 
    - Added :func:`metrics.log_loss` that computes log loss, aka cross-entropy
-     loss. By Jochen Wersdörfer and `Lars Buitinck`_.
+     loss. By Jochen Wersdörfer and :user:`Lars Buitinck<larsmans>`.
 
    - A bug that caused :class:`ensemble.AdaBoostClassifier`'s to output
      incorrect probabilities has been fixed.
@@ -2569,11 +2569,11 @@ Changelog
    - The new estimator :class:`sklearn.decomposition.TruncatedSVD`
      performs dimensionality reduction using SVD on sparse matrices,
      and can be used for latent semantic analysis (LSA).
-     By `Lars Buitinck`_.
+     By :user:`Lars Buitinck<larsmans>`.
 
    - Added self-contained example of out-of-core learning on text data
      :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`.
-     By `Eustache Diemert`_.
+     By :user:`Eustache Diemert<oddskool>`.
 
    - The default number of components for
      :class:`sklearn.decomposition.RandomizedPCA` is now correctly documented
@@ -2582,9 +2582,9 @@ Changelog
 
    - :class:`sklearn.cluster.KMeans` now fits several orders of magnitude
      faster on sparse data (the speedup depends on the sparsity). By
-     `Lars Buitinck`_.
+     :user:`Lars Buitinck<larsmans>`.
 
-   - Reduce memory footprint of FastICA by `Denis Engemann`_ and
+   - Reduce memory footprint of FastICA by :user:`Denis Engemann<dengemann>` and
      `Alexandre Gramfort`_.
 
    - Verbose output in :mod:`sklearn.ensemble.gradient_boosting` now uses
@@ -2598,7 +2598,7 @@ Changelog
      By `Peter Prettenhofer`_.
 
    - Most metrics now support string labels for multiclass classification
-     by `Arnaud Joly`_ and `Lars Buitinck`_.
+     by `Arnaud Joly`_ and :user:`Lars Buitinck<larsmans>`.
 
    - New OrthogonalMatchingPursuitCV class by `Alexandre Gramfort`_
      and `Vlad Niculae`_.
@@ -2636,7 +2636,7 @@ Changelog
      :class:`sklearn.naive_bayes.BernoulliNB` by adding the ``partial_fit``
      method by `Olivier Grisel`_.
 
-   - New website design and navigation by `Gilles Louppe`_, `Nelle Varoquaux`_,
+   - New website design and navigation by `Gilles Louppe`_, :user:`Nelle Varoquaux<nellev>`,
      Vincent Michel and `Andreas Müller`_.
 
    - Improved documentation on :ref:`multi-class, multi-label and multi-output
@@ -2645,7 +2645,7 @@ Changelog
    - Better input and error handling in the :mod:`metrics` module by
      `Arnaud Joly`_ and `Joel Nothman`_.
 
-   - Speed optimization of the :mod:`hmm` module by `Mikhail Korobov`_
+   - Speed optimization of the :mod:`hmm` module by :user:`Mikhail Korobov<kmike>`
 
    - Significant speed improvements for :class:`sklearn.cluster.DBSCAN`
      by `cleverless <https://github.com/cleverless>`_
@@ -2669,7 +2669,7 @@ API changes summary
      :class:`linear_model.enet_path` can return its results in the same
      format as that of :class:`linear_model.lars_path`. This is done by
      setting the ``return_models`` parameter to ``False``. By
-     `Jaques Grobler`_ and `Alexandre Gramfort`_
+     :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>` and `Alexandre Gramfort`_
 
    - :class:`grid_search.IterGrid` was renamed to
      :class:`grid_search.ParameterGrid`.
@@ -2843,7 +2843,7 @@ Changelog
     - Fixed a bug in the reassignment of small clusters in the :class:`cluster.MiniBatchKMeans`
       by `Gael Varoquaux`_.
 
-    - Fixed default value of ``gamma`` in :class:`decomposition.KernelPCA` by `Lars Buitinck`_.
+    - Fixed default value of ``gamma`` in :class:`decomposition.KernelPCA` by :user:`Lars Buitinck<larsmans>`.
 
     - Updated joblib to ``0.7.0d`` by `Gael Varoquaux`_.
 
@@ -2856,7 +2856,7 @@ Changelog
 People
 ------
 List of contributors for release 0.13.1 by number of commits.
- * 16  `Lars Buitinck`_
+ * 16  :user:`Lars Buitinck<larsmans>`
  * 12  `Andreas Müller`_
  *  8  `Gael Varoquaux`_
  *  5  Robert Marchman
@@ -2866,7 +2866,7 @@ List of contributors for release 0.13.1 by number of commits.
  *  1  Diego Molla
  *  1  `Gilles Louppe`_
  *  1  `Mathieu Blondel`_
- *  1  `Nelle Varoquaux`_
+ *  1  :user:`Nelle Varoquaux<nellev>`
  *  1  Rafael Cunha de Almeida
  *  1  Rolando Espinoza La fuente
  *  1  `Vlad Niculae`_
@@ -2894,7 +2894,7 @@ New Estimator Classes
 
    - :class:`feature_extraction.FeatureHasher`, a transformer implementing the
      "hashing trick" for fast, low-memory feature extraction from string fields
-     by `Lars Buitinck`_ and :class:`feature_extraction.text.HashingVectorizer`
+     by :user:`Lars Buitinck<larsmans>` and :class:`feature_extraction.text.HashingVectorizer`
      for text documents by `Olivier Grisel`_  See :ref:`feature_hashing` and
      :ref:`hashing_vectorizer` for the documentation and sample usage.
 
@@ -2933,7 +2933,7 @@ New Estimator Classes
      Li. See :ref:`spectral_embedding` in the user guide.
 
    - :class:`isotonic.IsotonicRegression` by `Fabian Pedregosa`_, `Alexandre Gramfort`_
-     and `Nelle Varoquaux`_,
+     and :user:`Nelle Varoquaux<nellev>`,
 
 
 Changelog
@@ -2945,7 +2945,7 @@ Changelog
      Kyle Beauchamp.
 
    - :class:`tree.DecisionTreeClassifier` and all derived ensemble models now
-     support sample weighting, by `Noel Dawe`_  and `Gilles Louppe`_.
+     support sample weighting, by :user:`Noel Dawe<ndawe>`  and `Gilles Louppe`_.
 
    - Speedup improvement when using bootstrap samples in forests of randomized
      trees, by `Peter Prettenhofer`_  and `Gilles Louppe`_.
@@ -2956,7 +2956,7 @@ Changelog
      example.
 
    - The table of contents on the website has now been made expandable by
-     `Jaques Grobler`_.
+     :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`.
 
    - :class:`feature_selection.SelectPercentile` now breaks ties
      deterministically instead of returning all equally ranked features.
@@ -2968,7 +2968,7 @@ Changelog
      previously.
 
    - Ridge regression and ridge classification fitting with ``sparse_cg`` solver
-     no longer has quadratic memory complexity, by `Lars Buitinck`_ and
+     no longer has quadratic memory complexity, by :user:`Lars Buitinck<larsmans>` and
      `Fabian Pedregosa`_.
 
    - Ridge regression and ridge classification now support a new fast solver
@@ -3150,12 +3150,12 @@ List of contributors for release 0.13 by number of commits.
  * 137  `Peter Prettenhofer`_
  * 131  `Gael Varoquaux`_
  * 117  `Mathieu Blondel`_
- * 108  `Lars Buitinck`_
+ * 108  :user:`Lars Buitinck<larsmans>`
  * 106  Wei Li
  * 101  `Olivier Grisel`_
  *  65  `Vlad Niculae`_
  *  54  `Gilles Louppe`_
- *  40  `Jaques Grobler`_
+ *  40  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
  *  38  `Alexandre Gramfort`_
  *  30  `Rob Zinkov`_
  *  19  Aymeric Masurelle
@@ -3164,7 +3164,7 @@ List of contributors for release 0.13 by number of commits.
  *  17  Nelle Varoquaux
  *  16  `Christian Osendorfer`_
  *  14  `Daniel Nouri`_
- *  13  `Virgile Fritsch`_
+ *  13  :user:`Virgile Fritsch<VirgileFritsch>`
  *  13  syhw
  *  12  `Satrajit Ghosh`_
  *  10  Corey Lynch
@@ -3236,17 +3236,17 @@ Changelog
 
  - Proper behavior with fortran-ordered NumPy arrays by `Gael Varoquaux`_
 
- - Make GridSearchCV work with non-CSR sparse matrix by `Lars Buitinck`_
+ - Make GridSearchCV work with non-CSR sparse matrix by :user:`Lars Buitinck<larsmans>`
 
  - Fix parallel computing in MDS by `Gael Varoquaux`_
 
  - Fix Unicode support in count vectorizer by `Andreas Müller`_
 
- - Fix MinCovDet breaking with X.shape = (3, 1) by `Virgile Fritsch`_
+ - Fix MinCovDet breaking with X.shape = (3, 1) by :user:`Virgile Fritsch<VirgileFritsch>`
 
  - Fix clone of SGD objects by `Peter Prettenhofer`_
 
- - Stabilize GMM by `Virgile Fritsch`_
+ - Stabilize GMM by :user:`Virgile Fritsch<VirgileFritsch>`
 
 People
 ------
@@ -3254,8 +3254,8 @@ People
  *  14  `Peter Prettenhofer`_
  *  12  `Gael Varoquaux`_
  *  10  `Andreas Müller`_
- *   5  `Lars Buitinck`_
- *   3  `Virgile Fritsch`_
+ *   5  :user:`Lars Buitinck<larsmans>`
+ *   3  :user:`Virgile Fritsch<VirgileFritsch>`
  *   1  `Alexandre Gramfort`_
  *   1  `Gilles Louppe`_
  *   1  `Mathieu Blondel`_
@@ -3294,7 +3294,7 @@ Changelog
    - Added :ref:`multidimensional_scaling`, by Nelle Varoquaux.
 
    - SVMlight file format loader now detects compressed (gzip/bzip2) files and
-     decompresses them on the fly, by `Lars Buitinck`_.
+     decompresses them on the fly, by :user:`Lars Buitinck<larsmans>`.
 
    - SVMlight file format serializer now preserves double precision floating
      point values, by `Olivier Grisel`_.
@@ -3320,7 +3320,7 @@ Changelog
      module by `Andreas Müller`_.
 
    - New word boundaries-aware character n-gram analyzer for the
-     :ref:`text_feature_extraction` module by `@kernc`_.
+     :ref:`text_feature_extraction` module by :user:`@kernc<kernc>`.
 
    - Fixed bug in spectral clustering that led to single point clusters
      by `Andreas Müller`_.
@@ -3412,16 +3412,16 @@ People
  *  60  `Mathieu Blondel`_
  *  57  `Alexandre Gramfort`_
  *  52  `Vlad Niculae`_
- *  45  `Lars Buitinck`_
+ *  45  :user:`Lars Buitinck<larsmans>`
  *  44  Nelle Varoquaux
- *  37  `Jaques Grobler`_
+ *  37  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
  *  30  Alexis Mignon
  *  30  Immanuel Bayer
  *  27  `Olivier Grisel`_
  *  16  Subhodeep Moitra
  *  13  Yannick Schwartz
- *  12  `@kernc`_
- *  11  `Virgile Fritsch`_
+ *  12  :user:`@kernc<kernc>`
+ *  11  :user:`Virgile Fritsch<VirgileFritsch>`
  *   9  Daniel Duckworth
  *   9  `Fabian Pedregosa`_
  *   9  `Robert Layton`_
@@ -3473,7 +3473,7 @@ Highlights
      and `Scott White`_ .
 
    - Simple dict-based feature loader with support for categorical variables
-     (:class:`feature_extraction.DictVectorizer`) by `Lars Buitinck`_.
+     (:class:`feature_extraction.DictVectorizer`) by :user:`Lars Buitinck<larsmans>`.
 
    - Added Matthews correlation coefficient (:func:`metrics.matthews_corrcoef`)
      and added macro and micro average options to
@@ -3513,7 +3513,7 @@ Other changes
      warm_start to the :ref:`sgd` module by `Mathieu Blondel`_.
 
    - Dense and sparse implementations of :ref:`svm` classes and
-     :class:`linear_model.LogisticRegression` merged by `Lars Buitinck`_.
+     :class:`linear_model.LogisticRegression` merged by :user:`Lars Buitinck<larsmans>`.
 
    - Regressors can now be used as base estimator in the :ref:`multiclass`
      module by `Mathieu Blondel`_.
@@ -3648,8 +3648,8 @@ People
    * 129  `Olivier Grisel`_
    * 114  `Mathieu Blondel`_
    * 103  Clay Woolam
-   *  96  `Lars Buitinck`_
-   *  88  `Jaques Grobler`_
+   *  96  :user:`Lars Buitinck<larsmans>`
+   *  88  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
    *  82  `Alexandre Gramfort`_
    *  50  `Bertrand Thirion`_
    *  42  `Robert Layton`_
@@ -3741,7 +3741,7 @@ Changelog
      extra-trees method, along with documentation and examples.
 
    - :ref:`outlier_detection`: outlier and novelty detection, by
-     `Virgile Fritsch`_.
+     :user:`Virgile Fritsch<VirgileFritsch>`.
 
    - :ref:`kernel_approximation`: a transform implementing kernel
      approximation for fast SGD on non-linear kernels by
@@ -3762,7 +3762,7 @@ Changelog
      (:func:`sklearn.datasets.fetch_20newsgroups_vectorized`) by
      `Mathieu Blondel`_.
 
-   - :ref:`multiclass` by `Lars Buitinck`_.
+   - :ref:`multiclass` by :user:`Lars Buitinck<larsmans>`.
 
    - Utilities for fast computation of mean and variance for sparse matrices
      by `Mathieu Blondel`_.
@@ -3850,7 +3850,7 @@ The following people contributed to scikit-learn since last release:
    * 220  `Gilles Louppe`_
    * 183  `Brian Holt`_
    * 166  `Gael Varoquaux`_
-   * 144  `Lars Buitinck`_
+   * 144  :user:`Lars Buitinck<larsmans>`
    *  73  `Vlad Niculae`_
    *  65  `Peter Prettenhofer`_
    *  64  `Fabian Pedregosa`_
@@ -3859,7 +3859,7 @@ The following people contributed to scikit-learn since last release:
    *  52  `Jake Vanderplas`_
    *  44  Noel Dawe
    *  38  `Alexandre Gramfort`_
-   *  24  `Virgile Fritsch`_
+   *  24  :user:`Virgile Fritsch<VirgileFritsch>`
    *  23  `Satrajit Ghosh`_
    *   3  Jan Hendrik Metzen
    *   3  Kenneth C. Arnold
@@ -3938,10 +3938,10 @@ Changelog
      `Alexandre Gramfort`_
 
    - Printing an estimator now behaves independently of architectures
-     and Python version thanks to `Jean Kossaifi`_.
+     and Python version thanks to :user:`Jean Kossaifi<JeanKossaifi>`.
 
    - :ref:`Loader for libsvm/svmlight format <libsvm_loader>` by
-     `Mathieu Blondel`_ and `Lars Buitinck`_
+     `Mathieu Blondel`_ and :user:`Lars Buitinck<larsmans>`
 
    - Documentation improvements: thumbnails in
      :ref:`example gallery <examples-index>` by `Fabian Pedregosa`_.
@@ -3950,12 +3950,12 @@ Changelog
      performance) by `Fabian Pedregosa`_.
 
    - Added :ref:`multinomial_naive_bayes` and :ref:`bernoulli_naive_bayes`
-     by `Lars Buitinck`_
+     by :user:`Lars Buitinck<larsmans>`
 
    - Text feature extraction optimizations by Lars Buitinck
 
    - Chi-Square feature selection
-     (:func:`feature_selection.univariate_selection.chi2`) by `Lars Buitinck`_.
+     (:func:`feature_selection.univariate_selection.chi2`) by :user:`Lars Buitinck<larsmans>`.
 
    - :ref:`sample_generators` module refactoring by `Gilles Louppe`_
 
@@ -4082,7 +4082,7 @@ People
 
    - 387  `Vlad Niculae`_
    - 320  `Olivier Grisel`_
-   - 192  `Lars Buitinck`_
+   - 192  :user:`Lars Buitinck<larsmans>`
    - 179  `Gael Varoquaux`_
    - 168  `Fabian Pedregosa`_ (`INRIA`_, `Parietal Team`_)
    - 127  `Jake Vanderplas`_
@@ -4093,7 +4093,7 @@ People
    - 56  `Gilles Louppe`_
    - 42  Robert Layton
    - 38  Nelle Varoquaux
-   - 32  `Jean Kossaifi`_
+   - 32  :user:`Jean Kossaifi<JeanKossaifi>`
    - 30  Conrad Lee
    - 22  Pietro Berkes
    - 18  andy
@@ -4101,7 +4101,7 @@ People
    - 12  Brian Holt
    - 11  Robert
    - 8  Amit Aides
-   - 8  `Virgile Fritsch`_
+   - 8  :user:`Virgile Fritsch<VirgileFritsch>`
    - 7  `Yaroslav Halchenko`_
    - 6  Salvatore Masecchia
    - 5  Paolo Losi
@@ -4150,7 +4150,7 @@ Several new modules where introduced during this release:
   - :ref:`NMF` module `Vlad Niculae`_
 
   - Implementation of the :ref:`oracle_approximating_shrinkage` algorithm by
-    `Virgile Fritsch`_ in the :ref:`covariance` module.
+    :user:`Virgile Fritsch<VirgileFritsch>` in the :ref:`covariance` module.
 
 
 Some other modules benefited from significant improvements or cleanups.
@@ -4203,7 +4203,7 @@ People that made this release possible preceded by number of commits:
    - 30  `Mathieu Blondel`_
    - 25  `Peter Prettenhofer`_
    - 22  `Nicolas Pinto`_
-   - 11  `Virgile Fritsch`_
+   - 11  :user:`Virgile Fritsch<VirgileFritsch>`
    -  7  Lars Buitinck
    -  6  Vincent Michel
    -  5  `Bertrand Thirion`_
@@ -4621,8 +4621,6 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Nicolas Pinto: https://twitter.com/npinto
 
-.. _Virgile Fritsch: https://github.com/VirgileFritsch
-
 .. _Bertrand Thirion: https://team.inria.fr/parietal/bertrand-thirions-page
 
 .. _Andreas Müller: http://peekaboo-vision.blogspot.com
@@ -4637,8 +4635,6 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Parietal Team: http://parietal.saclay.inria.fr/
 
-.. _Lars Buitinck: https://github.com/larsmans
-
 .. _David Warde-Farley: http://www-etud.iro.umontreal.ca/~wardefar/
 
 .. _Brian Holt: http://personal.ee.surrey.ac.uk/Personal/B.Holt
@@ -4649,31 +4645,15 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Scott White: https://twitter.com/scottblanc
 
-.. _Jaques Grobler: https://github.com/jaquesgrobler/scikit-learn/wiki/Jaques-Grobler
-
 .. _David Marek: http://www.davidmarek.cz/
 
-.. _@kernc: https://github.com/kernc
-
 .. _Christian Osendorfer: https://osdf.github.io
-
-.. _Noel Dawe: https://github.com/ndawe
 
 .. _Arnaud Joly: http://www.ajoly.org
 
 .. _Rob Zinkov: http://zinkov.com
 
-.. _Martin Luessi: https://github.com/mluessi
-
 .. _Joel Nothman: http://joelnothman.com
-
-.. _Norbert Crombach: https://github.com/norbert
-
-.. _Eustache Diemert: https://github.com/oddskool
-
-.. _Justin Vincent: https://github.com/justinvf
-
-.. _Denis Engemann: https://github.com/dengemann
 
 .. _Nicolas Trésegnie : http://nicolastr.com/
 
@@ -4681,204 +4661,44 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Yann Dauphin: http://ynd.github.io/
 
-.. _Nelle Varoquaux: https://github.com/nellev
-
-.. _Subhodeep Moitra: https://github.com/smoitra87
-
 .. _Yannick Schwartz: https://team.inria.fr/parietal/schwarty/
-
-.. _Mikhail Korobov: https://github.com/kmike
 
 .. _Kyle Kastner: http://kastnerkyle.github.io
 
-.. _@FedericoV: https://github.com/FedericoV/
-
 .. _Daniel Nouri: http://danielnouri.org
-
-.. _Johannes Schönberger: https://github.com/ahojnnes
 
 .. _Manoj Kumar: https://manojbits.wordpress.com
 
-.. _Maheshakya Wijewardena: https://github.com/maheshakya
-
-.. _Danny Sullivan: https://github.com/dsullivan7
-
-.. _Michael Eickenberg: https://github.com/eickenberg
-
-.. _Jeffrey Blackburne: https://github.com/jblackburne
-
-.. _Hamzeh Alsalhi: https://github.com/hamsal
-
-.. _Ronald Phlypo: https://github.com/rphlypo
-
-.. _Laurent Direr: https://github.com/ldirer
-
-.. _Nikolay Mayorov: https://github.com/nmayorov
-
-.. _Jatin Shah: https://github.com/jatinshah
-
-.. _Dougal Sutherland: https://github.com/dougalsutherland
-
-.. _Michal Romaniuk: https://github.com/romaniukm
-
-.. _Ian Gilmore: https://github.com/agileminor
-
-.. _Aaron Staple: https://github.com/staple
-
 .. _Luis Pedro Coelho: http://luispedro.org
-
-.. _Florian Wilhelm: https://github.com/FlorianWilhelm
 
 .. _Fares Hedyati: http://www.eecs.berkeley.edu/~fareshed
 
-.. _Matt Pico: https://github.com/MattpSoftware
-
-.. _Matt Terry: https://github.com/mrterry
-
 .. _Antony Lee: https://www.ocf.berkeley.edu/~antonyl/
-
-.. _Clemens Brunner: https://github.com/cle1109
 
 .. _Martin Billinger: http://tnsre.embs.org/author/martinbillinger
 
 .. _Matteo Visconti di Oleggio Castello: http://www.mvdoc.me
 
-.. _Raghav R V: https://github.com/raghavrv
-
 .. _Trevor Stephens: http://trevorstephens.com/
 
 .. _Jan Hendrik Metzen: https://jmetzen.github.io/
 
-.. _Cathy Deng: https://github.com/cathydeng
-
 .. _Will Dawson: http://www.dawsonresearch.com
 
-.. _Balazs Kegl: https://github.com/kegl
-
 .. _Andrew Tulloch: http://tullo.ch/
-
-.. _Alexis Mignon: https://github.com/AlexisMignon
-
-.. _Hasil Sharma: https://github.com/Hasil-Sharma
 
 .. _Hanna Wallach: http://dirichlet.net/
 
 .. _Yan Yi: http://seowyanyi.org
 
-.. _Kyle Beauchamp: https://github.com/kyleabeauchamp
-
 .. _Hervé Bredin: http://herve.niderb.fr/
-
-.. _Erich Schubert: https://github.com/kno10
-
-.. _Dan Blanchard: https://github.com/dan-blanchard
 
 .. _Eric Martin: http://www.ericmart.in
 
 .. _Nicolas Goix: https://perso.telecom-paristech.fr/~goix/
 
-.. _Cory Lorenz: https://github.com/clorenz7
-
-.. _Tim Head: https://github.com/betatim
-
-.. _Tom Dupre la Tour: https://github.com/TomDLT
-
 .. _Sebastian Raschka: http://sebastianraschka.com
-
-.. _Thomas Unterthiner: https://github.com/untom
-
-.. _Loic Esteve: https://github.com/lesteve
-
-.. _Peter Fischer: https://github.com/yanlend
 
 .. _Brian McFee: https://bmcfee.github.io
 
-.. _Vighnesh Birodkar: https://github.com/vighneshbirodkar
-
-.. _Chyi-Kwei Yau: https://github.com/chyikwei
-.. _Martino Sorbaro: https://github.com/martinosorb
-.. _Jaidev Deshpande: https://github.com/jaidevd
-.. _Arthur Mensch: https://github.com/arthurmensch
-.. _Daniel Galvez: https://github.com/galv
-.. _Jacob Schreiber: https://github.com/jmschrei
-.. _Ankur Ankan: https://github.com/ankurankan
 .. _Valentin Stolbunov: http://www.vstolbunov.com
-.. _Jean Kossaifi: https://github.com/JeanKossaifi
-.. _Andrew Lamb: https://github.com/andylamb
-.. _Graham Clenaghan: https://github.com/gclenaghan
-.. _Giorgio Patrini: https://github.com/giorgiop
-.. _Elvis Dohmatob: https://github.com/dohmatob
-.. _yelite: https://github.com/yelite
-.. _Issam H. Laradji: https://github.com/IssamLaradji
-
-.. _Asish Panda: https://github.com/kaichogami
-
-.. _Philipp Dowling: https://github.com/phdowling
-
-.. _Imaculate: https://github.com/Imaculate
-
-.. _Bernardo Stein: https://github.com/DanielSidhion
-
-.. _Andrea Bravi: https://github.com/AndreaBravi
-
-.. _Devashish Deshpande: https://github.com/dsquareindia
-
-.. _Jonathan Arfa: https://github.com/jarfa
-
-.. _Anish Shah: https://github.com/AnishShah
-
-.. _Ryad Zenine: https://github.com/ryadzenine
-
-.. _Guillaume Lemaitre: https://github.com/glemaitre
-
-.. _JPFrancoia: https://github.com/JPFrancoia
-
-.. _Thierry Guillemot: https://github.com/tguillemot
-
-.. _Wei Xue: https://github.com/xuewei4d
-
-.. _Ori Ziv: https://github.com/zivori
-
-.. _Sears Merritt: https://github.com/merritts
-
-.. _Wenhua Yang: https://github.com/geekoala
-
-.. _Arnaud Fouchet: https://github.com/afouchet
-
-.. _Sebastian Säger: https://github.com/ssaeger
-
-.. _YenChen Lin: https://github.com/yenchenlin
-
-.. _Nelson Liu: https://github.com/nelson-liu
-
-.. _Manvendra Singh: https://github.com/manu-chroma
-
-.. _Ibraim Ganiev: https://github.com/olologin
-
-.. _Konstantin Podshumok: https://github.com/podshumok
-
-.. _David Staub: https://github.com/staubda
-
-.. _Hong Guangguo: https://github.com/hongguangguo
-
-.. _Mads Jensen: https://github.com/indianajensen
-
-.. _Sebastián Vanrell: https://github.com/srvanrell
-
-.. _Robert McGibbon: https://github.com/rmcgibbo
-
-.. _Gregory Stupp: https://github.com/stuppie
-
-.. _Russell Smith: https://github.com/rsmith54
-
-.. _Utkarsh Upadhyay: https://github.com/musically-ut
-
-.. _Eugene Chen: https://github.com/eyc88
-
-.. _Narine Kokhlikyan: https://github.com/NarineK
-
-.. _Peng Meng: https://github.com/mpjlu
-
-.. _Dylan Werner-Meier: https://github.com/unautre
-
-.. _Alyssa Batula: https://github.com/abatula

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -367,7 +367,7 @@ Trees and ensembles
 Linear, kernelized and related models
 
    - In :class:`linear_model.LogisticRegression`, the SAG solver is now
-     available in the multinomial case. :issue:`5251` by :user:`Tom Dupre la Tour<TomDLT>`.
+     available in the multinomial case. :issue:`5251` by `Tom Dupre la Tour`_.
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
      :class:`svm.LinearSVR` now support ``sample_weight``.
@@ -538,7 +538,7 @@ Linear, kernelized and related models
 
     - Fix bug in :class:`linear_model.LogisticRegressionCV` where
       ``solver='liblinear'`` did not accept ``class_weights='balanced``.
-      (:issue:`6817`). By :user:`Tom Dupre la Tour<TomDLT>`.
+      (:issue:`6817`). By `Tom Dupre la Tour`_.
 
     - Fix bug in :class:`neighbors.RadiusNeighborsClassifier` where an error
       occurred when there were outliers being labelled and a weight function
@@ -621,7 +621,7 @@ Metrics
 
     - :func:`metrics.pairwise.pairwise_distances` now converts arrays to
       boolean arrays when required in ``scipy.spatial.distance``.
-      :issue:`5460` by :user:`Tom Dupre la Tour<TomDLT>`.
+      :issue:`5460` by `Tom Dupre la Tour`_.
 
     - Fix sparse input support in :func:`metrics.silhouette_score` as well as
       example examples/text/document_clustering.py. By :user:`YenChen Lin<yenchenlin>`.
@@ -864,7 +864,7 @@ New features
    - The new solver ``sag`` implements a Stochastic Average Gradient descent
      and is available in both :class:`linear_model.LogisticRegression` and
      :class:`linear_model.Ridge`. This solver is very efficient for large
-     datasets. By :user:`Danny Sullivan<dsullivan7>` and :user:`Tom Dupre la Tour<TomDLT>`.
+     datasets. By :user:`Danny Sullivan<dsullivan7>` and `Tom Dupre la Tour`_.
      (:issue:`4738`)
 
    - The new solver ``cd`` implements a Coordinate Descent in
@@ -875,7 +875,7 @@ New features
      ``eta``, ``beta`` and ``nls_max_iter``. New parameters ``alpha`` and
      ``l1_ratio`` control L1 and L2 regularization, and ``shuffle`` adds a
      shuffling step in the ``cd`` solver.
-     By :user:`Tom Dupre la Tour<TomDLT>` and `Mathieu Blondel`_.
+     By `Tom Dupre la Tour`_ and `Mathieu Blondel`_.
 
 Enhancements
 ............
@@ -917,7 +917,7 @@ Enhancements
 
    - Improved speed of ``newton-cg`` solver in
      :class:`linear_model.LogisticRegression`, by avoiding loss computation.
-     By `Mathieu Blondel`_ and :user:`Tom Dupre la Tour<TomDLT>`.
+     By `Mathieu Blondel`_ and `Tom Dupre la Tour`_.
 
    - The ``class_weight="auto"`` heuristic in classifiers supporting
      ``class_weight`` was deprecated and replaced by the ``class_weight="balanced"``
@@ -951,7 +951,7 @@ Enhancements
      By Chih-Wei Chang.
 
    - RCV1 dataset loader (:func:`sklearn.datasets.fetch_rcv1`).
-     By :user:`Tom Dupre la Tour<TomDLT>`.
+     By `Tom Dupre la Tour`_.
 
    - The "Wisconsin Breast Cancer" classical two-class classification dataset
      is now included in scikit-learn, available with
@@ -1009,12 +1009,12 @@ Enhancements
      the stopping criterion. By Santi Villalba. (:issue:`5186`)
 
    - Added optional parameter ``random_state`` in :class:`linear_model.Ridge`
-     , to set the seed of the pseudo random generator used in ``sag`` solver. By :user:`Tom Dupre la Tour<TomDLT>`.
+     , to set the seed of the pseudo random generator used in ``sag`` solver. By `Tom Dupre la Tour`_.
 
    - Added optional parameter ``warm_start`` in
      :class:`linear_model.LogisticRegression`. If set to True, the solvers
      ``lbfgs``, ``newton-cg`` and ``sag`` will be initialized with the
-     coefficients computed in the previous fit. By :user:`Tom Dupre la Tour<TomDLT>`.
+     coefficients computed in the previous fit. By `Tom Dupre la Tour`_.
 
    - Added ``sample_weight`` support to :class:`linear_model.LogisticRegression` for
      the ``lbfgs``, ``newton-cg``, and ``sag`` solvers. By `Valentin Stolbunov`_.
@@ -1108,7 +1108,7 @@ Bug fixes
     - Fixed temporarily :class:`linear_model.Ridge`, which was incorrect
       when fitting the intercept in the case of sparse data. The fix
       automatically changes the solver to 'sag' in this case.
-      :issue:`5360` by :user:`Tom Dupre la Tour<TomDLT>`.
+      :issue:`5360` by `Tom Dupre la Tour`_.
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (:issue:`4478`)
@@ -1148,7 +1148,7 @@ Bug fixes
     - Fixed a bug in :class:`linear_model.LogisticRegression` and
       :class:`linear_model.LogisticRegressionCV` when using
       ``class_weight='balanced'```or ``class_weight='auto'``.
-      By :user:`Tom Dupre la Tour<TomDLT>`.
+      By `Tom Dupre la Tour`_.
 
     - Fixed bug :issue:`5495` when
       doing OVR(SVC(decision_function_shape="ovr")). Fixed by :user:`Elvis Dohmatob<dohmatob>`.
@@ -1946,7 +1946,7 @@ New features
 
    - Added :class:`cluster.AgglomerativeClustering` for hierarchical
      agglomerative clustering with average linkage, complete linkage and
-     ward strategies, by  :user:`Nelle Varoquaux<nellev>` and `Gael Varoquaux`_.
+     ward strategies, by  `Nelle Varoquaux`_ and `Gael Varoquaux`_.
 
    - Shorthand constructors :func:`pipeline.make_pipeline` and
      :func:`pipeline.make_union` were added by `Lars Buitinck`_.
@@ -2536,7 +2536,7 @@ Changelog
      now supports percentage values. By `Gilles Louppe`_.
 
    - Performance improvements in :class:`isotonic.IsotonicRegression` by
-     :user:`Nelle Varoquaux<nellev>`.
+     `Nelle Varoquaux`_.
 
    - :func:`metrics.accuracy_score` has an option normalize to return
      the fraction or the number of correctly classified sample
@@ -2628,7 +2628,7 @@ Changelog
      :class:`sklearn.naive_bayes.BernoulliNB` by adding the ``partial_fit``
      method by `Olivier Grisel`_.
 
-   - New website design and navigation by `Gilles Louppe`_, :user:`Nelle Varoquaux<nellev>`,
+   - New website design and navigation by `Gilles Louppe`_, `Nelle Varoquaux`_,
      Vincent Michel and `Andreas Müller`_.
 
    - Improved documentation on :ref:`multi-class, multi-label and multi-output
@@ -2858,7 +2858,7 @@ List of contributors for release 0.13.1 by number of commits.
  *  1  Diego Molla
  *  1  `Gilles Louppe`_
  *  1  `Mathieu Blondel`_
- *  1  :user:`Nelle Varoquaux<nellev>`
+ *  1  `Nelle Varoquaux`_
  *  1  Rafael Cunha de Almeida
  *  1  Rolando Espinoza La fuente
  *  1  `Vlad Niculae`_
@@ -2925,7 +2925,7 @@ New Estimator Classes
      Li. See :ref:`spectral_embedding` in the user guide.
 
    - :class:`isotonic.IsotonicRegression` by `Fabian Pedregosa`_, `Alexandre Gramfort`_
-     and :user:`Nelle Varoquaux<nellev>`,
+     and `Nelle Varoquaux`_,
 
 
 Changelog
@@ -4705,4 +4705,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 
 .. _Raghav R V: https://github.com/raghavrv
 
+.. _Tom Dupre la Tour: https://github.com/TomDLT
+
+.. _Nelle Varoquaux: https://github.com/nellev
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,18 +30,18 @@ Enhancements
 
    - :class:`cluster.MiniBatchKMeans` and :class:`cluster.KMeans`
      now uses significantly less memory when assigning data points to their
-     nearest cluster center. :issue:`7721` by :user:`Jon Crall<Erotemic>`.
+     nearest cluster center. :issue:`7721` by :user:`Jon Crall <Erotemic>`.
 
    - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`
      that matches the ``classes_`` attribute of ``best_estimator_``. (`#7661
      <https://github.com/scikit-learn/scikit-learn/pull/7661>`_) by `Alyssa
-     Batula`_ and :user:`Dylan Werner-Meier<unautre>`.
+     Batula`_ and :user:`Dylan Werner-Meier <unautre>`.
 
    - The ``min_weight_fraction_leaf`` constraint in tree construction is now
      more efficient, taking a fast path to declare a node a leaf if its weight
      is less than 2 * the minimum. Note that the constructed tree will be
      different from previous versions where ``min_weight_fraction_leaf`` is
-     used. :issue:`7441` by :user:`Nelson Liu<nelson-liu>`.
+     used. :issue:`7441` by :user:`Nelson Liu <nelson-liu>`.
 
    - Added ``average`` parameter to perform weights averaging in
      :class:`linear_model.PassiveAggressiveClassifier`. :issue:`4939`
@@ -53,22 +53,22 @@ Enhancements
 
    - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
      now support sparse input for prediction.
-     :issue:`6101` by :user:`Ibraim Ganiev<olologin>`.
+     :issue:`6101` by :user:`Ibraim Ganiev <olologin>`.
 
    - Added ``shuffle`` and ``random_state`` parameters to shuffle training
      data before taking prefixes of it based on training sizes in
      :func:`model_selection.learning_curve`.
-     :issue:`7506` by :user:`Narine Kokhlikyan<NarineK>`.
+     :issue:`7506` by :user:`Narine Kokhlikyan <NarineK>`.
 
    - Added ``norm_order`` parameter to :class:`feature_selection.SelectFromModel`
      to enable selection of the norm order when ``coef_`` is more than 1D
 
    - Added ``sample_weight`` parameter to :meth:`pipeline.Pipeline.score`.
-     :issue:`7723` by :user:`Mikhail Korobov<kmike>`.
+     :issue:`7723` by :user:`Mikhail Korobov <kmike>`.
 
    - ``check_estimator`` now attempts to ensure that methods transform, predict, etc.
      do not set attributes on the estimator.
-     :issue:`7533` by :user:`Ekaterina Krivich<kiote>`.
+     :issue:`7533` by :user:`Ekaterina Krivich <kiote>`.
 
 Bug fixes
 .........
@@ -76,7 +76,7 @@ Bug fixes
    - Fix a bug where :class:`sklearn.feature_selection.SelectFdr` did not
      exactly implement Benjamini-Hochberg procedure. It formerly may have
      selected fewer features than it should.
-     :issue:`7490` by :user:`Peng Meng<mpjlu>`.
+     :issue:`7490` by :user:`Peng Meng <mpjlu>`.
 
    - :class:`sklearn.manifold.LocallyLinearEmbedding` now correctly handles
      integer inputs. :issue:`6282` by `Jake Vanderplas`_.
@@ -85,17 +85,17 @@ Bug fixes
      regressors now assumes uniform sample weights by default if the
      ``sample_weight`` argument is not passed to the ``fit`` function.
      Previously, the parameter was silently ignored. :issue:`7301`
-     by :user:`Nelson Liu<nelson-liu>`.
+     by :user:`Nelson Liu <nelson-liu>`.
 
    - Numerical issue with :class:`linear_model.RidgeCV` on centered data when
      `n_features > n_samples`. :issue:`6178` by `Bertrand Thirion`_
 
    - Tree splitting criterion classes' cloning/pickling is now memory safe
-     :issue:`7680` by :user:`Ibraim Ganiev<olologin>`.
+     :issue:`7680` by :user:`Ibraim Ganiev <olologin>`.
 
    - Fixed a bug where :class:`decomposition.NMF` sets its ``n_iters_``
      attribute in `transform()`. :issue:`7553` by :user:`Ekaterina
-     Krivich<kiote>`.
+     Krivich <kiote>`.
 
 .. _changes_0_18_1:
 
@@ -124,12 +124,12 @@ Bug fixes
 
    - Fix issue where ``min_grad_norm`` and ``n_iter_without_progress``
      parameters were not being utilised by :class:`manifold.TSNE`.
-     :issue:`6497` by :user:`Sebastian Säger<ssaeger>`
+     :issue:`6497` by :user:`Sebastian Säger <ssaeger>`
 
    - Attribute ``explained_variance_ratio`` of
      :class:`discriminant_analysis.LinearDiscriminantAnalysis` calculated
      with SVD and Eigen solver are now of the same length. :issue:`7632`
-     by :user:`JPFrancoia<JPFrancoia>`
+     by :user:`JPFrancoia <JPFrancoia>`
 
    - Fixes issue in :ref:`univariate_feature_selection` where score 
      functions were not accepting multi-label targets. :issue:`7676`
@@ -150,7 +150,7 @@ Linear, kernelized and related models
      :class:`discriminant_analysis.LinearDiscriminantAnalysis`
      changed for both Eigen and SVD solvers. The attribute has now a length
      of min(n_components, n_classes - 1). :issue:`7632`
-     by :user:`JPFrancoia<JPFrancoia>`
+     by :user:`JPFrancoia <JPFrancoia>`
 
 
 .. _changes_0_18:
@@ -282,21 +282,21 @@ Classifiers and Regressors
      examples are provided. By `Jan Hendrik Metzen`_.
 
    - Added new supervised learning algorithm: :ref:`Multi-layer Perceptron <multilayer_perceptron>`
-     :issue:`3204` by :user:`Issam H. Laradji<IssamLaradji>`
+     :issue:`3204` by :user:`Issam H. Laradji <IssamLaradji>`
 
    - Added :class:`linear_model.HuberRegressor`, a linear model robust to outliers.
      :issue:`5291` by `Manoj Kumar`_.
 
    - Added the :class:`multioutput.MultiOutputRegressor` meta-estimator. It
      converts single output regressors to multi-ouput regressors by fitting
-     one regressor per output. By :user:`Tim Head<betatim>`.
+     one regressor per output. By :user:`Tim Head <betatim>`.
 
 Other estimators
 
    - New :class:`mixture.GaussianMixture` and :class:`mixture.BayesianGaussianMixture`
      replace former mixture models, employing faster inference
-     for sounder results. :issue:`7295` by :user:`Wei Xue<xuewei4d>` and 
-     :user:`Thierry Guillemot<tguillemot>`.
+     for sounder results. :issue:`7295` by :user:`Wei Xue <xuewei4d>` and 
+     :user:`Thierry Guillemot <tguillemot>`.
 
    - Class :class:`decomposition.RandomizedPCA` is now factored into :class:`decomposition.PCA`
      and it is available calling with parameter ``svd_solver='randomized'``.
@@ -304,14 +304,14 @@ Other estimators
      behavior of PCA is recovered by ``svd_solver='full'``. An additional solver
      calls ``arpack`` and performs truncated (non-randomized) SVD. By default,
      the best solver is selected depending on the size of the input and the
-     number of components requested. :issue:`5299` by :user:`Giorgio Patrini<giorgiop>`.
+     number of components requested. :issue:`5299` by :user:`Giorgio Patrini <giorgiop>`.
 
    - Added two functions for mutual information estimation:
      :func:`feature_selection.mutual_info_classif` and
      :func:`feature_selection.mutual_info_regression`. These functions can be
      used in :class:`feature_selection.SelectKBest` and
      :class:`feature_selection.SelectPercentile` as score functions.
-     By :user:`Andrea Bravi<AndreaBravi>` and :user:`Nikolay Mayorov<nmayorov>`.
+     By :user:`Andrea Bravi <AndreaBravi>` and :user:`Nikolay Mayorov <nmayorov>`.
 
    - Added the :class:`ensemble.IsolationForest` class for anomaly detection based on
      random forests. By `Nicolas Goix`_.
@@ -323,15 +323,15 @@ Model selection and evaluation
 
    - Added :func:`metrics.cluster.fowlkes_mallows_score`, the Fowlkes Mallows
      Index which measures the similarity of two clusterings of a set of points
-     By :user:`Arnaud Fouchet<afouchet>` and :user:`Thierry Guillemot<tguillemot>`.
+     By :user:`Arnaud Fouchet <afouchet>` and :user:`Thierry Guillemot <tguillemot>`.
 
    - Added :func:`metrics.calinski_harabaz_score`, which computes the Calinski
      and Harabaz score to evaluate the resulting clustering of a set of points.
-     By :user:`Arnaud Fouchet<afouchet>` and :user:`Thierry Guillemot<tguillemot>`.
+     By :user:`Arnaud Fouchet <afouchet>` and :user:`Thierry Guillemot <tguillemot>`.
 
    - Added new cross-validation splitter
      :class:`model_selection.TimeSeriesSplit` to handle time series data.
-     :issue:`6586` by :user:`YenChen Lin<yenchenlin>`
+     :issue:`6586` by :user:`YenChen Lin <yenchenlin>`
 
    - The cross-validation iterators are replaced by cross-validation splitters
      available from :mod:`sklearn.model_selection`, allowing for nested
@@ -347,10 +347,10 @@ Trees and ensembles
      the mean absolute error. This criterion can also be used in
      :class:`ensemble.ExtraTreesRegressor`,
      :class:`ensemble.RandomForestRegressor`, and the gradient boosting
-     estimators. :issue:`6667` by :user:`Nelson Liu<nelson-liu>`.
+     estimators. :issue:`6667` by :user:`Nelson Liu <nelson-liu>`.
 
    - Added weighted impurity-based early stopping criterion for decision tree
-     growth. :issue:`6954` by :user:`Nelson Liu<nelson-liu>`
+     growth. :issue:`6954` by :user:`Nelson Liu <nelson-liu>`
 
    - The random forest, extra tree and decision tree estimators now has a
      method ``decision_path`` which returns the decision path of samples in
@@ -361,22 +361,22 @@ Trees and ensembles
 
    - Random forest, extra trees, decision trees and gradient boosting estimator
      accept the parameter ``min_samples_split`` and ``min_samples_leaf``
-     provided as a percentage of the training samples. By :user:`yelite<yelite>` and `Arnaud Joly`_.
+     provided as a percentage of the training samples. By :user:`yelite <yelite>` and `Arnaud Joly`_.
 
    - Gradient boosting estimators accept the parameter ``criterion`` to specify
      to splitting criterion used in built decision trees.
-     :issue:`6667` by :user:`Nelson Liu<nelson-liu>`.
+     :issue:`6667` by :user:`Nelson Liu <nelson-liu>`.
 
    - The memory footprint is reduced (sometimes greatly) for
      :class:`ensemble.bagging.BaseBagging` and classes that inherit from it,
      i.e, :class:`ensemble.BaggingClassifier`,
      :class:`ensemble.BaggingRegressor`, and :class:`ensemble.IsolationForest`,
      by dynamically generating attribute ``estimators_samples_`` only when it is
-     needed. By :user:`David Staub<staubda>`.
+     needed. By :user:`David Staub <staubda>`.
 
    - Added ``n_jobs`` and ``sample_weight`` parameters for
      :class:`ensemble.VotingClassifier` to fit underlying estimators in parallel.
-     :issue:`5805` by :user:`Ibraim Ganiev<olologin>`.
+     :issue:`5805` by :user:`Ibraim Ganiev <olologin>`.
 
 Linear, kernelized and related models
 
@@ -385,50 +385,50 @@ Linear, kernelized and related models
 
    - :class:`linear_model.RANSACRegressor`, :class:`svm.LinearSVC` and
      :class:`svm.LinearSVR` now support ``sample_weight``.
-     By :user:`Imaculate<Imaculate>`.
+     By :user:`Imaculate <Imaculate>`.
 
    - Add parameter ``loss`` to :class:`linear_model.RANSACRegressor` to measure the
      error on the samples for every trial. By `Manoj Kumar`_.
 
    - Prediction of out-of-sample events with Isotonic Regression
      (:class:`isotonic.IsotonicRegression`) is now much faster (over 1000x in tests with synthetic
-     data). By :user:`Jonathan Arfa<jarfa>`.
+     data). By :user:`Jonathan Arfa <jarfa>`.
 
    - Isotonic regression (:class:`isotonic.IsotonicRegression`) now uses a better algorithm to avoid
      `O(n^2)` behavior in pathological cases, and is also generally faster
      (:issue:`#6691`). By `Antony Lee`_.
 
    - :class:`naive_bayes.GaussianNB` now accepts data-independent class-priors
-     through the parameter ``priors``. By :user:`Guillaume Lemaitre<glemaitre>`.
+     through the parameter ``priors``. By :user:`Guillaume Lemaitre <glemaitre>`.
 
    - :class:`linear_model.ElasticNet` and :class:`linear_model.Lasso`
      now works with ``np.float32`` input data without converting it
      into ``np.float64``. This allows to reduce the memory
-     consumption. :issue:`6913` by :user:`YenChen Lin<yenchenlin>`.
+     consumption. :issue:`6913` by :user:`YenChen Lin <yenchenlin>`.
 
    - :class:`semi_supervised.LabelPropagation` and :class:`semi_supervised.LabelSpreading`
      now accept arbitrary kernel functions in addition to strings ``knn`` and ``rbf``.
-     :issue:`5762` by :user:`Utkarsh Upadhyay<musically-ut>`.
+     :issue:`5762` by :user:`Utkarsh Upadhyay <musically-ut>`.
 
 Decomposition, manifold learning and clustering
 
    - Added ``inverse_transform`` function to :class:`decomposition.NMF` to compute
-     data matrix of original shape. By :user:`Anish Shah<AnishShah>`.
+     data matrix of original shape. By :user:`Anish Shah <AnishShah>`.
 
    - :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now works
      with ``np.float32`` and ``np.float64`` input data without converting it.
      This allows to reduce the memory consumption by using ``np.float32``.
-     :issue:`6846` by :user:`Sebastian Säger<ssaeger>` and 
-     :user:`YenChen Lin<yenchenlin>`.
+     :issue:`6846` by :user:`Sebastian Säger <ssaeger>` and 
+     :user:`YenChen Lin <yenchenlin>`.
 
 Preprocessing and feature selection
 
    - :class:`preprocessing.RobustScaler` now accepts ``quantile_range`` parameter.
-     :issue:`5929` by :user:`Konstantin Podshumok<podshumok>`.
+     :issue:`5929` by :user:`Konstantin Podshumok <podshumok>`.
 
    - :class:`feature_extraction.FeatureHasher` now accepts string values.
-     :issue:`6173` by :user:`Ryad Zenine<ryadzenine>` and 
-     :user:`Devashish Deshpande<dsquareindia>`.
+     :issue:`6173` by :user:`Ryad Zenine <ryadzenine>` and 
+     :user:`Devashish Deshpande <dsquareindia>`.
 
    - Keyword arguments can now be supplied to ``func`` in
      :class:`preprocessing.FunctionTransformer` by means of the ``kw_args``
@@ -436,19 +436,19 @@ Preprocessing and feature selection
 
    - :class:`feature_selection.SelectKBest` and :class:`feature_selection.SelectPercentile`
      now accept score functions that take X, y as input and return only the scores.
-     By :user:`Nikolay Mayorov<nmayorov>`.
+     By :user:`Nikolay Mayorov <nmayorov>`.
 
 Model evaluation and meta-estimators
 
    - :class:`multiclass.OneVsOneClassifier` and :class:`multiclass.OneVsRestClassifier`
-     now support ``partial_fit``. By :user:`Asish Panda<kaichogami>` and 
-     :user:`Philipp Dowling<phdowling>`.
+     now support ``partial_fit``. By :user:`Asish Panda <kaichogami>` and 
+     :user:`Philipp Dowling <phdowling>`.
 
    - Added support for substituting or disabling :class:`pipeline.Pipeline`
      and :class:`pipeline.FeatureUnion` components using the ``set_params``
      interface that powers :mod:`sklearn.grid_search`.
      See :ref:`sphx_glr_plot_compare_reduction.py`. By `Joel Nothman`_ and
-     :user:`Robert McGibbon<rmcgibbo>`.
+     :user:`Robert McGibbon <rmcgibbo>`.
 
    - The new ``cv_results_`` attribute of :class:`model_selection.GridSearchCV`
      (and :class:`model_selection.RandomizedSearchCV`) can be easily imported
@@ -458,33 +458,33 @@ Model evaluation and meta-estimators
    - Generalization of :func:`model_selection.cross_val_predict`.
      One can pass method names such as `predict_proba` to be used in the cross
      validation framework instead of the default `predict`.
-     By :user:`Ori Ziv<zivori>` and :user:`Sears Merritt<merritts>`.
+     By :user:`Ori Ziv <zivori>` and :user:`Sears Merritt <merritts>`.
 
    - The training scores and time taken for training followed by scoring for
      each search candidate are now available at the ``cv_results_`` dict.
      See :ref:`model_selection_changes` for more information.
-     :issue:`7325` by :user:`Eugene Chen<eyc88>` and `Raghav R V`_.
+     :issue:`7325` by :user:`Eugene Chen <eyc88>` and `Raghav R V`_.
 
 Metrics
 
    - Added ``labels`` flag to :class:`metrics.log_loss` to to explicitly provide
      the labels when the number of classes in ``y_true`` and ``y_pred`` differ.
-     :issue:`7239` by :user:`Hong Guangguo<hongguangguo>` with help from 
-     :user:`Mads Jensen<indianajensen>` and :user:`Nelson Liu<nelson-liu>`.
+     :issue:`7239` by :user:`Hong Guangguo <hongguangguo>` with help from 
+     :user:`Mads Jensen <indianajensen>` and :user:`Nelson Liu <nelson-liu>`.
 
    - Support sparse contingency matrices in cluster evaluation
      (:mod:`metrics.cluster.supervised`) to scale to a large number of
      clusters.
-     :issue:`7419` by :user:`Gregory Stupp<stuppie>` and `Joel Nothman`_.
+     :issue:`7419` by :user:`Gregory Stupp <stuppie>` and `Joel Nothman`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
-     By :user:`Jatin Shah<jatinshah>` and `Raghav R V`_.
+     By :user:`Jatin Shah <jatinshah>` and `Raghav R V`_.
 
    - Speed up :func:`metrics.silhouette_score` by using vectorized operations.
      By `Manoj Kumar`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.confusion_matrix`.
-     By :user:`Bernardo Stein<DanielSidhion>`.
+     By :user:`Bernardo Stein <DanielSidhion>`.
 
 Miscellaneous
 
@@ -493,15 +493,15 @@ Miscellaneous
 
    - Codebase does not contain C/C++ cython generated files: they are
      generated during build. Distribution packages will still contain generated
-     C/C++ files. By :user:`Arthur Mensch<arthurmensch>`.
+     C/C++ files. By :user:`Arthur Mensch <arthurmensch>`.
 
    - Reduce the memory usage for 32-bit float input arrays of
      :func:`utils.sparse_func.mean_variance_axis` and
      :func:`utils.sparse_func.incr_mean_variance_axis` by supporting cython
-     fused types. By :user:`YenChen Lin<yenchenlin>`.
+     fused types. By :user:`YenChen Lin <yenchenlin>`.
 
    - The :func:`ignore_warnings` now accept a category argument to ignore only
-     the warnings of a specified type. By :user:`Thierry Guillemot<tguillemot>`.
+     the warnings of a specified type. By :user:`Thierry Guillemot <tguillemot>`.
 
    - Added parameter ``return_X_y`` and return type ``(data, target) : tuple`` option to
      :func:`load_iris` dataset
@@ -552,7 +552,7 @@ Linear, kernelized and related models
 
     - Fixed incorrect gradient computation for ``loss='squared_epsilon_insensitive'`` in
       :class:`linear_model.SGDClassifier` and :class:`linear_model.SGDRegressor`
-      (:issue:`6764`). By :user:`Wenhua Yang<geekoala>`.
+      (:issue:`6764`). By :user:`Wenhua Yang <geekoala>`.
 
     - Fix bug in :class:`linear_model.LogisticRegressionCV` where
       ``solver='liblinear'`` did not accept ``class_weights='balanced``.
@@ -569,7 +569,7 @@ Linear, kernelized and related models
 Decomposition, manifold learning and clustering
 
     - :class:`decomposition.RandomizedPCA` default number of `iterated_power` is 4 instead of 3.
-      :issue:`5141` by :user:`Giorgio Patrini<giorgiop>`.
+      :issue:`5141` by :user:`Giorgio Patrini <giorgiop>`.
 
     - :func:`utils.extmath.randomized_svd` performs 4 power iterations by default, instead or 0.
       In practice this is enough for obtaining a good approximation of the
@@ -581,20 +581,20 @@ Decomposition, manifold learning and clustering
     - Whiten/non-whiten inconsistency between components of :class:`decomposition.PCA`
       and :class:`decomposition.RandomizedPCA` (now factored into PCA, see the
       New features) is fixed. `components_` are stored with no whitening.
-      :issue:`5299` by :user:`Giorgio Patrini<giorgiop>`.
+      :issue:`5299` by :user:`Giorgio Patrini <giorgiop>`.
 
     - Fixed bug in :func:`manifold.spectral_embedding` where diagonal of unnormalized
-      Laplacian matrix was incorrectly set to 1. :issue:`4995` by :user:`Peter Fischer<yanlend>`.
+      Laplacian matrix was incorrectly set to 1. :issue:`4995` by :user:`Peter Fischer <yanlend>`.
 
     - Fixed incorrect initialization of :func:`utils.arpack.eigsh` on all
       occurrences. Affects :class:`cluster.bicluster.SpectralBiclustering`,
       :class:`decomposition.KernelPCA`, :class:`manifold.LocallyLinearEmbedding`,
       and :class:`manifold.SpectralEmbedding` (:issue:`5012`). By 
-      :user:`Peter Fischer<yanlend>`.
+      :user:`Peter Fischer <yanlend>`.
 
     - Attribute ``explained_variance_ratio_`` calculated with the SVD solver
       of :class:`discriminant_analysis.LinearDiscriminantAnalysis` now returns
-      correct results. By :user:`JPFrancoia<JPFrancoia>`
+      correct results. By :user:`JPFrancoia <JPFrancoia>`
 
 Preprocessing and feature selection
 
@@ -606,7 +606,7 @@ Model evaluation and meta-estimators
 
     - :class:`model_selection.StratifiedKFold` now raises error if all n_labels
       for individual classes is less than n_folds.
-      :issue:`6182` by :user:`Devashish Deshpande<dsquareindia>`.
+      :issue:`6182` by :user:`Devashish Deshpande <dsquareindia>`.
 
     - Fixed bug in :class:`model_selection.StratifiedShuffleSplit`
       where train and test sample could overlap in some edge cases,
@@ -619,7 +619,7 @@ Model evaluation and meta-estimators
 
     - Cross-validation of :class:`OneVsOneClassifier` and
       :class:`OneVsRestClassifier` now works with precomputed kernels.
-      :issue:`7350` by :user:`Russell Smith<rsmith54>`.
+      :issue:`7350` by :user:`Russell Smith <rsmith54>`.
 
     - Fix incomplete ``predict_proba`` method delegation from
       :class:`model_selection.GridSearchCV` to
@@ -643,7 +643,7 @@ Metrics
       :issue:`5460` by `Tom Dupre la Tour`_.
 
     - Fix sparse input support in :func:`metrics.silhouette_score` as well as
-      example examples/text/document_clustering.py. By :user:`YenChen Lin<yenchenlin>`.
+      example examples/text/document_clustering.py. By :user:`YenChen Lin <yenchenlin>`.
 
     - :func:`metrics.roc_curve` and :func:`metrics.precision_recall_curve` no
       longer round ``y_score`` values when creating ROC curves; this was causing
@@ -659,14 +659,14 @@ Miscellaneous
       power iterations are requested, since it applies LU normalization by default.
       If ``n_iter<2`` numerical issues are unlikely, thus no normalization is applied.
       Other normalization options are available: ``'none', 'LU'`` and ``'QR'``.
-      :issue:`5141` by :user:`Giorgio Patrini<giorgiop>`.
+      :issue:`5141` by :user:`Giorgio Patrini <giorgiop>`.
 
     - Fix a bug where some formats of ``scipy.sparse`` matrix, and estimators
       with them as parameters, could not be passed to :func:`base.clone`.
       By `Loic Esteve`_.
 
     - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
-      :issue:`7101` by :user:`Ibraim Ganiev<olologin>`.
+      :issue:`7101` by :user:`Ibraim Ganiev <olologin>`.
 
 
 API changes summary
@@ -678,7 +678,7 @@ Linear, kernelized and related models
      Use ``loss`` instead. By `Manoj Kumar`_.
 
    - Access to public attributes ``.X_`` and ``.y_`` has been deprecated in
-     :class:`isotonic.IsotonicRegression`. By :user:`Jonathan Arfa<jarfa>`.
+     :class:`isotonic.IsotonicRegression`. By :user:`Jonathan Arfa <jarfa>`.
 
 Decomposition, manifold learning and clustering
 
@@ -688,7 +688,7 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Gaussian mixture with a
      Dirichlet process prior faster than before.
-     :issue:`7295` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
+     :issue:`7295` by :user:`Wei Xue <xuewei4d>` and :user:`Thierry Guillemot <tguillemot>`.
 
    - The old :class:`mixture.VBGMM` is deprecated in favor of the new
      :class:`mixture.BayesianGaussianMixture` (with the parameter
@@ -696,12 +696,12 @@ Decomposition, manifold learning and clustering
      The new class solves the computational
      problems of the old class and computes the Variational Bayesian Gaussian
      mixture faster than before.
-     :issue:`6651` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
+     :issue:`6651` by :user:`Wei Xue <xuewei4d>` and :user:`Thierry Guillemot <tguillemot>`.
 
    - The old :class:`mixture.GMM` is deprecated in favor of the new
      :class:`mixture.GaussianMixture`. The new class computes the Gaussian mixture
      faster than before and some of computational problems have been solved.
-     :issue:`6666` by :user:`Wei Xue<xuewei4d>` and :user:`Thierry Guillemot<tguillemot>`.
+     :issue:`6666` by :user:`Wei Xue <xuewei4d>` and :user:`Thierry Guillemot <tguillemot>`.
 
 Model evaluation and meta-estimators
 
@@ -720,10 +720,10 @@ Model evaluation and meta-estimators
    - The parameters ``n_iter`` or ``n_folds`` in old CV splitters are replaced
      by the new parameter ``n_splits`` since it can provide a consistent
      and unambiguous interface to represent the number of train-test splits.
-     :issue:`7187` by :user:`YenChen Lin<yenchenlin>`.
+     :issue:`7187` by :user:`YenChen Lin <yenchenlin>`.
 
    - ``classes`` parameter was renamed to ``labels`` in
-     :func:`metrics.hamming_loss`. :issue:`7260` by :user:`Sebastián Vanrell<srvanrell>`.
+     :func:`metrics.hamming_loss`. :issue:`7260` by :user:`Sebastián Vanrell <srvanrell>`.
 
    - The splitter classes ``LabelKFold``, ``LabelShuffleSplit``,
      ``LeaveOneLabelOut`` and ``LeavePLabelsOut`` are renamed to
@@ -848,7 +848,7 @@ New features
 ............
 
    - All the Scaler classes but :class:`preprocessing.RobustScaler` can be fitted online by
-     calling `partial_fit`. By :user:`Giorgio Patrini<giorgiop>`.
+     calling `partial_fit`. By :user:`Giorgio Patrini <giorgiop>`.
 
    - The new class :class:`ensemble.VotingClassifier` implements a
      "majority rule" / "soft voting" ensemble classifier to combine
@@ -857,12 +857,12 @@ New features
    - The new class :class:`preprocessing.RobustScaler` provides an
      alternative to :class:`preprocessing.StandardScaler` for feature-wise
      centering and range normalization that is robust to outliers.
-     By :user:`Thomas Unterthiner<untom>`.
+     By :user:`Thomas Unterthiner <untom>`.
 
    - The new class :class:`preprocessing.MaxAbsScaler` provides an
      alternative to :class:`preprocessing.MinMaxScaler` for feature-wise
      range normalization when the data is already centered or sparse.
-     By :user:`Thomas Unterthiner<untom>`.
+     By :user:`Thomas Unterthiner <untom>`.
 
    - The new class :class:`preprocessing.FunctionTransformer` turns a Python
      function into a ``Pipeline``-compatible transformer object.
@@ -873,17 +873,17 @@ New features
      respectively similar to :class:`cross_validation.KFold` and
      :class:`cross_validation.ShuffleSplit`, except that the folds are
      conditioned on a label array. By `Brian McFee`_, :user:`Jean 
-     Kossaifi<JeanKossaifi>` and `Gilles Louppe`_.
+     Kossaifi <JeanKossaifi>` and `Gilles Louppe`_.
 
    - :class:`decomposition.LatentDirichletAllocation` implements the Latent
      Dirichlet Allocation topic model with online  variational
-     inference. By :user:`Chyi-Kwei Yau<chyikwei>`, with code based on an implementation
+     inference. By :user:`Chyi-Kwei Yau <chyikwei>`, with code based on an implementation
      by Matt Hoffman. (:issue:`3659`)
 
    - The new solver ``sag`` implements a Stochastic Average Gradient descent
      and is available in both :class:`linear_model.LogisticRegression` and
      :class:`linear_model.Ridge`. This solver is very efficient for large
-     datasets. By :user:`Danny Sullivan<dsullivan7>` and `Tom Dupre la Tour`_.
+     datasets. By :user:`Danny Sullivan <dsullivan7>` and `Tom Dupre la Tour`_.
      (:issue:`4738`)
 
    - The new solver ``cd`` implements a Coordinate Descent in
@@ -904,7 +904,7 @@ Enhancements
 
    - :class:`cluster.mean_shift_.MeanShift` now supports parallel execution,
      as implemented in the ``mean_shift`` function. By :user:`Martino
-     Sorbaro<martinosorb>`.
+     Sorbaro <martinosorb>`.
 
    - :class:`naive_bayes.GaussianNB` now supports fitting with ``sample_weight``.
      By `Jan Hendrik Metzen`_.
@@ -913,7 +913,7 @@ Enhancements
      By `Arnaud Joly`_.
 
    - Added a ``fit_predict`` method for :class:`mixture.GMM` and subclasses.
-     By :user:`Cory Lorenz<clorenz7>`.
+     By :user:`Cory Lorenz <clorenz7>`.
 
    - Added the :func:`metrics.label_ranking_loss` metric.
      By `Arnaud Joly`_.
@@ -921,7 +921,7 @@ Enhancements
    - Added the :func:`metrics.cohen_kappa_score` metric.
 
    - Added a ``warm_start`` constructor parameter to the bagging ensemble
-     models to increase the size of the ensemble. By :user:`Tim Head<betatim>`.
+     models to increase the size of the ensemble. By :user:`Tim Head <betatim>`.
 
    - Added option to use multi-output regression metrics without averaging.
      By Konstantin Shmelkov and :user:`Michael Eickenberg<eickenberg>`.
@@ -963,10 +963,10 @@ Enhancements
 
    - Provide an option for sparse output from
      :func:`sklearn.metrics.pairwise.cosine_similarity`. By 
-     :user:`Jaidev Deshpande<jaidevd>`.
+     :user:`Jaidev Deshpande <jaidevd>`.
 
    - Add :func:`minmax_scale` to provide a function interface for
-     :class:`MinMaxScaler`. By :user:`Thomas Unterthiner<untom>`.
+     :class:`MinMaxScaler`. By :user:`Thomas Unterthiner <untom>`.
 
    - ``dump_svmlight_file`` now handles multi-label datasets.
      By Chih-Wei Chang.
@@ -990,7 +990,7 @@ Enhancements
 
    - Improved speed (3 times per iteration) of
      :class:`decomposition.DictLearning` with coordinate descent method
-     from :class:`linear_model.Lasso`. By :user:`Arthur Mensch<arthurmensch>`.
+     from :class:`linear_model.Lasso`. By :user:`Arthur Mensch <arthurmensch>`.
 
    - Parallel processing (threaded) for queries of nearest neighbors
      (using the ball-tree) by Nikolay Mayorov.
@@ -1004,13 +1004,13 @@ Enhancements
 
    - :class:`tree.DecisionTreeClassifier` now exposes an ``apply`` method
      for retrieving the leaf indices samples are predicted as. By
-     :user:`Daniel Galvez<galv>` and `Gilles Louppe`_.
+     :user:`Daniel Galvez <galv>` and `Gilles Louppe`_.
 
    - Speed up decision tree regressors, random forest regressors, extra trees
      regressors and gradient boosting estimators by computing a proxy
      of the impurity improvement during the tree growth. The proxy quantity is
      such that the split that maximizes this value also maximizes the impurity
-     improvement. By `Arnaud Joly`_, :user:`Jacob Schreiber<jmschrei>`
+     improvement. By `Arnaud Joly`_, :user:`Jacob Schreiber <jmschrei>`
      and `Gilles Louppe`_.
 
    - Speed up tree based methods by reducing the number of computations needed
@@ -1022,7 +1022,7 @@ Enhancements
    - :class:`ensemble.GradientBoostingRegressor` and
      :class:`ensemble.GradientBoostingClassifier` now expose an ``apply``
      method for retrieving the leaf indices each sample ends up in under
-     each try. By :user:`Jacob Schreiber<jmschrei>`.
+     each try. By :user:`Jacob Schreiber <jmschrei>`.
 
    - Add ``sample_weight`` support to :class:`linear_model.LinearRegression`.
      By Sonny Hu. (:issue:`#4881`)
@@ -1045,15 +1045,15 @@ Enhancements
    - Added optional parameter ``presort`` to :class:`ensemble.GradientBoostingRegressor`
      and :class:`ensemble.GradientBoostingClassifier`, keeping default behavior
      the same. This allows gradient boosters to turn off presorting when building
-     deep trees or using sparse data. By :user:`Jacob Schreiber<jmschrei>`.
+     deep trees or using sparse data. By :user:`Jacob Schreiber <jmschrei>`.
 
    - Altered :func:`metrics.roc_curve` to drop unnecessary thresholds by
-     default. By :user:`Graham Clenaghan<gclenaghan>`.
+     default. By :user:`Graham Clenaghan <gclenaghan>`.
 
    - Added :class:`feature_selection.SelectFromModel` meta-transformer which can
      be used along with estimators that have `coef_` or `feature_importances_`
      attribute to select important features of the input data. By
-     :user:`Maheshakya Wijewardena<maheshakya>`, `Joel Nothman`_ and `Manoj Kumar`_.
+     :user:`Maheshakya Wijewardena <maheshakya>`, `Joel Nothman`_ and `Manoj Kumar`_.
 
    - Added :func:`metrics.pairwise.laplacian_kernel`.  By `Clyde Fare <https://github.com/Clyde-fare>`_.
 
@@ -1097,7 +1097,7 @@ Bug fixes
       in the final fit. By `Manoj Kumar`_.
 
     - Fixed bug in :class:`ensemble.forest.ForestClassifier` while computing
-      oob_score and X is a sparse.csc_matrix. By :user:`Ankur Ankan<ankurankan>`.
+      oob_score and X is a sparse.csc_matrix. By :user:`Ankur Ankan <ankurankan>`.
 
     - All regressors now consistently handle and warn when given ``y`` that is of
       shape ``(n_samples, 1)``. By `Andreas Müller`_ and Henry Lin.
@@ -1117,7 +1117,7 @@ Bug fixes
       (:issue:`5182`)
 
     - Fixed the :func:`partial_fit` method of :class:`linear_model.SGDClassifier`
-      when called with ``average=True``. By :user:`Andrew Lamb<andylamb>`.
+      when called with ``average=True``. By :user:`Andrew Lamb <andylamb>`.
       (:issue:`5282`)
 
     - Dataset fetchers use different filenames under Python 2 and Python 3 to
@@ -1134,11 +1134,11 @@ Bug fixes
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (:issue:`4478`)
-      By `Andreas Müller`_, `Loic Esteve`_ and :user:`Giorgio Patrini<giorgiop>`.
+      By `Andreas Müller`_, `Loic Esteve`_ and :user:`Giorgio Patrini <giorgiop>`.
 
     - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
       platform dependent output, and failed on `fit_transform`.
-      By :user:`Arthur Mensch<arthurmensch>`.
+      By :user:`Arthur Mensch <arthurmensch>`.
 
     - Fixes to the ``Bunch`` class used to store datasets.
 
@@ -1174,7 +1174,7 @@ Bug fixes
 
     - Fixed bug :issue:`5495` when
       doing OVR(SVC(decision_function_shape="ovr")). Fixed by 
-      :user:`Elvis Dohmatob<dohmatob>`.
+      :user:`Elvis Dohmatob <dohmatob>`.
 
 
 API changes summary
@@ -1182,12 +1182,12 @@ API changes summary
     - Attribute `data_min`, `data_max` and `data_range` in
       :class:`preprocessing.MinMaxScaler` are deprecated and won't be available
       from 0.19. Instead, the class now exposes `data_min_`, `data_max_`
-      and `data_range_`. By :user:`Giorgio Patrini<giorgiop>`.
+      and `data_range_`. By :user:`Giorgio Patrini <giorgiop>`.
 
     - All Scaler classes now have an `scale_` attribute, the feature-wise
       rescaling applied by their `transform` methods. The old attribute `std_`
       in :class:`preprocessing.StandardScaler` is deprecated and superseded
-      by `scale_`; it won't be available in 0.19. By :user:`Giorgio Patrini<giorgiop>`.
+      by `scale_`; it won't be available in 0.19. By :user:`Giorgio Patrini <giorgiop>`.
 
     - :class:`svm.SVC`` and :class:`svm.NuSVC` now have an ``decision_function_shape``
       parameter to make their decision function of shape ``(n_samples, n_classes)``
@@ -1198,7 +1198,7 @@ API changes summary
       caused confusion in how the array elements should be interpreted
       as features or as samples. All data arrays are now expected
       to be explicitly shaped ``(n_samples, n_features)``.
-      By :user:`Vighnesh Birodkar<vighneshbirodkar>`.
+      By :user:`Vighnesh Birodkar <vighneshbirodkar>`.
 
     - :class:`lda.LDA` and :class:`qda.QDA` have been moved to
       :class:`discriminant_analysis.LinearDiscriminantAnalysis` and
@@ -1220,7 +1220,7 @@ API changes summary
 
     - :class:`cluster.KMeans` re-runs cluster-assignments in case of non-convergence,
       to ensure consistency of ``predict(X)`` and ``labels_``. By
-      :user:`Vighnesh Birodkar<vighneshbirodkar>`.
+      :user:`Vighnesh Birodkar <vighneshbirodkar>`.
 
     - Classifier and Regressor models are now tagged as such using the
       ``_estimator_type`` attribute.
@@ -1380,7 +1380,7 @@ New features
      sample sizes than :class:`svm.SVR` with linear kernel. By
      `Fabian Pedregosa`_ and Qiang Luo.
 
-   - Incremental fit for :class:`GaussianNB <naive_bayes.GaussianNB>`.
+   - Incremental fit for :class:`GaussianNB  <naive_bayes.GaussianNB>`.
 
    - Added ``sample_weight`` support to :class:`dummy.DummyClassifier` and
      :class:`dummy.DummyRegressor`. By `Arnaud Joly`_.
@@ -1407,22 +1407,22 @@ New features
 
    - Averaged SGD for :class:`SGDClassifier <linear_model.SGDClassifier>`
      and :class:`SGDRegressor <linear_model.SGDRegressor>` By
-     :user:`Danny Sullivan<dsullivan7>`.
+     :user:`Danny Sullivan <dsullivan7>`.
 
    - Added :func:`cross_val_predict <cross_validation.cross_val_predict>`
      function which computes cross-validated estimates. By `Luis Pedro Coelho`_
 
    - Added :class:`linear_model.TheilSenRegressor`, a robust
-     generalized-median-based estimator. By :user:`Florian Wilhelm<FlorianWilhelm>`.
+     generalized-median-based estimator. By :user:`Florian Wilhelm <FlorianWilhelm>`.
 
    - Added :func:`metrics.median_absolute_error`, a robust metric.
-     By `Gael Varoquaux`_ and :user:`Florian Wilhelm<FlorianWilhelm>`.
+     By `Gael Varoquaux`_ and :user:`Florian Wilhelm <FlorianWilhelm>`.
 
    - Add :class:`cluster.Birch`, an online clustering algorithm. By
      `Manoj Kumar`_, `Alexandre Gramfort`_ and `Joel Nothman`_.
 
    - Added shrinkage support to :class:`discriminant_analysis.LinearDiscriminantAnalysis`
-     using two new solvers. By :user:`Clemens Brunner<cle1109>` and `Martin Billinger`_.
+     using two new solvers. By :user:`Clemens Brunner <cle1109>` and `Martin Billinger`_.
 
    - Added :class:`kernel_ridge.KernelRidge`, an implementation of
      kernelized ridge regression.
@@ -1433,12 +1433,12 @@ New features
 
    - Added :class:`cross_validation.PredefinedSplit` cross-validation
      for fixed user-provided cross-validation folds.
-     By :user:`Thomas Unterthiner<untom>`.
+     By :user:`Thomas Unterthiner <untom>`.
 
    - Added :class:`calibration.CalibratedClassifierCV`, an approach for
      calibrating the predicted probabilities of a classifier.
      By `Alexandre Gramfort`_, `Jan Hendrik Metzen`_, `Mathieu Blondel`_
-     and :user:`Balazs Kegl<kegl>`.
+     and :user:`Balazs Kegl <kegl>`.
 
 
 Enhancements
@@ -1463,11 +1463,11 @@ Enhancements
 
    - Add ``sample_weight`` parameter to
      :func:`metrics.jaccard_similarity_score` and :func:`metrics.log_loss`.
-     By :user:`Jatin Shah<jatinshah>`.
+     By :user:`Jatin Shah <jatinshah>`.
 
    - Support sparse multilabel indicator representation in
      :class:`preprocessing.LabelBinarizer` and
-     :class:`multiclass.OneVsRestClassifier` (by :user:`Hamzeh Alsalhi<hamsal>` with thanks
+     :class:`multiclass.OneVsRestClassifier` (by :user:`Hamzeh Alsalhi <hamsal>` with thanks
      to Rohit Sivaprasad), as well as evaluation metrics (by
      `Joel Nothman`_).
 
@@ -1489,20 +1489,20 @@ Enhancements
 
    - ``DictVectorizer`` can now perform ``fit_transform`` on an iterable in a
      single pass, when giving the option ``sort=False``. By :user:`Dan
-     Blanchard<dan-blanchard>`.
+     Blanchard <dan-blanchard>`.
 
    - :class:`GridSearchCV` and :class:`RandomizedSearchCV` can now be
      configured to work with estimators that may fail and raise errors on
      individual folds. This option is controlled by the `error_score`
      parameter. This does not affect errors raised on re-fit. By
-     :user:`Michal Romaniuk<romaniukm>`.
+     :user:`Michal Romaniuk <romaniukm>`.
 
    - Add ``digits`` parameter to `metrics.classification_report` to allow
      report to show different precision of floating point numbers. By
-     :user:`Ian Gilmore<agileminor>`.
+     :user:`Ian Gilmore <agileminor>`.
 
    - Add a quantile prediction strategy to the :class:`dummy.DummyRegressor`.
-     By :user:`Aaron Staple<staple>`.
+     By :user:`Aaron Staple <staple>`.
 
    - Add ``handle_unknown`` option to :class:`preprocessing.OneHotEncoder` to
      handle unknown categorical features more gracefully during transform.
@@ -1521,7 +1521,7 @@ Enhancements
      in their constructor. By `Manoj Kumar`_.
 
    - Added decision function for :class:`multiclass.OneVsOneClassifier`
-     By `Raghav R V`_ and :user:`Kyle Beauchamp<kyleabeauchamp>`.
+     By `Raghav R V`_ and :user:`Kyle Beauchamp <kyleabeauchamp>`.
 
    - :func:`neighbors.kneighbors_graph` and :func:`radius_neighbors_graph`
      support non-Euclidean metrics. By `Manoj Kumar`_
@@ -1560,7 +1560,7 @@ Enhancements
      instead of its sum over all samples. By `Hervé Bredin`_.
 
    - The outcome of :func:`manifold.spectral_embedding` was made deterministic
-     by flipping the sign of eigenvectors. By :user:`Hasil Sharma<Hasil-Sharma>`.
+     by flipping the sign of eigenvectors. By :user:`Hasil Sharma <Hasil-Sharma>`.
 
    - Significant performance and memory usage improvements in
      :class:`preprocessing.PolynomialFeatures`. By `Eric Martin`_.
@@ -1579,10 +1579,10 @@ Documentation improvements
 ..........................
 
    - Added example of using :class:`FeatureUnion` for heterogeneous input.
-     By :user:`Matt Terry<mrterry>`
+     By :user:`Matt Terry <mrterry>`
 
    - Documentation on scorers was improved, to highlight the handling of loss
-     functions. By :user:`Matt Pico<MattpSoftware>`.
+     functions. By :user:`Matt Pico <MattpSoftware>`.
 
    - A discrepancy between liblinear output and scikit-learn's wrappers
      is now noted. By `Manoj Kumar`_.
@@ -1620,11 +1620,11 @@ Bug fixes
       `Matteo Visconti di Oleggio Castello`_.
 
     - :class:`feature_selection.RFECV` now correctly handles cases when
-      ``step`` is not equal to 1. By :user:`Nikolay Mayorov<nmayorov>`
+      ``step`` is not equal to 1. By :user:`Nikolay Mayorov <nmayorov>`
 
     - The :class:`decomposition.PCA` now undoes whitening in its
       ``inverse_transform``. Also, its ``components_`` now always have unit
-      length. By :user:`Michael Eickenberg<eickenberg>`.
+      length. By :user:`Michael Eickenberg <eickenberg>`.
 
     - Fix incomplete download of the dataset when
       :func:`datasets.download_20newsgroups` is called. By `Manoj Kumar`_.
@@ -1634,14 +1634,14 @@ Bug fixes
 
     - Calling ``partial_fit`` with ``class_weight=='auto'`` throws an
       appropriate error message and suggests a work around.
-      By :user:`Danny Sullivan<dsullivan7>`.
+      By :user:`Danny Sullivan <dsullivan7>`.
 
     - :class:`RBFSampler <kernel_approximation.RBFSampler>` with ``gamma=g``
       formerly approximated :func:`rbf_kernel <metrics.pairwise.rbf_kernel>`
       with ``gamma=g/2.``; the definition of ``gamma`` is now consistent,
       which may substantially change your results if you use a fixed value.
       (If you cross-validated over ``gamma``, it probably doesn't matter
-      too much.) By :user:`Dougal Sutherland<dougalsutherland>`.
+      too much.) By :user:`Dougal Sutherland <dougalsutherland>`.
 
     - Pipeline object delegate the ``classes_`` attribute to the underlying
       estimator. It allows, for instance, to make bagging of a pipeline object.
@@ -1669,7 +1669,7 @@ Bug fixes
 
     - Fix handling of precomputed affinity matrices in
       :class:`cluster.AgglomerativeClustering` when using connectivity
-      constraints. By :user:`Cathy Deng<cathydeng>`
+      constraints. By :user:`Cathy Deng <cathydeng>`
 
     - Correct ``partial_fit`` handling of ``class_prior`` for
       :class:`sklearn.naive_bayes.MultinomialNB` and
@@ -1695,7 +1695,7 @@ Bug fixes
       By `Garret-R <https://github.com/Garrett-R>`_.
 
     - Fixed round off errors with non positive-definite covariance matrices
-      in GMM. By :user:`Alexis Mignon<AlexisMignon>`.
+      in GMM. By :user:`Alexis Mignon <AlexisMignon>`.
 
     - Fixed a error in the computation of conditional probabilities in
       :class:`naive_bayes.BernoulliNB`. By `Hanna Wallach`_.
@@ -1803,7 +1803,7 @@ API changes summary
       :class:`linear_model.PassiveAgressiveRegressor` now defaults to ``True``.
 
     - :class:`cluster.DBSCAN` now uses a deterministic initialization. The
-      `random_state` parameter is deprecated. By :user:`Erich Schubert<kno10>`.
+      `random_state` parameter is deprecated. By :user:`Erich Schubert <kno10>`.
 
 Code Contributors
 -----------------
@@ -1851,14 +1851,14 @@ Bug fixes
 
   - Fixed handling of the ``p`` parameter of the Minkowski distance that was
     previously ignored in nearest neighbors models. By :user:`Nikolay
-    Mayorov<nmayorov>`.
+    Mayorov <nmayorov>`.
 
   - Fixed duplicated alphas in :class:`linear_model.LassoLars` with early
     stopping on 32 bit Python. By `Olivier Grisel`_ and `Fabian Pedregosa`_.
 
   - Fixed the build under Windows when scikit-learn is built with MSVC while
     NumPy is built with MinGW. By `Olivier Grisel`_ and :user:`Federico
-    Vaggi<FedericoV>`.
+    Vaggi <FedericoV>`.
 
   - Fixed an array index overflow bug in the coordinate descent solver. By
     `Gael Varoquaux`_.
@@ -1883,7 +1883,7 @@ Bug fixes
     running the tests. By `Joel Nothman`_.
 
   - Many documentation and website fixes by `Joel Nothman`_, `Lars Buitinck`_
-    :user:`Matt Pico<MattpSoftware>`, and others.
+    :user:`Matt Pico <MattpSoftware>`, and others.
 
 .. _changes_0_15_1:
 
@@ -1898,7 +1898,7 @@ Bug fixes
    - Made :func:`cross_validation.cross_val_score` use
      :class:`cross_validation.KFold` instead of
      :class:`cross_validation.StratifiedKFold` on multi-output classification
-     problems. By :user:`Nikolay Mayorov<nmayorov>`.
+     problems. By :user:`Nikolay Mayorov <nmayorov>`.
 
    - Support unseen labels :class:`preprocessing.LabelBinarizer` to restore
      the default behavior of 0.14.1 for backward compatibility. By
@@ -1969,7 +1969,7 @@ New features
      :class:`feature_selection.VarianceThreshold`, by `Lars Buitinck`_.
 
    - Added :class:`linear_model.RANSACRegressor` meta-estimator for the robust
-     fitting of regression models. By :user:`Johannes Schönberger<ahojnnes>`.
+     fitting of regression models. By :user:`Johannes Schönberger <ahojnnes>`.
 
    - Added :class:`cluster.AgglomerativeClustering` for hierarchical
      agglomerative clustering with average linkage, complete linkage and
@@ -1979,14 +1979,14 @@ New features
      :func:`pipeline.make_union` were added by `Lars Buitinck`_.
 
    - Shuffle option for :class:`cross_validation.StratifiedKFold`.
-     By :user:`Jeffrey Blackburne<jblackburne>`.
+     By :user:`Jeffrey Blackburne <jblackburne>`.
 
    - Incremental learning (``partial_fit``) for Gaussian Naive Bayes by
      Imran Haque.
 
    - Added ``partial_fit`` to :class:`BernoulliRBM
      <neural_network.BernoulliRBM>`
-     By :user:`Danny Sullivan<dsullivan7>`.
+     By :user:`Danny Sullivan <dsullivan7>`.
 
    - Added :func:`learning_curve <learning_curve.learning_curve>` utility to
      chart performance with respect to training size. See
@@ -2006,7 +2006,7 @@ Enhancements
 
    - Add sparse input support to :class:`ensemble.AdaBoostClassifier` and
      :class:`ensemble.AdaBoostRegressor` meta-estimators.
-     By :user:`Hamzeh Alsalhi<hamsal>`.
+     By :user:`Hamzeh Alsalhi <hamsal>`.
 
    - Memory improvements of decision trees, by `Arnaud Joly`_.
 
@@ -2067,7 +2067,7 @@ Enhancements
      :class:`cluster.MeanShift`, by `Mathieu Blondel`_.
 
    - Vector and matrix multiplications have been optimised throughout the
-     library by :user:`Denis Engemann<dengemann>`, and `Alexandre Gramfort`_.
+     library by :user:`Denis Engemann <dengemann>`, and `Alexandre Gramfort`_.
      In particular, they should take less memory with older NumPy versions
      (prior to 1.7.2).
 
@@ -2080,7 +2080,7 @@ Enhancements
 
    - Added svd_method option with default value to "randomized" to
      :class:`decomposition.FactorAnalysis` to save memory and
-     significantly speedup computation by :user:`Denis Engemann<dengemann>`, and
+     significantly speedup computation by :user:`Denis Engemann <dengemann>`, and
      `Alexandre Gramfort`_.
 
    - Changed :class:`cross_validation.StratifiedKFold` to try and
@@ -2104,7 +2104,7 @@ Enhancements
 
    - :class:`dummy.DummyRegressor` has now a strategy parameter which allows
      to predict the mean, the median of the training set or a constant
-     output value. By :user:`Maheshakya Wijewardena<maheshakya>`.
+     output value. By :user:`Maheshakya Wijewardena <maheshakya>`.
 
    - Multi-label classification output in multilabel indicator format
      is now supported by :func:`metrics.roc_auc_score` and
@@ -2124,7 +2124,7 @@ Enhancements
      avoiding potentially skewed results.
 
    - Ridge regression can now deal with sample weights in feature space
-     (only sample space until then). By :user:`Michael Eickenberg<eickenberg>`.
+     (only sample space until then). By :user:`Michael Eickenberg <eickenberg>`.
      Both solutions are provided by the Cholesky solver.
 
    - Several classification and regression metrics now support weighted
@@ -2162,7 +2162,7 @@ Documentation improvements
      and different factors that have influence over speed. Additional tips for
      building faster models and choosing a relevant compromise between speed
      and predictive power.
-     By :user:`Eustache Diemert<oddskool>`.
+     By :user:`Eustache Diemert <oddskool>`.
 
 Bug fixes
 .........
@@ -2183,7 +2183,7 @@ Bug fixes
 
    - Fixed incorrect estimation of the degrees of freedom in
      :func:`feature_selection.f_regression` when variates are not centered.
-     By :user:`Virgile Fritsch<VirgileFritsch>`.
+     By :user:`Virgile Fritsch <VirgileFritsch>`.
 
    - Fixed a race condition in parallel processing with
      ``pre_dispatch != "all"`` (for instance, in ``cross_val_score``).
@@ -2287,7 +2287,7 @@ API changes summary
      weighted array that was returned was wrong. By `Manoj Kumar`_.
 
    - Fix :class:`cross_validation.Bootstrap` to return ``ValueError``
-     when ``n_train + n_test > n``. By :user:`Ronald Phlypo<rphlypo>`.
+     when ``n_train + n_test > n``. By :user:`Ronald Phlypo <rphlypo>`.
 
 
 People
@@ -2495,8 +2495,8 @@ Changelog
    - Added :ref:`Restricted Boltzmann Machines<rbm>`
      (:class:`neural_network.BernoulliRBM`). By `Yann Dauphin`_.
 
-   - Python 3 support by :user:`Justin Vincent<justinvf>`, `Lars Buitinck`_,
-     :user:`Subhodeep Moitra<smoitra87>` and `Olivier Grisel`_. All tests now pass under
+   - Python 3 support by :user:`Justin Vincent <justinvf>`, `Lars Buitinck`_,
+     :user:`Subhodeep Moitra <smoitra87>` and `Olivier Grisel`_. All tests now pass under
      Python 3.3.
 
    - Ability to pass one penalty (alpha value) per target in
@@ -2504,7 +2504,7 @@ Changelog
 
    - Fixed :mod:`sklearn.linear_model.stochastic_gradient.py` L2 regularization
      issue (minor practical significance).
-     By :user:`Norbert Crombach<norbert>` and `Mathieu Blondel`_ .
+     By :user:`Norbert Crombach <norbert>` and `Mathieu Blondel`_ .
 
    - Added an interactive version of `Andreas Müller`_'s
      `Machine Learning Cheat Sheet (for scikit-learn)
@@ -2592,7 +2592,7 @@ Changelog
 
    - Added self-contained example of out-of-core learning on text data
      :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`.
-     By :user:`Eustache Diemert<oddskool>`.
+     By :user:`Eustache Diemert <oddskool>`.
 
    - The default number of components for
      :class:`sklearn.decomposition.RandomizedPCA` is now correctly documented
@@ -2603,7 +2603,7 @@ Changelog
      faster on sparse data (the speedup depends on the sparsity). By
      `Lars Buitinck`_.
 
-   - Reduce memory footprint of FastICA by :user:`Denis Engemann<dengemann>` and
+   - Reduce memory footprint of FastICA by :user:`Denis Engemann <dengemann>` and
      `Alexandre Gramfort`_.
 
    - Verbose output in :mod:`sklearn.ensemble.gradient_boosting` now uses
@@ -2664,7 +2664,7 @@ Changelog
    - Better input and error handling in the :mod:`metrics` module by
      `Arnaud Joly`_ and `Joel Nothman`_.
 
-   - Speed optimization of the :mod:`hmm` module by :user:`Mikhail Korobov<kmike>`
+   - Speed optimization of the :mod:`hmm` module by :user:`Mikhail Korobov <kmike>`
 
    - Significant speed improvements for :class:`sklearn.cluster.DBSCAN`
      by `cleverless <https://github.com/cleverless>`_
@@ -3183,7 +3183,7 @@ List of contributors for release 0.13 by number of commits.
  *  17  Nelle Varoquaux
  *  16  `Christian Osendorfer`_
  *  14  `Daniel Nouri`_
- *  13  :user:`Virgile Fritsch<VirgileFritsch>`
+ *  13  :user:`Virgile Fritsch <VirgileFritsch>`
  *  13  syhw
  *  12  `Satrajit Ghosh`_
  *  10  Corey Lynch
@@ -3261,11 +3261,11 @@ Changelog
 
  - Fix Unicode support in count vectorizer by `Andreas Müller`_
 
- - Fix MinCovDet breaking with X.shape = (3, 1) by :user:`Virgile Fritsch<VirgileFritsch>`
+ - Fix MinCovDet breaking with X.shape = (3, 1) by :user:`Virgile Fritsch <VirgileFritsch>`
 
  - Fix clone of SGD objects by `Peter Prettenhofer`_
 
- - Stabilize GMM by :user:`Virgile Fritsch<VirgileFritsch>`
+ - Stabilize GMM by :user:`Virgile Fritsch <VirgileFritsch>`
 
 People
 ------
@@ -3274,7 +3274,7 @@ People
  *  12  `Gael Varoquaux`_
  *  10  `Andreas Müller`_
  *   5  `Lars Buitinck`_
- *   3  :user:`Virgile Fritsch<VirgileFritsch>`
+ *   3  :user:`Virgile Fritsch <VirgileFritsch>`
  *   1  `Alexandre Gramfort`_
  *   1  `Gilles Louppe`_
  *   1  `Mathieu Blondel`_
@@ -3339,7 +3339,7 @@ Changelog
      module by `Andreas Müller`_.
 
    - New word boundaries-aware character n-gram analyzer for the
-     :ref:`text_feature_extraction` module by :user:`@kernc<kernc>`.
+     :ref:`text_feature_extraction` module by :user:`@kernc <kernc>`.
 
    - Fixed bug in spectral clustering that led to single point clusters
      by `Andreas Müller`_.
@@ -3439,8 +3439,8 @@ People
  *  27  `Olivier Grisel`_
  *  16  Subhodeep Moitra
  *  13  Yannick Schwartz
- *  12  :user:`@kernc<kernc>`
- *  11  :user:`Virgile Fritsch<VirgileFritsch>`
+ *  12  :user:`@kernc <kernc>`
+ *  11  :user:`Virgile Fritsch <VirgileFritsch>`
  *   9  Daniel Duckworth
  *   9  `Fabian Pedregosa`_
  *   9  `Robert Layton`_
@@ -3760,7 +3760,7 @@ Changelog
      extra-trees method, along with documentation and examples.
 
    - :ref:`outlier_detection`: outlier and novelty detection, by
-     :user:`Virgile Fritsch<VirgileFritsch>`.
+     :user:`Virgile Fritsch <VirgileFritsch>`.
 
    - :ref:`kernel_approximation`: a transform implementing kernel
      approximation for fast SGD on non-linear kernels by
@@ -3878,7 +3878,7 @@ The following people contributed to scikit-learn since last release:
    *  52  `Jake Vanderplas`_
    *  44  Noel Dawe
    *  38  `Alexandre Gramfort`_
-   *  24  :user:`Virgile Fritsch<VirgileFritsch>`
+   *  24  :user:`Virgile Fritsch <VirgileFritsch>`
    *  23  `Satrajit Ghosh`_
    *   3  Jan Hendrik Metzen
    *   3  Kenneth C. Arnold
@@ -3957,7 +3957,7 @@ Changelog
      `Alexandre Gramfort`_
 
    - Printing an estimator now behaves independently of architectures
-     and Python version thanks to :user:`Jean Kossaifi<JeanKossaifi>`.
+     and Python version thanks to :user:`Jean Kossaifi <JeanKossaifi>`.
 
    - :ref:`Loader for libsvm/svmlight format <libsvm_loader>` by
      `Mathieu Blondel`_ and `Lars Buitinck`_
@@ -4112,7 +4112,7 @@ People
    - 56  `Gilles Louppe`_
    - 42  Robert Layton
    - 38  Nelle Varoquaux
-   - 32  :user:`Jean Kossaifi<JeanKossaifi>`
+   - 32  :user:`Jean Kossaifi <JeanKossaifi>`
    - 30  Conrad Lee
    - 22  Pietro Berkes
    - 18  andy
@@ -4120,7 +4120,7 @@ People
    - 12  Brian Holt
    - 11  Robert
    - 8  Amit Aides
-   - 8  :user:`Virgile Fritsch<VirgileFritsch>`
+   - 8  :user:`Virgile Fritsch <VirgileFritsch>`
    - 7  `Yaroslav Halchenko`_
    - 6  Salvatore Masecchia
    - 5  Paolo Losi
@@ -4169,7 +4169,7 @@ Several new modules where introduced during this release:
   - :ref:`NMF` module `Vlad Niculae`_
 
   - Implementation of the :ref:`oracle_approximating_shrinkage` algorithm by
-    :user:`Virgile Fritsch<VirgileFritsch>` in the :ref:`covariance` module.
+    :user:`Virgile Fritsch <VirgileFritsch>` in the :ref:`covariance` module.
 
 
 Some other modules benefited from significant improvements or cleanups.
@@ -4222,7 +4222,7 @@ People that made this release possible preceded by number of commits:
    - 30  `Mathieu Blondel`_
    - 25  `Peter Prettenhofer`_
    - 22  `Nicolas Pinto`_
-   - 11  :user:`Virgile Fritsch<VirgileFritsch>`
+   - 11  :user:`Virgile Fritsch <VirgileFritsch>`
    -  7  Lars Buitinck
    -  6  Vincent Michel
    -  5  `Bertrand Thirion`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -2136,7 +2136,7 @@ Documentation improvements
      Original tutorial created by several authors including
      `Olivier Grisel`_, Lars Buitinck and many others.
      Tutorial integration into the scikit-learn documentation
-     by :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
+     by :user:`Jaques Grobler<jaquesgrobler>`
 
    - Added :ref:`Computational Performance <computational_performance>`
      documentation. Discussion and examples of prediction latency / throughput
@@ -2491,7 +2491,7 @@ Changelog
      `Machine Learning Cheat Sheet (for scikit-learn)
      <http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html>`_
      to the documentation. See :ref:`Choosing the right estimator <ml_map>`.
-     By :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`.
+     By :user:`Jaques Grobler<jaquesgrobler>`.
 
    - :class:`grid_search.GridSearchCV` and
      :func:`cross_validation.cross_val_score` now support the use of advanced
@@ -2669,7 +2669,7 @@ API changes summary
      :class:`linear_model.enet_path` can return its results in the same
      format as that of :class:`linear_model.lars_path`. This is done by
      setting the ``return_models`` parameter to ``False``. By
-     :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>` and `Alexandre Gramfort`_
+     :user:`Jaques Grobler<jaquesgrobler>` and `Alexandre Gramfort`_
 
    - :class:`grid_search.IterGrid` was renamed to
      :class:`grid_search.ParameterGrid`.
@@ -2956,7 +2956,7 @@ Changelog
      example.
 
    - The table of contents on the website has now been made expandable by
-     :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`.
+     :user:`Jaques Grobler<jaquesgrobler>`.
 
    - :class:`feature_selection.SelectPercentile` now breaks ties
      deterministically instead of returning all equally ranked features.
@@ -3155,7 +3155,7 @@ List of contributors for release 0.13 by number of commits.
  * 101  `Olivier Grisel`_
  *  65  `Vlad Niculae`_
  *  54  `Gilles Louppe`_
- *  40  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
+ *  40  :user:`Jaques Grobler<jaquesgrobler>`
  *  38  `Alexandre Gramfort`_
  *  30  `Rob Zinkov`_
  *  19  Aymeric Masurelle
@@ -3414,7 +3414,7 @@ People
  *  52  `Vlad Niculae`_
  *  45  :user:`Lars Buitinck<larsmans>`
  *  44  Nelle Varoquaux
- *  37  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
+ *  37  :user:`Jaques Grobler<jaquesgrobler>`
  *  30  Alexis Mignon
  *  30  Immanuel Bayer
  *  27  `Olivier Grisel`_
@@ -3649,7 +3649,7 @@ People
    * 114  `Mathieu Blondel`_
    * 103  Clay Woolam
    *  96  :user:`Lars Buitinck<larsmans>`
-   *  88  :user:`Jaques Grobler<jaquesgrobler/scikit-learn/wiki/Jaques-Grobler>`
+   *  88  :user:`Jaques Grobler<jaquesgrobler>`
    *  82  `Alexandre Gramfort`_
    *  50  `Bertrand Thirion`_
    *  42  `Robert Layton`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -929,7 +929,7 @@ Enhancements
    - The ``class_weight="auto"`` heuristic in classifiers supporting
      ``class_weight`` was deprecated and replaced by the ``class_weight="balanced"``
      option, which has a simpler formula and interpretation.
-     By Hanna Wallach and `Andreas Müller`_.
+     By `Hanna Wallach`_ and `Andreas Müller`_.
 
    - Add ``class_weight`` parameter to automatically weight samples by class
      frequency for :class:`linear_model.PassiveAgressiveClassifier`. By
@@ -1685,7 +1685,7 @@ Bug fixes
       in GMM. By :user:`Alexis Mignon<AlexisMignon>`.
 
     - Fixed a error in the computation of conditional probabilities in
-      :class:`naive_bayes.BernoulliNB`. By Hanna Wallach.
+      :class:`naive_bayes.BernoulliNB`. By `Hanna Wallach`_.
 
     - Make the method ``radius_neighbors`` of
       :class:`neighbors.NearestNeighbors` return the samples lying on the

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -322,7 +322,7 @@ Model selection and evaluation
    - The cross-validation iterators are replaced by cross-validation splitters
      available from :mod:`sklearn.model_selection`, allowing for nested
      cross-validation. See :ref:`model_selection_changes` for more information.
-     :issue:`4294` by :user:`Raghav R V<raghavrv>`.
+     :issue:`4294` by `Raghav R V`_.
 
 Enhancements
 ............
@@ -436,7 +436,7 @@ Model evaluation and meta-estimators
    - The new ``cv_results_`` attribute of :class:`model_selection.GridSearchCV`
      (and :class:`model_selection.RandomizedSearchCV`) can be easily imported
      into pandas as a ``DataFrame``. Ref :ref:`model_selection_changes` for
-     more information. :issue:`6697` by :user:`Raghav R V<raghavrv>`.
+     more information. :issue:`6697` by `Raghav R V`_.
 
    - Generalization of :func:`model_selection.cross_val_predict`.
      One can pass method names such as `predict_proba` to be used in the cross
@@ -446,7 +446,7 @@ Model evaluation and meta-estimators
    - The training scores and time taken for training followed by scoring for
      each search candidate are now available at the ``cv_results_`` dict.
      See :ref:`model_selection_changes` for more information.
-     :issue:`7325` by :user:`Eugene Chen<eyc88>` and :user:`Raghav R V<raghavrv>`.
+     :issue:`7325` by :user:`Eugene Chen<eyc88>` and `Raghav R V`_.
 
 Metrics
 
@@ -460,7 +460,7 @@ Metrics
      :issue:`7419` by :user:`Gregory Stupp<stuppie>` and `Joel Nothman`_.
 
    - Add ``sample_weight`` parameter to :func:`metrics.matthews_corrcoef`.
-     By :user:`Jatin Shah<jatinshah>` and :user:`Raghav R V<raghavrv>`.
+     By :user:`Jatin Shah<jatinshah>` and `Raghav R V`_.
 
    - Speed up :func:`metrics.silhouette_score` by using vectorized operations.
      By `Manoj Kumar`_.
@@ -592,7 +592,7 @@ Model evaluation and meta-estimators
     - Fixed bug in :class:`model_selection.StratifiedShuffleSplit`
       where train and test sample could overlap in some edge cases,
       see :issue:`6121` for
-      more details. By :user:`Loic Esteve<lesteve>`.
+      more details. By `Loic Esteve`_.
 
     - Fix in :class:`sklearn.model_selection.StratifiedShuffleSplit` to
       return splits of size ``train_size`` and ``test_size`` in all cases
@@ -644,7 +644,7 @@ Miscellaneous
 
     - Fix a bug where some formats of ``scipy.sparse`` matrix, and estimators
       with them as parameters, could not be passed to :func:`base.clone`.
-      By :user:`Loic Esteve<lesteve>`.
+      By `Loic Esteve`_.
 
     - :func:`datasets.load_svmlight_file` now is able to read long int QID values.
       :issue:`7101` by :user:`Ibraim Ganiev<olologin>`.
@@ -690,13 +690,13 @@ Model evaluation and meta-estimators
      :mod:`sklearn.learning_curve` have been deprecated and the classes and
      functions have been reorganized into the :mod:`sklearn.model_selection`
      module. Ref :ref:`model_selection_changes` for more information.
-     :issue:`4294` by :user:`Raghav R V<raghavrv>`.
+     :issue:`4294` by `Raghav R V`_.
 
    - The ``grid_scores_`` attribute of :class:`model_selection.GridSearchCV`
      and :class:`model_selection.RandomizedSearchCV` is deprecated in favor of
      the attribute ``cv_results_``.
      Ref :ref:`model_selection_changes` for more information.
-     :issue:`6697` by :user:`Raghav R V<raghavrv>`.
+     :issue:`6697` by `Raghav R V`_.
 
    - The parameters ``n_iter`` or ``n_folds`` in old CV splitters are replaced
      by the new parameter ``n_splits`` since it can provide a consistent
@@ -717,7 +717,7 @@ Model evaluation and meta-estimators
      :class:`model_selection.LeavePGroupsOut` is renamed to
      ``groups``. Additionally in :class:`model_selection.LeavePGroupsOut`,
      the parameter ``n_labels`` is renamed to ``n_groups``.
-     :issue:`6660` by :user:`Raghav R V<raghavrv>`.
+     :issue:`6660` by `Raghav R V`_.
 
 Code Contributors
 -----------------
@@ -962,7 +962,7 @@ Enhancements
      parallelism when many very short tasks are executed in parallel, for
      instance by the :class:`grid_search.GridSearchCV` meta-estimator
      with ``n_jobs > 1`` used with a large grid of parameters on a small
-     dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and :user:`Loic Esteve<lesteve>`.
+     dataset. By `Vlad Niculae`_, `Olivier Grisel`_ and `Loic Esteve`_.
 
    - For more details about changes in joblib 0.9.3 see the release notes:
      https://github.com/joblib/joblib/blob/master/CHANGES.rst#release-093
@@ -1082,7 +1082,7 @@ Bug fixes
       (:issue:`5431`)
 
     - Fix in :class:`cluster.KMeans` cluster reassignment for sparse input by
-      :user:`Lars Buitinck<larsmans>`.
+      `Lars Buitinck`_.
 
     - Fixed a bug in :class:`lda.LDA` that could cause asymmetric covariance
       matrices when using shrinkage. By `Martin Billinger`_.
@@ -1112,7 +1112,7 @@ Bug fixes
 
     - Fixed a performance bug in :class:`decomposition.RandomizedPCA` on data
       with a large number of features and fewer samples. (:issue:`4478`)
-      By `Andreas Müller`_, :user:`Loic Esteve<lesteve>` and :user:`Giorgio Patrini<giorgiop>`.
+      By `Andreas Müller`_, `Loic Esteve`_ and :user:`Giorgio Patrini<giorgiop>`.
 
     - Fixed bug in :class:`cross_decomposition.PLS` that yielded unstable and
       platform dependent output, and failed on `fit_transform`.
@@ -1427,7 +1427,7 @@ Enhancements
      By `Manoj Kumar`_
 
    - Add support for sample weights in scorer objects.  Metrics with sample
-     weight support will automatically benefit from it. By :user:`Noel Dawe<ndawe>` and
+     weight support will automatically benefit from it. By `Noel Dawe`_ and
      `Vlad Niculae`_.
 
    - Added ``newton-cg`` and `lbfgs` solver support in
@@ -1460,7 +1460,7 @@ Enhancements
      :class:`linear_model.LogisticRegression` to implement a Logistic
      Regression solver that minimizes the cross-entropy or multinomial loss
      instead of the default One-vs-Rest setting. Supports `lbfgs` and
-     `newton-cg` solvers. By :user:`Lars Buitinck<larsmans>` and `Manoj Kumar`_. Solver option
+     `newton-cg` solvers. By `Lars Buitinck`_ and `Manoj Kumar`_. Solver option
      `newton-cg` by Simon Wu.
 
    - ``DictVectorizer`` can now perform ``fit_transform`` on an iterable in a
@@ -1496,7 +1496,7 @@ Enhancements
      in their constructor. By `Manoj Kumar`_.
 
    - Added decision function for :class:`multiclass.OneVsOneClassifier`
-     By :user:`Raghav R V<raghavrv>` and :user:`Kyle Beauchamp<kyleabeauchamp>`.
+     By `Raghav R V`_ and :user:`Kyle Beauchamp<kyleabeauchamp>`.
 
    - :func:`neighbors.kneighbors_graph` and :func:`radius_neighbors_graph`
      support non-Euclidean metrics. By `Manoj Kumar`_
@@ -1510,7 +1510,7 @@ Enhancements
    - :class:`cluster.DBSCAN` now supports sparse input and sample weights and
      has been optimized: the inner loop has been rewritten in Cython and
      radius neighbors queries are now computed in batch. By `Joel Nothman`_
-     and :user:`Lars Buitinck<larsmans>`.
+     and `Lars Buitinck`_.
 
    - Add ``class_weight`` parameter to automatically weight samples by class
      frequency for :class:`ensemble.RandomForestClassifier`,
@@ -1712,7 +1712,7 @@ API changes summary
       now returns two probabilities per sample in the multiclass case; this
       is consistent with other estimators and with the method's documentation,
       but previous versions accidentally returned only the positive
-      probability. Fixed by Will Lamond and :user:`Lars Buitinck<larsmans>`.
+      probability. Fixed by Will Lamond and `Lars Buitinck`_.
 
     - Change default value of precompute in :class:`ElasticNet` and :class:`Lasso`
       to False. Setting precompute to "auto" was found to be slower when
@@ -1743,7 +1743,7 @@ API changes summary
 
     - From now onwards, all estimators will uniformly raise ``NotFittedError``
       (:class:`utils.validation.NotFittedError`), when any of the ``predict``
-      like methods are called before the model is fit. By :user:`Raghav R V<raghavrv>`.
+      like methods are called before the model is fit. By `Raghav R V`_.
 
     - Input data validation was refactored for more consistent input
       validation. The ``check_arrays`` function was replaced by ``check_array``
@@ -1847,7 +1847,7 @@ Bug fixes
   - The ``transform`` of :class:`discriminant_analysis.LinearDiscriminantAnalysis`
     now projects the input on the most discriminant directions. By Martin Billinger.
 
-  - Fixed potential overflow in ``_tree.safe_realloc`` by :user:`Lars Buitinck<larsmans>`.
+  - Fixed potential overflow in ``_tree.safe_realloc`` by `Lars Buitinck`_.
 
   - Performance optimization in :class:`isotonic.IsotonicRegression`.
     By Robert Bradshaw.
@@ -1855,7 +1855,7 @@ Bug fixes
   - ``nose`` is non-longer a runtime dependency to import ``sklearn``, only for
     running the tests. By `Joel Nothman`_.
 
-  - Many documentation and website fixes by `Joel Nothman`_, :user:`Lars Buitinck<larsmans>`
+  - Many documentation and website fixes by `Joel Nothman`_, `Lars Buitinck`_
     :user:`Matt Pico<MattpSoftware>`, and others.
 
 .. _changes_0_15_1:
@@ -1939,7 +1939,7 @@ New features
      the user guide for details and examples. By `Gilles Louppe`_.
 
    - New unsupervised feature selection algorithm
-     :class:`feature_selection.VarianceThreshold`, by :user:`Lars Buitinck<larsmans>`.
+     :class:`feature_selection.VarianceThreshold`, by `Lars Buitinck`_.
 
    - Added :class:`linear_model.RANSACRegressor` meta-estimator for the robust
      fitting of regression models. By Johannes Schönberger.
@@ -1949,7 +1949,7 @@ New features
      ward strategies, by  :user:`Nelle Varoquaux<nellev>` and `Gael Varoquaux`_.
 
    - Shorthand constructors :func:`pipeline.make_pipeline` and
-     :func:`pipeline.make_union` were added by :user:`Lars Buitinck<larsmans>`.
+     :func:`pipeline.make_union` were added by `Lars Buitinck`_.
 
    - Shuffle option for :class:`cross_validation.StratifiedKFold`.
      By :user:`Jeffrey Blackburne<jblackburne>`.
@@ -2032,7 +2032,7 @@ Enhancements
 
    - Add ``min_weight_fraction_leaf`` pre-pruning parameter to tree-based
      methods: the minimum weighted fraction of the input samples required to be
-     at a leaf node. By :user:`Noel Dawe<ndawe>`.
+     at a leaf node. By `Noel Dawe`_.
 
    - Added :func:`metrics.pairwise_distances_argmin_min`, by Philippe Gervais.
 
@@ -2049,7 +2049,7 @@ Enhancements
 
    - The training algorithm for :class:`decomposition.NMF` is faster for
      sparse matrices and has much lower memory complexity, meaning it will
-     scale up gracefully to large datasets. By :user:`Lars Buitinck<larsmans>`.
+     scale up gracefully to large datasets. By `Lars Buitinck`_.
 
    - Added svd_method option with default value to "randomized" to
      :class:`decomposition.FactorAnalysis` to save memory and
@@ -2069,7 +2069,7 @@ Enhancements
      by `Robert Layton`_ and `Joel Nothman`_.
 
    - Norm computations optimized for NumPy 1.6 and later versions by
-     :user:`Lars Buitinck<larsmans>`. In particular, the k-means algorithm no longer
+     `Lars Buitinck`_. In particular, the k-means algorithm no longer
      needs a temporary data structure the size of its input.
 
    - :class:`dummy.DummyClassifier` can now be used to predict a constant
@@ -2089,7 +2089,7 @@ Enhancements
 
    - Speed and memory usage improvements to the SGD algorithm for linear
      models: it now uses threads, not separate processes, when ``n_jobs>1``.
-     By :user:`Lars Buitinck<larsmans>`.
+     By `Lars Buitinck`_.
 
    - Grid search and cross validation allow NaNs in the input arrays so that
      preprocessors such as :class:`preprocessing.Imputer
@@ -2114,7 +2114,7 @@ Enhancements
      :func:`metrics.mean_squared_error`,
      :func:`metrics.mean_absolute_error`,
      :func:`metrics.r2_score`.
-     By :user:`Noel Dawe<ndawe>`.
+     By `Noel Dawe`_.
 
    - Speed up of the sample generator
      :func:`datasets.make_multilabel_classification`. By `Joel Nothman`_.
@@ -2128,7 +2128,7 @@ Documentation improvements
      Original tutorial created by several authors including
      `Olivier Grisel`_, Lars Buitinck and many others.
      Tutorial integration into the scikit-learn documentation
-     by :user:`Jaques Grobler<jaquesgrobler>`
+     by `Jaques Grobler`_
 
    - Added :ref:`Computational Performance <computational_performance>`
      documentation. Discussion and examples of prediction latency / throughput
@@ -2450,7 +2450,7 @@ Changelog
      consumption in all tree-based estimators. By `Gilles Louppe`_.
 
    - Added :class:`ensemble.AdaBoostClassifier` and
-     :class:`ensemble.AdaBoostRegressor`, by :user:`Noel Dawe<ndawe>`  and
+     :class:`ensemble.AdaBoostRegressor`, by `Noel Dawe`_  and
      `Gilles Louppe`_. See the :ref:`AdaBoost <adaboost>` section of the user
      guide for details and examples.
 
@@ -2468,7 +2468,7 @@ Changelog
    - Added :ref:`Restricted Boltzmann Machines<rbm>`
      (:class:`neural_network.BernoulliRBM`). By `Yann Dauphin`_.
 
-   - Python 3 support by :user:`Justin Vincent<justinvf>`, :user:`Lars Buitinck<larsmans>`,
+   - Python 3 support by :user:`Justin Vincent<justinvf>`, `Lars Buitinck`_,
      :user:`Subhodeep Moitra<smoitra87>` and `Olivier Grisel`_. All tests now pass under
      Python 3.3.
 
@@ -2483,13 +2483,13 @@ Changelog
      `Machine Learning Cheat Sheet (for scikit-learn)
      <http://peekaboo-vision.blogspot.de/2013/01/machine-learning-cheat-sheet-for-scikit.html>`_
      to the documentation. See :ref:`Choosing the right estimator <ml_map>`.
-     By :user:`Jaques Grobler<jaquesgrobler>`.
+     By `Jaques Grobler`_.
 
    - :class:`grid_search.GridSearchCV` and
      :func:`cross_validation.cross_val_score` now support the use of advanced
      scoring function such as area under the ROC curve and f-beta scores.
      See :ref:`scoring_parameter` for details. By `Andreas Müller`_
-     and :user:`Lars Buitinck<larsmans>`.
+     and `Lars Buitinck`_.
      Passing a function from :mod:`sklearn.metrics` as ``score_func`` is
      deprecated.
 
@@ -2543,7 +2543,7 @@ Changelog
      by `Arnaud Joly`_.
 
    - Added :func:`metrics.log_loss` that computes log loss, aka cross-entropy
-     loss. By Jochen Wersdörfer and :user:`Lars Buitinck<larsmans>`.
+     loss. By Jochen Wersdörfer and `Lars Buitinck`_.
 
    - A bug that caused :class:`ensemble.AdaBoostClassifier`'s to output
      incorrect probabilities has been fixed.
@@ -2561,7 +2561,7 @@ Changelog
    - The new estimator :class:`sklearn.decomposition.TruncatedSVD`
      performs dimensionality reduction using SVD on sparse matrices,
      and can be used for latent semantic analysis (LSA).
-     By :user:`Lars Buitinck<larsmans>`.
+     By `Lars Buitinck`_.
 
    - Added self-contained example of out-of-core learning on text data
      :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`.
@@ -2574,7 +2574,7 @@ Changelog
 
    - :class:`sklearn.cluster.KMeans` now fits several orders of magnitude
      faster on sparse data (the speedup depends on the sparsity). By
-     :user:`Lars Buitinck<larsmans>`.
+     `Lars Buitinck`_.
 
    - Reduce memory footprint of FastICA by :user:`Denis Engemann<dengemann>` and
      `Alexandre Gramfort`_.
@@ -2590,7 +2590,7 @@ Changelog
      By `Peter Prettenhofer`_.
 
    - Most metrics now support string labels for multiclass classification
-     by `Arnaud Joly`_ and :user:`Lars Buitinck<larsmans>`.
+     by `Arnaud Joly`_ and `Lars Buitinck`_.
 
    - New OrthogonalMatchingPursuitCV class by `Alexandre Gramfort`_
      and `Vlad Niculae`_.
@@ -2661,7 +2661,7 @@ API changes summary
      :class:`linear_model.enet_path` can return its results in the same
      format as that of :class:`linear_model.lars_path`. This is done by
      setting the ``return_models`` parameter to ``False``. By
-     :user:`Jaques Grobler<jaquesgrobler>` and `Alexandre Gramfort`_
+     `Jaques Grobler`_ and `Alexandre Gramfort`_
 
    - :class:`grid_search.IterGrid` was renamed to
      :class:`grid_search.ParameterGrid`.
@@ -2835,7 +2835,7 @@ Changelog
     - Fixed a bug in the reassignment of small clusters in the :class:`cluster.MiniBatchKMeans`
       by `Gael Varoquaux`_.
 
-    - Fixed default value of ``gamma`` in :class:`decomposition.KernelPCA` by :user:`Lars Buitinck<larsmans>`.
+    - Fixed default value of ``gamma`` in :class:`decomposition.KernelPCA` by `Lars Buitinck`_.
 
     - Updated joblib to ``0.7.0d`` by `Gael Varoquaux`_.
 
@@ -2848,7 +2848,7 @@ Changelog
 People
 ------
 List of contributors for release 0.13.1 by number of commits.
- * 16  :user:`Lars Buitinck<larsmans>`
+ * 16  `Lars Buitinck`_
  * 12  `Andreas Müller`_
  *  8  `Gael Varoquaux`_
  *  5  Robert Marchman
@@ -2886,7 +2886,7 @@ New Estimator Classes
 
    - :class:`feature_extraction.FeatureHasher`, a transformer implementing the
      "hashing trick" for fast, low-memory feature extraction from string fields
-     by :user:`Lars Buitinck<larsmans>` and :class:`feature_extraction.text.HashingVectorizer`
+     by `Lars Buitinck`_ and :class:`feature_extraction.text.HashingVectorizer`
      for text documents by `Olivier Grisel`_  See :ref:`feature_hashing` and
      :ref:`hashing_vectorizer` for the documentation and sample usage.
 
@@ -2937,7 +2937,7 @@ Changelog
      Kyle Beauchamp.
 
    - :class:`tree.DecisionTreeClassifier` and all derived ensemble models now
-     support sample weighting, by :user:`Noel Dawe<ndawe>`  and `Gilles Louppe`_.
+     support sample weighting, by `Noel Dawe`_  and `Gilles Louppe`_.
 
    - Speedup improvement when using bootstrap samples in forests of randomized
      trees, by `Peter Prettenhofer`_  and `Gilles Louppe`_.
@@ -2948,7 +2948,7 @@ Changelog
      example.
 
    - The table of contents on the website has now been made expandable by
-     :user:`Jaques Grobler<jaquesgrobler>`.
+     `Jaques Grobler`_.
 
    - :class:`feature_selection.SelectPercentile` now breaks ties
      deterministically instead of returning all equally ranked features.
@@ -2960,7 +2960,7 @@ Changelog
      previously.
 
    - Ridge regression and ridge classification fitting with ``sparse_cg`` solver
-     no longer has quadratic memory complexity, by :user:`Lars Buitinck<larsmans>` and
+     no longer has quadratic memory complexity, by `Lars Buitinck`_ and
      `Fabian Pedregosa`_.
 
    - Ridge regression and ridge classification now support a new fast solver
@@ -3142,12 +3142,12 @@ List of contributors for release 0.13 by number of commits.
  * 137  `Peter Prettenhofer`_
  * 131  `Gael Varoquaux`_
  * 117  `Mathieu Blondel`_
- * 108  :user:`Lars Buitinck<larsmans>`
+ * 108  `Lars Buitinck`_
  * 106  Wei Li
  * 101  `Olivier Grisel`_
  *  65  `Vlad Niculae`_
  *  54  `Gilles Louppe`_
- *  40  :user:`Jaques Grobler<jaquesgrobler>`
+ *  40  `Jaques Grobler`_
  *  38  `Alexandre Gramfort`_
  *  30  `Rob Zinkov`_
  *  19  Aymeric Masurelle
@@ -3228,7 +3228,7 @@ Changelog
 
  - Proper behavior with fortran-ordered NumPy arrays by `Gael Varoquaux`_
 
- - Make GridSearchCV work with non-CSR sparse matrix by :user:`Lars Buitinck<larsmans>`
+ - Make GridSearchCV work with non-CSR sparse matrix by `Lars Buitinck`_
 
  - Fix parallel computing in MDS by `Gael Varoquaux`_
 
@@ -3246,7 +3246,7 @@ People
  *  14  `Peter Prettenhofer`_
  *  12  `Gael Varoquaux`_
  *  10  `Andreas Müller`_
- *   5  :user:`Lars Buitinck<larsmans>`
+ *   5  `Lars Buitinck`_
  *   3  :user:`Virgile Fritsch<VirgileFritsch>`
  *   1  `Alexandre Gramfort`_
  *   1  `Gilles Louppe`_
@@ -3286,7 +3286,7 @@ Changelog
    - Added :ref:`multidimensional_scaling`, by Nelle Varoquaux.
 
    - SVMlight file format loader now detects compressed (gzip/bzip2) files and
-     decompresses them on the fly, by :user:`Lars Buitinck<larsmans>`.
+     decompresses them on the fly, by `Lars Buitinck`_.
 
    - SVMlight file format serializer now preserves double precision floating
      point values, by `Olivier Grisel`_.
@@ -3404,9 +3404,9 @@ People
  *  60  `Mathieu Blondel`_
  *  57  `Alexandre Gramfort`_
  *  52  `Vlad Niculae`_
- *  45  :user:`Lars Buitinck<larsmans>`
+ *  45  `Lars Buitinck`_
  *  44  Nelle Varoquaux
- *  37  :user:`Jaques Grobler<jaquesgrobler>`
+ *  37  `Jaques Grobler`_
  *  30  Alexis Mignon
  *  30  Immanuel Bayer
  *  27  `Olivier Grisel`_
@@ -3465,7 +3465,7 @@ Highlights
      and `Scott White`_ .
 
    - Simple dict-based feature loader with support for categorical variables
-     (:class:`feature_extraction.DictVectorizer`) by :user:`Lars Buitinck<larsmans>`.
+     (:class:`feature_extraction.DictVectorizer`) by `Lars Buitinck`_.
 
    - Added Matthews correlation coefficient (:func:`metrics.matthews_corrcoef`)
      and added macro and micro average options to
@@ -3505,7 +3505,7 @@ Other changes
      warm_start to the :ref:`sgd` module by `Mathieu Blondel`_.
 
    - Dense and sparse implementations of :ref:`svm` classes and
-     :class:`linear_model.LogisticRegression` merged by :user:`Lars Buitinck<larsmans>`.
+     :class:`linear_model.LogisticRegression` merged by `Lars Buitinck`_.
 
    - Regressors can now be used as base estimator in the :ref:`multiclass`
      module by `Mathieu Blondel`_.
@@ -3640,8 +3640,8 @@ People
    * 129  `Olivier Grisel`_
    * 114  `Mathieu Blondel`_
    * 103  Clay Woolam
-   *  96  :user:`Lars Buitinck<larsmans>`
-   *  88  :user:`Jaques Grobler<jaquesgrobler>`
+   *  96  `Lars Buitinck`_
+   *  88  `Jaques Grobler`_
    *  82  `Alexandre Gramfort`_
    *  50  `Bertrand Thirion`_
    *  42  `Robert Layton`_
@@ -3754,7 +3754,7 @@ Changelog
      (:func:`sklearn.datasets.fetch_20newsgroups_vectorized`) by
      `Mathieu Blondel`_.
 
-   - :ref:`multiclass` by :user:`Lars Buitinck<larsmans>`.
+   - :ref:`multiclass` by `Lars Buitinck`_.
 
    - Utilities for fast computation of mean and variance for sparse matrices
      by `Mathieu Blondel`_.
@@ -3842,7 +3842,7 @@ The following people contributed to scikit-learn since last release:
    * 220  `Gilles Louppe`_
    * 183  `Brian Holt`_
    * 166  `Gael Varoquaux`_
-   * 144  :user:`Lars Buitinck<larsmans>`
+   * 144  `Lars Buitinck`_
    *  73  `Vlad Niculae`_
    *  65  `Peter Prettenhofer`_
    *  64  `Fabian Pedregosa`_
@@ -3933,7 +3933,7 @@ Changelog
      and Python version thanks to :user:`Jean Kossaifi<JeanKossaifi>`.
 
    - :ref:`Loader for libsvm/svmlight format <libsvm_loader>` by
-     `Mathieu Blondel`_ and :user:`Lars Buitinck<larsmans>`
+     `Mathieu Blondel`_ and `Lars Buitinck`_
 
    - Documentation improvements: thumbnails in
      :ref:`example gallery <examples-index>` by `Fabian Pedregosa`_.
@@ -3942,12 +3942,12 @@ Changelog
      performance) by `Fabian Pedregosa`_.
 
    - Added :ref:`multinomial_naive_bayes` and :ref:`bernoulli_naive_bayes`
-     by :user:`Lars Buitinck<larsmans>`
+     by `Lars Buitinck`_
 
    - Text feature extraction optimizations by Lars Buitinck
 
    - Chi-Square feature selection
-     (:func:`feature_selection.univariate_selection.chi2`) by :user:`Lars Buitinck<larsmans>`.
+     (:func:`feature_selection.univariate_selection.chi2`) by `Lars Buitinck`_.
 
    - :ref:`sample_generators` module refactoring by `Gilles Louppe`_
 
@@ -4074,7 +4074,7 @@ People
 
    - 387  `Vlad Niculae`_
    - 320  `Olivier Grisel`_
-   - 192  :user:`Lars Buitinck<larsmans>`
+   - 192  `Lars Buitinck`_
    - 179  `Gael Varoquaux`_
    - 168  `Fabian Pedregosa`_ (`INRIA`_, `Parietal Team`_)
    - 127  `Jake Vanderplas`_
@@ -4694,3 +4694,15 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Brian McFee: https://bmcfee.github.io
 
 .. _Valentin Stolbunov: http://www.vstolbunov.com
+
+.. _Jaques Grobler: https://github.com/jaquesgrobler
+
+.. _Lars Buitinck: https://github.com/larsmans
+
+.. _Loic Esteve: https://github.com/lesteve
+
+.. _Noel Dawe: https://github.com/ndawe
+
+.. _Raghav R V: https://github.com/raghavrv
+
+

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -49,7 +49,7 @@ Enhancements
 
    - Custom metrics for the :mod:`sklearn.neighbors` binary trees now have
      fewer constraints: they must take two 1d-arrays and return a float.
-     :issue:`6288` by `Jake VanderPlas`_.
+     :issue:`6288` by `Jake Vanderplas`_.
 
    - :class:`ensemble.GradientBoostingClassifier` and :class:`ensemble.GradientBoostingRegressor`
      now support sparse input for prediction.
@@ -747,7 +747,7 @@ Lemaitre, Gustav Mörtberg, halwai, Harizo Rajaona, Harry Mavroforakis,
 hashcode55, hdmetor, Henry Lin, Hobson Lane, Hugo Bowne-Anderson,
 Igor Andriushchenko, Imaculate, Inki Hwang, Isaac Sijaranamual,
 Ishank Gulati, Issam Laradji, Iver Jordal, jackmartin, Jacob Schreiber, Jake
-VanderPlas, James Fiedler, James Routley, Jan Zikes, Janna Brettingen, jarfa, Jason
+Vanderplas, James Fiedler, James Routley, Jan Zikes, Janna Brettingen, jarfa, Jason
 Laska, jblackburne, jeff levesque, Jeffrey Blackburne, Jeffrey04, Jeremy Hintz,
 jeremynixon, Jeroen, Jessica Yung, Jill-Jênn Vie, Jimmy Jia, Jiyuan Qian, Joel
 Nothman, johannah, John, John Boersma, John Kirkham, John Moeller,
@@ -1269,7 +1269,7 @@ Sutherland, edson duarte, Eduardo Caro, Eric Larson, Eric Martin, Erich
 Schubert, Fernando Carrillo, Frank C. Eckert, Frank Zalkow, Gael Varoquaux,
 Ganiev Ibraim, Gilles Louppe, Giorgio Patrini, giorgiop, Graham Clenaghan,
 Gryllos Prokopis, gwulfs, Henry Lin, Hsuan-Tien Lin, Immanuel Bayer, Ishank
-Gulati, Jack Martin, Jacob Schreiber, Jaidev Deshpande, Jake VanderPlas, Jan
+Gulati, Jack Martin, Jacob Schreiber, Jaidev Deshpande, Jake Vanderplas, Jan
 Hendrik Metzen, Jean Kossaifi, Jeffrey04, Jeremy, jfraj, Jiali Mei,
 Joe Jevnik, Joel Nothman, John Kirkham, John Wittenauer, Joseph, Joshua Loyal,
 Jungkook Park, KamalakerDadi, Kashif Rasul, Keith Goodman, Kian Ho, Konstantin
@@ -1807,7 +1807,7 @@ Pedregosa, Florian Wilhelm, floydsoft, Félix-Antoine Fortin, Gael Varoquaux,
 Garrett-R, Gilles Louppe, gpassino, gwulfs, Hampus Bengtsson, Hamzeh Alsalhi,
 Hanna Wallach, Harry Mavroforakis, Hasil Sharma, Helder, Herve Bredin,
 Hsiang-Fu Yu, Hugues SALAMIN, Ian Gilmore, Ilambharathi Kanniah, Imran Haque,
-isms, Jake VanderPlas, Jan Dlabal, Jan Hendrik Metzen, Jatin Shah, Javier López
+isms, Jake Vanderplas, Jan Dlabal, Jan Hendrik Metzen, Jatin Shah, Javier López
 Peña, jdcaballero, Jean Kossaifi, Jeff Hammerbacher, Joel Nothman, Jonathan
 Helmus, Joseph, Kaicheng Zhang, Kevin Markham, Kyle Beauchamp, Kyle Kastner,
 Lagacherie Matthieu, Lars Buitinck, Laurent Direr, leepei, Loic Esteve, Luis
@@ -1844,7 +1844,8 @@ Bug fixes
     stopping on 32 bit Python. By `Olivier Grisel`_ and `Fabian Pedregosa`_.
 
   - Fixed the build under Windows when scikit-learn is built with MSVC while
-    NumPy is built with MinGW. By `Olivier Grisel`_ and Federico Vaggi.
+    NumPy is built with MinGW. By `Olivier Grisel`_ and :user:`Federico
+    Vaggi<FedericoV>`.
 
   - Fixed an array index overflow bug in the coordinate descent solver. By
     `Gael Varoquaux`_.
@@ -1955,7 +1956,7 @@ New features
      :class:`feature_selection.VarianceThreshold`, by `Lars Buitinck`_.
 
    - Added :class:`linear_model.RANSACRegressor` meta-estimator for the robust
-     fitting of regression models. By Johannes Schönberger.
+     fitting of regression models. By :user:`Johannes Schönberger<ahojnnes>`.
 
    - Added :class:`cluster.AgglomerativeClustering` for hierarchical
      agglomerative clustering with average linkage, complete linkage and
@@ -2304,7 +2305,7 @@ List of contributors for release 0.15 by number of commits.
 *  21	Maheshakya Wijewardena
 *  21	Brooke Osborn
 *  21	Hamzeh Alsalhi
-*  21	Jake VanderPlas
+*  21	Jake Vanderplas
 *  21	Philippe Gervais
 *  19	Bala Subrahmanyam Varanasi
 *  12	Ronald Phlypo
@@ -2751,7 +2752,7 @@ List of contributors for release 0.14 by number of commits.
  * 102  Noel Dawe
  *  99  Kemal Eren
  *  79  Joel Nothman
- *  75  Jake VanderPlas
+ *  75  Jake Vanderplas
  *  73  Nelle Varoquaux
  *  71  Vlad Niculae
  *  65  Peter Prettenhofer
@@ -4405,7 +4406,7 @@ People that made this release possible preceded by number of commits:
 
    * 33  Vincent Dubourg
 
-   * 21  `Ron Weiss <http://www.ee.columbia.edu/~ronw/>`_
+   * 21  `Ron Weiss`_
 
    * 9  Bertrand Thirion
 
@@ -4721,3 +4722,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Tom Dupre la Tour: https://github.com/TomDLT
 
 .. _Nelle Varoquaux: https://github.com/nellev
+
+.. _Ron Weiss: http://www.ee.columbia.edu/~ronw

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -136,8 +136,8 @@ Linear, kernelized and related models
    - Length of `explained_variance_ratio` of
      :class:`discriminant_analysis.LinearDiscriminantAnalysis`
      changed for both Eigen and SVD solvers. The attribute has now a length
-     of min(n_components, n_classes - 1). :issue:`7632` by 
-     :user:`JPFrancoia<JPFrancoia>`
+     of min(n_components, n_classes - 1). :issue:`7632`
+     by :user:`JPFrancoia<JPFrancoia>`
 
 
 .. _changes_0_18:


### PR DESCRIPTION
#### Reference Issue
Addresses Issue #7748


#### What does this implement/fix? Explain your changes.
Added the :user: role to whats_new.rst for all contributors having a github url in the current version of whats_new.rst.

#### Any other comments?
Wrote a script for automating the process. No changes made for contributors not having the github URL linked.
