### PR TITLE
Fix PLS coef_ bug

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -317,6 +317,7 @@ Bug fixes
 
    - Fixed a memory leak in our LibLinear implementation. :issue:`9024` by
      :user:`Sergei Lebedev <superbobry>`
+   - Fixed improper scaling in :class:`sklearn.cross_decomposition.PLSRegression` with ``scale=True``. :issue:`7819` by :user:`jayzed82 <jayzed82>`.
 
 API changes summary
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -317,7 +317,8 @@ Bug fixes
 
    - Fixed a memory leak in our LibLinear implementation. :issue:`9024` by
      :user:`Sergei Lebedev <superbobry>`
-   - Fixed improper scaling in :class:`sklearn.cross_decomposition.PLSRegression` with ``scale=True``. :issue:`7819` by :user:`jayzed82 <jayzed82>`.
+   - Fixed improper scaling in :class:`sklearn.cross_decomposition.PLSRegression`
+     with ``scale=True``. :issue:`7819` by :user:`jayzed82 <jayzed82>`.
 
 API changes summary
 -------------------

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -366,8 +366,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             # Y = X W(P'W)^-1Q' + Err = XB + Err
             # => B = W*Q' (p x q)
             self.coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
-            self.coef_ = (1. / self.x_std_.reshape((p, 1)) * self.coef_ *
-                          self.y_std_)
+            self.coef_ =  self.coef_ * self.y_std_
         return self
 
     def transform(self, X, Y=None, copy=True):

--- a/sklearn/cross_decomposition/pls_.py
+++ b/sklearn/cross_decomposition/pls_.py
@@ -366,7 +366,7 @@ class _PLS(six.with_metaclass(ABCMeta), BaseEstimator, TransformerMixin,
             # Y = X W(P'W)^-1Q' + Err = XB + Err
             # => B = W*Q' (p x q)
             self.coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
-            self.coef_ =  self.coef_ * self.y_std_
+            self.coef_ = self.coef_ * self.y_std_
         return self
 
     def transform(self, X, Y=None, copy=True):

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -6,6 +6,7 @@ from sklearn.utils.testing import (assert_equal, assert_array_almost_equal,
                                    assert_raise_message)
 from sklearn.datasets import load_linnerud
 from sklearn.cross_decomposition import pls_, CCA
+from sklearn.preprocessing import StandardScaler
 
 
 def test_pls():
@@ -375,12 +376,12 @@ def test_pls_scaling():
 
     Q = rng.randn(n_targets, n_features)
     Y = rng.randn(n_samples, n_targets)
-    X = np.dot(Y, Q) + 2 * rng.randn(n_samples, n_features)
-
-    scale = 1000.
-    X_scaled = scale * X
+    X = np.dot(Y, Q) + 2 * rng.randn(n_samples, n_features) + 1
+    X *= 1000
+    X_scaled = StandardScaler().fit_transform(X)
 
     pls = pls_.PLSRegression(n_components=5, scale=True)
+
     pls.fit(X, Y)
     score = pls.score(X, Y)
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,4 +1,6 @@
 import numpy as np
+from numpy.testing import assert_approx_equal
+
 from sklearn.utils.testing import (assert_equal, assert_array_almost_equal,
                                    assert_array_equal, assert_true,
                                    assert_raise_message)
@@ -351,6 +353,7 @@ def test_scale_and_stability():
             assert_array_almost_equal(X_s_score, X_score)
             assert_array_almost_equal(Y_s_score, Y_score)
 
+
 def test_pls_errors():
     d = load_linnerud()
     X = d.data
@@ -358,4 +361,30 @@ def test_pls_errors():
     for clf in [pls_.PLSCanonical(), pls_.PLSRegression(),
                 pls_.PLSSVD()]:
         clf.n_components = 4
-        assert_raise_message(ValueError, "Invalid number of components", clf.fit, X, Y)
+        assert_raise_message(ValueError, "Invalid number of components",
+                             clf.fit, X, Y)
+
+
+def test_pls_scaling():
+    # sanity check for scale=True
+    n_samples = 1000
+    n_targets = 5
+    n_features = 10
+
+    rng = np.random.RandomState(0)
+
+    Q = rng.randn(n_targets, n_features)
+    Y = rng.randn(n_samples, n_targets)
+    X = np.dot(Y, Q) + 2 * rng.randn(n_samples, n_features)
+
+    scale = 1000.
+    X_scaled = scale * X
+
+    pls = pls_.PLSRegression(n_components=5, scale=True)
+    pls.fit(X, Y)
+    score = pls.score(X, Y)
+
+    pls.fit(X_scaled, Y)
+    score_scaled = pls.score(X_scaled, Y)
+
+    assert_approx_equal(score, score_scaled)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

In the PLS class, the Y predicted by fit function was being divided twice by x_std because X is standardized inside the fit function and the coef_ matrix was also divided by x_std.

I have removed the x_std coefficient from self.coef_.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Remove x_std divisor in coef_ because X is normalized in fit function