### PR TITLE
[MRG] changed BIC doc string to read that a lower BIC score is prefered.

### DIFF
--- a/sklearn/mixture/gaussian_mixture.py
+++ b/sklearn/mixture/gaussian_mixture.py
@@ -726,8 +726,7 @@ class GaussianMixture(BaseMixture):
 
         Returns
         -------
-        bic: float
-            The greater the better.
+        bic: float (the lower the better)
         """
         return (-2 * self.score(X) * X.shape[0] +
                 self._n_parameters() * np.log(X.shape[0]))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7785 


#### What does this implement/fix? Explain your changes.
The BIC score was incorrectly stated to be "the greater the better". I have changed it to be "the lower the better", which is consistant with the code and the wiki [wiki page](https://en.wikipedia.org/wiki/Bayesian_information_criterion)

#### Any other comments?

I don't understand why it says ...able below, but I'll leave it. Cheers!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

…able