### PR TITLE
Add Angular distance, a metric version of cosine distance

### DIFF
--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -19,7 +19,8 @@ VALID_METRICS = ['EuclideanDistance', 'SEuclideanDistance',
                  'DiceDistance', 'KulsinskiDistance',
                  'RogersTanimotoDistance', 'RussellRaoDistance',
                  'SokalMichenerDistance', 'SokalSneathDistance',
-                 'PyFuncDistance', 'HaversineDistance']
+                 'ArccosDistance', 'HaversineDistance'
+                 'PyFuncDistance']
 
 
 include "binary_tree.pxi"

--- a/sklearn/neighbors/ball_tree.pyx
+++ b/sklearn/neighbors/ball_tree.pyx
@@ -19,7 +19,7 @@ VALID_METRICS = ['EuclideanDistance', 'SEuclideanDistance',
                  'DiceDistance', 'KulsinskiDistance',
                  'RogersTanimotoDistance', 'RussellRaoDistance',
                  'SokalMichenerDistance', 'SokalSneathDistance',
-                 'ArccosDistance', 'HaversineDistance'
+                 'ArccosDistance', 'HaversineDistance',
                  'PyFuncDistance']
 
 

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -86,7 +86,6 @@ METRIC_MAPPING = {'euclidean': EuclideanDistance,
                   'sokalmichener': SokalMichenerDistance,
                   'sokalsneath': SokalSneathDistance,
                   'haversine': HaversineDistance,
-                  'cosine': ArccosDistance,
                   'arccos': ArccosDistance,
                   'angular': ArccosDistance,
                   'pyfunc': PyFuncDistance}

--- a/sklearn/neighbors/dist_metrics.pyx
+++ b/sklearn/neighbors/dist_metrics.pyx
@@ -1066,7 +1066,7 @@ cdef class ArccosDistance(DistanceMetric):
             d += x1[j] * x2[j]
             norm1 += x1[j] * x1[j]
             norm2 += x2[j] * x2[j]
-        return acos(1.0 - d / sqrt(norm1 * norm2)) / M_PI
+        return acos(d / sqrt(norm1 * norm2)) / M_PI
 
 
 #------------------------------------------------------------

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -17,6 +17,7 @@ METRICS = {'euclidean': {},
            'manhattan': {},
            'minkowski': dict(p=3),
            'chebyshev': {},
+           'arccos': {},
            'seuclidean': dict(V=np.random.random(DIMENSION)),
            'wminkowski': dict(p=3, w=np.random.random(DIMENSION)),
            'mahalanobis': dict(V=V)}

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -933,6 +933,7 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
                ('minkowski', dict(p=3)),
                ('minkowski', dict(p=np.inf)),
                ('chebyshev', {}),
+               ('arccos', {}),
                ('seuclidean', dict(V=rng.rand(n_features))),
                ('wminkowski', dict(p=3, w=rng.rand(n_features))),
                ('mahalanobis', dict(VI=VI))]
@@ -1014,7 +1015,7 @@ def test_non_euclidean_kneighbors():
     radius = dist_array[15]
 
     # Test kneighbors_graph
-    for metric in ['manhattan', 'chebyshev']:
+    for metric in ['manhattan', 'chebyshev', 'arccos']:
         nbrs_graph = neighbors.kneighbors_graph(
             X, 3, metric=metric, mode='connectivity',
             include_self=True).toarray()
@@ -1022,7 +1023,7 @@ def test_non_euclidean_kneighbors():
         assert_array_equal(nbrs_graph, nbrs1.kneighbors_graph(X).toarray())
 
     # Test radiusneighbors_graph
-    for metric in ['manhattan', 'chebyshev']:
+    for metric in ['manhattan', 'chebyshev', 'arccos']:
         nbrs_graph = neighbors.radius_neighbors_graph(
             X, radius, metric=metric, mode='connectivity',
             include_self=True).toarray()

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1014,7 +1014,7 @@ def test_non_euclidean_kneighbors():
     radius = dist_array[15]
 
     # Test kneighbors_graph
-    for metric in ['manhattan', 'chebyshev', 'cosine']:
+    for metric in ['manhattan', 'chebyshev']:
         nbrs_graph = neighbors.kneighbors_graph(
             X, 3, metric=metric, mode='connectivity',
             include_self=True).toarray()

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1022,7 +1022,7 @@ def test_non_euclidean_kneighbors():
         assert_array_equal(nbrs_graph, nbrs1.kneighbors_graph(X).toarray())
 
     # Test radiusneighbors_graph
-    for metric in ['manhattan', 'chebyshev', 'cosine']:
+    for metric in ['manhattan', 'chebyshev']:
         nbrs_graph = neighbors.radius_neighbors_graph(
             X, radius, metric=metric, mode='connectivity',
             include_self=True).toarray()

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -933,7 +933,6 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
                ('minkowski', dict(p=3)),
                ('minkowski', dict(p=np.inf)),
                ('chebyshev', {}),
-               ('cosine', {}),
                ('seuclidean', dict(V=rng.rand(n_features))),
                ('wminkowski', dict(p=3, w=rng.rand(n_features))),
                ('mahalanobis', dict(VI=VI))]

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -933,7 +933,7 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
                ('minkowski', dict(p=3)),
                ('minkowski', dict(p=np.inf)),
                ('chebyshev', {}),
-               ('arccos', {}),
+               ('cosine', {}),
                ('seuclidean', dict(V=rng.rand(n_features))),
                ('wminkowski', dict(p=3, w=rng.rand(n_features))),
                ('mahalanobis', dict(VI=VI))]
@@ -1015,7 +1015,7 @@ def test_non_euclidean_kneighbors():
     radius = dist_array[15]
 
     # Test kneighbors_graph
-    for metric in ['manhattan', 'chebyshev', 'arccos']:
+    for metric in ['manhattan', 'chebyshev', 'cosine']:
         nbrs_graph = neighbors.kneighbors_graph(
             X, 3, metric=metric, mode='connectivity',
             include_self=True).toarray()
@@ -1023,7 +1023,7 @@ def test_non_euclidean_kneighbors():
         assert_array_equal(nbrs_graph, nbrs1.kneighbors_graph(X).toarray())
 
     # Test radiusneighbors_graph
-    for metric in ['manhattan', 'chebyshev', 'arccos']:
+    for metric in ['manhattan', 'chebyshev', 'cosine']:
         nbrs_graph = neighbors.radius_neighbors_graph(
             X, radius, metric=metric, mode='connectivity',
             include_self=True).toarray()


### PR DESCRIPTION
Many algorithms, such as word2vec result in nearest neighbor computations based on cosine similarity. Unfortunately, since cosine (dis)similarity is not a metric it can't be used with kd-trees and ball-trees. This means that algorithms that make use of these structures (e.g. DBSCAN clustering, fast t-SNE, etc.) can't operate with regard to the "appropriate" (dis)similarity measure. Here we add angular (or arccos) distance which is the natural metric analogue of cosine dissimilarity to the valid metrics used for kd-trees and ball-trees. Credit for this work belongs to @brunoalano who submitted a similar change to hdbscan.

