### PR TITLE
[MRG+1] Fix estimators to work if sample_weight parameter is pandas Series type

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4828,4 +4828,5 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Srivatsan Ramesh: https://github.com/srivatsan-ramesh
 
 .. _Ron Weiss: http://www.ee.columbia.edu/~ronw
+
 .. _Kathleen Chen: https://github.com/kchen17

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -104,6 +104,10 @@ Bug fixes
      sparse array X and initial centroids, where X's means were unnecessarily
      being subtracted from the centroids. :issue:`7872` by `Josh Karnofsky <https://github.com/jkarno>`_.
 
+   - Fix estimators to accept a ``sample_weight`` parameter of type
+     ``pandas.Series`` in their ``fit`` function. :issue:`7825` by
+     `Kathleen Chen`_.
+
 .. _changes_0_18_1:
 
 Version 0.18.1
@@ -4824,3 +4828,4 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Srivatsan Ramesh: https://github.com/srivatsan-ramesh
 
 .. _Ron Weiss: http://www.ee.columbia.edu/~ronw
+.. _Kathleen Chen: https://github.com/kchen17

--- a/sklearn/ensemble/weight_boosting.py
+++ b/sklearn/ensemble/weight_boosting.py
@@ -116,6 +116,7 @@ class BaseWeightBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
             sample_weight = np.empty(X.shape[0], dtype=np.float64)
             sample_weight[:] = 1. / X.shape[0]
         else:
+            sample_weight = check_array(sample_weight, ensure_2d=False)
             # Normalize existing weights
             sample_weight = sample_weight / sample_weight.sum(dtype=np.float64)
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -11,6 +11,7 @@ __all__ = ['NotFittedError',
            'EfficiencyWarning',
            'FitFailedWarning',
            'NonBLASDotWarning',
+           'SkipTestWarning',
            'UndefinedMetricWarning']
 
 
@@ -135,6 +136,15 @@ class NonBLASDotWarning(EfficiencyWarning):
 
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation, extends EfficiencyWarning.
+    """
+
+
+class SkipTestWarning(UserWarning):
+    """Warning class used to notify the user of a test that was skipped.
+
+    For example, one of the estimator checks requires a pandas import.
+    If the pandas package cannot be imported, the test will be skipped rather
+    than register as a failure.
     """
 
 

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -145,8 +145,7 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True,
                          y_numeric=True)
-        
-        if sample_weight:
+        if sample_weight is not None:
             sample_weight = check_array(sample_weight, ensure_2d=False)
 
         K = self._get_kernel(X)

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -9,7 +9,7 @@ import numpy as np
 from .base import BaseEstimator, RegressorMixin
 from .metrics.pairwise import pairwise_kernels
 from .linear_model.ridge import _solve_cholesky_kernel
-from .utils import check_X_y
+from .utils import check_array, check_X_y
 from .utils.validation import check_is_fitted
 
 
@@ -145,6 +145,9 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True,
                          y_numeric=True)
+        
+        if sample_weight:
+            sample_weight = check_array(sample_weight, ensure_2d=False)
 
         K = self._get_kernel(X)
         alpha = np.atleast_1d(self.alpha)

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -135,7 +135,7 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         y : array-like, shape = [n_samples] or [n_samples, n_targets]
             Target values
 
-        sample_weight : float or numpy array of shape [n_samples]
+        sample_weight : float or array-like of shape [n_samples]
             Individual weights for each sample, ignored if None is passed.
 
         Returns
@@ -145,7 +145,7 @@ class KernelRidge(BaseEstimator, RegressorMixin):
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True,
                          y_numeric=True)
-        if sample_weight is not None:
+        if sample_weight is not None and not isinstance(sample_weight, float):
             sample_weight = check_array(sample_weight, ensure_2d=False)
 
         K = self._get_kernel(X)

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -957,7 +957,7 @@ class _RidgeGCV(LinearModel):
         """
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float64,
                          multi_output=True, y_numeric=True)
-        if sample_weight is not None:
+        if sample_weight is not None and not isinstance(sample_weight, float):
             sample_weight = check_array(sample_weight, ensure_2d=False)
         n_samples, n_features = X.shape
 

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -957,6 +957,8 @@ class _RidgeGCV(LinearModel):
         """
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float64,
                          multi_output=True, y_numeric=True)
+        if sample_weight:
+            sample_weight = check_array(sample_weight, ensure_2d=False)
         n_samples, n_features = X.shape
 
         X, y, X_offset, y_offset, X_scale = LinearModel._preprocess_data(

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -957,7 +957,7 @@ class _RidgeGCV(LinearModel):
         """
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float64,
                          multi_output=True, y_numeric=True)
-        if sample_weight:
+        if sample_weight is not None:
             sample_weight = check_array(sample_weight, ensure_2d=False)
         n_samples, n_features = X.shape
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -253,7 +253,12 @@ def check_estimator(Estimator):
     name = Estimator.__name__
     check_parameters_default_constructible(name, Estimator)
     for check in _yield_all_checks(name, Estimator):
-        check(name, Estimator)
+        try:
+            check(name, Estimator)
+        except SkipTest as message:
+            # the only SkipTest thrown currently results from not
+            # being able to import pandas.
+            warnings.warn(message, ImportWarning)
 
 
 def _boston_subset(n_samples=200):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -400,7 +400,7 @@ def check_pandas_series(name, Estimator):
                                  "'sample_weight' parameter is type "
                                  "pandas.Series.".format(name))
         except ImportError:
-            print("Could not import package 'pandas'")
+            pass
 
 
 @ignore_warnings(category=(DeprecationWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -382,7 +382,7 @@ def check_estimator_sparse_data(name, Estimator):
             raise
 
 
-@ignore_warnings(category=(DeprecationWarning, UserWarning))
+@ignore_warnings(category=(DeprecationWarning))
 def check_sample_weights_pandas_series(name, Estimator):
     # check that estimators will accept a 'sample_weight' parameter of
     # type pandas.Series in the 'fit' function.
@@ -397,10 +397,11 @@ def check_sample_weights_pandas_series(name, Estimator):
                 estimator.fit(X, y, sample_weight=weights)
             except ValueError:
                 raise ValueError("Estimator {0} raises error if "
-                                 "'sample_weight' parameter is type "
-                                 "{1}".format(name, pd.Series))
+                                 "'sample_weight' parameter is of "
+                                 "type pandas.Series".format(name))
         except ImportError:
-            pass
+            raise SkipTest("pandas is not installed: not testing for "
+                           "input of type pandas.Series to class weight.")
 
 
 @ignore_warnings(category=(DeprecationWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -45,6 +45,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.decomposition import NMF, ProjectedGradientNMF
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import DataConversionWarning
+from sklearn.exceptions import SkipTestWarning
 from sklearn.model_selection import train_test_split
 
 from sklearn.utils import shuffle
@@ -258,7 +259,7 @@ def check_estimator(Estimator):
         except SkipTest as message:
             # the only SkipTest thrown currently results from not
             # being able to import pandas.
-            warnings.warn(message, ImportWarning)
+            warnings.warn(message, SkipTestWarning)
 
 
 def _boston_subset(n_samples=200):
@@ -387,7 +388,7 @@ def check_estimator_sparse_data(name, Estimator):
             raise
 
 
-@ignore_warnings(category=(DeprecationWarning))
+@ignore_warnings(category=DeprecationWarning)
 def check_sample_weights_pandas_series(name, Estimator):
     # check that estimators will accept a 'sample_weight' parameter of
     # type pandas.Series in the 'fit' function.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -386,21 +386,21 @@ def check_estimator_sparse_data(name, Estimator):
 def check_pandas_series(name, Estimator):
     # check that estimators will accept a 'sample_weight' parameter of
     # type pandas.Series in the 'fit' function.
-    try:
-        import pandas as pd
-        X = pd.DataFrame([[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3]])
-        y = pd.Series([1, 1, 1, 2, 2, 2])
-        weights = pd.Series([1] * 6)
-        estimator = Estimator()
-        if has_fit_parameter(estimator, "sample_weight"):
+    estimator = Estimator()
+    if has_fit_parameter(estimator, "sample_weight"):
+        try:
+            import pandas as pd
+            X = pd.DataFrame([[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3]])
+            y = pd.Series([1, 1, 1, 2, 2, 2])
+            weights = pd.Series([1] * 6)
             try:
                 estimator.fit(X, y, sample_weight=weights)
             except:
                 raise ValueError("Estimator {0} raises error if "
                                  "'sample_weight' parameter is type "
                                  "pandas.Series.".format(name))
-    except ImportError:
-        print("Could not import package 'pandas'")
+        except ImportError:
+            print("Could not import package 'pandas'")
 
 
 @ignore_warnings(category=(DeprecationWarning, UserWarning))

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -398,7 +398,7 @@ def check_sample_weights_pandas_series(name, Estimator):
             except ValueError:
                 raise ValueError("Estimator {0} raises error if "
                                  "'sample_weight' parameter is type "
-                                 "pandas.Series.".format(name))
+                                 "{1}".format(name, pd.Series))
         except ImportError:
             pass
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -104,7 +104,7 @@ def _yield_non_meta_checks(name, Estimator):
         yield check_estimators_overwrite_params
     if hasattr(Estimator, 'sparsify'):
         yield check_sparsify_coefficients
-    
+
     yield check_estimator_sparse_data
 
     # Test that estimators can be pickled, and once pickled
@@ -198,7 +198,6 @@ def _yield_transformer_checks(name, Transformer):
                        'RandomizedLasso', 'LogisticRegressionCV']
     if name not in external_solver:
         yield check_transformer_n_iter
-
 
 
 def _yield_clustering_checks(name, Clusterer):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -81,7 +81,7 @@ def _yield_non_meta_checks(name, Estimator):
     yield check_estimators_dtypes
     yield check_fit_score_takes_y
     yield check_dtype_object
-    yield check_pandas_series
+    yield check_sample_weights_pandas_series
     yield check_estimators_fit_returns_self
 
     # Check that all estimator yield informative messages when
@@ -383,7 +383,7 @@ def check_estimator_sparse_data(name, Estimator):
 
 
 @ignore_warnings(category=(DeprecationWarning, UserWarning))
-def check_pandas_series(name, Estimator):
+def check_sample_weights_pandas_series(name, Estimator):
     # check that estimators will accept a 'sample_weight' parameter of
     # type pandas.Series in the 'fit' function.
     estimator = Estimator()
@@ -395,7 +395,7 @@ def check_pandas_series(name, Estimator):
             weights = pd.Series([1] * 6)
             try:
                 estimator.fit(X, y, sample_weight=weights)
-            except:
+            except ValueError:
                 raise ValueError("Estimator {0} raises error if "
                                  "'sample_weight' parameter is type "
                                  "pandas.Series.".format(name))

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -129,7 +129,10 @@ def test_check_estimators_unfitted():
     # or AttributeError
     check_estimators_unfitted("estimator", CorrectNotFittedErrorClassifier)
 
+
 def test_common():
+    # check that the fit function of an estimator will accept
+    # a 'sample_weight' parameter of type pandas.Series
     try:
         import pandas as pd
     except ImportError:
@@ -150,4 +153,3 @@ def test_common():
                 raise ValueError("Estimator {0} raises error if "
                                  "'sample_weight' parameter is type "
                                  "pandas.Series.".format(estimator_name))
-

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -13,6 +13,7 @@ from sklearn.linear_model import MultiTaskElasticNet
 from sklearn.utils.validation import check_X_y, check_array
 from sklearn.utils.validation import has_fit_parameter
 
+
 class CorrectNotFittedError(ValueError):
     """Exception class to raise if estimator is used before fitting.
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -80,13 +80,12 @@ class NoSampleWeightPandasSeriesType(BaseEstimator):
                          accept_sparse=("csr", "csc"),
                          multi_output=True,
                          y_numeric=True)
-        try:
-            from pandas import Series
-            if isinstance(sample_weight, Series):
-                raise ValueError("Estimator does not accept 'sample_weight'"
-                                 "of type pandas.Series")
-        except ImportError:
-            return self
+        # Function is only called after we verify that pandas is installed
+        from pandas import Series
+        if isinstance(sample_weight, Series):
+            raise ValueError(("Estimator does not accept 'sample_weight'"
+                             "of type {0}").format(Series))
+        return self
 
     def predict(self, X):
         X = check_array(X)
@@ -107,10 +106,14 @@ def test_check_estimator():
     msg = "TypeError not raised"
     assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
     # check that sample_weights in fit accepts pandas.Series type
-    msg = "Estimator NoSampleWeightPandasSeriesType raises error if " + \
-          "'sample_weight' parameter is type pandas.Series."
-    assert_raises_regex(
-        ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
+    try:
+        from pandas import Series
+        msg = ("Estimator NoSampleWeightPandasSeriesType raises error if "
+               "'sample_weight' parameter is type {0}").format(Series)
+        assert_raises_regex(
+            ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
+    except ImportError:
+        pass
     # check that predict does input validation (doesn't accept dicts in input)
     msg = "Estimator doesn't check for NaN and inf in predict"
     assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -76,7 +76,9 @@ class CorrectNotFittedErrorClassifier(BaseBadClassifier):
 class NoSampleWeightPandasSeriesType(BaseEstimator):
     def fit(self, X, y, sample_weight=None):
         # Convert data
-        X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True,
+        X, y = check_X_y(X, y,
+                         accept_sparse=("csr", "csc"),
+                         multi_output=True,
                          y_numeric=True)
         # Loosely based on _solve_cholesky_kernel (called in KernelRidge.fit)
         has_sw = isinstance(sample_weight, np.ndarray) \
@@ -104,10 +106,14 @@ def test_check_estimator():
     msg = "TypeError not raised"
     assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
     # check that sample_weights in fit accepts pandas.Series type
-    msg = "Estimator NoSampleWeightPandasSeriesType raises error if " + \
-          "'sample_weight' parameter is type pandas.Series."
-    assert_raises_regex(
-        ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
+    try:
+        from pandas import Series
+        msg = "Estimator NoSampleWeightPandasSeriesType raises error if " + \
+              "'sample_weight' parameter is type pandas.Series."
+        assert_raises_regex(
+            ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
+    except ImportError:
+        pass
     # check that predict does input validation (doesn't accept dicts in input)
     msg = "Estimator doesn't check for NaN and inf in predict"
     assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -83,8 +83,8 @@ class NoSampleWeightPandasSeriesType(BaseEstimator):
         # Function is only called after we verify that pandas is installed
         from pandas import Series
         if isinstance(sample_weight, Series):
-            raise ValueError(("Estimator does not accept 'sample_weight'"
-                             "of type {0}").format(Series))
+            raise ValueError("Estimator does not accept 'sample_weight'"
+                             "of type pandas.Series")
         return self
 
     def predict(self, X):
@@ -107,9 +107,9 @@ def test_check_estimator():
     assert_raises_regex(AssertionError, msg, check_estimator, BaseBadClassifier)
     # check that sample_weights in fit accepts pandas.Series type
     try:
-        from pandas import Series
+        from pandas import Series  # noqa
         msg = ("Estimator NoSampleWeightPandasSeriesType raises error if "
-               "'sample_weight' parameter is type {0}").format(Series)
+               "'sample_weight' parameter is of type pandas.Series")
         assert_raises_regex(
             ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
     except ImportError:

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -85,6 +85,10 @@ class NoSampleWeightPandasSeriesType(BaseBadClassifier):
             np.sqrt(np.atleast_1d(sample_weight))
         return self
 
+    def predict(self, X):
+        X = check_array(X)
+        return np.ones(X.shape[0])
+
 
 def test_check_estimator():
     # tests that the estimator actually fails on "bad" estimators.

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -73,7 +73,7 @@ class CorrectNotFittedErrorClassifier(BaseBadClassifier):
         return np.ones(X.shape[0])
 
 
-class NoSampleWeightPandasSeriesType(BaseBadClassifier):
+class NoSampleWeightPandasSeriesType(BaseEstimator):
     def fit(self, X, y, sample_weight=None):
         # Convert data
         X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), multi_output=True,


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
Finishes work in #5642

#### What does this implement/fix? Explain your changes.
This addresses the comments made on @pradyu1993's [commit](https://github.com/scikit-learn/scikit-learn/pull/5642/commits/a64023b31c21c55d6521322b5b26bff2772fd399)

#### Any other comments?
May still warrant a PEP8 linting. (Having trouble with my usual development machine so once I get back on that I'll run the linter & all). Let me know if there are any suggestions on tests or improvements to how the check is made. Thanks!